### PR TITLE
CLDR-17073 regen algorithmic locales before alpha2

### DIFF
--- a/common/annotations/ha_NE.xml
+++ b/common/annotations/ha_NE.xml
@@ -810,9 +810,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤥" type="tts">fuska mai yin ƙarya</annotation>
 		<annotation cp="🫨">fuska | gigice | girgiza | girgizar ƙasa</annotation>
 		<annotation cp="🫨" type="tts">girgiza fuska</annotation>
-		<annotation cp="🙂‍↔">aʼa, girgiza | girgiza kai a kwance</annotation>
+		<annotation cp="🙂‍↔">aʼa | girgiza | girgiza kai a kwance</annotation>
 		<annotation cp="🙂‍↔" type="tts">girgiza kai a kwance</annotation>
-		<annotation cp="🙂‍↕">girgiza kai a tsaye | Girgiza kai a tsaye | yarda da kai, e</annotation>
+		<annotation cp="🙂‍↕">e | girgiza kai a tsaye | Girgiza kai a tsaye | yarda da kai</annotation>
 		<annotation cp="🙂‍↕" type="tts">Girgiza kai a tsaye</annotation>
 		<annotation cp="😌">fuska | fuska mai kwancin hankali | kwancin hankali</annotation>
 		<annotation cp="😌" type="tts">fuska mai kwancin hankali</annotation>
@@ -1672,13 +1672,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫂" type="tts">mutane na runguma</annotation>
 		<annotation cp="👪">iyali</annotation>
 		<annotation cp="👪" type="tts">iyali</annotation>
-		<annotation cp="🧑‍🧑‍🧒">iyali: manya, manya, yara</annotation>
+		<annotation cp="🧑‍🧑‍🧒">iyali: manya | iyali: manya, manya, yara | manya | yara</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts">iyali: manya, manya, yara</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">iyali: manya, manya, yara, yara</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒">iyali: manya | iyali: manya, manya, yara, yara | manya | yara</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">iyali: manya, manya, yara, yara</annotation>
-		<annotation cp="🧑‍🧒">iyali: manya, yara</annotation>
+		<annotation cp="🧑‍🧒">iyali: manya | iyali: manya, yara | yara</annotation>
 		<annotation cp="🧑‍🧒" type="tts">iyali: manya, yara</annotation>
-		<annotation cp="🧑‍🧒‍🧒">iyali: manya, yara, yara</annotation>
+		<annotation cp="🧑‍🧒‍🧒">iyali: manya | iyali: manya, yara, yara | yara</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts">iyali: manya, yara, yara</annotation>
 		<annotation cp="👣">buga | sawaye | sawu | sutura</annotation>
 		<annotation cp="👣" type="tts">sawaye</annotation>
@@ -1864,7 +1864,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🐦‍⬛" type="tts">babban tsuntsu</annotation>
 		<annotation cp="🪿">gis | kowa | tsuntsu | wauta</annotation>
 		<annotation cp="🪿" type="tts">gis</annotation>
-		<annotation cp="🐦‍🔥">kirkirarren labari, tsuntsun wuta, sabon haihuwa, haihuwan matacce | phoenix</annotation>
+		<annotation cp="🐦‍🔥">haihuwan matacce | kirkirarren labari | phoenix | sabon haihuwa | tsuntsun wuta</annotation>
 		<annotation cp="🐦‍🔥" type="tts">phoenix</annotation>
 		<annotation cp="🐸">fuska | kwaɗo</annotation>
 		<annotation cp="🐸" type="tts">kwaɗo</annotation>
@@ -2006,7 +2006,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍊" type="tts">tanjarin</annotation>
 		<annotation cp="🍋">ɗan itace | kayan lemo | ruwan lemo</annotation>
 		<annotation cp="🍋" type="tts">ruwan lemo</annotation>
-		<annotation cp="🍋‍🟩">kayan lemu, ƴaƴan itace, wurare masu zafi | lemun tsami</annotation>
+		<annotation cp="🍋‍🟩">kayan lemu | lemun tsami | wurare masu zafi | ƴaƴan itace</annotation>
 		<annotation cp="🍋‍🟩" type="tts">lemun tsami</annotation>
 		<annotation cp="🍌">ayaba | ɗan itace</annotation>
 		<annotation cp="🍌" type="tts">ayaba</annotation>
@@ -2070,7 +2070,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫚" type="tts">saiwar citta</annotation>
 		<annotation cp="🫛">karen | kayan lambu | koren wake | koren wake na fis | legume | wake | wake na fis</annotation>
 		<annotation cp="🫛" type="tts">koren wake na fis</annotation>
-		<annotation cp="🍄‍🟫">abinci, naman gwari, yanayi, kayan lambu | naman kazan launin ruwan kasa</annotation>
+		<annotation cp="🍄‍🟫">abinci | kayan lambu | naman gwari | naman kazan launin ruwan kasa | yanayi</annotation>
 		<annotation cp="🍄‍🟫" type="tts">naman kazan launin ruwan kasa</annotation>
 		<annotation cp="🍞">burodi | burodi mai yanke-yanke</annotation>
 		<annotation cp="🍞" type="tts">burodi</annotation>
@@ -3288,7 +3288,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦯" type="tts">farar sanda</annotation>
 		<annotation cp="🔗">mahaɗa</annotation>
 		<annotation cp="🔗" type="tts">mahaɗa</annotation>
-		<annotation cp="⛓‍💥">karyayyen sarka | karyayyen sarkar | karye, karyewa, sarka, sarkar hannu, ƴanci</annotation>
+		<annotation cp="⛓‍💥">karyayyen sarka | karyayyen sarkar | karye | karyewa | sarka | sarkar hannu | ƴanci</annotation>
 		<annotation cp="⛓‍💥" type="tts">karyayyen sarkar</annotation>
 		<annotation cp="⛓">sarƙa | sarƙoƙi</annotation>
 		<annotation cp="⛓" type="tts">sarƙoƙi</annotation>

--- a/common/annotations/sr_Latn.xml
+++ b/common/annotations/sr_Latn.xml
@@ -810,9 +810,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤥" type="tts">lažljivac</annotation>
 		<annotation cp="🫨">drhteće lice | drhtenje | lice | šok | vibrira | zemljotres</annotation>
 		<annotation cp="🫨" type="tts">drhteće lice</annotation>
-		<annotation cp="🙂‍↔">glava trese horizontalno | ne, trese</annotation>
+		<annotation cp="🙂‍↔">glava trese horizontalno | ne | trese</annotation>
 		<annotation cp="🙂‍↔" type="tts">glava trese horizontalno</annotation>
-		<annotation cp="🙂‍↕">glava trese vertikalno | klima, da</annotation>
+		<annotation cp="🙂‍↕">da | glava trese vertikalno | klima</annotation>
 		<annotation cp="🙂‍↕" type="tts">glava trese vertikalno</annotation>
 		<annotation cp="😌">lice | olakšanje | spokojno lice</annotation>
 		<annotation cp="😌" type="tts">spokojno lice</annotation>
@@ -1684,13 +1684,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫂" type="tts">ljudi se grle</annotation>
 		<annotation cp="👪">porodica</annotation>
 		<annotation cp="👪" type="tts">porodica</annotation>
-		<annotation cp="🧑‍🧑‍🧒">porodica: odrasla osoba, odrasla osoba, dete</annotation>
+		<annotation cp="🧑‍🧑‍🧒">dete | odrasla osoba | porodica: odrasla osoba | porodica: odrasla osoba, odrasla osoba, dete</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts">porodica: odrasla osoba, odrasla osoba, dete</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">porodica: odrasla osoba, odrasla osoba, dete, dete</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒">dete | odrasla osoba | porodica: odrasla osoba | porodica: odrasla osoba, odrasla osoba, dete, dete</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">porodica: odrasla osoba, odrasla osoba, dete, dete</annotation>
-		<annotation cp="🧑‍🧒">porodica: odrasla osoba, dete</annotation>
+		<annotation cp="🧑‍🧒">dete | porodica: odrasla osoba | porodica: odrasla osoba, dete</annotation>
 		<annotation cp="🧑‍🧒" type="tts">porodica: odrasla osoba, dete</annotation>
-		<annotation cp="🧑‍🧒‍🧒">porodica: odrasla osoba, dete, dete</annotation>
+		<annotation cp="🧑‍🧒‍🧒">dete | porodica: odrasla osoba | porodica: odrasla osoba, dete, dete</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts">porodica: odrasla osoba, dete, dete</annotation>
 		<annotation cp="👣">noge | otisak | otisci stopala | stopala | telo</annotation>
 		<annotation cp="👣" type="tts">otisci stopala</annotation>
@@ -1876,7 +1876,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🐦‍⬛" type="tts">crna ptica</annotation>
 		<annotation cp="🪿">blesav | graktanje | guska | ptica</annotation>
 		<annotation cp="🪿" type="tts">guska</annotation>
-		<annotation cp="🐦‍🔥">fantazija, vatrena ptica, ponovno rođenje, reinkarnacija | feniks</annotation>
+		<annotation cp="🐦‍🔥">fantazija | feniks | ponovno rođenje | reinkarnacija | vatrena ptica</annotation>
 		<annotation cp="🐦‍🔥" type="tts">feniks</annotation>
 		<annotation cp="🐸">lice | žaba</annotation>
 		<annotation cp="🐸" type="tts">žaba</annotation>
@@ -2018,7 +2018,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍊" type="tts">mandarina</annotation>
 		<annotation cp="🍋">biljka | limun | voće</annotation>
 		<annotation cp="🍋" type="tts">limun</annotation>
-		<annotation cp="🍋‍🟩">citrusi, voće, tropsko | limeta</annotation>
+		<annotation cp="🍋‍🟩">citrusi | limeta | tropsko | voće</annotation>
 		<annotation cp="🍋‍🟩" type="tts">limeta</annotation>
 		<annotation cp="🍌">banana | voće</annotation>
 		<annotation cp="🍌" type="tts">banana</annotation>
@@ -2082,7 +2082,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫚" type="tts">koren đumbira</annotation>
 		<annotation cp="🫛">edamame | grašak | mahuna | mahuna graška | mahunarka | povrće</annotation>
 		<annotation cp="🫛" type="tts">mahuna graška</annotation>
-		<annotation cp="🍄‍🟫">hrana, gljive, priroda, povrće | smeđa pečurka</annotation>
+		<annotation cp="🍄‍🟫">gljive | hrana | povrće | priroda | smeđa pečurka</annotation>
 		<annotation cp="🍄‍🟫" type="tts">smeđa pečurka</annotation>
 		<annotation cp="🍞">hleb | vekna</annotation>
 		<annotation cp="🍞" type="tts">hleb</annotation>
@@ -3300,7 +3300,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦯" type="tts">beli štap</annotation>
 		<annotation cp="🔗">karike</annotation>
 		<annotation cp="🔗" type="tts">karike</annotation>
-		<annotation cp="⛓‍💥">prekid, lomljenje, lanac, lisice, sloboda | prekinut lanac</annotation>
+		<annotation cp="⛓‍💥">lanac | lisice | lomljenje | prekid | prekinut lanac | sloboda</annotation>
 		<annotation cp="⛓‍💥" type="tts">prekinut lanac</annotation>
 		<annotation cp="⛓">lanac | lanci</annotation>
 		<annotation cp="⛓" type="tts">lanci</annotation>

--- a/common/annotations/sr_Latn_BA.xml
+++ b/common/annotations/sr_Latn_BA.xml
@@ -1685,13 +1685,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫂" type="tts">↑↑↑</annotation>
 		<annotation cp="👪">↑↑↑</annotation>
 		<annotation cp="👪" type="tts">↑↑↑</annotation>
-		<annotation cp="🧑‍🧑‍🧒">porodica: odrasla osoba, odrasla osoba, dijete</annotation>
+		<annotation cp="🧑‍🧑‍🧒">dijete | odrasla osoba | porodica: odrasla osoba | porodica: odrasla osoba, odrasla osoba, dijete</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts">porodica: odrasla osoba, odrasla osoba, dijete</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">porodica: odrasla osoba, odrasla osoba, dijete, dijete</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒">dijete | odrasla osoba | porodica: odrasla osoba | porodica: odrasla osoba, odrasla osoba, dijete, dijete</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">porodica: odrasla osoba, odrasla osoba, dijete, dijete</annotation>
-		<annotation cp="🧑‍🧒">porodica: odrasla osoba, dijete</annotation>
+		<annotation cp="🧑‍🧒">dijete | porodica: odrasla osoba | porodica: odrasla osoba, dijete</annotation>
 		<annotation cp="🧑‍🧒" type="tts">porodica: odrasla osoba, dijete</annotation>
-		<annotation cp="🧑‍🧒‍🧒">porodica: odrasla osoba, dijete, dijete</annotation>
+		<annotation cp="🧑‍🧒‍🧒">dijete | porodica: odrasla osoba | porodica: odrasla osoba, dijete, dijete</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts">porodica: odrasla osoba, dijete, dijete</annotation>
 		<annotation cp="👣">odjeća | otisak | otisak stopala | otisci stopala</annotation>
 		<annotation cp="👣" type="tts">↑↑↑</annotation>

--- a/common/annotations/yo_BJ.xml
+++ b/common/annotations/yo_BJ.xml
@@ -802,9 +802,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤥" type="tts">Oju Irɔ</annotation>
 		<annotation cp="🫨">eru | gbigbɔ̀n | gbɔ̀n | iji | ojú | ojú gbígbɔ̀n</annotation>
 		<annotation cp="🫨" type="tts">ojú gbígbɔ̀n</annotation>
-		<annotation cp="🙂‍↔">orí mímì látɔ̀tún-sósì | rárá, gbɔn orí</annotation>
+		<annotation cp="🙂‍↔">gbɔn orí | orí mímì látɔ̀tún-sósì | rárá</annotation>
 		<annotation cp="🙂‍↔" type="tts">orí mímì látɔ̀tún-sósì</annotation>
-		<annotation cp="🙂‍↕">fi orí dáhùn, bɛ́ɛ̀ni | orí mímì látòkè-sílɛ̀</annotation>
+		<annotation cp="🙂‍↕">bɛ́ɛ̀ni | fi orí dáhùn | orí mímì látòkè-sílɛ̀</annotation>
 		<annotation cp="🙂‍↕" type="tts">orí mímì látòkè-sílɛ̀</annotation>
 		<annotation cp="😌">ìtura | ojú | Oju Itura</annotation>
 		<annotation cp="😌" type="tts">Oju Itura</annotation>
@@ -1676,13 +1676,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫂" type="tts">àwɔn ènìyàn tóndìmɔ́ra</annotation>
 		<annotation cp="👪">Ɛbí</annotation>
 		<annotation cp="👪" type="tts">Ɛbí</annotation>
-		<annotation cp="🧑‍🧑‍🧒">ìdílé: àgbàlagbà, àgbàlagbà, ɔmɔdé</annotation>
+		<annotation cp="🧑‍🧑‍🧒">àgbàlagbà | ìdílé: àgbàlagbà | ìdílé: àgbàlagbà, àgbàlagbà, ɔmɔdé | ɔmɔdé</annotation>
 		<annotation cp="🧑‍🧑‍🧒" type="tts">ìdílé: àgbàlagbà, àgbàlagbà, ɔmɔdé</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">ìdílé: àgbàlagbà, àgbàlagbà, ɔmɔdé, ɔmɔdé</annotation>
+		<annotation cp="🧑‍🧑‍🧒‍🧒">àgbàlagbà | ìdílé: àgbàlagbà | ìdílé: àgbàlagbà, àgbàlagbà, ɔmɔdé, ɔmɔdé | ɔmɔdé</annotation>
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">ìdílé: àgbàlagbà, àgbàlagbà, ɔmɔdé, ɔmɔdé</annotation>
-		<annotation cp="🧑‍🧒">ìdílé: àgbàlagbà, ɔmɔdé</annotation>
+		<annotation cp="🧑‍🧒">ìdílé: àgbàlagbà | ìdílé: àgbàlagbà, ɔmɔdé | ɔmɔdé</annotation>
 		<annotation cp="🧑‍🧒" type="tts">ìdílé: àgbàlagbà, ɔmɔdé</annotation>
-		<annotation cp="🧑‍🧒‍🧒">ìdílé: àgbàlagbà, ɔmɔdé, ɔmɔdé</annotation>
+		<annotation cp="🧑‍🧒‍🧒">ìdílé: àgbàlagbà | ìdílé: àgbàlagbà, ɔmɔdé, ɔmɔdé | ɔmɔdé</annotation>
 		<annotation cp="🧑‍🧒‍🧒" type="tts">ìdílé: àgbàlagbà, ɔmɔdé, ɔmɔdé</annotation>
 		<annotation cp="👣">ashɔ | Ipa ɛsɛ | ipasɛ̀ | ìpasɛ̀</annotation>
 		<annotation cp="👣" type="tts">Ipa ɛsɛ</annotation>
@@ -1868,7 +1868,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🐦‍⬛" type="tts">ɛyɛ dúdú</annotation>
 		<annotation cp="🪿">adie | atioro | eye | lekeleke | tòlotòló</annotation>
 		<annotation cp="🪿" type="tts">tòlotòló</annotation>
-		<annotation cp="🐦‍🔥">àlá àìlèshɛ, ɛyɛ oníná, àtúnbí, àtúnwáyé | ɛyɛ ìtàn àìlèkú</annotation>
+		<annotation cp="🐦‍🔥">àlá àìlèshɛ | àtúnbí | àtúnwáyé | ɛyɛ ìtàn àìlèkú | ɛyɛ oníná</annotation>
 		<annotation cp="🐦‍🔥" type="tts">ɛyɛ ìtàn àìlèkú</annotation>
 		<annotation cp="🐸">ojú | Oju Ɔpɔlɔ | ɔpɔlɔ</annotation>
 		<annotation cp="🐸" type="tts">Oju Ɔpɔlɔ</annotation>
@@ -2010,7 +2010,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍊" type="tts">Tanjarini</annotation>
 		<annotation cp="🍋">èso | Orombo-wɛwɛ Chiffon | ɔsàn</annotation>
 		<annotation cp="🍋" type="tts">Orombo-wɛwɛ Chiffon</annotation>
-		<annotation cp="🍋‍🟩">àwɔn èso ɔsàn, èso, agbègbè mímóoru | ɔsàn wɛ́wɛ́</annotation>
+		<annotation cp="🍋‍🟩">agbègbè mímóoru | àwɔn èso ɔsàn | èso | ɔsàn wɛ́wɛ́</annotation>
 		<annotation cp="🍋‍🟩" type="tts">ɔsàn wɛ́wɛ́</annotation>
 		<annotation cp="🍌">Èso | Ɔ̀gɛ̀dɛ̀</annotation>
 		<annotation cp="🍌" type="tts">Ɔ̀gɛ̀dɛ̀</annotation>
@@ -2074,7 +2074,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫚" type="tts">jínjà</annotation>
 		<annotation cp="🫛">ea | eap | efo | ewa</annotation>
 		<annotation cp="🫛" type="tts">eap</annotation>
-		<annotation cp="🍄‍🟫">olú aláwɔ̀ pupa rɛ́súrɛ́sú | oúnjɛ, olú híhù, ìshɛ̀dá, ewébɛ̀</annotation>
+		<annotation cp="🍄‍🟫">ewébɛ̀ | ìshɛ̀dá | olú aláwɔ̀ pupa rɛ́súrɛ́sú | olú híhù | oúnjɛ</annotation>
 		<annotation cp="🍄‍🟫" type="tts">olú aláwɔ̀ pupa rɛ́súrɛ́sú</annotation>
 		<annotation cp="🍞">Búrɛ́dì | búrɛ́dì gígé</annotation>
 		<annotation cp="🍞" type="tts">Búrɛ́dì</annotation>
@@ -3292,7 +3292,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦯" type="tts">egba funfun</annotation>
 		<annotation cp="🔗">ìtɔ́kasí</annotation>
 		<annotation cp="🔗" type="tts">ìtɔ́kasí</annotation>
-		<annotation cp="⛓‍💥">ìdè tó ti já | já, ń já, ìdè, àwɔn ìdè ɔwɔ́ tàbí ɛsɛ̀, òmìnira</annotation>
+		<annotation cp="⛓‍💥">àwɔn ìdè ɔwɔ́ tàbí ɛsɛ̀ | ìdè | ìdè tó ti já | já | ń já | òmìnira</annotation>
 		<annotation cp="⛓‍💥" type="tts">ìdè tó ti já</annotation>
 		<annotation cp="⛓">àwɔn she̩kɛ́shɛkɛ̀ | she̩kɛ́shɛkɛ̀</annotation>
 		<annotation cp="⛓" type="tts">àwɔn she̩kɛ́shɛkɛ̀</annotation>

--- a/common/annotationsDerived/sr_Latn.xml
+++ b/common/annotationsDerived/sr_Latn.xml
@@ -4,9 +4,8 @@
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
-
-Derived short names and annotations, using GenerateDerivedAnnotations.java. See warnings in /annotations/ file.
 -->
+<!-- Derived short names and annotations, using GenerateDerivedAnnotations.java. See warnings in /annotations/ file. -->
 <ldml>
 	<identity>
 		<version number="$Revision$"/>
@@ -14,4249 +13,4229 @@ Derived short names and annotations, using GenerateDerivedAnnotations.java. See 
 		<script type="Latn"/>
 	</identity>
 	<annotations>
-		<annotation cp="👋🏻">mahanje | ruka | ruka koja maše | ruka koja maše: svetla koža | svetla koža</annotation>
+		<annotation cp="👋🏻">mahanje | ruka | ruka koja maše | svetla koža</annotation>
 		<annotation cp="👋🏻" type="tts">ruka koja maše: svetla koža</annotation>
-		<annotation cp="👋🏼">mahanje | ruka | ruka koja maše | ruka koja maše: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👋🏼">mahanje | ruka | ruka koja maše | srednje svetla koža</annotation>
 		<annotation cp="👋🏼" type="tts">ruka koja maše: srednje svetla koža</annotation>
-		<annotation cp="👋🏽">mahanje | ni svetla ni tamna koža | ruka | ruka koja maše | ruka koja maše: ni svetla ni tamna koža</annotation>
+		<annotation cp="👋🏽">mahanje | ni svetla ni tamna koža | ruka | ruka koja maše</annotation>
 		<annotation cp="👋🏽" type="tts">ruka koja maše: ni svetla ni tamna koža</annotation>
-		<annotation cp="👋🏾">mahanje | ruka | ruka koja maše | ruka koja maše: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👋🏾">mahanje | ruka | ruka koja maše | srednje tamna koža</annotation>
 		<annotation cp="👋🏾" type="tts">ruka koja maše: srednje tamna koža</annotation>
-		<annotation cp="👋🏿">mahanje | ruka | ruka koja maše | ruka koja maše: tamna koža | tamna koža</annotation>
+		<annotation cp="👋🏿">mahanje | ruka | ruka koja maše | tamna koža</annotation>
 		<annotation cp="👋🏿" type="tts">ruka koja maše: tamna koža</annotation>
-		<annotation cp="🤚🏻">dlan | podignut dlan | podignut dlan: svetla koža | podignuto | svetla koža</annotation>
+		<annotation cp="🤚🏻">dlan | podignut dlan | podignuto | svetla koža</annotation>
 		<annotation cp="🤚🏻" type="tts">podignut dlan: svetla koža</annotation>
-		<annotation cp="🤚🏼">dlan | podignut dlan | podignut dlan: srednje svetla koža | podignuto | srednje svetla koža</annotation>
+		<annotation cp="🤚🏼">dlan | podignut dlan | podignuto | srednje svetla koža</annotation>
 		<annotation cp="🤚🏼" type="tts">podignut dlan: srednje svetla koža</annotation>
-		<annotation cp="🤚🏽">dlan | ni svetla ni tamna koža | podignut dlan | podignut dlan: ni svetla ni tamna koža | podignuto</annotation>
+		<annotation cp="🤚🏽">dlan | ni svetla ni tamna koža | podignut dlan | podignuto</annotation>
 		<annotation cp="🤚🏽" type="tts">podignut dlan: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤚🏾">dlan | podignut dlan | podignut dlan: srednje tamna koža | podignuto | srednje tamna koža</annotation>
+		<annotation cp="🤚🏾">dlan | podignut dlan | podignuto | srednje tamna koža</annotation>
 		<annotation cp="🤚🏾" type="tts">podignut dlan: srednje tamna koža</annotation>
-		<annotation cp="🤚🏿">dlan | podignut dlan | podignut dlan: tamna koža | podignuto | tamna koža</annotation>
+		<annotation cp="🤚🏿">dlan | podignut dlan | podignuto | tamna koža</annotation>
 		<annotation cp="🤚🏿" type="tts">podignut dlan: tamna koža</annotation>
-		<annotation cp="🖐🏻">prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: svetla koža | svetla koža</annotation>
+		<annotation cp="🖐🏻">prst | rašireno | ruka | šaka sa raširenim prstima | svetla koža</annotation>
 		<annotation cp="🖐🏻" type="tts">šaka sa raširenim prstima: svetla koža</annotation>
-		<annotation cp="🖐🏼">prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🖐🏼">prst | rašireno | ruka | šaka sa raširenim prstima | srednje svetla koža</annotation>
 		<annotation cp="🖐🏼" type="tts">šaka sa raširenim prstima: srednje svetla koža</annotation>
-		<annotation cp="🖐🏽">ni svetla ni tamna koža | prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: ni svetla ni tamna koža</annotation>
+		<annotation cp="🖐🏽">ni svetla ni tamna koža | prst | rašireno | ruka | šaka sa raširenim prstima</annotation>
 		<annotation cp="🖐🏽" type="tts">šaka sa raširenim prstima: ni svetla ni tamna koža</annotation>
-		<annotation cp="🖐🏾">prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🖐🏾">prst | rašireno | ruka | šaka sa raširenim prstima | srednje tamna koža</annotation>
 		<annotation cp="🖐🏾" type="tts">šaka sa raširenim prstima: srednje tamna koža</annotation>
-		<annotation cp="🖐🏿">prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: tamna koža | tamna koža</annotation>
+		<annotation cp="🖐🏿">prst | rašireno | ruka | šaka sa raširenim prstima | tamna koža</annotation>
 		<annotation cp="🖐🏿" type="tts">šaka sa raširenim prstima: tamna koža</annotation>
-		<annotation cp="✋🏻">podignuta ruka | podignuta ruka: svetla koža | ruka | svetla koža</annotation>
+		<annotation cp="✋🏻">podignuta ruka | ruka | svetla koža</annotation>
 		<annotation cp="✋🏻" type="tts">podignuta ruka: svetla koža</annotation>
-		<annotation cp="✋🏼">podignuta ruka | podignuta ruka: srednje svetla koža | ruka | srednje svetla koža</annotation>
+		<annotation cp="✋🏼">podignuta ruka | ruka | srednje svetla koža</annotation>
 		<annotation cp="✋🏼" type="tts">podignuta ruka: srednje svetla koža</annotation>
-		<annotation cp="✋🏽">ni svetla ni tamna koža | podignuta ruka | podignuta ruka: ni svetla ni tamna koža | ruka</annotation>
+		<annotation cp="✋🏽">ni svetla ni tamna koža | podignuta ruka | ruka</annotation>
 		<annotation cp="✋🏽" type="tts">podignuta ruka: ni svetla ni tamna koža</annotation>
-		<annotation cp="✋🏾">podignuta ruka | podignuta ruka: srednje tamna koža | ruka | srednje tamna koža</annotation>
+		<annotation cp="✋🏾">podignuta ruka | ruka | srednje tamna koža</annotation>
 		<annotation cp="✋🏾" type="tts">podignuta ruka: srednje tamna koža</annotation>
-		<annotation cp="✋🏿">podignuta ruka | podignuta ruka: tamna koža | ruka | tamna koža</annotation>
+		<annotation cp="✋🏿">podignuta ruka | ruka | tamna koža</annotation>
 		<annotation cp="✋🏿" type="tts">podignuta ruka: tamna koža</annotation>
-		<annotation cp="🖖🏻">prst | ruka | spok | svetla koža | vulkan | vulkanski pozdrav | vulkanski pozdrav: svetla koža</annotation>
+		<annotation cp="🖖🏻">prst | ruka | spok | svetla koža | vulkan | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏻" type="tts">vulkanski pozdrav: svetla koža</annotation>
-		<annotation cp="🖖🏼">prst | ruka | spok | srednje svetla koža | vulkan | vulkanski pozdrav | vulkanski pozdrav: srednje svetla koža</annotation>
+		<annotation cp="🖖🏼">prst | ruka | spok | srednje svetla koža | vulkan | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏼" type="tts">vulkanski pozdrav: srednje svetla koža</annotation>
-		<annotation cp="🖖🏽">ni svetla ni tamna koža | prst | ruka | spok | vulkan | vulkanski pozdrav | vulkanski pozdrav: ni svetla ni tamna koža</annotation>
+		<annotation cp="🖖🏽">ni svetla ni tamna koža | prst | ruka | spok | vulkan | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏽" type="tts">vulkanski pozdrav: ni svetla ni tamna koža</annotation>
-		<annotation cp="🖖🏾">prst | ruka | spok | srednje tamna koža | vulkan | vulkanski pozdrav | vulkanski pozdrav: srednje tamna koža</annotation>
+		<annotation cp="🖖🏾">prst | ruka | spok | srednje tamna koža | vulkan | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏾" type="tts">vulkanski pozdrav: srednje tamna koža</annotation>
-		<annotation cp="🖖🏿">prst | ruka | spok | tamna koža | vulkan | vulkanski pozdrav | vulkanski pozdrav: tamna koža</annotation>
+		<annotation cp="🖖🏿">prst | ruka | spok | tamna koža | vulkan | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏿" type="tts">vulkanski pozdrav: tamna koža</annotation>
-		<annotation cp="🫱🏻">desno | nadesno | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: svetla koža | svetla koža</annotation>
+		<annotation cp="🫱🏻">desno | nadesno | ruka | ruka okrenuta nadesno | svetla koža</annotation>
 		<annotation cp="🫱🏻" type="tts">ruka okrenuta nadesno: svetla koža</annotation>
-		<annotation cp="🫱🏼">desno | nadesno | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🫱🏼">desno | nadesno | ruka | ruka okrenuta nadesno | srednje svetla koža</annotation>
 		<annotation cp="🫱🏼" type="tts">ruka okrenuta nadesno: srednje svetla koža</annotation>
-		<annotation cp="🫱🏽">desno | nadesno | ni svetla ni tamna koža | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: ni svetla ni tamna koža</annotation>
+		<annotation cp="🫱🏽">desno | nadesno | ni svetla ni tamna koža | ruka | ruka okrenuta nadesno</annotation>
 		<annotation cp="🫱🏽" type="tts">ruka okrenuta nadesno: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫱🏾">desno | nadesno | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏾">desno | nadesno | ruka | ruka okrenuta nadesno | srednje tamna koža</annotation>
 		<annotation cp="🫱🏾" type="tts">ruka okrenuta nadesno: srednje tamna koža</annotation>
-		<annotation cp="🫱🏿">desno | nadesno | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: tamna koža | tamna koža</annotation>
+		<annotation cp="🫱🏿">desno | nadesno | ruka | ruka okrenuta nadesno | tamna koža</annotation>
 		<annotation cp="🫱🏿" type="tts">ruka okrenuta nadesno: tamna koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏼">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: svetla koža i srednje svetla koža | sastanak | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏼">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏼" type="tts">rukovanje: svetla koža i srednje svetla koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: svetla koža i ni svetla ni tamna koža | sastanak | svetla koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | svetla koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏽" type="tts">rukovanje: svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏾">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: svetla koža i srednje tamna koža | sastanak | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏾">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏾" type="tts">rukovanje: svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏿">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: svetla koža i tamna koža | sastanak | svetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏿">dogovor | dogovoreno | rešeno | rukovanje | sastanak | svetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏿" type="tts">rukovanje: svetla koža i tamna koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏻">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje svetla koža i svetla koža | sastanak | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏻">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏻" type="tts">rukovanje: srednje svetla koža i svetla koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: srednje svetla koža i ni svetla ni tamna koža | sastanak | srednje svetla koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | srednje svetla koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏽" type="tts">rukovanje: srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏾">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje svetla koža i srednje tamna koža | sastanak | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏾">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏾" type="tts">rukovanje: srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏿">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje svetla koža i tamna koža | sastanak | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏿">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏿" type="tts">rukovanje: srednje svetla koža i tamna koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏻">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: ni svetla ni tamna koža i svetla koža | sastanak | svetla koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏻">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | svetla koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏻" type="tts">rukovanje: ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏼">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: ni svetla ni tamna koža i srednje svetla koža | sastanak | srednje svetla koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏼">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | srednje svetla koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏼" type="tts">rukovanje: ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏾">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: ni svetla ni tamna koža i srednje tamna koža | sastanak | srednje tamna koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏾">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | srednje tamna koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏾" type="tts">rukovanje: ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏿">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: ni svetla ni tamna koža i tamna koža | sastanak | tamna koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏿">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | tamna koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏿" type="tts">rukovanje: ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏻">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje tamna koža i svetla koža | sastanak | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏻">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏻" type="tts">rukovanje: srednje tamna koža i svetla koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏼">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje tamna koža i srednje svetla koža | sastanak | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏼">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏼" type="tts">rukovanje: srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: srednje tamna koža i ni svetla ni tamna koža | sastanak | srednje tamna koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | srednje tamna koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏽" type="tts">rukovanje: srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏿">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje tamna koža i tamna koža | sastanak | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏿">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏿" type="tts">rukovanje: srednje tamna koža i tamna koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏻">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: tamna koža i svetla koža | sastanak | svetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏻">dogovor | dogovoreno | rešeno | rukovanje | sastanak | svetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏻" type="tts">rukovanje: tamna koža i svetla koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏼">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: tamna koža i srednje svetla koža | sastanak | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏼">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏼" type="tts">rukovanje: tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: tamna koža i ni svetla ni tamna koža | sastanak | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏽" type="tts">rukovanje: tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏾">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: tamna koža i srednje tamna koža | sastanak | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏾">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏾" type="tts">rukovanje: tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🫲🏻">levo | nalevo | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: svetla koža | svetla koža</annotation>
+		<annotation cp="🫲🏻">levo | nalevo | ruka | ruka okrenuta nalevo | svetla koža</annotation>
 		<annotation cp="🫲🏻" type="tts">ruka okrenuta nalevo: svetla koža</annotation>
-		<annotation cp="🫲🏼">levo | nalevo | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🫲🏼">levo | nalevo | ruka | ruka okrenuta nalevo | srednje svetla koža</annotation>
 		<annotation cp="🫲🏼" type="tts">ruka okrenuta nalevo: srednje svetla koža</annotation>
-		<annotation cp="🫲🏽">levo | nalevo | ni svetla ni tamna koža | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: ni svetla ni tamna koža</annotation>
+		<annotation cp="🫲🏽">levo | nalevo | ni svetla ni tamna koža | ruka | ruka okrenuta nalevo</annotation>
 		<annotation cp="🫲🏽" type="tts">ruka okrenuta nalevo: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫲🏾">levo | nalevo | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🫲🏾">levo | nalevo | ruka | ruka okrenuta nalevo | srednje tamna koža</annotation>
 		<annotation cp="🫲🏾" type="tts">ruka okrenuta nalevo: srednje tamna koža</annotation>
-		<annotation cp="🫲🏿">levo | nalevo | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: tamna koža | tamna koža</annotation>
+		<annotation cp="🫲🏿">levo | nalevo | ruka | ruka okrenuta nalevo | tamna koža</annotation>
 		<annotation cp="🫲🏿" type="tts">ruka okrenuta nalevo: tamna koža</annotation>
-		<annotation cp="🫳🏻">dlan okrenut nadole | dlan okrenut nadole: svetla koža | ispustiti | otpustiti | poterati | svetla koža</annotation>
+		<annotation cp="🫳🏻">dlan okrenut nadole | ispustiti | otpustiti | poterati | svetla koža</annotation>
 		<annotation cp="🫳🏻" type="tts">dlan okrenut nadole: svetla koža</annotation>
-		<annotation cp="🫳🏼">dlan okrenut nadole | dlan okrenut nadole: srednje svetla koža | ispustiti | otpustiti | poterati | srednje svetla koža</annotation>
+		<annotation cp="🫳🏼">dlan okrenut nadole | ispustiti | otpustiti | poterati | srednje svetla koža</annotation>
 		<annotation cp="🫳🏼" type="tts">dlan okrenut nadole: srednje svetla koža</annotation>
-		<annotation cp="🫳🏽">dlan okrenut nadole | dlan okrenut nadole: ni svetla ni tamna koža | ispustiti | ni svetla ni tamna koža | otpustiti | poterati</annotation>
+		<annotation cp="🫳🏽">dlan okrenut nadole | ispustiti | ni svetla ni tamna koža | otpustiti | poterati</annotation>
 		<annotation cp="🫳🏽" type="tts">dlan okrenut nadole: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫳🏾">dlan okrenut nadole | dlan okrenut nadole: srednje tamna koža | ispustiti | otpustiti | poterati | srednje tamna koža</annotation>
+		<annotation cp="🫳🏾">dlan okrenut nadole | ispustiti | otpustiti | poterati | srednje tamna koža</annotation>
 		<annotation cp="🫳🏾" type="tts">dlan okrenut nadole: srednje tamna koža</annotation>
-		<annotation cp="🫳🏿">dlan okrenut nadole | dlan okrenut nadole: tamna koža | ispustiti | otpustiti | poterati | tamna koža</annotation>
+		<annotation cp="🫳🏿">dlan okrenut nadole | ispustiti | otpustiti | poterati | tamna koža</annotation>
 		<annotation cp="🫳🏿" type="tts">dlan okrenut nadole: tamna koža</annotation>
-		<annotation cp="🫴🏻">dlan okrenut nagore | dlan okrenut nagore: svetla koža | dozivati | ponuda | poziv | svetla koža | uhvatiti</annotation>
+		<annotation cp="🫴🏻">dlan okrenut nagore | dozivati | ponuda | poziv | svetla koža | uhvatiti</annotation>
 		<annotation cp="🫴🏻" type="tts">dlan okrenut nagore: svetla koža</annotation>
-		<annotation cp="🫴🏼">dlan okrenut nagore | dlan okrenut nagore: srednje svetla koža | dozivati | ponuda | poziv | srednje svetla koža | uhvatiti</annotation>
+		<annotation cp="🫴🏼">dlan okrenut nagore | dozivati | ponuda | poziv | srednje svetla koža | uhvatiti</annotation>
 		<annotation cp="🫴🏼" type="tts">dlan okrenut nagore: srednje svetla koža</annotation>
-		<annotation cp="🫴🏽">dlan okrenut nagore | dlan okrenut nagore: ni svetla ni tamna koža | dozivati | ni svetla ni tamna koža | ponuda | poziv | uhvatiti</annotation>
+		<annotation cp="🫴🏽">dlan okrenut nagore | dozivati | ni svetla ni tamna koža | ponuda | poziv | uhvatiti</annotation>
 		<annotation cp="🫴🏽" type="tts">dlan okrenut nagore: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫴🏾">dlan okrenut nagore | dlan okrenut nagore: srednje tamna koža | dozivati | ponuda | poziv | srednje tamna koža | uhvatiti</annotation>
+		<annotation cp="🫴🏾">dlan okrenut nagore | dozivati | ponuda | poziv | srednje tamna koža | uhvatiti</annotation>
 		<annotation cp="🫴🏾" type="tts">dlan okrenut nagore: srednje tamna koža</annotation>
-		<annotation cp="🫴🏿">dlan okrenut nagore | dlan okrenut nagore: tamna koža | dozivati | ponuda | poziv | tamna koža | uhvatiti</annotation>
+		<annotation cp="🫴🏿">dlan okrenut nagore | dozivati | ponuda | poziv | tamna koža | uhvatiti</annotation>
 		<annotation cp="🫴🏿" type="tts">dlan okrenut nagore: tamna koža</annotation>
-		<annotation cp="🫷🏻">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | ruka gura ulevo: svetla koža | stop | svetla koža</annotation>
+		<annotation cp="🫷🏻">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | stop | svetla koža</annotation>
 		<annotation cp="🫷🏻" type="tts">ruka gura ulevo: svetla koža</annotation>
-		<annotation cp="🫷🏼">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | ruka gura ulevo: srednje svetla koža | srednje svetla koža | stop</annotation>
+		<annotation cp="🫷🏼">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | srednje svetla koža | stop</annotation>
 		<annotation cp="🫷🏼" type="tts">ruka gura ulevo: srednje svetla koža</annotation>
-		<annotation cp="🫷🏽">baci pet | čekaj | nalevo | ni svetla ni tamna koža | odbij | odgurni | ruka gura ulevo | ruka gura ulevo: ni svetla ni tamna koža | stop</annotation>
+		<annotation cp="🫷🏽">baci pet | čekaj | nalevo | ni svetla ni tamna koža | odbij | odgurni | ruka gura ulevo | stop</annotation>
 		<annotation cp="🫷🏽" type="tts">ruka gura ulevo: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫷🏾">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | ruka gura ulevo: srednje tamna koža | srednje tamna koža | stop</annotation>
+		<annotation cp="🫷🏾">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | srednje tamna koža | stop</annotation>
 		<annotation cp="🫷🏾" type="tts">ruka gura ulevo: srednje tamna koža</annotation>
-		<annotation cp="🫷🏿">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | ruka gura ulevo: tamna koža | stop | tamna koža</annotation>
+		<annotation cp="🫷🏿">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulevo | stop | tamna koža</annotation>
 		<annotation cp="🫷🏿" type="tts">ruka gura ulevo: tamna koža</annotation>
-		<annotation cp="🫸🏻">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | ruka gura udesno: svetla koža | stop | svetla koža</annotation>
+		<annotation cp="🫸🏻">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | stop | svetla koža</annotation>
 		<annotation cp="🫸🏻" type="tts">ruka gura udesno: svetla koža</annotation>
-		<annotation cp="🫸🏼">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | ruka gura udesno: srednje svetla koža | srednje svetla koža | stop</annotation>
+		<annotation cp="🫸🏼">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | srednje svetla koža | stop</annotation>
 		<annotation cp="🫸🏼" type="tts">ruka gura udesno: srednje svetla koža</annotation>
-		<annotation cp="🫸🏽">baci pet | čekaj | nadesno | ni svetla ni tamna koža | odbij | odgurni | ruka gura udesno | ruka gura udesno: ni svetla ni tamna koža | stop</annotation>
+		<annotation cp="🫸🏽">baci pet | čekaj | nadesno | ni svetla ni tamna koža | odbij | odgurni | ruka gura udesno | stop</annotation>
 		<annotation cp="🫸🏽" type="tts">ruka gura udesno: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫸🏾">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | ruka gura udesno: srednje tamna koža | srednje tamna koža | stop</annotation>
+		<annotation cp="🫸🏾">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | srednje tamna koža | stop</annotation>
 		<annotation cp="🫸🏾" type="tts">ruka gura udesno: srednje tamna koža</annotation>
-		<annotation cp="🫸🏿">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | ruka gura udesno: tamna koža | stop | tamna koža</annotation>
+		<annotation cp="🫸🏿">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | stop | tamna koža</annotation>
 		<annotation cp="🫸🏿" type="tts">ruka gura udesno: tamna koža</annotation>
-		<annotation cp="👌🏻">ruka | svetla koža | u redu | znak rukom „u redu“ | znak rukom „u redu“: svetla koža</annotation>
+		<annotation cp="👌🏻">ruka | svetla koža | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏻" type="tts">znak rukom „u redu“: svetla koža</annotation>
-		<annotation cp="👌🏼">ruka | srednje svetla koža | u redu | znak rukom „u redu“ | znak rukom „u redu“: srednje svetla koža</annotation>
+		<annotation cp="👌🏼">ruka | srednje svetla koža | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏼" type="tts">znak rukom „u redu“: srednje svetla koža</annotation>
-		<annotation cp="👌🏽">ni svetla ni tamna koža | ruka | u redu | znak rukom „u redu“ | znak rukom „u redu“: ni svetla ni tamna koža</annotation>
+		<annotation cp="👌🏽">ni svetla ni tamna koža | ruka | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏽" type="tts">znak rukom „u redu“: ni svetla ni tamna koža</annotation>
-		<annotation cp="👌🏾">ruka | srednje tamna koža | u redu | znak rukom „u redu“ | znak rukom „u redu“: srednje tamna koža</annotation>
+		<annotation cp="👌🏾">ruka | srednje tamna koža | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏾" type="tts">znak rukom „u redu“: srednje tamna koža</annotation>
-		<annotation cp="👌🏿">ruka | tamna koža | u redu | znak rukom „u redu“ | znak rukom „u redu“: tamna koža</annotation>
+		<annotation cp="👌🏿">ruka | tamna koža | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏿" type="tts">znak rukom „u redu“: tamna koža</annotation>
-		<annotation cp="🤌🏻">prsti | sarkastično | skupljeni prsti | skupljeni prsti: svetla koža | svetla koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏻">prsti | sarkastično | skupljeni prsti | svetla koža | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏻" type="tts">skupljeni prsti: svetla koža</annotation>
-		<annotation cp="🤌🏼">prsti | sarkastično | skupljeni prsti | skupljeni prsti: srednje svetla koža | srednje svetla koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏼">prsti | sarkastično | skupljeni prsti | srednje svetla koža | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏼" type="tts">skupljeni prsti: srednje svetla koža</annotation>
-		<annotation cp="🤌🏽">ni svetla ni tamna koža | prsti | sarkastično | skupljeni prsti | skupljeni prsti: ni svetla ni tamna koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏽">ni svetla ni tamna koža | prsti | sarkastično | skupljeni prsti | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏽" type="tts">skupljeni prsti: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤌🏾">prsti | sarkastično | skupljeni prsti | skupljeni prsti: srednje tamna koža | srednje tamna koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏾">prsti | sarkastično | skupljeni prsti | srednje tamna koža | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏾" type="tts">skupljeni prsti: srednje tamna koža</annotation>
-		<annotation cp="🤌🏿">prsti | sarkastično | skupljeni prsti | skupljeni prsti: tamna koža | tamna koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏿">prsti | sarkastično | skupljeni prsti | tamna koža | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏿" type="tts">skupljeni prsti: tamna koža</annotation>
-		<annotation cp="🤏🏻">malo | ruka štipa | ruka štipa: svetla koža | svetla koža</annotation>
+		<annotation cp="🤏🏻">malo | ruka štipa | svetla koža</annotation>
 		<annotation cp="🤏🏻" type="tts">ruka štipa: svetla koža</annotation>
-		<annotation cp="🤏🏼">malo | ruka štipa | ruka štipa: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🤏🏼">malo | ruka štipa | srednje svetla koža</annotation>
 		<annotation cp="🤏🏼" type="tts">ruka štipa: srednje svetla koža</annotation>
-		<annotation cp="🤏🏽">malo | ni svetla ni tamna koža | ruka štipa | ruka štipa: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤏🏽">malo | ni svetla ni tamna koža | ruka štipa</annotation>
 		<annotation cp="🤏🏽" type="tts">ruka štipa: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤏🏾">malo | ruka štipa | ruka štipa: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤏🏾">malo | ruka štipa | srednje tamna koža</annotation>
 		<annotation cp="🤏🏾" type="tts">ruka štipa: srednje tamna koža</annotation>
-		<annotation cp="🤏🏿">malo | ruka štipa | ruka štipa: tamna koža | tamna koža</annotation>
+		<annotation cp="🤏🏿">malo | ruka štipa | tamna koža</annotation>
 		<annotation cp="🤏🏿" type="tts">ruka štipa: tamna koža</annotation>
-		<annotation cp="✌🏻">pobeda | ruka | svetla koža | v | znak pobede | znak pobede: svetla koža</annotation>
+		<annotation cp="✌🏻">pobeda | ruka | svetla koža | v | znak pobede</annotation>
 		<annotation cp="✌🏻" type="tts">znak pobede: svetla koža</annotation>
-		<annotation cp="✌🏼">pobeda | ruka | srednje svetla koža | v | znak pobede | znak pobede: srednje svetla koža</annotation>
+		<annotation cp="✌🏼">pobeda | ruka | srednje svetla koža | v | znak pobede</annotation>
 		<annotation cp="✌🏼" type="tts">znak pobede: srednje svetla koža</annotation>
-		<annotation cp="✌🏽">ni svetla ni tamna koža | pobeda | ruka | v | znak pobede | znak pobede: ni svetla ni tamna koža</annotation>
+		<annotation cp="✌🏽">ni svetla ni tamna koža | pobeda | ruka | v | znak pobede</annotation>
 		<annotation cp="✌🏽" type="tts">znak pobede: ni svetla ni tamna koža</annotation>
-		<annotation cp="✌🏾">pobeda | ruka | srednje tamna koža | v | znak pobede | znak pobede: srednje tamna koža</annotation>
+		<annotation cp="✌🏾">pobeda | ruka | srednje tamna koža | v | znak pobede</annotation>
 		<annotation cp="✌🏾" type="tts">znak pobede: srednje tamna koža</annotation>
-		<annotation cp="✌🏿">pobeda | ruka | tamna koža | v | znak pobede | znak pobede: tamna koža</annotation>
+		<annotation cp="✌🏿">pobeda | ruka | tamna koža | v | znak pobede</annotation>
 		<annotation cp="✌🏿" type="tts">znak pobede: tamna koža</annotation>
-		<annotation cp="🤞🏻">katanac | obećanje | prekršteni prsti | prekršteni prsti: svetla koža | prsti | sreća | svetla koža | želja</annotation>
+		<annotation cp="🤞🏻">katanac | obećanje | prekršteni prsti | prsti | sreća | svetla koža | želja</annotation>
 		<annotation cp="🤞🏻" type="tts">prekršteni prsti: svetla koža</annotation>
-		<annotation cp="🤞🏼">katanac | obećanje | prekršteni prsti | prekršteni prsti: srednje svetla koža | prsti | sreća | srednje svetla koža | želja</annotation>
+		<annotation cp="🤞🏼">katanac | obećanje | prekršteni prsti | prsti | sreća | srednje svetla koža | želja</annotation>
 		<annotation cp="🤞🏼" type="tts">prekršteni prsti: srednje svetla koža</annotation>
-		<annotation cp="🤞🏽">katanac | ni svetla ni tamna koža | obećanje | prekršteni prsti | prekršteni prsti: ni svetla ni tamna koža | prsti | sreća | želja</annotation>
+		<annotation cp="🤞🏽">katanac | ni svetla ni tamna koža | obećanje | prekršteni prsti | prsti | sreća | želja</annotation>
 		<annotation cp="🤞🏽" type="tts">prekršteni prsti: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤞🏾">katanac | obećanje | prekršteni prsti | prekršteni prsti: srednje tamna koža | prsti | sreća | srednje tamna koža | želja</annotation>
+		<annotation cp="🤞🏾">katanac | obećanje | prekršteni prsti | prsti | sreća | srednje tamna koža | želja</annotation>
 		<annotation cp="🤞🏾" type="tts">prekršteni prsti: srednje tamna koža</annotation>
-		<annotation cp="🤞🏿">katanac | obećanje | prekršteni prsti | prekršteni prsti: tamna koža | prsti | sreća | tamna koža | želja</annotation>
+		<annotation cp="🤞🏿">katanac | obećanje | prekršteni prsti | prsti | sreća | tamna koža | želja</annotation>
 		<annotation cp="🤞🏿" type="tts">prekršteni prsti: tamna koža</annotation>
-		<annotation cp="🫰🏻">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: svetla koža | skupo | srce | svetla koža</annotation>
+		<annotation cp="🫰🏻">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce | svetla koža</annotation>
 		<annotation cp="🫰🏻" type="tts">ruka sa prekrštenim palcem i kažiprstom: svetla koža</annotation>
-		<annotation cp="🫰🏼">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: srednje svetla koža | skupo | srce | srednje svetla koža</annotation>
+		<annotation cp="🫰🏼">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce | srednje svetla koža</annotation>
 		<annotation cp="🫰🏼" type="tts">ruka sa prekrštenim palcem i kažiprstom: srednje svetla koža</annotation>
-		<annotation cp="🫰🏽">ljubav | ni svetla ni tamna koža | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: ni svetla ni tamna koža | skupo | srce</annotation>
+		<annotation cp="🫰🏽">ljubav | ni svetla ni tamna koža | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce</annotation>
 		<annotation cp="🫰🏽" type="tts">ruka sa prekrštenim palcem i kažiprstom: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫰🏾">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: srednje tamna koža | skupo | srce | srednje tamna koža</annotation>
+		<annotation cp="🫰🏾">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce | srednje tamna koža</annotation>
 		<annotation cp="🫰🏾" type="tts">ruka sa prekrštenim palcem i kažiprstom: srednje tamna koža</annotation>
-		<annotation cp="🫰🏿">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: tamna koža | skupo | srce | tamna koža</annotation>
+		<annotation cp="🫰🏿">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce | tamna koža</annotation>
 		<annotation cp="🫰🏿" type="tts">ruka sa prekrštenim palcem i kažiprstom: tamna koža</annotation>
-		<annotation cp="🤟🏻">pokret volim te | pokret volim te: svetla koža | ruka | svetla koža | volim te</annotation>
+		<annotation cp="🤟🏻">pokret volim te | ruka | svetla koža | volim te</annotation>
 		<annotation cp="🤟🏻" type="tts">pokret volim te: svetla koža</annotation>
-		<annotation cp="🤟🏼">pokret volim te | pokret volim te: srednje svetla koža | ruka | srednje svetla koža | volim te</annotation>
+		<annotation cp="🤟🏼">pokret volim te | ruka | srednje svetla koža | volim te</annotation>
 		<annotation cp="🤟🏼" type="tts">pokret volim te: srednje svetla koža</annotation>
-		<annotation cp="🤟🏽">ni svetla ni tamna koža | pokret volim te | pokret volim te: ni svetla ni tamna koža | ruka | volim te</annotation>
+		<annotation cp="🤟🏽">ni svetla ni tamna koža | pokret volim te | ruka | volim te</annotation>
 		<annotation cp="🤟🏽" type="tts">pokret volim te: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤟🏾">pokret volim te | pokret volim te: srednje tamna koža | ruka | srednje tamna koža | volim te</annotation>
+		<annotation cp="🤟🏾">pokret volim te | ruka | srednje tamna koža | volim te</annotation>
 		<annotation cp="🤟🏾" type="tts">pokret volim te: srednje tamna koža</annotation>
-		<annotation cp="🤟🏿">pokret volim te | pokret volim te: tamna koža | ruka | tamna koža | volim te</annotation>
+		<annotation cp="🤟🏿">pokret volim te | ruka | tamna koža | volim te</annotation>
 		<annotation cp="🤟🏿" type="tts">pokret volim te: tamna koža</annotation>
-		<annotation cp="🤘🏻">metal | prst | rogovi | ruka | šaka | svetla koža | telo | znak rogova | znak rogova: svetla koža</annotation>
+		<annotation cp="🤘🏻">metal | prst | rogovi | ruka | šaka | svetla koža | telo | znak rogova</annotation>
 		<annotation cp="🤘🏻" type="tts">znak rogova: svetla koža</annotation>
-		<annotation cp="🤘🏼">metal | prst | rogovi | ruka | šaka | srednje svetla koža | telo | znak rogova | znak rogova: srednje svetla koža</annotation>
+		<annotation cp="🤘🏼">metal | prst | rogovi | ruka | šaka | srednje svetla koža | telo | znak rogova</annotation>
 		<annotation cp="🤘🏼" type="tts">znak rogova: srednje svetla koža</annotation>
-		<annotation cp="🤘🏽">metal | ni svetla ni tamna koža | prst | rogovi | ruka | šaka | telo | znak rogova | znak rogova: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤘🏽">metal | ni svetla ni tamna koža | prst | rogovi | ruka | šaka | telo | znak rogova</annotation>
 		<annotation cp="🤘🏽" type="tts">znak rogova: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤘🏾">metal | prst | rogovi | ruka | šaka | srednje tamna koža | telo | znak rogova | znak rogova: srednje tamna koža</annotation>
+		<annotation cp="🤘🏾">metal | prst | rogovi | ruka | šaka | srednje tamna koža | telo | znak rogova</annotation>
 		<annotation cp="🤘🏾" type="tts">znak rogova: srednje tamna koža</annotation>
-		<annotation cp="🤘🏿">metal | prst | rogovi | ruka | šaka | tamna koža | telo | znak rogova | znak rogova: tamna koža</annotation>
+		<annotation cp="🤘🏿">metal | prst | rogovi | ruka | šaka | tamna koža | telo | znak rogova</annotation>
 		<annotation cp="🤘🏿" type="tts">znak rogova: tamna koža</annotation>
-		<annotation cp="🤙🏻">ruka | svetla koža | znak rukom za telefon | znak rukom za telefon: svetla koža | zovi</annotation>
+		<annotation cp="🤙🏻">ruka | svetla koža | znak rukom za telefon | zovi</annotation>
 		<annotation cp="🤙🏻" type="tts">znak rukom za telefon: svetla koža</annotation>
-		<annotation cp="🤙🏼">ruka | srednje svetla koža | znak rukom za telefon | znak rukom za telefon: srednje svetla koža | zovi</annotation>
+		<annotation cp="🤙🏼">ruka | srednje svetla koža | znak rukom za telefon | zovi</annotation>
 		<annotation cp="🤙🏼" type="tts">znak rukom za telefon: srednje svetla koža</annotation>
-		<annotation cp="🤙🏽">ni svetla ni tamna koža | ruka | znak rukom za telefon | znak rukom za telefon: ni svetla ni tamna koža | zovi</annotation>
+		<annotation cp="🤙🏽">ni svetla ni tamna koža | ruka | znak rukom za telefon | zovi</annotation>
 		<annotation cp="🤙🏽" type="tts">znak rukom za telefon: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤙🏾">ruka | srednje tamna koža | znak rukom za telefon | znak rukom za telefon: srednje tamna koža | zovi</annotation>
+		<annotation cp="🤙🏾">ruka | srednje tamna koža | znak rukom za telefon | zovi</annotation>
 		<annotation cp="🤙🏾" type="tts">znak rukom za telefon: srednje tamna koža</annotation>
-		<annotation cp="🤙🏿">ruka | tamna koža | znak rukom za telefon | znak rukom za telefon: tamna koža | zovi</annotation>
+		<annotation cp="🤙🏿">ruka | tamna koža | znak rukom za telefon | zovi</annotation>
 		<annotation cp="🤙🏿" type="tts">znak rukom za telefon: tamna koža</annotation>
-		<annotation cp="👈🏻">kažiprst | kažiprst koji pokazuje ulevo | kažiprst koji pokazuje ulevo: svetla koža | pokazivanje | prst | ruka | svetla koža | ulevo</annotation>
+		<annotation cp="👈🏻">kažiprst | kažiprst koji pokazuje ulevo | pokazivanje | prst | ruka | svetla koža | ulevo</annotation>
 		<annotation cp="👈🏻" type="tts">kažiprst koji pokazuje ulevo: svetla koža</annotation>
-		<annotation cp="👈🏼">kažiprst | kažiprst koji pokazuje ulevo | kažiprst koji pokazuje ulevo: srednje svetla koža | pokazivanje | prst | ruka | srednje svetla koža | ulevo</annotation>
+		<annotation cp="👈🏼">kažiprst | kažiprst koji pokazuje ulevo | pokazivanje | prst | ruka | srednje svetla koža | ulevo</annotation>
 		<annotation cp="👈🏼" type="tts">kažiprst koji pokazuje ulevo: srednje svetla koža</annotation>
-		<annotation cp="👈🏽">kažiprst | kažiprst koji pokazuje ulevo | kažiprst koji pokazuje ulevo: ni svetla ni tamna koža | ni svetla ni tamna koža | pokazivanje | prst | ruka | ulevo</annotation>
+		<annotation cp="👈🏽">kažiprst | kažiprst koji pokazuje ulevo | ni svetla ni tamna koža | pokazivanje | prst | ruka | ulevo</annotation>
 		<annotation cp="👈🏽" type="tts">kažiprst koji pokazuje ulevo: ni svetla ni tamna koža</annotation>
-		<annotation cp="👈🏾">kažiprst | kažiprst koji pokazuje ulevo | kažiprst koji pokazuje ulevo: srednje tamna koža | pokazivanje | prst | ruka | srednje tamna koža | ulevo</annotation>
+		<annotation cp="👈🏾">kažiprst | kažiprst koji pokazuje ulevo | pokazivanje | prst | ruka | srednje tamna koža | ulevo</annotation>
 		<annotation cp="👈🏾" type="tts">kažiprst koji pokazuje ulevo: srednje tamna koža</annotation>
-		<annotation cp="👈🏿">kažiprst | kažiprst koji pokazuje ulevo | kažiprst koji pokazuje ulevo: tamna koža | pokazivanje | prst | ruka | tamna koža | ulevo</annotation>
+		<annotation cp="👈🏿">kažiprst | kažiprst koji pokazuje ulevo | pokazivanje | prst | ruka | tamna koža | ulevo</annotation>
 		<annotation cp="👈🏿" type="tts">kažiprst koji pokazuje ulevo: tamna koža</annotation>
-		<annotation cp="👉🏻">kažiprst | kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: svetla koža | pokazivanje | prst | ruka | svetla koža | udesno</annotation>
+		<annotation cp="👉🏻">kažiprst | kažiprst koji pokazuje udesno | pokazivanje | prst | ruka | svetla koža | udesno</annotation>
 		<annotation cp="👉🏻" type="tts">kažiprst koji pokazuje udesno: svetla koža</annotation>
-		<annotation cp="👉🏼">kažiprst | kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: srednje svetla koža | pokazivanje | prst | ruka | srednje svetla koža | udesno</annotation>
+		<annotation cp="👉🏼">kažiprst | kažiprst koji pokazuje udesno | pokazivanje | prst | ruka | srednje svetla koža | udesno</annotation>
 		<annotation cp="👉🏼" type="tts">kažiprst koji pokazuje udesno: srednje svetla koža</annotation>
-		<annotation cp="👉🏽">kažiprst | kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: ni svetla ni tamna koža | ni svetla ni tamna koža | pokazivanje | prst | ruka | udesno</annotation>
+		<annotation cp="👉🏽">kažiprst | kažiprst koji pokazuje udesno | ni svetla ni tamna koža | pokazivanje | prst | ruka | udesno</annotation>
 		<annotation cp="👉🏽" type="tts">kažiprst koji pokazuje udesno: ni svetla ni tamna koža</annotation>
-		<annotation cp="👉🏾">kažiprst | kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: srednje tamna koža | pokazivanje | prst | ruka | srednje tamna koža | udesno</annotation>
+		<annotation cp="👉🏾">kažiprst | kažiprst koji pokazuje udesno | pokazivanje | prst | ruka | srednje tamna koža | udesno</annotation>
 		<annotation cp="👉🏾" type="tts">kažiprst koji pokazuje udesno: srednje tamna koža</annotation>
-		<annotation cp="👉🏿">kažiprst | kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: tamna koža | pokazivanje | prst | ruka | tamna koža | udesno</annotation>
+		<annotation cp="👉🏿">kažiprst | kažiprst koji pokazuje udesno | pokazivanje | prst | ruka | tamna koža | udesno</annotation>
 		<annotation cp="👉🏿" type="tts">kažiprst koji pokazuje udesno: tamna koža</annotation>
-		<annotation cp="👆🏻">kažiprst | kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: svetla koža | nagore | pokazivanje | prednja strana | prst | ruka | šaka | svetla koža | telo</annotation>
+		<annotation cp="👆🏻">kažiprst | kažiprst koji pokazuje nagore otpozadi | nagore | pokazivanje | prednja strana | prst | ruka | šaka | svetla koža | telo</annotation>
 		<annotation cp="👆🏻" type="tts">kažiprst koji pokazuje nagore otpozadi: svetla koža</annotation>
-		<annotation cp="👆🏼">kažiprst | kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: srednje svetla koža | nagore | pokazivanje | prednja strana | prst | ruka | šaka | srednje svetla koža | telo</annotation>
+		<annotation cp="👆🏼">kažiprst | kažiprst koji pokazuje nagore otpozadi | nagore | pokazivanje | prednja strana | prst | ruka | šaka | srednje svetla koža | telo</annotation>
 		<annotation cp="👆🏼" type="tts">kažiprst koji pokazuje nagore otpozadi: srednje svetla koža</annotation>
-		<annotation cp="👆🏽">kažiprst | kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: ni svetla ni tamna koža | nagore | ni svetla ni tamna koža | pokazivanje | prednja strana | prst | ruka | šaka | telo</annotation>
+		<annotation cp="👆🏽">kažiprst | kažiprst koji pokazuje nagore otpozadi | nagore | ni svetla ni tamna koža | pokazivanje | prednja strana | prst | ruka | šaka | telo</annotation>
 		<annotation cp="👆🏽" type="tts">kažiprst koji pokazuje nagore otpozadi: ni svetla ni tamna koža</annotation>
-		<annotation cp="👆🏾">kažiprst | kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: srednje tamna koža | nagore | pokazivanje | prednja strana | prst | ruka | šaka | srednje tamna koža | telo</annotation>
+		<annotation cp="👆🏾">kažiprst | kažiprst koji pokazuje nagore otpozadi | nagore | pokazivanje | prednja strana | prst | ruka | šaka | srednje tamna koža | telo</annotation>
 		<annotation cp="👆🏾" type="tts">kažiprst koji pokazuje nagore otpozadi: srednje tamna koža</annotation>
-		<annotation cp="👆🏿">kažiprst | kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: tamna koža | nagore | pokazivanje | prednja strana | prst | ruka | šaka | tamna koža | telo</annotation>
+		<annotation cp="👆🏿">kažiprst | kažiprst koji pokazuje nagore otpozadi | nagore | pokazivanje | prednja strana | prst | ruka | šaka | tamna koža | telo</annotation>
 		<annotation cp="👆🏿" type="tts">kažiprst koji pokazuje nagore otpozadi: tamna koža</annotation>
-		<annotation cp="🖕🏻">prst | ruka | srednji prst | srednji prst: svetla koža | svetla koža</annotation>
+		<annotation cp="🖕🏻">prst | ruka | srednji prst | svetla koža</annotation>
 		<annotation cp="🖕🏻" type="tts">srednji prst: svetla koža</annotation>
-		<annotation cp="🖕🏼">prst | ruka | srednje svetla koža | srednji prst | srednji prst: srednje svetla koža</annotation>
+		<annotation cp="🖕🏼">prst | ruka | srednje svetla koža | srednji prst</annotation>
 		<annotation cp="🖕🏼" type="tts">srednji prst: srednje svetla koža</annotation>
-		<annotation cp="🖕🏽">ni svetla ni tamna koža | prst | ruka | srednji prst | srednji prst: ni svetla ni tamna koža</annotation>
+		<annotation cp="🖕🏽">ni svetla ni tamna koža | prst | ruka | srednji prst</annotation>
 		<annotation cp="🖕🏽" type="tts">srednji prst: ni svetla ni tamna koža</annotation>
-		<annotation cp="🖕🏾">prst | ruka | srednje tamna koža | srednji prst | srednji prst: srednje tamna koža</annotation>
+		<annotation cp="🖕🏾">prst | ruka | srednje tamna koža | srednji prst</annotation>
 		<annotation cp="🖕🏾" type="tts">srednji prst: srednje tamna koža</annotation>
-		<annotation cp="🖕🏿">prst | ruka | srednji prst | srednji prst: tamna koža | tamna koža</annotation>
+		<annotation cp="🖕🏿">prst | ruka | srednji prst | tamna koža</annotation>
 		<annotation cp="🖕🏿" type="tts">srednji prst: tamna koža</annotation>
-		<annotation cp="👇🏻">kažiprst | kažiprst koji pokazuje nadole otpozadi | kažiprst koji pokazuje nadole otpozadi: svetla koža | nadole | pokazivanje | prst | ruka | šaka | svetla koža | telo</annotation>
+		<annotation cp="👇🏻">kažiprst | kažiprst koji pokazuje nadole otpozadi | nadole | pokazivanje | prst | ruka | šaka | svetla koža | telo</annotation>
 		<annotation cp="👇🏻" type="tts">kažiprst koji pokazuje nadole otpozadi: svetla koža</annotation>
-		<annotation cp="👇🏼">kažiprst | kažiprst koji pokazuje nadole otpozadi | kažiprst koji pokazuje nadole otpozadi: srednje svetla koža | nadole | pokazivanje | prst | ruka | šaka | srednje svetla koža | telo</annotation>
+		<annotation cp="👇🏼">kažiprst | kažiprst koji pokazuje nadole otpozadi | nadole | pokazivanje | prst | ruka | šaka | srednje svetla koža | telo</annotation>
 		<annotation cp="👇🏼" type="tts">kažiprst koji pokazuje nadole otpozadi: srednje svetla koža</annotation>
-		<annotation cp="👇🏽">kažiprst | kažiprst koji pokazuje nadole otpozadi | kažiprst koji pokazuje nadole otpozadi: ni svetla ni tamna koža | nadole | ni svetla ni tamna koža | pokazivanje | prst | ruka | šaka | telo</annotation>
+		<annotation cp="👇🏽">kažiprst | kažiprst koji pokazuje nadole otpozadi | nadole | ni svetla ni tamna koža | pokazivanje | prst | ruka | šaka | telo</annotation>
 		<annotation cp="👇🏽" type="tts">kažiprst koji pokazuje nadole otpozadi: ni svetla ni tamna koža</annotation>
-		<annotation cp="👇🏾">kažiprst | kažiprst koji pokazuje nadole otpozadi | kažiprst koji pokazuje nadole otpozadi: srednje tamna koža | nadole | pokazivanje | prst | ruka | šaka | srednje tamna koža | telo</annotation>
+		<annotation cp="👇🏾">kažiprst | kažiprst koji pokazuje nadole otpozadi | nadole | pokazivanje | prst | ruka | šaka | srednje tamna koža | telo</annotation>
 		<annotation cp="👇🏾" type="tts">kažiprst koji pokazuje nadole otpozadi: srednje tamna koža</annotation>
-		<annotation cp="👇🏿">kažiprst | kažiprst koji pokazuje nadole otpozadi | kažiprst koji pokazuje nadole otpozadi: tamna koža | nadole | pokazivanje | prst | ruka | šaka | tamna koža | telo</annotation>
+		<annotation cp="👇🏿">kažiprst | kažiprst koji pokazuje nadole otpozadi | nadole | pokazivanje | prst | ruka | šaka | tamna koža | telo</annotation>
 		<annotation cp="👇🏿" type="tts">kažiprst koji pokazuje nadole otpozadi: tamna koža</annotation>
-		<annotation cp="☝🏻">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: svetla koža | pokazivanje | prst | ruka | svetla koža</annotation>
+		<annotation cp="☝🏻">gore | kažiprst | kažiprst koji pokazuje nagore | pokazivanje | prst | ruka | svetla koža</annotation>
 		<annotation cp="☝🏻" type="tts">kažiprst koji pokazuje nagore: svetla koža</annotation>
-		<annotation cp="☝🏼">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: srednje svetla koža | pokazivanje | prst | ruka | srednje svetla koža</annotation>
+		<annotation cp="☝🏼">gore | kažiprst | kažiprst koji pokazuje nagore | pokazivanje | prst | ruka | srednje svetla koža</annotation>
 		<annotation cp="☝🏼" type="tts">kažiprst koji pokazuje nagore: srednje svetla koža</annotation>
-		<annotation cp="☝🏽">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: ni svetla ni tamna koža | ni svetla ni tamna koža | pokazivanje | prst | ruka</annotation>
+		<annotation cp="☝🏽">gore | kažiprst | kažiprst koji pokazuje nagore | ni svetla ni tamna koža | pokazivanje | prst | ruka</annotation>
 		<annotation cp="☝🏽" type="tts">kažiprst koji pokazuje nagore: ni svetla ni tamna koža</annotation>
-		<annotation cp="☝🏾">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: srednje tamna koža | pokazivanje | prst | ruka | srednje tamna koža</annotation>
+		<annotation cp="☝🏾">gore | kažiprst | kažiprst koji pokazuje nagore | pokazivanje | prst | ruka | srednje tamna koža</annotation>
 		<annotation cp="☝🏾" type="tts">kažiprst koji pokazuje nagore: srednje tamna koža</annotation>
-		<annotation cp="☝🏿">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: tamna koža | pokazivanje | prst | ruka | tamna koža</annotation>
+		<annotation cp="☝🏿">gore | kažiprst | kažiprst koji pokazuje nagore | pokazivanje | prst | ruka | tamna koža</annotation>
 		<annotation cp="☝🏿" type="tts">kažiprst koji pokazuje nagore: tamna koža</annotation>
-		<annotation cp="🫵🏻">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: svetla koža | pokazivanje | svetla koža | ti | vi</annotation>
+		<annotation cp="🫵🏻">kažiprst koji pokazuje prema gledaocu | pokazivanje | svetla koža | ti | vi</annotation>
 		<annotation cp="🫵🏻" type="tts">kažiprst koji pokazuje prema gledaocu: svetla koža</annotation>
-		<annotation cp="🫵🏼">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: srednje svetla koža | pokazivanje | srednje svetla koža | ti | vi</annotation>
+		<annotation cp="🫵🏼">kažiprst koji pokazuje prema gledaocu | pokazivanje | srednje svetla koža | ti | vi</annotation>
 		<annotation cp="🫵🏼" type="tts">kažiprst koji pokazuje prema gledaocu: srednje svetla koža</annotation>
-		<annotation cp="🫵🏽">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: ni svetla ni tamna koža | ni svetla ni tamna koža | pokazivanje | ti | vi</annotation>
+		<annotation cp="🫵🏽">kažiprst koji pokazuje prema gledaocu | ni svetla ni tamna koža | pokazivanje | ti | vi</annotation>
 		<annotation cp="🫵🏽" type="tts">kažiprst koji pokazuje prema gledaocu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫵🏾">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: srednje tamna koža | pokazivanje | srednje tamna koža | ti | vi</annotation>
+		<annotation cp="🫵🏾">kažiprst koji pokazuje prema gledaocu | pokazivanje | srednje tamna koža | ti | vi</annotation>
 		<annotation cp="🫵🏾" type="tts">kažiprst koji pokazuje prema gledaocu: srednje tamna koža</annotation>
-		<annotation cp="🫵🏿">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: tamna koža | pokazivanje | tamna koža | ti | vi</annotation>
+		<annotation cp="🫵🏿">kažiprst koji pokazuje prema gledaocu | pokazivanje | tamna koža | ti | vi</annotation>
 		<annotation cp="🫵🏿" type="tts">kažiprst koji pokazuje prema gledaocu: tamna koža</annotation>
-		<annotation cp="👍🏻">+1 | dobro | nagore | ocena | palac | palac nagore: svetla koža | ruka | svetla koža | telo</annotation>
+		<annotation cp="👍🏻">+1 | dobro | nagore | ocena | palac | ruka | svetla koža | telo</annotation>
 		<annotation cp="👍🏻" type="tts">palac nagore: svetla koža</annotation>
-		<annotation cp="👍🏼">+1 | dobro | nagore | ocena | palac | palac nagore: srednje svetla koža | ruka | srednje svetla koža | telo</annotation>
+		<annotation cp="👍🏼">+1 | dobro | nagore | ocena | palac | ruka | srednje svetla koža | telo</annotation>
 		<annotation cp="👍🏼" type="tts">palac nagore: srednje svetla koža</annotation>
-		<annotation cp="👍🏽">+1 | dobro | nagore | ni svetla ni tamna koža | ocena | palac | palac nagore: ni svetla ni tamna koža | ruka | telo</annotation>
+		<annotation cp="👍🏽">+1 | dobro | nagore | ni svetla ni tamna koža | ocena | palac | ruka | telo</annotation>
 		<annotation cp="👍🏽" type="tts">palac nagore: ni svetla ni tamna koža</annotation>
-		<annotation cp="👍🏾">+1 | dobro | nagore | ocena | palac | palac nagore: srednje tamna koža | ruka | srednje tamna koža | telo</annotation>
+		<annotation cp="👍🏾">+1 | dobro | nagore | ocena | palac | ruka | srednje tamna koža | telo</annotation>
 		<annotation cp="👍🏾" type="tts">palac nagore: srednje tamna koža</annotation>
-		<annotation cp="👍🏿">+1 | dobro | nagore | ocena | palac | palac nagore: tamna koža | ruka | tamna koža | telo</annotation>
+		<annotation cp="👍🏿">+1 | dobro | nagore | ocena | palac | ruka | tamna koža | telo</annotation>
 		<annotation cp="👍🏿" type="tts">palac nagore: tamna koža</annotation>
-		<annotation cp="👎🏻">-1 | nadole | palac | palac nadole: svetla koža | ruka | svetla koža</annotation>
+		<annotation cp="👎🏻">-1 | nadole | palac | ruka | svetla koža</annotation>
 		<annotation cp="👎🏻" type="tts">palac nadole: svetla koža</annotation>
-		<annotation cp="👎🏼">-1 | nadole | palac | palac nadole: srednje svetla koža | ruka | srednje svetla koža</annotation>
+		<annotation cp="👎🏼">-1 | nadole | palac | ruka | srednje svetla koža</annotation>
 		<annotation cp="👎🏼" type="tts">palac nadole: srednje svetla koža</annotation>
-		<annotation cp="👎🏽">-1 | nadole | ni svetla ni tamna koža | palac | palac nadole: ni svetla ni tamna koža | ruka</annotation>
+		<annotation cp="👎🏽">-1 | nadole | ni svetla ni tamna koža | palac | ruka</annotation>
 		<annotation cp="👎🏽" type="tts">palac nadole: ni svetla ni tamna koža</annotation>
-		<annotation cp="👎🏾">-1 | nadole | palac | palac nadole: srednje tamna koža | ruka | srednje tamna koža</annotation>
+		<annotation cp="👎🏾">-1 | nadole | palac | ruka | srednje tamna koža</annotation>
 		<annotation cp="👎🏾" type="tts">palac nadole: srednje tamna koža</annotation>
-		<annotation cp="👎🏿">-1 | nadole | palac | palac nadole: tamna koža | ruka | tamna koža</annotation>
+		<annotation cp="👎🏿">-1 | nadole | palac | ruka | tamna koža</annotation>
 		<annotation cp="👎🏿" type="tts">palac nadole: tamna koža</annotation>
-		<annotation cp="✊🏻">pesnica | pesnica: svetla koža | ruka | šaka | stisnuto | svetla koža | udarac</annotation>
+		<annotation cp="✊🏻">pesnica | ruka | šaka | stisnuto | svetla koža | udarac</annotation>
 		<annotation cp="✊🏻" type="tts">pesnica: svetla koža</annotation>
-		<annotation cp="✊🏼">pesnica | pesnica: srednje svetla koža | ruka | šaka | srednje svetla koža | stisnuto | udarac</annotation>
+		<annotation cp="✊🏼">pesnica | ruka | šaka | srednje svetla koža | stisnuto | udarac</annotation>
 		<annotation cp="✊🏼" type="tts">pesnica: srednje svetla koža</annotation>
-		<annotation cp="✊🏽">ni svetla ni tamna koža | pesnica | pesnica: ni svetla ni tamna koža | ruka | šaka | stisnuto | udarac</annotation>
+		<annotation cp="✊🏽">ni svetla ni tamna koža | pesnica | ruka | šaka | stisnuto | udarac</annotation>
 		<annotation cp="✊🏽" type="tts">pesnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="✊🏾">pesnica | pesnica: srednje tamna koža | ruka | šaka | srednje tamna koža | stisnuto | udarac</annotation>
+		<annotation cp="✊🏾">pesnica | ruka | šaka | srednje tamna koža | stisnuto | udarac</annotation>
 		<annotation cp="✊🏾" type="tts">pesnica: srednje tamna koža</annotation>
-		<annotation cp="✊🏿">pesnica | pesnica: tamna koža | ruka | šaka | stisnuto | tamna koža | udarac</annotation>
+		<annotation cp="✊🏿">pesnica | ruka | šaka | stisnuto | tamna koža | udarac</annotation>
 		<annotation cp="✊🏿" type="tts">pesnica: tamna koža</annotation>
-		<annotation cp="👊🏻">ruka | šaka | stisnuto | svetla koža | udarac | usmerena pesnica | usmerena pesnica: svetla koža</annotation>
+		<annotation cp="👊🏻">ruka | šaka | stisnuto | svetla koža | udarac | usmerena pesnica</annotation>
 		<annotation cp="👊🏻" type="tts">usmerena pesnica: svetla koža</annotation>
-		<annotation cp="👊🏼">ruka | šaka | srednje svetla koža | stisnuto | udarac | usmerena pesnica | usmerena pesnica: srednje svetla koža</annotation>
+		<annotation cp="👊🏼">ruka | šaka | srednje svetla koža | stisnuto | udarac | usmerena pesnica</annotation>
 		<annotation cp="👊🏼" type="tts">usmerena pesnica: srednje svetla koža</annotation>
-		<annotation cp="👊🏽">ni svetla ni tamna koža | ruka | šaka | stisnuto | udarac | usmerena pesnica | usmerena pesnica: ni svetla ni tamna koža</annotation>
+		<annotation cp="👊🏽">ni svetla ni tamna koža | ruka | šaka | stisnuto | udarac | usmerena pesnica</annotation>
 		<annotation cp="👊🏽" type="tts">usmerena pesnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👊🏾">ruka | šaka | srednje tamna koža | stisnuto | udarac | usmerena pesnica | usmerena pesnica: srednje tamna koža</annotation>
+		<annotation cp="👊🏾">ruka | šaka | srednje tamna koža | stisnuto | udarac | usmerena pesnica</annotation>
 		<annotation cp="👊🏾" type="tts">usmerena pesnica: srednje tamna koža</annotation>
-		<annotation cp="👊🏿">ruka | šaka | stisnuto | tamna koža | udarac | usmerena pesnica | usmerena pesnica: tamna koža</annotation>
+		<annotation cp="👊🏿">ruka | šaka | stisnuto | tamna koža | udarac | usmerena pesnica</annotation>
 		<annotation cp="👊🏿" type="tts">usmerena pesnica: tamna koža</annotation>
-		<annotation cp="🤛🏻">pesnica | pesnica ulevo: svetla koža | svetla koža | ulevo</annotation>
+		<annotation cp="🤛🏻">pesnica | svetla koža | ulevo</annotation>
 		<annotation cp="🤛🏻" type="tts">pesnica ulevo: svetla koža</annotation>
-		<annotation cp="🤛🏼">pesnica | pesnica ulevo: srednje svetla koža | srednje svetla koža | ulevo</annotation>
+		<annotation cp="🤛🏼">pesnica | srednje svetla koža | ulevo</annotation>
 		<annotation cp="🤛🏼" type="tts">pesnica ulevo: srednje svetla koža</annotation>
-		<annotation cp="🤛🏽">ni svetla ni tamna koža | pesnica | pesnica ulevo: ni svetla ni tamna koža | ulevo</annotation>
+		<annotation cp="🤛🏽">ni svetla ni tamna koža | pesnica | ulevo</annotation>
 		<annotation cp="🤛🏽" type="tts">pesnica ulevo: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤛🏾">pesnica | pesnica ulevo: srednje tamna koža | srednje tamna koža | ulevo</annotation>
+		<annotation cp="🤛🏾">pesnica | srednje tamna koža | ulevo</annotation>
 		<annotation cp="🤛🏾" type="tts">pesnica ulevo: srednje tamna koža</annotation>
-		<annotation cp="🤛🏿">pesnica | pesnica ulevo: tamna koža | tamna koža | ulevo</annotation>
+		<annotation cp="🤛🏿">pesnica | tamna koža | ulevo</annotation>
 		<annotation cp="🤛🏿" type="tts">pesnica ulevo: tamna koža</annotation>
-		<annotation cp="🤜🏻">pesnica | pesnica udesno: svetla koža | svetla koža | udesno</annotation>
+		<annotation cp="🤜🏻">pesnica | svetla koža | udesno</annotation>
 		<annotation cp="🤜🏻" type="tts">pesnica udesno: svetla koža</annotation>
-		<annotation cp="🤜🏼">pesnica | pesnica udesno: srednje svetla koža | srednje svetla koža | udesno</annotation>
+		<annotation cp="🤜🏼">pesnica | srednje svetla koža | udesno</annotation>
 		<annotation cp="🤜🏼" type="tts">pesnica udesno: srednje svetla koža</annotation>
-		<annotation cp="🤜🏽">ni svetla ni tamna koža | pesnica | pesnica udesno: ni svetla ni tamna koža | udesno</annotation>
+		<annotation cp="🤜🏽">ni svetla ni tamna koža | pesnica | udesno</annotation>
 		<annotation cp="🤜🏽" type="tts">pesnica udesno: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤜🏾">pesnica | pesnica udesno: srednje tamna koža | srednje tamna koža | udesno</annotation>
+		<annotation cp="🤜🏾">pesnica | srednje tamna koža | udesno</annotation>
 		<annotation cp="🤜🏾" type="tts">pesnica udesno: srednje tamna koža</annotation>
-		<annotation cp="🤜🏿">pesnica | pesnica udesno: tamna koža | tamna koža | udesno</annotation>
+		<annotation cp="🤜🏿">pesnica | tamna koža | udesno</annotation>
 		<annotation cp="🤜🏿" type="tts">pesnica udesno: tamna koža</annotation>
-		<annotation cp="👏🏻">ruka | ruke koje tapšu | ruke koje tapšu: svetla koža | svetla koža | tapšanje</annotation>
+		<annotation cp="👏🏻">ruka | ruke koje tapšu | svetla koža | tapšanje</annotation>
 		<annotation cp="👏🏻" type="tts">ruke koje tapšu: svetla koža</annotation>
-		<annotation cp="👏🏼">ruka | ruke koje tapšu | ruke koje tapšu: srednje svetla koža | srednje svetla koža | tapšanje</annotation>
+		<annotation cp="👏🏼">ruka | ruke koje tapšu | srednje svetla koža | tapšanje</annotation>
 		<annotation cp="👏🏼" type="tts">ruke koje tapšu: srednje svetla koža</annotation>
-		<annotation cp="👏🏽">ni svetla ni tamna koža | ruka | ruke koje tapšu | ruke koje tapšu: ni svetla ni tamna koža | tapšanje</annotation>
+		<annotation cp="👏🏽">ni svetla ni tamna koža | ruka | ruke koje tapšu | tapšanje</annotation>
 		<annotation cp="👏🏽" type="tts">ruke koje tapšu: ni svetla ni tamna koža</annotation>
-		<annotation cp="👏🏾">ruka | ruke koje tapšu | ruke koje tapšu: srednje tamna koža | srednje tamna koža | tapšanje</annotation>
+		<annotation cp="👏🏾">ruka | ruke koje tapšu | srednje tamna koža | tapšanje</annotation>
 		<annotation cp="👏🏾" type="tts">ruke koje tapšu: srednje tamna koža</annotation>
-		<annotation cp="👏🏿">ruka | ruke koje tapšu | ruke koje tapšu: tamna koža | tamna koža | tapšanje</annotation>
+		<annotation cp="👏🏿">ruka | ruke koje tapšu | tamna koža | tapšanje</annotation>
 		<annotation cp="👏🏿" type="tts">ruke koje tapšu: tamna koža</annotation>
-		<annotation cp="🙌🏻">bravo | podići | podignute ruke | podignute ruke: svetla koža | pokret | ruke | slava | svetla koža | ura</annotation>
+		<annotation cp="🙌🏻">bravo | podići | podignute ruke | pokret | ruke | slava | svetla koža | ura</annotation>
 		<annotation cp="🙌🏻" type="tts">podignute ruke: svetla koža</annotation>
-		<annotation cp="🙌🏼">bravo | podići | podignute ruke | podignute ruke: srednje svetla koža | pokret | ruke | slava | srednje svetla koža | ura</annotation>
+		<annotation cp="🙌🏼">bravo | podići | podignute ruke | pokret | ruke | slava | srednje svetla koža | ura</annotation>
 		<annotation cp="🙌🏼" type="tts">podignute ruke: srednje svetla koža</annotation>
-		<annotation cp="🙌🏽">bravo | ni svetla ni tamna koža | podići | podignute ruke | podignute ruke: ni svetla ni tamna koža | pokret | ruke | slava | ura</annotation>
+		<annotation cp="🙌🏽">bravo | ni svetla ni tamna koža | podići | podignute ruke | pokret | ruke | slava | ura</annotation>
 		<annotation cp="🙌🏽" type="tts">podignute ruke: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙌🏾">bravo | podići | podignute ruke | podignute ruke: srednje tamna koža | pokret | ruke | slava | srednje tamna koža | ura</annotation>
+		<annotation cp="🙌🏾">bravo | podići | podignute ruke | pokret | ruke | slava | srednje tamna koža | ura</annotation>
 		<annotation cp="🙌🏾" type="tts">podignute ruke: srednje tamna koža</annotation>
-		<annotation cp="🙌🏿">bravo | podići | podignute ruke | podignute ruke: tamna koža | pokret | ruke | slava | tamna koža | ura</annotation>
+		<annotation cp="🙌🏿">bravo | podići | podignute ruke | pokret | ruke | slava | tamna koža | ura</annotation>
 		<annotation cp="🙌🏿" type="tts">podignute ruke: tamna koža</annotation>
-		<annotation cp="🫶🏻">ljubav | ruke koje prave srce | ruke koje prave srce: svetla koža | svetla koža</annotation>
+		<annotation cp="🫶🏻">ljubav | ruke koje prave srce | svetla koža</annotation>
 		<annotation cp="🫶🏻" type="tts">ruke koje prave srce: svetla koža</annotation>
-		<annotation cp="🫶🏼">ljubav | ruke koje prave srce | ruke koje prave srce: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🫶🏼">ljubav | ruke koje prave srce | srednje svetla koža</annotation>
 		<annotation cp="🫶🏼" type="tts">ruke koje prave srce: srednje svetla koža</annotation>
-		<annotation cp="🫶🏽">ljubav | ni svetla ni tamna koža | ruke koje prave srce | ruke koje prave srce: ni svetla ni tamna koža</annotation>
+		<annotation cp="🫶🏽">ljubav | ni svetla ni tamna koža | ruke koje prave srce</annotation>
 		<annotation cp="🫶🏽" type="tts">ruke koje prave srce: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫶🏾">ljubav | ruke koje prave srce | ruke koje prave srce: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🫶🏾">ljubav | ruke koje prave srce | srednje tamna koža</annotation>
 		<annotation cp="🫶🏾" type="tts">ruke koje prave srce: srednje tamna koža</annotation>
-		<annotation cp="🫶🏿">ljubav | ruke koje prave srce | ruke koje prave srce: tamna koža | tamna koža</annotation>
+		<annotation cp="🫶🏿">ljubav | ruke koje prave srce | tamna koža</annotation>
 		<annotation cp="🫶🏿" type="tts">ruke koje prave srce: tamna koža</annotation>
-		<annotation cp="👐🏻">otvoreno | rasklopljene šake | rasklopljene šake: svetla koža | ruka | svetla koža</annotation>
+		<annotation cp="👐🏻">otvoreno | rasklopljene šake | ruka | svetla koža</annotation>
 		<annotation cp="👐🏻" type="tts">rasklopljene šake: svetla koža</annotation>
-		<annotation cp="👐🏼">otvoreno | rasklopljene šake | rasklopljene šake: srednje svetla koža | ruka | srednje svetla koža</annotation>
+		<annotation cp="👐🏼">otvoreno | rasklopljene šake | ruka | srednje svetla koža</annotation>
 		<annotation cp="👐🏼" type="tts">rasklopljene šake: srednje svetla koža</annotation>
-		<annotation cp="👐🏽">ni svetla ni tamna koža | otvoreno | rasklopljene šake | rasklopljene šake: ni svetla ni tamna koža | ruka</annotation>
+		<annotation cp="👐🏽">ni svetla ni tamna koža | otvoreno | rasklopljene šake | ruka</annotation>
 		<annotation cp="👐🏽" type="tts">rasklopljene šake: ni svetla ni tamna koža</annotation>
-		<annotation cp="👐🏾">otvoreno | rasklopljene šake | rasklopljene šake: srednje tamna koža | ruka | srednje tamna koža</annotation>
+		<annotation cp="👐🏾">otvoreno | rasklopljene šake | ruka | srednje tamna koža</annotation>
 		<annotation cp="👐🏾" type="tts">rasklopljene šake: srednje tamna koža</annotation>
-		<annotation cp="👐🏿">otvoreno | rasklopljene šake | rasklopljene šake: tamna koža | ruka | tamna koža</annotation>
+		<annotation cp="👐🏿">otvoreno | rasklopljene šake | ruka | tamna koža</annotation>
 		<annotation cp="👐🏿" type="tts">rasklopljene šake: tamna koža</annotation>
-		<annotation cp="🤲🏻">dlanovi nagore zajedno | dlanovi nagore zajedno: svetla koža | molitva | svetla koža</annotation>
+		<annotation cp="🤲🏻">dlanovi nagore zajedno | molitva | svetla koža</annotation>
 		<annotation cp="🤲🏻" type="tts">dlanovi nagore zajedno: svetla koža</annotation>
-		<annotation cp="🤲🏼">dlanovi nagore zajedno | dlanovi nagore zajedno: srednje svetla koža | molitva | srednje svetla koža</annotation>
+		<annotation cp="🤲🏼">dlanovi nagore zajedno | molitva | srednje svetla koža</annotation>
 		<annotation cp="🤲🏼" type="tts">dlanovi nagore zajedno: srednje svetla koža</annotation>
-		<annotation cp="🤲🏽">dlanovi nagore zajedno | dlanovi nagore zajedno: ni svetla ni tamna koža | molitva | ni svetla ni tamna koža</annotation>
+		<annotation cp="🤲🏽">dlanovi nagore zajedno | molitva | ni svetla ni tamna koža</annotation>
 		<annotation cp="🤲🏽" type="tts">dlanovi nagore zajedno: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤲🏾">dlanovi nagore zajedno | dlanovi nagore zajedno: srednje tamna koža | molitva | srednje tamna koža</annotation>
+		<annotation cp="🤲🏾">dlanovi nagore zajedno | molitva | srednje tamna koža</annotation>
 		<annotation cp="🤲🏾" type="tts">dlanovi nagore zajedno: srednje tamna koža</annotation>
-		<annotation cp="🤲🏿">dlanovi nagore zajedno | dlanovi nagore zajedno: tamna koža | molitva | tamna koža</annotation>
+		<annotation cp="🤲🏿">dlanovi nagore zajedno | molitva | tamna koža</annotation>
 		<annotation cp="🤲🏿" type="tts">dlanovi nagore zajedno: tamna koža</annotation>
-		<annotation cp="🤝🏻">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: svetla koža | sastanak | svetla koža</annotation>
+		<annotation cp="🤝🏻">dogovor | dogovoreno | rešeno | rukovanje | sastanak | svetla koža</annotation>
 		<annotation cp="🤝🏻" type="tts">rukovanje: svetla koža</annotation>
-		<annotation cp="🤝🏼">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje svetla koža | sastanak | srednje svetla koža</annotation>
+		<annotation cp="🤝🏼">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje svetla koža</annotation>
 		<annotation cp="🤝🏼" type="tts">rukovanje: srednje svetla koža</annotation>
-		<annotation cp="🤝🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | rukovanje: ni svetla ni tamna koža | sastanak</annotation>
+		<annotation cp="🤝🏽">dogovor | dogovoreno | ni svetla ni tamna koža | rešeno | rukovanje | sastanak</annotation>
 		<annotation cp="🤝🏽" type="tts">rukovanje: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤝🏾">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: srednje tamna koža | sastanak | srednje tamna koža</annotation>
+		<annotation cp="🤝🏾">dogovor | dogovoreno | rešeno | rukovanje | sastanak | srednje tamna koža</annotation>
 		<annotation cp="🤝🏾" type="tts">rukovanje: srednje tamna koža</annotation>
-		<annotation cp="🤝🏿">dogovor | dogovoreno | rešeno | rukovanje | rukovanje: tamna koža | sastanak | tamna koža</annotation>
+		<annotation cp="🤝🏿">dogovor | dogovoreno | rešeno | rukovanje | sastanak | tamna koža</annotation>
 		<annotation cp="🤝🏿" type="tts">rukovanje: tamna koža</annotation>
-		<annotation cp="🙏🏻">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | spojeni dlanovi: svetla koža | svetla koža | zahvalnost</annotation>
+		<annotation cp="🙏🏻">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | svetla koža | zahvalnost</annotation>
 		<annotation cp="🙏🏻" type="tts">spojeni dlanovi: svetla koža</annotation>
-		<annotation cp="🙏🏼">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | spojeni dlanovi: srednje svetla koža | srednje svetla koža | zahvalnost</annotation>
+		<annotation cp="🙏🏼">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | srednje svetla koža | zahvalnost</annotation>
 		<annotation cp="🙏🏼" type="tts">spojeni dlanovi: srednje svetla koža</annotation>
-		<annotation cp="🙏🏽">daj 5 | daj pet | molitva | moljenje | ni svetla ni tamna koža | pitati | ruka | spojeni dlanovi | spojeni dlanovi: ni svetla ni tamna koža | zahvalnost</annotation>
+		<annotation cp="🙏🏽">daj 5 | daj pet | molitva | moljenje | ni svetla ni tamna koža | pitati | ruka | spojeni dlanovi | zahvalnost</annotation>
 		<annotation cp="🙏🏽" type="tts">spojeni dlanovi: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙏🏾">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | spojeni dlanovi: srednje tamna koža | srednje tamna koža | zahvalnost</annotation>
+		<annotation cp="🙏🏾">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | srednje tamna koža | zahvalnost</annotation>
 		<annotation cp="🙏🏾" type="tts">spojeni dlanovi: srednje tamna koža</annotation>
-		<annotation cp="🙏🏿">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | spojeni dlanovi: tamna koža | tamna koža | zahvalnost</annotation>
+		<annotation cp="🙏🏿">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | tamna koža | zahvalnost</annotation>
 		<annotation cp="🙏🏿" type="tts">spojeni dlanovi: tamna koža</annotation>
-		<annotation cp="✍🏻">pisanje | ruka | ruka koja piše | ruka koja piše: svetla koža | svetla koža</annotation>
+		<annotation cp="✍🏻">pisanje | ruka | ruka koja piše | svetla koža</annotation>
 		<annotation cp="✍🏻" type="tts">ruka koja piše: svetla koža</annotation>
-		<annotation cp="✍🏼">pisanje | ruka | ruka koja piše | ruka koja piše: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="✍🏼">pisanje | ruka | ruka koja piše | srednje svetla koža</annotation>
 		<annotation cp="✍🏼" type="tts">ruka koja piše: srednje svetla koža</annotation>
-		<annotation cp="✍🏽">ni svetla ni tamna koža | pisanje | ruka | ruka koja piše | ruka koja piše: ni svetla ni tamna koža</annotation>
+		<annotation cp="✍🏽">ni svetla ni tamna koža | pisanje | ruka | ruka koja piše</annotation>
 		<annotation cp="✍🏽" type="tts">ruka koja piše: ni svetla ni tamna koža</annotation>
-		<annotation cp="✍🏾">pisanje | ruka | ruka koja piše | ruka koja piše: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="✍🏾">pisanje | ruka | ruka koja piše | srednje tamna koža</annotation>
 		<annotation cp="✍🏾" type="tts">ruka koja piše: srednje tamna koža</annotation>
-		<annotation cp="✍🏿">pisanje | ruka | ruka koja piše | ruka koja piše: tamna koža | tamna koža</annotation>
+		<annotation cp="✍🏿">pisanje | ruka | ruka koja piše | tamna koža</annotation>
 		<annotation cp="✍🏿" type="tts">ruka koja piše: tamna koža</annotation>
-		<annotation cp="💅🏻">kozmetika | lak za nokte | lak za nokte: svetla koža | manikir | nega | nokat | svetla koža</annotation>
+		<annotation cp="💅🏻">kozmetika | lak za nokte | manikir | nega | nokat | svetla koža</annotation>
 		<annotation cp="💅🏻" type="tts">lak za nokte: svetla koža</annotation>
-		<annotation cp="💅🏼">kozmetika | lak za nokte | lak za nokte: srednje svetla koža | manikir | nega | nokat | srednje svetla koža</annotation>
+		<annotation cp="💅🏼">kozmetika | lak za nokte | manikir | nega | nokat | srednje svetla koža</annotation>
 		<annotation cp="💅🏼" type="tts">lak za nokte: srednje svetla koža</annotation>
-		<annotation cp="💅🏽">kozmetika | lak za nokte | lak za nokte: ni svetla ni tamna koža | manikir | nega | ni svetla ni tamna koža | nokat</annotation>
+		<annotation cp="💅🏽">kozmetika | lak za nokte | manikir | nega | ni svetla ni tamna koža | nokat</annotation>
 		<annotation cp="💅🏽" type="tts">lak za nokte: ni svetla ni tamna koža</annotation>
-		<annotation cp="💅🏾">kozmetika | lak za nokte | lak za nokte: srednje tamna koža | manikir | nega | nokat | srednje tamna koža</annotation>
+		<annotation cp="💅🏾">kozmetika | lak za nokte | manikir | nega | nokat | srednje tamna koža</annotation>
 		<annotation cp="💅🏾" type="tts">lak za nokte: srednje tamna koža</annotation>
-		<annotation cp="💅🏿">kozmetika | lak za nokte | lak za nokte: tamna koža | manikir | nega | nokat | tamna koža</annotation>
+		<annotation cp="💅🏿">kozmetika | lak za nokte | manikir | nega | nokat | tamna koža</annotation>
 		<annotation cp="💅🏿" type="tts">lak za nokte: tamna koža</annotation>
-		<annotation cp="🤳🏻">kamera | selfi | selfi: svetla koža | svetla koža | telefon</annotation>
+		<annotation cp="🤳🏻">kamera | selfi | svetla koža | telefon</annotation>
 		<annotation cp="🤳🏻" type="tts">selfi: svetla koža</annotation>
-		<annotation cp="🤳🏼">kamera | selfi | selfi: srednje svetla koža | srednje svetla koža | telefon</annotation>
+		<annotation cp="🤳🏼">kamera | selfi | srednje svetla koža | telefon</annotation>
 		<annotation cp="🤳🏼" type="tts">selfi: srednje svetla koža</annotation>
-		<annotation cp="🤳🏽">kamera | ni svetla ni tamna koža | selfi | selfi: ni svetla ni tamna koža | telefon</annotation>
+		<annotation cp="🤳🏽">kamera | ni svetla ni tamna koža | selfi | telefon</annotation>
 		<annotation cp="🤳🏽" type="tts">selfi: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤳🏾">kamera | selfi | selfi: srednje tamna koža | srednje tamna koža | telefon</annotation>
+		<annotation cp="🤳🏾">kamera | selfi | srednje tamna koža | telefon</annotation>
 		<annotation cp="🤳🏾" type="tts">selfi: srednje tamna koža</annotation>
-		<annotation cp="🤳🏿">kamera | selfi | selfi: tamna koža | tamna koža | telefon</annotation>
+		<annotation cp="🤳🏿">kamera | selfi | tamna koža | telefon</annotation>
 		<annotation cp="🤳🏿" type="tts">selfi: tamna koža</annotation>
-		<annotation cp="💪🏻">biceps | mišić | stegnut | stegnuti biceps | stegnuti biceps: svetla koža | svetla koža | telo</annotation>
+		<annotation cp="💪🏻">biceps | mišić | stegnut | stegnuti biceps | svetla koža | telo</annotation>
 		<annotation cp="💪🏻" type="tts">stegnuti biceps: svetla koža</annotation>
-		<annotation cp="💪🏼">biceps | mišić | srednje svetla koža | stegnut | stegnuti biceps | stegnuti biceps: srednje svetla koža | telo</annotation>
+		<annotation cp="💪🏼">biceps | mišić | srednje svetla koža | stegnut | stegnuti biceps | telo</annotation>
 		<annotation cp="💪🏼" type="tts">stegnuti biceps: srednje svetla koža</annotation>
-		<annotation cp="💪🏽">biceps | mišić | ni svetla ni tamna koža | stegnut | stegnuti biceps | stegnuti biceps: ni svetla ni tamna koža | telo</annotation>
+		<annotation cp="💪🏽">biceps | mišić | ni svetla ni tamna koža | stegnut | stegnuti biceps | telo</annotation>
 		<annotation cp="💪🏽" type="tts">stegnuti biceps: ni svetla ni tamna koža</annotation>
-		<annotation cp="💪🏾">biceps | mišić | srednje tamna koža | stegnut | stegnuti biceps | stegnuti biceps: srednje tamna koža | telo</annotation>
+		<annotation cp="💪🏾">biceps | mišić | srednje tamna koža | stegnut | stegnuti biceps | telo</annotation>
 		<annotation cp="💪🏾" type="tts">stegnuti biceps: srednje tamna koža</annotation>
-		<annotation cp="💪🏿">biceps | mišić | stegnut | stegnuti biceps | stegnuti biceps: tamna koža | tamna koža | telo</annotation>
+		<annotation cp="💪🏿">biceps | mišić | stegnut | stegnuti biceps | tamna koža | telo</annotation>
 		<annotation cp="💪🏿" type="tts">stegnuti biceps: tamna koža</annotation>
-		<annotation cp="🦵🏻">noga | noga: svetla koža | šut | svetla koža | ud</annotation>
+		<annotation cp="🦵🏻">noga | šut | svetla koža | ud</annotation>
 		<annotation cp="🦵🏻" type="tts">noga: svetla koža</annotation>
-		<annotation cp="🦵🏼">noga | noga: srednje svetla koža | srednje svetla koža | šut | ud</annotation>
+		<annotation cp="🦵🏼">noga | srednje svetla koža | šut | ud</annotation>
 		<annotation cp="🦵🏼" type="tts">noga: srednje svetla koža</annotation>
-		<annotation cp="🦵🏽">ni svetla ni tamna koža | noga | noga: ni svetla ni tamna koža | šut | ud</annotation>
+		<annotation cp="🦵🏽">ni svetla ni tamna koža | noga | šut | ud</annotation>
 		<annotation cp="🦵🏽" type="tts">noga: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦵🏾">noga | noga: srednje tamna koža | srednje tamna koža | šut | ud</annotation>
+		<annotation cp="🦵🏾">noga | srednje tamna koža | šut | ud</annotation>
 		<annotation cp="🦵🏾" type="tts">noga: srednje tamna koža</annotation>
-		<annotation cp="🦵🏿">noga | noga: tamna koža | šut | tamna koža | ud</annotation>
+		<annotation cp="🦵🏿">noga | šut | tamna koža | ud</annotation>
 		<annotation cp="🦵🏿" type="tts">noga: tamna koža</annotation>
-		<annotation cp="🦶🏻">stopalo | stopalo: svetla koža | svetla koža | zgaziti</annotation>
+		<annotation cp="🦶🏻">stopalo | svetla koža | zgaziti</annotation>
 		<annotation cp="🦶🏻" type="tts">stopalo: svetla koža</annotation>
-		<annotation cp="🦶🏼">srednje svetla koža | stopalo | stopalo: srednje svetla koža | zgaziti</annotation>
+		<annotation cp="🦶🏼">srednje svetla koža | stopalo | zgaziti</annotation>
 		<annotation cp="🦶🏼" type="tts">stopalo: srednje svetla koža</annotation>
-		<annotation cp="🦶🏽">ni svetla ni tamna koža | stopalo | stopalo: ni svetla ni tamna koža | zgaziti</annotation>
+		<annotation cp="🦶🏽">ni svetla ni tamna koža | stopalo | zgaziti</annotation>
 		<annotation cp="🦶🏽" type="tts">stopalo: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦶🏾">srednje tamna koža | stopalo | stopalo: srednje tamna koža | zgaziti</annotation>
+		<annotation cp="🦶🏾">srednje tamna koža | stopalo | zgaziti</annotation>
 		<annotation cp="🦶🏾" type="tts">stopalo: srednje tamna koža</annotation>
-		<annotation cp="🦶🏿">stopalo | stopalo: tamna koža | tamna koža | zgaziti</annotation>
+		<annotation cp="🦶🏿">stopalo | tamna koža | zgaziti</annotation>
 		<annotation cp="🦶🏿" type="tts">stopalo: tamna koža</annotation>
-		<annotation cp="👂🏻">svetla koža | telo | uvo | uvo: svetla koža</annotation>
+		<annotation cp="👂🏻">svetla koža | telo | uvo</annotation>
 		<annotation cp="👂🏻" type="tts">uvo: svetla koža</annotation>
-		<annotation cp="👂🏼">srednje svetla koža | telo | uvo | uvo: srednje svetla koža</annotation>
+		<annotation cp="👂🏼">srednje svetla koža | telo | uvo</annotation>
 		<annotation cp="👂🏼" type="tts">uvo: srednje svetla koža</annotation>
-		<annotation cp="👂🏽">ni svetla ni tamna koža | telo | uvo | uvo: ni svetla ni tamna koža</annotation>
+		<annotation cp="👂🏽">ni svetla ni tamna koža | telo | uvo</annotation>
 		<annotation cp="👂🏽" type="tts">uvo: ni svetla ni tamna koža</annotation>
-		<annotation cp="👂🏾">srednje tamna koža | telo | uvo | uvo: srednje tamna koža</annotation>
+		<annotation cp="👂🏾">srednje tamna koža | telo | uvo</annotation>
 		<annotation cp="👂🏾" type="tts">uvo: srednje tamna koža</annotation>
-		<annotation cp="👂🏿">tamna koža | telo | uvo | uvo: tamna koža</annotation>
+		<annotation cp="👂🏿">tamna koža | telo | uvo</annotation>
 		<annotation cp="👂🏿" type="tts">uvo: tamna koža</annotation>
-		<annotation cp="🦻🏻">pristupačnost | svetla koža | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: svetla koža</annotation>
+		<annotation cp="🦻🏻">pristupačnost | svetla koža | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏻" type="tts">uvo sa slušnim aparatom: svetla koža</annotation>
-		<annotation cp="🦻🏼">pristupačnost | srednje svetla koža | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: srednje svetla koža</annotation>
+		<annotation cp="🦻🏼">pristupačnost | srednje svetla koža | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏼" type="tts">uvo sa slušnim aparatom: srednje svetla koža</annotation>
-		<annotation cp="🦻🏽">ni svetla ni tamna koža | pristupačnost | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: ni svetla ni tamna koža</annotation>
+		<annotation cp="🦻🏽">ni svetla ni tamna koža | pristupačnost | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏽" type="tts">uvo sa slušnim aparatom: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦻🏾">pristupačnost | srednje tamna koža | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: srednje tamna koža</annotation>
+		<annotation cp="🦻🏾">pristupačnost | srednje tamna koža | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏾" type="tts">uvo sa slušnim aparatom: srednje tamna koža</annotation>
-		<annotation cp="🦻🏿">pristupačnost | tamna koža | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: tamna koža</annotation>
+		<annotation cp="🦻🏿">pristupačnost | tamna koža | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏿" type="tts">uvo sa slušnim aparatom: tamna koža</annotation>
-		<annotation cp="👃🏻">nos | nos: svetla koža | svetla koža | telo</annotation>
+		<annotation cp="👃🏻">nos | svetla koža | telo</annotation>
 		<annotation cp="👃🏻" type="tts">nos: svetla koža</annotation>
-		<annotation cp="👃🏼">nos | nos: srednje svetla koža | srednje svetla koža | telo</annotation>
+		<annotation cp="👃🏼">nos | srednje svetla koža | telo</annotation>
 		<annotation cp="👃🏼" type="tts">nos: srednje svetla koža</annotation>
-		<annotation cp="👃🏽">ni svetla ni tamna koža | nos | nos: ni svetla ni tamna koža | telo</annotation>
+		<annotation cp="👃🏽">ni svetla ni tamna koža | nos | telo</annotation>
 		<annotation cp="👃🏽" type="tts">nos: ni svetla ni tamna koža</annotation>
-		<annotation cp="👃🏾">nos | nos: srednje tamna koža | srednje tamna koža | telo</annotation>
+		<annotation cp="👃🏾">nos | srednje tamna koža | telo</annotation>
 		<annotation cp="👃🏾" type="tts">nos: srednje tamna koža</annotation>
-		<annotation cp="👃🏿">nos | nos: tamna koža | tamna koža | telo</annotation>
+		<annotation cp="👃🏿">nos | tamna koža | telo</annotation>
 		<annotation cp="👃🏿" type="tts">nos: tamna koža</annotation>
-		<annotation cp="👶🏻">beba | beba: svetla koža | mladost | svetla koža</annotation>
+		<annotation cp="👶🏻">beba | mladost | svetla koža</annotation>
 		<annotation cp="👶🏻" type="tts">beba: svetla koža</annotation>
-		<annotation cp="👶🏼">beba | beba: srednje svetla koža | mladost | srednje svetla koža</annotation>
+		<annotation cp="👶🏼">beba | mladost | srednje svetla koža</annotation>
 		<annotation cp="👶🏼" type="tts">beba: srednje svetla koža</annotation>
-		<annotation cp="👶🏽">beba | beba: ni svetla ni tamna koža | mladost | ni svetla ni tamna koža</annotation>
+		<annotation cp="👶🏽">beba | mladost | ni svetla ni tamna koža</annotation>
 		<annotation cp="👶🏽" type="tts">beba: ni svetla ni tamna koža</annotation>
-		<annotation cp="👶🏾">beba | beba: srednje tamna koža | mladost | srednje tamna koža</annotation>
+		<annotation cp="👶🏾">beba | mladost | srednje tamna koža</annotation>
 		<annotation cp="👶🏾" type="tts">beba: srednje tamna koža</annotation>
-		<annotation cp="👶🏿">beba | beba: tamna koža | mladost | tamna koža</annotation>
+		<annotation cp="👶🏿">beba | mladost | tamna koža</annotation>
 		<annotation cp="👶🏿" type="tts">beba: tamna koža</annotation>
-		<annotation cp="🧒🏻">dete | dete: svetla koža | mladost | neodređen rod | rodno neutralno | svetla koža</annotation>
+		<annotation cp="🧒🏻">dete | mladost | neodređen rod | rodno neutralno | svetla koža</annotation>
 		<annotation cp="🧒🏻" type="tts">dete: svetla koža</annotation>
-		<annotation cp="🧒🏼">dete | dete: srednje svetla koža | mladost | neodređen rod | rodno neutralno | srednje svetla koža</annotation>
+		<annotation cp="🧒🏼">dete | mladost | neodređen rod | rodno neutralno | srednje svetla koža</annotation>
 		<annotation cp="🧒🏼" type="tts">dete: srednje svetla koža</annotation>
-		<annotation cp="🧒🏽">dete | dete: ni svetla ni tamna koža | mladost | neodređen rod | ni svetla ni tamna koža | rodno neutralno</annotation>
+		<annotation cp="🧒🏽">dete | mladost | neodređen rod | ni svetla ni tamna koža | rodno neutralno</annotation>
 		<annotation cp="🧒🏽" type="tts">dete: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧒🏾">dete | dete: srednje tamna koža | mladost | neodređen rod | rodno neutralno | srednje tamna koža</annotation>
+		<annotation cp="🧒🏾">dete | mladost | neodređen rod | rodno neutralno | srednje tamna koža</annotation>
 		<annotation cp="🧒🏾" type="tts">dete: srednje tamna koža</annotation>
-		<annotation cp="🧒🏿">dete | dete: tamna koža | mladost | neodređen rod | rodno neutralno | tamna koža</annotation>
+		<annotation cp="🧒🏿">dete | mladost | neodređen rod | rodno neutralno | tamna koža</annotation>
 		<annotation cp="🧒🏿" type="tts">dete: tamna koža</annotation>
-		<annotation cp="👦🏻">dečak | dečak: svetla koža | mladost | svetla koža</annotation>
+		<annotation cp="👦🏻">dečak | mladost | svetla koža</annotation>
 		<annotation cp="👦🏻" type="tts">dečak: svetla koža</annotation>
-		<annotation cp="👦🏼">dečak | dečak: srednje svetla koža | mladost | srednje svetla koža</annotation>
+		<annotation cp="👦🏼">dečak | mladost | srednje svetla koža</annotation>
 		<annotation cp="👦🏼" type="tts">dečak: srednje svetla koža</annotation>
-		<annotation cp="👦🏽">dečak | dečak: ni svetla ni tamna koža | mladost | ni svetla ni tamna koža</annotation>
+		<annotation cp="👦🏽">dečak | mladost | ni svetla ni tamna koža</annotation>
 		<annotation cp="👦🏽" type="tts">dečak: ni svetla ni tamna koža</annotation>
-		<annotation cp="👦🏾">dečak | dečak: srednje tamna koža | mladost | srednje tamna koža</annotation>
+		<annotation cp="👦🏾">dečak | mladost | srednje tamna koža</annotation>
 		<annotation cp="👦🏾" type="tts">dečak: srednje tamna koža</annotation>
-		<annotation cp="👦🏿">dečak | dečak: tamna koža | mladost | tamna koža</annotation>
+		<annotation cp="👦🏿">dečak | mladost | tamna koža</annotation>
 		<annotation cp="👦🏿" type="tts">dečak: tamna koža</annotation>
-		<annotation cp="👧🏻">devica | devojčica | devojčica: svetla koža | mladost | svetla koža | zodijak</annotation>
+		<annotation cp="👧🏻">devica | devojčica | mladost | svetla koža | zodijak</annotation>
 		<annotation cp="👧🏻" type="tts">devojčica: svetla koža</annotation>
-		<annotation cp="👧🏼">devica | devojčica | devojčica: srednje svetla koža | mladost | srednje svetla koža | zodijak</annotation>
+		<annotation cp="👧🏼">devica | devojčica | mladost | srednje svetla koža | zodijak</annotation>
 		<annotation cp="👧🏼" type="tts">devojčica: srednje svetla koža</annotation>
-		<annotation cp="👧🏽">devica | devojčica | devojčica: ni svetla ni tamna koža | mladost | ni svetla ni tamna koža | zodijak</annotation>
+		<annotation cp="👧🏽">devica | devojčica | mladost | ni svetla ni tamna koža | zodijak</annotation>
 		<annotation cp="👧🏽" type="tts">devojčica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👧🏾">devica | devojčica | devojčica: srednje tamna koža | mladost | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👧🏾">devica | devojčica | mladost | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👧🏾" type="tts">devojčica: srednje tamna koža</annotation>
-		<annotation cp="👧🏿">devica | devojčica | devojčica: tamna koža | mladost | tamna koža | zodijak</annotation>
+		<annotation cp="👧🏿">devica | devojčica | mladost | tamna koža | zodijak</annotation>
 		<annotation cp="👧🏿" type="tts">devojčica: tamna koža</annotation>
-		<annotation cp="🧑🏻">neutralan pol | odrasla osoba | odrasla osoba: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻">neutralan pol | odrasla osoba | svetla koža</annotation>
 		<annotation cp="🧑🏻" type="tts">odrasla osoba: svetla koža</annotation>
-		<annotation cp="🧑🏼">neutralan pol | odrasla osoba | odrasla osoba: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼">neutralan pol | odrasla osoba | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼" type="tts">odrasla osoba: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽">neutralan pol | ni svetla ni tamna koža | odrasla osoba | odrasla osoba: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽">neutralan pol | ni svetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="🧑🏽" type="tts">odrasla osoba: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾">neutralan pol | odrasla osoba | odrasla osoba: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾">neutralan pol | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾" type="tts">odrasla osoba: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿">neutralan pol | odrasla osoba | odrasla osoba: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿">neutralan pol | odrasla osoba | tamna koža</annotation>
 		<annotation cp="🧑🏿" type="tts">odrasla osoba: tamna koža</annotation>
-		<annotation cp="👱🏻">osoba sa plavom kosom | osoba sa plavom kosom: svetla koža | plava kosa | svetla koža</annotation>
+		<annotation cp="👱🏻">osoba sa plavom kosom | plava kosa | svetla koža</annotation>
 		<annotation cp="👱🏻" type="tts">osoba sa plavom kosom: svetla koža</annotation>
-		<annotation cp="👱🏼">osoba sa plavom kosom | osoba sa plavom kosom: srednje svetla koža | plava kosa | srednje svetla koža</annotation>
+		<annotation cp="👱🏼">osoba sa plavom kosom | plava kosa | srednje svetla koža</annotation>
 		<annotation cp="👱🏼" type="tts">osoba sa plavom kosom: srednje svetla koža</annotation>
-		<annotation cp="👱🏽">ni svetla ni tamna koža | osoba sa plavom kosom | osoba sa plavom kosom: ni svetla ni tamna koža | plava kosa</annotation>
+		<annotation cp="👱🏽">ni svetla ni tamna koža | osoba sa plavom kosom | plava kosa</annotation>
 		<annotation cp="👱🏽" type="tts">osoba sa plavom kosom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👱🏾">osoba sa plavom kosom | osoba sa plavom kosom: srednje tamna koža | plava kosa | srednje tamna koža</annotation>
+		<annotation cp="👱🏾">osoba sa plavom kosom | plava kosa | srednje tamna koža</annotation>
 		<annotation cp="👱🏾" type="tts">osoba sa plavom kosom: srednje tamna koža</annotation>
-		<annotation cp="👱🏿">osoba sa plavom kosom | osoba sa plavom kosom: tamna koža | plava kosa | tamna koža</annotation>
+		<annotation cp="👱🏿">osoba sa plavom kosom | plava kosa | tamna koža</annotation>
 		<annotation cp="👱🏿" type="tts">osoba sa plavom kosom: tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">odrasla osoba | par | poljubac | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, svetla koža i ni svetla ni tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | svetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">odrasla osoba | par | poljubac | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, svetla koža i tamna koža | svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">odrasla osoba | par | poljubac | svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, svetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">odrasla osoba | par | poljubac | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">odrasla osoba | par | poljubac | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">odrasla osoba | par | poljubac | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">ni svetla ni tamna koža | odrasla osoba | par | poljubac | svetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">ni svetla ni tamna koža | odrasla osoba | par | poljubac | srednje svetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">ni svetla ni tamna koža | odrasla osoba | par | poljubac | srednje tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">ni svetla ni tamna koža | odrasla osoba | par | poljubac | tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">odrasla osoba | par | poljubac | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">odrasla osoba | par | poljubac | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿">odrasla osoba | par | poljubac | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i svetla koža | svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">odrasla osoba | par | poljubac | svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">odrasla osoba | par | poljubac | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i ni svetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">ni svetla ni tamna koža | odrasla osoba | par | poljubac | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾">odrasla osoba | par | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾">odrasla osoba | par | poljubac | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏼">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏼">ljubav | odrasla osoba | par | par sa srcem | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svetla koža i ni svetla ni tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | svetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏾">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏾">ljubav | odrasla osoba | par | par sa srcem | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏿">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svetla koža i tamna koža | svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏿">ljubav | odrasla osoba | par | par sa srcem | svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏻">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏻">ljubav | odrasla osoba | par | par sa srcem | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏾">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏾">ljubav | odrasla osoba | par | par sa srcem | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏿">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏿">ljubav | odrasla osoba | par | par sa srcem | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏻">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏻">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | svetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏼">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏼">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | srednje svetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏾">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏾">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏿">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏿">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏻">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏻">ljubav | odrasla osoba | par | par sa srcem | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏼">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏼">ljubav | odrasla osoba | par | par sa srcem | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏿">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏿">ljubav | odrasla osoba | par | par sa srcem | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏻">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i svetla koža | svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏻">ljubav | odrasla osoba | par | par sa srcem | svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏼">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏼">ljubav | odrasla osoba | par | par sa srcem | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i ni svetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏽">ljubav | ni svetla ni tamna koža | odrasla osoba | par | par sa srcem | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏾">ljubav | odrasla osoba | par | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏾">ljubav | odrasla osoba | par | par sa srcem | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑‍🦰">crvena kosa | neutralan pol | odrasla osoba | odrasla osoba: crvena kosa</annotation>
+		<annotation cp="🧑‍🦰">crvena kosa | neutralan pol | odrasla osoba</annotation>
 		<annotation cp="🧑‍🦰" type="tts">odrasla osoba: crvena kosa</annotation>
-		<annotation cp="🧑🏻‍🦰">crvena kosa | neutralan pol | odrasla osoba | odrasla osoba: svetla koža i crvena kosa | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦰">crvena kosa | neutralan pol | odrasla osoba | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦰" type="tts">odrasla osoba: svetla koža i crvena kosa</annotation>
-		<annotation cp="🧑🏼‍🦰">crvena kosa | neutralan pol | odrasla osoba | odrasla osoba: srednje svetla koža i crvena kosa | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦰">crvena kosa | neutralan pol | odrasla osoba | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦰" type="tts">odrasla osoba: srednje svetla koža i crvena kosa</annotation>
-		<annotation cp="🧑🏽‍🦰">crvena kosa | neutralan pol | ni svetla ni tamna koža | odrasla osoba | odrasla osoba: ni svetla ni tamna koža i crvena kosa</annotation>
+		<annotation cp="🧑🏽‍🦰">crvena kosa | neutralan pol | ni svetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="🧑🏽‍🦰" type="tts">odrasla osoba: ni svetla ni tamna koža i crvena kosa</annotation>
-		<annotation cp="🧑🏾‍🦰">crvena kosa | neutralan pol | odrasla osoba | odrasla osoba: srednje tamna koža i crvena kosa | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦰">crvena kosa | neutralan pol | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦰" type="tts">odrasla osoba: srednje tamna koža i crvena kosa</annotation>
-		<annotation cp="🧑🏿‍🦰">crvena kosa | neutralan pol | odrasla osoba | odrasla osoba: tamna koža i crvena kosa | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦰">crvena kosa | neutralan pol | odrasla osoba | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦰" type="tts">odrasla osoba: tamna koža i crvena kosa</annotation>
-		<annotation cp="🧑‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | odrasla osoba: kovrdžava kosa</annotation>
+		<annotation cp="🧑‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba</annotation>
 		<annotation cp="🧑‍🦱" type="tts">odrasla osoba: kovrdžava kosa</annotation>
-		<annotation cp="🧑🏻‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | odrasla osoba: svetla koža i kovrdžava kosa | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦱" type="tts">odrasla osoba: svetla koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑🏼‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | odrasla osoba: srednje svetla koža i kovrdžava kosa | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦱" type="tts">odrasla osoba: srednje svetla koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑🏽‍🦱">kovrdžava kosa | neutralan pol | ni svetla ni tamna koža | odrasla osoba | odrasla osoba: ni svetla ni tamna koža i kovrdžava kosa</annotation>
+		<annotation cp="🧑🏽‍🦱">kovrdžava kosa | neutralan pol | ni svetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="🧑🏽‍🦱" type="tts">odrasla osoba: ni svetla ni tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑🏾‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | odrasla osoba: srednje tamna koža i kovrdžava kosa | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦱" type="tts">odrasla osoba: srednje tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑🏿‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | odrasla osoba: tamna koža i kovrdžava kosa | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦱">kovrdžava kosa | neutralan pol | odrasla osoba | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦱" type="tts">odrasla osoba: tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑‍🦳">neutralan pol | odrasla osoba | odrasla osoba: seda kosa | seda kosa</annotation>
+		<annotation cp="🧑‍🦳">neutralan pol | odrasla osoba | seda kosa</annotation>
 		<annotation cp="🧑‍🦳" type="tts">odrasla osoba: seda kosa</annotation>
-		<annotation cp="🧑🏻‍🦳">neutralan pol | odrasla osoba | odrasla osoba: svetla koža i seda kosa | seda kosa | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦳">neutralan pol | odrasla osoba | seda kosa | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦳" type="tts">odrasla osoba: svetla koža i seda kosa</annotation>
-		<annotation cp="🧑🏼‍🦳">neutralan pol | odrasla osoba | odrasla osoba: srednje svetla koža i seda kosa | seda kosa | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦳">neutralan pol | odrasla osoba | seda kosa | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦳" type="tts">odrasla osoba: srednje svetla koža i seda kosa</annotation>
-		<annotation cp="🧑🏽‍🦳">neutralan pol | ni svetla ni tamna koža | odrasla osoba | odrasla osoba: ni svetla ni tamna koža i seda kosa | seda kosa</annotation>
+		<annotation cp="🧑🏽‍🦳">neutralan pol | ni svetla ni tamna koža | odrasla osoba | seda kosa</annotation>
 		<annotation cp="🧑🏽‍🦳" type="tts">odrasla osoba: ni svetla ni tamna koža i seda kosa</annotation>
-		<annotation cp="🧑🏾‍🦳">neutralan pol | odrasla osoba | odrasla osoba: srednje tamna koža i seda kosa | seda kosa | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦳">neutralan pol | odrasla osoba | seda kosa | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦳" type="tts">odrasla osoba: srednje tamna koža i seda kosa</annotation>
-		<annotation cp="🧑🏿‍🦳">neutralan pol | odrasla osoba | odrasla osoba: tamna koža i seda kosa | seda kosa | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦳">neutralan pol | odrasla osoba | seda kosa | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦳" type="tts">odrasla osoba: tamna koža i seda kosa</annotation>
-		<annotation cp="🧑‍🦲">ćelav | neutralan pol | odrasla osoba | odrasla osoba: ćelav</annotation>
+		<annotation cp="🧑‍🦲">ćelav | neutralan pol | odrasla osoba</annotation>
 		<annotation cp="🧑‍🦲" type="tts">odrasla osoba: ćelav</annotation>
-		<annotation cp="🧑🏻‍🦲">ćelav | neutralan pol | odrasla osoba | odrasla osoba: svetla koža i ćelav | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦲">ćelav | neutralan pol | odrasla osoba | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦲" type="tts">odrasla osoba: svetla koža i ćelav</annotation>
-		<annotation cp="🧑🏼‍🦲">ćelav | neutralan pol | odrasla osoba | odrasla osoba: srednje svetla koža i ćelav | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦲">ćelav | neutralan pol | odrasla osoba | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦲" type="tts">odrasla osoba: srednje svetla koža i ćelav</annotation>
-		<annotation cp="🧑🏽‍🦲">ćelav | neutralan pol | ni svetla ni tamna koža | odrasla osoba | odrasla osoba: ni svetla ni tamna koža i ćelav</annotation>
+		<annotation cp="🧑🏽‍🦲">ćelav | neutralan pol | ni svetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="🧑🏽‍🦲" type="tts">odrasla osoba: ni svetla ni tamna koža i ćelav</annotation>
-		<annotation cp="🧑🏾‍🦲">ćelav | neutralan pol | odrasla osoba | odrasla osoba: srednje tamna koža i ćelav | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦲">ćelav | neutralan pol | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦲" type="tts">odrasla osoba: srednje tamna koža i ćelav</annotation>
-		<annotation cp="🧑🏿‍🦲">ćelav | neutralan pol | odrasla osoba | odrasla osoba: tamna koža i ćelav | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦲">ćelav | neutralan pol | odrasla osoba | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦲" type="tts">odrasla osoba: tamna koža i ćelav</annotation>
-		<annotation cp="👨🏻">muškarac | muškarac: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻">muškarac | svetla koža</annotation>
 		<annotation cp="👨🏻" type="tts">muškarac: svetla koža</annotation>
-		<annotation cp="👨🏼">muškarac | muškarac: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼">muškarac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼" type="tts">muškarac: srednje svetla koža</annotation>
-		<annotation cp="👨🏽">muškarac | muškarac: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽">muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽" type="tts">muškarac: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾">muškarac | muškarac: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾">muškarac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾" type="tts">muškarac: srednje tamna koža</annotation>
-		<annotation cp="👨🏿">muškarac | muškarac: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿">muškarac | tamna koža</annotation>
 		<annotation cp="👨🏿" type="tts">muškarac: tamna koža</annotation>
-		<annotation cp="🧔🏻">brada | osoba sa bradom | osoba sa bradom: svetla koža | svetla koža</annotation>
+		<annotation cp="🧔🏻">brada | osoba sa bradom | svetla koža</annotation>
 		<annotation cp="🧔🏻" type="tts">osoba sa bradom: svetla koža</annotation>
-		<annotation cp="🧔🏼">brada | osoba sa bradom | osoba sa bradom: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧔🏼">brada | osoba sa bradom | srednje svetla koža</annotation>
 		<annotation cp="🧔🏼" type="tts">osoba sa bradom: srednje svetla koža</annotation>
-		<annotation cp="🧔🏽">brada | ni svetla ni tamna koža | osoba sa bradom | osoba sa bradom: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧔🏽">brada | ni svetla ni tamna koža | osoba sa bradom</annotation>
 		<annotation cp="🧔🏽" type="tts">osoba sa bradom: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧔🏾">brada | osoba sa bradom | osoba sa bradom: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧔🏾">brada | osoba sa bradom | srednje tamna koža</annotation>
 		<annotation cp="🧔🏾" type="tts">osoba sa bradom: srednje tamna koža</annotation>
-		<annotation cp="🧔🏿">brada | osoba sa bradom | osoba sa bradom: tamna koža | tamna koža</annotation>
+		<annotation cp="🧔🏿">brada | osoba sa bradom | tamna koža</annotation>
 		<annotation cp="🧔🏿" type="tts">osoba sa bradom: tamna koža</annotation>
-		<annotation cp="🧔🏻‍♂">brada | muškarac | muškarac: brada | muškarac: svetla koža i brada | svetla koža</annotation>
+		<annotation cp="🧔🏻‍♂">brada | muškarac | muškarac: brada | svetla koža</annotation>
 		<annotation cp="🧔🏻‍♂" type="tts">muškarac: svetla koža i brada</annotation>
-		<annotation cp="🧔🏼‍♂">brada | muškarac | muškarac: brada | muškarac: srednje svetla koža i brada | srednje svetla koža</annotation>
+		<annotation cp="🧔🏼‍♂">brada | muškarac | muškarac: brada | srednje svetla koža</annotation>
 		<annotation cp="🧔🏼‍♂" type="tts">muškarac: srednje svetla koža i brada</annotation>
-		<annotation cp="🧔🏽‍♂">brada | muškarac | muškarac: brada | muškarac: ni svetla ni tamna koža i brada | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧔🏽‍♂">brada | muškarac | muškarac: brada | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧔🏽‍♂" type="tts">muškarac: ni svetla ni tamna koža i brada</annotation>
-		<annotation cp="🧔🏾‍♂">brada | muškarac | muškarac: brada | muškarac: srednje tamna koža i brada | srednje tamna koža</annotation>
+		<annotation cp="🧔🏾‍♂">brada | muškarac | muškarac: brada | srednje tamna koža</annotation>
 		<annotation cp="🧔🏾‍♂" type="tts">muškarac: srednje tamna koža i brada</annotation>
-		<annotation cp="🧔🏿‍♂">brada | muškarac | muškarac: brada | muškarac: tamna koža i brada | tamna koža</annotation>
+		<annotation cp="🧔🏿‍♂">brada | muškarac | muškarac: brada | tamna koža</annotation>
 		<annotation cp="🧔🏿‍♂" type="tts">muškarac: tamna koža i brada</annotation>
-		<annotation cp="👱🏻‍♂">muškarac | plav muškarac | plav muškarac: svetla koža | plava kosa | svetla koža</annotation>
+		<annotation cp="👱🏻‍♂">muškarac | plav muškarac | plava kosa | svetla koža</annotation>
 		<annotation cp="👱🏻‍♂" type="tts">plav muškarac: svetla koža</annotation>
-		<annotation cp="👱🏼‍♂">muškarac | plav muškarac | plav muškarac: srednje svetla koža | plava kosa | srednje svetla koža</annotation>
+		<annotation cp="👱🏼‍♂">muškarac | plav muškarac | plava kosa | srednje svetla koža</annotation>
 		<annotation cp="👱🏼‍♂" type="tts">plav muškarac: srednje svetla koža</annotation>
-		<annotation cp="👱🏽‍♂">muškarac | ni svetla ni tamna koža | plav muškarac | plav muškarac: ni svetla ni tamna koža | plava kosa</annotation>
+		<annotation cp="👱🏽‍♂">muškarac | ni svetla ni tamna koža | plav muškarac | plava kosa</annotation>
 		<annotation cp="👱🏽‍♂" type="tts">plav muškarac: ni svetla ni tamna koža</annotation>
-		<annotation cp="👱🏾‍♂">muškarac | plav muškarac | plav muškarac: srednje tamna koža | plava kosa | srednje tamna koža</annotation>
+		<annotation cp="👱🏾‍♂">muškarac | plav muškarac | plava kosa | srednje tamna koža</annotation>
 		<annotation cp="👱🏾‍♂" type="tts">plav muškarac: srednje tamna koža</annotation>
-		<annotation cp="👱🏿‍♂">muškarac | plav muškarac | plav muškarac: tamna koža | plava kosa | tamna koža</annotation>
+		<annotation cp="👱🏿‍♂">muškarac | plav muškarac | plava kosa | tamna koža</annotation>
 		<annotation cp="👱🏿‍♂" type="tts">plav muškarac: tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: muškarac, muškarac i svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏻">muškarac | par | poljubac | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac i svetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: muškarac, muškarac, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, svetla koža i ni svetla ni tamna koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: muškarac, muškarac, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: muškarac, muškarac, svetla koža i tamna koža | svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏿">muškarac | par | poljubac | svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, svetla koža i tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: muškarac, muškarac, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏻">muškarac | par | poljubac | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: muškarac, muškarac i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac i srednje svetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: muškarac, muškarac, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: muškarac, muškarac, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏿">muškarac | par | poljubac | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏻">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, ni svetla ni tamna koža i svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏻">muškarac | ni svetla ni tamna koža | par | poljubac | svetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏼">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏼">muškarac | ni svetla ni tamna koža | par | poljubac | srednje svetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac i ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏾">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏾">muškarac | ni svetla ni tamna koža | par | poljubac | srednje tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏿">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, ni svetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏿">muškarac | ni svetla ni tamna koža | par | poljubac | tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏻">muškarac | par | poljubac | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: muškarac, muškarac i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac i srednje tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏿">muškarac | par | poljubac | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: muškarac, muškarac, tamna koža i svetla koža | svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏻">muškarac | par | poljubac | svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: muškarac, muškarac, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: muškarac, muškarac, tamna koža i ni svetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: muškarac, muškarac, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: muškarac, muškarac i tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏿">muškarac | par | poljubac | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac i tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac i svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac i svetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, svetla koža i ni svetla ni tamna koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, svetla koža i tamna koža | svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, svetla koža i tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac i srednje svetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏻">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏻">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | svetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏼">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏼">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje svetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac i ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏾">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏾">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏿">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏿">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac i srednje tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i svetla koža | svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i ni svetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac, muškarac i tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac i tamna koža</annotation>
-		<annotation cp="👨‍🦰">crvena kosa | muškarac | muškarac: crvena kosa</annotation>
+		<annotation cp="👨‍🦰">crvena kosa | muškarac</annotation>
 		<annotation cp="👨‍🦰" type="tts">muškarac: crvena kosa</annotation>
-		<annotation cp="👨🏻‍🦰">crvena kosa | muškarac | muškarac: svetla koža i crvena kosa | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦰">crvena kosa | muškarac | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦰" type="tts">muškarac: svetla koža i crvena kosa</annotation>
-		<annotation cp="👨🏼‍🦰">crvena kosa | muškarac | muškarac: srednje svetla koža i crvena kosa | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦰">crvena kosa | muškarac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦰" type="tts">muškarac: srednje svetla koža i crvena kosa</annotation>
-		<annotation cp="👨🏽‍🦰">crvena kosa | muškarac | muškarac: ni svetla ni tamna koža i crvena kosa | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🦰">crvena kosa | muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🦰" type="tts">muškarac: ni svetla ni tamna koža i crvena kosa</annotation>
-		<annotation cp="👨🏾‍🦰">crvena kosa | muškarac | muškarac: srednje tamna koža i crvena kosa | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦰">crvena kosa | muškarac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦰" type="tts">muškarac: srednje tamna koža i crvena kosa</annotation>
-		<annotation cp="👨🏿‍🦰">crvena kosa | muškarac | muškarac: tamna koža i crvena kosa | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦰">crvena kosa | muškarac | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦰" type="tts">muškarac: tamna koža i crvena kosa</annotation>
-		<annotation cp="👨‍🦱">kovrdžava kosa | muškarac | muškarac: kovrdžava kosa</annotation>
+		<annotation cp="👨‍🦱">kovrdžava kosa | muškarac</annotation>
 		<annotation cp="👨‍🦱" type="tts">muškarac: kovrdžava kosa</annotation>
-		<annotation cp="👨🏻‍🦱">kovrdžava kosa | muškarac | muškarac: svetla koža i kovrdžava kosa | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦱">kovrdžava kosa | muškarac | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦱" type="tts">muškarac: svetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👨🏼‍🦱">kovrdžava kosa | muškarac | muškarac: srednje svetla koža i kovrdžava kosa | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦱">kovrdžava kosa | muškarac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦱" type="tts">muškarac: srednje svetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👨🏽‍🦱">kovrdžava kosa | muškarac | muškarac: ni svetla ni tamna koža i kovrdžava kosa | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🦱">kovrdžava kosa | muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🦱" type="tts">muškarac: ni svetla ni tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="👨🏾‍🦱">kovrdžava kosa | muškarac | muškarac: srednje tamna koža i kovrdžava kosa | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦱">kovrdžava kosa | muškarac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦱" type="tts">muškarac: srednje tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="👨🏿‍🦱">kovrdžava kosa | muškarac | muškarac: tamna koža i kovrdžava kosa | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦱">kovrdžava kosa | muškarac | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦱" type="tts">muškarac: tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="👨‍🦳">muškarac | muškarac: seda kosa | seda kosa</annotation>
+		<annotation cp="👨‍🦳">muškarac | seda kosa</annotation>
 		<annotation cp="👨‍🦳" type="tts">muškarac: seda kosa</annotation>
-		<annotation cp="👨🏻‍🦳">muškarac | muškarac: svetla koža i seda kosa | seda kosa | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦳">muškarac | seda kosa | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦳" type="tts">muškarac: svetla koža i seda kosa</annotation>
-		<annotation cp="👨🏼‍🦳">muškarac | muškarac: srednje svetla koža i seda kosa | seda kosa | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦳">muškarac | seda kosa | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦳" type="tts">muškarac: srednje svetla koža i seda kosa</annotation>
-		<annotation cp="👨🏽‍🦳">muškarac | muškarac: ni svetla ni tamna koža i seda kosa | ni svetla ni tamna koža | seda kosa</annotation>
+		<annotation cp="👨🏽‍🦳">muškarac | ni svetla ni tamna koža | seda kosa</annotation>
 		<annotation cp="👨🏽‍🦳" type="tts">muškarac: ni svetla ni tamna koža i seda kosa</annotation>
-		<annotation cp="👨🏾‍🦳">muškarac | muškarac: srednje tamna koža i seda kosa | seda kosa | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦳">muškarac | seda kosa | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦳" type="tts">muškarac: srednje tamna koža i seda kosa</annotation>
-		<annotation cp="👨🏿‍🦳">muškarac | muškarac: tamna koža i seda kosa | seda kosa | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦳">muškarac | seda kosa | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦳" type="tts">muškarac: tamna koža i seda kosa</annotation>
-		<annotation cp="👨‍🦲">ćelav | muškarac | muškarac: ćelav</annotation>
+		<annotation cp="👨‍🦲">ćelav | muškarac</annotation>
 		<annotation cp="👨‍🦲" type="tts">muškarac: ćelav</annotation>
-		<annotation cp="👨🏻‍🦲">ćelav | muškarac | muškarac: svetla koža i ćelav | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦲">ćelav | muškarac | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦲" type="tts">muškarac: svetla koža i ćelav</annotation>
-		<annotation cp="👨🏼‍🦲">ćelav | muškarac | muškarac: srednje svetla koža i ćelav | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦲">ćelav | muškarac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦲" type="tts">muškarac: srednje svetla koža i ćelav</annotation>
-		<annotation cp="👨🏽‍🦲">ćelav | muškarac | muškarac: ni svetla ni tamna koža i ćelav | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🦲">ćelav | muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🦲" type="tts">muškarac: ni svetla ni tamna koža i ćelav</annotation>
-		<annotation cp="👨🏾‍🦲">ćelav | muškarac | muškarac: srednje tamna koža i ćelav | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦲">ćelav | muškarac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦲" type="tts">muškarac: srednje tamna koža i ćelav</annotation>
-		<annotation cp="👨🏿‍🦲">ćelav | muškarac | muškarac: tamna koža i ćelav | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦲">ćelav | muškarac | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦲" type="tts">muškarac: tamna koža i ćelav</annotation>
-		<annotation cp="👩🏻">svetla koža | žena | žena: svetla koža</annotation>
+		<annotation cp="👩🏻">svetla koža | žena</annotation>
 		<annotation cp="👩🏻" type="tts">žena: svetla koža</annotation>
-		<annotation cp="👩🏼">srednje svetla koža | žena | žena: srednje svetla koža</annotation>
+		<annotation cp="👩🏼">srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼" type="tts">žena: srednje svetla koža</annotation>
-		<annotation cp="👩🏽">ni svetla ni tamna koža | žena | žena: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽">ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽" type="tts">žena: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾">srednje tamna koža | žena | žena: srednje tamna koža</annotation>
+		<annotation cp="👩🏾">srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾" type="tts">žena: srednje tamna koža</annotation>
-		<annotation cp="👩🏿">tamna koža | žena | žena: tamna koža</annotation>
+		<annotation cp="👩🏿">tamna koža | žena</annotation>
 		<annotation cp="👩🏿" type="tts">žena: tamna koža</annotation>
-		<annotation cp="🧔🏻‍♀">brada | svetla koža | žena | žena: brada | žena: svetla koža i brada</annotation>
+		<annotation cp="🧔🏻‍♀">brada | svetla koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏻‍♀" type="tts">žena: svetla koža i brada</annotation>
-		<annotation cp="🧔🏼‍♀">brada | srednje svetla koža | žena | žena: brada | žena: srednje svetla koža i brada</annotation>
+		<annotation cp="🧔🏼‍♀">brada | srednje svetla koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏼‍♀" type="tts">žena: srednje svetla koža i brada</annotation>
-		<annotation cp="🧔🏽‍♀">brada | ni svetla ni tamna koža | žena | žena: brada | žena: ni svetla ni tamna koža i brada</annotation>
+		<annotation cp="🧔🏽‍♀">brada | ni svetla ni tamna koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏽‍♀" type="tts">žena: ni svetla ni tamna koža i brada</annotation>
-		<annotation cp="🧔🏾‍♀">brada | srednje tamna koža | žena | žena: brada | žena: srednje tamna koža i brada</annotation>
+		<annotation cp="🧔🏾‍♀">brada | srednje tamna koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏾‍♀" type="tts">žena: srednje tamna koža i brada</annotation>
-		<annotation cp="🧔🏿‍♀">brada | tamna koža | žena | žena: brada | žena: tamna koža i brada</annotation>
+		<annotation cp="🧔🏿‍♀">brada | tamna koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏿‍♀" type="tts">žena: tamna koža i brada</annotation>
-		<annotation cp="👱🏻‍♀">plava kosa | plavuša | plavuša: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👱🏻‍♀">plava kosa | plavuša | svetla koža | žena</annotation>
 		<annotation cp="👱🏻‍♀" type="tts">plavuša: svetla koža</annotation>
-		<annotation cp="👱🏼‍♀">plava kosa | plavuša | plavuša: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👱🏼‍♀">plava kosa | plavuša | srednje svetla koža | žena</annotation>
 		<annotation cp="👱🏼‍♀" type="tts">plavuša: srednje svetla koža</annotation>
-		<annotation cp="👱🏽‍♀">ni svetla ni tamna koža | plava kosa | plavuša | plavuša: ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👱🏽‍♀">ni svetla ni tamna koža | plava kosa | plavuša | žena</annotation>
 		<annotation cp="👱🏽‍♀" type="tts">plavuša: ni svetla ni tamna koža</annotation>
-		<annotation cp="👱🏾‍♀">plava kosa | plavuša | plavuša: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👱🏾‍♀">plava kosa | plavuša | srednje tamna koža | žena</annotation>
 		<annotation cp="👱🏾‍♀" type="tts">plavuša: srednje tamna koža</annotation>
-		<annotation cp="👱🏿‍♀">plava kosa | plavuša | plavuša: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👱🏿‍♀">plava kosa | plavuša | tamna koža | žena</annotation>
 		<annotation cp="👱🏿‍♀" type="tts">plavuša: tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: žena, muškarac i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏻">muškarac | par | poljubac | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac i svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: žena, muškarac, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, svetla koža i ni svetla ni tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: žena, muškarac, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: žena, muškarac, svetla koža i tamna koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏿">muškarac | par | poljubac | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: žena, muškarac, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏻">muškarac | par | poljubac | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: žena, muškarac i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac i srednje svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: žena, muškarac, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: žena, muškarac, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏿">muškarac | par | poljubac | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏻">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, ni svetla ni tamna koža i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏻">muškarac | ni svetla ni tamna koža | par | poljubac | svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏼">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏼">muškarac | ni svetla ni tamna koža | par | poljubac | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac i ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏾">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏾">muškarac | ni svetla ni tamna koža | par | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏿">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, ni svetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏿">muškarac | ni svetla ni tamna koža | par | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: žena, muškarac, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏻">muškarac | par | poljubac | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: žena, muškarac, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: žena, muškarac i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac i srednje tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: žena, muškarac, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏿">muškarac | par | poljubac | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏻">muškarac | par | poljubac | poljubac: žena, muškarac, tamna koža i svetla koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏻">muškarac | par | poljubac | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏼">muškarac | par | poljubac | poljubac: žena, muškarac, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏼">muškarac | par | poljubac | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | poljubac: žena, muškarac, tamna koža i ni svetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏽">muškarac | ni svetla ni tamna koža | par | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏾">muškarac | par | poljubac | poljubac: žena, muškarac, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏾">muškarac | par | poljubac | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏿">muškarac | par | poljubac | poljubac: žena, muškarac i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏿">muškarac | par | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac i tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏻">par | poljubac | poljubac: žena, žena i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏻">par | poljubac | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena i svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏼">par | poljubac | poljubac: žena, žena, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏼">par | poljubac | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, svetla koža i ni svetla ni tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏾">par | poljubac | poljubac: žena, žena, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏾">par | poljubac | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏿">par | poljubac | poljubac: žena, žena, svetla koža i tamna koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏿">par | poljubac | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏻">par | poljubac | poljubac: žena, žena, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏻">par | poljubac | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏼">par | poljubac | poljubac: žena, žena i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏼">par | poljubac | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena i srednje svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏾">par | poljubac | poljubac: žena, žena, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏾">par | poljubac | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏿">par | poljubac | poljubac: žena, žena, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏿">par | poljubac | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏻">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, ni svetla ni tamna koža i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏻">ni svetla ni tamna koža | par | poljubac | svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏼">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏼">ni svetla ni tamna koža | par | poljubac | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena i ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏾">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏾">ni svetla ni tamna koža | par | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏿">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, ni svetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏿">ni svetla ni tamna koža | par | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏻">par | poljubac | poljubac: žena, žena, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏻">par | poljubac | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏼">par | poljubac | poljubac: žena, žena, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏼">par | poljubac | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏾">par | poljubac | poljubac: žena, žena i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏾">par | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena i srednje tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏿">par | poljubac | poljubac: žena, žena, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏿">par | poljubac | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏻">par | poljubac | poljubac: žena, žena, tamna koža i svetla koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏻">par | poljubac | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏼">par | poljubac | poljubac: žena, žena, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏼">par | poljubac | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | poljubac: žena, žena, tamna koža i ni svetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏽">ni svetla ni tamna koža | par | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏾">par | poljubac | poljubac: žena, žena, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏾">par | poljubac | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏿">par | poljubac | poljubac: žena, žena i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏿">par | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena i tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac i svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, svetla koža i ni svetla ni tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, svetla koža i tamna koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac i srednje svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏻">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, ni svetla ni tamna koža i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏻">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏼">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏼">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac i ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏾">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏾">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏿">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, ni svetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏿">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac i srednje tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, tamna koža i svetla koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏻">ljubav | muškarac | par | par sa srcem | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏼">ljubav | muškarac | par | par sa srcem | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, muškarac, tamna koža i ni svetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏽">ljubav | muškarac | ni svetla ni tamna koža | par | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏾">ljubav | muškarac | par | par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | par sa srcem: žena, muškarac i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏿">ljubav | muškarac | par | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac i tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏻">ljubav | par | par sa srcem | par sa srcem: žena, žena i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏻">ljubav | par | par sa srcem | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏻" type="tts">par sa srcem: žena, žena i svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏼">ljubav | par | par sa srcem | par sa srcem: žena, žena, svetla koža i srednje svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏼">ljubav | par | par sa srcem | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, svetla koža i ni svetla ni tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏾">ljubav | par | par sa srcem | par sa srcem: žena, žena, svetla koža i srednje tamna koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏾">ljubav | par | par sa srcem | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏿">ljubav | par | par sa srcem | par sa srcem: žena, žena, svetla koža i tamna koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏿">ljubav | par | par sa srcem | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏻">ljubav | par | par sa srcem | par sa srcem: žena, žena, srednje svetla koža i svetla koža | srednje svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏻">ljubav | par | par sa srcem | srednje svetla koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏼">ljubav | par | par sa srcem | par sa srcem: žena, žena i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏼">ljubav | par | par sa srcem | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏼" type="tts">par sa srcem: žena, žena i srednje svetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏾">ljubav | par | par sa srcem | par sa srcem: žena, žena, srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏾">ljubav | par | par sa srcem | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏿">ljubav | par | par sa srcem | par sa srcem: žena, žena, srednje svetla koža i tamna koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏿">ljubav | par | par sa srcem | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏻">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, ni svetla ni tamna koža i svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏻">ljubav | ni svetla ni tamna koža | par | par sa srcem | svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏼">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏼">ljubav | ni svetla ni tamna koža | par | par sa srcem | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena i ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏽" type="tts">par sa srcem: žena, žena i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏾">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏾">ljubav | ni svetla ni tamna koža | par | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏿">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, ni svetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏿">ljubav | ni svetla ni tamna koža | par | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏻">ljubav | par | par sa srcem | par sa srcem: žena, žena, srednje tamna koža i svetla koža | srednje tamna koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏻">ljubav | par | par sa srcem | srednje tamna koža | svetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏼">ljubav | par | par sa srcem | par sa srcem: žena, žena, srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏼">ljubav | par | par sa srcem | srednje svetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏾">ljubav | par | par sa srcem | par sa srcem: žena, žena i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏾">ljubav | par | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏾" type="tts">par sa srcem: žena, žena i srednje tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏿">ljubav | par | par sa srcem | par sa srcem: žena, žena, srednje tamna koža i tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏿">ljubav | par | par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏻">ljubav | par | par sa srcem | par sa srcem: žena, žena, tamna koža i svetla koža | svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏻">ljubav | par | par sa srcem | svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏼">ljubav | par | par sa srcem | par sa srcem: žena, žena, tamna koža i srednje svetla koža | srednje svetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏼">ljubav | par | par sa srcem | srednje svetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: žena, žena, tamna koža i ni svetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏾">ljubav | par | par sa srcem | par sa srcem: žena, žena, tamna koža i srednje tamna koža | srednje tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏾">ljubav | par | par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏿">ljubav | par | par sa srcem | par sa srcem: žena, žena i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏿">ljubav | par | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏿" type="tts">par sa srcem: žena, žena i tamna koža</annotation>
-		<annotation cp="👩‍🦰">crvena kosa | žena | žena: crvena kosa</annotation>
+		<annotation cp="👩‍🦰">crvena kosa | žena</annotation>
 		<annotation cp="👩‍🦰" type="tts">žena: crvena kosa</annotation>
-		<annotation cp="👩🏻‍🦰">crvena kosa | svetla koža | žena | žena: svetla koža i crvena kosa</annotation>
+		<annotation cp="👩🏻‍🦰">crvena kosa | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦰" type="tts">žena: svetla koža i crvena kosa</annotation>
-		<annotation cp="👩🏼‍🦰">crvena kosa | srednje svetla koža | žena | žena: srednje svetla koža i crvena kosa</annotation>
+		<annotation cp="👩🏼‍🦰">crvena kosa | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦰" type="tts">žena: srednje svetla koža i crvena kosa</annotation>
-		<annotation cp="👩🏽‍🦰">crvena kosa | ni svetla ni tamna koža | žena | žena: ni svetla ni tamna koža i crvena kosa</annotation>
+		<annotation cp="👩🏽‍🦰">crvena kosa | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🦰" type="tts">žena: ni svetla ni tamna koža i crvena kosa</annotation>
-		<annotation cp="👩🏾‍🦰">crvena kosa | srednje tamna koža | žena | žena: srednje tamna koža i crvena kosa</annotation>
+		<annotation cp="👩🏾‍🦰">crvena kosa | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🦰" type="tts">žena: srednje tamna koža i crvena kosa</annotation>
-		<annotation cp="👩🏿‍🦰">crvena kosa | tamna koža | žena | žena: tamna koža i crvena kosa</annotation>
+		<annotation cp="👩🏿‍🦰">crvena kosa | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦰" type="tts">žena: tamna koža i crvena kosa</annotation>
-		<annotation cp="👩‍🦱">kovrdžava kosa | žena | žena: kovrdžava kosa</annotation>
+		<annotation cp="👩‍🦱">kovrdžava kosa | žena</annotation>
 		<annotation cp="👩‍🦱" type="tts">žena: kovrdžava kosa</annotation>
-		<annotation cp="👩🏻‍🦱">kovrdžava kosa | svetla koža | žena | žena: svetla koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏻‍🦱">kovrdžava kosa | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦱" type="tts">žena: svetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👩🏼‍🦱">kovrdžava kosa | srednje svetla koža | žena | žena: srednje svetla koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏼‍🦱">kovrdžava kosa | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦱" type="tts">žena: srednje svetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👩🏽‍🦱">kovrdžava kosa | ni svetla ni tamna koža | žena | žena: ni svetla ni tamna koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏽‍🦱">kovrdžava kosa | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🦱" type="tts">žena: ni svetla ni tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="👩🏾‍🦱">kovrdžava kosa | srednje tamna koža | žena | žena: srednje tamna koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏾‍🦱">kovrdžava kosa | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🦱" type="tts">žena: srednje tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="👩🏿‍🦱">kovrdžava kosa | tamna koža | žena | žena: tamna koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏿‍🦱">kovrdžava kosa | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦱" type="tts">žena: tamna koža i kovrdžava kosa</annotation>
-		<annotation cp="👩‍🦳">seda kosa | žena | žena: seda kosa</annotation>
+		<annotation cp="👩‍🦳">seda kosa | žena</annotation>
 		<annotation cp="👩‍🦳" type="tts">žena: seda kosa</annotation>
-		<annotation cp="👩🏻‍🦳">seda kosa | svetla koža | žena | žena: svetla koža i seda kosa</annotation>
+		<annotation cp="👩🏻‍🦳">seda kosa | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦳" type="tts">žena: svetla koža i seda kosa</annotation>
-		<annotation cp="👩🏼‍🦳">seda kosa | srednje svetla koža | žena | žena: srednje svetla koža i seda kosa</annotation>
+		<annotation cp="👩🏼‍🦳">seda kosa | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦳" type="tts">žena: srednje svetla koža i seda kosa</annotation>
-		<annotation cp="👩🏽‍🦳">ni svetla ni tamna koža | seda kosa | žena | žena: ni svetla ni tamna koža i seda kosa</annotation>
+		<annotation cp="👩🏽‍🦳">ni svetla ni tamna koža | seda kosa | žena</annotation>
 		<annotation cp="👩🏽‍🦳" type="tts">žena: ni svetla ni tamna koža i seda kosa</annotation>
-		<annotation cp="👩🏾‍🦳">seda kosa | srednje tamna koža | žena | žena: srednje tamna koža i seda kosa</annotation>
+		<annotation cp="👩🏾‍🦳">seda kosa | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🦳" type="tts">žena: srednje tamna koža i seda kosa</annotation>
-		<annotation cp="👩🏿‍🦳">seda kosa | tamna koža | žena | žena: tamna koža i seda kosa</annotation>
+		<annotation cp="👩🏿‍🦳">seda kosa | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦳" type="tts">žena: tamna koža i seda kosa</annotation>
-		<annotation cp="👩‍🦲">ćelav | žena | žena: ćelav</annotation>
+		<annotation cp="👩‍🦲">ćelav | žena</annotation>
 		<annotation cp="👩‍🦲" type="tts">žena: ćelav</annotation>
-		<annotation cp="👩🏻‍🦲">ćelav | svetla koža | žena | žena: svetla koža i ćelav</annotation>
+		<annotation cp="👩🏻‍🦲">ćelav | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦲" type="tts">žena: svetla koža i ćelav</annotation>
-		<annotation cp="👩🏼‍🦲">ćelav | srednje svetla koža | žena | žena: srednje svetla koža i ćelav</annotation>
+		<annotation cp="👩🏼‍🦲">ćelav | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦲" type="tts">žena: srednje svetla koža i ćelav</annotation>
-		<annotation cp="👩🏽‍🦲">ćelav | ni svetla ni tamna koža | žena | žena: ni svetla ni tamna koža i ćelav</annotation>
+		<annotation cp="👩🏽‍🦲">ćelav | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🦲" type="tts">žena: ni svetla ni tamna koža i ćelav</annotation>
-		<annotation cp="👩🏾‍🦲">ćelav | srednje tamna koža | žena | žena: srednje tamna koža i ćelav</annotation>
+		<annotation cp="👩🏾‍🦲">ćelav | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🦲" type="tts">žena: srednje tamna koža i ćelav</annotation>
-		<annotation cp="👩🏿‍🦲">ćelav | tamna koža | žena | žena: tamna koža i ćelav</annotation>
+		<annotation cp="👩🏿‍🦲">ćelav | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦲" type="tts">žena: tamna koža i ćelav</annotation>
-		<annotation cp="🧓🏻">neutralan pol | starija odrasla osoba | starija odrasla osoba: svetla koža | starost | svetla koža</annotation>
+		<annotation cp="🧓🏻">neutralan pol | starija odrasla osoba | starost | svetla koža</annotation>
 		<annotation cp="🧓🏻" type="tts">starija odrasla osoba: svetla koža</annotation>
-		<annotation cp="🧓🏼">neutralan pol | srednje svetla koža | starija odrasla osoba | starija odrasla osoba: srednje svetla koža | starost</annotation>
+		<annotation cp="🧓🏼">neutralan pol | srednje svetla koža | starija odrasla osoba | starost</annotation>
 		<annotation cp="🧓🏼" type="tts">starija odrasla osoba: srednje svetla koža</annotation>
-		<annotation cp="🧓🏽">neutralan pol | ni svetla ni tamna koža | starija odrasla osoba | starija odrasla osoba: ni svetla ni tamna koža | starost</annotation>
+		<annotation cp="🧓🏽">neutralan pol | ni svetla ni tamna koža | starija odrasla osoba | starost</annotation>
 		<annotation cp="🧓🏽" type="tts">starija odrasla osoba: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧓🏾">neutralan pol | srednje tamna koža | starija odrasla osoba | starija odrasla osoba: srednje tamna koža | starost</annotation>
+		<annotation cp="🧓🏾">neutralan pol | srednje tamna koža | starija odrasla osoba | starost</annotation>
 		<annotation cp="🧓🏾" type="tts">starija odrasla osoba: srednje tamna koža</annotation>
-		<annotation cp="🧓🏿">neutralan pol | starija odrasla osoba | starija odrasla osoba: tamna koža | starost | tamna koža</annotation>
+		<annotation cp="🧓🏿">neutralan pol | starija odrasla osoba | starost | tamna koža</annotation>
 		<annotation cp="🧓🏿" type="tts">starija odrasla osoba: tamna koža</annotation>
-		<annotation cp="👴🏻">muškarac | odrasla osoba | starac | starac: svetla koža | svetla koža</annotation>
+		<annotation cp="👴🏻">muškarac | odrasla osoba | starac | svetla koža</annotation>
 		<annotation cp="👴🏻" type="tts">starac: svetla koža</annotation>
-		<annotation cp="👴🏼">muškarac | odrasla osoba | srednje svetla koža | starac | starac: srednje svetla koža</annotation>
+		<annotation cp="👴🏼">muškarac | odrasla osoba | srednje svetla koža | starac</annotation>
 		<annotation cp="👴🏼" type="tts">starac: srednje svetla koža</annotation>
-		<annotation cp="👴🏽">muškarac | ni svetla ni tamna koža | odrasla osoba | starac | starac: ni svetla ni tamna koža</annotation>
+		<annotation cp="👴🏽">muškarac | ni svetla ni tamna koža | odrasla osoba | starac</annotation>
 		<annotation cp="👴🏽" type="tts">starac: ni svetla ni tamna koža</annotation>
-		<annotation cp="👴🏾">muškarac | odrasla osoba | srednje tamna koža | starac | starac: srednje tamna koža</annotation>
+		<annotation cp="👴🏾">muškarac | odrasla osoba | srednje tamna koža | starac</annotation>
 		<annotation cp="👴🏾" type="tts">starac: srednje tamna koža</annotation>
-		<annotation cp="👴🏿">muškarac | odrasla osoba | starac | starac: tamna koža | tamna koža</annotation>
+		<annotation cp="👴🏿">muškarac | odrasla osoba | starac | tamna koža</annotation>
 		<annotation cp="👴🏿" type="tts">starac: tamna koža</annotation>
-		<annotation cp="👵🏻">odrasla osoba | starica | starica: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👵🏻">odrasla osoba | starica | svetla koža | žena</annotation>
 		<annotation cp="👵🏻" type="tts">starica: svetla koža</annotation>
-		<annotation cp="👵🏼">odrasla osoba | srednje svetla koža | starica | starica: srednje svetla koža | žena</annotation>
+		<annotation cp="👵🏼">odrasla osoba | srednje svetla koža | starica | žena</annotation>
 		<annotation cp="👵🏼" type="tts">starica: srednje svetla koža</annotation>
-		<annotation cp="👵🏽">ni svetla ni tamna koža | odrasla osoba | starica | starica: ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👵🏽">ni svetla ni tamna koža | odrasla osoba | starica | žena</annotation>
 		<annotation cp="👵🏽" type="tts">starica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👵🏾">odrasla osoba | srednje tamna koža | starica | starica: srednje tamna koža | žena</annotation>
+		<annotation cp="👵🏾">odrasla osoba | srednje tamna koža | starica | žena</annotation>
 		<annotation cp="👵🏾" type="tts">starica: srednje tamna koža</annotation>
-		<annotation cp="👵🏿">odrasla osoba | starica | starica: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👵🏿">odrasla osoba | starica | tamna koža | žena</annotation>
 		<annotation cp="👵🏿" type="tts">starica: tamna koža</annotation>
-		<annotation cp="🙍🏻">kretanje | mrštenje | namrštena osoba | namrštena osoba: svetla koža | svetla koža</annotation>
+		<annotation cp="🙍🏻">kretanje | mrštenje | namrštena osoba | svetla koža</annotation>
 		<annotation cp="🙍🏻" type="tts">namrštena osoba: svetla koža</annotation>
-		<annotation cp="🙍🏼">kretanje | mrštenje | namrštena osoba | namrštena osoba: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🙍🏼">kretanje | mrštenje | namrštena osoba | srednje svetla koža</annotation>
 		<annotation cp="🙍🏼" type="tts">namrštena osoba: srednje svetla koža</annotation>
-		<annotation cp="🙍🏽">kretanje | mrštenje | namrštena osoba | namrštena osoba: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🙍🏽">kretanje | mrštenje | namrštena osoba | ni svetla ni tamna koža</annotation>
 		<annotation cp="🙍🏽" type="tts">namrštena osoba: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙍🏾">kretanje | mrštenje | namrštena osoba | namrštena osoba: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🙍🏾">kretanje | mrštenje | namrštena osoba | srednje tamna koža</annotation>
 		<annotation cp="🙍🏾" type="tts">namrštena osoba: srednje tamna koža</annotation>
-		<annotation cp="🙍🏿">kretanje | mrštenje | namrštena osoba | namrštena osoba: tamna koža | tamna koža</annotation>
+		<annotation cp="🙍🏿">kretanje | mrštenje | namrštena osoba | tamna koža</annotation>
 		<annotation cp="🙍🏿" type="tts">namrštena osoba: tamna koža</annotation>
-		<annotation cp="🙍🏻‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: svetla koža | svetla koža</annotation>
+		<annotation cp="🙍🏻‍♂">mrštenje | muškarac | namršten muškarac | svetla koža</annotation>
 		<annotation cp="🙍🏻‍♂" type="tts">namršten muškarac: svetla koža</annotation>
-		<annotation cp="🙍🏼‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🙍🏼‍♂">mrštenje | muškarac | namršten muškarac | srednje svetla koža</annotation>
 		<annotation cp="🙍🏼‍♂" type="tts">namršten muškarac: srednje svetla koža</annotation>
-		<annotation cp="🙍🏽‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🙍🏽‍♂">mrštenje | muškarac | namršten muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="🙍🏽‍♂" type="tts">namršten muškarac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙍🏾‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🙍🏾‍♂">mrštenje | muškarac | namršten muškarac | srednje tamna koža</annotation>
 		<annotation cp="🙍🏾‍♂" type="tts">namršten muškarac: srednje tamna koža</annotation>
-		<annotation cp="🙍🏿‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: tamna koža | tamna koža</annotation>
+		<annotation cp="🙍🏿‍♂">mrštenje | muškarac | namršten muškarac | tamna koža</annotation>
 		<annotation cp="🙍🏿‍♂" type="tts">namršten muškarac: tamna koža</annotation>
-		<annotation cp="🙍🏻‍♀">mrštenje | namrštena žena | namrštena žena: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="🙍🏻‍♀">mrštenje | namrštena žena | svetla koža | žena</annotation>
 		<annotation cp="🙍🏻‍♀" type="tts">namrštena žena: svetla koža</annotation>
-		<annotation cp="🙍🏼‍♀">mrštenje | namrštena žena | namrštena žena: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="🙍🏼‍♀">mrštenje | namrštena žena | srednje svetla koža | žena</annotation>
 		<annotation cp="🙍🏼‍♀" type="tts">namrštena žena: srednje svetla koža</annotation>
-		<annotation cp="🙍🏽‍♀">mrštenje | namrštena žena | namrštena žena: ni svetla ni tamna koža | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🙍🏽‍♀">mrštenje | namrštena žena | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="🙍🏽‍♀" type="tts">namrštena žena: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙍🏾‍♀">mrštenje | namrštena žena | namrštena žena: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="🙍🏾‍♀">mrštenje | namrštena žena | srednje tamna koža | žena</annotation>
 		<annotation cp="🙍🏾‍♀" type="tts">namrštena žena: srednje tamna koža</annotation>
-		<annotation cp="🙍🏿‍♀">mrštenje | namrštena žena | namrštena žena: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="🙍🏿‍♀">mrštenje | namrštena žena | tamna koža | žena</annotation>
 		<annotation cp="🙍🏿‍♀" type="tts">namrštena žena: tamna koža</annotation>
-		<annotation cp="🙎🏻">durenje | kretanje | nadurena osoba | nadurena osoba: svetla koža | svetla koža</annotation>
+		<annotation cp="🙎🏻">durenje | kretanje | nadurena osoba | svetla koža</annotation>
 		<annotation cp="🙎🏻" type="tts">nadurena osoba: svetla koža</annotation>
-		<annotation cp="🙎🏼">durenje | kretanje | nadurena osoba | nadurena osoba: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🙎🏼">durenje | kretanje | nadurena osoba | srednje svetla koža</annotation>
 		<annotation cp="🙎🏼" type="tts">nadurena osoba: srednje svetla koža</annotation>
-		<annotation cp="🙎🏽">durenje | kretanje | nadurena osoba | nadurena osoba: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🙎🏽">durenje | kretanje | nadurena osoba | ni svetla ni tamna koža</annotation>
 		<annotation cp="🙎🏽" type="tts">nadurena osoba: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙎🏾">durenje | kretanje | nadurena osoba | nadurena osoba: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🙎🏾">durenje | kretanje | nadurena osoba | srednje tamna koža</annotation>
 		<annotation cp="🙎🏾" type="tts">nadurena osoba: srednje tamna koža</annotation>
-		<annotation cp="🙎🏿">durenje | kretanje | nadurena osoba | nadurena osoba: tamna koža | tamna koža</annotation>
+		<annotation cp="🙎🏿">durenje | kretanje | nadurena osoba | tamna koža</annotation>
 		<annotation cp="🙎🏿" type="tts">nadurena osoba: tamna koža</annotation>
-		<annotation cp="🙎🏻‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: svetla koža | svetla koža</annotation>
+		<annotation cp="🙎🏻‍♂">durenje | muškarac | naduren muškarac | svetla koža</annotation>
 		<annotation cp="🙎🏻‍♂" type="tts">naduren muškarac: svetla koža</annotation>
-		<annotation cp="🙎🏼‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🙎🏼‍♂">durenje | muškarac | naduren muškarac | srednje svetla koža</annotation>
 		<annotation cp="🙎🏼‍♂" type="tts">naduren muškarac: srednje svetla koža</annotation>
-		<annotation cp="🙎🏽‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🙎🏽‍♂">durenje | muškarac | naduren muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="🙎🏽‍♂" type="tts">naduren muškarac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙎🏾‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🙎🏾‍♂">durenje | muškarac | naduren muškarac | srednje tamna koža</annotation>
 		<annotation cp="🙎🏾‍♂" type="tts">naduren muškarac: srednje tamna koža</annotation>
-		<annotation cp="🙎🏿‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: tamna koža | tamna koža</annotation>
+		<annotation cp="🙎🏿‍♂">durenje | muškarac | naduren muškarac | tamna koža</annotation>
 		<annotation cp="🙎🏿‍♂" type="tts">naduren muškarac: tamna koža</annotation>
-		<annotation cp="🙎🏻‍♀">durenje | nadurena žena | nadurena žena: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="🙎🏻‍♀">durenje | nadurena žena | svetla koža | žena</annotation>
 		<annotation cp="🙎🏻‍♀" type="tts">nadurena žena: svetla koža</annotation>
-		<annotation cp="🙎🏼‍♀">durenje | nadurena žena | nadurena žena: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="🙎🏼‍♀">durenje | nadurena žena | srednje svetla koža | žena</annotation>
 		<annotation cp="🙎🏼‍♀" type="tts">nadurena žena: srednje svetla koža</annotation>
-		<annotation cp="🙎🏽‍♀">durenje | nadurena žena | nadurena žena: ni svetla ni tamna koža | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🙎🏽‍♀">durenje | nadurena žena | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="🙎🏽‍♀" type="tts">nadurena žena: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙎🏾‍♀">durenje | nadurena žena | nadurena žena: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="🙎🏾‍♀">durenje | nadurena žena | srednje tamna koža | žena</annotation>
 		<annotation cp="🙎🏾‍♀" type="tts">nadurena žena: srednje tamna koža</annotation>
-		<annotation cp="🙎🏿‍♀">durenje | nadurena žena | nadurena žena: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="🙎🏿‍♀">durenje | nadurena žena | tamna koža | žena</annotation>
 		<annotation cp="🙎🏿‍♀" type="tts">nadurena žena: tamna koža</annotation>
-		<annotation cp="🙅🏻">ne | nema | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: svetla koža | pokret | ruka | svetla koža | zabranjeno</annotation>
+		<annotation cp="🙅🏻">ne | nema | osoba koja pokazuje „ne“ | pokret | ruka | svetla koža | zabranjeno</annotation>
 		<annotation cp="🙅🏻" type="tts">osoba koja pokazuje „ne“: svetla koža</annotation>
-		<annotation cp="🙅🏼">ne | nema | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: srednje svetla koža | pokret | ruka | srednje svetla koža | zabranjeno</annotation>
+		<annotation cp="🙅🏼">ne | nema | osoba koja pokazuje „ne“ | pokret | ruka | srednje svetla koža | zabranjeno</annotation>
 		<annotation cp="🙅🏼" type="tts">osoba koja pokazuje „ne“: srednje svetla koža</annotation>
-		<annotation cp="🙅🏽">ne | nema | ni svetla ni tamna koža | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: ni svetla ni tamna koža | pokret | ruka | zabranjeno</annotation>
+		<annotation cp="🙅🏽">ne | nema | ni svetla ni tamna koža | osoba koja pokazuje „ne“ | pokret | ruka | zabranjeno</annotation>
 		<annotation cp="🙅🏽" type="tts">osoba koja pokazuje „ne“: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙅🏾">ne | nema | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: srednje tamna koža | pokret | ruka | srednje tamna koža | zabranjeno</annotation>
+		<annotation cp="🙅🏾">ne | nema | osoba koja pokazuje „ne“ | pokret | ruka | srednje tamna koža | zabranjeno</annotation>
 		<annotation cp="🙅🏾" type="tts">osoba koja pokazuje „ne“: srednje tamna koža</annotation>
-		<annotation cp="🙅🏿">ne | nema | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: tamna koža | pokret | ruka | tamna koža | zabranjeno</annotation>
+		<annotation cp="🙅🏿">ne | nema | osoba koja pokazuje „ne“ | pokret | ruka | tamna koža | zabranjeno</annotation>
 		<annotation cp="🙅🏿" type="tts">osoba koja pokazuje „ne“: tamna koža</annotation>
-		<annotation cp="🙅🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: svetla koža | ne | ruke | svetla koža</annotation>
+		<annotation cp="🙅🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ruke | svetla koža</annotation>
 		<annotation cp="🙅🏻‍♂" type="tts">muškarac pokazuje „ne“: svetla koža</annotation>
-		<annotation cp="🙅🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: srednje svetla koža | ne | ruke | srednje svetla koža</annotation>
+		<annotation cp="🙅🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ruke | srednje svetla koža</annotation>
 		<annotation cp="🙅🏼‍♂" type="tts">muškarac pokazuje „ne“: srednje svetla koža</annotation>
-		<annotation cp="🙅🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: ni svetla ni tamna koža | ne | ni svetla ni tamna koža | ruke</annotation>
+		<annotation cp="🙅🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ni svetla ni tamna koža | ruke</annotation>
 		<annotation cp="🙅🏽‍♂" type="tts">muškarac pokazuje „ne“: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙅🏾‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: srednje tamna koža | ne | ruke | srednje tamna koža</annotation>
+		<annotation cp="🙅🏾‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ruke | srednje tamna koža</annotation>
 		<annotation cp="🙅🏾‍♂" type="tts">muškarac pokazuje „ne“: srednje tamna koža</annotation>
-		<annotation cp="🙅🏿‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: tamna koža | ne | ruke | tamna koža</annotation>
+		<annotation cp="🙅🏿‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ruke | tamna koža</annotation>
 		<annotation cp="🙅🏿‍♂" type="tts">muškarac pokazuje „ne“: tamna koža</annotation>
-		<annotation cp="🙅🏻‍♀">gestikulacija | ne | ruke | svetla koža | žena | žena pokazuje „ne“ | žena pokazuje „ne“: svetla koža</annotation>
+		<annotation cp="🙅🏻‍♀">gestikulacija | ne | ruke | svetla koža | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏻‍♀" type="tts">žena pokazuje „ne“: svetla koža</annotation>
-		<annotation cp="🙅🏼‍♀">gestikulacija | ne | ruke | srednje svetla koža | žena | žena pokazuje „ne“ | žena pokazuje „ne“: srednje svetla koža</annotation>
+		<annotation cp="🙅🏼‍♀">gestikulacija | ne | ruke | srednje svetla koža | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏼‍♀" type="tts">žena pokazuje „ne“: srednje svetla koža</annotation>
-		<annotation cp="🙅🏽‍♀">gestikulacija | ne | ni svetla ni tamna koža | ruke | žena | žena pokazuje „ne“ | žena pokazuje „ne“: ni svetla ni tamna koža</annotation>
+		<annotation cp="🙅🏽‍♀">gestikulacija | ne | ni svetla ni tamna koža | ruke | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏽‍♀" type="tts">žena pokazuje „ne“: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙅🏾‍♀">gestikulacija | ne | ruke | srednje tamna koža | žena | žena pokazuje „ne“ | žena pokazuje „ne“: srednje tamna koža</annotation>
+		<annotation cp="🙅🏾‍♀">gestikulacija | ne | ruke | srednje tamna koža | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏾‍♀" type="tts">žena pokazuje „ne“: srednje tamna koža</annotation>
-		<annotation cp="🙅🏿‍♀">gestikulacija | ne | ruke | tamna koža | žena | žena pokazuje „ne“ | žena pokazuje „ne“: tamna koža</annotation>
+		<annotation cp="🙅🏿‍♀">gestikulacija | ne | ruke | tamna koža | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏿‍♀" type="tts">žena pokazuje „ne“: tamna koža</annotation>
-		<annotation cp="🙆🏻">dobro | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: svetla koža | pokret | ruka | svetla koža | u redu</annotation>
+		<annotation cp="🙆🏻">dobro | ok | osoba koja pokazuje „u redu“ | pokret | ruka | svetla koža | u redu</annotation>
 		<annotation cp="🙆🏻" type="tts">osoba koja pokazuje „u redu“: svetla koža</annotation>
-		<annotation cp="🙆🏼">dobro | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: srednje svetla koža | pokret | ruka | srednje svetla koža | u redu</annotation>
+		<annotation cp="🙆🏼">dobro | ok | osoba koja pokazuje „u redu“ | pokret | ruka | srednje svetla koža | u redu</annotation>
 		<annotation cp="🙆🏼" type="tts">osoba koja pokazuje „u redu“: srednje svetla koža</annotation>
-		<annotation cp="🙆🏽">dobro | ni svetla ni tamna koža | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: ni svetla ni tamna koža | pokret | ruka | u redu</annotation>
+		<annotation cp="🙆🏽">dobro | ni svetla ni tamna koža | ok | osoba koja pokazuje „u redu“ | pokret | ruka | u redu</annotation>
 		<annotation cp="🙆🏽" type="tts">osoba koja pokazuje „u redu“: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙆🏾">dobro | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: srednje tamna koža | pokret | ruka | srednje tamna koža | u redu</annotation>
+		<annotation cp="🙆🏾">dobro | ok | osoba koja pokazuje „u redu“ | pokret | ruka | srednje tamna koža | u redu</annotation>
 		<annotation cp="🙆🏾" type="tts">osoba koja pokazuje „u redu“: srednje tamna koža</annotation>
-		<annotation cp="🙆🏿">dobro | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: tamna koža | pokret | ruka | tamna koža | u redu</annotation>
+		<annotation cp="🙆🏿">dobro | ok | osoba koja pokazuje „u redu“ | pokret | ruka | tamna koža | u redu</annotation>
 		<annotation cp="🙆🏿" type="tts">osoba koja pokazuje „u redu“: tamna koža</annotation>
-		<annotation cp="🙆🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: svetla koža | ok | ruke | svetla koža</annotation>
+		<annotation cp="🙆🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ok | ruke | svetla koža</annotation>
 		<annotation cp="🙆🏻‍♂" type="tts">muškarac pokazuje „ok“: svetla koža</annotation>
-		<annotation cp="🙆🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: srednje svetla koža | ok | ruke | srednje svetla koža</annotation>
+		<annotation cp="🙆🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ok | ruke | srednje svetla koža</annotation>
 		<annotation cp="🙆🏼‍♂" type="tts">muškarac pokazuje „ok“: srednje svetla koža</annotation>
-		<annotation cp="🙆🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: ni svetla ni tamna koža | ni svetla ni tamna koža | ok | ruke</annotation>
+		<annotation cp="🙆🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ni svetla ni tamna koža | ok | ruke</annotation>
 		<annotation cp="🙆🏽‍♂" type="tts">muškarac pokazuje „ok“: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙆🏾‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: srednje tamna koža | ok | ruke | srednje tamna koža</annotation>
+		<annotation cp="🙆🏾‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ok | ruke | srednje tamna koža</annotation>
 		<annotation cp="🙆🏾‍♂" type="tts">muškarac pokazuje „ok“: srednje tamna koža</annotation>
-		<annotation cp="🙆🏿‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: tamna koža | ok | ruke | tamna koža</annotation>
+		<annotation cp="🙆🏿‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ok | ruke | tamna koža</annotation>
 		<annotation cp="🙆🏿‍♂" type="tts">muškarac pokazuje „ok“: tamna koža</annotation>
-		<annotation cp="🙆🏻‍♀">gestikulacija | ok | ruke | svetla koža | žena | žena pokazuje „ok“ | žena pokazuje „ok“: svetla koža</annotation>
+		<annotation cp="🙆🏻‍♀">gestikulacija | ok | ruke | svetla koža | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏻‍♀" type="tts">žena pokazuje „ok“: svetla koža</annotation>
-		<annotation cp="🙆🏼‍♀">gestikulacija | ok | ruke | srednje svetla koža | žena | žena pokazuje „ok“ | žena pokazuje „ok“: srednje svetla koža</annotation>
+		<annotation cp="🙆🏼‍♀">gestikulacija | ok | ruke | srednje svetla koža | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏼‍♀" type="tts">žena pokazuje „ok“: srednje svetla koža</annotation>
-		<annotation cp="🙆🏽‍♀">gestikulacija | ni svetla ni tamna koža | ok | ruke | žena | žena pokazuje „ok“ | žena pokazuje „ok“: ni svetla ni tamna koža</annotation>
+		<annotation cp="🙆🏽‍♀">gestikulacija | ni svetla ni tamna koža | ok | ruke | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏽‍♀" type="tts">žena pokazuje „ok“: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙆🏾‍♀">gestikulacija | ok | ruke | srednje tamna koža | žena | žena pokazuje „ok“ | žena pokazuje „ok“: srednje tamna koža</annotation>
+		<annotation cp="🙆🏾‍♀">gestikulacija | ok | ruke | srednje tamna koža | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏾‍♀" type="tts">žena pokazuje „ok“: srednje tamna koža</annotation>
-		<annotation cp="🙆🏿‍♀">gestikulacija | ok | ruke | tamna koža | žena | žena pokazuje „ok“ | žena pokazuje „ok“: tamna koža</annotation>
+		<annotation cp="🙆🏿‍♀">gestikulacija | ok | ruke | tamna koža | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏿‍♀" type="tts">žena pokazuje „ok“: tamna koža</annotation>
-		<annotation cp="💁🏻">informacije | osoba koja daje informacije | osoba koja daje informacije: svetla koža | pomoć | ruka | svetla koža</annotation>
+		<annotation cp="💁🏻">informacije | osoba koja daje informacije | pomoć | ruka | svetla koža</annotation>
 		<annotation cp="💁🏻" type="tts">osoba koja daje informacije: svetla koža</annotation>
-		<annotation cp="💁🏼">informacije | osoba koja daje informacije | osoba koja daje informacije: srednje svetla koža | pomoć | ruka | srednje svetla koža</annotation>
+		<annotation cp="💁🏼">informacije | osoba koja daje informacije | pomoć | ruka | srednje svetla koža</annotation>
 		<annotation cp="💁🏼" type="tts">osoba koja daje informacije: srednje svetla koža</annotation>
-		<annotation cp="💁🏽">informacije | ni svetla ni tamna koža | osoba koja daje informacije | osoba koja daje informacije: ni svetla ni tamna koža | pomoć | ruka</annotation>
+		<annotation cp="💁🏽">informacije | ni svetla ni tamna koža | osoba koja daje informacije | pomoć | ruka</annotation>
 		<annotation cp="💁🏽" type="tts">osoba koja daje informacije: ni svetla ni tamna koža</annotation>
-		<annotation cp="💁🏾">informacije | osoba koja daje informacije | osoba koja daje informacije: srednje tamna koža | pomoć | ruka | srednje tamna koža</annotation>
+		<annotation cp="💁🏾">informacije | osoba koja daje informacije | pomoć | ruka | srednje tamna koža</annotation>
 		<annotation cp="💁🏾" type="tts">osoba koja daje informacije: srednje tamna koža</annotation>
-		<annotation cp="💁🏿">informacije | osoba koja daje informacije | osoba koja daje informacije: tamna koža | pomoć | ruka | tamna koža</annotation>
+		<annotation cp="💁🏿">informacije | osoba koja daje informacije | pomoć | ruka | tamna koža</annotation>
 		<annotation cp="💁🏿" type="tts">osoba koja daje informacije: tamna koža</annotation>
-		<annotation cp="💁🏻‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | muškarac otkriva namere: svetla koža | ruke | svetla koža</annotation>
+		<annotation cp="💁🏻‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | ruke | svetla koža</annotation>
 		<annotation cp="💁🏻‍♂" type="tts">muškarac otkriva namere: svetla koža</annotation>
-		<annotation cp="💁🏼‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | muškarac otkriva namere: srednje svetla koža | ruke | srednje svetla koža</annotation>
+		<annotation cp="💁🏼‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | ruke | srednje svetla koža</annotation>
 		<annotation cp="💁🏼‍♂" type="tts">muškarac otkriva namere: srednje svetla koža</annotation>
-		<annotation cp="💁🏽‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | muškarac otkriva namere: ni svetla ni tamna koža | ni svetla ni tamna koža | ruke</annotation>
+		<annotation cp="💁🏽‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | ni svetla ni tamna koža | ruke</annotation>
 		<annotation cp="💁🏽‍♂" type="tts">muškarac otkriva namere: ni svetla ni tamna koža</annotation>
-		<annotation cp="💁🏾‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | muškarac otkriva namere: srednje tamna koža | ruke | srednje tamna koža</annotation>
+		<annotation cp="💁🏾‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | ruke | srednje tamna koža</annotation>
 		<annotation cp="💁🏾‍♂" type="tts">muškarac otkriva namere: srednje tamna koža</annotation>
-		<annotation cp="💁🏿‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | muškarac otkriva namere: tamna koža | ruke | tamna koža</annotation>
+		<annotation cp="💁🏿‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namere | ruke | tamna koža</annotation>
 		<annotation cp="💁🏿‍♂" type="tts">muškarac otkriva namere: tamna koža</annotation>
-		<annotation cp="💁🏻‍♀">gestikulacija | informacije | ruke | svetla koža | žena | žena otkriva namere | žena otkriva namere: svetla koža</annotation>
+		<annotation cp="💁🏻‍♀">gestikulacija | informacije | ruke | svetla koža | žena | žena otkriva namere</annotation>
 		<annotation cp="💁🏻‍♀" type="tts">žena otkriva namere: svetla koža</annotation>
-		<annotation cp="💁🏼‍♀">gestikulacija | informacije | ruke | srednje svetla koža | žena | žena otkriva namere | žena otkriva namere: srednje svetla koža</annotation>
+		<annotation cp="💁🏼‍♀">gestikulacija | informacije | ruke | srednje svetla koža | žena | žena otkriva namere</annotation>
 		<annotation cp="💁🏼‍♀" type="tts">žena otkriva namere: srednje svetla koža</annotation>
-		<annotation cp="💁🏽‍♀">gestikulacija | informacije | ni svetla ni tamna koža | ruke | žena | žena otkriva namere | žena otkriva namere: ni svetla ni tamna koža</annotation>
+		<annotation cp="💁🏽‍♀">gestikulacija | informacije | ni svetla ni tamna koža | ruke | žena | žena otkriva namere</annotation>
 		<annotation cp="💁🏽‍♀" type="tts">žena otkriva namere: ni svetla ni tamna koža</annotation>
-		<annotation cp="💁🏾‍♀">gestikulacija | informacije | ruke | srednje tamna koža | žena | žena otkriva namere | žena otkriva namere: srednje tamna koža</annotation>
+		<annotation cp="💁🏾‍♀">gestikulacija | informacije | ruke | srednje tamna koža | žena | žena otkriva namere</annotation>
 		<annotation cp="💁🏾‍♀" type="tts">žena otkriva namere: srednje tamna koža</annotation>
-		<annotation cp="💁🏿‍♀">gestikulacija | informacije | ruke | tamna koža | žena | žena otkriva namere | žena otkriva namere: tamna koža</annotation>
+		<annotation cp="💁🏿‍♀">gestikulacija | informacije | ruke | tamna koža | žena | žena otkriva namere</annotation>
 		<annotation cp="💁🏿‍♀" type="tts">žena otkriva namere: tamna koža</annotation>
-		<annotation cp="🙋🏻">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: svetla koža | svetla koža</annotation>
+		<annotation cp="🙋🏻">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | svetla koža</annotation>
 		<annotation cp="🙋🏻" type="tts">srećna osoba sa podignutom rukom: svetla koža</annotation>
-		<annotation cp="🙋🏼">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🙋🏼">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srednje svetla koža</annotation>
 		<annotation cp="🙋🏼" type="tts">srećna osoba sa podignutom rukom: srednje svetla koža</annotation>
-		<annotation cp="🙋🏽">kretanje | ni svetla ni tamna koža | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: ni svetla ni tamna koža</annotation>
+		<annotation cp="🙋🏽">kretanje | ni svetla ni tamna koža | podići | ruka | sreća | srećna osoba sa podignutom rukom</annotation>
 		<annotation cp="🙋🏽" type="tts">srećna osoba sa podignutom rukom: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙋🏾">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🙋🏾">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srednje tamna koža</annotation>
 		<annotation cp="🙋🏾" type="tts">srećna osoba sa podignutom rukom: srednje tamna koža</annotation>
-		<annotation cp="🙋🏿">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: tamna koža | tamna koža</annotation>
+		<annotation cp="🙋🏿">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | tamna koža</annotation>
 		<annotation cp="🙋🏿" type="tts">srećna osoba sa podignutom rukom: tamna koža</annotation>
-		<annotation cp="🙋🏻‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: svetla koža | ruke | svetla koža</annotation>
+		<annotation cp="🙋🏻‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ruke | svetla koža</annotation>
 		<annotation cp="🙋🏻‍♂" type="tts">muškarac podiže ruku: svetla koža</annotation>
-		<annotation cp="🙋🏼‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: srednje svetla koža | ruke | srednje svetla koža</annotation>
+		<annotation cp="🙋🏼‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ruke | srednje svetla koža</annotation>
 		<annotation cp="🙋🏼‍♂" type="tts">muškarac podiže ruku: srednje svetla koža</annotation>
-		<annotation cp="🙋🏽‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: ni svetla ni tamna koža | ni svetla ni tamna koža | ruke</annotation>
+		<annotation cp="🙋🏽‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ni svetla ni tamna koža | ruke</annotation>
 		<annotation cp="🙋🏽‍♂" type="tts">muškarac podiže ruku: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙋🏾‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: srednje tamna koža | ruke | srednje tamna koža</annotation>
+		<annotation cp="🙋🏾‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ruke | srednje tamna koža</annotation>
 		<annotation cp="🙋🏾‍♂" type="tts">muškarac podiže ruku: srednje tamna koža</annotation>
-		<annotation cp="🙋🏿‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: tamna koža | ruke | tamna koža</annotation>
+		<annotation cp="🙋🏿‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ruke | tamna koža</annotation>
 		<annotation cp="🙋🏿‍♂" type="tts">muškarac podiže ruku: tamna koža</annotation>
-		<annotation cp="🙋🏻‍♀">gestikulacija | informacije | ruke | svetla koža | žena | žena podiže ruku | žena podiže ruku: svetla koža</annotation>
+		<annotation cp="🙋🏻‍♀">gestikulacija | informacije | ruke | svetla koža | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏻‍♀" type="tts">žena podiže ruku: svetla koža</annotation>
-		<annotation cp="🙋🏼‍♀">gestikulacija | informacije | ruke | srednje svetla koža | žena | žena podiže ruku | žena podiže ruku: srednje svetla koža</annotation>
+		<annotation cp="🙋🏼‍♀">gestikulacija | informacije | ruke | srednje svetla koža | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏼‍♀" type="tts">žena podiže ruku: srednje svetla koža</annotation>
-		<annotation cp="🙋🏽‍♀">gestikulacija | informacije | ni svetla ni tamna koža | ruke | žena | žena podiže ruku | žena podiže ruku: ni svetla ni tamna koža</annotation>
+		<annotation cp="🙋🏽‍♀">gestikulacija | informacije | ni svetla ni tamna koža | ruke | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏽‍♀" type="tts">žena podiže ruku: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙋🏾‍♀">gestikulacija | informacije | ruke | srednje tamna koža | žena | žena podiže ruku | žena podiže ruku: srednje tamna koža</annotation>
+		<annotation cp="🙋🏾‍♀">gestikulacija | informacije | ruke | srednje tamna koža | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏾‍♀" type="tts">žena podiže ruku: srednje tamna koža</annotation>
-		<annotation cp="🙋🏿‍♀">gestikulacija | informacije | ruke | tamna koža | žena | žena podiže ruku | žena podiže ruku: tamna koža</annotation>
+		<annotation cp="🙋🏿‍♀">gestikulacija | informacije | ruke | tamna koža | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏿‍♀" type="tts">žena podiže ruku: tamna koža</annotation>
-		<annotation cp="🧏🏻">gluv | gluva osoba | gluva osoba: svetla koža | pristupačnost | sluh | svetla koža | uho</annotation>
+		<annotation cp="🧏🏻">gluv | gluva osoba | pristupačnost | sluh | svetla koža | uho</annotation>
 		<annotation cp="🧏🏻" type="tts">gluva osoba: svetla koža</annotation>
-		<annotation cp="🧏🏼">gluv | gluva osoba | gluva osoba: srednje svetla koža | pristupačnost | sluh | srednje svetla koža | uho</annotation>
+		<annotation cp="🧏🏼">gluv | gluva osoba | pristupačnost | sluh | srednje svetla koža | uho</annotation>
 		<annotation cp="🧏🏼" type="tts">gluva osoba: srednje svetla koža</annotation>
-		<annotation cp="🧏🏽">gluv | gluva osoba | gluva osoba: ni svetla ni tamna koža | ni svetla ni tamna koža | pristupačnost | sluh | uho</annotation>
+		<annotation cp="🧏🏽">gluv | gluva osoba | ni svetla ni tamna koža | pristupačnost | sluh | uho</annotation>
 		<annotation cp="🧏🏽" type="tts">gluva osoba: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧏🏾">gluv | gluva osoba | gluva osoba: srednje tamna koža | pristupačnost | sluh | srednje tamna koža | uho</annotation>
+		<annotation cp="🧏🏾">gluv | gluva osoba | pristupačnost | sluh | srednje tamna koža | uho</annotation>
 		<annotation cp="🧏🏾" type="tts">gluva osoba: srednje tamna koža</annotation>
-		<annotation cp="🧏🏿">gluv | gluva osoba | gluva osoba: tamna koža | pristupačnost | sluh | tamna koža | uho</annotation>
+		<annotation cp="🧏🏿">gluv | gluva osoba | pristupačnost | sluh | tamna koža | uho</annotation>
 		<annotation cp="🧏🏿" type="tts">gluva osoba: tamna koža</annotation>
-		<annotation cp="🧏🏻‍♂">čovek | gluv | gluv čovek: svetla koža | svetla koža</annotation>
+		<annotation cp="🧏🏻‍♂">čovek | gluv | svetla koža</annotation>
 		<annotation cp="🧏🏻‍♂" type="tts">gluv čovek: svetla koža</annotation>
-		<annotation cp="🧏🏼‍♂">čovek | gluv | gluv čovek: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧏🏼‍♂">čovek | gluv | srednje svetla koža</annotation>
 		<annotation cp="🧏🏼‍♂" type="tts">gluv čovek: srednje svetla koža</annotation>
-		<annotation cp="🧏🏽‍♂">čovek | gluv | gluv čovek: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧏🏽‍♂">čovek | gluv | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧏🏽‍♂" type="tts">gluv čovek: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧏🏾‍♂">čovek | gluv | gluv čovek: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧏🏾‍♂">čovek | gluv | srednje tamna koža</annotation>
 		<annotation cp="🧏🏾‍♂" type="tts">gluv čovek: srednje tamna koža</annotation>
-		<annotation cp="🧏🏿‍♂">čovek | gluv | gluv čovek: tamna koža | tamna koža</annotation>
+		<annotation cp="🧏🏿‍♂">čovek | gluv | tamna koža</annotation>
 		<annotation cp="🧏🏿‍♂" type="tts">gluv čovek: tamna koža</annotation>
-		<annotation cp="🧏🏻‍♀">gluva | gluva žena: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="🧏🏻‍♀">gluva | svetla koža | žena</annotation>
 		<annotation cp="🧏🏻‍♀" type="tts">gluva žena: svetla koža</annotation>
-		<annotation cp="🧏🏼‍♀">gluva | gluva žena: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="🧏🏼‍♀">gluva | srednje svetla koža | žena</annotation>
 		<annotation cp="🧏🏼‍♀" type="tts">gluva žena: srednje svetla koža</annotation>
-		<annotation cp="🧏🏽‍♀">gluva | gluva žena: ni svetla ni tamna koža | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🧏🏽‍♀">gluva | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="🧏🏽‍♀" type="tts">gluva žena: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧏🏾‍♀">gluva | gluva žena: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="🧏🏾‍♀">gluva | srednje tamna koža | žena</annotation>
 		<annotation cp="🧏🏾‍♀" type="tts">gluva žena: srednje tamna koža</annotation>
-		<annotation cp="🧏🏿‍♀">gluva | gluva žena: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="🧏🏿‍♀">gluva | tamna koža | žena</annotation>
 		<annotation cp="🧏🏿‍♀" type="tts">gluva žena: tamna koža</annotation>
-		<annotation cp="🙇🏻">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | osoba koja se klanja: svetla koža | svetla koža</annotation>
+		<annotation cp="🙇🏻">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | svetla koža</annotation>
 		<annotation cp="🙇🏻" type="tts">osoba koja se klanja: svetla koža</annotation>
-		<annotation cp="🙇🏼">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | osoba koja se klanja: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🙇🏼">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | srednje svetla koža</annotation>
 		<annotation cp="🙇🏼" type="tts">osoba koja se klanja: srednje svetla koža</annotation>
-		<annotation cp="🙇🏽">izvinjenje | klanjanje | kretanje | naklon | ni svetla ni tamna koža | osoba koja se klanja | osoba koja se klanja: ni svetla ni tamna koža</annotation>
+		<annotation cp="🙇🏽">izvinjenje | klanjanje | kretanje | naklon | ni svetla ni tamna koža | osoba koja se klanja</annotation>
 		<annotation cp="🙇🏽" type="tts">osoba koja se klanja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙇🏾">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | osoba koja se klanja: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🙇🏾">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | srednje tamna koža</annotation>
 		<annotation cp="🙇🏾" type="tts">osoba koja se klanja: srednje tamna koža</annotation>
-		<annotation cp="🙇🏿">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | osoba koja se klanja: tamna koža | tamna koža</annotation>
+		<annotation cp="🙇🏿">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | tamna koža</annotation>
 		<annotation cp="🙇🏿" type="tts">osoba koja se klanja: tamna koža</annotation>
-		<annotation cp="🙇🏻‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: svetla koža | naklon | svetla koža</annotation>
+		<annotation cp="🙇🏻‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | svetla koža</annotation>
 		<annotation cp="🙇🏻‍♂" type="tts">muški duboki naklon: svetla koža</annotation>
-		<annotation cp="🙇🏼‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: srednje svetla koža | naklon | srednje svetla koža</annotation>
+		<annotation cp="🙇🏼‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | srednje svetla koža</annotation>
 		<annotation cp="🙇🏼‍♂" type="tts">muški duboki naklon: srednje svetla koža</annotation>
-		<annotation cp="🙇🏽‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: ni svetla ni tamna koža | naklon | ni svetla ni tamna koža</annotation>
+		<annotation cp="🙇🏽‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | ni svetla ni tamna koža</annotation>
 		<annotation cp="🙇🏽‍♂" type="tts">muški duboki naklon: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙇🏾‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: srednje tamna koža | naklon | srednje tamna koža</annotation>
+		<annotation cp="🙇🏾‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | srednje tamna koža</annotation>
 		<annotation cp="🙇🏾‍♂" type="tts">muški duboki naklon: srednje tamna koža</annotation>
-		<annotation cp="🙇🏿‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: tamna koža | naklon | tamna koža</annotation>
+		<annotation cp="🙇🏿‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | tamna koža</annotation>
 		<annotation cp="🙇🏿‍♂" type="tts">muški duboki naklon: tamna koža</annotation>
-		<annotation cp="🙇🏻‍♀">gestikulacija | izvinjenje | naklon | svetla koža | žena | ženski duboki naklon | ženski duboki naklon: svetla koža</annotation>
+		<annotation cp="🙇🏻‍♀">gestikulacija | izvinjenje | naklon | svetla koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏻‍♀" type="tts">ženski duboki naklon: svetla koža</annotation>
-		<annotation cp="🙇🏼‍♀">gestikulacija | izvinjenje | naklon | srednje svetla koža | žena | ženski duboki naklon | ženski duboki naklon: srednje svetla koža</annotation>
+		<annotation cp="🙇🏼‍♀">gestikulacija | izvinjenje | naklon | srednje svetla koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏼‍♀" type="tts">ženski duboki naklon: srednje svetla koža</annotation>
-		<annotation cp="🙇🏽‍♀">gestikulacija | izvinjenje | naklon | ni svetla ni tamna koža | žena | ženski duboki naklon | ženski duboki naklon: ni svetla ni tamna koža</annotation>
+		<annotation cp="🙇🏽‍♀">gestikulacija | izvinjenje | naklon | ni svetla ni tamna koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏽‍♀" type="tts">ženski duboki naklon: ni svetla ni tamna koža</annotation>
-		<annotation cp="🙇🏾‍♀">gestikulacija | izvinjenje | naklon | srednje tamna koža | žena | ženski duboki naklon | ženski duboki naklon: srednje tamna koža</annotation>
+		<annotation cp="🙇🏾‍♀">gestikulacija | izvinjenje | naklon | srednje tamna koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏾‍♀" type="tts">ženski duboki naklon: srednje tamna koža</annotation>
-		<annotation cp="🙇🏿‍♀">gestikulacija | izvinjenje | naklon | tamna koža | žena | ženski duboki naklon | ženski duboki naklon: tamna koža</annotation>
+		<annotation cp="🙇🏿‍♀">gestikulacija | izvinjenje | naklon | tamna koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏿‍♀" type="tts">ženski duboki naklon: tamna koža</annotation>
-		<annotation cp="🤦🏻">čelo | glupost | kajanje | šaka o čelo | šaka o čelo: svetla koža | svetla koža</annotation>
+		<annotation cp="🤦🏻">čelo | glupost | kajanje | šaka o čelo | svetla koža</annotation>
 		<annotation cp="🤦🏻" type="tts">šaka o čelo: svetla koža</annotation>
-		<annotation cp="🤦🏼">čelo | glupost | kajanje | šaka o čelo | šaka o čelo: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🤦🏼">čelo | glupost | kajanje | šaka o čelo | srednje svetla koža</annotation>
 		<annotation cp="🤦🏼" type="tts">šaka o čelo: srednje svetla koža</annotation>
-		<annotation cp="🤦🏽">čelo | glupost | kajanje | ni svetla ni tamna koža | šaka o čelo | šaka o čelo: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤦🏽">čelo | glupost | kajanje | ni svetla ni tamna koža | šaka o čelo</annotation>
 		<annotation cp="🤦🏽" type="tts">šaka o čelo: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤦🏾">čelo | glupost | kajanje | šaka o čelo | šaka o čelo: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤦🏾">čelo | glupost | kajanje | šaka o čelo | srednje tamna koža</annotation>
 		<annotation cp="🤦🏾" type="tts">šaka o čelo: srednje tamna koža</annotation>
-		<annotation cp="🤦🏿">čelo | glupost | kajanje | šaka o čelo | šaka o čelo: tamna koža | tamna koža</annotation>
+		<annotation cp="🤦🏿">čelo | glupost | kajanje | šaka o čelo | tamna koža</annotation>
 		<annotation cp="🤦🏿" type="tts">šaka o čelo: tamna koža</annotation>
-		<annotation cp="🤦🏻‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: svetla koža | svetla koža</annotation>
+		<annotation cp="🤦🏻‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | svetla koža</annotation>
 		<annotation cp="🤦🏻‍♂" type="tts">muškarac s rukom na čelu: svetla koža</annotation>
-		<annotation cp="🤦🏼‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🤦🏼‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | srednje svetla koža</annotation>
 		<annotation cp="🤦🏼‍♂" type="tts">muškarac s rukom na čelu: srednje svetla koža</annotation>
-		<annotation cp="🤦🏽‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🤦🏽‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | ni svetla ni tamna koža</annotation>
 		<annotation cp="🤦🏽‍♂" type="tts">muškarac s rukom na čelu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤦🏾‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤦🏾‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | srednje tamna koža</annotation>
 		<annotation cp="🤦🏾‍♂" type="tts">muškarac s rukom na čelu: srednje tamna koža</annotation>
-		<annotation cp="🤦🏿‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: tamna koža | tamna koža</annotation>
+		<annotation cp="🤦🏿‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | tamna koža</annotation>
 		<annotation cp="🤦🏿‍♂" type="tts">muškarac s rukom na čelu: tamna koža</annotation>
-		<annotation cp="🤦🏻‍♀">gestikulacija | glupost | kajanje | svetla koža | žena | žena s rukom na čelu | žena s rukom na čelu: svetla koža</annotation>
+		<annotation cp="🤦🏻‍♀">gestikulacija | glupost | kajanje | svetla koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏻‍♀" type="tts">žena s rukom na čelu: svetla koža</annotation>
-		<annotation cp="🤦🏼‍♀">gestikulacija | glupost | kajanje | srednje svetla koža | žena | žena s rukom na čelu | žena s rukom na čelu: srednje svetla koža</annotation>
+		<annotation cp="🤦🏼‍♀">gestikulacija | glupost | kajanje | srednje svetla koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏼‍♀" type="tts">žena s rukom na čelu: srednje svetla koža</annotation>
-		<annotation cp="🤦🏽‍♀">gestikulacija | glupost | kajanje | ni svetla ni tamna koža | žena | žena s rukom na čelu | žena s rukom na čelu: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤦🏽‍♀">gestikulacija | glupost | kajanje | ni svetla ni tamna koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏽‍♀" type="tts">žena s rukom na čelu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤦🏾‍♀">gestikulacija | glupost | kajanje | srednje tamna koža | žena | žena s rukom na čelu | žena s rukom na čelu: srednje tamna koža</annotation>
+		<annotation cp="🤦🏾‍♀">gestikulacija | glupost | kajanje | srednje tamna koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏾‍♀" type="tts">žena s rukom na čelu: srednje tamna koža</annotation>
-		<annotation cp="🤦🏿‍♀">gestikulacija | glupost | kajanje | tamna koža | žena | žena s rukom na čelu | žena s rukom na čelu: tamna koža</annotation>
+		<annotation cp="🤦🏿‍♀">gestikulacija | glupost | kajanje | tamna koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏿‍♀" type="tts">žena s rukom na čelu: tamna koža</annotation>
-		<annotation cp="🤷🏻">neznanje | nznm | ravnodušnost | sleganje ramenima | sleganje ramenima: svetla koža | sumnja | svetla koža</annotation>
+		<annotation cp="🤷🏻">neznanje | nznm | ravnodušnost | sleganje ramenima | sumnja | svetla koža</annotation>
 		<annotation cp="🤷🏻" type="tts">sleganje ramenima: svetla koža</annotation>
-		<annotation cp="🤷🏼">neznanje | nznm | ravnodušnost | sleganje ramenima | sleganje ramenima: srednje svetla koža | srednje svetla koža | sumnja</annotation>
+		<annotation cp="🤷🏼">neznanje | nznm | ravnodušnost | sleganje ramenima | srednje svetla koža | sumnja</annotation>
 		<annotation cp="🤷🏼" type="tts">sleganje ramenima: srednje svetla koža</annotation>
-		<annotation cp="🤷🏽">neznanje | ni svetla ni tamna koža | nznm | ravnodušnost | sleganje ramenima | sleganje ramenima: ni svetla ni tamna koža | sumnja</annotation>
+		<annotation cp="🤷🏽">neznanje | ni svetla ni tamna koža | nznm | ravnodušnost | sleganje ramenima | sumnja</annotation>
 		<annotation cp="🤷🏽" type="tts">sleganje ramenima: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤷🏾">neznanje | nznm | ravnodušnost | sleganje ramenima | sleganje ramenima: srednje tamna koža | srednje tamna koža | sumnja</annotation>
+		<annotation cp="🤷🏾">neznanje | nznm | ravnodušnost | sleganje ramenima | srednje tamna koža | sumnja</annotation>
 		<annotation cp="🤷🏾" type="tts">sleganje ramenima: srednje tamna koža</annotation>
-		<annotation cp="🤷🏿">neznanje | nznm | ravnodušnost | sleganje ramenima | sleganje ramenima: tamna koža | sumnja | tamna koža</annotation>
+		<annotation cp="🤷🏿">neznanje | nznm | ravnodušnost | sleganje ramenima | sumnja | tamna koža</annotation>
 		<annotation cp="🤷🏿" type="tts">sleganje ramenima: tamna koža</annotation>
-		<annotation cp="🤷🏻‍♂">gestikulacija | muškarac | muškarac sleže ramenima | muškarac sleže ramenima: svetla koža | neznanje | ravnodušnost | svetla koža</annotation>
+		<annotation cp="🤷🏻‍♂">gestikulacija | muškarac | muškarac sleže ramenima | neznanje | ravnodušnost | svetla koža</annotation>
 		<annotation cp="🤷🏻‍♂" type="tts">muškarac sleže ramenima: svetla koža</annotation>
-		<annotation cp="🤷🏼‍♂">gestikulacija | muškarac | muškarac sleže ramenima | muškarac sleže ramenima: srednje svetla koža | neznanje | ravnodušnost | srednje svetla koža</annotation>
+		<annotation cp="🤷🏼‍♂">gestikulacija | muškarac | muškarac sleže ramenima | neznanje | ravnodušnost | srednje svetla koža</annotation>
 		<annotation cp="🤷🏼‍♂" type="tts">muškarac sleže ramenima: srednje svetla koža</annotation>
-		<annotation cp="🤷🏽‍♂">gestikulacija | muškarac | muškarac sleže ramenima | muškarac sleže ramenima: ni svetla ni tamna koža | neznanje | ni svetla ni tamna koža | ravnodušnost</annotation>
+		<annotation cp="🤷🏽‍♂">gestikulacija | muškarac | muškarac sleže ramenima | neznanje | ni svetla ni tamna koža | ravnodušnost</annotation>
 		<annotation cp="🤷🏽‍♂" type="tts">muškarac sleže ramenima: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤷🏾‍♂">gestikulacija | muškarac | muškarac sleže ramenima | muškarac sleže ramenima: srednje tamna koža | neznanje | ravnodušnost | srednje tamna koža</annotation>
+		<annotation cp="🤷🏾‍♂">gestikulacija | muškarac | muškarac sleže ramenima | neznanje | ravnodušnost | srednje tamna koža</annotation>
 		<annotation cp="🤷🏾‍♂" type="tts">muškarac sleže ramenima: srednje tamna koža</annotation>
-		<annotation cp="🤷🏿‍♂">gestikulacija | muškarac | muškarac sleže ramenima | muškarac sleže ramenima: tamna koža | neznanje | ravnodušnost | tamna koža</annotation>
+		<annotation cp="🤷🏿‍♂">gestikulacija | muškarac | muškarac sleže ramenima | neznanje | ravnodušnost | tamna koža</annotation>
 		<annotation cp="🤷🏿‍♂" type="tts">muškarac sleže ramenima: tamna koža</annotation>
-		<annotation cp="🤷🏻‍♀">gestikulacija | neznanje | ravnodušnost | svetla koža | žena | žena sleže ramenima | žena sleže ramenima: svetla koža</annotation>
+		<annotation cp="🤷🏻‍♀">gestikulacija | neznanje | ravnodušnost | svetla koža | žena | žena sleže ramenima</annotation>
 		<annotation cp="🤷🏻‍♀" type="tts">žena sleže ramenima: svetla koža</annotation>
-		<annotation cp="🤷🏼‍♀">gestikulacija | neznanje | ravnodušnost | srednje svetla koža | žena | žena sleže ramenima | žena sleže ramenima: srednje svetla koža</annotation>
+		<annotation cp="🤷🏼‍♀">gestikulacija | neznanje | ravnodušnost | srednje svetla koža | žena | žena sleže ramenima</annotation>
 		<annotation cp="🤷🏼‍♀" type="tts">žena sleže ramenima: srednje svetla koža</annotation>
-		<annotation cp="🤷🏽‍♀">gestikulacija | neznanje | ni svetla ni tamna koža | ravnodušnost | žena | žena sleže ramenima | žena sleže ramenima: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤷🏽‍♀">gestikulacija | neznanje | ni svetla ni tamna koža | ravnodušnost | žena | žena sleže ramenima</annotation>
 		<annotation cp="🤷🏽‍♀" type="tts">žena sleže ramenima: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤷🏾‍♀">gestikulacija | neznanje | ravnodušnost | srednje tamna koža | žena | žena sleže ramenima | žena sleže ramenima: srednje tamna koža</annotation>
+		<annotation cp="🤷🏾‍♀">gestikulacija | neznanje | ravnodušnost | srednje tamna koža | žena | žena sleže ramenima</annotation>
 		<annotation cp="🤷🏾‍♀" type="tts">žena sleže ramenima: srednje tamna koža</annotation>
-		<annotation cp="🤷🏿‍♀">gestikulacija | neznanje | ravnodušnost | tamna koža | žena | žena sleže ramenima | žena sleže ramenima: tamna koža</annotation>
+		<annotation cp="🤷🏿‍♀">gestikulacija | neznanje | ravnodušnost | tamna koža | žena | žena sleže ramenima</annotation>
 		<annotation cp="🤷🏿‍♀" type="tts">žena sleže ramenima: tamna koža</annotation>
-		<annotation cp="🧑🏻‍⚕">doktor | lekar | medicinska sestra | svetla koža | terapeut | zdravstveni radnik | zdravstveni radnik: svetla koža</annotation>
+		<annotation cp="🧑🏻‍⚕">doktor | lekar | medicinska sestra | svetla koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="🧑🏻‍⚕" type="tts">zdravstveni radnik: svetla koža</annotation>
-		<annotation cp="🧑🏼‍⚕">doktor | lekar | medicinska sestra | srednje svetla koža | terapeut | zdravstveni radnik | zdravstveni radnik: srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍⚕">doktor | lekar | medicinska sestra | srednje svetla koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="🧑🏼‍⚕" type="tts">zdravstveni radnik: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍⚕">doktor | lekar | medicinska sestra | ni svetla ni tamna koža | terapeut | zdravstveni radnik | zdravstveni radnik: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍⚕">doktor | lekar | medicinska sestra | ni svetla ni tamna koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="🧑🏽‍⚕" type="tts">zdravstveni radnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍⚕">doktor | lekar | medicinska sestra | srednje tamna koža | terapeut | zdravstveni radnik | zdravstveni radnik: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍⚕">doktor | lekar | medicinska sestra | srednje tamna koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="🧑🏾‍⚕" type="tts">zdravstveni radnik: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍⚕">doktor | lekar | medicinska sestra | tamna koža | terapeut | zdravstveni radnik | zdravstveni radnik: tamna koža</annotation>
+		<annotation cp="🧑🏿‍⚕">doktor | lekar | medicinska sestra | tamna koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="🧑🏿‍⚕" type="tts">zdravstveni radnik: tamna koža</annotation>
-		<annotation cp="👨🏻‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | muškarac zdravstveni radnik: svetla koža | svetla koža | terapeut | zdravstveni radnik</annotation>
+		<annotation cp="👨🏻‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | svetla koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="👨🏻‍⚕" type="tts">muškarac zdravstveni radnik: svetla koža</annotation>
-		<annotation cp="👨🏼‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | muškarac zdravstveni radnik: srednje svetla koža | srednje svetla koža | terapeut | zdravstveni radnik</annotation>
+		<annotation cp="👨🏼‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | srednje svetla koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="👨🏼‍⚕" type="tts">muškarac zdravstveni radnik: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | muškarac zdravstveni radnik: ni svetla ni tamna koža | ni svetla ni tamna koža | terapeut | zdravstveni radnik</annotation>
+		<annotation cp="👨🏽‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | ni svetla ni tamna koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="👨🏽‍⚕" type="tts">muškarac zdravstveni radnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | muškarac zdravstveni radnik: srednje tamna koža | srednje tamna koža | terapeut | zdravstveni radnik</annotation>
+		<annotation cp="👨🏾‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | srednje tamna koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="👨🏾‍⚕" type="tts">muškarac zdravstveni radnik: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | muškarac zdravstveni radnik: tamna koža | tamna koža | terapeut | zdravstveni radnik</annotation>
+		<annotation cp="👨🏿‍⚕">doktor | lekar | medicinski brat | muškarac zdravstveni radnik | tamna koža | terapeut | zdravstveni radnik</annotation>
 		<annotation cp="👨🏿‍⚕" type="tts">muškarac zdravstveni radnik: tamna koža</annotation>
-		<annotation cp="👩🏻‍⚕">doktor | lekar | svetla koža | zdravstvena radnica | zdravstvena radnica: svetla koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏻‍⚕">doktor | lekar | svetla koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏻‍⚕" type="tts">zdravstvena radnica: svetla koža</annotation>
-		<annotation cp="👩🏼‍⚕">doktor | lekar | srednje svetla koža | zdravstvena radnica | zdravstvena radnica: srednje svetla koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏼‍⚕">doktor | lekar | srednje svetla koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏼‍⚕" type="tts">zdravstvena radnica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍⚕">doktor | lekar | ni svetla ni tamna koža | zdravstvena radnica | zdravstvena radnica: ni svetla ni tamna koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏽‍⚕">doktor | lekar | ni svetla ni tamna koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏽‍⚕" type="tts">zdravstvena radnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍⚕">doktor | lekar | srednje tamna koža | zdravstvena radnica | zdravstvena radnica: srednje tamna koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏾‍⚕">doktor | lekar | srednje tamna koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏾‍⚕" type="tts">zdravstvena radnica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍⚕">doktor | lekar | tamna koža | zdravstvena radnica | zdravstvena radnica: tamna koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏿‍⚕">doktor | lekar | tamna koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏿‍⚕" type="tts">zdravstvena radnica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎓">diplomac | student/kinja | student/kinja: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🎓">diplomac | student/kinja | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🎓" type="tts">student/kinja: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🎓">diplomac | srednje svetla koža | student/kinja | student/kinja: srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🎓">diplomac | srednje svetla koža | student/kinja</annotation>
 		<annotation cp="🧑🏼‍🎓" type="tts">student/kinja: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🎓">diplomac | ni svetla ni tamna koža | student/kinja | student/kinja: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🎓">diplomac | ni svetla ni tamna koža | student/kinja</annotation>
 		<annotation cp="🧑🏽‍🎓" type="tts">student/kinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎓">diplomac | srednje tamna koža | student/kinja | student/kinja: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🎓">diplomac | srednje tamna koža | student/kinja</annotation>
 		<annotation cp="🧑🏾‍🎓" type="tts">student/kinja: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎓">diplomac | student/kinja | student/kinja: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🎓">diplomac | student/kinja | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🎓" type="tts">student/kinja: tamna koža</annotation>
-		<annotation cp="👨🏻‍🎓">diploma | matura | muškarac | student | student: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍🎓">diploma | matura | muškarac | student | svetla koža</annotation>
 		<annotation cp="👨🏻‍🎓" type="tts">student: svetla koža</annotation>
-		<annotation cp="👨🏼‍🎓">diploma | matura | muškarac | srednje svetla koža | student | student: srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🎓">diploma | matura | muškarac | srednje svetla koža | student</annotation>
 		<annotation cp="👨🏼‍🎓" type="tts">student: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🎓">diploma | matura | muškarac | ni svetla ni tamna koža | student | student: ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🎓">diploma | matura | muškarac | ni svetla ni tamna koža | student</annotation>
 		<annotation cp="👨🏽‍🎓" type="tts">student: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🎓">diploma | matura | muškarac | srednje tamna koža | student | student: srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🎓">diploma | matura | muškarac | srednje tamna koža | student</annotation>
 		<annotation cp="👨🏾‍🎓" type="tts">student: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🎓">diploma | matura | muškarac | student | student: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍🎓">diploma | matura | muškarac | student | tamna koža</annotation>
 		<annotation cp="👨🏿‍🎓" type="tts">student: tamna koža</annotation>
-		<annotation cp="👩🏻‍🎓">diploma | matura | student | studentkinja | studentkinja: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🎓">diploma | matura | student | studentkinja | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🎓" type="tts">studentkinja: svetla koža</annotation>
-		<annotation cp="👩🏼‍🎓">diploma | matura | srednje svetla koža | student | studentkinja | studentkinja: srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🎓">diploma | matura | srednje svetla koža | student | studentkinja | žena</annotation>
 		<annotation cp="👩🏼‍🎓" type="tts">studentkinja: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🎓">diploma | matura | ni svetla ni tamna koža | student | studentkinja | studentkinja: ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🎓">diploma | matura | ni svetla ni tamna koža | student | studentkinja | žena</annotation>
 		<annotation cp="👩🏽‍🎓" type="tts">studentkinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🎓">diploma | matura | srednje tamna koža | student | studentkinja | studentkinja: srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🎓">diploma | matura | srednje tamna koža | student | studentkinja | žena</annotation>
 		<annotation cp="👩🏾‍🎓" type="tts">studentkinja: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🎓">diploma | matura | student | studentkinja | studentkinja: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🎓">diploma | matura | student | studentkinja | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🎓" type="tts">studentkinja: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🏫">instruktor | profesor | svetla koža | učitelj | učitelj: svetla koža</annotation>
+		<annotation cp="🧑🏻‍🏫">instruktor | profesor | svetla koža | učitelj</annotation>
 		<annotation cp="🧑🏻‍🏫" type="tts">učitelj: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🏫">instruktor | profesor | srednje svetla koža | učitelj | učitelj: srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🏫">instruktor | profesor | srednje svetla koža | učitelj</annotation>
 		<annotation cp="🧑🏼‍🏫" type="tts">učitelj: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🏫">instruktor | ni svetla ni tamna koža | profesor | učitelj | učitelj: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🏫">instruktor | ni svetla ni tamna koža | profesor | učitelj</annotation>
 		<annotation cp="🧑🏽‍🏫" type="tts">učitelj: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🏫">instruktor | profesor | srednje tamna koža | učitelj | učitelj: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🏫">instruktor | profesor | srednje tamna koža | učitelj</annotation>
 		<annotation cp="🧑🏾‍🏫" type="tts">učitelj: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🏫">instruktor | profesor | tamna koža | učitelj | učitelj: tamna koža</annotation>
+		<annotation cp="🧑🏿‍🏫">instruktor | profesor | tamna koža | učitelj</annotation>
 		<annotation cp="🧑🏿‍🏫" type="tts">učitelj: tamna koža</annotation>
-		<annotation cp="👨🏻‍🏫">muškarac | profesor | profesor: svetla koža | svetla koža | učitelj</annotation>
+		<annotation cp="👨🏻‍🏫">muškarac | profesor | svetla koža | učitelj</annotation>
 		<annotation cp="👨🏻‍🏫" type="tts">profesor: svetla koža</annotation>
-		<annotation cp="👨🏼‍🏫">muškarac | profesor | profesor: srednje svetla koža | srednje svetla koža | učitelj</annotation>
+		<annotation cp="👨🏼‍🏫">muškarac | profesor | srednje svetla koža | učitelj</annotation>
 		<annotation cp="👨🏼‍🏫" type="tts">profesor: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🏫">muškarac | ni svetla ni tamna koža | profesor | profesor: ni svetla ni tamna koža | učitelj</annotation>
+		<annotation cp="👨🏽‍🏫">muškarac | ni svetla ni tamna koža | profesor | učitelj</annotation>
 		<annotation cp="👨🏽‍🏫" type="tts">profesor: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🏫">muškarac | profesor | profesor: srednje tamna koža | srednje tamna koža | učitelj</annotation>
+		<annotation cp="👨🏾‍🏫">muškarac | profesor | srednje tamna koža | učitelj</annotation>
 		<annotation cp="👨🏾‍🏫" type="tts">profesor: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🏫">muškarac | profesor | profesor: tamna koža | tamna koža | učitelj</annotation>
+		<annotation cp="👨🏿‍🏫">muškarac | profesor | tamna koža | učitelj</annotation>
 		<annotation cp="👨🏿‍🏫" type="tts">profesor: tamna koža</annotation>
-		<annotation cp="👩🏻‍🏫">profesor | profesorka | profesorka: svetla koža | svetla koža | učitelj | žena</annotation>
+		<annotation cp="👩🏻‍🏫">profesor | profesorka | svetla koža | učitelj | žena</annotation>
 		<annotation cp="👩🏻‍🏫" type="tts">profesorka: svetla koža</annotation>
-		<annotation cp="👩🏼‍🏫">profesor | profesorka | profesorka: srednje svetla koža | srednje svetla koža | učitelj | žena</annotation>
+		<annotation cp="👩🏼‍🏫">profesor | profesorka | srednje svetla koža | učitelj | žena</annotation>
 		<annotation cp="👩🏼‍🏫" type="tts">profesorka: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🏫">ni svetla ni tamna koža | profesor | profesorka | profesorka: ni svetla ni tamna koža | učitelj | žena</annotation>
+		<annotation cp="👩🏽‍🏫">ni svetla ni tamna koža | profesor | profesorka | učitelj | žena</annotation>
 		<annotation cp="👩🏽‍🏫" type="tts">profesorka: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🏫">profesor | profesorka | profesorka: srednje tamna koža | srednje tamna koža | učitelj | žena</annotation>
+		<annotation cp="👩🏾‍🏫">profesor | profesorka | srednje tamna koža | učitelj | žena</annotation>
 		<annotation cp="👩🏾‍🏫" type="tts">profesorka: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🏫">profesor | profesorka | profesorka: tamna koža | tamna koža | učitelj | žena</annotation>
+		<annotation cp="👩🏿‍🏫">profesor | profesorka | tamna koža | učitelj | žena</annotation>
 		<annotation cp="👩🏿‍🏫" type="tts">profesorka: tamna koža</annotation>
-		<annotation cp="🧑🏻‍⚖">pravda | sudija | sudija/nica | sudija/nica: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍⚖">pravda | sudija | sudija/nica | svetla koža</annotation>
 		<annotation cp="🧑🏻‍⚖" type="tts">sudija/nica: svetla koža</annotation>
-		<annotation cp="🧑🏼‍⚖">pravda | srednje svetla koža | sudija | sudija/nica | sudija/nica: srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍⚖">pravda | srednje svetla koža | sudija | sudija/nica</annotation>
 		<annotation cp="🧑🏼‍⚖" type="tts">sudija/nica: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍⚖">ni svetla ni tamna koža | pravda | sudija | sudija/nica | sudija/nica: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍⚖">ni svetla ni tamna koža | pravda | sudija | sudija/nica</annotation>
 		<annotation cp="🧑🏽‍⚖" type="tts">sudija/nica: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍⚖">pravda | srednje tamna koža | sudija | sudija/nica | sudija/nica: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍⚖">pravda | srednje tamna koža | sudija | sudija/nica</annotation>
 		<annotation cp="🧑🏾‍⚖" type="tts">sudija/nica: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍⚖">pravda | sudija | sudija/nica | sudija/nica: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍⚖">pravda | sudija | sudija/nica | tamna koža</annotation>
 		<annotation cp="🧑🏿‍⚖" type="tts">sudija/nica: tamna koža</annotation>
-		<annotation cp="👨🏻‍⚖">muškarac | muškarac sudija: svetla koža | pravda | sudija | svetla koža</annotation>
+		<annotation cp="👨🏻‍⚖">muškarac | pravda | sudija | svetla koža</annotation>
 		<annotation cp="👨🏻‍⚖" type="tts">muškarac sudija: svetla koža</annotation>
-		<annotation cp="👨🏼‍⚖">muškarac | muškarac sudija: srednje svetla koža | pravda | srednje svetla koža | sudija</annotation>
+		<annotation cp="👨🏼‍⚖">muškarac | pravda | srednje svetla koža | sudija</annotation>
 		<annotation cp="👨🏼‍⚖" type="tts">muškarac sudija: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍⚖">muškarac | muškarac sudija: ni svetla ni tamna koža | ni svetla ni tamna koža | pravda | sudija</annotation>
+		<annotation cp="👨🏽‍⚖">muškarac | ni svetla ni tamna koža | pravda | sudija</annotation>
 		<annotation cp="👨🏽‍⚖" type="tts">muškarac sudija: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍⚖">muškarac | muškarac sudija: srednje tamna koža | pravda | srednje tamna koža | sudija</annotation>
+		<annotation cp="👨🏾‍⚖">muškarac | pravda | srednje tamna koža | sudija</annotation>
 		<annotation cp="👨🏾‍⚖" type="tts">muškarac sudija: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍⚖">muškarac | muškarac sudija: tamna koža | pravda | sudija | tamna koža</annotation>
+		<annotation cp="👨🏿‍⚖">muškarac | pravda | sudija | tamna koža</annotation>
 		<annotation cp="👨🏿‍⚖" type="tts">muškarac sudija: tamna koža</annotation>
-		<annotation cp="👩🏻‍⚖">pravda | sudija | svetla koža | žena | žena sudija: svetla koža</annotation>
+		<annotation cp="👩🏻‍⚖">pravda | sudija | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍⚖" type="tts">žena sudija: svetla koža</annotation>
-		<annotation cp="👩🏼‍⚖">pravda | srednje svetla koža | sudija | žena | žena sudija: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍⚖">pravda | srednje svetla koža | sudija | žena</annotation>
 		<annotation cp="👩🏼‍⚖" type="tts">žena sudija: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍⚖">ni svetla ni tamna koža | pravda | sudija | žena | žena sudija: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍⚖">ni svetla ni tamna koža | pravda | sudija | žena</annotation>
 		<annotation cp="👩🏽‍⚖" type="tts">žena sudija: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍⚖">pravda | srednje tamna koža | sudija | žena | žena sudija: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍⚖">pravda | srednje tamna koža | sudija | žena</annotation>
 		<annotation cp="👩🏾‍⚖" type="tts">žena sudija: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍⚖">pravda | sudija | tamna koža | žena | žena sudija: tamna koža</annotation>
+		<annotation cp="👩🏿‍⚖">pravda | sudija | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍⚖" type="tts">žena sudija: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🌾">baštovan | poljoprivrednik | poljoprivrednik: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🌾">baštovan | poljoprivrednik | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🌾" type="tts">poljoprivrednik: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🌾">baštovan | poljoprivrednik | poljoprivrednik: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🌾">baštovan | poljoprivrednik | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🌾" type="tts">poljoprivrednik: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🌾">baštovan | ni svetla ni tamna koža | poljoprivrednik | poljoprivrednik: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🌾">baštovan | ni svetla ni tamna koža | poljoprivrednik</annotation>
 		<annotation cp="🧑🏽‍🌾" type="tts">poljoprivrednik: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🌾">baštovan | poljoprivrednik | poljoprivrednik: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🌾">baštovan | poljoprivrednik | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🌾" type="tts">poljoprivrednik: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🌾">baštovan | poljoprivrednik | poljoprivrednik: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🌾">baštovan | poljoprivrednik | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🌾" type="tts">poljoprivrednik: tamna koža</annotation>
-		<annotation cp="👨🏻‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: svetla koža | poljoprivrednik | selo | svetla koža</annotation>
+		<annotation cp="👨🏻‍🌾">bašta | farma | muškarac | poljoprivrednik | selo | svetla koža</annotation>
 		<annotation cp="👨🏻‍🌾" type="tts">muškarac poljoprivrednik: svetla koža</annotation>
-		<annotation cp="👨🏼‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: srednje svetla koža | poljoprivrednik | selo | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🌾">bašta | farma | muškarac | poljoprivrednik | selo | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🌾" type="tts">muškarac poljoprivrednik: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: ni svetla ni tamna koža | ni svetla ni tamna koža | poljoprivrednik | selo</annotation>
+		<annotation cp="👨🏽‍🌾">bašta | farma | muškarac | ni svetla ni tamna koža | poljoprivrednik | selo</annotation>
 		<annotation cp="👨🏽‍🌾" type="tts">muškarac poljoprivrednik: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: srednje tamna koža | poljoprivrednik | selo | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🌾">bašta | farma | muškarac | poljoprivrednik | selo | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🌾" type="tts">muškarac poljoprivrednik: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: tamna koža | poljoprivrednik | selo | tamna koža</annotation>
+		<annotation cp="👨🏿‍🌾">bašta | farma | muškarac | poljoprivrednik | selo | tamna koža</annotation>
 		<annotation cp="👨🏿‍🌾" type="tts">muškarac poljoprivrednik: tamna koža</annotation>
-		<annotation cp="👩🏻‍🌾">bašta | farma | poljoprivrednica | poljoprivrednica: svetla koža | selo | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🌾">bašta | farma | poljoprivrednica | selo | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🌾" type="tts">poljoprivrednica: svetla koža</annotation>
-		<annotation cp="👩🏼‍🌾">bašta | farma | poljoprivrednica | poljoprivrednica: srednje svetla koža | selo | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🌾">bašta | farma | poljoprivrednica | selo | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🌾" type="tts">poljoprivrednica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🌾">bašta | farma | ni svetla ni tamna koža | poljoprivrednica | poljoprivrednica: ni svetla ni tamna koža | selo | žena</annotation>
+		<annotation cp="👩🏽‍🌾">bašta | farma | ni svetla ni tamna koža | poljoprivrednica | selo | žena</annotation>
 		<annotation cp="👩🏽‍🌾" type="tts">poljoprivrednica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🌾">bašta | farma | poljoprivrednica | poljoprivrednica: srednje tamna koža | selo | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🌾">bašta | farma | poljoprivrednica | selo | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🌾" type="tts">poljoprivrednica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🌾">bašta | farma | poljoprivrednica | poljoprivrednica: tamna koža | selo | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🌾">bašta | farma | poljoprivrednica | selo | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🌾" type="tts">poljoprivrednica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🍳">kuvar | kuvar: svetla koža | šef | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🍳">kuvar | šef | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🍳" type="tts">kuvar: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🍳">kuvar | kuvar: srednje svetla koža | šef | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🍳">kuvar | šef | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🍳" type="tts">kuvar: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🍳">kuvar | kuvar: ni svetla ni tamna koža | ni svetla ni tamna koža | šef</annotation>
+		<annotation cp="🧑🏽‍🍳">kuvar | ni svetla ni tamna koža | šef</annotation>
 		<annotation cp="🧑🏽‍🍳" type="tts">kuvar: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🍳">kuvar | kuvar: srednje tamna koža | šef | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🍳">kuvar | šef | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🍳" type="tts">kuvar: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🍳">kuvar | kuvar: tamna koža | šef | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🍳">kuvar | šef | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🍳" type="tts">kuvar: tamna koža</annotation>
-		<annotation cp="👨🏻‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: svetla koža | šef | svetla koža</annotation>
+		<annotation cp="👨🏻‍🍳">kuhinja | kuvar | muškarac | šef | svetla koža</annotation>
 		<annotation cp="👨🏻‍🍳" type="tts">muškarac kuvar: svetla koža</annotation>
-		<annotation cp="👨🏼‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: srednje svetla koža | šef | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🍳">kuhinja | kuvar | muškarac | šef | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🍳" type="tts">muškarac kuvar: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: ni svetla ni tamna koža | ni svetla ni tamna koža | šef</annotation>
+		<annotation cp="👨🏽‍🍳">kuhinja | kuvar | muškarac | ni svetla ni tamna koža | šef</annotation>
 		<annotation cp="👨🏽‍🍳" type="tts">muškarac kuvar: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: srednje tamna koža | šef | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🍳">kuhinja | kuvar | muškarac | šef | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🍳" type="tts">muškarac kuvar: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: tamna koža | šef | tamna koža</annotation>
+		<annotation cp="👨🏿‍🍳">kuhinja | kuvar | muškarac | šef | tamna koža</annotation>
 		<annotation cp="👨🏿‍🍳" type="tts">muškarac kuvar: tamna koža</annotation>
-		<annotation cp="👩🏻‍🍳">kuhinja | kuvar | kuvarica | kuvarica: svetla koža | šef | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🍳">kuhinja | kuvar | kuvarica | šef | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🍳" type="tts">kuvarica: svetla koža</annotation>
-		<annotation cp="👩🏼‍🍳">kuhinja | kuvar | kuvarica | kuvarica: srednje svetla koža | šef | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🍳">kuhinja | kuvar | kuvarica | šef | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🍳" type="tts">kuvarica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🍳">kuhinja | kuvar | kuvarica | kuvarica: ni svetla ni tamna koža | ni svetla ni tamna koža | šef | žena</annotation>
+		<annotation cp="👩🏽‍🍳">kuhinja | kuvar | kuvarica | ni svetla ni tamna koža | šef | žena</annotation>
 		<annotation cp="👩🏽‍🍳" type="tts">kuvarica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🍳">kuhinja | kuvar | kuvarica | kuvarica: srednje tamna koža | šef | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🍳">kuhinja | kuvar | kuvarica | šef | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🍳" type="tts">kuvarica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🍳">kuhinja | kuvar | kuvarica | kuvarica: tamna koža | šef | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🍳">kuhinja | kuvar | kuvarica | šef | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🍳" type="tts">kuvarica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🔧">električar | majstor | mehaničar | mehaničar: svetla koža | svetla koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏻‍🔧">električar | majstor | mehaničar | svetla koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏻‍🔧" type="tts">mehaničar: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🔧">električar | majstor | mehaničar | mehaničar: srednje svetla koža | srednje svetla koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏼‍🔧">električar | majstor | mehaničar | srednje svetla koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏼‍🔧" type="tts">mehaničar: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🔧">električar | majstor | mehaničar | mehaničar: ni svetla ni tamna koža | ni svetla ni tamna koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏽‍🔧">električar | majstor | mehaničar | ni svetla ni tamna koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏽‍🔧" type="tts">mehaničar: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🔧">električar | majstor | mehaničar | mehaničar: srednje tamna koža | srednje tamna koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏾‍🔧">električar | majstor | mehaničar | srednje tamna koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏾‍🔧" type="tts">mehaničar: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🔧">električar | majstor | mehaničar | mehaničar: tamna koža | tamna koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏿‍🔧">električar | majstor | mehaničar | tamna koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏿‍🔧" type="tts">mehaničar: tamna koža</annotation>
-		<annotation cp="👨🏻‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍🔧">alat | majstor | mehaničar | muškarac | svetla koža</annotation>
 		<annotation cp="👨🏻‍🔧" type="tts">muškarac mehaničar: svetla koža</annotation>
-		<annotation cp="👨🏼‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🔧">alat | majstor | mehaničar | muškarac | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🔧" type="tts">muškarac mehaničar: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🔧">alat | majstor | mehaničar | muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🔧" type="tts">muškarac mehaničar: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🔧">alat | majstor | mehaničar | muškarac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🔧" type="tts">muškarac mehaničar: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍🔧">alat | majstor | mehaničar | muškarac | tamna koža</annotation>
 		<annotation cp="👨🏿‍🔧" type="tts">muškarac mehaničar: tamna koža</annotation>
-		<annotation cp="👩🏻‍🔧">alat | majstor | mehaničarka | mehaničarka: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🔧">alat | majstor | mehaničarka | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🔧" type="tts">mehaničarka: svetla koža</annotation>
-		<annotation cp="👩🏼‍🔧">alat | majstor | mehaničarka | mehaničarka: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🔧">alat | majstor | mehaničarka | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🔧" type="tts">mehaničarka: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🔧">alat | majstor | mehaničarka | mehaničarka: ni svetla ni tamna koža | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🔧">alat | majstor | mehaničarka | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🔧" type="tts">mehaničarka: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🔧">alat | majstor | mehaničarka | mehaničarka: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🔧">alat | majstor | mehaničarka | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🔧" type="tts">mehaničarka: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🔧">alat | majstor | mehaničarka | mehaničarka: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🔧">alat | majstor | mehaničarka | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🔧" type="tts">mehaničarka: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🏭" type="tts">radnik u fabrici: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🏭" type="tts">radnik u fabrici: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🏭">fabrika | industrija | ni svetla ni tamna koža | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🏭">fabrika | industrija | ni svetla ni tamna koža | proizvodna traka | radnik | radnik u fabrici</annotation>
 		<annotation cp="🧑🏽‍🏭" type="tts">radnik u fabrici: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🏭" type="tts">radnik u fabrici: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🏭" type="tts">radnik u fabrici: tamna koža</annotation>
-		<annotation cp="👨🏻‍🏭">fabrika | industrija | muškarac | radnik | radnik: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍🏭">fabrika | industrija | muškarac | radnik | svetla koža</annotation>
 		<annotation cp="👨🏻‍🏭" type="tts">radnik: svetla koža</annotation>
-		<annotation cp="👨🏼‍🏭">fabrika | industrija | muškarac | radnik | radnik: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🏭">fabrika | industrija | muškarac | radnik | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🏭" type="tts">radnik: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🏭">fabrika | industrija | muškarac | ni svetla ni tamna koža | radnik | radnik: ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🏭">fabrika | industrija | muškarac | ni svetla ni tamna koža | radnik</annotation>
 		<annotation cp="👨🏽‍🏭" type="tts">radnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🏭">fabrika | industrija | muškarac | radnik | radnik: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🏭">fabrika | industrija | muškarac | radnik | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🏭" type="tts">radnik: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🏭">fabrika | industrija | muškarac | radnik | radnik: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍🏭">fabrika | industrija | muškarac | radnik | tamna koža</annotation>
 		<annotation cp="👨🏿‍🏭" type="tts">radnik: tamna koža</annotation>
-		<annotation cp="👩🏻‍🏭">fabrika | industrija | radnica | radnica: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🏭">fabrika | industrija | radnica | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🏭" type="tts">radnica: svetla koža</annotation>
-		<annotation cp="👩🏼‍🏭">fabrika | industrija | radnica | radnica: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🏭">fabrika | industrija | radnica | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🏭" type="tts">radnica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🏭">fabrika | industrija | ni svetla ni tamna koža | radnica | radnica: ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🏭">fabrika | industrija | ni svetla ni tamna koža | radnica | žena</annotation>
 		<annotation cp="👩🏽‍🏭" type="tts">radnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🏭">fabrika | industrija | radnica | radnica: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🏭">fabrika | industrija | radnica | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🏭" type="tts">radnica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🏭">fabrika | industrija | radnica | radnica: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🏭">fabrika | industrija | radnica | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🏭" type="tts">radnica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: svetla koža | menadžer | svetla koža</annotation>
+		<annotation cp="🧑🏻‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | svetla koža</annotation>
 		<annotation cp="🧑🏻‍💼" type="tts">kancelarijski radnik: svetla koža</annotation>
-		<annotation cp="🧑🏼‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: srednje svetla koža | menadžer | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍💼" type="tts">kancelarijski radnik: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: ni svetla ni tamna koža | menadžer | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧑🏽‍💼" type="tts">kancelarijski radnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: srednje tamna koža | menadžer | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍💼" type="tts">kancelarijski radnik: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: tamna koža | menadžer | tamna koža</annotation>
+		<annotation cp="🧑🏿‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | tamna koža</annotation>
 		<annotation cp="🧑🏿‍💼" type="tts">kancelarijski radnik: tamna koža</annotation>
-		<annotation cp="👨🏻‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: svetla koža | sekretarica | svetla koža</annotation>
+		<annotation cp="👨🏻‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | sekretarica | svetla koža</annotation>
 		<annotation cp="👨🏻‍💼" type="tts">muškarac u kancelariji: svetla koža</annotation>
-		<annotation cp="👨🏼‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: srednje svetla koža | sekretarica | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | sekretarica | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍💼" type="tts">muškarac u kancelariji: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: ni svetla ni tamna koža | ni svetla ni tamna koža | sekretarica</annotation>
+		<annotation cp="👨🏽‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | ni svetla ni tamna koža | sekretarica</annotation>
 		<annotation cp="👨🏽‍💼" type="tts">muškarac u kancelariji: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: srednje tamna koža | sekretarica | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | sekretarica | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍💼" type="tts">muškarac u kancelariji: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: tamna koža | sekretarica | tamna koža</annotation>
+		<annotation cp="👨🏿‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | sekretarica | tamna koža</annotation>
 		<annotation cp="👨🏿‍💼" type="tts">muškarac u kancelariji: tamna koža</annotation>
-		<annotation cp="👩🏻‍💼">asistent | kancelarija | sekretarica | svetla koža | žena | žena u kancelariji | žena u kancelariji: svetla koža</annotation>
+		<annotation cp="👩🏻‍💼">asistent | kancelarija | sekretarica | svetla koža | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏻‍💼" type="tts">žena u kancelariji: svetla koža</annotation>
-		<annotation cp="👩🏼‍💼">asistent | kancelarija | sekretarica | srednje svetla koža | žena | žena u kancelariji | žena u kancelariji: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍💼">asistent | kancelarija | sekretarica | srednje svetla koža | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏼‍💼" type="tts">žena u kancelariji: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍💼">asistent | kancelarija | ni svetla ni tamna koža | sekretarica | žena | žena u kancelariji | žena u kancelariji: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍💼">asistent | kancelarija | ni svetla ni tamna koža | sekretarica | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏽‍💼" type="tts">žena u kancelariji: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍💼">asistent | kancelarija | sekretarica | srednje tamna koža | žena | žena u kancelariji | žena u kancelariji: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍💼">asistent | kancelarija | sekretarica | srednje tamna koža | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏾‍💼" type="tts">žena u kancelariji: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍💼">asistent | kancelarija | sekretarica | tamna koža | žena | žena u kancelariji | žena u kancelariji: tamna koža</annotation>
+		<annotation cp="👩🏿‍💼">asistent | kancelarija | sekretarica | tamna koža | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏿‍💼" type="tts">žena u kancelariji: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🔬" type="tts">naučnik/ca: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🔬" type="tts">naučnik/ca: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧑🏽‍🔬" type="tts">naučnik/ca: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🔬" type="tts">naučnik/ca: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🔬" type="tts">naučnik/ca: tamna koža</annotation>
-		<annotation cp="👨🏻‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍🔬">biolog | hemičar | muškarac | naučnik | svetla koža</annotation>
 		<annotation cp="👨🏻‍🔬" type="tts">naučnik: svetla koža</annotation>
-		<annotation cp="👨🏼‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🔬">biolog | hemičar | muškarac | naučnik | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🔬" type="tts">naučnik: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🔬">biolog | hemičar | muškarac | naučnik | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🔬" type="tts">naučnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🔬">biolog | hemičar | muškarac | naučnik | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🔬" type="tts">naučnik: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍🔬">biolog | hemičar | muškarac | naučnik | tamna koža</annotation>
 		<annotation cp="👨🏿‍🔬" type="tts">naučnik: tamna koža</annotation>
-		<annotation cp="👩🏻‍🔬">biolog | hemičar | naučnica | naučnica: svetla koža | naučnik | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🔬">biolog | hemičar | naučnica | naučnik | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🔬" type="tts">naučnica: svetla koža</annotation>
-		<annotation cp="👩🏼‍🔬">biolog | hemičar | naučnica | naučnica: srednje svetla koža | naučnik | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🔬">biolog | hemičar | naučnica | naučnik | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🔬" type="tts">naučnica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🔬">biolog | hemičar | naučnica | naučnica: ni svetla ni tamna koža | naučnik | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🔬">biolog | hemičar | naučnica | naučnik | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🔬" type="tts">naučnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🔬">biolog | hemičar | naučnica | naučnica: srednje tamna koža | naučnik | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🔬">biolog | hemičar | naučnica | naučnik | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🔬" type="tts">naučnica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🔬">biolog | hemičar | naučnica | naučnica: tamna koža | naučnik | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🔬">biolog | hemičar | naučnica | naučnik | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🔬" type="tts">naučnica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍💻">programer | pronalazač | softver | softveraš | svetla koža | tehnolog | tehnolog: svetla koža</annotation>
+		<annotation cp="🧑🏻‍💻">programer | pronalazač | softver | softveraš | svetla koža | tehnolog</annotation>
 		<annotation cp="🧑🏻‍💻" type="tts">tehnolog: svetla koža</annotation>
-		<annotation cp="🧑🏼‍💻">programer | pronalazač | softver | softveraš | srednje svetla koža | tehnolog | tehnolog: srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍💻">programer | pronalazač | softver | softveraš | srednje svetla koža | tehnolog</annotation>
 		<annotation cp="🧑🏼‍💻" type="tts">tehnolog: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍💻">ni svetla ni tamna koža | programer | pronalazač | softver | softveraš | tehnolog | tehnolog: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍💻">ni svetla ni tamna koža | programer | pronalazač | softver | softveraš | tehnolog</annotation>
 		<annotation cp="🧑🏽‍💻" type="tts">tehnolog: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍💻">programer | pronalazač | softver | softveraš | srednje tamna koža | tehnolog | tehnolog: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍💻">programer | pronalazač | softver | softveraš | srednje tamna koža | tehnolog</annotation>
 		<annotation cp="🧑🏾‍💻" type="tts">tehnolog: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍💻">programer | pronalazač | softver | softveraš | tamna koža | tehnolog | tehnolog: tamna koža</annotation>
+		<annotation cp="🧑🏿‍💻">programer | pronalazač | softver | softveraš | tamna koža | tehnolog</annotation>
 		<annotation cp="🧑🏿‍💻" type="tts">tehnolog: tamna koža</annotation>
-		<annotation cp="👨🏻‍💻">muškarac | muškarac tehnolog: svetla koža | programer | pronalazač | softver | svetla koža | tehnolog</annotation>
+		<annotation cp="👨🏻‍💻">muškarac | programer | pronalazač | softver | svetla koža | tehnolog</annotation>
 		<annotation cp="👨🏻‍💻" type="tts">muškarac tehnolog: svetla koža</annotation>
-		<annotation cp="👨🏼‍💻">muškarac | muškarac tehnolog: srednje svetla koža | programer | pronalazač | softver | srednje svetla koža | tehnolog</annotation>
+		<annotation cp="👨🏼‍💻">muškarac | programer | pronalazač | softver | srednje svetla koža | tehnolog</annotation>
 		<annotation cp="👨🏼‍💻" type="tts">muškarac tehnolog: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍💻">muškarac | muškarac tehnolog: ni svetla ni tamna koža | ni svetla ni tamna koža | programer | pronalazač | softver | tehnolog</annotation>
+		<annotation cp="👨🏽‍💻">muškarac | ni svetla ni tamna koža | programer | pronalazač | softver | tehnolog</annotation>
 		<annotation cp="👨🏽‍💻" type="tts">muškarac tehnolog: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍💻">muškarac | muškarac tehnolog: srednje tamna koža | programer | pronalazač | softver | srednje tamna koža | tehnolog</annotation>
+		<annotation cp="👨🏾‍💻">muškarac | programer | pronalazač | softver | srednje tamna koža | tehnolog</annotation>
 		<annotation cp="👨🏾‍💻" type="tts">muškarac tehnolog: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍💻">muškarac | muškarac tehnolog: tamna koža | programer | pronalazač | softver | tamna koža | tehnolog</annotation>
+		<annotation cp="👨🏿‍💻">muškarac | programer | pronalazač | softver | tamna koža | tehnolog</annotation>
 		<annotation cp="👨🏿‍💻" type="tts">muškarac tehnolog: tamna koža</annotation>
-		<annotation cp="👩🏻‍💻">programer | pronalazač | softver | svetla koža | žena | žena tehnolog | žena tehnolog: svetla koža</annotation>
+		<annotation cp="👩🏻‍💻">programer | pronalazač | softver | svetla koža | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏻‍💻" type="tts">žena tehnolog: svetla koža</annotation>
-		<annotation cp="👩🏼‍💻">programer | pronalazač | softver | srednje svetla koža | žena | žena tehnolog | žena tehnolog: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍💻">programer | pronalazač | softver | srednje svetla koža | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏼‍💻" type="tts">žena tehnolog: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍💻">ni svetla ni tamna koža | programer | pronalazač | softver | žena | žena tehnolog | žena tehnolog: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍💻">ni svetla ni tamna koža | programer | pronalazač | softver | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏽‍💻" type="tts">žena tehnolog: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍💻">programer | pronalazač | softver | srednje tamna koža | žena | žena tehnolog | žena tehnolog: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍💻">programer | pronalazač | softver | srednje tamna koža | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏾‍💻" type="tts">žena tehnolog: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍💻">programer | pronalazač | softver | tamna koža | žena | žena tehnolog | žena tehnolog: tamna koža</annotation>
+		<annotation cp="👩🏿‍💻">programer | pronalazač | softver | tamna koža | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏿‍💻" type="tts">žena tehnolog: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎤">glumac | pevač | pevač: svetla koža | rok | svetla koža | zabavljač | zvezda</annotation>
+		<annotation cp="🧑🏻‍🎤">glumac | pevač | rok | svetla koža | zabavljač | zvezda</annotation>
 		<annotation cp="🧑🏻‍🎤" type="tts">pevač: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🎤">glumac | pevač | pevač: srednje svetla koža | rok | srednje svetla koža | zabavljač | zvezda</annotation>
+		<annotation cp="🧑🏼‍🎤">glumac | pevač | rok | srednje svetla koža | zabavljač | zvezda</annotation>
 		<annotation cp="🧑🏼‍🎤" type="tts">pevač: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🎤">glumac | ni svetla ni tamna koža | pevač | pevač: ni svetla ni tamna koža | rok | zabavljač | zvezda</annotation>
+		<annotation cp="🧑🏽‍🎤">glumac | ni svetla ni tamna koža | pevač | rok | zabavljač | zvezda</annotation>
 		<annotation cp="🧑🏽‍🎤" type="tts">pevač: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎤">glumac | pevač | pevač: srednje tamna koža | rok | srednje tamna koža | zabavljač | zvezda</annotation>
+		<annotation cp="🧑🏾‍🎤">glumac | pevač | rok | srednje tamna koža | zabavljač | zvezda</annotation>
 		<annotation cp="🧑🏾‍🎤" type="tts">pevač: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎤">glumac | pevač | pevač: tamna koža | rok | tamna koža | zabavljač | zvezda</annotation>
+		<annotation cp="🧑🏿‍🎤">glumac | pevač | rok | tamna koža | zabavljač | zvezda</annotation>
 		<annotation cp="🧑🏿‍🎤" type="tts">pevač: tamna koža</annotation>
-		<annotation cp="👨🏻‍🎤">glumac | muškarac | muškarac pevač: svetla koža | pevač | rok | svetla koža</annotation>
+		<annotation cp="👨🏻‍🎤">glumac | muškarac | pevač | rok | svetla koža</annotation>
 		<annotation cp="👨🏻‍🎤" type="tts">muškarac pevač: svetla koža</annotation>
-		<annotation cp="👨🏼‍🎤">glumac | muškarac | muškarac pevač: srednje svetla koža | pevač | rok | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🎤">glumac | muškarac | pevač | rok | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🎤" type="tts">muškarac pevač: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🎤">glumac | muškarac | muškarac pevač: ni svetla ni tamna koža | ni svetla ni tamna koža | pevač | rok</annotation>
+		<annotation cp="👨🏽‍🎤">glumac | muškarac | ni svetla ni tamna koža | pevač | rok</annotation>
 		<annotation cp="👨🏽‍🎤" type="tts">muškarac pevač: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🎤">glumac | muškarac | muškarac pevač: srednje tamna koža | pevač | rok | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🎤">glumac | muškarac | pevač | rok | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🎤" type="tts">muškarac pevač: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🎤">glumac | muškarac | muškarac pevač: tamna koža | pevač | rok | tamna koža</annotation>
+		<annotation cp="👨🏿‍🎤">glumac | muškarac | pevač | rok | tamna koža</annotation>
 		<annotation cp="👨🏿‍🎤" type="tts">muškarac pevač: tamna koža</annotation>
-		<annotation cp="👩🏻‍🎤">glumica | pevačica | pevačica: svetla koža | rok | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🎤">glumica | pevačica | rok | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🎤" type="tts">pevačica: svetla koža</annotation>
-		<annotation cp="👩🏼‍🎤">glumica | pevačica | pevačica: srednje svetla koža | rok | srednje svetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🎤">glumica | pevačica | rok | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🎤" type="tts">pevačica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🎤">glumica | ni svetla ni tamna koža | pevačica | pevačica: ni svetla ni tamna koža | rok | žena</annotation>
+		<annotation cp="👩🏽‍🎤">glumica | ni svetla ni tamna koža | pevačica | rok | žena</annotation>
 		<annotation cp="👩🏽‍🎤" type="tts">pevačica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🎤">glumica | pevačica | pevačica: srednje tamna koža | rok | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🎤">glumica | pevačica | rok | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🎤" type="tts">pevačica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🎤">glumica | pevačica | pevačica: tamna koža | rok | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🎤">glumica | pevačica | rok | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🎤" type="tts">pevačica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎨">slikar | svetla koža | umetnik | umetnik: svetla koža</annotation>
+		<annotation cp="🧑🏻‍🎨">slikar | svetla koža | umetnik</annotation>
 		<annotation cp="🧑🏻‍🎨" type="tts">umetnik: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🎨">slikar | srednje svetla koža | umetnik | umetnik: srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🎨">slikar | srednje svetla koža | umetnik</annotation>
 		<annotation cp="🧑🏼‍🎨" type="tts">umetnik: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🎨">ni svetla ni tamna koža | slikar | umetnik | umetnik: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🎨">ni svetla ni tamna koža | slikar | umetnik</annotation>
 		<annotation cp="🧑🏽‍🎨" type="tts">umetnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎨">slikar | srednje tamna koža | umetnik | umetnik: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🎨">slikar | srednje tamna koža | umetnik</annotation>
 		<annotation cp="🧑🏾‍🎨" type="tts">umetnik: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎨">slikar | tamna koža | umetnik | umetnik: tamna koža</annotation>
+		<annotation cp="🧑🏿‍🎨">slikar | tamna koža | umetnik</annotation>
 		<annotation cp="🧑🏿‍🎨" type="tts">umetnik: tamna koža</annotation>
-		<annotation cp="👨🏻‍🎨">muškarac | muškarac umetnik: svetla koža | slikar | slikarstvo | svetla koža | umetnik</annotation>
+		<annotation cp="👨🏻‍🎨">muškarac | slikar | slikarstvo | svetla koža | umetnik</annotation>
 		<annotation cp="👨🏻‍🎨" type="tts">muškarac umetnik: svetla koža</annotation>
-		<annotation cp="👨🏼‍🎨">muškarac | muškarac umetnik: srednje svetla koža | slikar | slikarstvo | srednje svetla koža | umetnik</annotation>
+		<annotation cp="👨🏼‍🎨">muškarac | slikar | slikarstvo | srednje svetla koža | umetnik</annotation>
 		<annotation cp="👨🏼‍🎨" type="tts">muškarac umetnik: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🎨">muškarac | muškarac umetnik: ni svetla ni tamna koža | ni svetla ni tamna koža | slikar | slikarstvo | umetnik</annotation>
+		<annotation cp="👨🏽‍🎨">muškarac | ni svetla ni tamna koža | slikar | slikarstvo | umetnik</annotation>
 		<annotation cp="👨🏽‍🎨" type="tts">muškarac umetnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🎨">muškarac | muškarac umetnik: srednje tamna koža | slikar | slikarstvo | srednje tamna koža | umetnik</annotation>
+		<annotation cp="👨🏾‍🎨">muškarac | slikar | slikarstvo | srednje tamna koža | umetnik</annotation>
 		<annotation cp="👨🏾‍🎨" type="tts">muškarac umetnik: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🎨">muškarac | muškarac umetnik: tamna koža | slikar | slikarstvo | tamna koža | umetnik</annotation>
+		<annotation cp="👨🏿‍🎨">muškarac | slikar | slikarstvo | tamna koža | umetnik</annotation>
 		<annotation cp="👨🏿‍🎨" type="tts">muškarac umetnik: tamna koža</annotation>
-		<annotation cp="👩🏻‍🎨">slikar | slikarstvo | svetla koža | umetnica | umetnica: svetla koža | umetnik | žena</annotation>
+		<annotation cp="👩🏻‍🎨">slikar | slikarstvo | svetla koža | umetnica | umetnik | žena</annotation>
 		<annotation cp="👩🏻‍🎨" type="tts">umetnica: svetla koža</annotation>
-		<annotation cp="👩🏼‍🎨">slikar | slikarstvo | srednje svetla koža | umetnica | umetnica: srednje svetla koža | umetnik | žena</annotation>
+		<annotation cp="👩🏼‍🎨">slikar | slikarstvo | srednje svetla koža | umetnica | umetnik | žena</annotation>
 		<annotation cp="👩🏼‍🎨" type="tts">umetnica: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🎨">ni svetla ni tamna koža | slikar | slikarstvo | umetnica | umetnica: ni svetla ni tamna koža | umetnik | žena</annotation>
+		<annotation cp="👩🏽‍🎨">ni svetla ni tamna koža | slikar | slikarstvo | umetnica | umetnik | žena</annotation>
 		<annotation cp="👩🏽‍🎨" type="tts">umetnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🎨">slikar | slikarstvo | srednje tamna koža | umetnica | umetnica: srednje tamna koža | umetnik | žena</annotation>
+		<annotation cp="👩🏾‍🎨">slikar | slikarstvo | srednje tamna koža | umetnica | umetnik | žena</annotation>
 		<annotation cp="👩🏾‍🎨" type="tts">umetnica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🎨">slikar | slikarstvo | tamna koža | umetnica | umetnica: tamna koža | umetnik | žena</annotation>
+		<annotation cp="👩🏿‍🎨">slikar | slikarstvo | tamna koža | umetnica | umetnik | žena</annotation>
 		<annotation cp="👩🏿‍🎨" type="tts">umetnica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍✈">avion | pilot | pilot/kinja | pilot/kinja: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍✈">avion | pilot | pilot/kinja | svetla koža</annotation>
 		<annotation cp="🧑🏻‍✈" type="tts">pilot/kinja: svetla koža</annotation>
-		<annotation cp="🧑🏼‍✈">avion | pilot | pilot/kinja | pilot/kinja: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍✈">avion | pilot | pilot/kinja | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍✈" type="tts">pilot/kinja: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍✈">avion | ni svetla ni tamna koža | pilot | pilot/kinja | pilot/kinja: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍✈">avion | ni svetla ni tamna koža | pilot | pilot/kinja</annotation>
 		<annotation cp="🧑🏽‍✈" type="tts">pilot/kinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍✈">avion | pilot | pilot/kinja | pilot/kinja: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍✈">avion | pilot | pilot/kinja | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍✈" type="tts">pilot/kinja: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍✈">avion | pilot | pilot/kinja | pilot/kinja: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍✈">avion | pilot | pilot/kinja | tamna koža</annotation>
 		<annotation cp="🧑🏿‍✈" type="tts">pilot/kinja: tamna koža</annotation>
-		<annotation cp="👨🏻‍✈">avion | muškarac | pilot | pilot: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍✈">avion | muškarac | pilot | svetla koža</annotation>
 		<annotation cp="👨🏻‍✈" type="tts">pilot: svetla koža</annotation>
-		<annotation cp="👨🏼‍✈">avion | muškarac | pilot | pilot: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍✈">avion | muškarac | pilot | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍✈" type="tts">pilot: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍✈">avion | muškarac | ni svetla ni tamna koža | pilot | pilot: ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍✈">avion | muškarac | ni svetla ni tamna koža | pilot</annotation>
 		<annotation cp="👨🏽‍✈" type="tts">pilot: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍✈">avion | muškarac | pilot | pilot: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍✈">avion | muškarac | pilot | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍✈" type="tts">pilot: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍✈">avion | muškarac | pilot | pilot: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍✈">avion | muškarac | pilot | tamna koža</annotation>
 		<annotation cp="👨🏿‍✈" type="tts">pilot: tamna koža</annotation>
-		<annotation cp="👩🏻‍✈">avion | pilot | svetla koža | žena | žena pilot: svetla koža</annotation>
+		<annotation cp="👩🏻‍✈">avion | pilot | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍✈" type="tts">žena pilot: svetla koža</annotation>
-		<annotation cp="👩🏼‍✈">avion | pilot | srednje svetla koža | žena | žena pilot: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍✈">avion | pilot | srednje svetla koža | žena</annotation>
 		<annotation cp="👩🏼‍✈" type="tts">žena pilot: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍✈">avion | ni svetla ni tamna koža | pilot | žena | žena pilot: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍✈">avion | ni svetla ni tamna koža | pilot | žena</annotation>
 		<annotation cp="👩🏽‍✈" type="tts">žena pilot: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍✈">avion | pilot | srednje tamna koža | žena | žena pilot: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍✈">avion | pilot | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍✈" type="tts">žena pilot: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍✈">avion | pilot | tamna koža | žena | žena pilot: tamna koža</annotation>
+		<annotation cp="👩🏿‍✈">avion | pilot | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍✈" type="tts">žena pilot: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🚀">astronaut | astronaut: svetla koža | raketa | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🚀">astronaut | raketa | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🚀" type="tts">astronaut: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🚀">astronaut | astronaut: srednje svetla koža | raketa | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🚀">astronaut | raketa | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🚀" type="tts">astronaut: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🚀">astronaut | astronaut: ni svetla ni tamna koža | ni svetla ni tamna koža | raketa</annotation>
+		<annotation cp="🧑🏽‍🚀">astronaut | ni svetla ni tamna koža | raketa</annotation>
 		<annotation cp="🧑🏽‍🚀" type="tts">astronaut: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🚀">astronaut | astronaut: srednje tamna koža | raketa | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🚀">astronaut | raketa | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🚀" type="tts">astronaut: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🚀">astronaut | astronaut: tamna koža | raketa | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🚀">astronaut | raketa | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🚀" type="tts">astronaut: tamna koža</annotation>
-		<annotation cp="👨🏻‍🚀">astronaut | kosmonaut | kosmonaut: svetla koža | muškarac | raketa | svemir | svetla koža</annotation>
+		<annotation cp="👨🏻‍🚀">astronaut | kosmonaut | muškarac | raketa | svemir | svetla koža</annotation>
 		<annotation cp="👨🏻‍🚀" type="tts">kosmonaut: svetla koža</annotation>
-		<annotation cp="👨🏼‍🚀">astronaut | kosmonaut | kosmonaut: srednje svetla koža | muškarac | raketa | srednje svetla koža | svemir</annotation>
+		<annotation cp="👨🏼‍🚀">astronaut | kosmonaut | muškarac | raketa | srednje svetla koža | svemir</annotation>
 		<annotation cp="👨🏼‍🚀" type="tts">kosmonaut: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🚀">astronaut | kosmonaut | kosmonaut: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | raketa | svemir</annotation>
+		<annotation cp="👨🏽‍🚀">astronaut | kosmonaut | muškarac | ni svetla ni tamna koža | raketa | svemir</annotation>
 		<annotation cp="👨🏽‍🚀" type="tts">kosmonaut: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🚀">astronaut | kosmonaut | kosmonaut: srednje tamna koža | muškarac | raketa | srednje tamna koža | svemir</annotation>
+		<annotation cp="👨🏾‍🚀">astronaut | kosmonaut | muškarac | raketa | srednje tamna koža | svemir</annotation>
 		<annotation cp="👨🏾‍🚀" type="tts">kosmonaut: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🚀">astronaut | kosmonaut | kosmonaut: tamna koža | muškarac | raketa | svemir | tamna koža</annotation>
+		<annotation cp="👨🏿‍🚀">astronaut | kosmonaut | muškarac | raketa | svemir | tamna koža</annotation>
 		<annotation cp="👨🏿‍🚀" type="tts">kosmonaut: tamna koža</annotation>
-		<annotation cp="👩🏻‍🚀">astronaut | kosmonautkinja | kosmonautkinja: svetla koža | raketa | svemir | svetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🚀">astronaut | kosmonautkinja | raketa | svemir | svetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🚀" type="tts">kosmonautkinja: svetla koža</annotation>
-		<annotation cp="👩🏼‍🚀">astronaut | kosmonautkinja | kosmonautkinja: srednje svetla koža | raketa | srednje svetla koža | svemir | žena</annotation>
+		<annotation cp="👩🏼‍🚀">astronaut | kosmonautkinja | raketa | srednje svetla koža | svemir | žena</annotation>
 		<annotation cp="👩🏼‍🚀" type="tts">kosmonautkinja: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🚀">astronaut | kosmonautkinja | kosmonautkinja: ni svetla ni tamna koža | ni svetla ni tamna koža | raketa | svemir | žena</annotation>
+		<annotation cp="👩🏽‍🚀">astronaut | kosmonautkinja | ni svetla ni tamna koža | raketa | svemir | žena</annotation>
 		<annotation cp="👩🏽‍🚀" type="tts">kosmonautkinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🚀">astronaut | kosmonautkinja | kosmonautkinja: srednje tamna koža | raketa | srednje tamna koža | svemir | žena</annotation>
+		<annotation cp="👩🏾‍🚀">astronaut | kosmonautkinja | raketa | srednje tamna koža | svemir | žena</annotation>
 		<annotation cp="👩🏾‍🚀" type="tts">kosmonautkinja: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🚀">astronaut | kosmonautkinja | kosmonautkinja: tamna koža | raketa | svemir | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🚀">astronaut | kosmonautkinja | raketa | svemir | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🚀" type="tts">kosmonautkinja: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🚒">svetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: svetla koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏻‍🚒">svetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏻‍🚒" type="tts">vatrogasac / žena vatrogasac: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🚒">srednje svetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: srednje svetla koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏼‍🚒">srednje svetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏼‍🚒" type="tts">vatrogasac / žena vatrogasac: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🚒">ni svetla ni tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: ni svetla ni tamna koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏽‍🚒">ni svetla ni tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏽‍🚒" type="tts">vatrogasac / žena vatrogasac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🚒">srednje tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: srednje tamna koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏾‍🚒">srednje tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏾‍🚒" type="tts">vatrogasac / žena vatrogasac: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🚒">tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: tamna koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏿‍🚒">tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏿‍🚒" type="tts">vatrogasac / žena vatrogasac: tamna koža</annotation>
-		<annotation cp="👨🏻‍🚒">kamion | muškarac | svetla koža | vatra | vatrogasac | vatrogasac: svetla koža</annotation>
+		<annotation cp="👨🏻‍🚒">kamion | muškarac | svetla koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏻‍🚒" type="tts">vatrogasac: svetla koža</annotation>
-		<annotation cp="👨🏼‍🚒">kamion | muškarac | srednje svetla koža | vatra | vatrogasac | vatrogasac: srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🚒">kamion | muškarac | srednje svetla koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏼‍🚒" type="tts">vatrogasac: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🚒">kamion | muškarac | ni svetla ni tamna koža | vatra | vatrogasac | vatrogasac: ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🚒">kamion | muškarac | ni svetla ni tamna koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏽‍🚒" type="tts">vatrogasac: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🚒">kamion | muškarac | srednje tamna koža | vatra | vatrogasac | vatrogasac: srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🚒">kamion | muškarac | srednje tamna koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏾‍🚒" type="tts">vatrogasac: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🚒">kamion | muškarac | tamna koža | vatra | vatrogasac | vatrogasac: tamna koža</annotation>
+		<annotation cp="👨🏿‍🚒">kamion | muškarac | tamna koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏿‍🚒" type="tts">vatrogasac: tamna koža</annotation>
-		<annotation cp="👩🏻‍🚒">kamion | svetla koža | vatra | vatrogasac | žena | žena vatrogasac: svetla koža</annotation>
+		<annotation cp="👩🏻‍🚒">kamion | svetla koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏻‍🚒" type="tts">žena vatrogasac: svetla koža</annotation>
-		<annotation cp="👩🏼‍🚒">kamion | srednje svetla koža | vatra | vatrogasac | žena | žena vatrogasac: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍🚒">kamion | srednje svetla koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏼‍🚒" type="tts">žena vatrogasac: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🚒">kamion | ni svetla ni tamna koža | vatra | vatrogasac | žena | žena vatrogasac: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🚒">kamion | ni svetla ni tamna koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏽‍🚒" type="tts">žena vatrogasac: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🚒">kamion | srednje tamna koža | vatra | vatrogasac | žena | žena vatrogasac: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍🚒">kamion | srednje tamna koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏾‍🚒" type="tts">žena vatrogasac: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🚒">kamion | tamna koža | vatra | vatrogasac | žena | žena vatrogasac: tamna koža</annotation>
+		<annotation cp="👩🏿‍🚒">kamion | tamna koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏿‍🚒" type="tts">žena vatrogasac: tamna koža</annotation>
-		<annotation cp="👮🏻">policajac | policija | pozornik | predstavnik policije | predstavnik policije: svetla koža | svetla koža</annotation>
+		<annotation cp="👮🏻">policajac | policija | pozornik | predstavnik policije | svetla koža</annotation>
 		<annotation cp="👮🏻" type="tts">predstavnik policije: svetla koža</annotation>
-		<annotation cp="👮🏼">policajac | policija | pozornik | predstavnik policije | predstavnik policije: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👮🏼">policajac | policija | pozornik | predstavnik policije | srednje svetla koža</annotation>
 		<annotation cp="👮🏼" type="tts">predstavnik policije: srednje svetla koža</annotation>
-		<annotation cp="👮🏽">ni svetla ni tamna koža | policajac | policija | pozornik | predstavnik policije | predstavnik policije: ni svetla ni tamna koža</annotation>
+		<annotation cp="👮🏽">ni svetla ni tamna koža | policajac | policija | pozornik | predstavnik policije</annotation>
 		<annotation cp="👮🏽" type="tts">predstavnik policije: ni svetla ni tamna koža</annotation>
-		<annotation cp="👮🏾">policajac | policija | pozornik | predstavnik policije | predstavnik policije: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👮🏾">policajac | policija | pozornik | predstavnik policije | srednje tamna koža</annotation>
 		<annotation cp="👮🏾" type="tts">predstavnik policije: srednje tamna koža</annotation>
-		<annotation cp="👮🏿">policajac | policija | pozornik | predstavnik policije | predstavnik policije: tamna koža | tamna koža</annotation>
+		<annotation cp="👮🏿">policajac | policija | pozornik | predstavnik policije | tamna koža</annotation>
 		<annotation cp="👮🏿" type="tts">predstavnik policije: tamna koža</annotation>
-		<annotation cp="👮🏻‍♂">muškarac | pandur | policajac | policajac: svetla koža | policija | svetla koža</annotation>
+		<annotation cp="👮🏻‍♂">muškarac | pandur | policajac | policija | svetla koža</annotation>
 		<annotation cp="👮🏻‍♂" type="tts">policajac: svetla koža</annotation>
-		<annotation cp="👮🏼‍♂">muškarac | pandur | policajac | policajac: srednje svetla koža | policija | srednje svetla koža</annotation>
+		<annotation cp="👮🏼‍♂">muškarac | pandur | policajac | policija | srednje svetla koža</annotation>
 		<annotation cp="👮🏼‍♂" type="tts">policajac: srednje svetla koža</annotation>
-		<annotation cp="👮🏽‍♂">muškarac | ni svetla ni tamna koža | pandur | policajac | policajac: ni svetla ni tamna koža | policija</annotation>
+		<annotation cp="👮🏽‍♂">muškarac | ni svetla ni tamna koža | pandur | policajac | policija</annotation>
 		<annotation cp="👮🏽‍♂" type="tts">policajac: ni svetla ni tamna koža</annotation>
-		<annotation cp="👮🏾‍♂">muškarac | pandur | policajac | policajac: srednje tamna koža | policija | srednje tamna koža</annotation>
+		<annotation cp="👮🏾‍♂">muškarac | pandur | policajac | policija | srednje tamna koža</annotation>
 		<annotation cp="👮🏾‍♂" type="tts">policajac: srednje tamna koža</annotation>
-		<annotation cp="👮🏿‍♂">muškarac | pandur | policajac | policajac: tamna koža | policija | tamna koža</annotation>
+		<annotation cp="👮🏿‍♂">muškarac | pandur | policajac | policija | tamna koža</annotation>
 		<annotation cp="👮🏿‍♂" type="tts">policajac: tamna koža</annotation>
-		<annotation cp="👮🏻‍♀">pandurka | policajka | policajka: svetla koža | policija | svetla koža | žena</annotation>
+		<annotation cp="👮🏻‍♀">pandurka | policajka | policija | svetla koža | žena</annotation>
 		<annotation cp="👮🏻‍♀" type="tts">policajka: svetla koža</annotation>
-		<annotation cp="👮🏼‍♀">pandurka | policajka | policajka: srednje svetla koža | policija | srednje svetla koža | žena</annotation>
+		<annotation cp="👮🏼‍♀">pandurka | policajka | policija | srednje svetla koža | žena</annotation>
 		<annotation cp="👮🏼‍♀" type="tts">policajka: srednje svetla koža</annotation>
-		<annotation cp="👮🏽‍♀">ni svetla ni tamna koža | pandurka | policajka | policajka: ni svetla ni tamna koža | policija | žena</annotation>
+		<annotation cp="👮🏽‍♀">ni svetla ni tamna koža | pandurka | policajka | policija | žena</annotation>
 		<annotation cp="👮🏽‍♀" type="tts">policajka: ni svetla ni tamna koža</annotation>
-		<annotation cp="👮🏾‍♀">pandurka | policajka | policajka: srednje tamna koža | policija | srednje tamna koža | žena</annotation>
+		<annotation cp="👮🏾‍♀">pandurka | policajka | policija | srednje tamna koža | žena</annotation>
 		<annotation cp="👮🏾‍♀" type="tts">policajka: srednje tamna koža</annotation>
-		<annotation cp="👮🏿‍♀">pandurka | policajka | policajka: tamna koža | policija | tamna koža | žena</annotation>
+		<annotation cp="👮🏿‍♀">pandurka | policajka | policija | tamna koža | žena</annotation>
 		<annotation cp="👮🏿‍♀" type="tts">policajka: tamna koža</annotation>
-		<annotation cp="🕵🏻">detektiv | inspektor | inspektor: svetla koža | špijun | svetla koža</annotation>
+		<annotation cp="🕵🏻">detektiv | inspektor | špijun | svetla koža</annotation>
 		<annotation cp="🕵🏻" type="tts">inspektor: svetla koža</annotation>
-		<annotation cp="🕵🏼">detektiv | inspektor | inspektor: srednje svetla koža | špijun | srednje svetla koža</annotation>
+		<annotation cp="🕵🏼">detektiv | inspektor | špijun | srednje svetla koža</annotation>
 		<annotation cp="🕵🏼" type="tts">inspektor: srednje svetla koža</annotation>
-		<annotation cp="🕵🏽">detektiv | inspektor | inspektor: ni svetla ni tamna koža | ni svetla ni tamna koža | špijun</annotation>
+		<annotation cp="🕵🏽">detektiv | inspektor | ni svetla ni tamna koža | špijun</annotation>
 		<annotation cp="🕵🏽" type="tts">inspektor: ni svetla ni tamna koža</annotation>
-		<annotation cp="🕵🏾">detektiv | inspektor | inspektor: srednje tamna koža | špijun | srednje tamna koža</annotation>
+		<annotation cp="🕵🏾">detektiv | inspektor | špijun | srednje tamna koža</annotation>
 		<annotation cp="🕵🏾" type="tts">inspektor: srednje tamna koža</annotation>
-		<annotation cp="🕵🏿">detektiv | inspektor | inspektor: tamna koža | špijun | tamna koža</annotation>
+		<annotation cp="🕵🏿">detektiv | inspektor | špijun | tamna koža</annotation>
 		<annotation cp="🕵🏿" type="tts">inspektor: tamna koža</annotation>
-		<annotation cp="🕵🏻‍♂">detektiv | detektiv: svetla koža | muškarac | špijun | svetla koža</annotation>
+		<annotation cp="🕵🏻‍♂">detektiv | muškarac | špijun | svetla koža</annotation>
 		<annotation cp="🕵🏻‍♂" type="tts">detektiv: svetla koža</annotation>
-		<annotation cp="🕵🏼‍♂">detektiv | detektiv: srednje svetla koža | muškarac | špijun | srednje svetla koža</annotation>
+		<annotation cp="🕵🏼‍♂">detektiv | muškarac | špijun | srednje svetla koža</annotation>
 		<annotation cp="🕵🏼‍♂" type="tts">detektiv: srednje svetla koža</annotation>
-		<annotation cp="🕵🏽‍♂">detektiv | detektiv: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | špijun</annotation>
+		<annotation cp="🕵🏽‍♂">detektiv | muškarac | ni svetla ni tamna koža | špijun</annotation>
 		<annotation cp="🕵🏽‍♂" type="tts">detektiv: ni svetla ni tamna koža</annotation>
-		<annotation cp="🕵🏾‍♂">detektiv | detektiv: srednje tamna koža | muškarac | špijun | srednje tamna koža</annotation>
+		<annotation cp="🕵🏾‍♂">detektiv | muškarac | špijun | srednje tamna koža</annotation>
 		<annotation cp="🕵🏾‍♂" type="tts">detektiv: srednje tamna koža</annotation>
-		<annotation cp="🕵🏿‍♂">detektiv | detektiv: tamna koža | muškarac | špijun | tamna koža</annotation>
+		<annotation cp="🕵🏿‍♂">detektiv | muškarac | špijun | tamna koža</annotation>
 		<annotation cp="🕵🏿‍♂" type="tts">detektiv: tamna koža</annotation>
-		<annotation cp="🕵🏻‍♀">detektiv | detektivka | detektivka: svetla koža | špijun | svetla koža | žena</annotation>
+		<annotation cp="🕵🏻‍♀">detektiv | detektivka | špijun | svetla koža | žena</annotation>
 		<annotation cp="🕵🏻‍♀" type="tts">detektivka: svetla koža</annotation>
-		<annotation cp="🕵🏼‍♀">detektiv | detektivka | detektivka: srednje svetla koža | špijun | srednje svetla koža | žena</annotation>
+		<annotation cp="🕵🏼‍♀">detektiv | detektivka | špijun | srednje svetla koža | žena</annotation>
 		<annotation cp="🕵🏼‍♀" type="tts">detektivka: srednje svetla koža</annotation>
-		<annotation cp="🕵🏽‍♀">detektiv | detektivka | detektivka: ni svetla ni tamna koža | ni svetla ni tamna koža | špijun | žena</annotation>
+		<annotation cp="🕵🏽‍♀">detektiv | detektivka | ni svetla ni tamna koža | špijun | žena</annotation>
 		<annotation cp="🕵🏽‍♀" type="tts">detektivka: ni svetla ni tamna koža</annotation>
-		<annotation cp="🕵🏾‍♀">detektiv | detektivka | detektivka: srednje tamna koža | špijun | srednje tamna koža | žena</annotation>
+		<annotation cp="🕵🏾‍♀">detektiv | detektivka | špijun | srednje tamna koža | žena</annotation>
 		<annotation cp="🕵🏾‍♀" type="tts">detektivka: srednje tamna koža</annotation>
-		<annotation cp="🕵🏿‍♀">detektiv | detektivka | detektivka: tamna koža | špijun | tamna koža | žena</annotation>
+		<annotation cp="🕵🏿‍♀">detektiv | detektivka | špijun | tamna koža | žena</annotation>
 		<annotation cp="🕵🏿‍♀" type="tts">detektivka: tamna koža</annotation>
-		<annotation cp="💂🏻">čuvar | čuvar: svetla koža | stražar | svetla koža</annotation>
+		<annotation cp="💂🏻">čuvar | stražar | svetla koža</annotation>
 		<annotation cp="💂🏻" type="tts">čuvar: svetla koža</annotation>
-		<annotation cp="💂🏼">čuvar | čuvar: srednje svetla koža | srednje svetla koža | stražar</annotation>
+		<annotation cp="💂🏼">čuvar | srednje svetla koža | stražar</annotation>
 		<annotation cp="💂🏼" type="tts">čuvar: srednje svetla koža</annotation>
-		<annotation cp="💂🏽">čuvar | čuvar: ni svetla ni tamna koža | ni svetla ni tamna koža | stražar</annotation>
+		<annotation cp="💂🏽">čuvar | ni svetla ni tamna koža | stražar</annotation>
 		<annotation cp="💂🏽" type="tts">čuvar: ni svetla ni tamna koža</annotation>
-		<annotation cp="💂🏾">čuvar | čuvar: srednje tamna koža | srednje tamna koža | stražar</annotation>
+		<annotation cp="💂🏾">čuvar | srednje tamna koža | stražar</annotation>
 		<annotation cp="💂🏾" type="tts">čuvar: srednje tamna koža</annotation>
-		<annotation cp="💂🏿">čuvar | čuvar: tamna koža | stražar | tamna koža</annotation>
+		<annotation cp="💂🏿">čuvar | stražar | tamna koža</annotation>
 		<annotation cp="💂🏿" type="tts">čuvar: tamna koža</annotation>
-		<annotation cp="💂🏻‍♂">čuvar | gardista | gardista: svetla koža | muškarac | stražar | svetla koža</annotation>
+		<annotation cp="💂🏻‍♂">čuvar | gardista | muškarac | stražar | svetla koža</annotation>
 		<annotation cp="💂🏻‍♂" type="tts">gardista: svetla koža</annotation>
-		<annotation cp="💂🏼‍♂">čuvar | gardista | gardista: srednje svetla koža | muškarac | srednje svetla koža | stražar</annotation>
+		<annotation cp="💂🏼‍♂">čuvar | gardista | muškarac | srednje svetla koža | stražar</annotation>
 		<annotation cp="💂🏼‍♂" type="tts">gardista: srednje svetla koža</annotation>
-		<annotation cp="💂🏽‍♂">čuvar | gardista | gardista: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | stražar</annotation>
+		<annotation cp="💂🏽‍♂">čuvar | gardista | muškarac | ni svetla ni tamna koža | stražar</annotation>
 		<annotation cp="💂🏽‍♂" type="tts">gardista: ni svetla ni tamna koža</annotation>
-		<annotation cp="💂🏾‍♂">čuvar | gardista | gardista: srednje tamna koža | muškarac | srednje tamna koža | stražar</annotation>
+		<annotation cp="💂🏾‍♂">čuvar | gardista | muškarac | srednje tamna koža | stražar</annotation>
 		<annotation cp="💂🏾‍♂" type="tts">gardista: srednje tamna koža</annotation>
-		<annotation cp="💂🏿‍♂">čuvar | gardista | gardista: tamna koža | muškarac | stražar | tamna koža</annotation>
+		<annotation cp="💂🏿‍♂">čuvar | gardista | muškarac | stražar | tamna koža</annotation>
 		<annotation cp="💂🏿‍♂" type="tts">gardista: tamna koža</annotation>
-		<annotation cp="💂🏻‍♀">čuvar | gardistkinja | gardistkinja: svetla koža | stražar | svetla koža | žena</annotation>
+		<annotation cp="💂🏻‍♀">čuvar | gardistkinja | stražar | svetla koža | žena</annotation>
 		<annotation cp="💂🏻‍♀" type="tts">gardistkinja: svetla koža</annotation>
-		<annotation cp="💂🏼‍♀">čuvar | gardistkinja | gardistkinja: srednje svetla koža | srednje svetla koža | stražar | žena</annotation>
+		<annotation cp="💂🏼‍♀">čuvar | gardistkinja | srednje svetla koža | stražar | žena</annotation>
 		<annotation cp="💂🏼‍♀" type="tts">gardistkinja: srednje svetla koža</annotation>
-		<annotation cp="💂🏽‍♀">čuvar | gardistkinja | gardistkinja: ni svetla ni tamna koža | ni svetla ni tamna koža | stražar | žena</annotation>
+		<annotation cp="💂🏽‍♀">čuvar | gardistkinja | ni svetla ni tamna koža | stražar | žena</annotation>
 		<annotation cp="💂🏽‍♀" type="tts">gardistkinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="💂🏾‍♀">čuvar | gardistkinja | gardistkinja: srednje tamna koža | srednje tamna koža | stražar | žena</annotation>
+		<annotation cp="💂🏾‍♀">čuvar | gardistkinja | srednje tamna koža | stražar | žena</annotation>
 		<annotation cp="💂🏾‍♀" type="tts">gardistkinja: srednje tamna koža</annotation>
-		<annotation cp="💂🏿‍♀">čuvar | gardistkinja | gardistkinja: tamna koža | stražar | tamna koža | žena</annotation>
+		<annotation cp="💂🏿‍♀">čuvar | gardistkinja | stražar | tamna koža | žena</annotation>
 		<annotation cp="💂🏿‍♀" type="tts">gardistkinja: tamna koža</annotation>
-		<annotation cp="🥷🏻">borac | nevidljiv | nindža | nindža: svetla koža | skriven | svetla koža</annotation>
+		<annotation cp="🥷🏻">borac | nevidljiv | nindža | skriven | svetla koža</annotation>
 		<annotation cp="🥷🏻" type="tts">nindža: svetla koža</annotation>
-		<annotation cp="🥷🏼">borac | nevidljiv | nindža | nindža: srednje svetla koža | skriven | srednje svetla koža</annotation>
+		<annotation cp="🥷🏼">borac | nevidljiv | nindža | skriven | srednje svetla koža</annotation>
 		<annotation cp="🥷🏼" type="tts">nindža: srednje svetla koža</annotation>
-		<annotation cp="🥷🏽">borac | nevidljiv | ni svetla ni tamna koža | nindža | nindža: ni svetla ni tamna koža | skriven</annotation>
+		<annotation cp="🥷🏽">borac | nevidljiv | ni svetla ni tamna koža | nindža | skriven</annotation>
 		<annotation cp="🥷🏽" type="tts">nindža: ni svetla ni tamna koža</annotation>
-		<annotation cp="🥷🏾">borac | nevidljiv | nindža | nindža: srednje tamna koža | skriven | srednje tamna koža</annotation>
+		<annotation cp="🥷🏾">borac | nevidljiv | nindža | skriven | srednje tamna koža</annotation>
 		<annotation cp="🥷🏾" type="tts">nindža: srednje tamna koža</annotation>
-		<annotation cp="🥷🏿">borac | nevidljiv | nindža | nindža: tamna koža | skriven | tamna koža</annotation>
+		<annotation cp="🥷🏿">borac | nevidljiv | nindža | skriven | tamna koža</annotation>
 		<annotation cp="🥷🏿" type="tts">nindža: tamna koža</annotation>
-		<annotation cp="👷🏻">građevinski radnik | građevinski radnik: svetla koža | radnik | šlem | svetla koža</annotation>
+		<annotation cp="👷🏻">građevinski radnik | radnik | šlem | svetla koža</annotation>
 		<annotation cp="👷🏻" type="tts">građevinski radnik: svetla koža</annotation>
-		<annotation cp="👷🏼">građevinski radnik | građevinski radnik: srednje svetla koža | radnik | šlem | srednje svetla koža</annotation>
+		<annotation cp="👷🏼">građevinski radnik | radnik | šlem | srednje svetla koža</annotation>
 		<annotation cp="👷🏼" type="tts">građevinski radnik: srednje svetla koža</annotation>
-		<annotation cp="👷🏽">građevinski radnik | građevinski radnik: ni svetla ni tamna koža | ni svetla ni tamna koža | radnik | šlem</annotation>
+		<annotation cp="👷🏽">građevinski radnik | ni svetla ni tamna koža | radnik | šlem</annotation>
 		<annotation cp="👷🏽" type="tts">građevinski radnik: ni svetla ni tamna koža</annotation>
-		<annotation cp="👷🏾">građevinski radnik | građevinski radnik: srednje tamna koža | radnik | šlem | srednje tamna koža</annotation>
+		<annotation cp="👷🏾">građevinski radnik | radnik | šlem | srednje tamna koža</annotation>
 		<annotation cp="👷🏾" type="tts">građevinski radnik: srednje tamna koža</annotation>
-		<annotation cp="👷🏿">građevinski radnik | građevinski radnik: tamna koža | radnik | šlem | tamna koža</annotation>
+		<annotation cp="👷🏿">građevinski radnik | radnik | šlem | tamna koža</annotation>
 		<annotation cp="👷🏿" type="tts">građevinski radnik: tamna koža</annotation>
-		<annotation cp="👷🏻‍♂">građevinar | građevinar: svetla koža | muškarac | radnik | šlem | svetla koža</annotation>
+		<annotation cp="👷🏻‍♂">građevinar | muškarac | radnik | šlem | svetla koža</annotation>
 		<annotation cp="👷🏻‍♂" type="tts">građevinar: svetla koža</annotation>
-		<annotation cp="👷🏼‍♂">građevinar | građevinar: srednje svetla koža | muškarac | radnik | šlem | srednje svetla koža</annotation>
+		<annotation cp="👷🏼‍♂">građevinar | muškarac | radnik | šlem | srednje svetla koža</annotation>
 		<annotation cp="👷🏼‍♂" type="tts">građevinar: srednje svetla koža</annotation>
-		<annotation cp="👷🏽‍♂">građevinar | građevinar: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | radnik | šlem</annotation>
+		<annotation cp="👷🏽‍♂">građevinar | muškarac | ni svetla ni tamna koža | radnik | šlem</annotation>
 		<annotation cp="👷🏽‍♂" type="tts">građevinar: ni svetla ni tamna koža</annotation>
-		<annotation cp="👷🏾‍♂">građevinar | građevinar: srednje tamna koža | muškarac | radnik | šlem | srednje tamna koža</annotation>
+		<annotation cp="👷🏾‍♂">građevinar | muškarac | radnik | šlem | srednje tamna koža</annotation>
 		<annotation cp="👷🏾‍♂" type="tts">građevinar: srednje tamna koža</annotation>
-		<annotation cp="👷🏿‍♂">građevinar | građevinar: tamna koža | muškarac | radnik | šlem | tamna koža</annotation>
+		<annotation cp="👷🏿‍♂">građevinar | muškarac | radnik | šlem | tamna koža</annotation>
 		<annotation cp="👷🏿‍♂" type="tts">građevinar: tamna koža</annotation>
-		<annotation cp="👷🏻‍♀">građevinar | građevinarka | građevinarka: svetla koža | radnica | šlem | svetla koža | žena</annotation>
+		<annotation cp="👷🏻‍♀">građevinar | građevinarka | radnica | šlem | svetla koža | žena</annotation>
 		<annotation cp="👷🏻‍♀" type="tts">građevinarka: svetla koža</annotation>
-		<annotation cp="👷🏼‍♀">građevinar | građevinarka | građevinarka: srednje svetla koža | radnica | šlem | srednje svetla koža | žena</annotation>
+		<annotation cp="👷🏼‍♀">građevinar | građevinarka | radnica | šlem | srednje svetla koža | žena</annotation>
 		<annotation cp="👷🏼‍♀" type="tts">građevinarka: srednje svetla koža</annotation>
-		<annotation cp="👷🏽‍♀">građevinar | građevinarka | građevinarka: ni svetla ni tamna koža | ni svetla ni tamna koža | radnica | šlem | žena</annotation>
+		<annotation cp="👷🏽‍♀">građevinar | građevinarka | ni svetla ni tamna koža | radnica | šlem | žena</annotation>
 		<annotation cp="👷🏽‍♀" type="tts">građevinarka: ni svetla ni tamna koža</annotation>
-		<annotation cp="👷🏾‍♀">građevinar | građevinarka | građevinarka: srednje tamna koža | radnica | šlem | srednje tamna koža | žena</annotation>
+		<annotation cp="👷🏾‍♀">građevinar | građevinarka | radnica | šlem | srednje tamna koža | žena</annotation>
 		<annotation cp="👷🏾‍♀" type="tts">građevinarka: srednje tamna koža</annotation>
-		<annotation cp="👷🏿‍♀">građevinar | građevinarka | građevinarka: tamna koža | radnica | šlem | tamna koža | žena</annotation>
+		<annotation cp="👷🏿‍♀">građevinar | građevinarka | radnica | šlem | tamna koža | žena</annotation>
 		<annotation cp="👷🏿‍♀" type="tts">građevinarka: tamna koža</annotation>
-		<annotation cp="🫅🏻">kraljevski | monarh | osoba sa krunom | osoba sa krunom: svetla koža | plemenit | plemić | svetla koža</annotation>
+		<annotation cp="🫅🏻">kraljevski | monarh | osoba sa krunom | plemenit | plemić | svetla koža</annotation>
 		<annotation cp="🫅🏻" type="tts">osoba sa krunom: svetla koža</annotation>
-		<annotation cp="🫅🏼">kraljevski | monarh | osoba sa krunom | osoba sa krunom: srednje svetla koža | plemenit | plemić | srednje svetla koža</annotation>
+		<annotation cp="🫅🏼">kraljevski | monarh | osoba sa krunom | plemenit | plemić | srednje svetla koža</annotation>
 		<annotation cp="🫅🏼" type="tts">osoba sa krunom: srednje svetla koža</annotation>
-		<annotation cp="🫅🏽">kraljevski | monarh | ni svetla ni tamna koža | osoba sa krunom | osoba sa krunom: ni svetla ni tamna koža | plemenit | plemić</annotation>
+		<annotation cp="🫅🏽">kraljevski | monarh | ni svetla ni tamna koža | osoba sa krunom | plemenit | plemić</annotation>
 		<annotation cp="🫅🏽" type="tts">osoba sa krunom: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫅🏾">kraljevski | monarh | osoba sa krunom | osoba sa krunom: srednje tamna koža | plemenit | plemić | srednje tamna koža</annotation>
+		<annotation cp="🫅🏾">kraljevski | monarh | osoba sa krunom | plemenit | plemić | srednje tamna koža</annotation>
 		<annotation cp="🫅🏾" type="tts">osoba sa krunom: srednje tamna koža</annotation>
-		<annotation cp="🫅🏿">kraljevski | monarh | osoba sa krunom | osoba sa krunom: tamna koža | plemenit | plemić | tamna koža</annotation>
+		<annotation cp="🫅🏿">kraljevski | monarh | osoba sa krunom | plemenit | plemić | tamna koža</annotation>
 		<annotation cp="🫅🏿" type="tts">osoba sa krunom: tamna koža</annotation>
-		<annotation cp="🤴🏻">princ | princ: svetla koža | svetla koža</annotation>
+		<annotation cp="🤴🏻">princ | svetla koža</annotation>
 		<annotation cp="🤴🏻" type="tts">princ: svetla koža</annotation>
-		<annotation cp="🤴🏼">princ | princ: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🤴🏼">princ | srednje svetla koža</annotation>
 		<annotation cp="🤴🏼" type="tts">princ: srednje svetla koža</annotation>
-		<annotation cp="🤴🏽">ni svetla ni tamna koža | princ | princ: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤴🏽">ni svetla ni tamna koža | princ</annotation>
 		<annotation cp="🤴🏽" type="tts">princ: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤴🏾">princ | princ: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤴🏾">princ | srednje tamna koža</annotation>
 		<annotation cp="🤴🏾" type="tts">princ: srednje tamna koža</annotation>
-		<annotation cp="🤴🏿">princ | princ: tamna koža | tamna koža</annotation>
+		<annotation cp="🤴🏿">princ | tamna koža</annotation>
 		<annotation cp="🤴🏿" type="tts">princ: tamna koža</annotation>
-		<annotation cp="👸🏻">bajka | mašta | princeza | princeza: svetla koža | svetla koža</annotation>
+		<annotation cp="👸🏻">bajka | mašta | princeza | svetla koža</annotation>
 		<annotation cp="👸🏻" type="tts">princeza: svetla koža</annotation>
-		<annotation cp="👸🏼">bajka | mašta | princeza | princeza: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👸🏼">bajka | mašta | princeza | srednje svetla koža</annotation>
 		<annotation cp="👸🏼" type="tts">princeza: srednje svetla koža</annotation>
-		<annotation cp="👸🏽">bajka | mašta | ni svetla ni tamna koža | princeza | princeza: ni svetla ni tamna koža</annotation>
+		<annotation cp="👸🏽">bajka | mašta | ni svetla ni tamna koža | princeza</annotation>
 		<annotation cp="👸🏽" type="tts">princeza: ni svetla ni tamna koža</annotation>
-		<annotation cp="👸🏾">bajka | mašta | princeza | princeza: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👸🏾">bajka | mašta | princeza | srednje tamna koža</annotation>
 		<annotation cp="👸🏾" type="tts">princeza: srednje tamna koža</annotation>
-		<annotation cp="👸🏿">bajka | mašta | princeza | princeza: tamna koža | tamna koža</annotation>
+		<annotation cp="👸🏿">bajka | mašta | princeza | tamna koža</annotation>
 		<annotation cp="👸🏿" type="tts">princeza: tamna koža</annotation>
-		<annotation cp="👳🏻">osoba sa turbanom | osoba sa turbanom: svetla koža | svetla koža | turban</annotation>
+		<annotation cp="👳🏻">osoba sa turbanom | svetla koža | turban</annotation>
 		<annotation cp="👳🏻" type="tts">osoba sa turbanom: svetla koža</annotation>
-		<annotation cp="👳🏼">osoba sa turbanom | osoba sa turbanom: srednje svetla koža | srednje svetla koža | turban</annotation>
+		<annotation cp="👳🏼">osoba sa turbanom | srednje svetla koža | turban</annotation>
 		<annotation cp="👳🏼" type="tts">osoba sa turbanom: srednje svetla koža</annotation>
-		<annotation cp="👳🏽">ni svetla ni tamna koža | osoba sa turbanom | osoba sa turbanom: ni svetla ni tamna koža | turban</annotation>
+		<annotation cp="👳🏽">ni svetla ni tamna koža | osoba sa turbanom | turban</annotation>
 		<annotation cp="👳🏽" type="tts">osoba sa turbanom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👳🏾">osoba sa turbanom | osoba sa turbanom: srednje tamna koža | srednje tamna koža | turban</annotation>
+		<annotation cp="👳🏾">osoba sa turbanom | srednje tamna koža | turban</annotation>
 		<annotation cp="👳🏾" type="tts">osoba sa turbanom: srednje tamna koža</annotation>
-		<annotation cp="👳🏿">osoba sa turbanom | osoba sa turbanom: tamna koža | tamna koža | turban</annotation>
+		<annotation cp="👳🏿">osoba sa turbanom | tamna koža | turban</annotation>
 		<annotation cp="👳🏿" type="tts">osoba sa turbanom: tamna koža</annotation>
-		<annotation cp="👳🏻‍♂">čovek sa turbanom | čovek sa turbanom: svetla koža | muškarac | svetla koža | turban</annotation>
+		<annotation cp="👳🏻‍♂">čovek sa turbanom | muškarac | svetla koža | turban</annotation>
 		<annotation cp="👳🏻‍♂" type="tts">čovek sa turbanom: svetla koža</annotation>
-		<annotation cp="👳🏼‍♂">čovek sa turbanom | čovek sa turbanom: srednje svetla koža | muškarac | srednje svetla koža | turban</annotation>
+		<annotation cp="👳🏼‍♂">čovek sa turbanom | muškarac | srednje svetla koža | turban</annotation>
 		<annotation cp="👳🏼‍♂" type="tts">čovek sa turbanom: srednje svetla koža</annotation>
-		<annotation cp="👳🏽‍♂">čovek sa turbanom | čovek sa turbanom: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | turban</annotation>
+		<annotation cp="👳🏽‍♂">čovek sa turbanom | muškarac | ni svetla ni tamna koža | turban</annotation>
 		<annotation cp="👳🏽‍♂" type="tts">čovek sa turbanom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👳🏾‍♂">čovek sa turbanom | čovek sa turbanom: srednje tamna koža | muškarac | srednje tamna koža | turban</annotation>
+		<annotation cp="👳🏾‍♂">čovek sa turbanom | muškarac | srednje tamna koža | turban</annotation>
 		<annotation cp="👳🏾‍♂" type="tts">čovek sa turbanom: srednje tamna koža</annotation>
-		<annotation cp="👳🏿‍♂">čovek sa turbanom | čovek sa turbanom: tamna koža | muškarac | tamna koža | turban</annotation>
+		<annotation cp="👳🏿‍♂">čovek sa turbanom | muškarac | tamna koža | turban</annotation>
 		<annotation cp="👳🏿‍♂" type="tts">čovek sa turbanom: tamna koža</annotation>
-		<annotation cp="👳🏻‍♀">svetla koža | turban | žena | žena sa turbanom | žena sa turbanom: svetla koža</annotation>
+		<annotation cp="👳🏻‍♀">svetla koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏻‍♀" type="tts">žena sa turbanom: svetla koža</annotation>
-		<annotation cp="👳🏼‍♀">srednje svetla koža | turban | žena | žena sa turbanom | žena sa turbanom: srednje svetla koža</annotation>
+		<annotation cp="👳🏼‍♀">srednje svetla koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏼‍♀" type="tts">žena sa turbanom: srednje svetla koža</annotation>
-		<annotation cp="👳🏽‍♀">ni svetla ni tamna koža | turban | žena | žena sa turbanom | žena sa turbanom: ni svetla ni tamna koža</annotation>
+		<annotation cp="👳🏽‍♀">ni svetla ni tamna koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏽‍♀" type="tts">žena sa turbanom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👳🏾‍♀">srednje tamna koža | turban | žena | žena sa turbanom | žena sa turbanom: srednje tamna koža</annotation>
+		<annotation cp="👳🏾‍♀">srednje tamna koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏾‍♀" type="tts">žena sa turbanom: srednje tamna koža</annotation>
-		<annotation cp="👳🏿‍♀">tamna koža | turban | žena | žena sa turbanom | žena sa turbanom: tamna koža</annotation>
+		<annotation cp="👳🏿‍♀">tamna koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏿‍♀" type="tts">žena sa turbanom: tamna koža</annotation>
-		<annotation cp="👲🏻">čovek sa kineskom kapom | čovek sa kineskom kapom: svetla koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | svetla koža</annotation>
+		<annotation cp="👲🏻">čovek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | svetla koža</annotation>
 		<annotation cp="👲🏻" type="tts">čovek sa kineskom kapom: svetla koža</annotation>
-		<annotation cp="👲🏼">čovek sa kineskom kapom | čovek sa kineskom kapom: srednje svetla koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje svetla koža</annotation>
+		<annotation cp="👲🏼">čovek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje svetla koža</annotation>
 		<annotation cp="👲🏼" type="tts">čovek sa kineskom kapom: srednje svetla koža</annotation>
-		<annotation cp="👲🏽">čovek sa kineskom kapom | čovek sa kineskom kapom: ni svetla ni tamna koža | gua pi mao | kapa | kineska kapa | ni svetla ni tamna koža | osoba | osoba sa kineskom kapom | šešir</annotation>
+		<annotation cp="👲🏽">čovek sa kineskom kapom | gua pi mao | kapa | kineska kapa | ni svetla ni tamna koža | osoba | osoba sa kineskom kapom | šešir</annotation>
 		<annotation cp="👲🏽" type="tts">čovek sa kineskom kapom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👲🏾">čovek sa kineskom kapom | čovek sa kineskom kapom: srednje tamna koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje tamna koža</annotation>
+		<annotation cp="👲🏾">čovek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje tamna koža</annotation>
 		<annotation cp="👲🏾" type="tts">čovek sa kineskom kapom: srednje tamna koža</annotation>
-		<annotation cp="👲🏿">čovek sa kineskom kapom | čovek sa kineskom kapom: tamna koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | tamna koža</annotation>
+		<annotation cp="👲🏿">čovek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | tamna koža</annotation>
 		<annotation cp="👲🏿" type="tts">čovek sa kineskom kapom: tamna koža</annotation>
-		<annotation cp="🧕🏻">hidžab | marama za na glavu | svetla koža | žena sa maramom na glavi | žena sa maramom na glavi: svetla koža</annotation>
+		<annotation cp="🧕🏻">hidžab | marama za na glavu | svetla koža | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏻" type="tts">žena sa maramom na glavi: svetla koža</annotation>
-		<annotation cp="🧕🏼">hidžab | marama za na glavu | srednje svetla koža | žena sa maramom na glavi | žena sa maramom na glavi: srednje svetla koža</annotation>
+		<annotation cp="🧕🏼">hidžab | marama za na glavu | srednje svetla koža | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏼" type="tts">žena sa maramom na glavi: srednje svetla koža</annotation>
-		<annotation cp="🧕🏽">hidžab | marama za na glavu | ni svetla ni tamna koža | žena sa maramom na glavi | žena sa maramom na glavi: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧕🏽">hidžab | marama za na glavu | ni svetla ni tamna koža | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏽" type="tts">žena sa maramom na glavi: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧕🏾">hidžab | marama za na glavu | srednje tamna koža | žena sa maramom na glavi | žena sa maramom na glavi: srednje tamna koža</annotation>
+		<annotation cp="🧕🏾">hidžab | marama za na glavu | srednje tamna koža | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏾" type="tts">žena sa maramom na glavi: srednje tamna koža</annotation>
-		<annotation cp="🧕🏿">hidžab | marama za na glavu | tamna koža | žena sa maramom na glavi | žena sa maramom na glavi: tamna koža</annotation>
+		<annotation cp="🧕🏿">hidžab | marama za na glavu | tamna koža | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏿" type="tts">žena sa maramom na glavi: tamna koža</annotation>
-		<annotation cp="🤵🏻">čovek | čovek u smokingu | čovek u smokingu: svetla koža | mladoženja | smoking | svetla koža</annotation>
+		<annotation cp="🤵🏻">čovek | čovek u smokingu | mladoženja | smoking | svetla koža</annotation>
 		<annotation cp="🤵🏻" type="tts">čovek u smokingu: svetla koža</annotation>
-		<annotation cp="🤵🏼">čovek | čovek u smokingu | čovek u smokingu: srednje svetla koža | mladoženja | smoking | srednje svetla koža</annotation>
+		<annotation cp="🤵🏼">čovek | čovek u smokingu | mladoženja | smoking | srednje svetla koža</annotation>
 		<annotation cp="🤵🏼" type="tts">čovek u smokingu: srednje svetla koža</annotation>
-		<annotation cp="🤵🏽">čovek | čovek u smokingu | čovek u smokingu: ni svetla ni tamna koža | mladoženja | ni svetla ni tamna koža | smoking</annotation>
+		<annotation cp="🤵🏽">čovek | čovek u smokingu | mladoženja | ni svetla ni tamna koža | smoking</annotation>
 		<annotation cp="🤵🏽" type="tts">čovek u smokingu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤵🏾">čovek | čovek u smokingu | čovek u smokingu: srednje tamna koža | mladoženja | smoking | srednje tamna koža</annotation>
+		<annotation cp="🤵🏾">čovek | čovek u smokingu | mladoženja | smoking | srednje tamna koža</annotation>
 		<annotation cp="🤵🏾" type="tts">čovek u smokingu: srednje tamna koža</annotation>
-		<annotation cp="🤵🏿">čovek | čovek u smokingu | čovek u smokingu: tamna koža | mladoženja | smoking | tamna koža</annotation>
+		<annotation cp="🤵🏿">čovek | čovek u smokingu | mladoženja | smoking | tamna koža</annotation>
 		<annotation cp="🤵🏿" type="tts">čovek u smokingu: tamna koža</annotation>
-		<annotation cp="🤵🏻‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: svetla koža | smoking | svetla koža</annotation>
+		<annotation cp="🤵🏻‍♂">muškarac | muškarac u smokingu | smoking | svetla koža</annotation>
 		<annotation cp="🤵🏻‍♂" type="tts">muškarac u smokingu: svetla koža</annotation>
-		<annotation cp="🤵🏼‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: srednje svetla koža | smoking | srednje svetla koža</annotation>
+		<annotation cp="🤵🏼‍♂">muškarac | muškarac u smokingu | smoking | srednje svetla koža</annotation>
 		<annotation cp="🤵🏼‍♂" type="tts">muškarac u smokingu: srednje svetla koža</annotation>
-		<annotation cp="🤵🏽‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: ni svetla ni tamna koža | ni svetla ni tamna koža | smoking</annotation>
+		<annotation cp="🤵🏽‍♂">muškarac | muškarac u smokingu | ni svetla ni tamna koža | smoking</annotation>
 		<annotation cp="🤵🏽‍♂" type="tts">muškarac u smokingu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤵🏾‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: srednje tamna koža | smoking | srednje tamna koža</annotation>
+		<annotation cp="🤵🏾‍♂">muškarac | muškarac u smokingu | smoking | srednje tamna koža</annotation>
 		<annotation cp="🤵🏾‍♂" type="tts">muškarac u smokingu: srednje tamna koža</annotation>
-		<annotation cp="🤵🏿‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: tamna koža | smoking | tamna koža</annotation>
+		<annotation cp="🤵🏿‍♂">muškarac | muškarac u smokingu | smoking | tamna koža</annotation>
 		<annotation cp="🤵🏿‍♂" type="tts">muškarac u smokingu: tamna koža</annotation>
-		<annotation cp="🤵🏻‍♀">smoking | svetla koža | žena | žena u smokingu | žena u smokingu: svetla koža</annotation>
+		<annotation cp="🤵🏻‍♀">smoking | svetla koža | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏻‍♀" type="tts">žena u smokingu: svetla koža</annotation>
-		<annotation cp="🤵🏼‍♀">smoking | srednje svetla koža | žena | žena u smokingu | žena u smokingu: srednje svetla koža</annotation>
+		<annotation cp="🤵🏼‍♀">smoking | srednje svetla koža | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏼‍♀" type="tts">žena u smokingu: srednje svetla koža</annotation>
-		<annotation cp="🤵🏽‍♀">ni svetla ni tamna koža | smoking | žena | žena u smokingu | žena u smokingu: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤵🏽‍♀">ni svetla ni tamna koža | smoking | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏽‍♀" type="tts">žena u smokingu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤵🏾‍♀">smoking | srednje tamna koža | žena | žena u smokingu | žena u smokingu: srednje tamna koža</annotation>
+		<annotation cp="🤵🏾‍♀">smoking | srednje tamna koža | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏾‍♀" type="tts">žena u smokingu: srednje tamna koža</annotation>
-		<annotation cp="🤵🏿‍♀">smoking | tamna koža | žena | žena u smokingu | žena u smokingu: tamna koža</annotation>
+		<annotation cp="🤵🏿‍♀">smoking | tamna koža | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏿‍♀" type="tts">žena u smokingu: tamna koža</annotation>
-		<annotation cp="👰🏻">nevesta | nevesta sa velom | nevesta sa velom: svetla koža | svetla koža | venčanje | veo</annotation>
+		<annotation cp="👰🏻">nevesta | nevesta sa velom | svetla koža | venčanje | veo</annotation>
 		<annotation cp="👰🏻" type="tts">nevesta sa velom: svetla koža</annotation>
-		<annotation cp="👰🏼">nevesta | nevesta sa velom | nevesta sa velom: srednje svetla koža | srednje svetla koža | venčanje | veo</annotation>
+		<annotation cp="👰🏼">nevesta | nevesta sa velom | srednje svetla koža | venčanje | veo</annotation>
 		<annotation cp="👰🏼" type="tts">nevesta sa velom: srednje svetla koža</annotation>
-		<annotation cp="👰🏽">nevesta | nevesta sa velom | nevesta sa velom: ni svetla ni tamna koža | ni svetla ni tamna koža | venčanje | veo</annotation>
+		<annotation cp="👰🏽">nevesta | nevesta sa velom | ni svetla ni tamna koža | venčanje | veo</annotation>
 		<annotation cp="👰🏽" type="tts">nevesta sa velom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👰🏾">nevesta | nevesta sa velom | nevesta sa velom: srednje tamna koža | srednje tamna koža | venčanje | veo</annotation>
+		<annotation cp="👰🏾">nevesta | nevesta sa velom | srednje tamna koža | venčanje | veo</annotation>
 		<annotation cp="👰🏾" type="tts">nevesta sa velom: srednje tamna koža</annotation>
-		<annotation cp="👰🏿">nevesta | nevesta sa velom | nevesta sa velom: tamna koža | tamna koža | venčanje | veo</annotation>
+		<annotation cp="👰🏿">nevesta | nevesta sa velom | tamna koža | venčanje | veo</annotation>
 		<annotation cp="👰🏿" type="tts">nevesta sa velom: tamna koža</annotation>
-		<annotation cp="👰🏻‍♂">muškarac | muškarac sa velom | muškarac sa velom: svetla koža | svetla koža | veo</annotation>
+		<annotation cp="👰🏻‍♂">muškarac | muškarac sa velom | svetla koža | veo</annotation>
 		<annotation cp="👰🏻‍♂" type="tts">muškarac sa velom: svetla koža</annotation>
-		<annotation cp="👰🏼‍♂">muškarac | muškarac sa velom | muškarac sa velom: srednje svetla koža | srednje svetla koža | veo</annotation>
+		<annotation cp="👰🏼‍♂">muškarac | muškarac sa velom | srednje svetla koža | veo</annotation>
 		<annotation cp="👰🏼‍♂" type="tts">muškarac sa velom: srednje svetla koža</annotation>
-		<annotation cp="👰🏽‍♂">muškarac | muškarac sa velom | muškarac sa velom: ni svetla ni tamna koža | ni svetla ni tamna koža | veo</annotation>
+		<annotation cp="👰🏽‍♂">muškarac | muškarac sa velom | ni svetla ni tamna koža | veo</annotation>
 		<annotation cp="👰🏽‍♂" type="tts">muškarac sa velom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👰🏾‍♂">muškarac | muškarac sa velom | muškarac sa velom: srednje tamna koža | srednje tamna koža | veo</annotation>
+		<annotation cp="👰🏾‍♂">muškarac | muškarac sa velom | srednje tamna koža | veo</annotation>
 		<annotation cp="👰🏾‍♂" type="tts">muškarac sa velom: srednje tamna koža</annotation>
-		<annotation cp="👰🏿‍♂">muškarac | muškarac sa velom | muškarac sa velom: tamna koža | tamna koža | veo</annotation>
+		<annotation cp="👰🏿‍♂">muškarac | muškarac sa velom | tamna koža | veo</annotation>
 		<annotation cp="👰🏿‍♂" type="tts">muškarac sa velom: tamna koža</annotation>
-		<annotation cp="👰🏻‍♀">svetla koža | veo | žena | žena sa velom | žena sa velom: svetla koža</annotation>
+		<annotation cp="👰🏻‍♀">svetla koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏻‍♀" type="tts">žena sa velom: svetla koža</annotation>
-		<annotation cp="👰🏼‍♀">srednje svetla koža | veo | žena | žena sa velom | žena sa velom: srednje svetla koža</annotation>
+		<annotation cp="👰🏼‍♀">srednje svetla koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏼‍♀" type="tts">žena sa velom: srednje svetla koža</annotation>
-		<annotation cp="👰🏽‍♀">ni svetla ni tamna koža | veo | žena | žena sa velom | žena sa velom: ni svetla ni tamna koža</annotation>
+		<annotation cp="👰🏽‍♀">ni svetla ni tamna koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏽‍♀" type="tts">žena sa velom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👰🏾‍♀">srednje tamna koža | veo | žena | žena sa velom | žena sa velom: srednje tamna koža</annotation>
+		<annotation cp="👰🏾‍♀">srednje tamna koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏾‍♀" type="tts">žena sa velom: srednje tamna koža</annotation>
-		<annotation cp="👰🏿‍♀">tamna koža | veo | žena | žena sa velom | žena sa velom: tamna koža</annotation>
+		<annotation cp="👰🏿‍♀">tamna koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏿‍♀" type="tts">žena sa velom: tamna koža</annotation>
-		<annotation cp="🤰🏻">svetla koža | trudnica | trudnica: svetla koža | žena</annotation>
+		<annotation cp="🤰🏻">svetla koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏻" type="tts">trudnica: svetla koža</annotation>
-		<annotation cp="🤰🏼">srednje svetla koža | trudnica | trudnica: srednje svetla koža | žena</annotation>
+		<annotation cp="🤰🏼">srednje svetla koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏼" type="tts">trudnica: srednje svetla koža</annotation>
-		<annotation cp="🤰🏽">ni svetla ni tamna koža | trudnica | trudnica: ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🤰🏽">ni svetla ni tamna koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏽" type="tts">trudnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤰🏾">srednje tamna koža | trudnica | trudnica: srednje tamna koža | žena</annotation>
+		<annotation cp="🤰🏾">srednje tamna koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏾" type="tts">trudnica: srednje tamna koža</annotation>
-		<annotation cp="🤰🏿">tamna koža | trudnica | trudnica: tamna koža | žena</annotation>
+		<annotation cp="🤰🏿">tamna koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏿" type="tts">trudnica: tamna koža</annotation>
-		<annotation cp="🫃🏻">nadut | pun | stomak | svetla koža | trudan | trudni muškarac | trudni muškarac: svetla koža</annotation>
+		<annotation cp="🫃🏻">nadut | pun | stomak | svetla koža | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏻" type="tts">trudni muškarac: svetla koža</annotation>
-		<annotation cp="🫃🏼">nadut | pun | srednje svetla koža | stomak | trudan | trudni muškarac | trudni muškarac: srednje svetla koža</annotation>
+		<annotation cp="🫃🏼">nadut | pun | srednje svetla koža | stomak | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏼" type="tts">trudni muškarac: srednje svetla koža</annotation>
-		<annotation cp="🫃🏽">nadut | ni svetla ni tamna koža | pun | stomak | trudan | trudni muškarac | trudni muškarac: ni svetla ni tamna koža</annotation>
+		<annotation cp="🫃🏽">nadut | ni svetla ni tamna koža | pun | stomak | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏽" type="tts">trudni muškarac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫃🏾">nadut | pun | srednje tamna koža | stomak | trudan | trudni muškarac | trudni muškarac: srednje tamna koža</annotation>
+		<annotation cp="🫃🏾">nadut | pun | srednje tamna koža | stomak | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏾" type="tts">trudni muškarac: srednje tamna koža</annotation>
-		<annotation cp="🫃🏿">nadut | pun | stomak | tamna koža | trudan | trudni muškarac | trudni muškarac: tamna koža</annotation>
+		<annotation cp="🫃🏿">nadut | pun | stomak | tamna koža | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏿" type="tts">trudni muškarac: tamna koža</annotation>
-		<annotation cp="🫄🏻">nadut | pun | stomak | svetla koža | trudan | trudna osoba | trudna osoba: svetla koža</annotation>
+		<annotation cp="🫄🏻">nadut | pun | stomak | svetla koža | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏻" type="tts">trudna osoba: svetla koža</annotation>
-		<annotation cp="🫄🏼">nadut | pun | srednje svetla koža | stomak | trudan | trudna osoba | trudna osoba: srednje svetla koža</annotation>
+		<annotation cp="🫄🏼">nadut | pun | srednje svetla koža | stomak | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏼" type="tts">trudna osoba: srednje svetla koža</annotation>
-		<annotation cp="🫄🏽">nadut | ni svetla ni tamna koža | pun | stomak | trudan | trudna osoba | trudna osoba: ni svetla ni tamna koža</annotation>
+		<annotation cp="🫄🏽">nadut | ni svetla ni tamna koža | pun | stomak | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏽" type="tts">trudna osoba: ni svetla ni tamna koža</annotation>
-		<annotation cp="🫄🏾">nadut | pun | srednje tamna koža | stomak | trudan | trudna osoba | trudna osoba: srednje tamna koža</annotation>
+		<annotation cp="🫄🏾">nadut | pun | srednje tamna koža | stomak | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏾" type="tts">trudna osoba: srednje tamna koža</annotation>
-		<annotation cp="🫄🏿">nadut | pun | stomak | tamna koža | trudan | trudna osoba | trudna osoba: tamna koža</annotation>
+		<annotation cp="🫄🏿">nadut | pun | stomak | tamna koža | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏿" type="tts">trudna osoba: tamna koža</annotation>
-		<annotation cp="🤱🏻">beba | dojenje | dojenje: svetla koža | grudi | hranjenje | svetla koža</annotation>
+		<annotation cp="🤱🏻">beba | dojenje | grudi | hranjenje | svetla koža</annotation>
 		<annotation cp="🤱🏻" type="tts">dojenje: svetla koža</annotation>
-		<annotation cp="🤱🏼">beba | dojenje | dojenje: srednje svetla koža | grudi | hranjenje | srednje svetla koža</annotation>
+		<annotation cp="🤱🏼">beba | dojenje | grudi | hranjenje | srednje svetla koža</annotation>
 		<annotation cp="🤱🏼" type="tts">dojenje: srednje svetla koža</annotation>
-		<annotation cp="🤱🏽">beba | dojenje | dojenje: ni svetla ni tamna koža | grudi | hranjenje | ni svetla ni tamna koža</annotation>
+		<annotation cp="🤱🏽">beba | dojenje | grudi | hranjenje | ni svetla ni tamna koža</annotation>
 		<annotation cp="🤱🏽" type="tts">dojenje: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤱🏾">beba | dojenje | dojenje: srednje tamna koža | grudi | hranjenje | srednje tamna koža</annotation>
+		<annotation cp="🤱🏾">beba | dojenje | grudi | hranjenje | srednje tamna koža</annotation>
 		<annotation cp="🤱🏾" type="tts">dojenje: srednje tamna koža</annotation>
-		<annotation cp="🤱🏿">beba | dojenje | dojenje: tamna koža | grudi | hranjenje | tamna koža</annotation>
+		<annotation cp="🤱🏿">beba | dojenje | grudi | hranjenje | tamna koža</annotation>
 		<annotation cp="🤱🏿" type="tts">dojenje: tamna koža</annotation>
-		<annotation cp="👩🏻‍🍼">beba | dojenje | hranjenje | svetla koža | žena | žena hrani bebu | žena hrani bebu: svetla koža</annotation>
+		<annotation cp="👩🏻‍🍼">beba | dojenje | hranjenje | svetla koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏻‍🍼" type="tts">žena hrani bebu: svetla koža</annotation>
-		<annotation cp="👩🏼‍🍼">beba | dojenje | hranjenje | srednje svetla koža | žena | žena hrani bebu | žena hrani bebu: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍🍼">beba | dojenje | hranjenje | srednje svetla koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏼‍🍼" type="tts">žena hrani bebu: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🍼">beba | dojenje | hranjenje | ni svetla ni tamna koža | žena | žena hrani bebu | žena hrani bebu: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🍼">beba | dojenje | hranjenje | ni svetla ni tamna koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏽‍🍼" type="tts">žena hrani bebu: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🍼">beba | dojenje | hranjenje | srednje tamna koža | žena | žena hrani bebu | žena hrani bebu: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍🍼">beba | dojenje | hranjenje | srednje tamna koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏾‍🍼" type="tts">žena hrani bebu: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🍼">beba | dojenje | hranjenje | tamna koža | žena | žena hrani bebu | žena hrani bebu: tamna koža</annotation>
+		<annotation cp="👩🏿‍🍼">beba | dojenje | hranjenje | tamna koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏿‍🍼" type="tts">žena hrani bebu: tamna koža</annotation>
-		<annotation cp="👨🏻‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: svetla koža | svetla koža</annotation>
+		<annotation cp="👨🏻‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | svetla koža</annotation>
 		<annotation cp="👨🏻‍🍼" type="tts">muškarac hrani bebu: svetla koža</annotation>
-		<annotation cp="👨🏼‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🍼" type="tts">muškarac hrani bebu: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🍼" type="tts">muškarac hrani bebu: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🍼" type="tts">muškarac hrani bebu: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | tamna koža</annotation>
 		<annotation cp="👨🏿‍🍼" type="tts">muškarac hrani bebu: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | osoba hrani bebu: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🍼" type="tts">osoba hrani bebu: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | osoba hrani bebu: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🍼" type="tts">osoba hrani bebu: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🍼">beba | dojenje | hranjenje | muškarac | ni svetla ni tamna koža | osoba hrani bebu | osoba hrani bebu: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🍼">beba | dojenje | hranjenje | muškarac | ni svetla ni tamna koža | osoba hrani bebu</annotation>
 		<annotation cp="🧑🏽‍🍼" type="tts">osoba hrani bebu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | osoba hrani bebu: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🍼" type="tts">osoba hrani bebu: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | osoba hrani bebu: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🍼" type="tts">osoba hrani bebu: tamna koža</annotation>
-		<annotation cp="👼🏻">anđeo | bajka | beba | beba anđeo: svetla koža | lice | mašta | svetla koža</annotation>
+		<annotation cp="👼🏻">anđeo | bajka | beba | lice | mašta | svetla koža</annotation>
 		<annotation cp="👼🏻" type="tts">beba anđeo: svetla koža</annotation>
-		<annotation cp="👼🏼">anđeo | bajka | beba | beba anđeo: srednje svetla koža | lice | mašta | srednje svetla koža</annotation>
+		<annotation cp="👼🏼">anđeo | bajka | beba | lice | mašta | srednje svetla koža</annotation>
 		<annotation cp="👼🏼" type="tts">beba anđeo: srednje svetla koža</annotation>
-		<annotation cp="👼🏽">anđeo | bajka | beba | beba anđeo: ni svetla ni tamna koža | lice | mašta | ni svetla ni tamna koža</annotation>
+		<annotation cp="👼🏽">anđeo | bajka | beba | lice | mašta | ni svetla ni tamna koža</annotation>
 		<annotation cp="👼🏽" type="tts">beba anđeo: ni svetla ni tamna koža</annotation>
-		<annotation cp="👼🏾">anđeo | bajka | beba | beba anđeo: srednje tamna koža | lice | mašta | srednje tamna koža</annotation>
+		<annotation cp="👼🏾">anđeo | bajka | beba | lice | mašta | srednje tamna koža</annotation>
 		<annotation cp="👼🏾" type="tts">beba anđeo: srednje tamna koža</annotation>
-		<annotation cp="👼🏿">anđeo | bajka | beba | beba anđeo: tamna koža | lice | mašta | tamna koža</annotation>
+		<annotation cp="👼🏿">anđeo | bajka | beba | lice | mašta | tamna koža</annotation>
 		<annotation cp="👼🏿" type="tts">beba anđeo: tamna koža</annotation>
-		<annotation cp="🎅🏻">bajka | božić | božić bata | deda mraz | Deda Mraz | Deda Mraz: svetla koža | proslava | svetla koža</annotation>
+		<annotation cp="🎅🏻">bajka | božić | božić bata | deda mraz | Deda Mraz | proslava | svetla koža</annotation>
 		<annotation cp="🎅🏻" type="tts">Deda Mraz: svetla koža</annotation>
-		<annotation cp="🎅🏼">bajka | božić | božić bata | deda mraz | Deda Mraz | Deda Mraz: srednje svetla koža | proslava | srednje svetla koža</annotation>
+		<annotation cp="🎅🏼">bajka | božić | božić bata | deda mraz | Deda Mraz | proslava | srednje svetla koža</annotation>
 		<annotation cp="🎅🏼" type="tts">Deda Mraz: srednje svetla koža</annotation>
-		<annotation cp="🎅🏽">bajka | božić | božić bata | deda mraz | Deda Mraz | Deda Mraz: ni svetla ni tamna koža | ni svetla ni tamna koža | proslava</annotation>
+		<annotation cp="🎅🏽">bajka | božić | božić bata | deda mraz | Deda Mraz | ni svetla ni tamna koža | proslava</annotation>
 		<annotation cp="🎅🏽" type="tts">Deda Mraz: ni svetla ni tamna koža</annotation>
-		<annotation cp="🎅🏾">bajka | božić | božić bata | deda mraz | Deda Mraz | Deda Mraz: srednje tamna koža | proslava | srednje tamna koža</annotation>
+		<annotation cp="🎅🏾">bajka | božić | božić bata | deda mraz | Deda Mraz | proslava | srednje tamna koža</annotation>
 		<annotation cp="🎅🏾" type="tts">Deda Mraz: srednje tamna koža</annotation>
-		<annotation cp="🎅🏿">bajka | božić | božić bata | deda mraz | Deda Mraz | Deda Mraz: tamna koža | proslava | tamna koža</annotation>
+		<annotation cp="🎅🏿">bajka | božić | božić bata | deda mraz | Deda Mraz | proslava | tamna koža</annotation>
 		<annotation cp="🎅🏿" type="tts">Deda Mraz: tamna koža</annotation>
-		<annotation cp="🤶🏻">baka | baka Mraz: svetla koža | božić | mraz | svetla koža</annotation>
+		<annotation cp="🤶🏻">baka | božić | mraz | svetla koža</annotation>
 		<annotation cp="🤶🏻" type="tts">baka Mraz: svetla koža</annotation>
-		<annotation cp="🤶🏼">baka | baka Mraz: srednje svetla koža | božić | mraz | srednje svetla koža</annotation>
+		<annotation cp="🤶🏼">baka | božić | mraz | srednje svetla koža</annotation>
 		<annotation cp="🤶🏼" type="tts">baka Mraz: srednje svetla koža</annotation>
-		<annotation cp="🤶🏽">baka | baka Mraz: ni svetla ni tamna koža | božić | mraz | ni svetla ni tamna koža</annotation>
+		<annotation cp="🤶🏽">baka | božić | mraz | ni svetla ni tamna koža</annotation>
 		<annotation cp="🤶🏽" type="tts">baka Mraz: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤶🏾">baka | baka Mraz: srednje tamna koža | božić | mraz | srednje tamna koža</annotation>
+		<annotation cp="🤶🏾">baka | božić | mraz | srednje tamna koža</annotation>
 		<annotation cp="🤶🏾" type="tts">baka Mraz: srednje tamna koža</annotation>
-		<annotation cp="🤶🏿">baka | baka Mraz: tamna koža | božić | mraz | tamna koža</annotation>
+		<annotation cp="🤶🏿">baka | božić | mraz | tamna koža</annotation>
 		<annotation cp="🤶🏿" type="tts">baka Mraz: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎄">Božić | Mraz | osoba Mraz | osoba Mraz: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🎄">Božić | Mraz | osoba Mraz | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🎄" type="tts">osoba Mraz: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🎄">Božić | Mraz | osoba Mraz | osoba Mraz: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🎄">Božić | Mraz | osoba Mraz | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🎄" type="tts">osoba Mraz: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🎄">Božić | Mraz | ni svetla ni tamna koža | osoba Mraz | osoba Mraz: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🎄">Božić | Mraz | ni svetla ni tamna koža | osoba Mraz</annotation>
 		<annotation cp="🧑🏽‍🎄" type="tts">osoba Mraz: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎄">Božić | Mraz | osoba Mraz | osoba Mraz: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🎄">Božić | Mraz | osoba Mraz | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🎄" type="tts">osoba Mraz: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎄">Božić | Mraz | osoba Mraz | osoba Mraz: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🎄">Božić | Mraz | osoba Mraz | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🎄" type="tts">osoba Mraz: tamna koža</annotation>
-		<annotation cp="🦸🏻">dobro | heroj | super heroj | super heroj: svetla koža | super moć | svetla koža</annotation>
+		<annotation cp="🦸🏻">dobro | heroj | super heroj | super moć | svetla koža</annotation>
 		<annotation cp="🦸🏻" type="tts">super heroj: svetla koža</annotation>
-		<annotation cp="🦸🏼">dobro | heroj | srednje svetla koža | super heroj | super heroj: srednje svetla koža | super moć</annotation>
+		<annotation cp="🦸🏼">dobro | heroj | srednje svetla koža | super heroj | super moć</annotation>
 		<annotation cp="🦸🏼" type="tts">super heroj: srednje svetla koža</annotation>
-		<annotation cp="🦸🏽">dobro | heroj | ni svetla ni tamna koža | super heroj | super heroj: ni svetla ni tamna koža | super moć</annotation>
+		<annotation cp="🦸🏽">dobro | heroj | ni svetla ni tamna koža | super heroj | super moć</annotation>
 		<annotation cp="🦸🏽" type="tts">super heroj: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦸🏾">dobro | heroj | srednje tamna koža | super heroj | super heroj: srednje tamna koža | super moć</annotation>
+		<annotation cp="🦸🏾">dobro | heroj | srednje tamna koža | super heroj | super moć</annotation>
 		<annotation cp="🦸🏾" type="tts">super heroj: srednje tamna koža</annotation>
-		<annotation cp="🦸🏿">dobro | heroj | super heroj | super heroj: tamna koža | super moć | tamna koža</annotation>
+		<annotation cp="🦸🏿">dobro | heroj | super heroj | super moć | tamna koža</annotation>
 		<annotation cp="🦸🏿" type="tts">super heroj: tamna koža</annotation>
-		<annotation cp="🦸🏻‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac super heroj: svetla koža | super moć | svetla koža</annotation>
+		<annotation cp="🦸🏻‍♂">dobro | heroj | muškarac | muškarac super heroj | super moć | svetla koža</annotation>
 		<annotation cp="🦸🏻‍♂" type="tts">muškarac super heroj: svetla koža</annotation>
-		<annotation cp="🦸🏼‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac super heroj: srednje svetla koža | srednje svetla koža | super moć</annotation>
+		<annotation cp="🦸🏼‍♂">dobro | heroj | muškarac | muškarac super heroj | srednje svetla koža | super moć</annotation>
 		<annotation cp="🦸🏼‍♂" type="tts">muškarac super heroj: srednje svetla koža</annotation>
-		<annotation cp="🦸🏽‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac super heroj: ni svetla ni tamna koža | ni svetla ni tamna koža | super moć</annotation>
+		<annotation cp="🦸🏽‍♂">dobro | heroj | muškarac | muškarac super heroj | ni svetla ni tamna koža | super moć</annotation>
 		<annotation cp="🦸🏽‍♂" type="tts">muškarac super heroj: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦸🏾‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac super heroj: srednje tamna koža | srednje tamna koža | super moć</annotation>
+		<annotation cp="🦸🏾‍♂">dobro | heroj | muškarac | muškarac super heroj | srednje tamna koža | super moć</annotation>
 		<annotation cp="🦸🏾‍♂" type="tts">muškarac super heroj: srednje tamna koža</annotation>
-		<annotation cp="🦸🏿‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac super heroj: tamna koža | super moć | tamna koža</annotation>
+		<annotation cp="🦸🏿‍♂">dobro | heroj | muškarac | muškarac super heroj | super moć | tamna koža</annotation>
 		<annotation cp="🦸🏿‍♂" type="tts">muškarac super heroj: tamna koža</annotation>
-		<annotation cp="🦸🏻‍♀">dobro | heroina | super moć | svetla koža | žena | žena super heroj | žena super heroj: svetla koža</annotation>
+		<annotation cp="🦸🏻‍♀">dobro | heroina | super moć | svetla koža | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏻‍♀" type="tts">žena super heroj: svetla koža</annotation>
-		<annotation cp="🦸🏼‍♀">dobro | heroina | srednje svetla koža | super moć | žena | žena super heroj | žena super heroj: srednje svetla koža</annotation>
+		<annotation cp="🦸🏼‍♀">dobro | heroina | srednje svetla koža | super moć | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏼‍♀" type="tts">žena super heroj: srednje svetla koža</annotation>
-		<annotation cp="🦸🏽‍♀">dobro | heroina | ni svetla ni tamna koža | super moć | žena | žena super heroj | žena super heroj: ni svetla ni tamna koža</annotation>
+		<annotation cp="🦸🏽‍♀">dobro | heroina | ni svetla ni tamna koža | super moć | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏽‍♀" type="tts">žena super heroj: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦸🏾‍♀">dobro | heroina | srednje tamna koža | super moć | žena | žena super heroj | žena super heroj: srednje tamna koža</annotation>
+		<annotation cp="🦸🏾‍♀">dobro | heroina | srednje tamna koža | super moć | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏾‍♀" type="tts">žena super heroj: srednje tamna koža</annotation>
-		<annotation cp="🦸🏿‍♀">dobro | heroina | super moć | tamna koža | žena | žena super heroj | žena super heroj: tamna koža</annotation>
+		<annotation cp="🦸🏿‍♀">dobro | heroina | super moć | tamna koža | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏿‍♀" type="tts">žena super heroj: tamna koža</annotation>
-		<annotation cp="🦹🏻">kriminal | negativac | negativac: svetla koža | super moć | svetla koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏻">kriminal | negativac | super moć | svetla koža | zlo | zločinac</annotation>
 		<annotation cp="🦹🏻" type="tts">negativac: svetla koža</annotation>
-		<annotation cp="🦹🏼">kriminal | negativac | negativac: srednje svetla koža | srednje svetla koža | super moć | zlo | zločinac</annotation>
+		<annotation cp="🦹🏼">kriminal | negativac | srednje svetla koža | super moć | zlo | zločinac</annotation>
 		<annotation cp="🦹🏼" type="tts">negativac: srednje svetla koža</annotation>
-		<annotation cp="🦹🏽">kriminal | negativac | negativac: ni svetla ni tamna koža | ni svetla ni tamna koža | super moć | zlo | zločinac</annotation>
+		<annotation cp="🦹🏽">kriminal | negativac | ni svetla ni tamna koža | super moć | zlo | zločinac</annotation>
 		<annotation cp="🦹🏽" type="tts">negativac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦹🏾">kriminal | negativac | negativac: srednje tamna koža | srednje tamna koža | super moć | zlo | zločinac</annotation>
+		<annotation cp="🦹🏾">kriminal | negativac | srednje tamna koža | super moć | zlo | zločinac</annotation>
 		<annotation cp="🦹🏾" type="tts">negativac: srednje tamna koža</annotation>
-		<annotation cp="🦹🏿">kriminal | negativac | negativac: tamna koža | super moć | tamna koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏿">kriminal | negativac | super moć | tamna koža | zlo | zločinac</annotation>
 		<annotation cp="🦹🏿" type="tts">negativac: tamna koža</annotation>
-		<annotation cp="🦹🏻‍♂">kriminal | muškarac | muškarac negativac: svetla koža | negativac | super moć | svetla koža | zlo</annotation>
+		<annotation cp="🦹🏻‍♂">kriminal | muškarac | negativac | super moć | svetla koža | zlo</annotation>
 		<annotation cp="🦹🏻‍♂" type="tts">muškarac negativac: svetla koža</annotation>
-		<annotation cp="🦹🏼‍♂">kriminal | muškarac | muškarac negativac: srednje svetla koža | negativac | srednje svetla koža | super moć | zlo</annotation>
+		<annotation cp="🦹🏼‍♂">kriminal | muškarac | negativac | srednje svetla koža | super moć | zlo</annotation>
 		<annotation cp="🦹🏼‍♂" type="tts">muškarac negativac: srednje svetla koža</annotation>
-		<annotation cp="🦹🏽‍♂">kriminal | muškarac | muškarac negativac: ni svetla ni tamna koža | negativac | ni svetla ni tamna koža | super moć | zlo</annotation>
+		<annotation cp="🦹🏽‍♂">kriminal | muškarac | negativac | ni svetla ni tamna koža | super moć | zlo</annotation>
 		<annotation cp="🦹🏽‍♂" type="tts">muškarac negativac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦹🏾‍♂">kriminal | muškarac | muškarac negativac: srednje tamna koža | negativac | srednje tamna koža | super moć | zlo</annotation>
+		<annotation cp="🦹🏾‍♂">kriminal | muškarac | negativac | srednje tamna koža | super moć | zlo</annotation>
 		<annotation cp="🦹🏾‍♂" type="tts">muškarac negativac: srednje tamna koža</annotation>
-		<annotation cp="🦹🏿‍♂">kriminal | muškarac | muškarac negativac: tamna koža | negativac | super moć | tamna koža | zlo</annotation>
+		<annotation cp="🦹🏿‍♂">kriminal | muškarac | negativac | super moć | tamna koža | zlo</annotation>
 		<annotation cp="🦹🏿‍♂" type="tts">muškarac negativac: tamna koža</annotation>
-		<annotation cp="🦹🏻‍♀">kriminal | super moć | svetla koža | žena | žena negativac | žena negativac: svetla koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏻‍♀">kriminal | super moć | svetla koža | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏻‍♀" type="tts">žena negativac: svetla koža</annotation>
-		<annotation cp="🦹🏼‍♀">kriminal | srednje svetla koža | super moć | žena | žena negativac | žena negativac: srednje svetla koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏼‍♀">kriminal | srednje svetla koža | super moć | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏼‍♀" type="tts">žena negativac: srednje svetla koža</annotation>
-		<annotation cp="🦹🏽‍♀">kriminal | ni svetla ni tamna koža | super moć | žena | žena negativac | žena negativac: ni svetla ni tamna koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏽‍♀">kriminal | ni svetla ni tamna koža | super moć | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏽‍♀" type="tts">žena negativac: ni svetla ni tamna koža</annotation>
-		<annotation cp="🦹🏾‍♀">kriminal | srednje tamna koža | super moć | žena | žena negativac | žena negativac: srednje tamna koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏾‍♀">kriminal | srednje tamna koža | super moć | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏾‍♀" type="tts">žena negativac: srednje tamna koža</annotation>
-		<annotation cp="🦹🏿‍♀">kriminal | super moć | tamna koža | žena | žena negativac | žena negativac: tamna koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏿‍♀">kriminal | super moć | tamna koža | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏿‍♀" type="tts">žena negativac: tamna koža</annotation>
-		<annotation cp="🧙🏻">čarobnjak | mag | mag: svetla koža | svetla koža | veštica</annotation>
+		<annotation cp="🧙🏻">čarobnjak | mag | svetla koža | veštica</annotation>
 		<annotation cp="🧙🏻" type="tts">mag: svetla koža</annotation>
-		<annotation cp="🧙🏼">čarobnjak | mag | mag: srednje svetla koža | srednje svetla koža | veštica</annotation>
+		<annotation cp="🧙🏼">čarobnjak | mag | srednje svetla koža | veštica</annotation>
 		<annotation cp="🧙🏼" type="tts">mag: srednje svetla koža</annotation>
-		<annotation cp="🧙🏽">čarobnjak | mag | mag: ni svetla ni tamna koža | ni svetla ni tamna koža | veštica</annotation>
+		<annotation cp="🧙🏽">čarobnjak | mag | ni svetla ni tamna koža | veštica</annotation>
 		<annotation cp="🧙🏽" type="tts">mag: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧙🏾">čarobnjak | mag | mag: srednje tamna koža | srednje tamna koža | veštica</annotation>
+		<annotation cp="🧙🏾">čarobnjak | mag | srednje tamna koža | veštica</annotation>
 		<annotation cp="🧙🏾" type="tts">mag: srednje tamna koža</annotation>
-		<annotation cp="🧙🏿">čarobnjak | mag | mag: tamna koža | tamna koža | veštica</annotation>
+		<annotation cp="🧙🏿">čarobnjak | mag | tamna koža | veštica</annotation>
 		<annotation cp="🧙🏿" type="tts">mag: tamna koža</annotation>
-		<annotation cp="🧙🏻‍♂">čarobnjak | čarobnjak: svetla koža | svetla koža | veštac</annotation>
+		<annotation cp="🧙🏻‍♂">čarobnjak | svetla koža | veštac</annotation>
 		<annotation cp="🧙🏻‍♂" type="tts">čarobnjak: svetla koža</annotation>
-		<annotation cp="🧙🏼‍♂">čarobnjak | čarobnjak: srednje svetla koža | srednje svetla koža | veštac</annotation>
+		<annotation cp="🧙🏼‍♂">čarobnjak | srednje svetla koža | veštac</annotation>
 		<annotation cp="🧙🏼‍♂" type="tts">čarobnjak: srednje svetla koža</annotation>
-		<annotation cp="🧙🏽‍♂">čarobnjak | čarobnjak: ni svetla ni tamna koža | ni svetla ni tamna koža | veštac</annotation>
+		<annotation cp="🧙🏽‍♂">čarobnjak | ni svetla ni tamna koža | veštac</annotation>
 		<annotation cp="🧙🏽‍♂" type="tts">čarobnjak: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧙🏾‍♂">čarobnjak | čarobnjak: srednje tamna koža | srednje tamna koža | veštac</annotation>
+		<annotation cp="🧙🏾‍♂">čarobnjak | srednje tamna koža | veštac</annotation>
 		<annotation cp="🧙🏾‍♂" type="tts">čarobnjak: srednje tamna koža</annotation>
-		<annotation cp="🧙🏿‍♂">čarobnjak | čarobnjak: tamna koža | tamna koža | veštac</annotation>
+		<annotation cp="🧙🏿‍♂">čarobnjak | tamna koža | veštac</annotation>
 		<annotation cp="🧙🏿‍♂" type="tts">čarobnjak: tamna koža</annotation>
-		<annotation cp="🧙🏻‍♀">čarobnica | čarobnica: svetla koža | svetla koža | veštica</annotation>
+		<annotation cp="🧙🏻‍♀">čarobnica | svetla koža | veštica</annotation>
 		<annotation cp="🧙🏻‍♀" type="tts">čarobnica: svetla koža</annotation>
-		<annotation cp="🧙🏼‍♀">čarobnica | čarobnica: srednje svetla koža | srednje svetla koža | veštica</annotation>
+		<annotation cp="🧙🏼‍♀">čarobnica | srednje svetla koža | veštica</annotation>
 		<annotation cp="🧙🏼‍♀" type="tts">čarobnica: srednje svetla koža</annotation>
-		<annotation cp="🧙🏽‍♀">čarobnica | čarobnica: ni svetla ni tamna koža | ni svetla ni tamna koža | veštica</annotation>
+		<annotation cp="🧙🏽‍♀">čarobnica | ni svetla ni tamna koža | veštica</annotation>
 		<annotation cp="🧙🏽‍♀" type="tts">čarobnica: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧙🏾‍♀">čarobnica | čarobnica: srednje tamna koža | srednje tamna koža | veštica</annotation>
+		<annotation cp="🧙🏾‍♀">čarobnica | srednje tamna koža | veštica</annotation>
 		<annotation cp="🧙🏾‍♀" type="tts">čarobnica: srednje tamna koža</annotation>
-		<annotation cp="🧙🏿‍♀">čarobnica | čarobnica: tamna koža | tamna koža | veštica</annotation>
+		<annotation cp="🧙🏿‍♀">čarobnica | tamna koža | veštica</annotation>
 		<annotation cp="🧙🏿‍♀" type="tts">čarobnica: tamna koža</annotation>
-		<annotation cp="🧚🏻">Oberon | Pak | svetla koža | Titanija | vila | vila: svetla koža</annotation>
+		<annotation cp="🧚🏻">Oberon | Pak | svetla koža | Titanija | vila</annotation>
 		<annotation cp="🧚🏻" type="tts">vila: svetla koža</annotation>
-		<annotation cp="🧚🏼">Oberon | Pak | srednje svetla koža | Titanija | vila | vila: srednje svetla koža</annotation>
+		<annotation cp="🧚🏼">Oberon | Pak | srednje svetla koža | Titanija | vila</annotation>
 		<annotation cp="🧚🏼" type="tts">vila: srednje svetla koža</annotation>
-		<annotation cp="🧚🏽">ni svetla ni tamna koža | Oberon | Pak | Titanija | vila | vila: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧚🏽">ni svetla ni tamna koža | Oberon | Pak | Titanija | vila</annotation>
 		<annotation cp="🧚🏽" type="tts">vila: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧚🏾">Oberon | Pak | srednje tamna koža | Titanija | vila | vila: srednje tamna koža</annotation>
+		<annotation cp="🧚🏾">Oberon | Pak | srednje tamna koža | Titanija | vila</annotation>
 		<annotation cp="🧚🏾" type="tts">vila: srednje tamna koža</annotation>
-		<annotation cp="🧚🏿">Oberon | Pak | tamna koža | Titanija | vila | vila: tamna koža</annotation>
+		<annotation cp="🧚🏿">Oberon | Pak | tamna koža | Titanija | vila</annotation>
 		<annotation cp="🧚🏿" type="tts">vila: tamna koža</annotation>
-		<annotation cp="🧚🏻‍♂">Oberon | Pak | svetla koža | vilenjak | vilenjak: svetla koža</annotation>
+		<annotation cp="🧚🏻‍♂">Oberon | Pak | svetla koža | vilenjak</annotation>
 		<annotation cp="🧚🏻‍♂" type="tts">vilenjak: svetla koža</annotation>
-		<annotation cp="🧚🏼‍♂">Oberon | Pak | srednje svetla koža | vilenjak | vilenjak: srednje svetla koža</annotation>
+		<annotation cp="🧚🏼‍♂">Oberon | Pak | srednje svetla koža | vilenjak</annotation>
 		<annotation cp="🧚🏼‍♂" type="tts">vilenjak: srednje svetla koža</annotation>
-		<annotation cp="🧚🏽‍♂">ni svetla ni tamna koža | Oberon | Pak | vilenjak | vilenjak: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧚🏽‍♂">ni svetla ni tamna koža | Oberon | Pak | vilenjak</annotation>
 		<annotation cp="🧚🏽‍♂" type="tts">vilenjak: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧚🏾‍♂">Oberon | Pak | srednje tamna koža | vilenjak | vilenjak: srednje tamna koža</annotation>
+		<annotation cp="🧚🏾‍♂">Oberon | Pak | srednje tamna koža | vilenjak</annotation>
 		<annotation cp="🧚🏾‍♂" type="tts">vilenjak: srednje tamna koža</annotation>
-		<annotation cp="🧚🏿‍♂">Oberon | Pak | tamna koža | vilenjak | vilenjak: tamna koža</annotation>
+		<annotation cp="🧚🏿‍♂">Oberon | Pak | tamna koža | vilenjak</annotation>
 		<annotation cp="🧚🏿‍♂" type="tts">vilenjak: tamna koža</annotation>
-		<annotation cp="🧚🏻‍♀">svetla koža | Titanija | žena vila | žena vila: svetla koža</annotation>
+		<annotation cp="🧚🏻‍♀">svetla koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏻‍♀" type="tts">žena vila: svetla koža</annotation>
-		<annotation cp="🧚🏼‍♀">srednje svetla koža | Titanija | žena vila | žena vila: srednje svetla koža</annotation>
+		<annotation cp="🧚🏼‍♀">srednje svetla koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏼‍♀" type="tts">žena vila: srednje svetla koža</annotation>
-		<annotation cp="🧚🏽‍♀">ni svetla ni tamna koža | Titanija | žena vila | žena vila: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧚🏽‍♀">ni svetla ni tamna koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏽‍♀" type="tts">žena vila: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧚🏾‍♀">srednje tamna koža | Titanija | žena vila | žena vila: srednje tamna koža</annotation>
+		<annotation cp="🧚🏾‍♀">srednje tamna koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏾‍♀" type="tts">žena vila: srednje tamna koža</annotation>
-		<annotation cp="🧚🏿‍♀">tamna koža | Titanija | žena vila | žena vila: tamna koža</annotation>
+		<annotation cp="🧚🏿‍♀">tamna koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏿‍♀" type="tts">žena vila: tamna koža</annotation>
-		<annotation cp="🧛🏻">Drakula | povampiren | svetla koža | vampir | vampir: svetla koža</annotation>
+		<annotation cp="🧛🏻">Drakula | povampiren | svetla koža | vampir</annotation>
 		<annotation cp="🧛🏻" type="tts">vampir: svetla koža</annotation>
-		<annotation cp="🧛🏼">Drakula | povampiren | srednje svetla koža | vampir | vampir: srednje svetla koža</annotation>
+		<annotation cp="🧛🏼">Drakula | povampiren | srednje svetla koža | vampir</annotation>
 		<annotation cp="🧛🏼" type="tts">vampir: srednje svetla koža</annotation>
-		<annotation cp="🧛🏽">Drakula | ni svetla ni tamna koža | povampiren | vampir | vampir: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧛🏽">Drakula | ni svetla ni tamna koža | povampiren | vampir</annotation>
 		<annotation cp="🧛🏽" type="tts">vampir: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧛🏾">Drakula | povampiren | srednje tamna koža | vampir | vampir: srednje tamna koža</annotation>
+		<annotation cp="🧛🏾">Drakula | povampiren | srednje tamna koža | vampir</annotation>
 		<annotation cp="🧛🏾" type="tts">vampir: srednje tamna koža</annotation>
-		<annotation cp="🧛🏿">Drakula | povampiren | tamna koža | vampir | vampir: tamna koža</annotation>
+		<annotation cp="🧛🏿">Drakula | povampiren | tamna koža | vampir</annotation>
 		<annotation cp="🧛🏿" type="tts">vampir: tamna koža</annotation>
-		<annotation cp="🧛🏻‍♂">Drakula | muški vampir | muški vampir: svetla koža | povampiren | svetla koža</annotation>
+		<annotation cp="🧛🏻‍♂">Drakula | muški vampir | povampiren | svetla koža</annotation>
 		<annotation cp="🧛🏻‍♂" type="tts">muški vampir: svetla koža</annotation>
-		<annotation cp="🧛🏼‍♂">Drakula | muški vampir | muški vampir: srednje svetla koža | povampiren | srednje svetla koža</annotation>
+		<annotation cp="🧛🏼‍♂">Drakula | muški vampir | povampiren | srednje svetla koža</annotation>
 		<annotation cp="🧛🏼‍♂" type="tts">muški vampir: srednje svetla koža</annotation>
-		<annotation cp="🧛🏽‍♂">Drakula | muški vampir | muški vampir: ni svetla ni tamna koža | ni svetla ni tamna koža | povampiren</annotation>
+		<annotation cp="🧛🏽‍♂">Drakula | muški vampir | ni svetla ni tamna koža | povampiren</annotation>
 		<annotation cp="🧛🏽‍♂" type="tts">muški vampir: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧛🏾‍♂">Drakula | muški vampir | muški vampir: srednje tamna koža | povampiren | srednje tamna koža</annotation>
+		<annotation cp="🧛🏾‍♂">Drakula | muški vampir | povampiren | srednje tamna koža</annotation>
 		<annotation cp="🧛🏾‍♂" type="tts">muški vampir: srednje tamna koža</annotation>
-		<annotation cp="🧛🏿‍♂">Drakula | muški vampir | muški vampir: tamna koža | povampiren | tamna koža</annotation>
+		<annotation cp="🧛🏿‍♂">Drakula | muški vampir | povampiren | tamna koža</annotation>
 		<annotation cp="🧛🏿‍♂" type="tts">muški vampir: tamna koža</annotation>
-		<annotation cp="🧛🏻‍♀">povampiren | svetla koža | ženski vampir | ženski vampir: svetla koža</annotation>
+		<annotation cp="🧛🏻‍♀">povampiren | svetla koža | ženski vampir</annotation>
 		<annotation cp="🧛🏻‍♀" type="tts">ženski vampir: svetla koža</annotation>
-		<annotation cp="🧛🏼‍♀">povampiren | srednje svetla koža | ženski vampir | ženski vampir: srednje svetla koža</annotation>
+		<annotation cp="🧛🏼‍♀">povampiren | srednje svetla koža | ženski vampir</annotation>
 		<annotation cp="🧛🏼‍♀" type="tts">ženski vampir: srednje svetla koža</annotation>
-		<annotation cp="🧛🏽‍♀">ni svetla ni tamna koža | povampiren | ženski vampir | ženski vampir: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧛🏽‍♀">ni svetla ni tamna koža | povampiren | ženski vampir</annotation>
 		<annotation cp="🧛🏽‍♀" type="tts">ženski vampir: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧛🏾‍♀">povampiren | srednje tamna koža | ženski vampir | ženski vampir: srednje tamna koža</annotation>
+		<annotation cp="🧛🏾‍♀">povampiren | srednje tamna koža | ženski vampir</annotation>
 		<annotation cp="🧛🏾‍♀" type="tts">ženski vampir: srednje tamna koža</annotation>
-		<annotation cp="🧛🏿‍♀">povampiren | tamna koža | ženski vampir | ženski vampir: tamna koža</annotation>
+		<annotation cp="🧛🏿‍♀">povampiren | tamna koža | ženski vampir</annotation>
 		<annotation cp="🧛🏿‍♀" type="tts">ženski vampir: tamna koža</annotation>
-		<annotation cp="🧜🏻">osoba iz mora | osoba iz mora: svetla koža | sirena | svetla koža</annotation>
+		<annotation cp="🧜🏻">osoba iz mora | sirena | svetla koža</annotation>
 		<annotation cp="🧜🏻" type="tts">osoba iz mora: svetla koža</annotation>
-		<annotation cp="🧜🏼">osoba iz mora | osoba iz mora: srednje svetla koža | sirena | srednje svetla koža</annotation>
+		<annotation cp="🧜🏼">osoba iz mora | sirena | srednje svetla koža</annotation>
 		<annotation cp="🧜🏼" type="tts">osoba iz mora: srednje svetla koža</annotation>
-		<annotation cp="🧜🏽">ni svetla ni tamna koža | osoba iz mora | osoba iz mora: ni svetla ni tamna koža | sirena</annotation>
+		<annotation cp="🧜🏽">ni svetla ni tamna koža | osoba iz mora | sirena</annotation>
 		<annotation cp="🧜🏽" type="tts">osoba iz mora: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧜🏾">osoba iz mora | osoba iz mora: srednje tamna koža | sirena | srednje tamna koža</annotation>
+		<annotation cp="🧜🏾">osoba iz mora | sirena | srednje tamna koža</annotation>
 		<annotation cp="🧜🏾" type="tts">osoba iz mora: srednje tamna koža</annotation>
-		<annotation cp="🧜🏿">osoba iz mora | osoba iz mora: tamna koža | sirena | tamna koža</annotation>
+		<annotation cp="🧜🏿">osoba iz mora | sirena | tamna koža</annotation>
 		<annotation cp="🧜🏿" type="tts">osoba iz mora: tamna koža</annotation>
-		<annotation cp="🧜🏻‍♂">muškarac iz mora | muškarac iz mora: svetla koža | svetla koža | Triton</annotation>
+		<annotation cp="🧜🏻‍♂">muškarac iz mora | svetla koža | Triton</annotation>
 		<annotation cp="🧜🏻‍♂" type="tts">muškarac iz mora: svetla koža</annotation>
-		<annotation cp="🧜🏼‍♂">muškarac iz mora | muškarac iz mora: srednje svetla koža | srednje svetla koža | Triton</annotation>
+		<annotation cp="🧜🏼‍♂">muškarac iz mora | srednje svetla koža | Triton</annotation>
 		<annotation cp="🧜🏼‍♂" type="tts">muškarac iz mora: srednje svetla koža</annotation>
-		<annotation cp="🧜🏽‍♂">muškarac iz mora | muškarac iz mora: ni svetla ni tamna koža | ni svetla ni tamna koža | Triton</annotation>
+		<annotation cp="🧜🏽‍♂">muškarac iz mora | ni svetla ni tamna koža | Triton</annotation>
 		<annotation cp="🧜🏽‍♂" type="tts">muškarac iz mora: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧜🏾‍♂">muškarac iz mora | muškarac iz mora: srednje tamna koža | srednje tamna koža | Triton</annotation>
+		<annotation cp="🧜🏾‍♂">muškarac iz mora | srednje tamna koža | Triton</annotation>
 		<annotation cp="🧜🏾‍♂" type="tts">muškarac iz mora: srednje tamna koža</annotation>
-		<annotation cp="🧜🏿‍♂">muškarac iz mora | muškarac iz mora: tamna koža | tamna koža | Triton</annotation>
+		<annotation cp="🧜🏿‍♂">muškarac iz mora | tamna koža | Triton</annotation>
 		<annotation cp="🧜🏿‍♂" type="tts">muškarac iz mora: tamna koža</annotation>
-		<annotation cp="🧜🏻‍♀">sirena | sirena: svetla koža | svetla koža | žena iz mora</annotation>
+		<annotation cp="🧜🏻‍♀">sirena | svetla koža | žena iz mora</annotation>
 		<annotation cp="🧜🏻‍♀" type="tts">sirena: svetla koža</annotation>
-		<annotation cp="🧜🏼‍♀">sirena | sirena: srednje svetla koža | srednje svetla koža | žena iz mora</annotation>
+		<annotation cp="🧜🏼‍♀">sirena | srednje svetla koža | žena iz mora</annotation>
 		<annotation cp="🧜🏼‍♀" type="tts">sirena: srednje svetla koža</annotation>
-		<annotation cp="🧜🏽‍♀">ni svetla ni tamna koža | sirena | sirena: ni svetla ni tamna koža | žena iz mora</annotation>
+		<annotation cp="🧜🏽‍♀">ni svetla ni tamna koža | sirena | žena iz mora</annotation>
 		<annotation cp="🧜🏽‍♀" type="tts">sirena: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧜🏾‍♀">sirena | sirena: srednje tamna koža | srednje tamna koža | žena iz mora</annotation>
+		<annotation cp="🧜🏾‍♀">sirena | srednje tamna koža | žena iz mora</annotation>
 		<annotation cp="🧜🏾‍♀" type="tts">sirena: srednje tamna koža</annotation>
-		<annotation cp="🧜🏿‍♀">sirena | sirena: tamna koža | tamna koža | žena iz mora</annotation>
+		<annotation cp="🧜🏿‍♀">sirena | tamna koža | žena iz mora</annotation>
 		<annotation cp="🧜🏿‍♀" type="tts">sirena: tamna koža</annotation>
-		<annotation cp="🧝🏻">magično | svetla koža | vilovnjak | vilovnjak: svetla koža</annotation>
+		<annotation cp="🧝🏻">magično | svetla koža | vilovnjak</annotation>
 		<annotation cp="🧝🏻" type="tts">vilovnjak: svetla koža</annotation>
-		<annotation cp="🧝🏼">magično | srednje svetla koža | vilovnjak | vilovnjak: srednje svetla koža</annotation>
+		<annotation cp="🧝🏼">magično | srednje svetla koža | vilovnjak</annotation>
 		<annotation cp="🧝🏼" type="tts">vilovnjak: srednje svetla koža</annotation>
-		<annotation cp="🧝🏽">magično | ni svetla ni tamna koža | vilovnjak | vilovnjak: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧝🏽">magično | ni svetla ni tamna koža | vilovnjak</annotation>
 		<annotation cp="🧝🏽" type="tts">vilovnjak: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧝🏾">magično | srednje tamna koža | vilovnjak | vilovnjak: srednje tamna koža</annotation>
+		<annotation cp="🧝🏾">magično | srednje tamna koža | vilovnjak</annotation>
 		<annotation cp="🧝🏾" type="tts">vilovnjak: srednje tamna koža</annotation>
-		<annotation cp="🧝🏿">magično | tamna koža | vilovnjak | vilovnjak: tamna koža</annotation>
+		<annotation cp="🧝🏿">magično | tamna koža | vilovnjak</annotation>
 		<annotation cp="🧝🏿" type="tts">vilovnjak: tamna koža</annotation>
-		<annotation cp="🧝🏻‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: svetla koža | svetla koža</annotation>
+		<annotation cp="🧝🏻‍♂">magičan muškarac | muškarac vilovnjak | svetla koža</annotation>
 		<annotation cp="🧝🏻‍♂" type="tts">muškarac vilovnjak: svetla koža</annotation>
-		<annotation cp="🧝🏼‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧝🏼‍♂">magičan muškarac | muškarac vilovnjak | srednje svetla koža</annotation>
 		<annotation cp="🧝🏼‍♂" type="tts">muškarac vilovnjak: srednje svetla koža</annotation>
-		<annotation cp="🧝🏽‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧝🏽‍♂">magičan muškarac | muškarac vilovnjak | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧝🏽‍♂" type="tts">muškarac vilovnjak: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧝🏾‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧝🏾‍♂">magičan muškarac | muškarac vilovnjak | srednje tamna koža</annotation>
 		<annotation cp="🧝🏾‍♂" type="tts">muškarac vilovnjak: srednje tamna koža</annotation>
-		<annotation cp="🧝🏿‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: tamna koža | tamna koža</annotation>
+		<annotation cp="🧝🏿‍♂">magičan muškarac | muškarac vilovnjak | tamna koža</annotation>
 		<annotation cp="🧝🏿‍♂" type="tts">muškarac vilovnjak: tamna koža</annotation>
-		<annotation cp="🧝🏻‍♀">magična žena | svetla koža | žena vilovnjak | žena vilovnjak: svetla koža</annotation>
+		<annotation cp="🧝🏻‍♀">magična žena | svetla koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏻‍♀" type="tts">žena vilovnjak: svetla koža</annotation>
-		<annotation cp="🧝🏼‍♀">magična žena | srednje svetla koža | žena vilovnjak | žena vilovnjak: srednje svetla koža</annotation>
+		<annotation cp="🧝🏼‍♀">magična žena | srednje svetla koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏼‍♀" type="tts">žena vilovnjak: srednje svetla koža</annotation>
-		<annotation cp="🧝🏽‍♀">magična žena | ni svetla ni tamna koža | žena vilovnjak | žena vilovnjak: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧝🏽‍♀">magična žena | ni svetla ni tamna koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏽‍♀" type="tts">žena vilovnjak: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧝🏾‍♀">magična žena | srednje tamna koža | žena vilovnjak | žena vilovnjak: srednje tamna koža</annotation>
+		<annotation cp="🧝🏾‍♀">magična žena | srednje tamna koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏾‍♀" type="tts">žena vilovnjak: srednje tamna koža</annotation>
-		<annotation cp="🧝🏿‍♀">magična žena | tamna koža | žena vilovnjak | žena vilovnjak: tamna koža</annotation>
+		<annotation cp="🧝🏿‍♀">magična žena | tamna koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏿‍♀" type="tts">žena vilovnjak: tamna koža</annotation>
-		<annotation cp="💆🏻">lice | masaža | masaža lica | masaža lica: svetla koža | salon | svetla koža</annotation>
+		<annotation cp="💆🏻">lice | masaža | masaža lica | salon | svetla koža</annotation>
 		<annotation cp="💆🏻" type="tts">masaža lica: svetla koža</annotation>
-		<annotation cp="💆🏼">lice | masaža | masaža lica | masaža lica: srednje svetla koža | salon | srednje svetla koža</annotation>
+		<annotation cp="💆🏼">lice | masaža | masaža lica | salon | srednje svetla koža</annotation>
 		<annotation cp="💆🏼" type="tts">masaža lica: srednje svetla koža</annotation>
-		<annotation cp="💆🏽">lice | masaža | masaža lica | masaža lica: ni svetla ni tamna koža | ni svetla ni tamna koža | salon</annotation>
+		<annotation cp="💆🏽">lice | masaža | masaža lica | ni svetla ni tamna koža | salon</annotation>
 		<annotation cp="💆🏽" type="tts">masaža lica: ni svetla ni tamna koža</annotation>
-		<annotation cp="💆🏾">lice | masaža | masaža lica | masaža lica: srednje tamna koža | salon | srednje tamna koža</annotation>
+		<annotation cp="💆🏾">lice | masaža | masaža lica | salon | srednje tamna koža</annotation>
 		<annotation cp="💆🏾" type="tts">masaža lica: srednje tamna koža</annotation>
-		<annotation cp="💆🏿">lice | masaža | masaža lica | masaža lica: tamna koža | salon | tamna koža</annotation>
+		<annotation cp="💆🏿">lice | masaža | masaža lica | salon | tamna koža</annotation>
 		<annotation cp="💆🏿" type="tts">masaža lica: tamna koža</annotation>
-		<annotation cp="💆🏻‍♂">lice | masaža | muška masaža lica | muška masaža lica: svetla koža | muškarac | salon | svetla koža</annotation>
+		<annotation cp="💆🏻‍♂">lice | masaža | muška masaža lica | muškarac | salon | svetla koža</annotation>
 		<annotation cp="💆🏻‍♂" type="tts">muška masaža lica: svetla koža</annotation>
-		<annotation cp="💆🏼‍♂">lice | masaža | muška masaža lica | muška masaža lica: srednje svetla koža | muškarac | salon | srednje svetla koža</annotation>
+		<annotation cp="💆🏼‍♂">lice | masaža | muška masaža lica | muškarac | salon | srednje svetla koža</annotation>
 		<annotation cp="💆🏼‍♂" type="tts">muška masaža lica: srednje svetla koža</annotation>
-		<annotation cp="💆🏽‍♂">lice | masaža | muška masaža lica | muška masaža lica: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | salon</annotation>
+		<annotation cp="💆🏽‍♂">lice | masaža | muška masaža lica | muškarac | ni svetla ni tamna koža | salon</annotation>
 		<annotation cp="💆🏽‍♂" type="tts">muška masaža lica: ni svetla ni tamna koža</annotation>
-		<annotation cp="💆🏾‍♂">lice | masaža | muška masaža lica | muška masaža lica: srednje tamna koža | muškarac | salon | srednje tamna koža</annotation>
+		<annotation cp="💆🏾‍♂">lice | masaža | muška masaža lica | muškarac | salon | srednje tamna koža</annotation>
 		<annotation cp="💆🏾‍♂" type="tts">muška masaža lica: srednje tamna koža</annotation>
-		<annotation cp="💆🏿‍♂">lice | masaža | muška masaža lica | muška masaža lica: tamna koža | muškarac | salon | tamna koža</annotation>
+		<annotation cp="💆🏿‍♂">lice | masaža | muška masaža lica | muškarac | salon | tamna koža</annotation>
 		<annotation cp="💆🏿‍♂" type="tts">muška masaža lica: tamna koža</annotation>
-		<annotation cp="💆🏻‍♀">lice | masaža | salon | svetla koža | žena | ženska masaža lica | ženska masaža lica: svetla koža</annotation>
+		<annotation cp="💆🏻‍♀">lice | masaža | salon | svetla koža | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏻‍♀" type="tts">ženska masaža lica: svetla koža</annotation>
-		<annotation cp="💆🏼‍♀">lice | masaža | salon | srednje svetla koža | žena | ženska masaža lica | ženska masaža lica: srednje svetla koža</annotation>
+		<annotation cp="💆🏼‍♀">lice | masaža | salon | srednje svetla koža | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏼‍♀" type="tts">ženska masaža lica: srednje svetla koža</annotation>
-		<annotation cp="💆🏽‍♀">lice | masaža | ni svetla ni tamna koža | salon | žena | ženska masaža lica | ženska masaža lica: ni svetla ni tamna koža</annotation>
+		<annotation cp="💆🏽‍♀">lice | masaža | ni svetla ni tamna koža | salon | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏽‍♀" type="tts">ženska masaža lica: ni svetla ni tamna koža</annotation>
-		<annotation cp="💆🏾‍♀">lice | masaža | salon | srednje tamna koža | žena | ženska masaža lica | ženska masaža lica: srednje tamna koža</annotation>
+		<annotation cp="💆🏾‍♀">lice | masaža | salon | srednje tamna koža | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏾‍♀" type="tts">ženska masaža lica: srednje tamna koža</annotation>
-		<annotation cp="💆🏿‍♀">lice | masaža | salon | tamna koža | žena | ženska masaža lica | ženska masaža lica: tamna koža</annotation>
+		<annotation cp="💆🏿‍♀">lice | masaža | salon | tamna koža | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏿‍♀" type="tts">ženska masaža lica: tamna koža</annotation>
-		<annotation cp="💇🏻">frizer | salon | šišanje | šišanje: svetla koža | svetla koža | ulepšavanje</annotation>
+		<annotation cp="💇🏻">frizer | salon | šišanje | svetla koža | ulepšavanje</annotation>
 		<annotation cp="💇🏻" type="tts">šišanje: svetla koža</annotation>
-		<annotation cp="💇🏼">frizer | salon | šišanje | šišanje: srednje svetla koža | srednje svetla koža | ulepšavanje</annotation>
+		<annotation cp="💇🏼">frizer | salon | šišanje | srednje svetla koža | ulepšavanje</annotation>
 		<annotation cp="💇🏼" type="tts">šišanje: srednje svetla koža</annotation>
-		<annotation cp="💇🏽">frizer | ni svetla ni tamna koža | salon | šišanje | šišanje: ni svetla ni tamna koža | ulepšavanje</annotation>
+		<annotation cp="💇🏽">frizer | ni svetla ni tamna koža | salon | šišanje | ulepšavanje</annotation>
 		<annotation cp="💇🏽" type="tts">šišanje: ni svetla ni tamna koža</annotation>
-		<annotation cp="💇🏾">frizer | salon | šišanje | šišanje: srednje tamna koža | srednje tamna koža | ulepšavanje</annotation>
+		<annotation cp="💇🏾">frizer | salon | šišanje | srednje tamna koža | ulepšavanje</annotation>
 		<annotation cp="💇🏾" type="tts">šišanje: srednje tamna koža</annotation>
-		<annotation cp="💇🏿">frizer | salon | šišanje | šišanje: tamna koža | tamna koža | ulepšavanje</annotation>
+		<annotation cp="💇🏿">frizer | salon | šišanje | tamna koža | ulepšavanje</annotation>
 		<annotation cp="💇🏿" type="tts">šišanje: tamna koža</annotation>
-		<annotation cp="💇🏻‍♂">frizer | muškarac | muško šišanje | muško šišanje: svetla koža | salon | svetla koža | ulepšavanje</annotation>
+		<annotation cp="💇🏻‍♂">frizer | muškarac | muško šišanje | salon | svetla koža | ulepšavanje</annotation>
 		<annotation cp="💇🏻‍♂" type="tts">muško šišanje: svetla koža</annotation>
-		<annotation cp="💇🏼‍♂">frizer | muškarac | muško šišanje | muško šišanje: srednje svetla koža | salon | srednje svetla koža | ulepšavanje</annotation>
+		<annotation cp="💇🏼‍♂">frizer | muškarac | muško šišanje | salon | srednje svetla koža | ulepšavanje</annotation>
 		<annotation cp="💇🏼‍♂" type="tts">muško šišanje: srednje svetla koža</annotation>
-		<annotation cp="💇🏽‍♂">frizer | muškarac | muško šišanje | muško šišanje: ni svetla ni tamna koža | ni svetla ni tamna koža | salon | ulepšavanje</annotation>
+		<annotation cp="💇🏽‍♂">frizer | muškarac | muško šišanje | ni svetla ni tamna koža | salon | ulepšavanje</annotation>
 		<annotation cp="💇🏽‍♂" type="tts">muško šišanje: ni svetla ni tamna koža</annotation>
-		<annotation cp="💇🏾‍♂">frizer | muškarac | muško šišanje | muško šišanje: srednje tamna koža | salon | srednje tamna koža | ulepšavanje</annotation>
+		<annotation cp="💇🏾‍♂">frizer | muškarac | muško šišanje | salon | srednje tamna koža | ulepšavanje</annotation>
 		<annotation cp="💇🏾‍♂" type="tts">muško šišanje: srednje tamna koža</annotation>
-		<annotation cp="💇🏿‍♂">frizer | muškarac | muško šišanje | muško šišanje: tamna koža | salon | tamna koža | ulepšavanje</annotation>
+		<annotation cp="💇🏿‍♂">frizer | muškarac | muško šišanje | salon | tamna koža | ulepšavanje</annotation>
 		<annotation cp="💇🏿‍♂" type="tts">muško šišanje: tamna koža</annotation>
-		<annotation cp="💇🏻‍♀">frizer | salon | svetla koža | ulepšavanje | žena | žensko šišanje | žensko šišanje: svetla koža</annotation>
+		<annotation cp="💇🏻‍♀">frizer | salon | svetla koža | ulepšavanje | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏻‍♀" type="tts">žensko šišanje: svetla koža</annotation>
-		<annotation cp="💇🏼‍♀">frizer | salon | srednje svetla koža | ulepšavanje | žena | žensko šišanje | žensko šišanje: srednje svetla koža</annotation>
+		<annotation cp="💇🏼‍♀">frizer | salon | srednje svetla koža | ulepšavanje | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏼‍♀" type="tts">žensko šišanje: srednje svetla koža</annotation>
-		<annotation cp="💇🏽‍♀">frizer | ni svetla ni tamna koža | salon | ulepšavanje | žena | žensko šišanje | žensko šišanje: ni svetla ni tamna koža</annotation>
+		<annotation cp="💇🏽‍♀">frizer | ni svetla ni tamna koža | salon | ulepšavanje | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏽‍♀" type="tts">žensko šišanje: ni svetla ni tamna koža</annotation>
-		<annotation cp="💇🏾‍♀">frizer | salon | srednje tamna koža | ulepšavanje | žena | žensko šišanje | žensko šišanje: srednje tamna koža</annotation>
+		<annotation cp="💇🏾‍♀">frizer | salon | srednje tamna koža | ulepšavanje | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏾‍♀" type="tts">žensko šišanje: srednje tamna koža</annotation>
-		<annotation cp="💇🏿‍♀">frizer | salon | tamna koža | ulepšavanje | žena | žensko šišanje | žensko šišanje: tamna koža</annotation>
+		<annotation cp="💇🏿‍♀">frizer | salon | tamna koža | ulepšavanje | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏿‍♀" type="tts">žensko šišanje: tamna koža</annotation>
-		<annotation cp="🚶🏻">hodanje | pešak | pešak: svetla koža | šetanje | svetla koža</annotation>
+		<annotation cp="🚶🏻">hodanje | pešak | šetanje | svetla koža</annotation>
 		<annotation cp="🚶🏻" type="tts">pešak: svetla koža</annotation>
-		<annotation cp="🚶🏼">hodanje | pešak | pešak: srednje svetla koža | šetanje | srednje svetla koža</annotation>
+		<annotation cp="🚶🏼">hodanje | pešak | šetanje | srednje svetla koža</annotation>
 		<annotation cp="🚶🏼" type="tts">pešak: srednje svetla koža</annotation>
-		<annotation cp="🚶🏽">hodanje | ni svetla ni tamna koža | pešak | pešak: ni svetla ni tamna koža | šetanje</annotation>
+		<annotation cp="🚶🏽">hodanje | ni svetla ni tamna koža | pešak | šetanje</annotation>
 		<annotation cp="🚶🏽" type="tts">pešak: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚶🏾">hodanje | pešak | pešak: srednje tamna koža | šetanje | srednje tamna koža</annotation>
+		<annotation cp="🚶🏾">hodanje | pešak | šetanje | srednje tamna koža</annotation>
 		<annotation cp="🚶🏾" type="tts">pešak: srednje tamna koža</annotation>
-		<annotation cp="🚶🏿">hodanje | pešak | pešak: tamna koža | šetanje | tamna koža</annotation>
+		<annotation cp="🚶🏿">hodanje | pešak | šetanje | tamna koža</annotation>
 		<annotation cp="🚶🏿" type="tts">pešak: tamna koža</annotation>
-		<annotation cp="🚶🏻‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: svetla koža | šetanje | svetla koža</annotation>
+		<annotation cp="🚶🏻‍♂">hodanje | muškarac | muškarac hoda | šetanje | svetla koža</annotation>
 		<annotation cp="🚶🏻‍♂" type="tts">muškarac hoda: svetla koža</annotation>
-		<annotation cp="🚶🏼‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: srednje svetla koža | šetanje | srednje svetla koža</annotation>
+		<annotation cp="🚶🏼‍♂">hodanje | muškarac | muškarac hoda | šetanje | srednje svetla koža</annotation>
 		<annotation cp="🚶🏼‍♂" type="tts">muškarac hoda: srednje svetla koža</annotation>
-		<annotation cp="🚶🏽‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: ni svetla ni tamna koža | ni svetla ni tamna koža | šetanje</annotation>
+		<annotation cp="🚶🏽‍♂">hodanje | muškarac | muškarac hoda | ni svetla ni tamna koža | šetanje</annotation>
 		<annotation cp="🚶🏽‍♂" type="tts">muškarac hoda: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚶🏾‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: srednje tamna koža | šetanje | srednje tamna koža</annotation>
+		<annotation cp="🚶🏾‍♂">hodanje | muškarac | muškarac hoda | šetanje | srednje tamna koža</annotation>
 		<annotation cp="🚶🏾‍♂" type="tts">muškarac hoda: srednje tamna koža</annotation>
-		<annotation cp="🚶🏿‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: tamna koža | šetanje | tamna koža</annotation>
+		<annotation cp="🚶🏿‍♂">hodanje | muškarac | muškarac hoda | šetanje | tamna koža</annotation>
 		<annotation cp="🚶🏿‍♂" type="tts">muškarac hoda: tamna koža</annotation>
-		<annotation cp="🚶🏻‍♀">hodanje | šetanje | svetla koža | žena | žena hoda | žena hoda: svetla koža</annotation>
+		<annotation cp="🚶🏻‍♀">hodanje | šetanje | svetla koža | žena | žena hoda</annotation>
 		<annotation cp="🚶🏻‍♀" type="tts">žena hoda: svetla koža</annotation>
-		<annotation cp="🚶🏼‍♀">hodanje | šetanje | srednje svetla koža | žena | žena hoda | žena hoda: srednje svetla koža</annotation>
+		<annotation cp="🚶🏼‍♀">hodanje | šetanje | srednje svetla koža | žena | žena hoda</annotation>
 		<annotation cp="🚶🏼‍♀" type="tts">žena hoda: srednje svetla koža</annotation>
-		<annotation cp="🚶🏽‍♀">hodanje | ni svetla ni tamna koža | šetanje | žena | žena hoda | žena hoda: ni svetla ni tamna koža</annotation>
+		<annotation cp="🚶🏽‍♀">hodanje | ni svetla ni tamna koža | šetanje | žena | žena hoda</annotation>
 		<annotation cp="🚶🏽‍♀" type="tts">žena hoda: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚶🏾‍♀">hodanje | šetanje | srednje tamna koža | žena | žena hoda | žena hoda: srednje tamna koža</annotation>
+		<annotation cp="🚶🏾‍♀">hodanje | šetanje | srednje tamna koža | žena | žena hoda</annotation>
 		<annotation cp="🚶🏾‍♀" type="tts">žena hoda: srednje tamna koža</annotation>
-		<annotation cp="🚶🏿‍♀">hodanje | šetanje | tamna koža | žena | žena hoda | žena hoda: tamna koža</annotation>
+		<annotation cp="🚶🏿‍♀">hodanje | šetanje | tamna koža | žena | žena hoda</annotation>
 		<annotation cp="🚶🏿‍♀" type="tts">žena hoda: tamna koža</annotation>
-		<annotation cp="🧍🏻">osoba stoji | osoba stoji: svetla koža | stajanje | stajati | svetla koža</annotation>
+		<annotation cp="🧍🏻">osoba stoji | stajanje | stajati | svetla koža</annotation>
 		<annotation cp="🧍🏻" type="tts">osoba stoji: svetla koža</annotation>
-		<annotation cp="🧍🏼">osoba stoji | osoba stoji: srednje svetla koža | srednje svetla koža | stajanje | stajati</annotation>
+		<annotation cp="🧍🏼">osoba stoji | srednje svetla koža | stajanje | stajati</annotation>
 		<annotation cp="🧍🏼" type="tts">osoba stoji: srednje svetla koža</annotation>
-		<annotation cp="🧍🏽">ni svetla ni tamna koža | osoba stoji | osoba stoji: ni svetla ni tamna koža | stajanje | stajati</annotation>
+		<annotation cp="🧍🏽">ni svetla ni tamna koža | osoba stoji | stajanje | stajati</annotation>
 		<annotation cp="🧍🏽" type="tts">osoba stoji: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧍🏾">osoba stoji | osoba stoji: srednje tamna koža | srednje tamna koža | stajanje | stajati</annotation>
+		<annotation cp="🧍🏾">osoba stoji | srednje tamna koža | stajanje | stajati</annotation>
 		<annotation cp="🧍🏾" type="tts">osoba stoji: srednje tamna koža</annotation>
-		<annotation cp="🧍🏿">osoba stoji | osoba stoji: tamna koža | stajanje | stajati | tamna koža</annotation>
+		<annotation cp="🧍🏿">osoba stoji | stajanje | stajati | tamna koža</annotation>
 		<annotation cp="🧍🏿" type="tts">osoba stoji: tamna koža</annotation>
-		<annotation cp="🧍🏻‍♂">čovek | čovek stoji: svetla koža | stoji | svetla koža</annotation>
+		<annotation cp="🧍🏻‍♂">čovek | stoji | svetla koža</annotation>
 		<annotation cp="🧍🏻‍♂" type="tts">čovek stoji: svetla koža</annotation>
-		<annotation cp="🧍🏼‍♂">čovek | čovek stoji: srednje svetla koža | srednje svetla koža | stoji</annotation>
+		<annotation cp="🧍🏼‍♂">čovek | srednje svetla koža | stoji</annotation>
 		<annotation cp="🧍🏼‍♂" type="tts">čovek stoji: srednje svetla koža</annotation>
-		<annotation cp="🧍🏽‍♂">čovek | čovek stoji: ni svetla ni tamna koža | ni svetla ni tamna koža | stoji</annotation>
+		<annotation cp="🧍🏽‍♂">čovek | ni svetla ni tamna koža | stoji</annotation>
 		<annotation cp="🧍🏽‍♂" type="tts">čovek stoji: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧍🏾‍♂">čovek | čovek stoji: srednje tamna koža | srednje tamna koža | stoji</annotation>
+		<annotation cp="🧍🏾‍♂">čovek | srednje tamna koža | stoji</annotation>
 		<annotation cp="🧍🏾‍♂" type="tts">čovek stoji: srednje tamna koža</annotation>
-		<annotation cp="🧍🏿‍♂">čovek | čovek stoji: tamna koža | stoji | tamna koža</annotation>
+		<annotation cp="🧍🏿‍♂">čovek | stoji | tamna koža</annotation>
 		<annotation cp="🧍🏿‍♂" type="tts">čovek stoji: tamna koža</annotation>
-		<annotation cp="🧍🏻‍♀">stoji | svetla koža | žena | žena stoji: svetla koža</annotation>
+		<annotation cp="🧍🏻‍♀">stoji | svetla koža | žena</annotation>
 		<annotation cp="🧍🏻‍♀" type="tts">žena stoji: svetla koža</annotation>
-		<annotation cp="🧍🏼‍♀">srednje svetla koža | stoji | žena | žena stoji: srednje svetla koža</annotation>
+		<annotation cp="🧍🏼‍♀">srednje svetla koža | stoji | žena</annotation>
 		<annotation cp="🧍🏼‍♀" type="tts">žena stoji: srednje svetla koža</annotation>
-		<annotation cp="🧍🏽‍♀">ni svetla ni tamna koža | stoji | žena | žena stoji: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧍🏽‍♀">ni svetla ni tamna koža | stoji | žena</annotation>
 		<annotation cp="🧍🏽‍♀" type="tts">žena stoji: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧍🏾‍♀">srednje tamna koža | stoji | žena | žena stoji: srednje tamna koža</annotation>
+		<annotation cp="🧍🏾‍♀">srednje tamna koža | stoji | žena</annotation>
 		<annotation cp="🧍🏾‍♀" type="tts">žena stoji: srednje tamna koža</annotation>
-		<annotation cp="🧍🏿‍♀">stoji | tamna koža | žena | žena stoji: tamna koža</annotation>
+		<annotation cp="🧍🏿‍♀">stoji | tamna koža | žena</annotation>
 		<annotation cp="🧍🏿‍♀" type="tts">žena stoji: tamna koža</annotation>
-		<annotation cp="🧎🏻">klečanje | klečati | osoba kleči | osoba kleči: svetla koža | svetla koža</annotation>
+		<annotation cp="🧎🏻">klečanje | klečati | osoba kleči | svetla koža</annotation>
 		<annotation cp="🧎🏻" type="tts">osoba kleči: svetla koža</annotation>
-		<annotation cp="🧎🏼">klečanje | klečati | osoba kleči | osoba kleči: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧎🏼">klečanje | klečati | osoba kleči | srednje svetla koža</annotation>
 		<annotation cp="🧎🏼" type="tts">osoba kleči: srednje svetla koža</annotation>
-		<annotation cp="🧎🏽">klečanje | klečati | ni svetla ni tamna koža | osoba kleči | osoba kleči: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧎🏽">klečanje | klečati | ni svetla ni tamna koža | osoba kleči</annotation>
 		<annotation cp="🧎🏽" type="tts">osoba kleči: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧎🏾">klečanje | klečati | osoba kleči | osoba kleči: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧎🏾">klečanje | klečati | osoba kleči | srednje tamna koža</annotation>
 		<annotation cp="🧎🏾" type="tts">osoba kleči: srednje tamna koža</annotation>
-		<annotation cp="🧎🏿">klečanje | klečati | osoba kleči | osoba kleči: tamna koža | tamna koža</annotation>
+		<annotation cp="🧎🏿">klečanje | klečati | osoba kleči | tamna koža</annotation>
 		<annotation cp="🧎🏿" type="tts">osoba kleči: tamna koža</annotation>
-		<annotation cp="🧎🏻‍♂">čovek | čovek kleči: svetla koža | kleči | svetla koža</annotation>
+		<annotation cp="🧎🏻‍♂">čovek | kleči | svetla koža</annotation>
 		<annotation cp="🧎🏻‍♂" type="tts">čovek kleči: svetla koža</annotation>
-		<annotation cp="🧎🏼‍♂">čovek | čovek kleči: srednje svetla koža | kleči | srednje svetla koža</annotation>
+		<annotation cp="🧎🏼‍♂">čovek | kleči | srednje svetla koža</annotation>
 		<annotation cp="🧎🏼‍♂" type="tts">čovek kleči: srednje svetla koža</annotation>
-		<annotation cp="🧎🏽‍♂">čovek | čovek kleči: ni svetla ni tamna koža | kleči | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧎🏽‍♂">čovek | kleči | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧎🏽‍♂" type="tts">čovek kleči: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧎🏾‍♂">čovek | čovek kleči: srednje tamna koža | kleči | srednje tamna koža</annotation>
+		<annotation cp="🧎🏾‍♂">čovek | kleči | srednje tamna koža</annotation>
 		<annotation cp="🧎🏾‍♂" type="tts">čovek kleči: srednje tamna koža</annotation>
-		<annotation cp="🧎🏿‍♂">čovek | čovek kleči: tamna koža | kleči | tamna koža</annotation>
+		<annotation cp="🧎🏿‍♂">čovek | kleči | tamna koža</annotation>
 		<annotation cp="🧎🏿‍♂" type="tts">čovek kleči: tamna koža</annotation>
-		<annotation cp="🧎🏻‍♀">kleči | svetla koža | žena | žena kleči: svetla koža</annotation>
+		<annotation cp="🧎🏻‍♀">kleči | svetla koža | žena</annotation>
 		<annotation cp="🧎🏻‍♀" type="tts">žena kleči: svetla koža</annotation>
-		<annotation cp="🧎🏼‍♀">kleči | srednje svetla koža | žena | žena kleči: srednje svetla koža</annotation>
+		<annotation cp="🧎🏼‍♀">kleči | srednje svetla koža | žena</annotation>
 		<annotation cp="🧎🏼‍♀" type="tts">žena kleči: srednje svetla koža</annotation>
-		<annotation cp="🧎🏽‍♀">kleči | ni svetla ni tamna koža | žena | žena kleči: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧎🏽‍♀">kleči | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="🧎🏽‍♀" type="tts">žena kleči: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧎🏾‍♀">kleči | srednje tamna koža | žena | žena kleči: srednje tamna koža</annotation>
+		<annotation cp="🧎🏾‍♀">kleči | srednje tamna koža | žena</annotation>
 		<annotation cp="🧎🏾‍♀" type="tts">žena kleči: srednje tamna koža</annotation>
-		<annotation cp="🧎🏿‍♀">kleči | tamna koža | žena | žena kleči: tamna koža</annotation>
+		<annotation cp="🧎🏿‍♀">kleči | tamna koža | žena</annotation>
 		<annotation cp="🧎🏿‍♀" type="tts">žena kleči: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🦯">osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: svetla koža | pristupačnost | slep | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦯">osoba sa pomoćnim štapom | pristupačnost | slep | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦯" type="tts">osoba sa pomoćnim štapom: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🦯">osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: srednje svetla koža | pristupačnost | slep | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦯">osoba sa pomoćnim štapom | pristupačnost | slep | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦯" type="tts">osoba sa pomoćnim štapom: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🦯">ni svetla ni tamna koža | osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: ni svetla ni tamna koža | pristupačnost | slep</annotation>
+		<annotation cp="🧑🏽‍🦯">ni svetla ni tamna koža | osoba sa pomoćnim štapom | pristupačnost | slep</annotation>
 		<annotation cp="🧑🏽‍🦯" type="tts">osoba sa pomoćnim štapom: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🦯">osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: srednje tamna koža | pristupačnost | slep | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦯">osoba sa pomoćnim štapom | pristupačnost | slep | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦯" type="tts">osoba sa pomoćnim štapom: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🦯">osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: tamna koža | pristupačnost | slep | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦯">osoba sa pomoćnim štapom | pristupačnost | slep | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦯" type="tts">osoba sa pomoćnim štapom: tamna koža</annotation>
-		<annotation cp="👨🏻‍🦯">čovek | čovek sa pomoćnim štapom | čovek sa pomoćnim štapom: svetla koža | pristupačnost | slep | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦯">čovek | čovek sa pomoćnim štapom | pristupačnost | slep | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦯" type="tts">čovek sa pomoćnim štapom: svetla koža</annotation>
-		<annotation cp="👨🏼‍🦯">čovek | čovek sa pomoćnim štapom | čovek sa pomoćnim štapom: srednje svetla koža | pristupačnost | slep | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦯">čovek | čovek sa pomoćnim štapom | pristupačnost | slep | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦯" type="tts">čovek sa pomoćnim štapom: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🦯">čovek | čovek sa pomoćnim štapom | čovek sa pomoćnim štapom: ni svetla ni tamna koža | ni svetla ni tamna koža | pristupačnost | slep</annotation>
+		<annotation cp="👨🏽‍🦯">čovek | čovek sa pomoćnim štapom | ni svetla ni tamna koža | pristupačnost | slep</annotation>
 		<annotation cp="👨🏽‍🦯" type="tts">čovek sa pomoćnim štapom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🦯">čovek | čovek sa pomoćnim štapom | čovek sa pomoćnim štapom: srednje tamna koža | pristupačnost | slep | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦯">čovek | čovek sa pomoćnim štapom | pristupačnost | slep | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦯" type="tts">čovek sa pomoćnim štapom: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🦯">čovek | čovek sa pomoćnim štapom | čovek sa pomoćnim štapom: tamna koža | pristupačnost | slep | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦯">čovek | čovek sa pomoćnim štapom | pristupačnost | slep | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦯" type="tts">čovek sa pomoćnim štapom: tamna koža</annotation>
-		<annotation cp="👩🏻‍🦯">pristupačnost | slepa | svetla koža | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: svetla koža</annotation>
+		<annotation cp="👩🏻‍🦯">pristupačnost | slepa | svetla koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏻‍🦯" type="tts">žena sa pomoćnim štapom: svetla koža</annotation>
-		<annotation cp="👩🏼‍🦯">pristupačnost | slepa | srednje svetla koža | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍🦯">pristupačnost | slepa | srednje svetla koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏼‍🦯" type="tts">žena sa pomoćnim štapom: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🦯">ni svetla ni tamna koža | pristupačnost | slepa | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🦯">ni svetla ni tamna koža | pristupačnost | slepa | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏽‍🦯" type="tts">žena sa pomoćnim štapom: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🦯">pristupačnost | slepa | srednje tamna koža | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍🦯">pristupačnost | slepa | srednje tamna koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏾‍🦯" type="tts">žena sa pomoćnim štapom: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🦯">pristupačnost | slepa | tamna koža | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: tamna koža</annotation>
+		<annotation cp="👩🏿‍🦯">pristupačnost | slepa | tamna koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏿‍🦯" type="tts">žena sa pomoćnim štapom: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🦼">kolica | osoba u motornim kolicima | osoba u motornim kolicima: svetla koža | pristupačnost | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦼">kolica | osoba u motornim kolicima | pristupačnost | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦼" type="tts">osoba u motornim kolicima: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🦼">kolica | osoba u motornim kolicima | osoba u motornim kolicima: srednje svetla koža | pristupačnost | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦼">kolica | osoba u motornim kolicima | pristupačnost | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦼" type="tts">osoba u motornim kolicima: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🦼">kolica | ni svetla ni tamna koža | osoba u motornim kolicima | osoba u motornim kolicima: ni svetla ni tamna koža | pristupačnost</annotation>
+		<annotation cp="🧑🏽‍🦼">kolica | ni svetla ni tamna koža | osoba u motornim kolicima | pristupačnost</annotation>
 		<annotation cp="🧑🏽‍🦼" type="tts">osoba u motornim kolicima: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🦼">kolica | osoba u motornim kolicima | osoba u motornim kolicima: srednje tamna koža | pristupačnost | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦼">kolica | osoba u motornim kolicima | pristupačnost | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦼" type="tts">osoba u motornim kolicima: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🦼">kolica | osoba u motornim kolicima | osoba u motornim kolicima: tamna koža | pristupačnost | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦼">kolica | osoba u motornim kolicima | pristupačnost | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦼" type="tts">osoba u motornim kolicima: tamna koža</annotation>
-		<annotation cp="👨🏻‍🦼">čovek | čovek u motornim kolicima | čovek u motornim kolicima: svetla koža | dostupnost | kolica | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦼">čovek | čovek u motornim kolicima | dostupnost | kolica | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦼" type="tts">čovek u motornim kolicima: svetla koža</annotation>
-		<annotation cp="👨🏼‍🦼">čovek | čovek u motornim kolicima | čovek u motornim kolicima: srednje svetla koža | dostupnost | kolica | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦼">čovek | čovek u motornim kolicima | dostupnost | kolica | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦼" type="tts">čovek u motornim kolicima: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🦼">čovek | čovek u motornim kolicima | čovek u motornim kolicima: ni svetla ni tamna koža | dostupnost | kolica | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🦼">čovek | čovek u motornim kolicima | dostupnost | kolica | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🦼" type="tts">čovek u motornim kolicima: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🦼">čovek | čovek u motornim kolicima | čovek u motornim kolicima: srednje tamna koža | dostupnost | kolica | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦼">čovek | čovek u motornim kolicima | dostupnost | kolica | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦼" type="tts">čovek u motornim kolicima: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🦼">čovek | čovek u motornim kolicima | čovek u motornim kolicima: tamna koža | dostupnost | kolica | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦼">čovek | čovek u motornim kolicima | dostupnost | kolica | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦼" type="tts">čovek u motornim kolicima: tamna koža</annotation>
-		<annotation cp="👩🏻‍🦼">dostupnost | kolica | svetla koža | žena | žena u motornim kolicima | žena u motornim kolicima: svetla koža</annotation>
+		<annotation cp="👩🏻‍🦼">dostupnost | kolica | svetla koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏻‍🦼" type="tts">žena u motornim kolicima: svetla koža</annotation>
-		<annotation cp="👩🏼‍🦼">dostupnost | kolica | srednje svetla koža | žena | žena u motornim kolicima | žena u motornim kolicima: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍🦼">dostupnost | kolica | srednje svetla koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏼‍🦼" type="tts">žena u motornim kolicima: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🦼">dostupnost | kolica | ni svetla ni tamna koža | žena | žena u motornim kolicima | žena u motornim kolicima: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🦼">dostupnost | kolica | ni svetla ni tamna koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏽‍🦼" type="tts">žena u motornim kolicima: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🦼">dostupnost | kolica | srednje tamna koža | žena | žena u motornim kolicima | žena u motornim kolicima: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍🦼">dostupnost | kolica | srednje tamna koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏾‍🦼" type="tts">žena u motornim kolicima: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🦼">dostupnost | kolica | tamna koža | žena | žena u motornim kolicima | žena u motornim kolicima: tamna koža</annotation>
+		<annotation cp="👩🏿‍🦼">dostupnost | kolica | tamna koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏿‍🦼" type="tts">žena u motornim kolicima: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🦽">kolica | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: svetla koža | pristupačnost | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🦽">kolica | osoba u mehaničkim kolicima | pristupačnost | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🦽" type="tts">osoba u mehaničkim kolicima: svetla koža</annotation>
-		<annotation cp="🧑🏼‍🦽">kolica | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: srednje svetla koža | pristupačnost | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🦽">kolica | osoba u mehaničkim kolicima | pristupačnost | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🦽" type="tts">osoba u mehaničkim kolicima: srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🦽">kolica | ni svetla ni tamna koža | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: ni svetla ni tamna koža | pristupačnost</annotation>
+		<annotation cp="🧑🏽‍🦽">kolica | ni svetla ni tamna koža | osoba u mehaničkim kolicima | pristupačnost</annotation>
 		<annotation cp="🧑🏽‍🦽" type="tts">osoba u mehaničkim kolicima: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🦽">kolica | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: srednje tamna koža | pristupačnost | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦽">kolica | osoba u mehaničkim kolicima | pristupačnost | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦽" type="tts">osoba u mehaničkim kolicima: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🦽">kolica | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: tamna koža | pristupačnost | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦽">kolica | osoba u mehaničkim kolicima | pristupačnost | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦽" type="tts">osoba u mehaničkim kolicima: tamna koža</annotation>
-		<annotation cp="👨🏻‍🦽">čovek | čovek u mehaničkim kolicima | čovek u mehaničkim kolicima: svetla koža | dostupnost | kolica | svetla koža</annotation>
+		<annotation cp="👨🏻‍🦽">čovek | čovek u mehaničkim kolicima | dostupnost | kolica | svetla koža</annotation>
 		<annotation cp="👨🏻‍🦽" type="tts">čovek u mehaničkim kolicima: svetla koža</annotation>
-		<annotation cp="👨🏼‍🦽">čovek | čovek u mehaničkim kolicima | čovek u mehaničkim kolicima: srednje svetla koža | dostupnost | kolica | srednje svetla koža</annotation>
+		<annotation cp="👨🏼‍🦽">čovek | čovek u mehaničkim kolicima | dostupnost | kolica | srednje svetla koža</annotation>
 		<annotation cp="👨🏼‍🦽" type="tts">čovek u mehaničkim kolicima: srednje svetla koža</annotation>
-		<annotation cp="👨🏽‍🦽">čovek | čovek u mehaničkim kolicima | čovek u mehaničkim kolicima: ni svetla ni tamna koža | dostupnost | kolica | ni svetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🦽">čovek | čovek u mehaničkim kolicima | dostupnost | kolica | ni svetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🦽" type="tts">čovek u mehaničkim kolicima: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🦽">čovek | čovek u mehaničkim kolicima | čovek u mehaničkim kolicima: srednje tamna koža | dostupnost | kolica | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦽">čovek | čovek u mehaničkim kolicima | dostupnost | kolica | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦽" type="tts">čovek u mehaničkim kolicima: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🦽">čovek | čovek u mehaničkim kolicima | čovek u mehaničkim kolicima: tamna koža | dostupnost | kolica | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦽">čovek | čovek u mehaničkim kolicima | dostupnost | kolica | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦽" type="tts">čovek u mehaničkim kolicima: tamna koža</annotation>
-		<annotation cp="👩🏻‍🦽">dostupnost | kolica | svetla koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: svetla koža</annotation>
+		<annotation cp="👩🏻‍🦽">dostupnost | kolica | svetla koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏻‍🦽" type="tts">žena u mehaničkim kolicima: svetla koža</annotation>
-		<annotation cp="👩🏼‍🦽">dostupnost | kolica | srednje svetla koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: srednje svetla koža</annotation>
+		<annotation cp="👩🏼‍🦽">dostupnost | kolica | srednje svetla koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏼‍🦽" type="tts">žena u mehaničkim kolicima: srednje svetla koža</annotation>
-		<annotation cp="👩🏽‍🦽">dostupnost | kolica | ni svetla ni tamna koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🦽">dostupnost | kolica | ni svetla ni tamna koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏽‍🦽" type="tts">žena u mehaničkim kolicima: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🦽">dostupnost | kolica | srednje tamna koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: srednje tamna koža</annotation>
+		<annotation cp="👩🏾‍🦽">dostupnost | kolica | srednje tamna koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏾‍🦽" type="tts">žena u mehaničkim kolicima: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🦽">dostupnost | kolica | tamna koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: tamna koža</annotation>
+		<annotation cp="👩🏿‍🦽">dostupnost | kolica | tamna koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏿‍🦽" type="tts">žena u mehaničkim kolicima: tamna koža</annotation>
-		<annotation cp="🏃🏻">maraton | svetla koža | trčanje | trkač | trkač: svetla koža</annotation>
+		<annotation cp="🏃🏻">maraton | svetla koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏻" type="tts">trkač: svetla koža</annotation>
-		<annotation cp="🏃🏼">maraton | srednje svetla koža | trčanje | trkač | trkač: srednje svetla koža</annotation>
+		<annotation cp="🏃🏼">maraton | srednje svetla koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏼" type="tts">trkač: srednje svetla koža</annotation>
-		<annotation cp="🏃🏽">maraton | ni svetla ni tamna koža | trčanje | trkač | trkač: ni svetla ni tamna koža</annotation>
+		<annotation cp="🏃🏽">maraton | ni svetla ni tamna koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏽" type="tts">trkač: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏃🏾">maraton | srednje tamna koža | trčanje | trkač | trkač: srednje tamna koža</annotation>
+		<annotation cp="🏃🏾">maraton | srednje tamna koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏾" type="tts">trkač: srednje tamna koža</annotation>
-		<annotation cp="🏃🏿">maraton | tamna koža | trčanje | trkač | trkač: tamna koža</annotation>
+		<annotation cp="🏃🏿">maraton | tamna koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏿" type="tts">trkač: tamna koža</annotation>
-		<annotation cp="🏃🏻‍♂">maraton | muškarac | muškarac trči | muškarac trči: svetla koža | svetla koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏻‍♂">maraton | muškarac | muškarac trči | svetla koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏻‍♂" type="tts">muškarac trči: svetla koža</annotation>
-		<annotation cp="🏃🏼‍♂">maraton | muškarac | muškarac trči | muškarac trči: srednje svetla koža | srednje svetla koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏼‍♂">maraton | muškarac | muškarac trči | srednje svetla koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏼‍♂" type="tts">muškarac trči: srednje svetla koža</annotation>
-		<annotation cp="🏃🏽‍♂">maraton | muškarac | muškarac trči | muškarac trči: ni svetla ni tamna koža | ni svetla ni tamna koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏽‍♂">maraton | muškarac | muškarac trči | ni svetla ni tamna koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏽‍♂" type="tts">muškarac trči: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏃🏾‍♂">maraton | muškarac | muškarac trči | muškarac trči: srednje tamna koža | srednje tamna koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏾‍♂">maraton | muškarac | muškarac trči | srednje tamna koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏾‍♂" type="tts">muškarac trči: srednje tamna koža</annotation>
-		<annotation cp="🏃🏿‍♂">maraton | muškarac | muškarac trči | muškarac trči: tamna koža | tamna koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏿‍♂">maraton | muškarac | muškarac trči | tamna koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏿‍♂" type="tts">muškarac trči: tamna koža</annotation>
-		<annotation cp="🏃🏻‍♀">maraton | svetla koža | trčanje | trka | žena | žena trči | žena trči: svetla koža</annotation>
+		<annotation cp="🏃🏻‍♀">maraton | svetla koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏻‍♀" type="tts">žena trči: svetla koža</annotation>
-		<annotation cp="🏃🏼‍♀">maraton | srednje svetla koža | trčanje | trka | žena | žena trči | žena trči: srednje svetla koža</annotation>
+		<annotation cp="🏃🏼‍♀">maraton | srednje svetla koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏼‍♀" type="tts">žena trči: srednje svetla koža</annotation>
-		<annotation cp="🏃🏽‍♀">maraton | ni svetla ni tamna koža | trčanje | trka | žena | žena trči | žena trči: ni svetla ni tamna koža</annotation>
+		<annotation cp="🏃🏽‍♀">maraton | ni svetla ni tamna koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏽‍♀" type="tts">žena trči: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏃🏾‍♀">maraton | srednje tamna koža | trčanje | trka | žena | žena trči | žena trči: srednje tamna koža</annotation>
+		<annotation cp="🏃🏾‍♀">maraton | srednje tamna koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏾‍♀" type="tts">žena trči: srednje tamna koža</annotation>
-		<annotation cp="🏃🏿‍♀">maraton | tamna koža | trčanje | trka | žena | žena trči | žena trči: tamna koža</annotation>
+		<annotation cp="🏃🏿‍♀">maraton | tamna koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏿‍♀" type="tts">žena trči: tamna koža</annotation>
-		<annotation cp="💃🏻">ples | plesačica | plesačica: svetla koža | plesanje | svetla koža | žena</annotation>
+		<annotation cp="💃🏻">ples | plesačica | plesanje | svetla koža | žena</annotation>
 		<annotation cp="💃🏻" type="tts">plesačica: svetla koža</annotation>
-		<annotation cp="💃🏼">ples | plesačica | plesačica: srednje svetla koža | plesanje | srednje svetla koža | žena</annotation>
+		<annotation cp="💃🏼">ples | plesačica | plesanje | srednje svetla koža | žena</annotation>
 		<annotation cp="💃🏼" type="tts">plesačica: srednje svetla koža</annotation>
-		<annotation cp="💃🏽">ni svetla ni tamna koža | ples | plesačica | plesačica: ni svetla ni tamna koža | plesanje | žena</annotation>
+		<annotation cp="💃🏽">ni svetla ni tamna koža | ples | plesačica | plesanje | žena</annotation>
 		<annotation cp="💃🏽" type="tts">plesačica: ni svetla ni tamna koža</annotation>
-		<annotation cp="💃🏾">ples | plesačica | plesačica: srednje tamna koža | plesanje | srednje tamna koža | žena</annotation>
+		<annotation cp="💃🏾">ples | plesačica | plesanje | srednje tamna koža | žena</annotation>
 		<annotation cp="💃🏾" type="tts">plesačica: srednje tamna koža</annotation>
-		<annotation cp="💃🏿">ples | plesačica | plesačica: tamna koža | plesanje | tamna koža | žena</annotation>
+		<annotation cp="💃🏿">ples | plesačica | plesanje | tamna koža | žena</annotation>
 		<annotation cp="💃🏿" type="tts">plesačica: tamna koža</annotation>
-		<annotation cp="🕺🏻">muškarac | ples | plesač | plesač: svetla koža | plesanje | svetla koža</annotation>
+		<annotation cp="🕺🏻">muškarac | ples | plesač | plesanje | svetla koža</annotation>
 		<annotation cp="🕺🏻" type="tts">plesač: svetla koža</annotation>
-		<annotation cp="🕺🏼">muškarac | ples | plesač | plesač: srednje svetla koža | plesanje | srednje svetla koža</annotation>
+		<annotation cp="🕺🏼">muškarac | ples | plesač | plesanje | srednje svetla koža</annotation>
 		<annotation cp="🕺🏼" type="tts">plesač: srednje svetla koža</annotation>
-		<annotation cp="🕺🏽">muškarac | ni svetla ni tamna koža | ples | plesač | plesač: ni svetla ni tamna koža | plesanje</annotation>
+		<annotation cp="🕺🏽">muškarac | ni svetla ni tamna koža | ples | plesač | plesanje</annotation>
 		<annotation cp="🕺🏽" type="tts">plesač: ni svetla ni tamna koža</annotation>
-		<annotation cp="🕺🏾">muškarac | ples | plesač | plesač: srednje tamna koža | plesanje | srednje tamna koža</annotation>
+		<annotation cp="🕺🏾">muškarac | ples | plesač | plesanje | srednje tamna koža</annotation>
 		<annotation cp="🕺🏾" type="tts">plesač: srednje tamna koža</annotation>
-		<annotation cp="🕺🏿">muškarac | ples | plesač | plesač: tamna koža | plesanje | tamna koža</annotation>
+		<annotation cp="🕺🏿">muškarac | ples | plesač | plesanje | tamna koža</annotation>
 		<annotation cp="🕺🏿" type="tts">plesač: tamna koža</annotation>
-		<annotation cp="🕴🏻">muškarac u poslovnom odelu koji lebdi | muškarac u poslovnom odelu koji lebdi: svetla koža | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | svetla koža</annotation>
+		<annotation cp="🕴🏻">muškarac u poslovnom odelu koji lebdi | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | svetla koža</annotation>
 		<annotation cp="🕴🏻" type="tts">muškarac u poslovnom odelu koji lebdi: svetla koža</annotation>
-		<annotation cp="🕴🏼">muškarac u poslovnom odelu koji lebdi | muškarac u poslovnom odelu koji lebdi: srednje svetla koža | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | srednje svetla koža</annotation>
+		<annotation cp="🕴🏼">muškarac u poslovnom odelu koji lebdi | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | srednje svetla koža</annotation>
 		<annotation cp="🕴🏼" type="tts">muškarac u poslovnom odelu koji lebdi: srednje svetla koža</annotation>
-		<annotation cp="🕴🏽">muškarac u poslovnom odelu koji lebdi | muškarac u poslovnom odelu koji lebdi: ni svetla ni tamna koža | ni svetla ni tamna koža | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao</annotation>
+		<annotation cp="🕴🏽">muškarac u poslovnom odelu koji lebdi | ni svetla ni tamna koža | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao</annotation>
 		<annotation cp="🕴🏽" type="tts">muškarac u poslovnom odelu koji lebdi: ni svetla ni tamna koža</annotation>
-		<annotation cp="🕴🏾">muškarac u poslovnom odelu koji lebdi | muškarac u poslovnom odelu koji lebdi: srednje tamna koža | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | srednje tamna koža</annotation>
+		<annotation cp="🕴🏾">muškarac u poslovnom odelu koji lebdi | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | srednje tamna koža</annotation>
 		<annotation cp="🕴🏾" type="tts">muškarac u poslovnom odelu koji lebdi: srednje tamna koža</annotation>
-		<annotation cp="🕴🏿">muškarac u poslovnom odelu koji lebdi | muškarac u poslovnom odelu koji lebdi: tamna koža | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | tamna koža</annotation>
+		<annotation cp="🕴🏿">muškarac u poslovnom odelu koji lebdi | odelo | osoba | osoba u poslovnom odelu koja lebdi | posao | tamna koža</annotation>
 		<annotation cp="🕴🏿" type="tts">muškarac u poslovnom odelu koji lebdi: tamna koža</annotation>
-		<annotation cp="🧖🏻">osoba u parnom kupatilu | osoba u parnom kupatilu: svetla koža | parno kupatilo | sauna | svetla koža</annotation>
+		<annotation cp="🧖🏻">osoba u parnom kupatilu | parno kupatilo | sauna | svetla koža</annotation>
 		<annotation cp="🧖🏻" type="tts">osoba u parnom kupatilu: svetla koža</annotation>
-		<annotation cp="🧖🏼">osoba u parnom kupatilu | osoba u parnom kupatilu: srednje svetla koža | parno kupatilo | sauna | srednje svetla koža</annotation>
+		<annotation cp="🧖🏼">osoba u parnom kupatilu | parno kupatilo | sauna | srednje svetla koža</annotation>
 		<annotation cp="🧖🏼" type="tts">osoba u parnom kupatilu: srednje svetla koža</annotation>
-		<annotation cp="🧖🏽">ni svetla ni tamna koža | osoba u parnom kupatilu | osoba u parnom kupatilu: ni svetla ni tamna koža | parno kupatilo | sauna</annotation>
+		<annotation cp="🧖🏽">ni svetla ni tamna koža | osoba u parnom kupatilu | parno kupatilo | sauna</annotation>
 		<annotation cp="🧖🏽" type="tts">osoba u parnom kupatilu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧖🏾">osoba u parnom kupatilu | osoba u parnom kupatilu: srednje tamna koža | parno kupatilo | sauna | srednje tamna koža</annotation>
+		<annotation cp="🧖🏾">osoba u parnom kupatilu | parno kupatilo | sauna | srednje tamna koža</annotation>
 		<annotation cp="🧖🏾" type="tts">osoba u parnom kupatilu: srednje tamna koža</annotation>
-		<annotation cp="🧖🏿">osoba u parnom kupatilu | osoba u parnom kupatilu: tamna koža | parno kupatilo | sauna | tamna koža</annotation>
+		<annotation cp="🧖🏿">osoba u parnom kupatilu | parno kupatilo | sauna | tamna koža</annotation>
 		<annotation cp="🧖🏿" type="tts">osoba u parnom kupatilu: tamna koža</annotation>
-		<annotation cp="🧖🏻‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: svetla koža | parno kupatilo | sauna | svetla koža</annotation>
+		<annotation cp="🧖🏻‍♂">muškarac u parnom kupatilu | parno kupatilo | sauna | svetla koža</annotation>
 		<annotation cp="🧖🏻‍♂" type="tts">muškarac u parnom kupatilu: svetla koža</annotation>
-		<annotation cp="🧖🏼‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: srednje svetla koža | parno kupatilo | sauna | srednje svetla koža</annotation>
+		<annotation cp="🧖🏼‍♂">muškarac u parnom kupatilu | parno kupatilo | sauna | srednje svetla koža</annotation>
 		<annotation cp="🧖🏼‍♂" type="tts">muškarac u parnom kupatilu: srednje svetla koža</annotation>
-		<annotation cp="🧖🏽‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: ni svetla ni tamna koža | ni svetla ni tamna koža | parno kupatilo | sauna</annotation>
+		<annotation cp="🧖🏽‍♂">muškarac u parnom kupatilu | ni svetla ni tamna koža | parno kupatilo | sauna</annotation>
 		<annotation cp="🧖🏽‍♂" type="tts">muškarac u parnom kupatilu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧖🏾‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: srednje tamna koža | parno kupatilo | sauna | srednje tamna koža</annotation>
+		<annotation cp="🧖🏾‍♂">muškarac u parnom kupatilu | parno kupatilo | sauna | srednje tamna koža</annotation>
 		<annotation cp="🧖🏾‍♂" type="tts">muškarac u parnom kupatilu: srednje tamna koža</annotation>
-		<annotation cp="🧖🏿‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: tamna koža | parno kupatilo | sauna | tamna koža</annotation>
+		<annotation cp="🧖🏿‍♂">muškarac u parnom kupatilu | parno kupatilo | sauna | tamna koža</annotation>
 		<annotation cp="🧖🏿‍♂" type="tts">muškarac u parnom kupatilu: tamna koža</annotation>
-		<annotation cp="🧖🏻‍♀">parno kupatilo | sauna | svetla koža | žena u parnom kupatilu | žena u parnom kupatilu: svetla koža</annotation>
+		<annotation cp="🧖🏻‍♀">parno kupatilo | sauna | svetla koža | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏻‍♀" type="tts">žena u parnom kupatilu: svetla koža</annotation>
-		<annotation cp="🧖🏼‍♀">parno kupatilo | sauna | srednje svetla koža | žena u parnom kupatilu | žena u parnom kupatilu: srednje svetla koža</annotation>
+		<annotation cp="🧖🏼‍♀">parno kupatilo | sauna | srednje svetla koža | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏼‍♀" type="tts">žena u parnom kupatilu: srednje svetla koža</annotation>
-		<annotation cp="🧖🏽‍♀">ni svetla ni tamna koža | parno kupatilo | sauna | žena u parnom kupatilu | žena u parnom kupatilu: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧖🏽‍♀">ni svetla ni tamna koža | parno kupatilo | sauna | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏽‍♀" type="tts">žena u parnom kupatilu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧖🏾‍♀">parno kupatilo | sauna | srednje tamna koža | žena u parnom kupatilu | žena u parnom kupatilu: srednje tamna koža</annotation>
+		<annotation cp="🧖🏾‍♀">parno kupatilo | sauna | srednje tamna koža | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏾‍♀" type="tts">žena u parnom kupatilu: srednje tamna koža</annotation>
-		<annotation cp="🧖🏿‍♀">parno kupatilo | sauna | tamna koža | žena u parnom kupatilu | žena u parnom kupatilu: tamna koža</annotation>
+		<annotation cp="🧖🏿‍♀">parno kupatilo | sauna | tamna koža | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏿‍♀" type="tts">žena u parnom kupatilu: tamna koža</annotation>
-		<annotation cp="🧗🏻">penjač | penjanje | penjanje: svetla koža | svetla koža</annotation>
+		<annotation cp="🧗🏻">penjač | penjanje | svetla koža</annotation>
 		<annotation cp="🧗🏻" type="tts">penjanje: svetla koža</annotation>
-		<annotation cp="🧗🏼">penjač | penjanje | penjanje: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧗🏼">penjač | penjanje | srednje svetla koža</annotation>
 		<annotation cp="🧗🏼" type="tts">penjanje: srednje svetla koža</annotation>
-		<annotation cp="🧗🏽">ni svetla ni tamna koža | penjač | penjanje | penjanje: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧗🏽">ni svetla ni tamna koža | penjač | penjanje</annotation>
 		<annotation cp="🧗🏽" type="tts">penjanje: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧗🏾">penjač | penjanje | penjanje: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧗🏾">penjač | penjanje | srednje tamna koža</annotation>
 		<annotation cp="🧗🏾" type="tts">penjanje: srednje tamna koža</annotation>
-		<annotation cp="🧗🏿">penjač | penjanje | penjanje: tamna koža | tamna koža</annotation>
+		<annotation cp="🧗🏿">penjač | penjanje | tamna koža</annotation>
 		<annotation cp="🧗🏿" type="tts">penjanje: tamna koža</annotation>
-		<annotation cp="🧗🏻‍♂">muškarac se penje | muškarac se penje: svetla koža | penjač | svetla koža</annotation>
+		<annotation cp="🧗🏻‍♂">muškarac se penje | penjač | svetla koža</annotation>
 		<annotation cp="🧗🏻‍♂" type="tts">muškarac se penje: svetla koža</annotation>
-		<annotation cp="🧗🏼‍♂">muškarac se penje | muškarac se penje: srednje svetla koža | penjač | srednje svetla koža</annotation>
+		<annotation cp="🧗🏼‍♂">muškarac se penje | penjač | srednje svetla koža</annotation>
 		<annotation cp="🧗🏼‍♂" type="tts">muškarac se penje: srednje svetla koža</annotation>
-		<annotation cp="🧗🏽‍♂">muškarac se penje | muškarac se penje: ni svetla ni tamna koža | ni svetla ni tamna koža | penjač</annotation>
+		<annotation cp="🧗🏽‍♂">muškarac se penje | ni svetla ni tamna koža | penjač</annotation>
 		<annotation cp="🧗🏽‍♂" type="tts">muškarac se penje: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧗🏾‍♂">muškarac se penje | muškarac se penje: srednje tamna koža | penjač | srednje tamna koža</annotation>
+		<annotation cp="🧗🏾‍♂">muškarac se penje | penjač | srednje tamna koža</annotation>
 		<annotation cp="🧗🏾‍♂" type="tts">muškarac se penje: srednje tamna koža</annotation>
-		<annotation cp="🧗🏿‍♂">muškarac se penje | muškarac se penje: tamna koža | penjač | tamna koža</annotation>
+		<annotation cp="🧗🏿‍♂">muškarac se penje | penjač | tamna koža</annotation>
 		<annotation cp="🧗🏿‍♂" type="tts">muškarac se penje: tamna koža</annotation>
-		<annotation cp="🧗🏻‍♀">penjačica | svetla koža | žena se penje | žena se penje: svetla koža</annotation>
+		<annotation cp="🧗🏻‍♀">penjačica | svetla koža | žena se penje</annotation>
 		<annotation cp="🧗🏻‍♀" type="tts">žena se penje: svetla koža</annotation>
-		<annotation cp="🧗🏼‍♀">penjačica | srednje svetla koža | žena se penje | žena se penje: srednje svetla koža</annotation>
+		<annotation cp="🧗🏼‍♀">penjačica | srednje svetla koža | žena se penje</annotation>
 		<annotation cp="🧗🏼‍♀" type="tts">žena se penje: srednje svetla koža</annotation>
-		<annotation cp="🧗🏽‍♀">ni svetla ni tamna koža | penjačica | žena se penje | žena se penje: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧗🏽‍♀">ni svetla ni tamna koža | penjačica | žena se penje</annotation>
 		<annotation cp="🧗🏽‍♀" type="tts">žena se penje: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧗🏾‍♀">penjačica | srednje tamna koža | žena se penje | žena se penje: srednje tamna koža</annotation>
+		<annotation cp="🧗🏾‍♀">penjačica | srednje tamna koža | žena se penje</annotation>
 		<annotation cp="🧗🏾‍♀" type="tts">žena se penje: srednje tamna koža</annotation>
-		<annotation cp="🧗🏿‍♀">penjačica | tamna koža | žena se penje | žena se penje: tamna koža</annotation>
+		<annotation cp="🧗🏿‍♀">penjačica | tamna koža | žena se penje</annotation>
 		<annotation cp="🧗🏿‍♀" type="tts">žena se penje: tamna koža</annotation>
-		<annotation cp="🏇🏻">džokej | konj | svetla koža | trkaći konj | trke konja | trke konja: svetla koža</annotation>
+		<annotation cp="🏇🏻">džokej | konj | svetla koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏻" type="tts">trke konja: svetla koža</annotation>
-		<annotation cp="🏇🏼">džokej | konj | srednje svetla koža | trkaći konj | trke konja | trke konja: srednje svetla koža</annotation>
+		<annotation cp="🏇🏼">džokej | konj | srednje svetla koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏼" type="tts">trke konja: srednje svetla koža</annotation>
-		<annotation cp="🏇🏽">džokej | konj | ni svetla ni tamna koža | trkaći konj | trke konja | trke konja: ni svetla ni tamna koža</annotation>
+		<annotation cp="🏇🏽">džokej | konj | ni svetla ni tamna koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏽" type="tts">trke konja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏇🏾">džokej | konj | srednje tamna koža | trkaći konj | trke konja | trke konja: srednje tamna koža</annotation>
+		<annotation cp="🏇🏾">džokej | konj | srednje tamna koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏾" type="tts">trke konja: srednje tamna koža</annotation>
-		<annotation cp="🏇🏿">džokej | konj | tamna koža | trkaći konj | trke konja | trke konja: tamna koža</annotation>
+		<annotation cp="🏇🏿">džokej | konj | tamna koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏿" type="tts">trke konja: tamna koža</annotation>
-		<annotation cp="🏂🏻">skijanje | sneg | snoubord | svetla koža | vozač snouborda | vozač snouborda: svetla koža</annotation>
+		<annotation cp="🏂🏻">skijanje | sneg | snoubord | svetla koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏻" type="tts">vozač snouborda: svetla koža</annotation>
-		<annotation cp="🏂🏼">skijanje | sneg | snoubord | srednje svetla koža | vozač snouborda | vozač snouborda: srednje svetla koža</annotation>
+		<annotation cp="🏂🏼">skijanje | sneg | snoubord | srednje svetla koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏼" type="tts">vozač snouborda: srednje svetla koža</annotation>
-		<annotation cp="🏂🏽">ni svetla ni tamna koža | skijanje | sneg | snoubord | vozač snouborda | vozač snouborda: ni svetla ni tamna koža</annotation>
+		<annotation cp="🏂🏽">ni svetla ni tamna koža | skijanje | sneg | snoubord | vozač snouborda</annotation>
 		<annotation cp="🏂🏽" type="tts">vozač snouborda: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏂🏾">skijanje | sneg | snoubord | srednje tamna koža | vozač snouborda | vozač snouborda: srednje tamna koža</annotation>
+		<annotation cp="🏂🏾">skijanje | sneg | snoubord | srednje tamna koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏾" type="tts">vozač snouborda: srednje tamna koža</annotation>
-		<annotation cp="🏂🏿">skijanje | sneg | snoubord | tamna koža | vozač snouborda | vozač snouborda: tamna koža</annotation>
+		<annotation cp="🏂🏿">skijanje | sneg | snoubord | tamna koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏿" type="tts">vozač snouborda: tamna koža</annotation>
-		<annotation cp="🏌🏻">golf | loptica | osoba igra golf | osoba igra golf: svetla koža | svetla koža</annotation>
+		<annotation cp="🏌🏻">golf | loptica | osoba igra golf | svetla koža</annotation>
 		<annotation cp="🏌🏻" type="tts">osoba igra golf: svetla koža</annotation>
-		<annotation cp="🏌🏼">golf | loptica | osoba igra golf | osoba igra golf: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🏌🏼">golf | loptica | osoba igra golf | srednje svetla koža</annotation>
 		<annotation cp="🏌🏼" type="tts">osoba igra golf: srednje svetla koža</annotation>
-		<annotation cp="🏌🏽">golf | loptica | ni svetla ni tamna koža | osoba igra golf | osoba igra golf: ni svetla ni tamna koža</annotation>
+		<annotation cp="🏌🏽">golf | loptica | ni svetla ni tamna koža | osoba igra golf</annotation>
 		<annotation cp="🏌🏽" type="tts">osoba igra golf: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏌🏾">golf | loptica | osoba igra golf | osoba igra golf: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🏌🏾">golf | loptica | osoba igra golf | srednje tamna koža</annotation>
 		<annotation cp="🏌🏾" type="tts">osoba igra golf: srednje tamna koža</annotation>
-		<annotation cp="🏌🏿">golf | loptica | osoba igra golf | osoba igra golf: tamna koža | tamna koža</annotation>
+		<annotation cp="🏌🏿">golf | loptica | osoba igra golf | tamna koža</annotation>
 		<annotation cp="🏌🏿" type="tts">osoba igra golf: tamna koža</annotation>
-		<annotation cp="🏌🏻‍♂">golf | golfer | golfer: svetla koža | loptica | muškarac | svetla koža</annotation>
+		<annotation cp="🏌🏻‍♂">golf | golfer | loptica | muškarac | svetla koža</annotation>
 		<annotation cp="🏌🏻‍♂" type="tts">golfer: svetla koža</annotation>
-		<annotation cp="🏌🏼‍♂">golf | golfer | golfer: srednje svetla koža | loptica | muškarac | srednje svetla koža</annotation>
+		<annotation cp="🏌🏼‍♂">golf | golfer | loptica | muškarac | srednje svetla koža</annotation>
 		<annotation cp="🏌🏼‍♂" type="tts">golfer: srednje svetla koža</annotation>
-		<annotation cp="🏌🏽‍♂">golf | golfer | golfer: ni svetla ni tamna koža | loptica | muškarac | ni svetla ni tamna koža</annotation>
+		<annotation cp="🏌🏽‍♂">golf | golfer | loptica | muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="🏌🏽‍♂" type="tts">golfer: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏌🏾‍♂">golf | golfer | golfer: srednje tamna koža | loptica | muškarac | srednje tamna koža</annotation>
+		<annotation cp="🏌🏾‍♂">golf | golfer | loptica | muškarac | srednje tamna koža</annotation>
 		<annotation cp="🏌🏾‍♂" type="tts">golfer: srednje tamna koža</annotation>
-		<annotation cp="🏌🏿‍♂">golf | golfer | golfer: tamna koža | loptica | muškarac | tamna koža</annotation>
+		<annotation cp="🏌🏿‍♂">golf | golfer | loptica | muškarac | tamna koža</annotation>
 		<annotation cp="🏌🏿‍♂" type="tts">golfer: tamna koža</annotation>
-		<annotation cp="🏌🏻‍♀">golf | golferka | golferka: svetla koža | loptica | svetla koža | žena</annotation>
+		<annotation cp="🏌🏻‍♀">golf | golferka | loptica | svetla koža | žena</annotation>
 		<annotation cp="🏌🏻‍♀" type="tts">golferka: svetla koža</annotation>
-		<annotation cp="🏌🏼‍♀">golf | golferka | golferka: srednje svetla koža | loptica | srednje svetla koža | žena</annotation>
+		<annotation cp="🏌🏼‍♀">golf | golferka | loptica | srednje svetla koža | žena</annotation>
 		<annotation cp="🏌🏼‍♀" type="tts">golferka: srednje svetla koža</annotation>
-		<annotation cp="🏌🏽‍♀">golf | golferka | golferka: ni svetla ni tamna koža | loptica | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🏌🏽‍♀">golf | golferka | loptica | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="🏌🏽‍♀" type="tts">golferka: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏌🏾‍♀">golf | golferka | golferka: srednje tamna koža | loptica | srednje tamna koža | žena</annotation>
+		<annotation cp="🏌🏾‍♀">golf | golferka | loptica | srednje tamna koža | žena</annotation>
 		<annotation cp="🏌🏾‍♀" type="tts">golferka: srednje tamna koža</annotation>
-		<annotation cp="🏌🏿‍♀">golf | golferka | golferka: tamna koža | loptica | tamna koža | žena</annotation>
+		<annotation cp="🏌🏿‍♀">golf | golferka | loptica | tamna koža | žena</annotation>
 		<annotation cp="🏌🏿‍♀" type="tts">golferka: tamna koža</annotation>
-		<annotation cp="🏄🏻">osoba surfuje | osoba surfuje: svetla koža | surfovanje | svetla koža</annotation>
+		<annotation cp="🏄🏻">osoba surfuje | surfovanje | svetla koža</annotation>
 		<annotation cp="🏄🏻" type="tts">osoba surfuje: svetla koža</annotation>
-		<annotation cp="🏄🏼">osoba surfuje | osoba surfuje: srednje svetla koža | srednje svetla koža | surfovanje</annotation>
+		<annotation cp="🏄🏼">osoba surfuje | srednje svetla koža | surfovanje</annotation>
 		<annotation cp="🏄🏼" type="tts">osoba surfuje: srednje svetla koža</annotation>
-		<annotation cp="🏄🏽">ni svetla ni tamna koža | osoba surfuje | osoba surfuje: ni svetla ni tamna koža | surfovanje</annotation>
+		<annotation cp="🏄🏽">ni svetla ni tamna koža | osoba surfuje | surfovanje</annotation>
 		<annotation cp="🏄🏽" type="tts">osoba surfuje: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏄🏾">osoba surfuje | osoba surfuje: srednje tamna koža | srednje tamna koža | surfovanje</annotation>
+		<annotation cp="🏄🏾">osoba surfuje | srednje tamna koža | surfovanje</annotation>
 		<annotation cp="🏄🏾" type="tts">osoba surfuje: srednje tamna koža</annotation>
-		<annotation cp="🏄🏿">osoba surfuje | osoba surfuje: tamna koža | surfovanje | tamna koža</annotation>
+		<annotation cp="🏄🏿">osoba surfuje | surfovanje | tamna koža</annotation>
 		<annotation cp="🏄🏿" type="tts">osoba surfuje: tamna koža</annotation>
-		<annotation cp="🏄🏻‍♂">muškarac | surfer | surfer: svetla koža | surfovanje | svetla koža</annotation>
+		<annotation cp="🏄🏻‍♂">muškarac | surfer | surfovanje | svetla koža</annotation>
 		<annotation cp="🏄🏻‍♂" type="tts">surfer: svetla koža</annotation>
-		<annotation cp="🏄🏼‍♂">muškarac | srednje svetla koža | surfer | surfer: srednje svetla koža | surfovanje</annotation>
+		<annotation cp="🏄🏼‍♂">muškarac | srednje svetla koža | surfer | surfovanje</annotation>
 		<annotation cp="🏄🏼‍♂" type="tts">surfer: srednje svetla koža</annotation>
-		<annotation cp="🏄🏽‍♂">muškarac | ni svetla ni tamna koža | surfer | surfer: ni svetla ni tamna koža | surfovanje</annotation>
+		<annotation cp="🏄🏽‍♂">muškarac | ni svetla ni tamna koža | surfer | surfovanje</annotation>
 		<annotation cp="🏄🏽‍♂" type="tts">surfer: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏄🏾‍♂">muškarac | srednje tamna koža | surfer | surfer: srednje tamna koža | surfovanje</annotation>
+		<annotation cp="🏄🏾‍♂">muškarac | srednje tamna koža | surfer | surfovanje</annotation>
 		<annotation cp="🏄🏾‍♂" type="tts">surfer: srednje tamna koža</annotation>
-		<annotation cp="🏄🏿‍♂">muškarac | surfer | surfer: tamna koža | surfovanje | tamna koža</annotation>
+		<annotation cp="🏄🏿‍♂">muškarac | surfer | surfovanje | tamna koža</annotation>
 		<annotation cp="🏄🏿‍♂" type="tts">surfer: tamna koža</annotation>
-		<annotation cp="🏄🏻‍♀">surferka | surferka: svetla koža | surfovanje | svetla koža | žena</annotation>
+		<annotation cp="🏄🏻‍♀">surferka | surfovanje | svetla koža | žena</annotation>
 		<annotation cp="🏄🏻‍♀" type="tts">surferka: svetla koža</annotation>
-		<annotation cp="🏄🏼‍♀">srednje svetla koža | surferka | surferka: srednje svetla koža | surfovanje | žena</annotation>
+		<annotation cp="🏄🏼‍♀">srednje svetla koža | surferka | surfovanje | žena</annotation>
 		<annotation cp="🏄🏼‍♀" type="tts">surferka: srednje svetla koža</annotation>
-		<annotation cp="🏄🏽‍♀">ni svetla ni tamna koža | surferka | surferka: ni svetla ni tamna koža | surfovanje | žena</annotation>
+		<annotation cp="🏄🏽‍♀">ni svetla ni tamna koža | surferka | surfovanje | žena</annotation>
 		<annotation cp="🏄🏽‍♀" type="tts">surferka: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏄🏾‍♀">srednje tamna koža | surferka | surferka: srednje tamna koža | surfovanje | žena</annotation>
+		<annotation cp="🏄🏾‍♀">srednje tamna koža | surferka | surfovanje | žena</annotation>
 		<annotation cp="🏄🏾‍♀" type="tts">surferka: srednje tamna koža</annotation>
-		<annotation cp="🏄🏿‍♀">surferka | surferka: tamna koža | surfovanje | tamna koža | žena</annotation>
+		<annotation cp="🏄🏿‍♀">surferka | surfovanje | tamna koža | žena</annotation>
 		<annotation cp="🏄🏿‍♀" type="tts">surferka: tamna koža</annotation>
-		<annotation cp="🚣🏻">čamac | čamac na vesla | čamac na vesla: svetla koža | svetla koža | vozilo</annotation>
+		<annotation cp="🚣🏻">čamac | čamac na vesla | svetla koža | vozilo</annotation>
 		<annotation cp="🚣🏻" type="tts">čamac na vesla: svetla koža</annotation>
-		<annotation cp="🚣🏼">čamac | čamac na vesla | čamac na vesla: srednje svetla koža | srednje svetla koža | vozilo</annotation>
+		<annotation cp="🚣🏼">čamac | čamac na vesla | srednje svetla koža | vozilo</annotation>
 		<annotation cp="🚣🏼" type="tts">čamac na vesla: srednje svetla koža</annotation>
-		<annotation cp="🚣🏽">čamac | čamac na vesla | čamac na vesla: ni svetla ni tamna koža | ni svetla ni tamna koža | vozilo</annotation>
+		<annotation cp="🚣🏽">čamac | čamac na vesla | ni svetla ni tamna koža | vozilo</annotation>
 		<annotation cp="🚣🏽" type="tts">čamac na vesla: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚣🏾">čamac | čamac na vesla | čamac na vesla: srednje tamna koža | srednje tamna koža | vozilo</annotation>
+		<annotation cp="🚣🏾">čamac | čamac na vesla | srednje tamna koža | vozilo</annotation>
 		<annotation cp="🚣🏾" type="tts">čamac na vesla: srednje tamna koža</annotation>
-		<annotation cp="🚣🏿">čamac | čamac na vesla | čamac na vesla: tamna koža | tamna koža | vozilo</annotation>
+		<annotation cp="🚣🏿">čamac | čamac na vesla | tamna koža | vozilo</annotation>
 		<annotation cp="🚣🏿" type="tts">čamac na vesla: tamna koža</annotation>
-		<annotation cp="🚣🏻‍♂">čamac | muškarac | svetla koža | veslač | veslač: svetla koža | veslanje</annotation>
+		<annotation cp="🚣🏻‍♂">čamac | muškarac | svetla koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏻‍♂" type="tts">veslač: svetla koža</annotation>
-		<annotation cp="🚣🏼‍♂">čamac | muškarac | srednje svetla koža | veslač | veslač: srednje svetla koža | veslanje</annotation>
+		<annotation cp="🚣🏼‍♂">čamac | muškarac | srednje svetla koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏼‍♂" type="tts">veslač: srednje svetla koža</annotation>
-		<annotation cp="🚣🏽‍♂">čamac | muškarac | ni svetla ni tamna koža | veslač | veslač: ni svetla ni tamna koža | veslanje</annotation>
+		<annotation cp="🚣🏽‍♂">čamac | muškarac | ni svetla ni tamna koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏽‍♂" type="tts">veslač: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚣🏾‍♂">čamac | muškarac | srednje tamna koža | veslač | veslač: srednje tamna koža | veslanje</annotation>
+		<annotation cp="🚣🏾‍♂">čamac | muškarac | srednje tamna koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏾‍♂" type="tts">veslač: srednje tamna koža</annotation>
-		<annotation cp="🚣🏿‍♂">čamac | muškarac | tamna koža | veslač | veslač: tamna koža | veslanje</annotation>
+		<annotation cp="🚣🏿‍♂">čamac | muškarac | tamna koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏿‍♂" type="tts">veslač: tamna koža</annotation>
-		<annotation cp="🚣🏻‍♀">čamac | svetla koža | veslačica | veslačica: svetla koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏻‍♀">čamac | svetla koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏻‍♀" type="tts">veslačica: svetla koža</annotation>
-		<annotation cp="🚣🏼‍♀">čamac | srednje svetla koža | veslačica | veslačica: srednje svetla koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏼‍♀">čamac | srednje svetla koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏼‍♀" type="tts">veslačica: srednje svetla koža</annotation>
-		<annotation cp="🚣🏽‍♀">čamac | ni svetla ni tamna koža | veslačica | veslačica: ni svetla ni tamna koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏽‍♀">čamac | ni svetla ni tamna koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏽‍♀" type="tts">veslačica: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚣🏾‍♀">čamac | srednje tamna koža | veslačica | veslačica: srednje tamna koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏾‍♀">čamac | srednje tamna koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏾‍♀" type="tts">veslačica: srednje tamna koža</annotation>
-		<annotation cp="🚣🏿‍♀">čamac | tamna koža | veslačica | veslačica: tamna koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏿‍♀">čamac | tamna koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏿‍♀" type="tts">veslačica: tamna koža</annotation>
-		<annotation cp="🏊🏻">osoba pliva | osoba pliva: svetla koža | plivanje | svetla koža</annotation>
+		<annotation cp="🏊🏻">osoba pliva | plivanje | svetla koža</annotation>
 		<annotation cp="🏊🏻" type="tts">osoba pliva: svetla koža</annotation>
-		<annotation cp="🏊🏼">osoba pliva | osoba pliva: srednje svetla koža | plivanje | srednje svetla koža</annotation>
+		<annotation cp="🏊🏼">osoba pliva | plivanje | srednje svetla koža</annotation>
 		<annotation cp="🏊🏼" type="tts">osoba pliva: srednje svetla koža</annotation>
-		<annotation cp="🏊🏽">ni svetla ni tamna koža | osoba pliva | osoba pliva: ni svetla ni tamna koža | plivanje</annotation>
+		<annotation cp="🏊🏽">ni svetla ni tamna koža | osoba pliva | plivanje</annotation>
 		<annotation cp="🏊🏽" type="tts">osoba pliva: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏊🏾">osoba pliva | osoba pliva: srednje tamna koža | plivanje | srednje tamna koža</annotation>
+		<annotation cp="🏊🏾">osoba pliva | plivanje | srednje tamna koža</annotation>
 		<annotation cp="🏊🏾" type="tts">osoba pliva: srednje tamna koža</annotation>
-		<annotation cp="🏊🏿">osoba pliva | osoba pliva: tamna koža | plivanje | tamna koža</annotation>
+		<annotation cp="🏊🏿">osoba pliva | plivanje | tamna koža</annotation>
 		<annotation cp="🏊🏿" type="tts">osoba pliva: tamna koža</annotation>
-		<annotation cp="🏊🏻‍♂">muškarac | plivač | plivač: svetla koža | plivanje | svetla koža</annotation>
+		<annotation cp="🏊🏻‍♂">muškarac | plivač | plivanje | svetla koža</annotation>
 		<annotation cp="🏊🏻‍♂" type="tts">plivač: svetla koža</annotation>
-		<annotation cp="🏊🏼‍♂">muškarac | plivač | plivač: srednje svetla koža | plivanje | srednje svetla koža</annotation>
+		<annotation cp="🏊🏼‍♂">muškarac | plivač | plivanje | srednje svetla koža</annotation>
 		<annotation cp="🏊🏼‍♂" type="tts">plivač: srednje svetla koža</annotation>
-		<annotation cp="🏊🏽‍♂">muškarac | ni svetla ni tamna koža | plivač | plivač: ni svetla ni tamna koža | plivanje</annotation>
+		<annotation cp="🏊🏽‍♂">muškarac | ni svetla ni tamna koža | plivač | plivanje</annotation>
 		<annotation cp="🏊🏽‍♂" type="tts">plivač: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏊🏾‍♂">muškarac | plivač | plivač: srednje tamna koža | plivanje | srednje tamna koža</annotation>
+		<annotation cp="🏊🏾‍♂">muškarac | plivač | plivanje | srednje tamna koža</annotation>
 		<annotation cp="🏊🏾‍♂" type="tts">plivač: srednje tamna koža</annotation>
-		<annotation cp="🏊🏿‍♂">muškarac | plivač | plivač: tamna koža | plivanje | tamna koža</annotation>
+		<annotation cp="🏊🏿‍♂">muškarac | plivač | plivanje | tamna koža</annotation>
 		<annotation cp="🏊🏿‍♂" type="tts">plivač: tamna koža</annotation>
-		<annotation cp="🏊🏻‍♀">plivačica | plivačica: svetla koža | plivanje | svetla koža | žena</annotation>
+		<annotation cp="🏊🏻‍♀">plivačica | plivanje | svetla koža | žena</annotation>
 		<annotation cp="🏊🏻‍♀" type="tts">plivačica: svetla koža</annotation>
-		<annotation cp="🏊🏼‍♀">plivačica | plivačica: srednje svetla koža | plivanje | srednje svetla koža | žena</annotation>
+		<annotation cp="🏊🏼‍♀">plivačica | plivanje | srednje svetla koža | žena</annotation>
 		<annotation cp="🏊🏼‍♀" type="tts">plivačica: srednje svetla koža</annotation>
-		<annotation cp="🏊🏽‍♀">ni svetla ni tamna koža | plivačica | plivačica: ni svetla ni tamna koža | plivanje | žena</annotation>
+		<annotation cp="🏊🏽‍♀">ni svetla ni tamna koža | plivačica | plivanje | žena</annotation>
 		<annotation cp="🏊🏽‍♀" type="tts">plivačica: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏊🏾‍♀">plivačica | plivačica: srednje tamna koža | plivanje | srednje tamna koža | žena</annotation>
+		<annotation cp="🏊🏾‍♀">plivačica | plivanje | srednje tamna koža | žena</annotation>
 		<annotation cp="🏊🏾‍♀" type="tts">plivačica: srednje tamna koža</annotation>
-		<annotation cp="🏊🏿‍♀">plivačica | plivačica: tamna koža | plivanje | tamna koža | žena</annotation>
+		<annotation cp="🏊🏿‍♀">plivačica | plivanje | tamna koža | žena</annotation>
 		<annotation cp="🏊🏿‍♀" type="tts">plivačica: tamna koža</annotation>
-		<annotation cp="⛹🏻">lopta | osoba sa loptom | osoba sa loptom: svetla koža | svetla koža</annotation>
+		<annotation cp="⛹🏻">lopta | osoba sa loptom | svetla koža</annotation>
 		<annotation cp="⛹🏻" type="tts">osoba sa loptom: svetla koža</annotation>
-		<annotation cp="⛹🏼">lopta | osoba sa loptom | osoba sa loptom: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="⛹🏼">lopta | osoba sa loptom | srednje svetla koža</annotation>
 		<annotation cp="⛹🏼" type="tts">osoba sa loptom: srednje svetla koža</annotation>
-		<annotation cp="⛹🏽">lopta | ni svetla ni tamna koža | osoba sa loptom | osoba sa loptom: ni svetla ni tamna koža</annotation>
+		<annotation cp="⛹🏽">lopta | ni svetla ni tamna koža | osoba sa loptom</annotation>
 		<annotation cp="⛹🏽" type="tts">osoba sa loptom: ni svetla ni tamna koža</annotation>
-		<annotation cp="⛹🏾">lopta | osoba sa loptom | osoba sa loptom: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="⛹🏾">lopta | osoba sa loptom | srednje tamna koža</annotation>
 		<annotation cp="⛹🏾" type="tts">osoba sa loptom: srednje tamna koža</annotation>
-		<annotation cp="⛹🏿">lopta | osoba sa loptom | osoba sa loptom: tamna koža | tamna koža</annotation>
+		<annotation cp="⛹🏿">lopta | osoba sa loptom | tamna koža</annotation>
 		<annotation cp="⛹🏿" type="tts">osoba sa loptom: tamna koža</annotation>
-		<annotation cp="⛹🏻‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: svetla koža | svetla koža</annotation>
+		<annotation cp="⛹🏻‍♂">lopta | muškarac | muškarac sa loptom | svetla koža</annotation>
 		<annotation cp="⛹🏻‍♂" type="tts">muškarac sa loptom: svetla koža</annotation>
-		<annotation cp="⛹🏼‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="⛹🏼‍♂">lopta | muškarac | muškarac sa loptom | srednje svetla koža</annotation>
 		<annotation cp="⛹🏼‍♂" type="tts">muškarac sa loptom: srednje svetla koža</annotation>
-		<annotation cp="⛹🏽‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: ni svetla ni tamna koža | ni svetla ni tamna koža</annotation>
+		<annotation cp="⛹🏽‍♂">lopta | muškarac | muškarac sa loptom | ni svetla ni tamna koža</annotation>
 		<annotation cp="⛹🏽‍♂" type="tts">muškarac sa loptom: ni svetla ni tamna koža</annotation>
-		<annotation cp="⛹🏾‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="⛹🏾‍♂">lopta | muškarac | muškarac sa loptom | srednje tamna koža</annotation>
 		<annotation cp="⛹🏾‍♂" type="tts">muškarac sa loptom: srednje tamna koža</annotation>
-		<annotation cp="⛹🏿‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: tamna koža | tamna koža</annotation>
+		<annotation cp="⛹🏿‍♂">lopta | muškarac | muškarac sa loptom | tamna koža</annotation>
 		<annotation cp="⛹🏿‍♂" type="tts">muškarac sa loptom: tamna koža</annotation>
-		<annotation cp="⛹🏻‍♀">lopta | svetla koža | žena | žena sa loptom | žena sa loptom: svetla koža</annotation>
+		<annotation cp="⛹🏻‍♀">lopta | svetla koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏻‍♀" type="tts">žena sa loptom: svetla koža</annotation>
-		<annotation cp="⛹🏼‍♀">lopta | srednje svetla koža | žena | žena sa loptom | žena sa loptom: srednje svetla koža</annotation>
+		<annotation cp="⛹🏼‍♀">lopta | srednje svetla koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏼‍♀" type="tts">žena sa loptom: srednje svetla koža</annotation>
-		<annotation cp="⛹🏽‍♀">lopta | ni svetla ni tamna koža | žena | žena sa loptom | žena sa loptom: ni svetla ni tamna koža</annotation>
+		<annotation cp="⛹🏽‍♀">lopta | ni svetla ni tamna koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏽‍♀" type="tts">žena sa loptom: ni svetla ni tamna koža</annotation>
-		<annotation cp="⛹🏾‍♀">lopta | srednje tamna koža | žena | žena sa loptom | žena sa loptom: srednje tamna koža</annotation>
+		<annotation cp="⛹🏾‍♀">lopta | srednje tamna koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏾‍♀" type="tts">žena sa loptom: srednje tamna koža</annotation>
-		<annotation cp="⛹🏿‍♀">lopta | tamna koža | žena | žena sa loptom | žena sa loptom: tamna koža</annotation>
+		<annotation cp="⛹🏿‍♀">lopta | tamna koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏿‍♀" type="tts">žena sa loptom: tamna koža</annotation>
-		<annotation cp="🏋🏻">dizač | osoba diže tegove | osoba diže tegove: svetla koža | svetla koža | tegovi</annotation>
+		<annotation cp="🏋🏻">dizač | osoba diže tegove | svetla koža | tegovi</annotation>
 		<annotation cp="🏋🏻" type="tts">osoba diže tegove: svetla koža</annotation>
-		<annotation cp="🏋🏼">dizač | osoba diže tegove | osoba diže tegove: srednje svetla koža | srednje svetla koža | tegovi</annotation>
+		<annotation cp="🏋🏼">dizač | osoba diže tegove | srednje svetla koža | tegovi</annotation>
 		<annotation cp="🏋🏼" type="tts">osoba diže tegove: srednje svetla koža</annotation>
-		<annotation cp="🏋🏽">dizač | ni svetla ni tamna koža | osoba diže tegove | osoba diže tegove: ni svetla ni tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏽">dizač | ni svetla ni tamna koža | osoba diže tegove | tegovi</annotation>
 		<annotation cp="🏋🏽" type="tts">osoba diže tegove: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏋🏾">dizač | osoba diže tegove | osoba diže tegove: srednje tamna koža | srednje tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏾">dizač | osoba diže tegove | srednje tamna koža | tegovi</annotation>
 		<annotation cp="🏋🏾" type="tts">osoba diže tegove: srednje tamna koža</annotation>
-		<annotation cp="🏋🏿">dizač | osoba diže tegove | osoba diže tegove: tamna koža | tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏿">dizač | osoba diže tegove | tamna koža | tegovi</annotation>
 		<annotation cp="🏋🏿" type="tts">osoba diže tegove: tamna koža</annotation>
-		<annotation cp="🏋🏻‍♂">dizač tegova | dizač tegova: svetla koža | dizanje | muškarac | svetla koža | tegovi</annotation>
+		<annotation cp="🏋🏻‍♂">dizač tegova | dizanje | muškarac | svetla koža | tegovi</annotation>
 		<annotation cp="🏋🏻‍♂" type="tts">dizač tegova: svetla koža</annotation>
-		<annotation cp="🏋🏼‍♂">dizač tegova | dizač tegova: srednje svetla koža | dizanje | muškarac | srednje svetla koža | tegovi</annotation>
+		<annotation cp="🏋🏼‍♂">dizač tegova | dizanje | muškarac | srednje svetla koža | tegovi</annotation>
 		<annotation cp="🏋🏼‍♂" type="tts">dizač tegova: srednje svetla koža</annotation>
-		<annotation cp="🏋🏽‍♂">dizač tegova | dizač tegova: ni svetla ni tamna koža | dizanje | muškarac | ni svetla ni tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏽‍♂">dizač tegova | dizanje | muškarac | ni svetla ni tamna koža | tegovi</annotation>
 		<annotation cp="🏋🏽‍♂" type="tts">dizač tegova: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏋🏾‍♂">dizač tegova | dizač tegova: srednje tamna koža | dizanje | muškarac | srednje tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏾‍♂">dizač tegova | dizanje | muškarac | srednje tamna koža | tegovi</annotation>
 		<annotation cp="🏋🏾‍♂" type="tts">dizač tegova: srednje tamna koža</annotation>
-		<annotation cp="🏋🏿‍♂">dizač tegova | dizač tegova: tamna koža | dizanje | muškarac | tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏿‍♂">dizač tegova | dizanje | muškarac | tamna koža | tegovi</annotation>
 		<annotation cp="🏋🏿‍♂" type="tts">dizač tegova: tamna koža</annotation>
-		<annotation cp="🏋🏻‍♀">dizačica tegova | dizačica tegova: svetla koža | dizanje | svetla koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏻‍♀">dizačica tegova | dizanje | svetla koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏻‍♀" type="tts">dizačica tegova: svetla koža</annotation>
-		<annotation cp="🏋🏼‍♀">dizačica tegova | dizačica tegova: srednje svetla koža | dizanje | srednje svetla koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏼‍♀">dizačica tegova | dizanje | srednje svetla koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏼‍♀" type="tts">dizačica tegova: srednje svetla koža</annotation>
-		<annotation cp="🏋🏽‍♀">dizačica tegova | dizačica tegova: ni svetla ni tamna koža | dizanje | ni svetla ni tamna koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏽‍♀">dizačica tegova | dizanje | ni svetla ni tamna koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏽‍♀" type="tts">dizačica tegova: ni svetla ni tamna koža</annotation>
-		<annotation cp="🏋🏾‍♀">dizačica tegova | dizačica tegova: srednje tamna koža | dizanje | srednje tamna koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏾‍♀">dizačica tegova | dizanje | srednje tamna koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏾‍♀" type="tts">dizačica tegova: srednje tamna koža</annotation>
-		<annotation cp="🏋🏿‍♀">dizačica tegova | dizačica tegova: tamna koža | dizanje | tamna koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏿‍♀">dizačica tegova | dizanje | tamna koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏿‍♀" type="tts">dizačica tegova: tamna koža</annotation>
-		<annotation cp="🚴🏻">bicikl | osoba na biciklu | osoba na biciklu: svetla koža | svetla koža</annotation>
+		<annotation cp="🚴🏻">bicikl | osoba na biciklu | svetla koža</annotation>
 		<annotation cp="🚴🏻" type="tts">osoba na biciklu: svetla koža</annotation>
-		<annotation cp="🚴🏼">bicikl | osoba na biciklu | osoba na biciklu: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🚴🏼">bicikl | osoba na biciklu | srednje svetla koža</annotation>
 		<annotation cp="🚴🏼" type="tts">osoba na biciklu: srednje svetla koža</annotation>
-		<annotation cp="🚴🏽">bicikl | ni svetla ni tamna koža | osoba na biciklu | osoba na biciklu: ni svetla ni tamna koža</annotation>
+		<annotation cp="🚴🏽">bicikl | ni svetla ni tamna koža | osoba na biciklu</annotation>
 		<annotation cp="🚴🏽" type="tts">osoba na biciklu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚴🏾">bicikl | osoba na biciklu | osoba na biciklu: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🚴🏾">bicikl | osoba na biciklu | srednje tamna koža</annotation>
 		<annotation cp="🚴🏾" type="tts">osoba na biciklu: srednje tamna koža</annotation>
-		<annotation cp="🚴🏿">bicikl | osoba na biciklu | osoba na biciklu: tamna koža | tamna koža</annotation>
+		<annotation cp="🚴🏿">bicikl | osoba na biciklu | tamna koža</annotation>
 		<annotation cp="🚴🏿" type="tts">osoba na biciklu: tamna koža</annotation>
-		<annotation cp="🚴🏻‍♂">bicikl | biciklista | biciklista: svetla koža | muškarac | svetla koža</annotation>
+		<annotation cp="🚴🏻‍♂">bicikl | biciklista | muškarac | svetla koža</annotation>
 		<annotation cp="🚴🏻‍♂" type="tts">biciklista: svetla koža</annotation>
-		<annotation cp="🚴🏼‍♂">bicikl | biciklista | biciklista: srednje svetla koža | muškarac | srednje svetla koža</annotation>
+		<annotation cp="🚴🏼‍♂">bicikl | biciklista | muškarac | srednje svetla koža</annotation>
 		<annotation cp="🚴🏼‍♂" type="tts">biciklista: srednje svetla koža</annotation>
-		<annotation cp="🚴🏽‍♂">bicikl | biciklista | biciklista: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža</annotation>
+		<annotation cp="🚴🏽‍♂">bicikl | biciklista | muškarac | ni svetla ni tamna koža</annotation>
 		<annotation cp="🚴🏽‍♂" type="tts">biciklista: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚴🏾‍♂">bicikl | biciklista | biciklista: srednje tamna koža | muškarac | srednje tamna koža</annotation>
+		<annotation cp="🚴🏾‍♂">bicikl | biciklista | muškarac | srednje tamna koža</annotation>
 		<annotation cp="🚴🏾‍♂" type="tts">biciklista: srednje tamna koža</annotation>
-		<annotation cp="🚴🏿‍♂">bicikl | biciklista | biciklista: tamna koža | muškarac | tamna koža</annotation>
+		<annotation cp="🚴🏿‍♂">bicikl | biciklista | muškarac | tamna koža</annotation>
 		<annotation cp="🚴🏿‍♂" type="tts">biciklista: tamna koža</annotation>
-		<annotation cp="🚴🏻‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="🚴🏻‍♀">bicikl | biciklista | biciklistkinja | svetla koža | žena</annotation>
 		<annotation cp="🚴🏻‍♀" type="tts">biciklistkinja: svetla koža</annotation>
-		<annotation cp="🚴🏼‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="🚴🏼‍♀">bicikl | biciklista | biciklistkinja | srednje svetla koža | žena</annotation>
 		<annotation cp="🚴🏼‍♀" type="tts">biciklistkinja: srednje svetla koža</annotation>
-		<annotation cp="🚴🏽‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: ni svetla ni tamna koža | ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🚴🏽‍♀">bicikl | biciklista | biciklistkinja | ni svetla ni tamna koža | žena</annotation>
 		<annotation cp="🚴🏽‍♀" type="tts">biciklistkinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚴🏾‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="🚴🏾‍♀">bicikl | biciklista | biciklistkinja | srednje tamna koža | žena</annotation>
 		<annotation cp="🚴🏾‍♀" type="tts">biciklistkinja: srednje tamna koža</annotation>
-		<annotation cp="🚴🏿‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="🚴🏿‍♀">bicikl | biciklista | biciklistkinja | tamna koža | žena</annotation>
 		<annotation cp="🚴🏿‍♀" type="tts">biciklistkinja: tamna koža</annotation>
-		<annotation cp="🚵🏻">bicikl | biciklista | brdo | osoba na brdskom biciklu | osoba na brdskom biciklu: svetla koža | planina | svetla koža</annotation>
+		<annotation cp="🚵🏻">bicikl | biciklista | brdo | osoba na brdskom biciklu | planina | svetla koža</annotation>
 		<annotation cp="🚵🏻" type="tts">osoba na brdskom biciklu: svetla koža</annotation>
-		<annotation cp="🚵🏼">bicikl | biciklista | brdo | osoba na brdskom biciklu | osoba na brdskom biciklu: srednje svetla koža | planina | srednje svetla koža</annotation>
+		<annotation cp="🚵🏼">bicikl | biciklista | brdo | osoba na brdskom biciklu | planina | srednje svetla koža</annotation>
 		<annotation cp="🚵🏼" type="tts">osoba na brdskom biciklu: srednje svetla koža</annotation>
-		<annotation cp="🚵🏽">bicikl | biciklista | brdo | ni svetla ni tamna koža | osoba na brdskom biciklu | osoba na brdskom biciklu: ni svetla ni tamna koža | planina</annotation>
+		<annotation cp="🚵🏽">bicikl | biciklista | brdo | ni svetla ni tamna koža | osoba na brdskom biciklu | planina</annotation>
 		<annotation cp="🚵🏽" type="tts">osoba na brdskom biciklu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚵🏾">bicikl | biciklista | brdo | osoba na brdskom biciklu | osoba na brdskom biciklu: srednje tamna koža | planina | srednje tamna koža</annotation>
+		<annotation cp="🚵🏾">bicikl | biciklista | brdo | osoba na brdskom biciklu | planina | srednje tamna koža</annotation>
 		<annotation cp="🚵🏾" type="tts">osoba na brdskom biciklu: srednje tamna koža</annotation>
-		<annotation cp="🚵🏿">bicikl | biciklista | brdo | osoba na brdskom biciklu | osoba na brdskom biciklu: tamna koža | planina | tamna koža</annotation>
+		<annotation cp="🚵🏿">bicikl | biciklista | brdo | osoba na brdskom biciklu | planina | tamna koža</annotation>
 		<annotation cp="🚵🏿" type="tts">osoba na brdskom biciklu: tamna koža</annotation>
-		<annotation cp="🚵🏻‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: svetla koža | muškarac | planina | svetla koža</annotation>
+		<annotation cp="🚵🏻‍♂">bicikl | biciklista | brdski biciklista | muškarac | planina | svetla koža</annotation>
 		<annotation cp="🚵🏻‍♂" type="tts">brdski biciklista: svetla koža</annotation>
-		<annotation cp="🚵🏼‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: srednje svetla koža | muškarac | planina | srednje svetla koža</annotation>
+		<annotation cp="🚵🏼‍♂">bicikl | biciklista | brdski biciklista | muškarac | planina | srednje svetla koža</annotation>
 		<annotation cp="🚵🏼‍♂" type="tts">brdski biciklista: srednje svetla koža</annotation>
-		<annotation cp="🚵🏽‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: ni svetla ni tamna koža | muškarac | ni svetla ni tamna koža | planina</annotation>
+		<annotation cp="🚵🏽‍♂">bicikl | biciklista | brdski biciklista | muškarac | ni svetla ni tamna koža | planina</annotation>
 		<annotation cp="🚵🏽‍♂" type="tts">brdski biciklista: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚵🏾‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: srednje tamna koža | muškarac | planina | srednje tamna koža</annotation>
+		<annotation cp="🚵🏾‍♂">bicikl | biciklista | brdski biciklista | muškarac | planina | srednje tamna koža</annotation>
 		<annotation cp="🚵🏾‍♂" type="tts">brdski biciklista: srednje tamna koža</annotation>
-		<annotation cp="🚵🏿‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: tamna koža | muškarac | planina | tamna koža</annotation>
+		<annotation cp="🚵🏿‍♂">bicikl | biciklista | brdski biciklista | muškarac | planina | tamna koža</annotation>
 		<annotation cp="🚵🏿‍♂" type="tts">brdski biciklista: tamna koža</annotation>
-		<annotation cp="🚵🏻‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: svetla koža | planina | svetla koža | žena</annotation>
+		<annotation cp="🚵🏻‍♀">bicikl | biciklista | brdska biciklistkinja | planina | svetla koža | žena</annotation>
 		<annotation cp="🚵🏻‍♀" type="tts">brdska biciklistkinja: svetla koža</annotation>
-		<annotation cp="🚵🏼‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: srednje svetla koža | planina | srednje svetla koža | žena</annotation>
+		<annotation cp="🚵🏼‍♀">bicikl | biciklista | brdska biciklistkinja | planina | srednje svetla koža | žena</annotation>
 		<annotation cp="🚵🏼‍♀" type="tts">brdska biciklistkinja: srednje svetla koža</annotation>
-		<annotation cp="🚵🏽‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: ni svetla ni tamna koža | ni svetla ni tamna koža | planina | žena</annotation>
+		<annotation cp="🚵🏽‍♀">bicikl | biciklista | brdska biciklistkinja | ni svetla ni tamna koža | planina | žena</annotation>
 		<annotation cp="🚵🏽‍♀" type="tts">brdska biciklistkinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🚵🏾‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: srednje tamna koža | planina | srednje tamna koža | žena</annotation>
+		<annotation cp="🚵🏾‍♀">bicikl | biciklista | brdska biciklistkinja | planina | srednje tamna koža | žena</annotation>
 		<annotation cp="🚵🏾‍♀" type="tts">brdska biciklistkinja: srednje tamna koža</annotation>
-		<annotation cp="🚵🏿‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: tamna koža | planina | tamna koža | žena</annotation>
+		<annotation cp="🚵🏿‍♀">bicikl | biciklista | brdska biciklistkinja | planina | tamna koža | žena</annotation>
 		<annotation cp="🚵🏿‍♀" type="tts">brdska biciklistkinja: tamna koža</annotation>
-		<annotation cp="🤸🏻">gimnastičarska zvezda | gimnastičarska zvezda: svetla koža | gimnastika | svetla koža | zvezda</annotation>
+		<annotation cp="🤸🏻">gimnastičarska zvezda | gimnastika | svetla koža | zvezda</annotation>
 		<annotation cp="🤸🏻" type="tts">gimnastičarska zvezda: svetla koža</annotation>
-		<annotation cp="🤸🏼">gimnastičarska zvezda | gimnastičarska zvezda: srednje svetla koža | gimnastika | srednje svetla koža | zvezda</annotation>
+		<annotation cp="🤸🏼">gimnastičarska zvezda | gimnastika | srednje svetla koža | zvezda</annotation>
 		<annotation cp="🤸🏼" type="tts">gimnastičarska zvezda: srednje svetla koža</annotation>
-		<annotation cp="🤸🏽">gimnastičarska zvezda | gimnastičarska zvezda: ni svetla ni tamna koža | gimnastika | ni svetla ni tamna koža | zvezda</annotation>
+		<annotation cp="🤸🏽">gimnastičarska zvezda | gimnastika | ni svetla ni tamna koža | zvezda</annotation>
 		<annotation cp="🤸🏽" type="tts">gimnastičarska zvezda: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤸🏾">gimnastičarska zvezda | gimnastičarska zvezda: srednje tamna koža | gimnastika | srednje tamna koža | zvezda</annotation>
+		<annotation cp="🤸🏾">gimnastičarska zvezda | gimnastika | srednje tamna koža | zvezda</annotation>
 		<annotation cp="🤸🏾" type="tts">gimnastičarska zvezda: srednje tamna koža</annotation>
-		<annotation cp="🤸🏿">gimnastičarska zvezda | gimnastičarska zvezda: tamna koža | gimnastika | tamna koža | zvezda</annotation>
+		<annotation cp="🤸🏿">gimnastičarska zvezda | gimnastika | tamna koža | zvezda</annotation>
 		<annotation cp="🤸🏿" type="tts">gimnastičarska zvezda: tamna koža</annotation>
-		<annotation cp="🤸🏻‍♂">akrobata | gimnastičar | gimnastičar: svetla koža | gimnastika | muškarac | svetla koža | zvezda</annotation>
+		<annotation cp="🤸🏻‍♂">akrobata | gimnastičar | gimnastika | muškarac | svetla koža | zvezda</annotation>
 		<annotation cp="🤸🏻‍♂" type="tts">gimnastičar: svetla koža</annotation>
-		<annotation cp="🤸🏼‍♂">akrobata | gimnastičar | gimnastičar: srednje svetla koža | gimnastika | muškarac | srednje svetla koža | zvezda</annotation>
+		<annotation cp="🤸🏼‍♂">akrobata | gimnastičar | gimnastika | muškarac | srednje svetla koža | zvezda</annotation>
 		<annotation cp="🤸🏼‍♂" type="tts">gimnastičar: srednje svetla koža</annotation>
-		<annotation cp="🤸🏽‍♂">akrobata | gimnastičar | gimnastičar: ni svetla ni tamna koža | gimnastika | muškarac | ni svetla ni tamna koža | zvezda</annotation>
+		<annotation cp="🤸🏽‍♂">akrobata | gimnastičar | gimnastika | muškarac | ni svetla ni tamna koža | zvezda</annotation>
 		<annotation cp="🤸🏽‍♂" type="tts">gimnastičar: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤸🏾‍♂">akrobata | gimnastičar | gimnastičar: srednje tamna koža | gimnastika | muškarac | srednje tamna koža | zvezda</annotation>
+		<annotation cp="🤸🏾‍♂">akrobata | gimnastičar | gimnastika | muškarac | srednje tamna koža | zvezda</annotation>
 		<annotation cp="🤸🏾‍♂" type="tts">gimnastičar: srednje tamna koža</annotation>
-		<annotation cp="🤸🏿‍♂">akrobata | gimnastičar | gimnastičar: tamna koža | gimnastika | muškarac | tamna koža | zvezda</annotation>
+		<annotation cp="🤸🏿‍♂">akrobata | gimnastičar | gimnastika | muškarac | tamna koža | zvezda</annotation>
 		<annotation cp="🤸🏿‍♂" type="tts">gimnastičar: tamna koža</annotation>
-		<annotation cp="🤸🏻‍♀">akrobata | gimnastičarka | gimnastičarka: svetla koža | gimnastika | svetla koža | žena | zvezda</annotation>
+		<annotation cp="🤸🏻‍♀">akrobata | gimnastičarka | gimnastika | svetla koža | žena | zvezda</annotation>
 		<annotation cp="🤸🏻‍♀" type="tts">gimnastičarka: svetla koža</annotation>
-		<annotation cp="🤸🏼‍♀">akrobata | gimnastičarka | gimnastičarka: srednje svetla koža | gimnastika | srednje svetla koža | žena | zvezda</annotation>
+		<annotation cp="🤸🏼‍♀">akrobata | gimnastičarka | gimnastika | srednje svetla koža | žena | zvezda</annotation>
 		<annotation cp="🤸🏼‍♀" type="tts">gimnastičarka: srednje svetla koža</annotation>
-		<annotation cp="🤸🏽‍♀">akrobata | gimnastičarka | gimnastičarka: ni svetla ni tamna koža | gimnastika | ni svetla ni tamna koža | žena | zvezda</annotation>
+		<annotation cp="🤸🏽‍♀">akrobata | gimnastičarka | gimnastika | ni svetla ni tamna koža | žena | zvezda</annotation>
 		<annotation cp="🤸🏽‍♀" type="tts">gimnastičarka: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤸🏾‍♀">akrobata | gimnastičarka | gimnastičarka: srednje tamna koža | gimnastika | srednje tamna koža | žena | zvezda</annotation>
+		<annotation cp="🤸🏾‍♀">akrobata | gimnastičarka | gimnastika | srednje tamna koža | žena | zvezda</annotation>
 		<annotation cp="🤸🏾‍♀" type="tts">gimnastičarka: srednje tamna koža</annotation>
-		<annotation cp="🤸🏿‍♀">akrobata | gimnastičarka | gimnastičarka: tamna koža | gimnastika | tamna koža | žena | zvezda</annotation>
+		<annotation cp="🤸🏿‍♀">akrobata | gimnastičarka | gimnastika | tamna koža | žena | zvezda</annotation>
 		<annotation cp="🤸🏿‍♀" type="tts">gimnastičarka: tamna koža</annotation>
-		<annotation cp="🤽🏻">bazen | sport | svetla koža | vaterpolo | vaterpolo: svetla koža | voda</annotation>
+		<annotation cp="🤽🏻">bazen | sport | svetla koža | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏻" type="tts">vaterpolo: svetla koža</annotation>
-		<annotation cp="🤽🏼">bazen | sport | srednje svetla koža | vaterpolo | vaterpolo: srednje svetla koža | voda</annotation>
+		<annotation cp="🤽🏼">bazen | sport | srednje svetla koža | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏼" type="tts">vaterpolo: srednje svetla koža</annotation>
-		<annotation cp="🤽🏽">bazen | ni svetla ni tamna koža | sport | vaterpolo | vaterpolo: ni svetla ni tamna koža | voda</annotation>
+		<annotation cp="🤽🏽">bazen | ni svetla ni tamna koža | sport | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏽" type="tts">vaterpolo: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤽🏾">bazen | sport | srednje tamna koža | vaterpolo | vaterpolo: srednje tamna koža | voda</annotation>
+		<annotation cp="🤽🏾">bazen | sport | srednje tamna koža | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏾" type="tts">vaterpolo: srednje tamna koža</annotation>
-		<annotation cp="🤽🏿">bazen | sport | tamna koža | vaterpolo | vaterpolo: tamna koža | voda</annotation>
+		<annotation cp="🤽🏿">bazen | sport | tamna koža | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏿" type="tts">vaterpolo: tamna koža</annotation>
-		<annotation cp="🤽🏻‍♂">bazen | muškarac | svetla koža | vaterpolista | vaterpolista: svetla koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏻‍♂">bazen | muškarac | svetla koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏻‍♂" type="tts">vaterpolista: svetla koža</annotation>
-		<annotation cp="🤽🏼‍♂">bazen | muškarac | srednje svetla koža | vaterpolista | vaterpolista: srednje svetla koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏼‍♂">bazen | muškarac | srednje svetla koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏼‍♂" type="tts">vaterpolista: srednje svetla koža</annotation>
-		<annotation cp="🤽🏽‍♂">bazen | muškarac | ni svetla ni tamna koža | vaterpolista | vaterpolista: ni svetla ni tamna koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏽‍♂">bazen | muškarac | ni svetla ni tamna koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏽‍♂" type="tts">vaterpolista: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤽🏾‍♂">bazen | muškarac | srednje tamna koža | vaterpolista | vaterpolista: srednje tamna koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏾‍♂">bazen | muškarac | srednje tamna koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏾‍♂" type="tts">vaterpolista: srednje tamna koža</annotation>
-		<annotation cp="🤽🏿‍♂">bazen | muškarac | tamna koža | vaterpolista | vaterpolista: tamna koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏿‍♂">bazen | muškarac | tamna koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏿‍♂" type="tts">vaterpolista: tamna koža</annotation>
-		<annotation cp="🤽🏻‍♀">bazen | svetla koža | vaterpolistkinja | vaterpolistkinja: svetla koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏻‍♀">bazen | svetla koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏻‍♀" type="tts">vaterpolistkinja: svetla koža</annotation>
-		<annotation cp="🤽🏼‍♀">bazen | srednje svetla koža | vaterpolistkinja | vaterpolistkinja: srednje svetla koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏼‍♀">bazen | srednje svetla koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏼‍♀" type="tts">vaterpolistkinja: srednje svetla koža</annotation>
-		<annotation cp="🤽🏽‍♀">bazen | ni svetla ni tamna koža | vaterpolistkinja | vaterpolistkinja: ni svetla ni tamna koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏽‍♀">bazen | ni svetla ni tamna koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏽‍♀" type="tts">vaterpolistkinja: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤽🏾‍♀">bazen | srednje tamna koža | vaterpolistkinja | vaterpolistkinja: srednje tamna koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏾‍♀">bazen | srednje tamna koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏾‍♀" type="tts">vaterpolistkinja: srednje tamna koža</annotation>
-		<annotation cp="🤽🏿‍♀">bazen | tamna koža | vaterpolistkinja | vaterpolistkinja: tamna koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏿‍♀">bazen | tamna koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏿‍♀" type="tts">vaterpolistkinja: tamna koža</annotation>
-		<annotation cp="🤾🏻">bacanje | lopta | osoba | rukomet | rukomet: svetla koža | sport | svetla koža</annotation>
+		<annotation cp="🤾🏻">bacanje | lopta | osoba | rukomet | sport | svetla koža</annotation>
 		<annotation cp="🤾🏻" type="tts">rukomet: svetla koža</annotation>
-		<annotation cp="🤾🏼">bacanje | lopta | osoba | rukomet | rukomet: srednje svetla koža | sport | srednje svetla koža</annotation>
+		<annotation cp="🤾🏼">bacanje | lopta | osoba | rukomet | sport | srednje svetla koža</annotation>
 		<annotation cp="🤾🏼" type="tts">rukomet: srednje svetla koža</annotation>
-		<annotation cp="🤾🏽">bacanje | lopta | ni svetla ni tamna koža | osoba | rukomet | rukomet: ni svetla ni tamna koža | sport</annotation>
+		<annotation cp="🤾🏽">bacanje | lopta | ni svetla ni tamna koža | osoba | rukomet | sport</annotation>
 		<annotation cp="🤾🏽" type="tts">rukomet: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤾🏾">bacanje | lopta | osoba | rukomet | rukomet: srednje tamna koža | sport | srednje tamna koža</annotation>
+		<annotation cp="🤾🏾">bacanje | lopta | osoba | rukomet | sport | srednje tamna koža</annotation>
 		<annotation cp="🤾🏾" type="tts">rukomet: srednje tamna koža</annotation>
-		<annotation cp="🤾🏿">bacanje | lopta | osoba | rukomet | rukomet: tamna koža | sport | tamna koža</annotation>
+		<annotation cp="🤾🏿">bacanje | lopta | osoba | rukomet | sport | tamna koža</annotation>
 		<annotation cp="🤾🏿" type="tts">rukomet: tamna koža</annotation>
-		<annotation cp="🤾🏻‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | rukometaš: svetla koža | svetla koža</annotation>
+		<annotation cp="🤾🏻‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | svetla koža</annotation>
 		<annotation cp="🤾🏻‍♂" type="tts">rukometaš: svetla koža</annotation>
-		<annotation cp="🤾🏼‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | rukometaš: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🤾🏼‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | srednje svetla koža</annotation>
 		<annotation cp="🤾🏼‍♂" type="tts">rukometaš: srednje svetla koža</annotation>
-		<annotation cp="🤾🏽‍♂">bacanje | lopta | muškarac | ni svetla ni tamna koža | rukomet | rukometaš | rukometaš: ni svetla ni tamna koža</annotation>
+		<annotation cp="🤾🏽‍♂">bacanje | lopta | muškarac | ni svetla ni tamna koža | rukomet | rukometaš</annotation>
 		<annotation cp="🤾🏽‍♂" type="tts">rukometaš: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤾🏾‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | rukometaš: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤾🏾‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | srednje tamna koža</annotation>
 		<annotation cp="🤾🏾‍♂" type="tts">rukometaš: srednje tamna koža</annotation>
-		<annotation cp="🤾🏿‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | rukometaš: tamna koža | tamna koža</annotation>
+		<annotation cp="🤾🏿‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | tamna koža</annotation>
 		<annotation cp="🤾🏿‍♂" type="tts">rukometaš: tamna koža</annotation>
-		<annotation cp="🤾🏻‍♀">bacanje | lopta | rukomet | rukometašica | rukometašica: svetla koža | svetla koža | žena</annotation>
+		<annotation cp="🤾🏻‍♀">bacanje | lopta | rukomet | rukometašica | svetla koža | žena</annotation>
 		<annotation cp="🤾🏻‍♀" type="tts">rukometašica: svetla koža</annotation>
-		<annotation cp="🤾🏼‍♀">bacanje | lopta | rukomet | rukometašica | rukometašica: srednje svetla koža | srednje svetla koža | žena</annotation>
+		<annotation cp="🤾🏼‍♀">bacanje | lopta | rukomet | rukometašica | srednje svetla koža | žena</annotation>
 		<annotation cp="🤾🏼‍♀" type="tts">rukometašica: srednje svetla koža</annotation>
-		<annotation cp="🤾🏽‍♀">bacanje | lopta | ni svetla ni tamna koža | rukomet | rukometašica | rukometašica: ni svetla ni tamna koža | žena</annotation>
+		<annotation cp="🤾🏽‍♀">bacanje | lopta | ni svetla ni tamna koža | rukomet | rukometašica | žena</annotation>
 		<annotation cp="🤾🏽‍♀" type="tts">rukometašica: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤾🏾‍♀">bacanje | lopta | rukomet | rukometašica | rukometašica: srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="🤾🏾‍♀">bacanje | lopta | rukomet | rukometašica | srednje tamna koža | žena</annotation>
 		<annotation cp="🤾🏾‍♀" type="tts">rukometašica: srednje tamna koža</annotation>
-		<annotation cp="🤾🏿‍♀">bacanje | lopta | rukomet | rukometašica | rukometašica: tamna koža | tamna koža | žena</annotation>
+		<annotation cp="🤾🏿‍♀">bacanje | lopta | rukomet | rukometašica | tamna koža | žena</annotation>
 		<annotation cp="🤾🏿‍♀" type="tts">rukometašica: tamna koža</annotation>
-		<annotation cp="🤹🏻">cirkus | osoba žonglira | osoba žonglira: svetla koža | svetla koža | veština | žongliranje</annotation>
+		<annotation cp="🤹🏻">cirkus | osoba žonglira | svetla koža | veština | žongliranje</annotation>
 		<annotation cp="🤹🏻" type="tts">osoba žonglira: svetla koža</annotation>
-		<annotation cp="🤹🏼">cirkus | osoba žonglira | osoba žonglira: srednje svetla koža | srednje svetla koža | veština | žongliranje</annotation>
+		<annotation cp="🤹🏼">cirkus | osoba žonglira | srednje svetla koža | veština | žongliranje</annotation>
 		<annotation cp="🤹🏼" type="tts">osoba žonglira: srednje svetla koža</annotation>
-		<annotation cp="🤹🏽">cirkus | ni svetla ni tamna koža | osoba žonglira | osoba žonglira: ni svetla ni tamna koža | veština | žongliranje</annotation>
+		<annotation cp="🤹🏽">cirkus | ni svetla ni tamna koža | osoba žonglira | veština | žongliranje</annotation>
 		<annotation cp="🤹🏽" type="tts">osoba žonglira: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤹🏾">cirkus | osoba žonglira | osoba žonglira: srednje tamna koža | srednje tamna koža | veština | žongliranje</annotation>
+		<annotation cp="🤹🏾">cirkus | osoba žonglira | srednje tamna koža | veština | žongliranje</annotation>
 		<annotation cp="🤹🏾" type="tts">osoba žonglira: srednje tamna koža</annotation>
-		<annotation cp="🤹🏿">cirkus | osoba žonglira | osoba žonglira: tamna koža | tamna koža | veština | žongliranje</annotation>
+		<annotation cp="🤹🏿">cirkus | osoba žonglira | tamna koža | veština | žongliranje</annotation>
 		<annotation cp="🤹🏿" type="tts">osoba žonglira: tamna koža</annotation>
-		<annotation cp="🤹🏻‍♂">cirkus | muškarac | svetla koža | veština | žongler | žongler: svetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏻‍♂">cirkus | muškarac | svetla koža | veština | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏻‍♂" type="tts">žongler: svetla koža</annotation>
-		<annotation cp="🤹🏼‍♂">cirkus | muškarac | srednje svetla koža | veština | žongler | žongler: srednje svetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏼‍♂">cirkus | muškarac | srednje svetla koža | veština | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏼‍♂" type="tts">žongler: srednje svetla koža</annotation>
-		<annotation cp="🤹🏽‍♂">cirkus | muškarac | ni svetla ni tamna koža | veština | žongler | žongler: ni svetla ni tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏽‍♂">cirkus | muškarac | ni svetla ni tamna koža | veština | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏽‍♂" type="tts">žongler: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤹🏾‍♂">cirkus | muškarac | srednje tamna koža | veština | žongler | žongler: srednje tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏾‍♂">cirkus | muškarac | srednje tamna koža | veština | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏾‍♂" type="tts">žongler: srednje tamna koža</annotation>
-		<annotation cp="🤹🏿‍♂">cirkus | muškarac | tamna koža | veština | žongler | žongler: tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏿‍♂">cirkus | muškarac | tamna koža | veština | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏿‍♂" type="tts">žongler: tamna koža</annotation>
-		<annotation cp="🤹🏻‍♀">cirkus | svetla koža | veština | žena | žonglerka | žonglerka: svetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏻‍♀">cirkus | svetla koža | veština | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏻‍♀" type="tts">žonglerka: svetla koža</annotation>
-		<annotation cp="🤹🏼‍♀">cirkus | srednje svetla koža | veština | žena | žonglerka | žonglerka: srednje svetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏼‍♀">cirkus | srednje svetla koža | veština | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏼‍♀" type="tts">žonglerka: srednje svetla koža</annotation>
-		<annotation cp="🤹🏽‍♀">cirkus | ni svetla ni tamna koža | veština | žena | žonglerka | žonglerka: ni svetla ni tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏽‍♀">cirkus | ni svetla ni tamna koža | veština | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏽‍♀" type="tts">žonglerka: ni svetla ni tamna koža</annotation>
-		<annotation cp="🤹🏾‍♀">cirkus | srednje tamna koža | veština | žena | žonglerka | žonglerka: srednje tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏾‍♀">cirkus | srednje tamna koža | veština | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏾‍♀" type="tts">žonglerka: srednje tamna koža</annotation>
-		<annotation cp="🤹🏿‍♀">cirkus | tamna koža | veština | žena | žonglerka | žonglerka: tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏿‍♀">cirkus | tamna koža | veština | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏿‍♀" type="tts">žonglerka: tamna koža</annotation>
-		<annotation cp="🧘🏻">joga | lotos poza | lotos poza: svetla koža | meditacija | svetla koža</annotation>
+		<annotation cp="🧘🏻">joga | lotos poza | meditacija | svetla koža</annotation>
 		<annotation cp="🧘🏻" type="tts">lotos poza: svetla koža</annotation>
-		<annotation cp="🧘🏼">joga | lotos poza | lotos poza: srednje svetla koža | meditacija | srednje svetla koža</annotation>
+		<annotation cp="🧘🏼">joga | lotos poza | meditacija | srednje svetla koža</annotation>
 		<annotation cp="🧘🏼" type="tts">lotos poza: srednje svetla koža</annotation>
-		<annotation cp="🧘🏽">joga | lotos poza | lotos poza: ni svetla ni tamna koža | meditacija | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧘🏽">joga | lotos poza | meditacija | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧘🏽" type="tts">lotos poza: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧘🏾">joga | lotos poza | lotos poza: srednje tamna koža | meditacija | srednje tamna koža</annotation>
+		<annotation cp="🧘🏾">joga | lotos poza | meditacija | srednje tamna koža</annotation>
 		<annotation cp="🧘🏾" type="tts">lotos poza: srednje tamna koža</annotation>
-		<annotation cp="🧘🏿">joga | lotos poza | lotos poza: tamna koža | meditacija | tamna koža</annotation>
+		<annotation cp="🧘🏿">joga | lotos poza | meditacija | tamna koža</annotation>
 		<annotation cp="🧘🏿" type="tts">lotos poza: tamna koža</annotation>
-		<annotation cp="🧘🏻‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: svetla koža | muškarac u lotus pozi | svetla koža</annotation>
+		<annotation cp="🧘🏻‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | svetla koža</annotation>
 		<annotation cp="🧘🏻‍♂" type="tts">muškarac u lotos pozi: svetla koža</annotation>
-		<annotation cp="🧘🏼‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: srednje svetla koža | muškarac u lotus pozi | srednje svetla koža</annotation>
+		<annotation cp="🧘🏼‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | srednje svetla koža</annotation>
 		<annotation cp="🧘🏼‍♂" type="tts">muškarac u lotos pozi: srednje svetla koža</annotation>
-		<annotation cp="🧘🏽‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: ni svetla ni tamna koža | muškarac u lotus pozi | ni svetla ni tamna koža</annotation>
+		<annotation cp="🧘🏽‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | ni svetla ni tamna koža</annotation>
 		<annotation cp="🧘🏽‍♂" type="tts">muškarac u lotos pozi: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧘🏾‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: srednje tamna koža | muškarac u lotus pozi | srednje tamna koža</annotation>
+		<annotation cp="🧘🏾‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | srednje tamna koža</annotation>
 		<annotation cp="🧘🏾‍♂" type="tts">muškarac u lotos pozi: srednje tamna koža</annotation>
-		<annotation cp="🧘🏿‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: tamna koža | muškarac u lotus pozi | tamna koža</annotation>
+		<annotation cp="🧘🏿‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | tamna koža</annotation>
 		<annotation cp="🧘🏿‍♂" type="tts">muškarac u lotos pozi: tamna koža</annotation>
-		<annotation cp="🧘🏻‍♀">joga | meditacija | svetla koža | žena u lotos pozi | žena u lotos pozi: svetla koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏻‍♀">joga | meditacija | svetla koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏻‍♀" type="tts">žena u lotos pozi: svetla koža</annotation>
-		<annotation cp="🧘🏼‍♀">joga | meditacija | srednje svetla koža | žena u lotos pozi | žena u lotos pozi: srednje svetla koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏼‍♀">joga | meditacija | srednje svetla koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏼‍♀" type="tts">žena u lotos pozi: srednje svetla koža</annotation>
-		<annotation cp="🧘🏽‍♀">joga | meditacija | ni svetla ni tamna koža | žena u lotos pozi | žena u lotos pozi: ni svetla ni tamna koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏽‍♀">joga | meditacija | ni svetla ni tamna koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏽‍♀" type="tts">žena u lotos pozi: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧘🏾‍♀">joga | meditacija | srednje tamna koža | žena u lotos pozi | žena u lotos pozi: srednje tamna koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏾‍♀">joga | meditacija | srednje tamna koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏾‍♀" type="tts">žena u lotos pozi: srednje tamna koža</annotation>
-		<annotation cp="🧘🏿‍♀">joga | meditacija | tamna koža | žena u lotos pozi | žena u lotos pozi: tamna koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏿‍♀">joga | meditacija | tamna koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏿‍♀" type="tts">žena u lotos pozi: tamna koža</annotation>
-		<annotation cp="🛀🏻">kada | kupanje | osoba koja se kupa | osoba koja se kupa: svetla koža | svetla koža</annotation>
+		<annotation cp="🛀🏻">kada | kupanje | osoba koja se kupa | svetla koža</annotation>
 		<annotation cp="🛀🏻" type="tts">osoba koja se kupa: svetla koža</annotation>
-		<annotation cp="🛀🏼">kada | kupanje | osoba koja se kupa | osoba koja se kupa: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🛀🏼">kada | kupanje | osoba koja se kupa | srednje svetla koža</annotation>
 		<annotation cp="🛀🏼" type="tts">osoba koja se kupa: srednje svetla koža</annotation>
-		<annotation cp="🛀🏽">kada | kupanje | ni svetla ni tamna koža | osoba koja se kupa | osoba koja se kupa: ni svetla ni tamna koža</annotation>
+		<annotation cp="🛀🏽">kada | kupanje | ni svetla ni tamna koža | osoba koja se kupa</annotation>
 		<annotation cp="🛀🏽" type="tts">osoba koja se kupa: ni svetla ni tamna koža</annotation>
-		<annotation cp="🛀🏾">kada | kupanje | osoba koja se kupa | osoba koja se kupa: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🛀🏾">kada | kupanje | osoba koja se kupa | srednje tamna koža</annotation>
 		<annotation cp="🛀🏾" type="tts">osoba koja se kupa: srednje tamna koža</annotation>
-		<annotation cp="🛀🏿">kada | kupanje | osoba koja se kupa | osoba koja se kupa: tamna koža | tamna koža</annotation>
+		<annotation cp="🛀🏿">kada | kupanje | osoba koja se kupa | tamna koža</annotation>
 		<annotation cp="🛀🏿" type="tts">osoba koja se kupa: tamna koža</annotation>
-		<annotation cp="🛌🏻">hotel | osoba u krevetu | osoba u krevetu: svetla koža | spavanje | svetla koža</annotation>
+		<annotation cp="🛌🏻">hotel | osoba u krevetu | spavanje | svetla koža</annotation>
 		<annotation cp="🛌🏻" type="tts">osoba u krevetu: svetla koža</annotation>
-		<annotation cp="🛌🏼">hotel | osoba u krevetu | osoba u krevetu: srednje svetla koža | spavanje | srednje svetla koža</annotation>
+		<annotation cp="🛌🏼">hotel | osoba u krevetu | spavanje | srednje svetla koža</annotation>
 		<annotation cp="🛌🏼" type="tts">osoba u krevetu: srednje svetla koža</annotation>
-		<annotation cp="🛌🏽">hotel | ni svetla ni tamna koža | osoba u krevetu | osoba u krevetu: ni svetla ni tamna koža | spavanje</annotation>
+		<annotation cp="🛌🏽">hotel | ni svetla ni tamna koža | osoba u krevetu | spavanje</annotation>
 		<annotation cp="🛌🏽" type="tts">osoba u krevetu: ni svetla ni tamna koža</annotation>
-		<annotation cp="🛌🏾">hotel | osoba u krevetu | osoba u krevetu: srednje tamna koža | spavanje | srednje tamna koža</annotation>
+		<annotation cp="🛌🏾">hotel | osoba u krevetu | spavanje | srednje tamna koža</annotation>
 		<annotation cp="🛌🏾" type="tts">osoba u krevetu: srednje tamna koža</annotation>
-		<annotation cp="🛌🏿">hotel | osoba u krevetu | osoba u krevetu: tamna koža | spavanje | tamna koža</annotation>
+		<annotation cp="🛌🏿">hotel | osoba u krevetu | spavanje | tamna koža</annotation>
 		<annotation cp="🛌🏿" type="tts">osoba u krevetu: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏻">osobe se drže za ruke | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: svetla koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: svetla koža i srednje svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏼">osobe se drže za ruke | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: svetla koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: svetla koža i ni svetla ni tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏾">osobe se drže za ruke | osobe se drže za ruke: svetla koža i srednje tamna koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏾">osobe se drže za ruke | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏿">osobe se drže za ruke | osobe se drže za ruke: svetla koža i tamna koža | svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏿">osobe se drže za ruke | svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: svetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: srednje svetla koža i svetla koža | srednje svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏻">osobe se drže za ruke | srednje svetla koža | svetla koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: srednje svetla koža i svetla koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏼">osobe se drže za ruke | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: srednje svetla koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: srednje svetla koža i ni svetla ni tamna koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | srednje svetla koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏾">osobe se drže za ruke | osobe se drže za ruke: srednje svetla koža i srednje tamna koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏾">osobe se drže za ruke | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏿">osobe se drže za ruke | osobe se drže za ruke: srednje svetla koža i tamna koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏿">osobe se drže za ruke | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: srednje svetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏻">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svetla ni tamna koža i svetla koža | svetla koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏻">ni svetla ni tamna koža | osobe se drže za ruke | svetla koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏼">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svetla ni tamna koža i srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏼">ni svetla ni tamna koža | osobe se drže za ruke | srednje svetla koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏾">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏾">ni svetla ni tamna koža | osobe se drže za ruke | srednje tamna koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏿">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏿">ni svetla ni tamna koža | osobe se drže za ruke | tamna koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i svetla koža | srednje tamna koža | svetla koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏻">osobe se drže za ruke | srednje tamna koža | svetla koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: srednje tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i srednje svetla koža | srednje svetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏼">osobe se drže za ruke | srednje svetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i ni svetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏾">osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏾">osobe se drže za ruke | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: srednje tamna koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏿">osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏿">osobe se drže za ruke | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: srednje tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: tamna koža i svetla koža | svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏻">osobe se drže za ruke | svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: tamna koža i svetla koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: tamna koža i srednje svetla koža | srednje svetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏼">osobe se drže za ruke | srednje svetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: tamna koža i srednje svetla koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: tamna koža i ni svetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏽">ni svetla ni tamna koža | osobe se drže za ruke | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏾">osobe se drže za ruke | osobe se drže za ruke: tamna koža i srednje tamna koža | srednje tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏾">osobe se drže za ruke | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏿">osobe se drže za ruke | osobe se drže za ruke: tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏿">osobe se drže za ruke | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: tamna koža</annotation>
-		<annotation cp="👭🏻">držanje za ruke | par | ruka | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: svetla koža</annotation>
+		<annotation cp="👭🏻">držanje za ruke | par | ruka | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏻" type="tts">žene se drže za ruke: svetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svetla koža | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: svetla koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svetla koža | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏼" type="tts">žene se drže za ruke: svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: svetla koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏽" type="tts">žene se drže za ruke: svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje tamna koža | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: svetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje tamna koža | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏾" type="tts">žene se drže za ruke: svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏿">držanje za ruke | par | ruka | svetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: svetla koža i tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏿">držanje za ruke | par | ruka | svetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏿" type="tts">žene se drže za ruke: svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje svetla koža | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svetla koža i svetla koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje svetla koža | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏻" type="tts">žene se drže za ruke: srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👭🏼">držanje za ruke | par | ruka | srednje svetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svetla koža</annotation>
+		<annotation cp="👭🏼">držanje za ruke | par | ruka | srednje svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏼" type="tts">žene se drže za ruke: srednje svetla koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje svetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svetla koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏽" type="tts">žene se drže za ruke: srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje svetla koža | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje svetla koža | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏾" type="tts">žene se drže za ruke: srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏿">držanje za ruke | par | ruka | srednje svetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svetla koža i tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏿">držanje za ruke | par | ruka | srednje svetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏿" type="tts">žene se drže za ruke: srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏻">držanje za ruke | ni svetla ni tamna koža | par | ruka | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: ni svetla ni tamna koža i svetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏻">držanje za ruke | ni svetla ni tamna koža | par | ruka | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏻" type="tts">žene se drže za ruke: ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏼">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje svetla koža | žene | žene se drže za ruke | žene se drže za ruke: ni svetla ni tamna koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏼">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏼" type="tts">žene se drže za ruke: ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👭🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | žene | žene se drže za ruke | žene se drže za ruke: ni svetla ni tamna koža</annotation>
+		<annotation cp="👭🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏽" type="tts">žene se drže za ruke: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏾">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: ni svetla ni tamna koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏾">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏾" type="tts">žene se drže za ruke: ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏿">držanje za ruke | ni svetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: ni svetla ni tamna koža i tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏿">držanje za ruke | ni svetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏿" type="tts">žene se drže za ruke: ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje tamna koža | svetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i svetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje tamna koža | svetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏻" type="tts">žene se drže za ruke: srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svetla koža | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svetla koža | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏼" type="tts">žene se drže za ruke: srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏽" type="tts">žene se drže za ruke: srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👭🏾">držanje za ruke | par | ruka | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža</annotation>
+		<annotation cp="👭🏾">držanje za ruke | par | ruka | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏾" type="tts">žene se drže za ruke: srednje tamna koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏿">držanje za ruke | par | ruka | srednje tamna koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i tamna koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏿">držanje za ruke | par | ruka | srednje tamna koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏿" type="tts">žene se drže za ruke: srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏻">držanje za ruke | par | ruka | svetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i svetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏻">držanje za ruke | par | ruka | svetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏻" type="tts">žene se drže za ruke: tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏼" type="tts">žene se drže za ruke: tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏽">držanje za ruke | ni svetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏽" type="tts">žene se drže za ruke: tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje tamna koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje tamna koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏾" type="tts">žene se drže za ruke: tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👭🏿">držanje za ruke | par | ruka | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža</annotation>
+		<annotation cp="👭🏿">držanje za ruke | par | ruka | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏿" type="tts">žene se drže za ruke: tamna koža</annotation>
-		<annotation cp="👫🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svetla koža</annotation>
+		<annotation cp="👫🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏻" type="tts">žena i muškarac se drže za ruke: svetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svetla koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svetla koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svetla koža i tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svetla koža i svetla koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👫🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svetla koža</annotation>
+		<annotation cp="👫🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏼" type="tts">žena i muškarac se drže za ruke: srednje svetla koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svetla koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svetla koža i tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svetla ni tamna koža i svetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svetla ni tamna koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👫🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svetla ni tamna koža</annotation>
+		<annotation cp="👫🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏽" type="tts">žena i muškarac se drže za ruke: ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svetla ni tamna koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svetla ni tamna koža i tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i svetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👫🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža</annotation>
+		<annotation cp="👫🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏾" type="tts">žena i muškarac se drže za ruke: srednje tamna koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i tamna koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i svetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: tamna koža i svetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i srednje svetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i ni svetla ni tamna koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👫🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža</annotation>
+		<annotation cp="👫🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏿" type="tts">žena i muškarac se drže za ruke: tamna koža</annotation>
-		<annotation cp="👬🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svetla koža | par | ruke | svetla koža | zodijak</annotation>
+		<annotation cp="👬🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | svetla koža | zodijak</annotation>
 		<annotation cp="👬🏻" type="tts">muškarci se drže za ruke: svetla koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svetla koža i srednje svetla koža | par | ruke | srednje svetla koža | svetla koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | svetla koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: svetla koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svetla koža i ni svetla ni tamna koža | ni svetla ni tamna koža | par | ruke | svetla koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | svetla koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svetla koža i srednje tamna koža | par | ruke | srednje tamna koža | svetla koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | svetla koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svetla koža i tamna koža | par | ruke | svetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | svetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: svetla koža i tamna koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svetla koža i svetla koža | par | ruke | srednje svetla koža | svetla koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | svetla koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: srednje svetla koža i svetla koža</annotation>
-		<annotation cp="👬🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svetla koža | par | ruke | srednje svetla koža | zodijak</annotation>
+		<annotation cp="👬🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | zodijak</annotation>
 		<annotation cp="👬🏼" type="tts">muškarci se drže za ruke: srednje svetla koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svetla koža i ni svetla ni tamna koža | ni svetla ni tamna koža | par | ruke | srednje svetla koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje svetla koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: srednje svetla koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svetla koža i srednje tamna koža | par | ruke | srednje svetla koža | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: srednje svetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svetla koža i tamna koža | par | ruke | srednje svetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: srednje svetla koža i tamna koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svetla ni tamna koža i svetla koža | ni svetla ni tamna koža | par | ruke | svetla koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | svetla koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: ni svetla ni tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svetla ni tamna koža i srednje svetla koža | ni svetla ni tamna koža | par | ruke | srednje svetla koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje svetla koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: ni svetla ni tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👬🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svetla ni tamna koža | ni svetla ni tamna koža | par | ruke | zodijak</annotation>
+		<annotation cp="👬🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | zodijak</annotation>
 		<annotation cp="👬🏽" type="tts">muškarci se drže za ruke: ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svetla ni tamna koža i srednje tamna koža | ni svetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: ni svetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svetla ni tamna koža i tamna koža | ni svetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: ni svetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i svetla koža | par | ruke | srednje tamna koža | svetla koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | svetla koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: srednje tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i srednje svetla koža | par | ruke | srednje svetla koža | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: srednje tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i ni svetla ni tamna koža | ni svetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: srednje tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👬🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👬🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👬🏾" type="tts">muškarci se drže za ruke: srednje tamna koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i tamna koža | par | ruke | srednje tamna koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: srednje tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i svetla koža | par | ruke | svetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | svetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: tamna koža i svetla koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i srednje svetla koža | par | ruke | srednje svetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: tamna koža i srednje svetla koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i ni svetla ni tamna koža | ni svetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: tamna koža i ni svetla ni tamna koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i srednje tamna koža | par | ruke | srednje tamna koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👬🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža | par | ruke | tamna koža | zodijak</annotation>
+		<annotation cp="👬🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | tamna koža | zodijak</annotation>
 		<annotation cp="👬🏿" type="tts">muškarci se drže za ruke: tamna koža</annotation>
-		<annotation cp="💏🏻">par | poljubac | poljubac: svetla koža | svetla koža</annotation>
+		<annotation cp="💏🏻">par | poljubac | svetla koža</annotation>
 		<annotation cp="💏🏻" type="tts">poljubac: svetla koža</annotation>
-		<annotation cp="💏🏼">par | poljubac | poljubac: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="💏🏼">par | poljubac | srednje svetla koža</annotation>
 		<annotation cp="💏🏼" type="tts">poljubac: srednje svetla koža</annotation>
-		<annotation cp="💏🏽">ni svetla ni tamna koža | par | poljubac | poljubac: ni svetla ni tamna koža</annotation>
+		<annotation cp="💏🏽">ni svetla ni tamna koža | par | poljubac</annotation>
 		<annotation cp="💏🏽" type="tts">poljubac: ni svetla ni tamna koža</annotation>
-		<annotation cp="💏🏾">par | poljubac | poljubac: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="💏🏾">par | poljubac | srednje tamna koža</annotation>
 		<annotation cp="💏🏾" type="tts">poljubac: srednje tamna koža</annotation>
-		<annotation cp="💏🏿">par | poljubac | poljubac: tamna koža | tamna koža</annotation>
+		<annotation cp="💏🏿">par | poljubac | tamna koža</annotation>
 		<annotation cp="💏🏿" type="tts">poljubac: tamna koža</annotation>
-		<annotation cp="👩‍❤‍💋‍👨">muškarac | par | poljubac | poljubac: žena i muškarac | žena</annotation>
+		<annotation cp="👩‍❤‍💋‍👨">muškarac | par | poljubac | žena</annotation>
 		<annotation cp="👩‍❤‍💋‍👨" type="tts">poljubac: žena i muškarac</annotation>
-		<annotation cp="👨‍❤‍💋‍👨">muškarac | par | poljubac | poljubac: muškarac i muškarac</annotation>
+		<annotation cp="👨‍❤‍💋‍👨">muškarac | par | poljubac</annotation>
 		<annotation cp="👨‍❤‍💋‍👨" type="tts">poljubac: muškarac i muškarac</annotation>
-		<annotation cp="👩‍❤‍💋‍👩">par | poljubac | poljubac: žena i žena | žena</annotation>
+		<annotation cp="👩‍❤‍💋‍👩">par | poljubac | žena</annotation>
 		<annotation cp="👩‍❤‍💋‍👩" type="tts">poljubac: žena i žena</annotation>
-		<annotation cp="💑🏻">ljubav | par | par sa srcem | par sa srcem: svetla koža | svetla koža</annotation>
+		<annotation cp="💑🏻">ljubav | par | par sa srcem | svetla koža</annotation>
 		<annotation cp="💑🏻" type="tts">par sa srcem: svetla koža</annotation>
-		<annotation cp="💑🏼">ljubav | par | par sa srcem | par sa srcem: srednje svetla koža | srednje svetla koža</annotation>
+		<annotation cp="💑🏼">ljubav | par | par sa srcem | srednje svetla koža</annotation>
 		<annotation cp="💑🏼" type="tts">par sa srcem: srednje svetla koža</annotation>
-		<annotation cp="💑🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem | par sa srcem: ni svetla ni tamna koža</annotation>
+		<annotation cp="💑🏽">ljubav | ni svetla ni tamna koža | par | par sa srcem</annotation>
 		<annotation cp="💑🏽" type="tts">par sa srcem: ni svetla ni tamna koža</annotation>
-		<annotation cp="💑🏾">ljubav | par | par sa srcem | par sa srcem: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="💑🏾">ljubav | par | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="💑🏾" type="tts">par sa srcem: srednje tamna koža</annotation>
-		<annotation cp="💑🏿">ljubav | par | par sa srcem | par sa srcem: tamna koža | tamna koža</annotation>
+		<annotation cp="💑🏿">ljubav | par | par sa srcem | tamna koža</annotation>
 		<annotation cp="💑🏿" type="tts">par sa srcem: tamna koža</annotation>
-		<annotation cp="👩‍❤‍👨">ljubav | muškarac | par | par sa srcem | par sa srcem: žena i muškarac | žena</annotation>
+		<annotation cp="👩‍❤‍👨">ljubav | muškarac | par | par sa srcem | žena</annotation>
 		<annotation cp="👩‍❤‍👨" type="tts">par sa srcem: žena i muškarac</annotation>
-		<annotation cp="👨‍❤‍👨">ljubav | muškarac | par | par sa srcem | par sa srcem: muškarac i muškarac</annotation>
+		<annotation cp="👨‍❤‍👨">ljubav | muškarac | par | par sa srcem</annotation>
 		<annotation cp="👨‍❤‍👨" type="tts">par sa srcem: muškarac i muškarac</annotation>
-		<annotation cp="👩‍❤‍👩">ljubav | par | par sa srcem | par sa srcem: žena i žena | žena</annotation>
+		<annotation cp="👩‍❤‍👩">ljubav | par | par sa srcem | žena</annotation>
 		<annotation cp="👩‍❤‍👩" type="tts">par sa srcem: žena i žena</annotation>
-		<annotation cp="👨‍👩‍👦">dečak | muškarac | porodica | porodica: muškarac, žena i dečak | žena</annotation>
+		<annotation cp="👨‍👩‍👦">dečak | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👦" type="tts">porodica: muškarac, žena i dečak</annotation>
-		<annotation cp="👨‍👩‍👧">devojčica | muškarac | porodica | porodica: muškarac, žena i devojčica | žena</annotation>
+		<annotation cp="👨‍👩‍👧">devojčica | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👧" type="tts">porodica: muškarac, žena i devojčica</annotation>
-		<annotation cp="👨‍👩‍👧‍👦">dečak | devojčica | muškarac | porodica | porodica: muškarac, žena, devojčica i dečak | žena</annotation>
+		<annotation cp="👨‍👩‍👧‍👦">dečak | devojčica | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👧‍👦" type="tts">porodica: muškarac, žena, devojčica i dečak</annotation>
-		<annotation cp="👨‍👩‍👦‍👦">dečak | muškarac | porodica | porodica: muškarac, žena, dečak i dečak | žena</annotation>
+		<annotation cp="👨‍👩‍👦‍👦">dečak | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👦‍👦" type="tts">porodica: muškarac, žena, dečak i dečak</annotation>
-		<annotation cp="👨‍👩‍👧‍👧">devojčica | muškarac | porodica | porodica: muškarac, žena, devojčica i devojčica | žena</annotation>
+		<annotation cp="👨‍👩‍👧‍👧">devojčica | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👧‍👧" type="tts">porodica: muškarac, žena, devojčica i devojčica</annotation>
-		<annotation cp="👨‍👨‍👦">dečak | muškarac | porodica | porodica: muškarac, muškarac i dečak</annotation>
+		<annotation cp="👨‍👨‍👦">dečak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👦" type="tts">porodica: muškarac, muškarac i dečak</annotation>
-		<annotation cp="👨‍👨‍👧">devojčica | muškarac | porodica | porodica: muškarac, muškarac i devojčica</annotation>
+		<annotation cp="👨‍👨‍👧">devojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👧" type="tts">porodica: muškarac, muškarac i devojčica</annotation>
-		<annotation cp="👨‍👨‍👧‍👦">dečak | devojčica | muškarac | porodica | porodica: muškarac, muškarac, devojčica i dečak</annotation>
+		<annotation cp="👨‍👨‍👧‍👦">dečak | devojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👧‍👦" type="tts">porodica: muškarac, muškarac, devojčica i dečak</annotation>
-		<annotation cp="👨‍👨‍👦‍👦">dečak | muškarac | porodica | porodica: muškarac, muškarac, dečak i dečak</annotation>
+		<annotation cp="👨‍👨‍👦‍👦">dečak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👦‍👦" type="tts">porodica: muškarac, muškarac, dečak i dečak</annotation>
-		<annotation cp="👨‍👨‍👧‍👧">devojčica | muškarac | porodica | porodica: muškarac, muškarac, devojčica i devojčica</annotation>
+		<annotation cp="👨‍👨‍👧‍👧">devojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👧‍👧" type="tts">porodica: muškarac, muškarac, devojčica i devojčica</annotation>
-		<annotation cp="👩‍👩‍👦">dečak | porodica | porodica: žena, žena i dečak | žena</annotation>
+		<annotation cp="👩‍👩‍👦">dečak | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👦" type="tts">porodica: žena, žena i dečak</annotation>
-		<annotation cp="👩‍👩‍👧">devojčica | porodica | porodica: žena, žena i devojčica | žena</annotation>
+		<annotation cp="👩‍👩‍👧">devojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👧" type="tts">porodica: žena, žena i devojčica</annotation>
-		<annotation cp="👩‍👩‍👧‍👦">dečak | devojčica | porodica | porodica: žena, žena, devojčica i dečak | žena</annotation>
+		<annotation cp="👩‍👩‍👧‍👦">dečak | devojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👧‍👦" type="tts">porodica: žena, žena, devojčica i dečak</annotation>
-		<annotation cp="👩‍👩‍👦‍👦">dečak | porodica | porodica: žena, žena, dečak i dečak | žena</annotation>
+		<annotation cp="👩‍👩‍👦‍👦">dečak | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👦‍👦" type="tts">porodica: žena, žena, dečak i dečak</annotation>
-		<annotation cp="👩‍👩‍👧‍👧">devojčica | porodica | porodica: žena, žena, devojčica i devojčica | žena</annotation>
+		<annotation cp="👩‍👩‍👧‍👧">devojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👧‍👧" type="tts">porodica: žena, žena, devojčica i devojčica</annotation>
-		<annotation cp="👨‍👦">dečak | muškarac | porodica | porodica: muškarac i dečak</annotation>
+		<annotation cp="👨‍👦">dečak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👦" type="tts">porodica: muškarac i dečak</annotation>
-		<annotation cp="👨‍👦‍👦">dečak | muškarac | porodica | porodica: muškarac, dečak i dečak</annotation>
+		<annotation cp="👨‍👦‍👦">dečak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👦‍👦" type="tts">porodica: muškarac, dečak i dečak</annotation>
-		<annotation cp="👨‍👧">devojčica | muškarac | porodica | porodica: muškarac i devojčica</annotation>
+		<annotation cp="👨‍👧">devojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👧" type="tts">porodica: muškarac i devojčica</annotation>
-		<annotation cp="👨‍👧‍👦">dečak | devojčica | muškarac | porodica | porodica: muškarac, devojčica i dečak</annotation>
+		<annotation cp="👨‍👧‍👦">dečak | devojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👧‍👦" type="tts">porodica: muškarac, devojčica i dečak</annotation>
-		<annotation cp="👨‍👧‍👧">devojčica | muškarac | porodica | porodica: muškarac, devojčica i devojčica</annotation>
+		<annotation cp="👨‍👧‍👧">devojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👧‍👧" type="tts">porodica: muškarac, devojčica i devojčica</annotation>
-		<annotation cp="👩‍👦">dečak | porodica | porodica: žena i dečak | žena</annotation>
+		<annotation cp="👩‍👦">dečak | porodica | žena</annotation>
 		<annotation cp="👩‍👦" type="tts">porodica: žena i dečak</annotation>
-		<annotation cp="👩‍👦‍👦">dečak | porodica | porodica: žena, dečak i dečak | žena</annotation>
+		<annotation cp="👩‍👦‍👦">dečak | porodica | žena</annotation>
 		<annotation cp="👩‍👦‍👦" type="tts">porodica: žena, dečak i dečak</annotation>
-		<annotation cp="👩‍👧">devojčica | porodica | porodica: žena i devojčica | žena</annotation>
+		<annotation cp="👩‍👧">devojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👧" type="tts">porodica: žena i devojčica</annotation>
-		<annotation cp="👩‍👧‍👦">dečak | devojčica | porodica | porodica: žena, devojčica i dečak | žena</annotation>
+		<annotation cp="👩‍👧‍👦">dečak | devojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👧‍👦" type="tts">porodica: žena, devojčica i dečak</annotation>
-		<annotation cp="👩‍👧‍👧">devojčica | porodica | porodica: žena, devojčica i devojčica | žena</annotation>
+		<annotation cp="👩‍👧‍👧">devojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👧‍👧" type="tts">porodica: žena, devojčica i devojčica</annotation>
-		<annotation cp="#⃣">taster | taster: #</annotation>
+		<annotation cp="#⃣">taster</annotation>
 		<annotation cp="#⃣" type="tts">taster: #</annotation>
-		<annotation cp="*⃣">taster | taster: *</annotation>
+		<annotation cp="*⃣">taster</annotation>
 		<annotation cp="*⃣" type="tts">taster: *</annotation>
-		<annotation cp="🔟">taster | taster: 10</annotation>
+		<annotation cp="🔟">taster</annotation>
 		<annotation cp="🔟" type="tts">taster: 10</annotation>
-		<annotation cp="🇦🇨">zastava | zastava: Ostrvo Asension</annotation>
+		<annotation cp="🇦🇨">zastava</annotation>
 		<annotation cp="🇦🇨" type="tts">zastava: Ostrvo Asension</annotation>
-		<annotation cp="🇦🇩">zastava | zastava: Andora</annotation>
+		<annotation cp="🇦🇩">zastava</annotation>
 		<annotation cp="🇦🇩" type="tts">zastava: Andora</annotation>
-		<annotation cp="🇦🇪">zastava | zastava: Ujedinjeni Arapski Emirati</annotation>
+		<annotation cp="🇦🇪">zastava</annotation>
 		<annotation cp="🇦🇪" type="tts">zastava: Ujedinjeni Arapski Emirati</annotation>
-		<annotation cp="🇦🇫">zastava | zastava: Avganistan</annotation>
+		<annotation cp="🇦🇫">zastava</annotation>
 		<annotation cp="🇦🇫" type="tts">zastava: Avganistan</annotation>
-		<annotation cp="🇦🇬">zastava | zastava: Antigva i Barbuda</annotation>
+		<annotation cp="🇦🇬">zastava</annotation>
 		<annotation cp="🇦🇬" type="tts">zastava: Antigva i Barbuda</annotation>
-		<annotation cp="🇦🇮">zastava | zastava: Angvila</annotation>
+		<annotation cp="🇦🇮">zastava</annotation>
 		<annotation cp="🇦🇮" type="tts">zastava: Angvila</annotation>
-		<annotation cp="🇦🇱">zastava | zastava: Albanija</annotation>
+		<annotation cp="🇦🇱">zastava</annotation>
 		<annotation cp="🇦🇱" type="tts">zastava: Albanija</annotation>
-		<annotation cp="🇦🇲">zastava | zastava: Jermenija</annotation>
+		<annotation cp="🇦🇲">zastava</annotation>
 		<annotation cp="🇦🇲" type="tts">zastava: Jermenija</annotation>
-		<annotation cp="🇦🇴">zastava | zastava: Angola</annotation>
+		<annotation cp="🇦🇴">zastava</annotation>
 		<annotation cp="🇦🇴" type="tts">zastava: Angola</annotation>
-		<annotation cp="🇦🇶">zastava | zastava: Antarktik</annotation>
+		<annotation cp="🇦🇶">zastava</annotation>
 		<annotation cp="🇦🇶" type="tts">zastava: Antarktik</annotation>
-		<annotation cp="🇦🇷">zastava | zastava: Argentina</annotation>
+		<annotation cp="🇦🇷">zastava</annotation>
 		<annotation cp="🇦🇷" type="tts">zastava: Argentina</annotation>
-		<annotation cp="🇦🇸">zastava | zastava: Američka Samoa</annotation>
+		<annotation cp="🇦🇸">zastava</annotation>
 		<annotation cp="🇦🇸" type="tts">zastava: Američka Samoa</annotation>
-		<annotation cp="🇦🇹">zastava | zastava: Austrija</annotation>
+		<annotation cp="🇦🇹">zastava</annotation>
 		<annotation cp="🇦🇹" type="tts">zastava: Austrija</annotation>
-		<annotation cp="🇦🇺">zastava | zastava: Australija</annotation>
+		<annotation cp="🇦🇺">zastava</annotation>
 		<annotation cp="🇦🇺" type="tts">zastava: Australija</annotation>
-		<annotation cp="🇦🇼">zastava | zastava: Aruba</annotation>
+		<annotation cp="🇦🇼">zastava</annotation>
 		<annotation cp="🇦🇼" type="tts">zastava: Aruba</annotation>
-		<annotation cp="🇦🇽">zastava | zastava: Olandska Ostrva</annotation>
+		<annotation cp="🇦🇽">zastava</annotation>
 		<annotation cp="🇦🇽" type="tts">zastava: Olandska Ostrva</annotation>
-		<annotation cp="🇦🇿">zastava | zastava: Azerbejdžan</annotation>
+		<annotation cp="🇦🇿">zastava</annotation>
 		<annotation cp="🇦🇿" type="tts">zastava: Azerbejdžan</annotation>
-		<annotation cp="🇧🇦">zastava | zastava: Bosna i Hercegovina</annotation>
+		<annotation cp="🇧🇦">zastava</annotation>
 		<annotation cp="🇧🇦" type="tts">zastava: Bosna i Hercegovina</annotation>
-		<annotation cp="🇧🇧">zastava | zastava: Barbados</annotation>
+		<annotation cp="🇧🇧">zastava</annotation>
 		<annotation cp="🇧🇧" type="tts">zastava: Barbados</annotation>
-		<annotation cp="🇧🇩">zastava | zastava: Bangladeš</annotation>
+		<annotation cp="🇧🇩">zastava</annotation>
 		<annotation cp="🇧🇩" type="tts">zastava: Bangladeš</annotation>
-		<annotation cp="🇧🇪">zastava | zastava: Belgija</annotation>
+		<annotation cp="🇧🇪">zastava</annotation>
 		<annotation cp="🇧🇪" type="tts">zastava: Belgija</annotation>
-		<annotation cp="🇧🇫">zastava | zastava: Burkina Faso</annotation>
+		<annotation cp="🇧🇫">zastava</annotation>
 		<annotation cp="🇧🇫" type="tts">zastava: Burkina Faso</annotation>
-		<annotation cp="🇧🇬">zastava | zastava: Bugarska</annotation>
+		<annotation cp="🇧🇬">zastava</annotation>
 		<annotation cp="🇧🇬" type="tts">zastava: Bugarska</annotation>
-		<annotation cp="🇧🇭">zastava | zastava: Bahrein</annotation>
+		<annotation cp="🇧🇭">zastava</annotation>
 		<annotation cp="🇧🇭" type="tts">zastava: Bahrein</annotation>
-		<annotation cp="🇧🇮">zastava | zastava: Burundi</annotation>
+		<annotation cp="🇧🇮">zastava</annotation>
 		<annotation cp="🇧🇮" type="tts">zastava: Burundi</annotation>
-		<annotation cp="🇧🇯">zastava | zastava: Benin</annotation>
+		<annotation cp="🇧🇯">zastava</annotation>
 		<annotation cp="🇧🇯" type="tts">zastava: Benin</annotation>
-		<annotation cp="🇧🇱">zastava | zastava: Sveti Bartolomej</annotation>
+		<annotation cp="🇧🇱">zastava</annotation>
 		<annotation cp="🇧🇱" type="tts">zastava: Sveti Bartolomej</annotation>
-		<annotation cp="🇧🇲">zastava | zastava: Bermuda</annotation>
+		<annotation cp="🇧🇲">zastava</annotation>
 		<annotation cp="🇧🇲" type="tts">zastava: Bermuda</annotation>
-		<annotation cp="🇧🇳">zastava | zastava: Brunej</annotation>
+		<annotation cp="🇧🇳">zastava</annotation>
 		<annotation cp="🇧🇳" type="tts">zastava: Brunej</annotation>
-		<annotation cp="🇧🇴">zastava | zastava: Bolivija</annotation>
+		<annotation cp="🇧🇴">zastava</annotation>
 		<annotation cp="🇧🇴" type="tts">zastava: Bolivija</annotation>
-		<annotation cp="🇧🇶">zastava | zastava: Karipska Holandija</annotation>
+		<annotation cp="🇧🇶">zastava</annotation>
 		<annotation cp="🇧🇶" type="tts">zastava: Karipska Holandija</annotation>
-		<annotation cp="🇧🇷">zastava | zastava: Brazil</annotation>
+		<annotation cp="🇧🇷">zastava</annotation>
 		<annotation cp="🇧🇷" type="tts">zastava: Brazil</annotation>
-		<annotation cp="🇧🇸">zastava | zastava: Bahami</annotation>
+		<annotation cp="🇧🇸">zastava</annotation>
 		<annotation cp="🇧🇸" type="tts">zastava: Bahami</annotation>
-		<annotation cp="🇧🇹">zastava | zastava: Butan</annotation>
+		<annotation cp="🇧🇹">zastava</annotation>
 		<annotation cp="🇧🇹" type="tts">zastava: Butan</annotation>
-		<annotation cp="🇧🇻">zastava | zastava: Ostrvo Buve</annotation>
+		<annotation cp="🇧🇻">zastava</annotation>
 		<annotation cp="🇧🇻" type="tts">zastava: Ostrvo Buve</annotation>
-		<annotation cp="🇧🇼">zastava | zastava: Bocvana</annotation>
+		<annotation cp="🇧🇼">zastava</annotation>
 		<annotation cp="🇧🇼" type="tts">zastava: Bocvana</annotation>
-		<annotation cp="🇧🇾">zastava | zastava: Belorusija</annotation>
+		<annotation cp="🇧🇾">zastava</annotation>
 		<annotation cp="🇧🇾" type="tts">zastava: Belorusija</annotation>
-		<annotation cp="🇧🇿">zastava | zastava: Belize</annotation>
+		<annotation cp="🇧🇿">zastava</annotation>
 		<annotation cp="🇧🇿" type="tts">zastava: Belize</annotation>
-		<annotation cp="🇨🇦">zastava | zastava: Kanada</annotation>
+		<annotation cp="🇨🇦">zastava</annotation>
 		<annotation cp="🇨🇦" type="tts">zastava: Kanada</annotation>
-		<annotation cp="🇨🇨">zastava | zastava: Kokosova (Kilingova) Ostrva</annotation>
+		<annotation cp="🇨🇨">zastava</annotation>
 		<annotation cp="🇨🇨" type="tts">zastava: Kokosova (Kilingova) Ostrva</annotation>
-		<annotation cp="🇨🇩">zastava | zastava: Kongo - Kinšasa</annotation>
+		<annotation cp="🇨🇩">zastava</annotation>
 		<annotation cp="🇨🇩" type="tts">zastava: Kongo - Kinšasa</annotation>
-		<annotation cp="🇨🇫">zastava | zastava: Centralnoafrička Republika</annotation>
+		<annotation cp="🇨🇫">zastava</annotation>
 		<annotation cp="🇨🇫" type="tts">zastava: Centralnoafrička Republika</annotation>
-		<annotation cp="🇨🇬">zastava | zastava: Kongo - Brazavil</annotation>
+		<annotation cp="🇨🇬">zastava</annotation>
 		<annotation cp="🇨🇬" type="tts">zastava: Kongo - Brazavil</annotation>
-		<annotation cp="🇨🇭">zastava | zastava: Švajcarska</annotation>
+		<annotation cp="🇨🇭">zastava</annotation>
 		<annotation cp="🇨🇭" type="tts">zastava: Švajcarska</annotation>
-		<annotation cp="🇨🇮">zastava | zastava: Obala Slonovače (Kot d’Ivoar)</annotation>
+		<annotation cp="🇨🇮">zastava</annotation>
 		<annotation cp="🇨🇮" type="tts">zastava: Obala Slonovače (Kot d’Ivoar)</annotation>
-		<annotation cp="🇨🇰">zastava | zastava: Kukova Ostrva</annotation>
+		<annotation cp="🇨🇰">zastava</annotation>
 		<annotation cp="🇨🇰" type="tts">zastava: Kukova Ostrva</annotation>
-		<annotation cp="🇨🇱">zastava | zastava: Čile</annotation>
+		<annotation cp="🇨🇱">zastava</annotation>
 		<annotation cp="🇨🇱" type="tts">zastava: Čile</annotation>
-		<annotation cp="🇨🇲">zastava | zastava: Kamerun</annotation>
+		<annotation cp="🇨🇲">zastava</annotation>
 		<annotation cp="🇨🇲" type="tts">zastava: Kamerun</annotation>
-		<annotation cp="🇨🇳">zastava | zastava: Kina</annotation>
+		<annotation cp="🇨🇳">zastava</annotation>
 		<annotation cp="🇨🇳" type="tts">zastava: Kina</annotation>
-		<annotation cp="🇨🇴">zastava | zastava: Kolumbija</annotation>
+		<annotation cp="🇨🇴">zastava</annotation>
 		<annotation cp="🇨🇴" type="tts">zastava: Kolumbija</annotation>
-		<annotation cp="🇨🇵">zastava | zastava: Ostrvo Kliperton</annotation>
+		<annotation cp="🇨🇵">zastava</annotation>
 		<annotation cp="🇨🇵" type="tts">zastava: Ostrvo Kliperton</annotation>
-		<annotation cp="🇨🇷">zastava | zastava: Kostarika</annotation>
+		<annotation cp="🇨🇷">zastava</annotation>
 		<annotation cp="🇨🇷" type="tts">zastava: Kostarika</annotation>
-		<annotation cp="🇨🇺">zastava | zastava: Kuba</annotation>
+		<annotation cp="🇨🇺">zastava</annotation>
 		<annotation cp="🇨🇺" type="tts">zastava: Kuba</annotation>
-		<annotation cp="🇨🇻">zastava | zastava: Zelenortska Ostrva</annotation>
+		<annotation cp="🇨🇻">zastava</annotation>
 		<annotation cp="🇨🇻" type="tts">zastava: Zelenortska Ostrva</annotation>
-		<annotation cp="🇨🇼">zastava | zastava: Kurasao</annotation>
+		<annotation cp="🇨🇼">zastava</annotation>
 		<annotation cp="🇨🇼" type="tts">zastava: Kurasao</annotation>
-		<annotation cp="🇨🇽">zastava | zastava: Božićno Ostrvo</annotation>
+		<annotation cp="🇨🇽">zastava</annotation>
 		<annotation cp="🇨🇽" type="tts">zastava: Božićno Ostrvo</annotation>
-		<annotation cp="🇨🇾">zastava | zastava: Kipar</annotation>
+		<annotation cp="🇨🇾">zastava</annotation>
 		<annotation cp="🇨🇾" type="tts">zastava: Kipar</annotation>
-		<annotation cp="🇨🇿">zastava | zastava: Češka</annotation>
+		<annotation cp="🇨🇿">zastava</annotation>
 		<annotation cp="🇨🇿" type="tts">zastava: Češka</annotation>
-		<annotation cp="🇩🇪">zastava | zastava: Nemačka</annotation>
+		<annotation cp="🇩🇪">zastava</annotation>
 		<annotation cp="🇩🇪" type="tts">zastava: Nemačka</annotation>
-		<annotation cp="🇩🇬">zastava | zastava: Dijego Garsija</annotation>
+		<annotation cp="🇩🇬">zastava</annotation>
 		<annotation cp="🇩🇬" type="tts">zastava: Dijego Garsija</annotation>
-		<annotation cp="🇩🇯">zastava | zastava: Džibuti</annotation>
+		<annotation cp="🇩🇯">zastava</annotation>
 		<annotation cp="🇩🇯" type="tts">zastava: Džibuti</annotation>
-		<annotation cp="🇩🇰">zastava | zastava: Danska</annotation>
+		<annotation cp="🇩🇰">zastava</annotation>
 		<annotation cp="🇩🇰" type="tts">zastava: Danska</annotation>
-		<annotation cp="🇩🇲">zastava | zastava: Dominika</annotation>
+		<annotation cp="🇩🇲">zastava</annotation>
 		<annotation cp="🇩🇲" type="tts">zastava: Dominika</annotation>
-		<annotation cp="🇩🇴">zastava | zastava: Dominikanska Republika</annotation>
+		<annotation cp="🇩🇴">zastava</annotation>
 		<annotation cp="🇩🇴" type="tts">zastava: Dominikanska Republika</annotation>
-		<annotation cp="🇩🇿">zastava | zastava: Alžir</annotation>
+		<annotation cp="🇩🇿">zastava</annotation>
 		<annotation cp="🇩🇿" type="tts">zastava: Alžir</annotation>
-		<annotation cp="🇪🇦">zastava | zastava: Seuta i Melilja</annotation>
+		<annotation cp="🇪🇦">zastava</annotation>
 		<annotation cp="🇪🇦" type="tts">zastava: Seuta i Melilja</annotation>
-		<annotation cp="🇪🇨">zastava | zastava: Ekvador</annotation>
+		<annotation cp="🇪🇨">zastava</annotation>
 		<annotation cp="🇪🇨" type="tts">zastava: Ekvador</annotation>
-		<annotation cp="🇪🇪">zastava | zastava: Estonija</annotation>
+		<annotation cp="🇪🇪">zastava</annotation>
 		<annotation cp="🇪🇪" type="tts">zastava: Estonija</annotation>
-		<annotation cp="🇪🇬">zastava | zastava: Egipat</annotation>
+		<annotation cp="🇪🇬">zastava</annotation>
 		<annotation cp="🇪🇬" type="tts">zastava: Egipat</annotation>
-		<annotation cp="🇪🇭">zastava | zastava: Zapadna Sahara</annotation>
+		<annotation cp="🇪🇭">zastava</annotation>
 		<annotation cp="🇪🇭" type="tts">zastava: Zapadna Sahara</annotation>
-		<annotation cp="🇪🇷">zastava | zastava: Eritreja</annotation>
+		<annotation cp="🇪🇷">zastava</annotation>
 		<annotation cp="🇪🇷" type="tts">zastava: Eritreja</annotation>
-		<annotation cp="🇪🇸">zastava | zastava: Španija</annotation>
+		<annotation cp="🇪🇸">zastava</annotation>
 		<annotation cp="🇪🇸" type="tts">zastava: Španija</annotation>
-		<annotation cp="🇪🇹">zastava | zastava: Etiopija</annotation>
+		<annotation cp="🇪🇹">zastava</annotation>
 		<annotation cp="🇪🇹" type="tts">zastava: Etiopija</annotation>
-		<annotation cp="🇪🇺">zastava | zastava: Evropska unija</annotation>
+		<annotation cp="🇪🇺">zastava</annotation>
 		<annotation cp="🇪🇺" type="tts">zastava: Evropska unija</annotation>
-		<annotation cp="🇫🇮">zastava | zastava: Finska</annotation>
+		<annotation cp="🇫🇮">zastava</annotation>
 		<annotation cp="🇫🇮" type="tts">zastava: Finska</annotation>
-		<annotation cp="🇫🇯">zastava | zastava: Fidži</annotation>
+		<annotation cp="🇫🇯">zastava</annotation>
 		<annotation cp="🇫🇯" type="tts">zastava: Fidži</annotation>
-		<annotation cp="🇫🇰">zastava | zastava: Foklandska Ostrva</annotation>
+		<annotation cp="🇫🇰">zastava</annotation>
 		<annotation cp="🇫🇰" type="tts">zastava: Foklandska Ostrva</annotation>
-		<annotation cp="🇫🇲">zastava | zastava: Mikronezija</annotation>
+		<annotation cp="🇫🇲">zastava</annotation>
 		<annotation cp="🇫🇲" type="tts">zastava: Mikronezija</annotation>
-		<annotation cp="🇫🇴">zastava | zastava: Farska Ostrva</annotation>
+		<annotation cp="🇫🇴">zastava</annotation>
 		<annotation cp="🇫🇴" type="tts">zastava: Farska Ostrva</annotation>
-		<annotation cp="🇫🇷">zastava | zastava: Francuska</annotation>
+		<annotation cp="🇫🇷">zastava</annotation>
 		<annotation cp="🇫🇷" type="tts">zastava: Francuska</annotation>
-		<annotation cp="🇬🇦">zastava | zastava: Gabon</annotation>
+		<annotation cp="🇬🇦">zastava</annotation>
 		<annotation cp="🇬🇦" type="tts">zastava: Gabon</annotation>
-		<annotation cp="🇬🇧">zastava | zastava: Ujedinjeno Kraljevstvo</annotation>
+		<annotation cp="🇬🇧">zastava</annotation>
 		<annotation cp="🇬🇧" type="tts">zastava: Ujedinjeno Kraljevstvo</annotation>
-		<annotation cp="🇬🇩">zastava | zastava: Grenada</annotation>
+		<annotation cp="🇬🇩">zastava</annotation>
 		<annotation cp="🇬🇩" type="tts">zastava: Grenada</annotation>
-		<annotation cp="🇬🇪">zastava | zastava: Gruzija</annotation>
+		<annotation cp="🇬🇪">zastava</annotation>
 		<annotation cp="🇬🇪" type="tts">zastava: Gruzija</annotation>
-		<annotation cp="🇬🇫">zastava | zastava: Francuska Gvajana</annotation>
+		<annotation cp="🇬🇫">zastava</annotation>
 		<annotation cp="🇬🇫" type="tts">zastava: Francuska Gvajana</annotation>
-		<annotation cp="🇬🇬">zastava | zastava: Gernzi</annotation>
+		<annotation cp="🇬🇬">zastava</annotation>
 		<annotation cp="🇬🇬" type="tts">zastava: Gernzi</annotation>
-		<annotation cp="🇬🇭">zastava | zastava: Gana</annotation>
+		<annotation cp="🇬🇭">zastava</annotation>
 		<annotation cp="🇬🇭" type="tts">zastava: Gana</annotation>
-		<annotation cp="🇬🇮">zastava | zastava: Gibraltar</annotation>
+		<annotation cp="🇬🇮">zastava</annotation>
 		<annotation cp="🇬🇮" type="tts">zastava: Gibraltar</annotation>
-		<annotation cp="🇬🇱">zastava | zastava: Grenland</annotation>
+		<annotation cp="🇬🇱">zastava</annotation>
 		<annotation cp="🇬🇱" type="tts">zastava: Grenland</annotation>
-		<annotation cp="🇬🇲">zastava | zastava: Gambija</annotation>
+		<annotation cp="🇬🇲">zastava</annotation>
 		<annotation cp="🇬🇲" type="tts">zastava: Gambija</annotation>
-		<annotation cp="🇬🇳">zastava | zastava: Gvineja</annotation>
+		<annotation cp="🇬🇳">zastava</annotation>
 		<annotation cp="🇬🇳" type="tts">zastava: Gvineja</annotation>
-		<annotation cp="🇬🇵">zastava | zastava: Gvadelup</annotation>
+		<annotation cp="🇬🇵">zastava</annotation>
 		<annotation cp="🇬🇵" type="tts">zastava: Gvadelup</annotation>
-		<annotation cp="🇬🇶">zastava | zastava: Ekvatorijalna Gvineja</annotation>
+		<annotation cp="🇬🇶">zastava</annotation>
 		<annotation cp="🇬🇶" type="tts">zastava: Ekvatorijalna Gvineja</annotation>
-		<annotation cp="🇬🇷">zastava | zastava: Grčka</annotation>
+		<annotation cp="🇬🇷">zastava</annotation>
 		<annotation cp="🇬🇷" type="tts">zastava: Grčka</annotation>
-		<annotation cp="🇬🇸">zastava | zastava: Južna Džordžija i Južna Sendvička Ostrva</annotation>
+		<annotation cp="🇬🇸">zastava</annotation>
 		<annotation cp="🇬🇸" type="tts">zastava: Južna Džordžija i Južna Sendvička Ostrva</annotation>
-		<annotation cp="🇬🇹">zastava | zastava: Gvatemala</annotation>
+		<annotation cp="🇬🇹">zastava</annotation>
 		<annotation cp="🇬🇹" type="tts">zastava: Gvatemala</annotation>
-		<annotation cp="🇬🇺">zastava | zastava: Guam</annotation>
+		<annotation cp="🇬🇺">zastava</annotation>
 		<annotation cp="🇬🇺" type="tts">zastava: Guam</annotation>
-		<annotation cp="🇬🇼">zastava | zastava: Gvineja-Bisao</annotation>
+		<annotation cp="🇬🇼">zastava</annotation>
 		<annotation cp="🇬🇼" type="tts">zastava: Gvineja-Bisao</annotation>
-		<annotation cp="🇬🇾">zastava | zastava: Gvajana</annotation>
+		<annotation cp="🇬🇾">zastava</annotation>
 		<annotation cp="🇬🇾" type="tts">zastava: Gvajana</annotation>
-		<annotation cp="🇭🇰">zastava | zastava: SAR Hongkong (Kina)</annotation>
+		<annotation cp="🇭🇰">zastava</annotation>
 		<annotation cp="🇭🇰" type="tts">zastava: SAR Hongkong (Kina)</annotation>
-		<annotation cp="🇭🇲">zastava | zastava: Ostrvo Herd i Mekdonaldova ostrva</annotation>
+		<annotation cp="🇭🇲">zastava</annotation>
 		<annotation cp="🇭🇲" type="tts">zastava: Ostrvo Herd i Mekdonaldova ostrva</annotation>
-		<annotation cp="🇭🇳">zastava | zastava: Honduras</annotation>
+		<annotation cp="🇭🇳">zastava</annotation>
 		<annotation cp="🇭🇳" type="tts">zastava: Honduras</annotation>
-		<annotation cp="🇭🇷">zastava | zastava: Hrvatska</annotation>
+		<annotation cp="🇭🇷">zastava</annotation>
 		<annotation cp="🇭🇷" type="tts">zastava: Hrvatska</annotation>
-		<annotation cp="🇭🇹">zastava | zastava: Haiti</annotation>
+		<annotation cp="🇭🇹">zastava</annotation>
 		<annotation cp="🇭🇹" type="tts">zastava: Haiti</annotation>
-		<annotation cp="🇭🇺">zastava | zastava: Mađarska</annotation>
+		<annotation cp="🇭🇺">zastava</annotation>
 		<annotation cp="🇭🇺" type="tts">zastava: Mađarska</annotation>
-		<annotation cp="🇮🇨">zastava | zastava: Kanarska Ostrva</annotation>
+		<annotation cp="🇮🇨">zastava</annotation>
 		<annotation cp="🇮🇨" type="tts">zastava: Kanarska Ostrva</annotation>
-		<annotation cp="🇮🇩">zastava | zastava: Indonezija</annotation>
+		<annotation cp="🇮🇩">zastava</annotation>
 		<annotation cp="🇮🇩" type="tts">zastava: Indonezija</annotation>
-		<annotation cp="🇮🇪">zastava | zastava: Irska</annotation>
+		<annotation cp="🇮🇪">zastava</annotation>
 		<annotation cp="🇮🇪" type="tts">zastava: Irska</annotation>
-		<annotation cp="🇮🇱">zastava | zastava: Izrael</annotation>
+		<annotation cp="🇮🇱">zastava</annotation>
 		<annotation cp="🇮🇱" type="tts">zastava: Izrael</annotation>
-		<annotation cp="🇮🇲">zastava | zastava: Ostrvo Man</annotation>
+		<annotation cp="🇮🇲">zastava</annotation>
 		<annotation cp="🇮🇲" type="tts">zastava: Ostrvo Man</annotation>
-		<annotation cp="🇮🇳">zastava | zastava: Indija</annotation>
+		<annotation cp="🇮🇳">zastava</annotation>
 		<annotation cp="🇮🇳" type="tts">zastava: Indija</annotation>
-		<annotation cp="🇮🇴">zastava | zastava: Britanska teritorija Indijskog okeana</annotation>
+		<annotation cp="🇮🇴">zastava</annotation>
 		<annotation cp="🇮🇴" type="tts">zastava: Britanska teritorija Indijskog okeana</annotation>
-		<annotation cp="🇮🇶">zastava | zastava: Irak</annotation>
+		<annotation cp="🇮🇶">zastava</annotation>
 		<annotation cp="🇮🇶" type="tts">zastava: Irak</annotation>
-		<annotation cp="🇮🇷">zastava | zastava: Iran</annotation>
+		<annotation cp="🇮🇷">zastava</annotation>
 		<annotation cp="🇮🇷" type="tts">zastava: Iran</annotation>
-		<annotation cp="🇮🇸">zastava | zastava: Island</annotation>
+		<annotation cp="🇮🇸">zastava</annotation>
 		<annotation cp="🇮🇸" type="tts">zastava: Island</annotation>
-		<annotation cp="🇮🇹">zastava | zastava: Italija</annotation>
+		<annotation cp="🇮🇹">zastava</annotation>
 		<annotation cp="🇮🇹" type="tts">zastava: Italija</annotation>
-		<annotation cp="🇯🇪">zastava | zastava: Džerzi</annotation>
+		<annotation cp="🇯🇪">zastava</annotation>
 		<annotation cp="🇯🇪" type="tts">zastava: Džerzi</annotation>
-		<annotation cp="🇯🇲">zastava | zastava: Jamajka</annotation>
+		<annotation cp="🇯🇲">zastava</annotation>
 		<annotation cp="🇯🇲" type="tts">zastava: Jamajka</annotation>
-		<annotation cp="🇯🇴">zastava | zastava: Jordan</annotation>
+		<annotation cp="🇯🇴">zastava</annotation>
 		<annotation cp="🇯🇴" type="tts">zastava: Jordan</annotation>
-		<annotation cp="🇯🇵">zastava | zastava: Japan</annotation>
+		<annotation cp="🇯🇵">zastava</annotation>
 		<annotation cp="🇯🇵" type="tts">zastava: Japan</annotation>
-		<annotation cp="🇰🇪">zastava | zastava: Kenija</annotation>
+		<annotation cp="🇰🇪">zastava</annotation>
 		<annotation cp="🇰🇪" type="tts">zastava: Kenija</annotation>
-		<annotation cp="🇰🇬">zastava | zastava: Kirgistan</annotation>
+		<annotation cp="🇰🇬">zastava</annotation>
 		<annotation cp="🇰🇬" type="tts">zastava: Kirgistan</annotation>
-		<annotation cp="🇰🇭">zastava | zastava: Kambodža</annotation>
+		<annotation cp="🇰🇭">zastava</annotation>
 		<annotation cp="🇰🇭" type="tts">zastava: Kambodža</annotation>
-		<annotation cp="🇰🇮">zastava | zastava: Kiribati</annotation>
+		<annotation cp="🇰🇮">zastava</annotation>
 		<annotation cp="🇰🇮" type="tts">zastava: Kiribati</annotation>
-		<annotation cp="🇰🇲">zastava | zastava: Komorska Ostrva</annotation>
+		<annotation cp="🇰🇲">zastava</annotation>
 		<annotation cp="🇰🇲" type="tts">zastava: Komorska Ostrva</annotation>
-		<annotation cp="🇰🇳">zastava | zastava: Sent Kits i Nevis</annotation>
+		<annotation cp="🇰🇳">zastava</annotation>
 		<annotation cp="🇰🇳" type="tts">zastava: Sent Kits i Nevis</annotation>
-		<annotation cp="🇰🇵">zastava | zastava: Severna Koreja</annotation>
+		<annotation cp="🇰🇵">zastava</annotation>
 		<annotation cp="🇰🇵" type="tts">zastava: Severna Koreja</annotation>
-		<annotation cp="🇰🇷">zastava | zastava: Južna Koreja</annotation>
+		<annotation cp="🇰🇷">zastava</annotation>
 		<annotation cp="🇰🇷" type="tts">zastava: Južna Koreja</annotation>
-		<annotation cp="🇰🇼">zastava | zastava: Kuvajt</annotation>
+		<annotation cp="🇰🇼">zastava</annotation>
 		<annotation cp="🇰🇼" type="tts">zastava: Kuvajt</annotation>
-		<annotation cp="🇰🇾">zastava | zastava: Kajmanska Ostrva</annotation>
+		<annotation cp="🇰🇾">zastava</annotation>
 		<annotation cp="🇰🇾" type="tts">zastava: Kajmanska Ostrva</annotation>
-		<annotation cp="🇰🇿">zastava | zastava: Kazahstan</annotation>
+		<annotation cp="🇰🇿">zastava</annotation>
 		<annotation cp="🇰🇿" type="tts">zastava: Kazahstan</annotation>
-		<annotation cp="🇱🇦">zastava | zastava: Laos</annotation>
+		<annotation cp="🇱🇦">zastava</annotation>
 		<annotation cp="🇱🇦" type="tts">zastava: Laos</annotation>
-		<annotation cp="🇱🇧">zastava | zastava: Liban</annotation>
+		<annotation cp="🇱🇧">zastava</annotation>
 		<annotation cp="🇱🇧" type="tts">zastava: Liban</annotation>
-		<annotation cp="🇱🇨">zastava | zastava: Sveta Lucija</annotation>
+		<annotation cp="🇱🇨">zastava</annotation>
 		<annotation cp="🇱🇨" type="tts">zastava: Sveta Lucija</annotation>
-		<annotation cp="🇱🇮">zastava | zastava: Lihtenštajn</annotation>
+		<annotation cp="🇱🇮">zastava</annotation>
 		<annotation cp="🇱🇮" type="tts">zastava: Lihtenštajn</annotation>
-		<annotation cp="🇱🇰">zastava | zastava: Šri Lanka</annotation>
+		<annotation cp="🇱🇰">zastava</annotation>
 		<annotation cp="🇱🇰" type="tts">zastava: Šri Lanka</annotation>
-		<annotation cp="🇱🇷">zastava | zastava: Liberija</annotation>
+		<annotation cp="🇱🇷">zastava</annotation>
 		<annotation cp="🇱🇷" type="tts">zastava: Liberija</annotation>
-		<annotation cp="🇱🇸">zastava | zastava: Lesoto</annotation>
+		<annotation cp="🇱🇸">zastava</annotation>
 		<annotation cp="🇱🇸" type="tts">zastava: Lesoto</annotation>
-		<annotation cp="🇱🇹">zastava | zastava: Litvanija</annotation>
+		<annotation cp="🇱🇹">zastava</annotation>
 		<annotation cp="🇱🇹" type="tts">zastava: Litvanija</annotation>
-		<annotation cp="🇱🇺">zastava | zastava: Luksemburg</annotation>
+		<annotation cp="🇱🇺">zastava</annotation>
 		<annotation cp="🇱🇺" type="tts">zastava: Luksemburg</annotation>
-		<annotation cp="🇱🇻">zastava | zastava: Letonija</annotation>
+		<annotation cp="🇱🇻">zastava</annotation>
 		<annotation cp="🇱🇻" type="tts">zastava: Letonija</annotation>
-		<annotation cp="🇱🇾">zastava | zastava: Libija</annotation>
+		<annotation cp="🇱🇾">zastava</annotation>
 		<annotation cp="🇱🇾" type="tts">zastava: Libija</annotation>
-		<annotation cp="🇲🇦">zastava | zastava: Maroko</annotation>
+		<annotation cp="🇲🇦">zastava</annotation>
 		<annotation cp="🇲🇦" type="tts">zastava: Maroko</annotation>
-		<annotation cp="🇲🇨">zastava | zastava: Monako</annotation>
+		<annotation cp="🇲🇨">zastava</annotation>
 		<annotation cp="🇲🇨" type="tts">zastava: Monako</annotation>
-		<annotation cp="🇲🇩">zastava | zastava: Moldavija</annotation>
+		<annotation cp="🇲🇩">zastava</annotation>
 		<annotation cp="🇲🇩" type="tts">zastava: Moldavija</annotation>
-		<annotation cp="🇲🇪">zastava | zastava: Crna Gora</annotation>
+		<annotation cp="🇲🇪">zastava</annotation>
 		<annotation cp="🇲🇪" type="tts">zastava: Crna Gora</annotation>
-		<annotation cp="🇲🇫">zastava | zastava: Sveti Martin (Francuska)</annotation>
+		<annotation cp="🇲🇫">zastava</annotation>
 		<annotation cp="🇲🇫" type="tts">zastava: Sveti Martin (Francuska)</annotation>
-		<annotation cp="🇲🇬">zastava | zastava: Madagaskar</annotation>
+		<annotation cp="🇲🇬">zastava</annotation>
 		<annotation cp="🇲🇬" type="tts">zastava: Madagaskar</annotation>
-		<annotation cp="🇲🇭">zastava | zastava: Maršalska Ostrva</annotation>
+		<annotation cp="🇲🇭">zastava</annotation>
 		<annotation cp="🇲🇭" type="tts">zastava: Maršalska Ostrva</annotation>
-		<annotation cp="🇲🇰">zastava | zastava: Severna Makedonija</annotation>
+		<annotation cp="🇲🇰">zastava</annotation>
 		<annotation cp="🇲🇰" type="tts">zastava: Severna Makedonija</annotation>
-		<annotation cp="🇲🇱">zastava | zastava: Mali</annotation>
+		<annotation cp="🇲🇱">zastava</annotation>
 		<annotation cp="🇲🇱" type="tts">zastava: Mali</annotation>
-		<annotation cp="🇲🇲">zastava | zastava: Mijanmar (Burma)</annotation>
+		<annotation cp="🇲🇲">zastava</annotation>
 		<annotation cp="🇲🇲" type="tts">zastava: Mijanmar (Burma)</annotation>
-		<annotation cp="🇲🇳">zastava | zastava: Mongolija</annotation>
+		<annotation cp="🇲🇳">zastava</annotation>
 		<annotation cp="🇲🇳" type="tts">zastava: Mongolija</annotation>
-		<annotation cp="🇲🇴">zastava | zastava: SAR Makao (Kina)</annotation>
+		<annotation cp="🇲🇴">zastava</annotation>
 		<annotation cp="🇲🇴" type="tts">zastava: SAR Makao (Kina)</annotation>
-		<annotation cp="🇲🇵">zastava | zastava: Severna Marijanska Ostrva</annotation>
+		<annotation cp="🇲🇵">zastava</annotation>
 		<annotation cp="🇲🇵" type="tts">zastava: Severna Marijanska Ostrva</annotation>
-		<annotation cp="🇲🇶">zastava | zastava: Martinik</annotation>
+		<annotation cp="🇲🇶">zastava</annotation>
 		<annotation cp="🇲🇶" type="tts">zastava: Martinik</annotation>
-		<annotation cp="🇲🇷">zastava | zastava: Mauritanija</annotation>
+		<annotation cp="🇲🇷">zastava</annotation>
 		<annotation cp="🇲🇷" type="tts">zastava: Mauritanija</annotation>
-		<annotation cp="🇲🇸">zastava | zastava: Monserat</annotation>
+		<annotation cp="🇲🇸">zastava</annotation>
 		<annotation cp="🇲🇸" type="tts">zastava: Monserat</annotation>
-		<annotation cp="🇲🇹">zastava | zastava: Malta</annotation>
+		<annotation cp="🇲🇹">zastava</annotation>
 		<annotation cp="🇲🇹" type="tts">zastava: Malta</annotation>
-		<annotation cp="🇲🇺">zastava | zastava: Mauricijus</annotation>
+		<annotation cp="🇲🇺">zastava</annotation>
 		<annotation cp="🇲🇺" type="tts">zastava: Mauricijus</annotation>
-		<annotation cp="🇲🇻">zastava | zastava: Maldivi</annotation>
+		<annotation cp="🇲🇻">zastava</annotation>
 		<annotation cp="🇲🇻" type="tts">zastava: Maldivi</annotation>
-		<annotation cp="🇲🇼">zastava | zastava: Malavi</annotation>
+		<annotation cp="🇲🇼">zastava</annotation>
 		<annotation cp="🇲🇼" type="tts">zastava: Malavi</annotation>
-		<annotation cp="🇲🇽">zastava | zastava: Meksiko</annotation>
+		<annotation cp="🇲🇽">zastava</annotation>
 		<annotation cp="🇲🇽" type="tts">zastava: Meksiko</annotation>
-		<annotation cp="🇲🇾">zastava | zastava: Malezija</annotation>
+		<annotation cp="🇲🇾">zastava</annotation>
 		<annotation cp="🇲🇾" type="tts">zastava: Malezija</annotation>
-		<annotation cp="🇲🇿">zastava | zastava: Mozambik</annotation>
+		<annotation cp="🇲🇿">zastava</annotation>
 		<annotation cp="🇲🇿" type="tts">zastava: Mozambik</annotation>
-		<annotation cp="🇳🇦">zastava | zastava: Namibija</annotation>
+		<annotation cp="🇳🇦">zastava</annotation>
 		<annotation cp="🇳🇦" type="tts">zastava: Namibija</annotation>
-		<annotation cp="🇳🇨">zastava | zastava: Nova Kaledonija</annotation>
+		<annotation cp="🇳🇨">zastava</annotation>
 		<annotation cp="🇳🇨" type="tts">zastava: Nova Kaledonija</annotation>
-		<annotation cp="🇳🇪">zastava | zastava: Niger</annotation>
+		<annotation cp="🇳🇪">zastava</annotation>
 		<annotation cp="🇳🇪" type="tts">zastava: Niger</annotation>
-		<annotation cp="🇳🇫">zastava | zastava: Ostrvo Norfok</annotation>
+		<annotation cp="🇳🇫">zastava</annotation>
 		<annotation cp="🇳🇫" type="tts">zastava: Ostrvo Norfok</annotation>
-		<annotation cp="🇳🇬">zastava | zastava: Nigerija</annotation>
+		<annotation cp="🇳🇬">zastava</annotation>
 		<annotation cp="🇳🇬" type="tts">zastava: Nigerija</annotation>
-		<annotation cp="🇳🇮">zastava | zastava: Nikaragva</annotation>
+		<annotation cp="🇳🇮">zastava</annotation>
 		<annotation cp="🇳🇮" type="tts">zastava: Nikaragva</annotation>
-		<annotation cp="🇳🇱">zastava | zastava: Holandija</annotation>
+		<annotation cp="🇳🇱">zastava</annotation>
 		<annotation cp="🇳🇱" type="tts">zastava: Holandija</annotation>
-		<annotation cp="🇳🇴">zastava | zastava: Norveška</annotation>
+		<annotation cp="🇳🇴">zastava</annotation>
 		<annotation cp="🇳🇴" type="tts">zastava: Norveška</annotation>
-		<annotation cp="🇳🇵">zastava | zastava: Nepal</annotation>
+		<annotation cp="🇳🇵">zastava</annotation>
 		<annotation cp="🇳🇵" type="tts">zastava: Nepal</annotation>
-		<annotation cp="🇳🇷">zastava | zastava: Nauru</annotation>
+		<annotation cp="🇳🇷">zastava</annotation>
 		<annotation cp="🇳🇷" type="tts">zastava: Nauru</annotation>
-		<annotation cp="🇳🇺">zastava | zastava: Niue</annotation>
+		<annotation cp="🇳🇺">zastava</annotation>
 		<annotation cp="🇳🇺" type="tts">zastava: Niue</annotation>
-		<annotation cp="🇳🇿">zastava | zastava: Novi Zeland</annotation>
+		<annotation cp="🇳🇿">zastava</annotation>
 		<annotation cp="🇳🇿" type="tts">zastava: Novi Zeland</annotation>
-		<annotation cp="🇴🇲">zastava | zastava: Oman</annotation>
+		<annotation cp="🇴🇲">zastava</annotation>
 		<annotation cp="🇴🇲" type="tts">zastava: Oman</annotation>
-		<annotation cp="🇵🇦">zastava | zastava: Panama</annotation>
+		<annotation cp="🇵🇦">zastava</annotation>
 		<annotation cp="🇵🇦" type="tts">zastava: Panama</annotation>
-		<annotation cp="🇵🇪">zastava | zastava: Peru</annotation>
+		<annotation cp="🇵🇪">zastava</annotation>
 		<annotation cp="🇵🇪" type="tts">zastava: Peru</annotation>
-		<annotation cp="🇵🇫">zastava | zastava: Francuska Polinezija</annotation>
+		<annotation cp="🇵🇫">zastava</annotation>
 		<annotation cp="🇵🇫" type="tts">zastava: Francuska Polinezija</annotation>
-		<annotation cp="🇵🇬">zastava | zastava: Papua Nova Gvineja</annotation>
+		<annotation cp="🇵🇬">zastava</annotation>
 		<annotation cp="🇵🇬" type="tts">zastava: Papua Nova Gvineja</annotation>
-		<annotation cp="🇵🇭">zastava | zastava: Filipini</annotation>
+		<annotation cp="🇵🇭">zastava</annotation>
 		<annotation cp="🇵🇭" type="tts">zastava: Filipini</annotation>
-		<annotation cp="🇵🇰">zastava | zastava: Pakistan</annotation>
+		<annotation cp="🇵🇰">zastava</annotation>
 		<annotation cp="🇵🇰" type="tts">zastava: Pakistan</annotation>
-		<annotation cp="🇵🇱">zastava | zastava: Poljska</annotation>
+		<annotation cp="🇵🇱">zastava</annotation>
 		<annotation cp="🇵🇱" type="tts">zastava: Poljska</annotation>
-		<annotation cp="🇵🇲">zastava | zastava: Sen Pjer i Mikelon</annotation>
+		<annotation cp="🇵🇲">zastava</annotation>
 		<annotation cp="🇵🇲" type="tts">zastava: Sen Pjer i Mikelon</annotation>
-		<annotation cp="🇵🇳">zastava | zastava: Pitkern</annotation>
+		<annotation cp="🇵🇳">zastava</annotation>
 		<annotation cp="🇵🇳" type="tts">zastava: Pitkern</annotation>
-		<annotation cp="🇵🇷">zastava | zastava: Portoriko</annotation>
+		<annotation cp="🇵🇷">zastava</annotation>
 		<annotation cp="🇵🇷" type="tts">zastava: Portoriko</annotation>
-		<annotation cp="🇵🇸">zastava | zastava: Palestinske teritorije</annotation>
+		<annotation cp="🇵🇸">zastava</annotation>
 		<annotation cp="🇵🇸" type="tts">zastava: Palestinske teritorije</annotation>
-		<annotation cp="🇵🇹">zastava | zastava: Portugalija</annotation>
+		<annotation cp="🇵🇹">zastava</annotation>
 		<annotation cp="🇵🇹" type="tts">zastava: Portugalija</annotation>
-		<annotation cp="🇵🇼">zastava | zastava: Palau</annotation>
+		<annotation cp="🇵🇼">zastava</annotation>
 		<annotation cp="🇵🇼" type="tts">zastava: Palau</annotation>
-		<annotation cp="🇵🇾">zastava | zastava: Paragvaj</annotation>
+		<annotation cp="🇵🇾">zastava</annotation>
 		<annotation cp="🇵🇾" type="tts">zastava: Paragvaj</annotation>
-		<annotation cp="🇶🇦">zastava | zastava: Katar</annotation>
+		<annotation cp="🇶🇦">zastava</annotation>
 		<annotation cp="🇶🇦" type="tts">zastava: Katar</annotation>
-		<annotation cp="🇷🇪">zastava | zastava: Reinion</annotation>
+		<annotation cp="🇷🇪">zastava</annotation>
 		<annotation cp="🇷🇪" type="tts">zastava: Reinion</annotation>
-		<annotation cp="🇷🇴">zastava | zastava: Rumunija</annotation>
+		<annotation cp="🇷🇴">zastava</annotation>
 		<annotation cp="🇷🇴" type="tts">zastava: Rumunija</annotation>
-		<annotation cp="🇷🇸">zastava | zastava: Srbija</annotation>
+		<annotation cp="🇷🇸">zastava</annotation>
 		<annotation cp="🇷🇸" type="tts">zastava: Srbija</annotation>
-		<annotation cp="🇷🇺">zastava | zastava: Rusija</annotation>
+		<annotation cp="🇷🇺">zastava</annotation>
 		<annotation cp="🇷🇺" type="tts">zastava: Rusija</annotation>
-		<annotation cp="🇷🇼">zastava | zastava: Ruanda</annotation>
+		<annotation cp="🇷🇼">zastava</annotation>
 		<annotation cp="🇷🇼" type="tts">zastava: Ruanda</annotation>
-		<annotation cp="🇸🇦">zastava | zastava: Saudijska Arabija</annotation>
+		<annotation cp="🇸🇦">zastava</annotation>
 		<annotation cp="🇸🇦" type="tts">zastava: Saudijska Arabija</annotation>
-		<annotation cp="🇸🇧">zastava | zastava: Solomonska Ostrva</annotation>
+		<annotation cp="🇸🇧">zastava</annotation>
 		<annotation cp="🇸🇧" type="tts">zastava: Solomonska Ostrva</annotation>
-		<annotation cp="🇸🇨">zastava | zastava: Sejšeli</annotation>
+		<annotation cp="🇸🇨">zastava</annotation>
 		<annotation cp="🇸🇨" type="tts">zastava: Sejšeli</annotation>
-		<annotation cp="🇸🇩">zastava | zastava: Sudan</annotation>
+		<annotation cp="🇸🇩">zastava</annotation>
 		<annotation cp="🇸🇩" type="tts">zastava: Sudan</annotation>
-		<annotation cp="🇸🇪">zastava | zastava: Švedska</annotation>
+		<annotation cp="🇸🇪">zastava</annotation>
 		<annotation cp="🇸🇪" type="tts">zastava: Švedska</annotation>
-		<annotation cp="🇸🇬">zastava | zastava: Singapur</annotation>
+		<annotation cp="🇸🇬">zastava</annotation>
 		<annotation cp="🇸🇬" type="tts">zastava: Singapur</annotation>
-		<annotation cp="🇸🇭">zastava | zastava: Sveta Jelena</annotation>
+		<annotation cp="🇸🇭">zastava</annotation>
 		<annotation cp="🇸🇭" type="tts">zastava: Sveta Jelena</annotation>
-		<annotation cp="🇸🇮">zastava | zastava: Slovenija</annotation>
+		<annotation cp="🇸🇮">zastava</annotation>
 		<annotation cp="🇸🇮" type="tts">zastava: Slovenija</annotation>
-		<annotation cp="🇸🇯">zastava | zastava: Svalbard i Jan Majen</annotation>
+		<annotation cp="🇸🇯">zastava</annotation>
 		<annotation cp="🇸🇯" type="tts">zastava: Svalbard i Jan Majen</annotation>
-		<annotation cp="🇸🇰">zastava | zastava: Slovačka</annotation>
+		<annotation cp="🇸🇰">zastava</annotation>
 		<annotation cp="🇸🇰" type="tts">zastava: Slovačka</annotation>
-		<annotation cp="🇸🇱">zastava | zastava: Sijera Leone</annotation>
+		<annotation cp="🇸🇱">zastava</annotation>
 		<annotation cp="🇸🇱" type="tts">zastava: Sijera Leone</annotation>
-		<annotation cp="🇸🇲">zastava | zastava: San Marino</annotation>
+		<annotation cp="🇸🇲">zastava</annotation>
 		<annotation cp="🇸🇲" type="tts">zastava: San Marino</annotation>
-		<annotation cp="🇸🇳">zastava | zastava: Senegal</annotation>
+		<annotation cp="🇸🇳">zastava</annotation>
 		<annotation cp="🇸🇳" type="tts">zastava: Senegal</annotation>
-		<annotation cp="🇸🇴">zastava | zastava: Somalija</annotation>
+		<annotation cp="🇸🇴">zastava</annotation>
 		<annotation cp="🇸🇴" type="tts">zastava: Somalija</annotation>
-		<annotation cp="🇸🇷">zastava | zastava: Surinam</annotation>
+		<annotation cp="🇸🇷">zastava</annotation>
 		<annotation cp="🇸🇷" type="tts">zastava: Surinam</annotation>
-		<annotation cp="🇸🇸">zastava | zastava: Južni Sudan</annotation>
+		<annotation cp="🇸🇸">zastava</annotation>
 		<annotation cp="🇸🇸" type="tts">zastava: Južni Sudan</annotation>
-		<annotation cp="🇸🇹">zastava | zastava: Sao Tome i Principe</annotation>
+		<annotation cp="🇸🇹">zastava</annotation>
 		<annotation cp="🇸🇹" type="tts">zastava: Sao Tome i Principe</annotation>
-		<annotation cp="🇸🇻">zastava | zastava: Salvador</annotation>
+		<annotation cp="🇸🇻">zastava</annotation>
 		<annotation cp="🇸🇻" type="tts">zastava: Salvador</annotation>
-		<annotation cp="🇸🇽">zastava | zastava: Sveti Martin (Holandija)</annotation>
+		<annotation cp="🇸🇽">zastava</annotation>
 		<annotation cp="🇸🇽" type="tts">zastava: Sveti Martin (Holandija)</annotation>
-		<annotation cp="🇸🇾">zastava | zastava: Sirija</annotation>
+		<annotation cp="🇸🇾">zastava</annotation>
 		<annotation cp="🇸🇾" type="tts">zastava: Sirija</annotation>
-		<annotation cp="🇸🇿">zastava | zastava: Svazilend</annotation>
+		<annotation cp="🇸🇿">zastava</annotation>
 		<annotation cp="🇸🇿" type="tts">zastava: Svazilend</annotation>
-		<annotation cp="🇹🇦">zastava | zastava: Tristan da Kunja</annotation>
+		<annotation cp="🇹🇦">zastava</annotation>
 		<annotation cp="🇹🇦" type="tts">zastava: Tristan da Kunja</annotation>
-		<annotation cp="🇹🇨">zastava | zastava: Ostrva Turks i Kaikos</annotation>
+		<annotation cp="🇹🇨">zastava</annotation>
 		<annotation cp="🇹🇨" type="tts">zastava: Ostrva Turks i Kaikos</annotation>
-		<annotation cp="🇹🇩">zastava | zastava: Čad</annotation>
+		<annotation cp="🇹🇩">zastava</annotation>
 		<annotation cp="🇹🇩" type="tts">zastava: Čad</annotation>
-		<annotation cp="🇹🇫">zastava | zastava: Francuske Južne Teritorije</annotation>
+		<annotation cp="🇹🇫">zastava</annotation>
 		<annotation cp="🇹🇫" type="tts">zastava: Francuske Južne Teritorije</annotation>
-		<annotation cp="🇹🇬">zastava | zastava: Togo</annotation>
+		<annotation cp="🇹🇬">zastava</annotation>
 		<annotation cp="🇹🇬" type="tts">zastava: Togo</annotation>
-		<annotation cp="🇹🇭">zastava | zastava: Tajland</annotation>
+		<annotation cp="🇹🇭">zastava</annotation>
 		<annotation cp="🇹🇭" type="tts">zastava: Tajland</annotation>
-		<annotation cp="🇹🇯">zastava | zastava: Tadžikistan</annotation>
+		<annotation cp="🇹🇯">zastava</annotation>
 		<annotation cp="🇹🇯" type="tts">zastava: Tadžikistan</annotation>
-		<annotation cp="🇹🇰">zastava | zastava: Tokelau</annotation>
+		<annotation cp="🇹🇰">zastava</annotation>
 		<annotation cp="🇹🇰" type="tts">zastava: Tokelau</annotation>
-		<annotation cp="🇹🇱">zastava | zastava: Timor-Leste (Istočni Timor)</annotation>
+		<annotation cp="🇹🇱">zastava</annotation>
 		<annotation cp="🇹🇱" type="tts">zastava: Timor-Leste (Istočni Timor)</annotation>
-		<annotation cp="🇹🇲">zastava | zastava: Turkmenistan</annotation>
+		<annotation cp="🇹🇲">zastava</annotation>
 		<annotation cp="🇹🇲" type="tts">zastava: Turkmenistan</annotation>
-		<annotation cp="🇹🇳">zastava | zastava: Tunis</annotation>
+		<annotation cp="🇹🇳">zastava</annotation>
 		<annotation cp="🇹🇳" type="tts">zastava: Tunis</annotation>
-		<annotation cp="🇹🇴">zastava | zastava: Tonga</annotation>
+		<annotation cp="🇹🇴">zastava</annotation>
 		<annotation cp="🇹🇴" type="tts">zastava: Tonga</annotation>
-		<annotation cp="🇹🇷">zastava | zastava: Turska</annotation>
+		<annotation cp="🇹🇷">zastava</annotation>
 		<annotation cp="🇹🇷" type="tts">zastava: Turska</annotation>
-		<annotation cp="🇹🇹">zastava | zastava: Trinidad i Tobago</annotation>
+		<annotation cp="🇹🇹">zastava</annotation>
 		<annotation cp="🇹🇹" type="tts">zastava: Trinidad i Tobago</annotation>
-		<annotation cp="🇹🇻">zastava | zastava: Tuvalu</annotation>
+		<annotation cp="🇹🇻">zastava</annotation>
 		<annotation cp="🇹🇻" type="tts">zastava: Tuvalu</annotation>
-		<annotation cp="🇹🇼">zastava | zastava: Tajvan</annotation>
+		<annotation cp="🇹🇼">zastava</annotation>
 		<annotation cp="🇹🇼" type="tts">zastava: Tajvan</annotation>
-		<annotation cp="🇹🇿">zastava | zastava: Tanzanija</annotation>
+		<annotation cp="🇹🇿">zastava</annotation>
 		<annotation cp="🇹🇿" type="tts">zastava: Tanzanija</annotation>
-		<annotation cp="🇺🇦">zastava | zastava: Ukrajina</annotation>
+		<annotation cp="🇺🇦">zastava</annotation>
 		<annotation cp="🇺🇦" type="tts">zastava: Ukrajina</annotation>
-		<annotation cp="🇺🇬">zastava | zastava: Uganda</annotation>
+		<annotation cp="🇺🇬">zastava</annotation>
 		<annotation cp="🇺🇬" type="tts">zastava: Uganda</annotation>
-		<annotation cp="🇺🇲">zastava | zastava: Udaljena ostrva SAD</annotation>
+		<annotation cp="🇺🇲">zastava</annotation>
 		<annotation cp="🇺🇲" type="tts">zastava: Udaljena ostrva SAD</annotation>
-		<annotation cp="🇺🇳">zastava | zastava: Ujedinjene nacije</annotation>
+		<annotation cp="🇺🇳">zastava</annotation>
 		<annotation cp="🇺🇳" type="tts">zastava: Ujedinjene nacije</annotation>
-		<annotation cp="🇺🇸">zastava | zastava: Sjedinjene Države</annotation>
+		<annotation cp="🇺🇸">zastava</annotation>
 		<annotation cp="🇺🇸" type="tts">zastava: Sjedinjene Države</annotation>
-		<annotation cp="🇺🇾">zastava | zastava: Urugvaj</annotation>
+		<annotation cp="🇺🇾">zastava</annotation>
 		<annotation cp="🇺🇾" type="tts">zastava: Urugvaj</annotation>
-		<annotation cp="🇺🇿">zastava | zastava: Uzbekistan</annotation>
+		<annotation cp="🇺🇿">zastava</annotation>
 		<annotation cp="🇺🇿" type="tts">zastava: Uzbekistan</annotation>
-		<annotation cp="🇻🇦">zastava | zastava: Vatikan</annotation>
+		<annotation cp="🇻🇦">zastava</annotation>
 		<annotation cp="🇻🇦" type="tts">zastava: Vatikan</annotation>
-		<annotation cp="🇻🇨">zastava | zastava: Sent Vinsent i Grenadini</annotation>
+		<annotation cp="🇻🇨">zastava</annotation>
 		<annotation cp="🇻🇨" type="tts">zastava: Sent Vinsent i Grenadini</annotation>
-		<annotation cp="🇻🇪">zastava | zastava: Venecuela</annotation>
+		<annotation cp="🇻🇪">zastava</annotation>
 		<annotation cp="🇻🇪" type="tts">zastava: Venecuela</annotation>
-		<annotation cp="🇻🇬">zastava | zastava: Britanska Devičanska Ostrva</annotation>
+		<annotation cp="🇻🇬">zastava</annotation>
 		<annotation cp="🇻🇬" type="tts">zastava: Britanska Devičanska Ostrva</annotation>
-		<annotation cp="🇻🇮">zastava | zastava: Američka Devičanska Ostrva</annotation>
+		<annotation cp="🇻🇮">zastava</annotation>
 		<annotation cp="🇻🇮" type="tts">zastava: Američka Devičanska Ostrva</annotation>
-		<annotation cp="🇻🇳">zastava | zastava: Vijetnam</annotation>
+		<annotation cp="🇻🇳">zastava</annotation>
 		<annotation cp="🇻🇳" type="tts">zastava: Vijetnam</annotation>
-		<annotation cp="🇻🇺">zastava | zastava: Vanuatu</annotation>
+		<annotation cp="🇻🇺">zastava</annotation>
 		<annotation cp="🇻🇺" type="tts">zastava: Vanuatu</annotation>
-		<annotation cp="🇼🇫">zastava | zastava: Valis i Futuna</annotation>
+		<annotation cp="🇼🇫">zastava</annotation>
 		<annotation cp="🇼🇫" type="tts">zastava: Valis i Futuna</annotation>
-		<annotation cp="🇼🇸">zastava | zastava: Samoa</annotation>
+		<annotation cp="🇼🇸">zastava</annotation>
 		<annotation cp="🇼🇸" type="tts">zastava: Samoa</annotation>
-		<annotation cp="🇽🇰">zastava | zastava: Kosovo</annotation>
+		<annotation cp="🇽🇰">zastava</annotation>
 		<annotation cp="🇽🇰" type="tts">zastava: Kosovo</annotation>
-		<annotation cp="🇾🇪">zastava | zastava: Jemen</annotation>
+		<annotation cp="🇾🇪">zastava</annotation>
 		<annotation cp="🇾🇪" type="tts">zastava: Jemen</annotation>
-		<annotation cp="🇾🇹">zastava | zastava: Majot</annotation>
+		<annotation cp="🇾🇹">zastava</annotation>
 		<annotation cp="🇾🇹" type="tts">zastava: Majot</annotation>
-		<annotation cp="🇿🇦">zastava | zastava: Južnoafrička Republika</annotation>
+		<annotation cp="🇿🇦">zastava</annotation>
 		<annotation cp="🇿🇦" type="tts">zastava: Južnoafrička Republika</annotation>
-		<annotation cp="🇿🇲">zastava | zastava: Zambija</annotation>
+		<annotation cp="🇿🇲">zastava</annotation>
 		<annotation cp="🇿🇲" type="tts">zastava: Zambija</annotation>
-		<annotation cp="🇿🇼">zastava | zastava: Zimbabve</annotation>
+		<annotation cp="🇿🇼">zastava</annotation>
 		<annotation cp="🇿🇼" type="tts">zastava: Zimbabve</annotation>
-		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿">zastava | zastava: Engleska</annotation>
+		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿">zastava</annotation>
 		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿" type="tts">zastava: Engleska</annotation>
-		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿">zastava | zastava: Škotska</annotation>
+		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿">zastava</annotation>
 		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿" type="tts">zastava: Škotska</annotation>
-		<annotation cp="🏴󠁧󠁢󠁷󠁬󠁳󠁿">zastava | zastava: Vels</annotation>
+		<annotation cp="🏴󠁧󠁢󠁷󠁬󠁳󠁿">zastava</annotation>
 		<annotation cp="🏴󠁧󠁢󠁷󠁬󠁳󠁿" type="tts">zastava: Vels</annotation>
-		<annotation cp="¤">Nepoznata valuta</annotation>
 		<annotation cp="¤" type="tts">Nepoznata valuta</annotation>
-		<annotation cp="֏">jermenski dram</annotation>
 		<annotation cp="֏" type="tts">jermenski dram</annotation>
-		<annotation cp="؋">avganistanski avgani</annotation>
 		<annotation cp="؋" type="tts">avganistanski avgani</annotation>
-		<annotation cp="৳">bangladeška taka</annotation>
 		<annotation cp="৳" type="tts">bangladeška taka</annotation>
-		<annotation cp="฿">tajlandski bat</annotation>
 		<annotation cp="฿" type="tts">tajlandski bat</annotation>
-		<annotation cp="៛">kambodžanski rijel</annotation>
 		<annotation cp="៛" type="tts">kambodžanski rijel</annotation>
-		<annotation cp="₡">kostarikanski kolon</annotation>
 		<annotation cp="₡" type="tts">kostarikanski kolon</annotation>
-		<annotation cp="₦">nigerijska naira</annotation>
 		<annotation cp="₦" type="tts">nigerijska naira</annotation>
-		<annotation cp="₪">izraelski novi šekel</annotation>
 		<annotation cp="₪" type="tts">izraelski novi šekel</annotation>
-		<annotation cp="₫">vijetnamski dong</annotation>
 		<annotation cp="₫" type="tts">vijetnamski dong</annotation>
-		<annotation cp="₭">laoski kip</annotation>
 		<annotation cp="₭" type="tts">laoski kip</annotation>
-		<annotation cp="₮">mongolski tugrik</annotation>
 		<annotation cp="₮" type="tts">mongolski tugrik</annotation>
-		<annotation cp="₲">paragvajski gvarani</annotation>
 		<annotation cp="₲" type="tts">paragvajski gvarani</annotation>
-		<annotation cp="₴">ukrajinska grivna</annotation>
 		<annotation cp="₴" type="tts">ukrajinska grivna</annotation>
-		<annotation cp="₵">ganski sedi</annotation>
 		<annotation cp="₵" type="tts">ganski sedi</annotation>
-		<annotation cp="₸">kazahstanski tenge</annotation>
 		<annotation cp="₸" type="tts">kazahstanski tenge</annotation>
-		<annotation cp="₺">turska lira</annotation>
 		<annotation cp="₺" type="tts">turska lira</annotation>
-		<annotation cp="₼">azerbejdžanski manat</annotation>
 		<annotation cp="₼" type="tts">azerbejdžanski manat</annotation>
-		<annotation cp="₾">gruzijski lari</annotation>
 		<annotation cp="₾" type="tts">gruzijski lari</annotation>
-		<annotation cp="0⃣">taster | taster: 0</annotation>
+		<annotation cp="0⃣">taster</annotation>
 		<annotation cp="0⃣" type="tts">taster: 0</annotation>
-		<annotation cp="1⃣">taster | taster: 1</annotation>
+		<annotation cp="1⃣">taster</annotation>
 		<annotation cp="1⃣" type="tts">taster: 1</annotation>
-		<annotation cp="2⃣">taster | taster: 2</annotation>
+		<annotation cp="2⃣">taster</annotation>
 		<annotation cp="2⃣" type="tts">taster: 2</annotation>
-		<annotation cp="3⃣">taster | taster: 3</annotation>
+		<annotation cp="3⃣">taster</annotation>
 		<annotation cp="3⃣" type="tts">taster: 3</annotation>
-		<annotation cp="4⃣">taster | taster: 4</annotation>
+		<annotation cp="4⃣">taster</annotation>
 		<annotation cp="4⃣" type="tts">taster: 4</annotation>
-		<annotation cp="5⃣">taster | taster: 5</annotation>
+		<annotation cp="5⃣">taster</annotation>
 		<annotation cp="5⃣" type="tts">taster: 5</annotation>
-		<annotation cp="6⃣">taster | taster: 6</annotation>
+		<annotation cp="6⃣">taster</annotation>
 		<annotation cp="6⃣" type="tts">taster: 6</annotation>
-		<annotation cp="7⃣">taster | taster: 7</annotation>
+		<annotation cp="7⃣">taster</annotation>
 		<annotation cp="7⃣" type="tts">taster: 7</annotation>
-		<annotation cp="8⃣">taster | taster: 8</annotation>
+		<annotation cp="8⃣">taster</annotation>
 		<annotation cp="8⃣" type="tts">taster: 8</annotation>
-		<annotation cp="9⃣">taster | taster: 9</annotation>
+		<annotation cp="9⃣">taster</annotation>
 		<annotation cp="9⃣" type="tts">taster: 9</annotation>
-		<annotation cp="₧">Španska pezeta</annotation>
 		<annotation cp="₧" type="tts">Španska pezeta</annotation>
 	</annotations>
 </ldml>

--- a/common/annotationsDerived/sr_Latn_BA.xml
+++ b/common/annotationsDerived/sr_Latn_BA.xml
@@ -15,2750 +15,2719 @@ Derived short names and annotations, using GenerateDerivedAnnotations.java. See 
 		<territory type="BA"/>
 	</identity>
 	<annotations>
-		<annotation cp="👋🏻">ruka koja maše | ruka koja maše: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👋🏻">ruka koja maše | svijetla koža</annotation>
 		<annotation cp="👋🏻" type="tts">ruka koja maše: svijetla koža</annotation>
-		<annotation cp="👋🏼">ruka koja maše | ruka koja maše: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👋🏼">ruka koja maše | srednje svijetla koža</annotation>
 		<annotation cp="👋🏼" type="tts">ruka koja maše: srednje svijetla koža</annotation>
-		<annotation cp="👋🏽">ni svijetla ni tamna koža | ruka koja maše | ruka koja maše: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👋🏽">ni svijetla ni tamna koža | ruka koja maše</annotation>
 		<annotation cp="👋🏽" type="tts">ruka koja maše: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👋🏾">ruka koja maše | srednje tamna koža</annotation>
 		<annotation cp="👋🏿">ruka koja maše | tamna koža</annotation>
-		<annotation cp="🤚🏻">dlan | podignut dlan | podignut dlan: svijetla koža | podignuto | svijetla koža</annotation>
+		<annotation cp="🤚🏻">dlan | podignut dlan | podignuto | svijetla koža</annotation>
 		<annotation cp="🤚🏻" type="tts">podignut dlan: svijetla koža</annotation>
-		<annotation cp="🤚🏼">dlan | podignut dlan | podignut dlan: srednje svijetla koža | podignuto | srednje svijetla koža</annotation>
+		<annotation cp="🤚🏼">dlan | podignut dlan | podignuto | srednje svijetla koža</annotation>
 		<annotation cp="🤚🏼" type="tts">podignut dlan: srednje svijetla koža</annotation>
-		<annotation cp="🤚🏽">dlan | ni svijetla ni tamna koža | podignut dlan | podignut dlan: ni svijetla ni tamna koža | podignuto</annotation>
+		<annotation cp="🤚🏽">dlan | ni svijetla ni tamna koža | podignut dlan | podignuto</annotation>
 		<annotation cp="🤚🏽" type="tts">podignut dlan: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🖐🏻">prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🖐🏻">prst | rašireno | ruka | šaka sa raširenim prstima | svijetla koža</annotation>
 		<annotation cp="🖐🏻" type="tts">šaka sa raširenim prstima: svijetla koža</annotation>
-		<annotation cp="🖐🏼">prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🖐🏼">prst | rašireno | ruka | šaka sa raširenim prstima | srednje svijetla koža</annotation>
 		<annotation cp="🖐🏼" type="tts">šaka sa raširenim prstima: srednje svijetla koža</annotation>
-		<annotation cp="🖐🏽">ni svijetla ni tamna koža | prst | rašireno | ruka | šaka sa raširenim prstima | šaka sa raširenim prstima: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🖐🏽">ni svijetla ni tamna koža | prst | rašireno | ruka | šaka sa raširenim prstima</annotation>
 		<annotation cp="🖐🏽" type="tts">šaka sa raširenim prstima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="✋🏻">podignuta ruka | podignuta ruka: svijetla koža | svijetla koža</annotation>
+		<annotation cp="✋🏻">podignuta ruka | svijetla koža</annotation>
 		<annotation cp="✋🏻" type="tts">podignuta ruka: svijetla koža</annotation>
-		<annotation cp="✋🏼">podignuta ruka | podignuta ruka: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="✋🏼">podignuta ruka | srednje svijetla koža</annotation>
 		<annotation cp="✋🏼" type="tts">podignuta ruka: srednje svijetla koža</annotation>
-		<annotation cp="✋🏽">ni svijetla ni tamna koža | podignuta ruka | podignuta ruka: ni svijetla ni tamna koža</annotation>
+		<annotation cp="✋🏽">ni svijetla ni tamna koža | podignuta ruka</annotation>
 		<annotation cp="✋🏽" type="tts">podignuta ruka: ni svijetla ni tamna koža</annotation>
 		<annotation cp="✋🏾">podignuta ruka | srednje tamna koža</annotation>
 		<annotation cp="✋🏿">podignuta ruka | tamna koža</annotation>
-		<annotation cp="🖖🏻">svijetla koža | vulkanski pozdrav | vulkanski pozdrav: svijetla koža</annotation>
+		<annotation cp="🖖🏻">svijetla koža | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏻" type="tts">vulkanski pozdrav: svijetla koža</annotation>
-		<annotation cp="🖖🏼">srednje svijetla koža | vulkanski pozdrav | vulkanski pozdrav: srednje svijetla koža</annotation>
+		<annotation cp="🖖🏼">srednje svijetla koža | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏼" type="tts">vulkanski pozdrav: srednje svijetla koža</annotation>
-		<annotation cp="🖖🏽">ni svijetla ni tamna koža | vulkanski pozdrav | vulkanski pozdrav: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🖖🏽">ni svijetla ni tamna koža | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏽" type="tts">vulkanski pozdrav: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🖖🏾">srednje tamna koža | vulkanski pozdrav</annotation>
 		<annotation cp="🖖🏿">tamna koža | vulkanski pozdrav</annotation>
-		<annotation cp="🫱🏻">desno | nadesno | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🫱🏻">desno | nadesno | ruka | ruka okrenuta nadesno | svijetla koža</annotation>
 		<annotation cp="🫱🏻" type="tts">ruka okrenuta nadesno: svijetla koža</annotation>
-		<annotation cp="🫱🏼">desno | nadesno | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🫱🏼">desno | nadesno | ruka | ruka okrenuta nadesno | srednje svijetla koža</annotation>
 		<annotation cp="🫱🏼" type="tts">ruka okrenuta nadesno: srednje svijetla koža</annotation>
-		<annotation cp="🫱🏽">desno | nadesno | ni svijetla ni tamna koža | ruka | ruka okrenuta nadesno | ruka okrenuta nadesno: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🫱🏽">desno | nadesno | ni svijetla ni tamna koža | ruka | ruka okrenuta nadesno</annotation>
 		<annotation cp="🫱🏽" type="tts">ruka okrenuta nadesno: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏼">rukovanje | rukovanje: svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏼">rukovanje | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏼" type="tts">rukovanje: svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏽">ni svijetla ni tamna koža | rukovanje | rukovanje: svijetla koža i ni svijetla ni tamna koža | svijetla koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏽">ni svijetla ni tamna koža | rukovanje | svijetla koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏽" type="tts">rukovanje: svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏾">rukovanje | rukovanje: svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏾">rukovanje | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏾" type="tts">rukovanje: svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🫱🏻‍🫲🏿">rukovanje | rukovanje: svijetla koža i tamna koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏻‍🫲🏿">rukovanje | svijetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏻‍🫲🏿" type="tts">rukovanje: svijetla koža i tamna koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏻">rukovanje | rukovanje: srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏻">rukovanje | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏻" type="tts">rukovanje: srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏽">ni svijetla ni tamna koža | rukovanje | rukovanje: srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏽">ni svijetla ni tamna koža | rukovanje | srednje svijetla koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏽" type="tts">rukovanje: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏾">rukovanje | rukovanje: srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏾">rukovanje | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏾" type="tts">rukovanje: srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🫱🏼‍🫲🏿">rukovanje | rukovanje: srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏼‍🫲🏿">rukovanje | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏼‍🫲🏿" type="tts">rukovanje: srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏻">ni svijetla ni tamna koža | rukovanje | rukovanje: ni svijetla ni tamna koža i svijetla koža | svijetla koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏻">ni svijetla ni tamna koža | rukovanje | svijetla koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏻" type="tts">rukovanje: ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏼">ni svijetla ni tamna koža | rukovanje | rukovanje: ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏼">ni svijetla ni tamna koža | rukovanje | srednje svijetla koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏼" type="tts">rukovanje: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏾">ni svijetla ni tamna koža | rukovanje | rukovanje: ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏾">ni svijetla ni tamna koža | rukovanje | srednje tamna koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏾" type="tts">rukovanje: ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🫱🏽‍🫲🏿">ni svijetla ni tamna koža | rukovanje | rukovanje: ni svijetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🫱🏽‍🫲🏿">ni svijetla ni tamna koža | rukovanje | tamna koža</annotation>
 		<annotation cp="🫱🏽‍🫲🏿" type="tts">rukovanje: ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏻">rukovanje | rukovanje: srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏻">rukovanje | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏻" type="tts">rukovanje: srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏼">rukovanje | rukovanje: srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏼">rukovanje | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏼" type="tts">rukovanje: srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🫱🏾‍🫲🏽">ni svijetla ni tamna koža | rukovanje | rukovanje: srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🫱🏾‍🫲🏽">ni svijetla ni tamna koža | rukovanje | srednje tamna koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏽" type="tts">rukovanje: srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="🫱🏾‍🫲🏿">rukovanje | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏻">rukovanje | rukovanje: tamna koža i svijetla koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏻">rukovanje | svijetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏻" type="tts">rukovanje: tamna koža i svijetla koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏼">rukovanje | rukovanje: tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏼">rukovanje | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏼" type="tts">rukovanje: tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🫱🏿‍🫲🏽">ni svijetla ni tamna koža | rukovanje | rukovanje: tamna koža i ni svijetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🫱🏿‍🫲🏽">ni svijetla ni tamna koža | rukovanje | tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏽" type="tts">rukovanje: tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="🫱🏿‍🫲🏾">rukovanje | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="🫲🏻">levo | nalevo | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🫲🏻">levo | nalevo | ruka | ruka okrenuta nalevo | svijetla koža</annotation>
 		<annotation cp="🫲🏻" type="tts">ruka okrenuta nalevo: svijetla koža</annotation>
-		<annotation cp="🫲🏼">levo | nalevo | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🫲🏼">levo | nalevo | ruka | ruka okrenuta nalevo | srednje svijetla koža</annotation>
 		<annotation cp="🫲🏼" type="tts">ruka okrenuta nalevo: srednje svijetla koža</annotation>
-		<annotation cp="🫲🏽">levo | nalevo | ni svijetla ni tamna koža | ruka | ruka okrenuta nalevo | ruka okrenuta nalevo: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🫲🏽">levo | nalevo | ni svijetla ni tamna koža | ruka | ruka okrenuta nalevo</annotation>
 		<annotation cp="🫲🏽" type="tts">ruka okrenuta nalevo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫳🏻">dlan okrenut nadole | dlan okrenut nadole: svijetla koža | ispustiti | otpustiti | poterati | svijetla koža</annotation>
+		<annotation cp="🫳🏻">dlan okrenut nadole | ispustiti | otpustiti | poterati | svijetla koža</annotation>
 		<annotation cp="🫳🏻" type="tts">dlan okrenut nadole: svijetla koža</annotation>
-		<annotation cp="🫳🏼">dlan okrenut nadole | dlan okrenut nadole: srednje svijetla koža | ispustiti | otpustiti | poterati | srednje svijetla koža</annotation>
+		<annotation cp="🫳🏼">dlan okrenut nadole | ispustiti | otpustiti | poterati | srednje svijetla koža</annotation>
 		<annotation cp="🫳🏼" type="tts">dlan okrenut nadole: srednje svijetla koža</annotation>
-		<annotation cp="🫳🏽">dlan okrenut nadole | dlan okrenut nadole: ni svijetla ni tamna koža | ispustiti | ni svijetla ni tamna koža | otpustiti | poterati</annotation>
+		<annotation cp="🫳🏽">dlan okrenut nadole | ispustiti | ni svijetla ni tamna koža | otpustiti | poterati</annotation>
 		<annotation cp="🫳🏽" type="tts">dlan okrenut nadole: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫴🏻">dlan okrenut nagore | dlan okrenut nagore: svijetla koža | dozivati | ponuda | poziv | svijetla koža | uhvatiti</annotation>
+		<annotation cp="🫴🏻">dlan okrenut nagore | dozivati | ponuda | poziv | svijetla koža | uhvatiti</annotation>
 		<annotation cp="🫴🏻" type="tts">dlan okrenut nagore: svijetla koža</annotation>
-		<annotation cp="🫴🏼">dlan okrenut nagore | dlan okrenut nagore: srednje svijetla koža | dozivati | ponuda | poziv | srednje svijetla koža | uhvatiti</annotation>
+		<annotation cp="🫴🏼">dlan okrenut nagore | dozivati | ponuda | poziv | srednje svijetla koža | uhvatiti</annotation>
 		<annotation cp="🫴🏼" type="tts">dlan okrenut nagore: srednje svijetla koža</annotation>
-		<annotation cp="🫴🏽">dlan okrenut nagore | dlan okrenut nagore: ni svijetla ni tamna koža | dozivati | ni svijetla ni tamna koža | ponuda | poziv | uhvatiti</annotation>
+		<annotation cp="🫴🏽">dlan okrenut nagore | dozivati | ni svijetla ni tamna koža | ponuda | poziv | uhvatiti</annotation>
 		<annotation cp="🫴🏽" type="tts">dlan okrenut nagore: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫷🏻">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | ruka gura ulijevo: svijetla koža | stop | svijetla koža</annotation>
+		<annotation cp="🫷🏻">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | stop | svijetla koža</annotation>
 		<annotation cp="🫷🏻" type="tts">ruka gura ulijevo: svijetla koža</annotation>
-		<annotation cp="🫷🏼">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | ruka gura ulijevo: srednje svijetla koža | srednje svijetla koža | stop</annotation>
+		<annotation cp="🫷🏼">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | srednje svijetla koža | stop</annotation>
 		<annotation cp="🫷🏼" type="tts">ruka gura ulijevo: srednje svijetla koža</annotation>
-		<annotation cp="🫷🏽">baci pet | čekaj | nalevo | ni svijetla ni tamna koža | odbij | odgurni | ruka gura ulijevo | ruka gura ulijevo: ni svijetla ni tamna koža | stop</annotation>
+		<annotation cp="🫷🏽">baci pet | čekaj | nalevo | ni svijetla ni tamna koža | odbij | odgurni | ruka gura ulijevo | stop</annotation>
 		<annotation cp="🫷🏽" type="tts">ruka gura ulijevo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫷🏾">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | ruka gura ulijevo: srednje tamna koža | srednje tamna koža | stop</annotation>
+		<annotation cp="🫷🏾">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | srednje tamna koža | stop</annotation>
 		<annotation cp="🫷🏾" type="tts">ruka gura ulijevo: srednje tamna koža</annotation>
-		<annotation cp="🫷🏿">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | ruka gura ulijevo: tamna koža | stop | tamna koža</annotation>
+		<annotation cp="🫷🏿">baci pet | čekaj | nalevo | odbij | odgurni | ruka gura ulijevo | stop | tamna koža</annotation>
 		<annotation cp="🫷🏿" type="tts">ruka gura ulijevo: tamna koža</annotation>
-		<annotation cp="🫸🏻">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | ruka gura udesno: svijetla koža | stop | svijetla koža</annotation>
+		<annotation cp="🫸🏻">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | stop | svijetla koža</annotation>
 		<annotation cp="🫸🏻" type="tts">ruka gura udesno: svijetla koža</annotation>
-		<annotation cp="🫸🏼">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | ruka gura udesno: srednje svijetla koža | srednje svijetla koža | stop</annotation>
+		<annotation cp="🫸🏼">baci pet | čekaj | nadesno | odbij | odgurni | ruka gura udesno | srednje svijetla koža | stop</annotation>
 		<annotation cp="🫸🏼" type="tts">ruka gura udesno: srednje svijetla koža</annotation>
-		<annotation cp="🫸🏽">baci pet | čekaj | nadesno | ni svijetla ni tamna koža | odbij | odgurni | ruka gura udesno | ruka gura udesno: ni svijetla ni tamna koža | stop</annotation>
+		<annotation cp="🫸🏽">baci pet | čekaj | nadesno | ni svijetla ni tamna koža | odbij | odgurni | ruka gura udesno | stop</annotation>
 		<annotation cp="🫸🏽" type="tts">ruka gura udesno: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👌🏻">ruka | svijetla koža | u redu | znak rukom „u redu“ | znak rukom „u redu“: svijetla koža</annotation>
+		<annotation cp="👌🏻">ruka | svijetla koža | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏻" type="tts">znak rukom „u redu“: svijetla koža</annotation>
-		<annotation cp="👌🏼">ruka | srednje svijetla koža | u redu | znak rukom „u redu“ | znak rukom „u redu“: srednje svijetla koža</annotation>
+		<annotation cp="👌🏼">ruka | srednje svijetla koža | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏼" type="tts">znak rukom „u redu“: srednje svijetla koža</annotation>
-		<annotation cp="👌🏽">ni svijetla ni tamna koža | ruka | u redu | znak rukom „u redu“ | znak rukom „u redu“: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👌🏽">ni svijetla ni tamna koža | ruka | u redu | znak rukom „u redu“</annotation>
 		<annotation cp="👌🏽" type="tts">znak rukom „u redu“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤌🏻">prsti | sarkastično | skupljeni prsti | skupljeni prsti: svijetla koža | svijetla koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏻">prsti | sarkastično | skupljeni prsti | svijetla koža | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏻" type="tts">skupljeni prsti: svijetla koža</annotation>
-		<annotation cp="🤌🏼">prsti | sarkastično | skupljeni prsti | skupljeni prsti: srednje svijetla koža | srednje svijetla koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏼">prsti | sarkastično | skupljeni prsti | srednje svijetla koža | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏼" type="tts">skupljeni prsti: srednje svijetla koža</annotation>
-		<annotation cp="🤌🏽">ni svijetla ni tamna koža | prsti | sarkastično | skupljeni prsti | skupljeni prsti: ni svijetla ni tamna koža | upitno | znak rukom</annotation>
+		<annotation cp="🤌🏽">ni svijetla ni tamna koža | prsti | sarkastično | skupljeni prsti | upitno | znak rukom</annotation>
 		<annotation cp="🤌🏽" type="tts">skupljeni prsti: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤏🏻">malo | ruka štipa | ruka štipa: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤏🏻">malo | ruka štipa | svijetla koža</annotation>
 		<annotation cp="🤏🏻" type="tts">ruka štipa: svijetla koža</annotation>
-		<annotation cp="🤏🏼">malo | ruka štipa | ruka štipa: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤏🏼">malo | ruka štipa | srednje svijetla koža</annotation>
 		<annotation cp="🤏🏼" type="tts">ruka štipa: srednje svijetla koža</annotation>
-		<annotation cp="🤏🏽">malo | ni svijetla ni tamna koža | ruka štipa | ruka štipa: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤏🏽">malo | ni svijetla ni tamna koža | ruka štipa</annotation>
 		<annotation cp="🤏🏽" type="tts">ruka štipa: ni svijetla ni tamna koža</annotation>
-		<annotation cp="✌🏻">pobeda | ruka | svijetla koža | v | znak pobjede | znak pobjede: svijetla koža</annotation>
+		<annotation cp="✌🏻">pobeda | ruka | svijetla koža | v | znak pobjede</annotation>
 		<annotation cp="✌🏻" type="tts">znak pobjede: svijetla koža</annotation>
-		<annotation cp="✌🏼">pobeda | ruka | srednje svijetla koža | v | znak pobjede | znak pobjede: srednje svijetla koža</annotation>
+		<annotation cp="✌🏼">pobeda | ruka | srednje svijetla koža | v | znak pobjede</annotation>
 		<annotation cp="✌🏼" type="tts">znak pobjede: srednje svijetla koža</annotation>
-		<annotation cp="✌🏽">ni svijetla ni tamna koža | pobeda | ruka | v | znak pobjede | znak pobjede: ni svijetla ni tamna koža</annotation>
+		<annotation cp="✌🏽">ni svijetla ni tamna koža | pobeda | ruka | v | znak pobjede</annotation>
 		<annotation cp="✌🏽" type="tts">znak pobjede: ni svijetla ni tamna koža</annotation>
-		<annotation cp="✌🏾">pobeda | ruka | srednje tamna koža | v | znak pobjede | znak pobjede: srednje tamna koža</annotation>
+		<annotation cp="✌🏾">pobeda | ruka | srednje tamna koža | v | znak pobjede</annotation>
 		<annotation cp="✌🏾" type="tts">znak pobjede: srednje tamna koža</annotation>
-		<annotation cp="✌🏿">pobeda | ruka | tamna koža | v | znak pobjede | znak pobjede: tamna koža</annotation>
+		<annotation cp="✌🏿">pobeda | ruka | tamna koža | v | znak pobjede</annotation>
 		<annotation cp="✌🏿" type="tts">znak pobjede: tamna koža</annotation>
-		<annotation cp="🤞🏻">prekršteni prsti | prekršteni prsti: svijetla koža | prekršteno | prst | ruka | sreća | svijetla koža</annotation>
+		<annotation cp="🤞🏻">prekršteni prsti | prekršteno | prst | ruka | sreća | svijetla koža</annotation>
 		<annotation cp="🤞🏻" type="tts">prekršteni prsti: svijetla koža</annotation>
-		<annotation cp="🤞🏼">prekršteni prsti | prekršteni prsti: srednje svijetla koža | prekršteno | prst | ruka | sreća | srednje svijetla koža</annotation>
+		<annotation cp="🤞🏼">prekršteni prsti | prekršteno | prst | ruka | sreća | srednje svijetla koža</annotation>
 		<annotation cp="🤞🏼" type="tts">prekršteni prsti: srednje svijetla koža</annotation>
-		<annotation cp="🤞🏽">ni svijetla ni tamna koža | prekršteni prsti | prekršteni prsti: ni svijetla ni tamna koža | prekršteno | prst | ruka | sreća</annotation>
+		<annotation cp="🤞🏽">ni svijetla ni tamna koža | prekršteni prsti | prekršteno | prst | ruka | sreća</annotation>
 		<annotation cp="🤞🏽" type="tts">prekršteni prsti: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤞🏾">prekršteni prsti | prekršteno | prst | ruka | sreća | srednje tamna koža</annotation>
 		<annotation cp="🤞🏿">prekršteni prsti | prekršteno | prst | ruka | sreća | tamna koža</annotation>
-		<annotation cp="🫰🏻">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: svijetla koža | skupo | srce | svijetla koža</annotation>
+		<annotation cp="🫰🏻">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce | svijetla koža</annotation>
 		<annotation cp="🫰🏻" type="tts">ruka sa prekrštenim palcem i kažiprstom: svijetla koža</annotation>
-		<annotation cp="🫰🏼">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: srednje svijetla koža | skupo | srce | srednje svijetla koža</annotation>
+		<annotation cp="🫰🏼">ljubav | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce | srednje svijetla koža</annotation>
 		<annotation cp="🫰🏼" type="tts">ruka sa prekrštenim palcem i kažiprstom: srednje svijetla koža</annotation>
-		<annotation cp="🫰🏽">ljubav | ni svijetla ni tamna koža | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | ruka sa prekrštenim palcem i kažiprstom: ni svijetla ni tamna koža | skupo | srce</annotation>
+		<annotation cp="🫰🏽">ljubav | ni svijetla ni tamna koža | novac | pucketanje | ruka sa prekrštenim palcem i kažiprstom | skupo | srce</annotation>
 		<annotation cp="🫰🏽" type="tts">ruka sa prekrštenim palcem i kažiprstom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤟🏻">pokret volim te | pokret volim te: svijetla koža | ruka | svijetla koža | volim te</annotation>
+		<annotation cp="🤟🏻">pokret volim te | ruka | svijetla koža | volim te</annotation>
 		<annotation cp="🤟🏻" type="tts">pokret volim te: svijetla koža</annotation>
-		<annotation cp="🤟🏼">pokret volim te | pokret volim te: srednje svijetla koža | ruka | srednje svijetla koža | volim te</annotation>
+		<annotation cp="🤟🏼">pokret volim te | ruka | srednje svijetla koža | volim te</annotation>
 		<annotation cp="🤟🏼" type="tts">pokret volim te: srednje svijetla koža</annotation>
-		<annotation cp="🤟🏽">ni svijetla ni tamna koža | pokret volim te | pokret volim te: ni svijetla ni tamna koža | ruka | volim te</annotation>
+		<annotation cp="🤟🏽">ni svijetla ni tamna koža | pokret volim te | ruka | volim te</annotation>
 		<annotation cp="🤟🏽" type="tts">pokret volim te: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤘🏻">metal | prst | rogovi | ruka | svijetla koža | znak rogova | znak rogova: svijetla koža</annotation>
+		<annotation cp="🤘🏻">metal | prst | rogovi | ruka | svijetla koža | znak rogova</annotation>
 		<annotation cp="🤘🏻" type="tts">znak rogova: svijetla koža</annotation>
-		<annotation cp="🤘🏼">metal | prst | rogovi | ruka | srednje svijetla koža | znak rogova | znak rogova: srednje svijetla koža</annotation>
+		<annotation cp="🤘🏼">metal | prst | rogovi | ruka | srednje svijetla koža | znak rogova</annotation>
 		<annotation cp="🤘🏼" type="tts">znak rogova: srednje svijetla koža</annotation>
-		<annotation cp="🤘🏽">metal | ni svijetla ni tamna koža | prst | rogovi | ruka | znak rogova | znak rogova: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤘🏽">metal | ni svijetla ni tamna koža | prst | rogovi | ruka | znak rogova</annotation>
 		<annotation cp="🤘🏽" type="tts">znak rogova: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤘🏾">metal | prst | rogovi | ruka | srednje tamna koža | znak rogova</annotation>
 		<annotation cp="🤘🏿">metal | prst | rogovi | ruka | tamna koža | znak rogova</annotation>
-		<annotation cp="🤙🏻">svijetla koža | znak rukom za telefon | znak rukom za telefon: svijetla koža</annotation>
+		<annotation cp="🤙🏻">svijetla koža | znak rukom za telefon</annotation>
 		<annotation cp="🤙🏻" type="tts">znak rukom za telefon: svijetla koža</annotation>
-		<annotation cp="🤙🏼">srednje svijetla koža | znak rukom za telefon | znak rukom za telefon: srednje svijetla koža</annotation>
+		<annotation cp="🤙🏼">srednje svijetla koža | znak rukom za telefon</annotation>
 		<annotation cp="🤙🏼" type="tts">znak rukom za telefon: srednje svijetla koža</annotation>
-		<annotation cp="🤙🏽">ni svijetla ni tamna koža | znak rukom za telefon | znak rukom za telefon: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤙🏽">ni svijetla ni tamna koža | znak rukom za telefon</annotation>
 		<annotation cp="🤙🏽" type="tts">znak rukom za telefon: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤙🏾">srednje tamna koža | znak rukom za telefon</annotation>
 		<annotation cp="🤙🏿">tamna koža | znak rukom za telefon</annotation>
-		<annotation cp="👈🏻">kažiprst koji pokazuje ulijevo | kažiprst koji pokazuje ulijevo: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👈🏻">kažiprst koji pokazuje ulijevo | svijetla koža</annotation>
 		<annotation cp="👈🏻" type="tts">kažiprst koji pokazuje ulijevo: svijetla koža</annotation>
-		<annotation cp="👈🏼">kažiprst koji pokazuje ulijevo | kažiprst koji pokazuje ulijevo: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👈🏼">kažiprst koji pokazuje ulijevo | srednje svijetla koža</annotation>
 		<annotation cp="👈🏼" type="tts">kažiprst koji pokazuje ulijevo: srednje svijetla koža</annotation>
-		<annotation cp="👈🏽">kažiprst koji pokazuje ulijevo | kažiprst koji pokazuje ulijevo: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👈🏽">kažiprst koji pokazuje ulijevo | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👈🏽" type="tts">kažiprst koji pokazuje ulijevo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👈🏾">kažiprst koji pokazuje ulijevo | kažiprst koji pokazuje ulijevo: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👈🏾">kažiprst koji pokazuje ulijevo | srednje tamna koža</annotation>
 		<annotation cp="👈🏾" type="tts">kažiprst koji pokazuje ulijevo: srednje tamna koža</annotation>
-		<annotation cp="👈🏿">kažiprst koji pokazuje ulijevo | kažiprst koji pokazuje ulijevo: tamna koža | tamna koža</annotation>
+		<annotation cp="👈🏿">kažiprst koji pokazuje ulijevo | tamna koža</annotation>
 		<annotation cp="👈🏿" type="tts">kažiprst koji pokazuje ulijevo: tamna koža</annotation>
-		<annotation cp="👉🏻">kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👉🏻">kažiprst koji pokazuje udesno | svijetla koža</annotation>
 		<annotation cp="👉🏻" type="tts">kažiprst koji pokazuje udesno: svijetla koža</annotation>
-		<annotation cp="👉🏼">kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👉🏼">kažiprst koji pokazuje udesno | srednje svijetla koža</annotation>
 		<annotation cp="👉🏼" type="tts">kažiprst koji pokazuje udesno: srednje svijetla koža</annotation>
-		<annotation cp="👉🏽">kažiprst koji pokazuje udesno | kažiprst koji pokazuje udesno: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👉🏽">kažiprst koji pokazuje udesno | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👉🏽" type="tts">kažiprst koji pokazuje udesno: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👉🏾">kažiprst koji pokazuje udesno | srednje tamna koža</annotation>
 		<annotation cp="👉🏿">kažiprst koji pokazuje udesno | tamna koža</annotation>
-		<annotation cp="👆🏻">kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: svijetla koža | nagore | otpozadi | pokazivanje | prst | ruka | svijetla koža</annotation>
+		<annotation cp="👆🏻">kažiprst koji pokazuje nagore otpozadi | nagore | otpozadi | pokazivanje | prst | ruka | svijetla koža</annotation>
 		<annotation cp="👆🏻" type="tts">kažiprst koji pokazuje nagore otpozadi: svijetla koža</annotation>
-		<annotation cp="👆🏼">kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: srednje svijetla koža | nagore | otpozadi | pokazivanje | prst | ruka | srednje svijetla koža</annotation>
+		<annotation cp="👆🏼">kažiprst koji pokazuje nagore otpozadi | nagore | otpozadi | pokazivanje | prst | ruka | srednje svijetla koža</annotation>
 		<annotation cp="👆🏼" type="tts">kažiprst koji pokazuje nagore otpozadi: srednje svijetla koža</annotation>
-		<annotation cp="👆🏽">kažiprst koji pokazuje nagore otpozadi | kažiprst koji pokazuje nagore otpozadi: ni svijetla ni tamna koža | nagore | ni svijetla ni tamna koža | otpozadi | pokazivanje | prst | ruka</annotation>
+		<annotation cp="👆🏽">kažiprst koji pokazuje nagore otpozadi | nagore | ni svijetla ni tamna koža | otpozadi | pokazivanje | prst | ruka</annotation>
 		<annotation cp="👆🏽" type="tts">kažiprst koji pokazuje nagore otpozadi: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👆🏾">kažiprst koji pokazuje nagore otpozadi | nagore | otpozadi | pokazivanje | prst | ruka | srednje tamna koža</annotation>
 		<annotation cp="👆🏿">kažiprst koji pokazuje nagore otpozadi | nagore | otpozadi | pokazivanje | prst | ruka | tamna koža</annotation>
-		<annotation cp="🖕🏻">srednji prst | srednji prst: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🖕🏻">srednji prst | svijetla koža</annotation>
 		<annotation cp="🖕🏻" type="tts">srednji prst: svijetla koža</annotation>
-		<annotation cp="🖕🏼">srednje svijetla koža | srednji prst | srednji prst: srednje svijetla koža</annotation>
+		<annotation cp="🖕🏼">srednje svijetla koža | srednji prst</annotation>
 		<annotation cp="🖕🏼" type="tts">srednji prst: srednje svijetla koža</annotation>
-		<annotation cp="🖕🏽">ni svijetla ni tamna koža | srednji prst | srednji prst: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🖕🏽">ni svijetla ni tamna koža | srednji prst</annotation>
 		<annotation cp="🖕🏽" type="tts">srednji prst: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🖕🏾">srednje tamna koža | srednji prst</annotation>
 		<annotation cp="🖕🏿">srednji prst | tamna koža</annotation>
-		<annotation cp="👇🏻">kažiprst koji pokazuje nadolje otpozadi | kažiprst koji pokazuje nadolje otpozadi: svijetla koža | nadolje | otpozadi | pokazivanje | prst | ruka | svijetla koža</annotation>
+		<annotation cp="👇🏻">kažiprst koji pokazuje nadolje otpozadi | nadolje | otpozadi | pokazivanje | prst | ruka | svijetla koža</annotation>
 		<annotation cp="👇🏻" type="tts">kažiprst koji pokazuje nadolje otpozadi: svijetla koža</annotation>
-		<annotation cp="👇🏼">kažiprst koji pokazuje nadolje otpozadi | kažiprst koji pokazuje nadolje otpozadi: srednje svijetla koža | nadolje | otpozadi | pokazivanje | prst | ruka | srednje svijetla koža</annotation>
+		<annotation cp="👇🏼">kažiprst koji pokazuje nadolje otpozadi | nadolje | otpozadi | pokazivanje | prst | ruka | srednje svijetla koža</annotation>
 		<annotation cp="👇🏼" type="tts">kažiprst koji pokazuje nadolje otpozadi: srednje svijetla koža</annotation>
-		<annotation cp="👇🏽">kažiprst koji pokazuje nadolje otpozadi | kažiprst koji pokazuje nadolje otpozadi: ni svijetla ni tamna koža | nadolje | ni svijetla ni tamna koža | otpozadi | pokazivanje | prst | ruka</annotation>
+		<annotation cp="👇🏽">kažiprst koji pokazuje nadolje otpozadi | nadolje | ni svijetla ni tamna koža | otpozadi | pokazivanje | prst | ruka</annotation>
 		<annotation cp="👇🏽" type="tts">kažiprst koji pokazuje nadolje otpozadi: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👇🏾">kažiprst koji pokazuje nadolje otpozadi | kažiprst koji pokazuje nadolje otpozadi: srednje tamna koža | nadolje | otpozadi | pokazivanje | prst | ruka | srednje tamna koža</annotation>
+		<annotation cp="👇🏾">kažiprst koji pokazuje nadolje otpozadi | nadolje | otpozadi | pokazivanje | prst | ruka | srednje tamna koža</annotation>
 		<annotation cp="👇🏾" type="tts">kažiprst koji pokazuje nadolje otpozadi: srednje tamna koža</annotation>
-		<annotation cp="👇🏿">kažiprst koji pokazuje nadolje otpozadi | kažiprst koji pokazuje nadolje otpozadi: tamna koža | nadolje | otpozadi | pokazivanje | prst | ruka | tamna koža</annotation>
+		<annotation cp="👇🏿">kažiprst koji pokazuje nadolje otpozadi | nadolje | otpozadi | pokazivanje | prst | ruka | tamna koža</annotation>
 		<annotation cp="👇🏿" type="tts">kažiprst koji pokazuje nadolje otpozadi: tamna koža</annotation>
-		<annotation cp="☝🏻">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: svijetla koža | pokazivanje | prst | ruka | svijetla koža</annotation>
+		<annotation cp="☝🏻">gore | kažiprst | kažiprst koji pokazuje nagore | pokazivanje | prst | ruka | svijetla koža</annotation>
 		<annotation cp="☝🏻" type="tts">kažiprst koji pokazuje nagore: svijetla koža</annotation>
-		<annotation cp="☝🏼">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: srednje svijetla koža | pokazivanje | prst | ruka | srednje svijetla koža</annotation>
+		<annotation cp="☝🏼">gore | kažiprst | kažiprst koji pokazuje nagore | pokazivanje | prst | ruka | srednje svijetla koža</annotation>
 		<annotation cp="☝🏼" type="tts">kažiprst koji pokazuje nagore: srednje svijetla koža</annotation>
-		<annotation cp="☝🏽">gore | kažiprst | kažiprst koji pokazuje nagore | kažiprst koji pokazuje nagore: ni svijetla ni tamna koža | ni svijetla ni tamna koža | pokazivanje | prst | ruka</annotation>
+		<annotation cp="☝🏽">gore | kažiprst | kažiprst koji pokazuje nagore | ni svijetla ni tamna koža | pokazivanje | prst | ruka</annotation>
 		<annotation cp="☝🏽" type="tts">kažiprst koji pokazuje nagore: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫵🏻">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: svijetla koža | pokazivanje | svijetla koža | ti | vi</annotation>
+		<annotation cp="🫵🏻">kažiprst koji pokazuje prema gledaocu | pokazivanje | svijetla koža | ti | vi</annotation>
 		<annotation cp="🫵🏻" type="tts">kažiprst koji pokazuje prema gledaocu: svijetla koža</annotation>
-		<annotation cp="🫵🏼">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: srednje svijetla koža | pokazivanje | srednje svijetla koža | ti | vi</annotation>
+		<annotation cp="🫵🏼">kažiprst koji pokazuje prema gledaocu | pokazivanje | srednje svijetla koža | ti | vi</annotation>
 		<annotation cp="🫵🏼" type="tts">kažiprst koji pokazuje prema gledaocu: srednje svijetla koža</annotation>
-		<annotation cp="🫵🏽">kažiprst koji pokazuje prema gledaocu | kažiprst koji pokazuje prema gledaocu: ni svijetla ni tamna koža | ni svijetla ni tamna koža | pokazivanje | ti | vi</annotation>
+		<annotation cp="🫵🏽">kažiprst koji pokazuje prema gledaocu | ni svijetla ni tamna koža | pokazivanje | ti | vi</annotation>
 		<annotation cp="🫵🏽" type="tts">kažiprst koji pokazuje prema gledaocu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👍🏻">+1 | nagore | palac | palac nagore: svijetla koža | ruka | svijetla koža</annotation>
+		<annotation cp="👍🏻">+1 | nagore | palac | ruka | svijetla koža</annotation>
 		<annotation cp="👍🏻" type="tts">palac nagore: svijetla koža</annotation>
-		<annotation cp="👍🏼">+1 | nagore | palac | palac nagore: srednje svijetla koža | ruka | srednje svijetla koža</annotation>
+		<annotation cp="👍🏼">+1 | nagore | palac | ruka | srednje svijetla koža</annotation>
 		<annotation cp="👍🏼" type="tts">palac nagore: srednje svijetla koža</annotation>
-		<annotation cp="👍🏽">+1 | nagore | ni svijetla ni tamna koža | palac | palac nagore: ni svijetla ni tamna koža | ruka</annotation>
+		<annotation cp="👍🏽">+1 | nagore | ni svijetla ni tamna koža | palac | ruka</annotation>
 		<annotation cp="👍🏽" type="tts">palac nagore: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👍🏾">+1 | nagore | palac | ruka | srednje tamna koža</annotation>
 		<annotation cp="👍🏿">+1 | nagore | palac | ruka | tamna koža</annotation>
-		<annotation cp="👎🏻">-1 | nadolje | palac | palac nadolje: svijetla koža | ruka | svijetla koža</annotation>
+		<annotation cp="👎🏻">-1 | nadolje | palac | ruka | svijetla koža</annotation>
 		<annotation cp="👎🏻" type="tts">palac nadolje: svijetla koža</annotation>
-		<annotation cp="👎🏼">-1 | nadolje | palac | palac nadolje: srednje svijetla koža | ruka | srednje svijetla koža</annotation>
+		<annotation cp="👎🏼">-1 | nadolje | palac | ruka | srednje svijetla koža</annotation>
 		<annotation cp="👎🏼" type="tts">palac nadolje: srednje svijetla koža</annotation>
-		<annotation cp="👎🏽">-1 | nadolje | ni svijetla ni tamna koža | palac | palac nadolje: ni svijetla ni tamna koža | ruka</annotation>
+		<annotation cp="👎🏽">-1 | nadolje | ni svijetla ni tamna koža | palac | ruka</annotation>
 		<annotation cp="👎🏽" type="tts">palac nadolje: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👎🏾">-1 | nadolje | palac | palac nadolje: srednje tamna koža | ruka | srednje tamna koža</annotation>
+		<annotation cp="👎🏾">-1 | nadolje | palac | ruka | srednje tamna koža</annotation>
 		<annotation cp="👎🏾" type="tts">palac nadolje: srednje tamna koža</annotation>
-		<annotation cp="👎🏿">-1 | nadolje | palac | palac nadolje: tamna koža | ruka | tamna koža</annotation>
+		<annotation cp="👎🏿">-1 | nadolje | palac | ruka | tamna koža</annotation>
 		<annotation cp="👎🏿" type="tts">palac nadolje: tamna koža</annotation>
-		<annotation cp="✊🏻">pesnica | pesnica: svijetla koža | ruka | šaka | stisnuto | svijetla koža | udarac</annotation>
+		<annotation cp="✊🏻">pesnica | ruka | šaka | stisnuto | svijetla koža | udarac</annotation>
 		<annotation cp="✊🏻" type="tts">pesnica: svijetla koža</annotation>
-		<annotation cp="✊🏼">pesnica | pesnica: srednje svijetla koža | ruka | šaka | srednje svijetla koža | stisnuto | udarac</annotation>
+		<annotation cp="✊🏼">pesnica | ruka | šaka | srednje svijetla koža | stisnuto | udarac</annotation>
 		<annotation cp="✊🏼" type="tts">pesnica: srednje svijetla koža</annotation>
-		<annotation cp="✊🏽">ni svijetla ni tamna koža | pesnica | pesnica: ni svijetla ni tamna koža | ruka | šaka | stisnuto | udarac</annotation>
+		<annotation cp="✊🏽">ni svijetla ni tamna koža | pesnica | ruka | šaka | stisnuto | udarac</annotation>
 		<annotation cp="✊🏽" type="tts">pesnica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👊🏻">ruka | šaka | stisnuto | svijetla koža | udarac | usmjerena pesnica | usmjerena pesnica: svijetla koža</annotation>
+		<annotation cp="👊🏻">ruka | šaka | stisnuto | svijetla koža | udarac | usmjerena pesnica</annotation>
 		<annotation cp="👊🏻" type="tts">usmjerena pesnica: svijetla koža</annotation>
-		<annotation cp="👊🏼">ruka | šaka | srednje svijetla koža | stisnuto | udarac | usmjerena pesnica | usmjerena pesnica: srednje svijetla koža</annotation>
+		<annotation cp="👊🏼">ruka | šaka | srednje svijetla koža | stisnuto | udarac | usmjerena pesnica</annotation>
 		<annotation cp="👊🏼" type="tts">usmjerena pesnica: srednje svijetla koža</annotation>
-		<annotation cp="👊🏽">ni svijetla ni tamna koža | ruka | šaka | stisnuto | udarac | usmjerena pesnica | usmjerena pesnica: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👊🏽">ni svijetla ni tamna koža | ruka | šaka | stisnuto | udarac | usmjerena pesnica</annotation>
 		<annotation cp="👊🏽" type="tts">usmjerena pesnica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👊🏾">ruka | šaka | srednje tamna koža | stisnuto | udarac | usmjerena pesnica | usmjerena pesnica: srednje tamna koža</annotation>
+		<annotation cp="👊🏾">ruka | šaka | srednje tamna koža | stisnuto | udarac | usmjerena pesnica</annotation>
 		<annotation cp="👊🏾" type="tts">usmjerena pesnica: srednje tamna koža</annotation>
-		<annotation cp="👊🏿">ruka | šaka | stisnuto | tamna koža | udarac | usmjerena pesnica | usmjerena pesnica: tamna koža</annotation>
+		<annotation cp="👊🏿">ruka | šaka | stisnuto | tamna koža | udarac | usmjerena pesnica</annotation>
 		<annotation cp="👊🏿" type="tts">usmjerena pesnica: tamna koža</annotation>
-		<annotation cp="🤛🏻">pesnica ulijevo | pesnica ulijevo: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤛🏻">pesnica ulijevo | svijetla koža</annotation>
 		<annotation cp="🤛🏻" type="tts">pesnica ulijevo: svijetla koža</annotation>
-		<annotation cp="🤛🏼">pesnica ulijevo | pesnica ulijevo: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤛🏼">pesnica ulijevo | srednje svijetla koža</annotation>
 		<annotation cp="🤛🏼" type="tts">pesnica ulijevo: srednje svijetla koža</annotation>
-		<annotation cp="🤛🏽">ni svijetla ni tamna koža | pesnica ulijevo | pesnica ulijevo: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤛🏽">ni svijetla ni tamna koža | pesnica ulijevo</annotation>
 		<annotation cp="🤛🏽" type="tts">pesnica ulijevo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤛🏾">pesnica ulijevo | pesnica ulijevo: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤛🏾">pesnica ulijevo | srednje tamna koža</annotation>
 		<annotation cp="🤛🏾" type="tts">pesnica ulijevo: srednje tamna koža</annotation>
-		<annotation cp="🤛🏿">pesnica ulijevo | pesnica ulijevo: tamna koža | tamna koža</annotation>
+		<annotation cp="🤛🏿">pesnica ulijevo | tamna koža</annotation>
 		<annotation cp="🤛🏿" type="tts">pesnica ulijevo: tamna koža</annotation>
-		<annotation cp="🤜🏻">pesnica | pesnica udesno: svijetla koža | svijetla koža | udesno</annotation>
+		<annotation cp="🤜🏻">pesnica | svijetla koža | udesno</annotation>
 		<annotation cp="🤜🏻" type="tts">pesnica udesno: svijetla koža</annotation>
-		<annotation cp="🤜🏼">pesnica | pesnica udesno: srednje svijetla koža | srednje svijetla koža | udesno</annotation>
+		<annotation cp="🤜🏼">pesnica | srednje svijetla koža | udesno</annotation>
 		<annotation cp="🤜🏼" type="tts">pesnica udesno: srednje svijetla koža</annotation>
-		<annotation cp="🤜🏽">ni svijetla ni tamna koža | pesnica | pesnica udesno: ni svijetla ni tamna koža | udesno</annotation>
+		<annotation cp="🤜🏽">ni svijetla ni tamna koža | pesnica | udesno</annotation>
 		<annotation cp="🤜🏽" type="tts">pesnica udesno: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👏🏻">ruka | ruke koje tapšu | ruke koje tapšu: svijetla koža | svijetla koža | tapšanje</annotation>
+		<annotation cp="👏🏻">ruka | ruke koje tapšu | svijetla koža | tapšanje</annotation>
 		<annotation cp="👏🏻" type="tts">ruke koje tapšu: svijetla koža</annotation>
-		<annotation cp="👏🏼">ruka | ruke koje tapšu | ruke koje tapšu: srednje svijetla koža | srednje svijetla koža | tapšanje</annotation>
+		<annotation cp="👏🏼">ruka | ruke koje tapšu | srednje svijetla koža | tapšanje</annotation>
 		<annotation cp="👏🏼" type="tts">ruke koje tapšu: srednje svijetla koža</annotation>
-		<annotation cp="👏🏽">ni svijetla ni tamna koža | ruka | ruke koje tapšu | ruke koje tapšu: ni svijetla ni tamna koža | tapšanje</annotation>
+		<annotation cp="👏🏽">ni svijetla ni tamna koža | ruka | ruke koje tapšu | tapšanje</annotation>
 		<annotation cp="👏🏽" type="tts">ruke koje tapšu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙌🏻">bravo | podići | podignute ruke | podignute ruke: svijetla koža | pokret | ruka | slava | svijetla koža</annotation>
+		<annotation cp="🙌🏻">bravo | podići | podignute ruke | pokret | ruka | slava | svijetla koža</annotation>
 		<annotation cp="🙌🏻" type="tts">podignute ruke: svijetla koža</annotation>
-		<annotation cp="🙌🏼">bravo | podići | podignute ruke | podignute ruke: srednje svijetla koža | pokret | ruka | slava | srednje svijetla koža</annotation>
+		<annotation cp="🙌🏼">bravo | podići | podignute ruke | pokret | ruka | slava | srednje svijetla koža</annotation>
 		<annotation cp="🙌🏼" type="tts">podignute ruke: srednje svijetla koža</annotation>
-		<annotation cp="🙌🏽">bravo | ni svijetla ni tamna koža | podići | podignute ruke | podignute ruke: ni svijetla ni tamna koža | pokret | ruka | slava</annotation>
+		<annotation cp="🙌🏽">bravo | ni svijetla ni tamna koža | podići | podignute ruke | pokret | ruka | slava</annotation>
 		<annotation cp="🙌🏽" type="tts">podignute ruke: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🙌🏾">bravo | podići | podignute ruke | pokret | ruka | slava | srednje tamna koža</annotation>
 		<annotation cp="🙌🏿">bravo | podići | podignute ruke | pokret | ruka | slava | tamna koža</annotation>
-		<annotation cp="🫶🏻">ljubav | ruke koje prave srce | ruke koje prave srce: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🫶🏻">ljubav | ruke koje prave srce | svijetla koža</annotation>
 		<annotation cp="🫶🏻" type="tts">ruke koje prave srce: svijetla koža</annotation>
-		<annotation cp="🫶🏼">ljubav | ruke koje prave srce | ruke koje prave srce: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🫶🏼">ljubav | ruke koje prave srce | srednje svijetla koža</annotation>
 		<annotation cp="🫶🏼" type="tts">ruke koje prave srce: srednje svijetla koža</annotation>
-		<annotation cp="🫶🏽">ljubav | ni svijetla ni tamna koža | ruke koje prave srce | ruke koje prave srce: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🫶🏽">ljubav | ni svijetla ni tamna koža | ruke koje prave srce</annotation>
 		<annotation cp="🫶🏽" type="tts">ruke koje prave srce: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👐🏻">otvoreno | rasklopljene šake | rasklopljene šake: svijetla koža | ruka | svijetla koža</annotation>
+		<annotation cp="👐🏻">otvoreno | rasklopljene šake | ruka | svijetla koža</annotation>
 		<annotation cp="👐🏻" type="tts">rasklopljene šake: svijetla koža</annotation>
-		<annotation cp="👐🏼">otvoreno | rasklopljene šake | rasklopljene šake: srednje svijetla koža | ruka | srednje svijetla koža</annotation>
+		<annotation cp="👐🏼">otvoreno | rasklopljene šake | ruka | srednje svijetla koža</annotation>
 		<annotation cp="👐🏼" type="tts">rasklopljene šake: srednje svijetla koža</annotation>
-		<annotation cp="👐🏽">ni svijetla ni tamna koža | otvoreno | rasklopljene šake | rasklopljene šake: ni svijetla ni tamna koža | ruka</annotation>
+		<annotation cp="👐🏽">ni svijetla ni tamna koža | otvoreno | rasklopljene šake | ruka</annotation>
 		<annotation cp="👐🏽" type="tts">rasklopljene šake: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤲🏻">dlanovi nagore zajedno | dlanovi nagore zajedno: svijetla koža | molitva | svijetla koža</annotation>
+		<annotation cp="🤲🏻">dlanovi nagore zajedno | molitva | svijetla koža</annotation>
 		<annotation cp="🤲🏻" type="tts">dlanovi nagore zajedno: svijetla koža</annotation>
-		<annotation cp="🤲🏼">dlanovi nagore zajedno | dlanovi nagore zajedno: srednje svijetla koža | molitva | srednje svijetla koža</annotation>
+		<annotation cp="🤲🏼">dlanovi nagore zajedno | molitva | srednje svijetla koža</annotation>
 		<annotation cp="🤲🏼" type="tts">dlanovi nagore zajedno: srednje svijetla koža</annotation>
-		<annotation cp="🤲🏽">dlanovi nagore zajedno | dlanovi nagore zajedno: ni svijetla ni tamna koža | molitva | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤲🏽">dlanovi nagore zajedno | molitva | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤲🏽" type="tts">dlanovi nagore zajedno: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤝🏻">rukovanje | rukovanje: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤝🏻">rukovanje | svijetla koža</annotation>
 		<annotation cp="🤝🏻" type="tts">rukovanje: svijetla koža</annotation>
-		<annotation cp="🤝🏼">rukovanje | rukovanje: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤝🏼">rukovanje | srednje svijetla koža</annotation>
 		<annotation cp="🤝🏼" type="tts">rukovanje: srednje svijetla koža</annotation>
-		<annotation cp="🤝🏽">ni svijetla ni tamna koža | rukovanje | rukovanje: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤝🏽">ni svijetla ni tamna koža | rukovanje</annotation>
 		<annotation cp="🤝🏽" type="tts">rukovanje: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤝🏾">rukovanje | srednje tamna koža</annotation>
 		<annotation cp="🤝🏿">rukovanje | tamna koža</annotation>
-		<annotation cp="🙏🏻">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | spojeni dlanovi: svijetla koža | svijetla koža | zahvalnost</annotation>
+		<annotation cp="🙏🏻">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | svijetla koža | zahvalnost</annotation>
 		<annotation cp="🙏🏻" type="tts">spojeni dlanovi: svijetla koža</annotation>
-		<annotation cp="🙏🏼">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | spojeni dlanovi: srednje svijetla koža | srednje svijetla koža | zahvalnost</annotation>
+		<annotation cp="🙏🏼">daj 5 | daj pet | molitva | moljenje | pitati | ruka | spojeni dlanovi | srednje svijetla koža | zahvalnost</annotation>
 		<annotation cp="🙏🏼" type="tts">spojeni dlanovi: srednje svijetla koža</annotation>
-		<annotation cp="🙏🏽">daj 5 | daj pet | molitva | moljenje | ni svijetla ni tamna koža | pitati | ruka | spojeni dlanovi | spojeni dlanovi: ni svijetla ni tamna koža | zahvalnost</annotation>
+		<annotation cp="🙏🏽">daj 5 | daj pet | molitva | moljenje | ni svijetla ni tamna koža | pitati | ruka | spojeni dlanovi | zahvalnost</annotation>
 		<annotation cp="🙏🏽" type="tts">spojeni dlanovi: ni svijetla ni tamna koža</annotation>
-		<annotation cp="✍🏻">pisanje | ruka | ruka koja piše | ruka koja piše: svijetla koža | svijetla koža</annotation>
+		<annotation cp="✍🏻">pisanje | ruka | ruka koja piše | svijetla koža</annotation>
 		<annotation cp="✍🏻" type="tts">ruka koja piše: svijetla koža</annotation>
-		<annotation cp="✍🏼">pisanje | ruka | ruka koja piše | ruka koja piše: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="✍🏼">pisanje | ruka | ruka koja piše | srednje svijetla koža</annotation>
 		<annotation cp="✍🏼" type="tts">ruka koja piše: srednje svijetla koža</annotation>
-		<annotation cp="✍🏽">ni svijetla ni tamna koža | pisanje | ruka | ruka koja piše | ruka koja piše: ni svijetla ni tamna koža</annotation>
+		<annotation cp="✍🏽">ni svijetla ni tamna koža | pisanje | ruka | ruka koja piše</annotation>
 		<annotation cp="✍🏽" type="tts">ruka koja piše: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💅🏻">kozmetika | lak za nokte | lak za nokte: svijetla koža | manikir | njega | nokat | svijetla koža</annotation>
+		<annotation cp="💅🏻">kozmetika | lak za nokte | manikir | njega | nokat | svijetla koža</annotation>
 		<annotation cp="💅🏻" type="tts">lak za nokte: svijetla koža</annotation>
-		<annotation cp="💅🏼">kozmetika | lak za nokte | lak za nokte: srednje svijetla koža | manikir | njega | nokat | srednje svijetla koža</annotation>
+		<annotation cp="💅🏼">kozmetika | lak za nokte | manikir | njega | nokat | srednje svijetla koža</annotation>
 		<annotation cp="💅🏼" type="tts">lak za nokte: srednje svijetla koža</annotation>
-		<annotation cp="💅🏽">kozmetika | lak za nokte | lak za nokte: ni svijetla ni tamna koža | manikir | ni svijetla ni tamna koža | njega | nokat</annotation>
+		<annotation cp="💅🏽">kozmetika | lak za nokte | manikir | ni svijetla ni tamna koža | njega | nokat</annotation>
 		<annotation cp="💅🏽" type="tts">lak za nokte: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💅🏾">kozmetika | lak za nokte | manikir | njega | nokat | srednje tamna koža</annotation>
 		<annotation cp="💅🏿">kozmetika | lak za nokte | manikir | njega | nokat | tamna koža</annotation>
-		<annotation cp="🤳🏻">selfi | selfi: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤳🏻">selfi | svijetla koža</annotation>
 		<annotation cp="🤳🏻" type="tts">selfi: svijetla koža</annotation>
-		<annotation cp="🤳🏼">selfi | selfi: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤳🏼">selfi | srednje svijetla koža</annotation>
 		<annotation cp="🤳🏼" type="tts">selfi: srednje svijetla koža</annotation>
-		<annotation cp="🤳🏽">ni svijetla ni tamna koža | selfi | selfi: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤳🏽">ni svijetla ni tamna koža | selfi</annotation>
 		<annotation cp="🤳🏽" type="tts">selfi: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤳🏾">selfi | srednje tamna koža</annotation>
 		<annotation cp="🤳🏿">selfi | tamna koža</annotation>
-		<annotation cp="💪🏻">stegnuti biceps | stegnuti biceps: svijetla koža | svijetla koža</annotation>
+		<annotation cp="💪🏻">stegnuti biceps | svijetla koža</annotation>
 		<annotation cp="💪🏻" type="tts">stegnuti biceps: svijetla koža</annotation>
-		<annotation cp="💪🏼">srednje svijetla koža | stegnuti biceps | stegnuti biceps: srednje svijetla koža</annotation>
+		<annotation cp="💪🏼">srednje svijetla koža | stegnuti biceps</annotation>
 		<annotation cp="💪🏼" type="tts">stegnuti biceps: srednje svijetla koža</annotation>
-		<annotation cp="💪🏽">ni svijetla ni tamna koža | stegnuti biceps | stegnuti biceps: ni svijetla ni tamna koža</annotation>
+		<annotation cp="💪🏽">ni svijetla ni tamna koža | stegnuti biceps</annotation>
 		<annotation cp="💪🏽" type="tts">stegnuti biceps: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💪🏾">srednje tamna koža | stegnuti biceps</annotation>
 		<annotation cp="💪🏿">stegnuti biceps | tamna koža</annotation>
-		<annotation cp="🦵🏻">noga | noga: svijetla koža | šut | svijetla koža | ud</annotation>
+		<annotation cp="🦵🏻">noga | šut | svijetla koža | ud</annotation>
 		<annotation cp="🦵🏻" type="tts">noga: svijetla koža</annotation>
-		<annotation cp="🦵🏼">noga | noga: srednje svijetla koža | srednje svijetla koža | šut | ud</annotation>
+		<annotation cp="🦵🏼">noga | srednje svijetla koža | šut | ud</annotation>
 		<annotation cp="🦵🏼" type="tts">noga: srednje svijetla koža</annotation>
-		<annotation cp="🦵🏽">ni svijetla ni tamna koža | noga | noga: ni svijetla ni tamna koža | šut | ud</annotation>
+		<annotation cp="🦵🏽">ni svijetla ni tamna koža | noga | šut | ud</annotation>
 		<annotation cp="🦵🏽" type="tts">noga: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦶🏻">stopalo | stopalo: svijetla koža | svijetla koža | zgaziti</annotation>
+		<annotation cp="🦶🏻">stopalo | svijetla koža | zgaziti</annotation>
 		<annotation cp="🦶🏻" type="tts">stopalo: svijetla koža</annotation>
-		<annotation cp="🦶🏼">srednje svijetla koža | stopalo | stopalo: srednje svijetla koža | zgaziti</annotation>
+		<annotation cp="🦶🏼">srednje svijetla koža | stopalo | zgaziti</annotation>
 		<annotation cp="🦶🏼" type="tts">stopalo: srednje svijetla koža</annotation>
-		<annotation cp="🦶🏽">ni svijetla ni tamna koža | stopalo | stopalo: ni svijetla ni tamna koža | zgaziti</annotation>
+		<annotation cp="🦶🏽">ni svijetla ni tamna koža | stopalo | zgaziti</annotation>
 		<annotation cp="🦶🏽" type="tts">stopalo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👂🏻">svijetla koža | uvo | uvo: svijetla koža</annotation>
+		<annotation cp="👂🏻">svijetla koža | uvo</annotation>
 		<annotation cp="👂🏻" type="tts">uvo: svijetla koža</annotation>
-		<annotation cp="👂🏼">srednje svijetla koža | uvo | uvo: srednje svijetla koža</annotation>
+		<annotation cp="👂🏼">srednje svijetla koža | uvo</annotation>
 		<annotation cp="👂🏼" type="tts">uvo: srednje svijetla koža</annotation>
-		<annotation cp="👂🏽">ni svijetla ni tamna koža | uvo | uvo: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👂🏽">ni svijetla ni tamna koža | uvo</annotation>
 		<annotation cp="👂🏽" type="tts">uvo: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👂🏾">srednje tamna koža | uvo</annotation>
 		<annotation cp="👂🏿">tamna koža | uvo</annotation>
-		<annotation cp="🦻🏻">pristupačnost | svijetla koža | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: svijetla koža</annotation>
+		<annotation cp="🦻🏻">pristupačnost | svijetla koža | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏻" type="tts">uvo sa slušnim aparatom: svijetla koža</annotation>
-		<annotation cp="🦻🏼">pristupačnost | srednje svijetla koža | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: srednje svijetla koža</annotation>
+		<annotation cp="🦻🏼">pristupačnost | srednje svijetla koža | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏼" type="tts">uvo sa slušnim aparatom: srednje svijetla koža</annotation>
-		<annotation cp="🦻🏽">ni svijetla ni tamna koža | pristupačnost | tvrd na uši | uvo sa slušnim aparatom | uvo sa slušnim aparatom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🦻🏽">ni svijetla ni tamna koža | pristupačnost | tvrd na uši | uvo sa slušnim aparatom</annotation>
 		<annotation cp="🦻🏽" type="tts">uvo sa slušnim aparatom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👃🏻">nos | nos: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👃🏻">nos | svijetla koža</annotation>
 		<annotation cp="👃🏻" type="tts">nos: svijetla koža</annotation>
-		<annotation cp="👃🏼">nos | nos: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👃🏼">nos | srednje svijetla koža</annotation>
 		<annotation cp="👃🏼" type="tts">nos: srednje svijetla koža</annotation>
-		<annotation cp="👃🏽">ni svijetla ni tamna koža | nos | nos: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👃🏽">ni svijetla ni tamna koža | nos</annotation>
 		<annotation cp="👃🏽" type="tts">nos: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👃🏾">nos | srednje tamna koža</annotation>
 		<annotation cp="👃🏿">nos | tamna koža</annotation>
-		<annotation cp="👶🏻">beba | beba: svijetla koža | mladost | svijetla koža</annotation>
+		<annotation cp="👶🏻">beba | mladost | svijetla koža</annotation>
 		<annotation cp="👶🏻" type="tts">beba: svijetla koža</annotation>
-		<annotation cp="👶🏼">beba | beba: srednje svijetla koža | mladost | srednje svijetla koža</annotation>
+		<annotation cp="👶🏼">beba | mladost | srednje svijetla koža</annotation>
 		<annotation cp="👶🏼" type="tts">beba: srednje svijetla koža</annotation>
-		<annotation cp="👶🏽">beba | beba: ni svijetla ni tamna koža | mladost | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👶🏽">beba | mladost | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👶🏽" type="tts">beba: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧒🏻">dijete | dijete: svijetla koža | mladost | neodređen rod | rodno neutralno | svijetla koža</annotation>
+		<annotation cp="🧒🏻">dijete | mladost | neodređen rod | rodno neutralno | svijetla koža</annotation>
 		<annotation cp="🧒🏻" type="tts">dijete: svijetla koža</annotation>
-		<annotation cp="🧒🏼">dijete | dijete: srednje svijetla koža | mladost | neodređen rod | rodno neutralno | srednje svijetla koža</annotation>
+		<annotation cp="🧒🏼">dijete | mladost | neodređen rod | rodno neutralno | srednje svijetla koža</annotation>
 		<annotation cp="🧒🏼" type="tts">dijete: srednje svijetla koža</annotation>
-		<annotation cp="🧒🏽">dijete | dijete: ni svijetla ni tamna koža | mladost | neodređen rod | ni svijetla ni tamna koža | rodno neutralno</annotation>
+		<annotation cp="🧒🏽">dijete | mladost | neodređen rod | ni svijetla ni tamna koža | rodno neutralno</annotation>
 		<annotation cp="🧒🏽" type="tts">dijete: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧒🏾">dijete | dijete: srednje tamna koža | mladost | neodređen rod | rodno neutralno | srednje tamna koža</annotation>
+		<annotation cp="🧒🏾">dijete | mladost | neodređen rod | rodno neutralno | srednje tamna koža</annotation>
 		<annotation cp="🧒🏾" type="tts">dijete: srednje tamna koža</annotation>
-		<annotation cp="🧒🏿">dijete | dijete: tamna koža | mladost | neodređen rod | rodno neutralno | tamna koža</annotation>
+		<annotation cp="🧒🏿">dijete | mladost | neodređen rod | rodno neutralno | tamna koža</annotation>
 		<annotation cp="🧒🏿" type="tts">dijete: tamna koža</annotation>
-		<annotation cp="👦🏻">dječak | dječak: svijetla koža | mladost | svijetla koža</annotation>
+		<annotation cp="👦🏻">dječak | mladost | svijetla koža</annotation>
 		<annotation cp="👦🏻" type="tts">dječak: svijetla koža</annotation>
-		<annotation cp="👦🏼">dječak | dječak: srednje svijetla koža | mladost | srednje svijetla koža</annotation>
+		<annotation cp="👦🏼">dječak | mladost | srednje svijetla koža</annotation>
 		<annotation cp="👦🏼" type="tts">dječak: srednje svijetla koža</annotation>
-		<annotation cp="👦🏽">dječak | dječak: ni svijetla ni tamna koža | mladost | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👦🏽">dječak | mladost | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👦🏽" type="tts">dječak: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👦🏾">dječak | dječak: srednje tamna koža | mladost | srednje tamna koža</annotation>
+		<annotation cp="👦🏾">dječak | mladost | srednje tamna koža</annotation>
 		<annotation cp="👦🏾" type="tts">dječak: srednje tamna koža</annotation>
-		<annotation cp="👦🏿">dječak | dječak: tamna koža | mladost | tamna koža</annotation>
+		<annotation cp="👦🏿">dječak | mladost | tamna koža</annotation>
 		<annotation cp="👦🏿" type="tts">dječak: tamna koža</annotation>
-		<annotation cp="👧🏻">djevojčica | djevojčica: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👧🏻">djevojčica | svijetla koža</annotation>
 		<annotation cp="👧🏻" type="tts">djevojčica: svijetla koža</annotation>
-		<annotation cp="👧🏼">djevojčica | djevojčica: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👧🏼">djevojčica | srednje svijetla koža</annotation>
 		<annotation cp="👧🏼" type="tts">djevojčica: srednje svijetla koža</annotation>
-		<annotation cp="👧🏽">djevojčica | djevojčica: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👧🏽">djevojčica | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👧🏽" type="tts">djevojčica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👧🏾">djevojčica | djevojčica: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👧🏾">djevojčica | srednje tamna koža</annotation>
 		<annotation cp="👧🏾" type="tts">djevojčica: srednje tamna koža</annotation>
-		<annotation cp="👧🏿">djevojčica | djevojčica: tamna koža | tamna koža</annotation>
+		<annotation cp="👧🏿">djevojčica | tamna koža</annotation>
 		<annotation cp="👧🏿" type="tts">djevojčica: tamna koža</annotation>
-		<annotation cp="🧑🏻">neodređen rod | odrasla osoba | odrasla osoba: svijetla koža | osoba | rodno neutralno | svijetla koža</annotation>
+		<annotation cp="🧑🏻">neodređen rod | odrasla osoba | osoba | rodno neutralno | svijetla koža</annotation>
 		<annotation cp="🧑🏻" type="tts">odrasla osoba: svijetla koža</annotation>
-		<annotation cp="🧑🏼">neodređen rod | odrasla osoba | odrasla osoba: srednje svijetla koža | osoba | rodno neutralno | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼">neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼" type="tts">odrasla osoba: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽">neodređen rod | ni svijetla ni tamna koža | odrasla osoba | odrasla osoba: ni svijetla ni tamna koža | osoba | rodno neutralno</annotation>
+		<annotation cp="🧑🏽">neodređen rod | ni svijetla ni tamna koža | odrasla osoba | osoba | rodno neutralno</annotation>
 		<annotation cp="🧑🏽" type="tts">odrasla osoba: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏾">neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje tamna koža</annotation>
 		<annotation cp="🧑🏿">neodređen rod | odrasla osoba | osoba | rodno neutralno | tamna koža</annotation>
-		<annotation cp="👱🏻">osoba sa plavom kosom | osoba sa plavom kosom: svijetla koža | plava kosa | svijetla koža</annotation>
+		<annotation cp="👱🏻">osoba sa plavom kosom | plava kosa | svijetla koža</annotation>
 		<annotation cp="👱🏻" type="tts">osoba sa plavom kosom: svijetla koža</annotation>
-		<annotation cp="👱🏼">osoba sa plavom kosom | osoba sa plavom kosom: srednje svijetla koža | plava kosa | srednje svijetla koža</annotation>
+		<annotation cp="👱🏼">osoba sa plavom kosom | plava kosa | srednje svijetla koža</annotation>
 		<annotation cp="👱🏼" type="tts">osoba sa plavom kosom: srednje svijetla koža</annotation>
-		<annotation cp="👱🏽">ni svijetla ni tamna koža | osoba sa plavom kosom | osoba sa plavom kosom: ni svijetla ni tamna koža | plava kosa</annotation>
+		<annotation cp="👱🏽">ni svijetla ni tamna koža | osoba sa plavom kosom | plava kosa</annotation>
 		<annotation cp="👱🏽" type="tts">osoba sa plavom kosom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">odrasla osoba | poljubac | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, svijetla koža i ni svijetla ni tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">odrasla osoba | poljubac | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, svijetla koža i tamna koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">odrasla osoba | poljubac | svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, svijetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">odrasla osoba | poljubac | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">odrasla osoba | poljubac | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">odrasla osoba | poljubac | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">ni svijetla ni tamna koža | odrasla osoba | poljubac | svijetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">ni svijetla ni tamna koža | odrasla osoba | poljubac | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">ni svijetla ni tamna koža | odrasla osoba | poljubac | srednje tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">ni svijetla ni tamna koža | odrasla osoba | poljubac | tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿" type="tts">poljubac: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">odrasla osoba | poljubac | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">odrasla osoba | poljubac | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿">odrasla osoba | poljubac | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i svijetla koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">odrasla osoba | poljubac | svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">odrasla osoba | poljubac | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | poljubac: odrasla osoba, odrasla osoba, tamna koža i ni svijetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | poljubac | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽" type="tts">poljubac: odrasla osoba, odrasla osoba, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾">odrasla osoba | poljubac | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏼">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏼">odrasla osoba | par sa srcem | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i ni svijetla ni tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏾">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏾">odrasla osoba | par sa srcem | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏿">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i tamna koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏿">odrasla osoba | par sa srcem | svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, svijetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏻">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏻">odrasla osoba | par sa srcem | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏾">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏾">odrasla osoba | par sa srcem | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏿">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏿">odrasla osoba | par sa srcem | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏻">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏻">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | svijetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏼">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏼">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏾">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏾">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏾" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏿">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏿">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | tamna koža</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏿" type="tts">par sa srcem: odrasla osoba, odrasla osoba, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏻">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏻">odrasla osoba | par sa srcem | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏼">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏼">odrasla osoba | par sa srcem | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏿">odrasla osoba | par sa srcem | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏻">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i svijetla koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏻">odrasla osoba | par sa srcem | svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏻" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏼">odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏼">odrasla osoba | par sa srcem | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏼" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | par sa srcem: odrasla osoba, odrasla osoba, tamna koža i ni svijetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏽">ni svijetla ni tamna koža | odrasla osoba | par sa srcem | tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏽" type="tts">par sa srcem: odrasla osoba, odrasla osoba, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏾">odrasla osoba | par sa srcem | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="🧑‍🦰">crvena kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno</annotation>
-		<annotation cp="🧑🏻‍🦰">crvena kosa | neodređen rod | odrasla osoba | odrasla osoba: svijetla koža i crvena kosa | osoba | rodno neutralno | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦰">crvena kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦰" type="tts">odrasla osoba: svijetla koža i crvena kosa</annotation>
-		<annotation cp="🧑🏼‍🦰">crvena kosa | neodređen rod | odrasla osoba | odrasla osoba: srednje svijetla koža i crvena kosa | osoba | rodno neutralno | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦰">crvena kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦰" type="tts">odrasla osoba: srednje svijetla koža i crvena kosa</annotation>
-		<annotation cp="🧑🏽‍🦰">crvena kosa | neodređen rod | ni svijetla ni tamna koža | odrasla osoba | odrasla osoba: ni svijetla ni tamna koža i crvena kosa | osoba | rodno neutralno</annotation>
+		<annotation cp="🧑🏽‍🦰">crvena kosa | neodređen rod | ni svijetla ni tamna koža | odrasla osoba | osoba | rodno neutralno</annotation>
 		<annotation cp="🧑🏽‍🦰" type="tts">odrasla osoba: ni svijetla ni tamna koža i crvena kosa</annotation>
 		<annotation cp="🧑🏾‍🦰">crvena kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦰">crvena kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | tamna koža</annotation>
 		<annotation cp="🧑‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno</annotation>
-		<annotation cp="🧑🏻‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | odrasla osoba: svijetla koža i kovrdžava kosa | osoba | rodno neutralno | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦱" type="tts">odrasla osoba: svijetla koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑🏼‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | odrasla osoba: srednje svijetla koža i kovrdžava kosa | osoba | rodno neutralno | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦱" type="tts">odrasla osoba: srednje svijetla koža i kovrdžava kosa</annotation>
-		<annotation cp="🧑🏽‍🦱">kovrdžava kosa | neodređen rod | ni svijetla ni tamna koža | odrasla osoba | odrasla osoba: ni svijetla ni tamna koža i kovrdžava kosa | osoba | rodno neutralno</annotation>
+		<annotation cp="🧑🏽‍🦱">kovrdžava kosa | neodređen rod | ni svijetla ni tamna koža | odrasla osoba | osoba | rodno neutralno</annotation>
 		<annotation cp="🧑🏽‍🦱" type="tts">odrasla osoba: ni svijetla ni tamna koža i kovrdžava kosa</annotation>
 		<annotation cp="🧑🏾‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦱">kovrdžava kosa | neodređen rod | odrasla osoba | osoba | rodno neutralno | tamna koža</annotation>
-		<annotation cp="🧑‍🦳">neodređen rod | odrasla osoba | odrasla osoba: sijeda kosa | osoba | rodno neutralno | sijeda kosa</annotation>
+		<annotation cp="🧑‍🦳">neodređen rod | odrasla osoba | osoba | rodno neutralno | sijeda kosa</annotation>
 		<annotation cp="🧑‍🦳" type="tts">odrasla osoba: sijeda kosa</annotation>
-		<annotation cp="🧑🏻‍🦳">neodređen rod | odrasla osoba | odrasla osoba: svijetla koža i sijeda kosa | osoba | rodno neutralno | sijeda kosa | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦳">neodređen rod | odrasla osoba | osoba | rodno neutralno | sijeda kosa | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦳" type="tts">odrasla osoba: svijetla koža i sijeda kosa</annotation>
-		<annotation cp="🧑🏼‍🦳">neodređen rod | odrasla osoba | odrasla osoba: srednje svijetla koža i sijeda kosa | osoba | rodno neutralno | sijeda kosa | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦳">neodređen rod | odrasla osoba | osoba | rodno neutralno | sijeda kosa | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦳" type="tts">odrasla osoba: srednje svijetla koža i sijeda kosa</annotation>
-		<annotation cp="🧑🏽‍🦳">neodređen rod | ni svijetla ni tamna koža | odrasla osoba | odrasla osoba: ni svijetla ni tamna koža i sijeda kosa | osoba | rodno neutralno | sijeda kosa</annotation>
+		<annotation cp="🧑🏽‍🦳">neodređen rod | ni svijetla ni tamna koža | odrasla osoba | osoba | rodno neutralno | sijeda kosa</annotation>
 		<annotation cp="🧑🏽‍🦳" type="tts">odrasla osoba: ni svijetla ni tamna koža i sijeda kosa</annotation>
-		<annotation cp="🧑🏾‍🦳">neodređen rod | odrasla osoba | odrasla osoba: srednje tamna koža i sijeda kosa | osoba | rodno neutralno | sijeda kosa | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🦳">neodređen rod | odrasla osoba | osoba | rodno neutralno | sijeda kosa | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦳" type="tts">odrasla osoba: srednje tamna koža i sijeda kosa</annotation>
-		<annotation cp="🧑🏿‍🦳">neodređen rod | odrasla osoba | odrasla osoba: tamna koža i sijeda kosa | osoba | rodno neutralno | sijeda kosa | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🦳">neodređen rod | odrasla osoba | osoba | rodno neutralno | sijeda kosa | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦳" type="tts">odrasla osoba: tamna koža i sijeda kosa</annotation>
 		<annotation cp="🧑‍🦲">ćelav | neodređen rod | odrasla osoba | osoba | rodno neutralno</annotation>
-		<annotation cp="🧑🏻‍🦲">ćelav | neodređen rod | odrasla osoba | odrasla osoba: svijetla koža i ćelav | osoba | rodno neutralno | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦲">ćelav | neodređen rod | odrasla osoba | osoba | rodno neutralno | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦲" type="tts">odrasla osoba: svijetla koža i ćelav</annotation>
-		<annotation cp="🧑🏼‍🦲">ćelav | neodređen rod | odrasla osoba | odrasla osoba: srednje svijetla koža i ćelav | osoba | rodno neutralno | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦲">ćelav | neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦲" type="tts">odrasla osoba: srednje svijetla koža i ćelav</annotation>
-		<annotation cp="🧑🏽‍🦲">ćelav | neodređen rod | ni svijetla ni tamna koža | odrasla osoba | odrasla osoba: ni svijetla ni tamna koža i ćelav | osoba | rodno neutralno</annotation>
+		<annotation cp="🧑🏽‍🦲">ćelav | neodređen rod | ni svijetla ni tamna koža | odrasla osoba | osoba | rodno neutralno</annotation>
 		<annotation cp="🧑🏽‍🦲" type="tts">odrasla osoba: ni svijetla ni tamna koža i ćelav</annotation>
 		<annotation cp="🧑🏾‍🦲">ćelav | neodređen rod | odrasla osoba | osoba | rodno neutralno | srednje tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦲">ćelav | neodređen rod | odrasla osoba | osoba | rodno neutralno | tamna koža</annotation>
-		<annotation cp="👨🏻">muškarac | muškarac: svijetla koža | odrasla osoba | svijetla koža</annotation>
+		<annotation cp="👨🏻">muškarac | odrasla osoba | svijetla koža</annotation>
 		<annotation cp="👨🏻" type="tts">muškarac: svijetla koža</annotation>
-		<annotation cp="👨🏼">muškarac | muškarac: srednje svijetla koža | odrasla osoba | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼">muškarac | odrasla osoba | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼" type="tts">muškarac: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽">muškarac | muškarac: ni svijetla ni tamna koža | ni svijetla ni tamna koža | odrasla osoba</annotation>
+		<annotation cp="👨🏽">muškarac | ni svijetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="👨🏽" type="tts">muškarac: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏾">muškarac | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="👨🏿">muškarac | odrasla osoba | tamna koža</annotation>
-		<annotation cp="🧔🏻">brada | osoba sa bradom | osoba sa bradom: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧔🏻">brada | osoba sa bradom | svijetla koža</annotation>
 		<annotation cp="🧔🏻" type="tts">osoba sa bradom: svijetla koža</annotation>
-		<annotation cp="🧔🏼">brada | osoba sa bradom | osoba sa bradom: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧔🏼">brada | osoba sa bradom | srednje svijetla koža</annotation>
 		<annotation cp="🧔🏼" type="tts">osoba sa bradom: srednje svijetla koža</annotation>
-		<annotation cp="🧔🏽">brada | ni svijetla ni tamna koža | osoba sa bradom | osoba sa bradom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧔🏽">brada | ni svijetla ni tamna koža | osoba sa bradom</annotation>
 		<annotation cp="🧔🏽" type="tts">osoba sa bradom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧔🏻‍♂">brada | muškarac | muškarac: brada | muškarac: svijetla koža i brada | svijetla koža</annotation>
+		<annotation cp="🧔🏻‍♂">brada | muškarac | muškarac: brada | svijetla koža</annotation>
 		<annotation cp="🧔🏻‍♂" type="tts">muškarac: svijetla koža i brada</annotation>
-		<annotation cp="🧔🏼‍♂">brada | muškarac | muškarac: brada | muškarac: srednje svijetla koža i brada | srednje svijetla koža</annotation>
+		<annotation cp="🧔🏼‍♂">brada | muškarac | muškarac: brada | srednje svijetla koža</annotation>
 		<annotation cp="🧔🏼‍♂" type="tts">muškarac: srednje svijetla koža i brada</annotation>
-		<annotation cp="🧔🏽‍♂">brada | muškarac | muškarac: brada | muškarac: ni svijetla ni tamna koža i brada | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧔🏽‍♂">brada | muškarac | muškarac: brada | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧔🏽‍♂" type="tts">muškarac: ni svijetla ni tamna koža i brada</annotation>
-		<annotation cp="👱🏻‍♂">muškarac | plav muškarac | plav muškarac: svijetla koža | plava kosa | svijetla koža</annotation>
+		<annotation cp="👱🏻‍♂">muškarac | plav muškarac | plava kosa | svijetla koža</annotation>
 		<annotation cp="👱🏻‍♂" type="tts">plav muškarac: svijetla koža</annotation>
-		<annotation cp="👱🏼‍♂">muškarac | plav muškarac | plav muškarac: srednje svijetla koža | plava kosa | srednje svijetla koža</annotation>
+		<annotation cp="👱🏼‍♂">muškarac | plav muškarac | plava kosa | srednje svijetla koža</annotation>
 		<annotation cp="👱🏼‍♂" type="tts">plav muškarac: srednje svijetla koža</annotation>
-		<annotation cp="👱🏽‍♂">muškarac | ni svijetla ni tamna koža | plav muškarac | plav muškarac: ni svijetla ni tamna koža | plava kosa</annotation>
+		<annotation cp="👱🏽‍♂">muškarac | ni svijetla ni tamna koža | plav muškarac | plava kosa</annotation>
 		<annotation cp="👱🏽‍♂" type="tts">plav muškarac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: muškarac, muškarac i svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏻">muškarac | poljubac | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac i svijetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: muškarac, muškarac, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, svijetla koža i ni svijetla ni tamna koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏾">muškarac | poljubac | poljubac: muškarac, muškarac, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏾">muškarac | poljubac | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏿">muškarac | poljubac | poljubac: muškarac, muškarac, svijetla koža i tamna koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏿">muškarac | poljubac | svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, svijetla koža i tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: muškarac, muškarac, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏻">muškarac | poljubac | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: muškarac, muškarac i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac i srednje svijetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏾">muškarac | poljubac | poljubac: muškarac, muškarac, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏾">muškarac | poljubac | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏿">muškarac | poljubac | poljubac: muškarac, muškarac, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏿">muškarac | poljubac | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏻">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, ni svijetla ni tamna koža i svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏻">muškarac | ni svijetla ni tamna koža | poljubac | svijetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏼">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏼">muškarac | ni svijetla ni tamna koža | poljubac | srednje svijetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏾">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏾">muškarac | ni svijetla ni tamna koža | poljubac | srednje tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏾" type="tts">poljubac: muškarac, muškarac, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏿">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, ni svijetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏿">muškarac | ni svijetla ni tamna koža | poljubac | tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏿" type="tts">poljubac: muškarac, muškarac, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏻">muškarac | poljubac | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏾">muškarac | poljubac | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏿">muškarac | poljubac | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: muškarac, muškarac, tamna koža i svijetla koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏻">muškarac | poljubac | svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏻" type="tts">poljubac: muškarac, muškarac, tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: muškarac, muškarac, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏼" type="tts">poljubac: muškarac, muškarac, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: muškarac, muškarac, tamna koža i ni svijetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏽" type="tts">poljubac: muškarac, muškarac, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏾">muškarac | poljubac | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏿">muškarac | poljubac | tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: muškarac, muškarac i svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏻">muškarac | par sa srcem | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac i svijetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, svijetla koža i ni svijetla ni tamna koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏾">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏾">muškarac | par sa srcem | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏿">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, svijetla koža i tamna koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏿">muškarac | par sa srcem | svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, svijetla koža i tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏻">muškarac | par sa srcem | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: muškarac, muškarac i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac i srednje svijetla koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏾">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏾">muškarac | par sa srcem | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏿">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏿">muškarac | par sa srcem | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏻">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏻">muškarac | ni svijetla ni tamna koža | par sa srcem | svijetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏼">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏼">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje svijetla koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏾">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏾">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏾" type="tts">par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏿">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏿">muškarac | ni svijetla ni tamna koža | par sa srcem | tamna koža</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏿" type="tts">par sa srcem: muškarac, muškarac, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏻">muškarac | par sa srcem | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏾">muškarac | par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏿">muškarac | par sa srcem | srednje tamna koža | tamna koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i svijetla koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏻">muškarac | par sa srcem | svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏻" type="tts">par sa srcem: muškarac, muškarac, tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏼" type="tts">par sa srcem: muškarac, muškarac, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: muškarac, muškarac, tamna koža i ni svijetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏽" type="tts">par sa srcem: muškarac, muškarac, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏾">muškarac | par sa srcem | srednje tamna koža | tamna koža</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏿">muškarac | par sa srcem | tamna koža</annotation>
 		<annotation cp="👨‍🦰">crvena kosa | muškarac | odrasla osoba</annotation>
-		<annotation cp="👨🏻‍🦰">crvena kosa | muškarac | muškarac: svijetla koža i crvena kosa | odrasla osoba | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦰">crvena kosa | muškarac | odrasla osoba | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦰" type="tts">muškarac: svijetla koža i crvena kosa</annotation>
-		<annotation cp="👨🏼‍🦰">crvena kosa | muškarac | muškarac: srednje svijetla koža i crvena kosa | odrasla osoba | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦰">crvena kosa | muškarac | odrasla osoba | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦰" type="tts">muškarac: srednje svijetla koža i crvena kosa</annotation>
-		<annotation cp="👨🏽‍🦰">crvena kosa | muškarac | muškarac: ni svijetla ni tamna koža i crvena kosa | ni svijetla ni tamna koža | odrasla osoba</annotation>
+		<annotation cp="👨🏽‍🦰">crvena kosa | muškarac | ni svijetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="👨🏽‍🦰" type="tts">muškarac: ni svijetla ni tamna koža i crvena kosa</annotation>
 		<annotation cp="👨🏾‍🦰">crvena kosa | muškarac | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="👨🏿‍🦰">crvena kosa | muškarac | odrasla osoba | tamna koža</annotation>
 		<annotation cp="👨‍🦱">kovrdžava kosa | muškarac | odrasla osoba</annotation>
-		<annotation cp="👨🏻‍🦱">kovrdžava kosa | muškarac | muškarac: svijetla koža i kovrdžava kosa | odrasla osoba | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦱">kovrdžava kosa | muškarac | odrasla osoba | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦱" type="tts">muškarac: svijetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👨🏼‍🦱">kovrdžava kosa | muškarac | muškarac: srednje svijetla koža i kovrdžava kosa | odrasla osoba | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦱">kovrdžava kosa | muškarac | odrasla osoba | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦱" type="tts">muškarac: srednje svijetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👨🏽‍🦱">kovrdžava kosa | muškarac | muškarac: ni svijetla ni tamna koža i kovrdžava kosa | ni svijetla ni tamna koža | odrasla osoba</annotation>
+		<annotation cp="👨🏽‍🦱">kovrdžava kosa | muškarac | ni svijetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="👨🏽‍🦱" type="tts">muškarac: ni svijetla ni tamna koža i kovrdžava kosa</annotation>
 		<annotation cp="👨🏾‍🦱">kovrdžava kosa | muškarac | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="👨🏿‍🦱">kovrdžava kosa | muškarac | odrasla osoba | tamna koža</annotation>
-		<annotation cp="👨‍🦳">muškarac | muškarac: sijeda kosa | odrasla osoba | sijeda kosa</annotation>
+		<annotation cp="👨‍🦳">muškarac | odrasla osoba | sijeda kosa</annotation>
 		<annotation cp="👨‍🦳" type="tts">muškarac: sijeda kosa</annotation>
-		<annotation cp="👨🏻‍🦳">muškarac | muškarac: svijetla koža i sijeda kosa | odrasla osoba | sijeda kosa | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦳">muškarac | odrasla osoba | sijeda kosa | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦳" type="tts">muškarac: svijetla koža i sijeda kosa</annotation>
-		<annotation cp="👨🏼‍🦳">muškarac | muškarac: srednje svijetla koža i sijeda kosa | odrasla osoba | sijeda kosa | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦳">muškarac | odrasla osoba | sijeda kosa | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦳" type="tts">muškarac: srednje svijetla koža i sijeda kosa</annotation>
-		<annotation cp="👨🏽‍🦳">muškarac | muškarac: ni svijetla ni tamna koža i sijeda kosa | ni svijetla ni tamna koža | odrasla osoba | sijeda kosa</annotation>
+		<annotation cp="👨🏽‍🦳">muškarac | ni svijetla ni tamna koža | odrasla osoba | sijeda kosa</annotation>
 		<annotation cp="👨🏽‍🦳" type="tts">muškarac: ni svijetla ni tamna koža i sijeda kosa</annotation>
-		<annotation cp="👨🏾‍🦳">muškarac | muškarac: srednje tamna koža i sijeda kosa | odrasla osoba | sijeda kosa | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦳">muškarac | odrasla osoba | sijeda kosa | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦳" type="tts">muškarac: srednje tamna koža i sijeda kosa</annotation>
-		<annotation cp="👨🏿‍🦳">muškarac | muškarac: tamna koža i sijeda kosa | odrasla osoba | sijeda kosa | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦳">muškarac | odrasla osoba | sijeda kosa | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦳" type="tts">muškarac: tamna koža i sijeda kosa</annotation>
 		<annotation cp="👨‍🦲">ćelav | muškarac | odrasla osoba</annotation>
-		<annotation cp="👨🏻‍🦲">ćelav | muškarac | muškarac: svijetla koža i ćelav | odrasla osoba | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦲">ćelav | muškarac | odrasla osoba | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦲" type="tts">muškarac: svijetla koža i ćelav</annotation>
-		<annotation cp="👨🏼‍🦲">ćelav | muškarac | muškarac: srednje svijetla koža i ćelav | odrasla osoba | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦲">ćelav | muškarac | odrasla osoba | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦲" type="tts">muškarac: srednje svijetla koža i ćelav</annotation>
-		<annotation cp="👨🏽‍🦲">ćelav | muškarac | muškarac: ni svijetla ni tamna koža i ćelav | ni svijetla ni tamna koža | odrasla osoba</annotation>
+		<annotation cp="👨🏽‍🦲">ćelav | muškarac | ni svijetla ni tamna koža | odrasla osoba</annotation>
 		<annotation cp="👨🏽‍🦲" type="tts">muškarac: ni svijetla ni tamna koža i ćelav</annotation>
 		<annotation cp="👨🏾‍🦲">ćelav | muškarac | odrasla osoba | srednje tamna koža</annotation>
 		<annotation cp="👨🏿‍🦲">ćelav | muškarac | odrasla osoba | tamna koža</annotation>
-		<annotation cp="👩🏻">odrasla osoba | svijetla koža | žena | žena: svijetla koža</annotation>
+		<annotation cp="👩🏻">odrasla osoba | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻" type="tts">žena: svijetla koža</annotation>
-		<annotation cp="👩🏼">odrasla osoba | srednje svijetla koža | žena | žena: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼">odrasla osoba | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼" type="tts">žena: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽">ni svijetla ni tamna koža | odrasla osoba | žena | žena: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽">ni svijetla ni tamna koža | odrasla osoba | žena</annotation>
 		<annotation cp="👩🏽" type="tts">žena: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾">odrasla osoba | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏿">odrasla osoba | tamna koža | žena</annotation>
-		<annotation cp="🧔🏻‍♀">brada | svijetla koža | žena | žena: brada | žena: svijetla koža i brada</annotation>
+		<annotation cp="🧔🏻‍♀">brada | svijetla koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏻‍♀" type="tts">žena: svijetla koža i brada</annotation>
-		<annotation cp="🧔🏼‍♀">brada | srednje svijetla koža | žena | žena: brada | žena: srednje svijetla koža i brada</annotation>
+		<annotation cp="🧔🏼‍♀">brada | srednje svijetla koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏼‍♀" type="tts">žena: srednje svijetla koža i brada</annotation>
-		<annotation cp="🧔🏽‍♀">brada | ni svijetla ni tamna koža | žena | žena: brada | žena: ni svijetla ni tamna koža i brada</annotation>
+		<annotation cp="🧔🏽‍♀">brada | ni svijetla ni tamna koža | žena | žena: brada</annotation>
 		<annotation cp="🧔🏽‍♀" type="tts">žena: ni svijetla ni tamna koža i brada</annotation>
-		<annotation cp="👱🏻‍♀">plava kosa | plavuša | plavuša: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👱🏻‍♀">plava kosa | plavuša | svijetla koža | žena</annotation>
 		<annotation cp="👱🏻‍♀" type="tts">plavuša: svijetla koža</annotation>
-		<annotation cp="👱🏼‍♀">plava kosa | plavuša | plavuša: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👱🏼‍♀">plava kosa | plavuša | srednje svijetla koža | žena</annotation>
 		<annotation cp="👱🏼‍♀" type="tts">plavuša: srednje svijetla koža</annotation>
-		<annotation cp="👱🏽‍♀">ni svijetla ni tamna koža | plava kosa | plavuša | plavuša: ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👱🏽‍♀">ni svijetla ni tamna koža | plava kosa | plavuša | žena</annotation>
 		<annotation cp="👱🏽‍♀" type="tts">plavuša: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: žena, muškarac i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏻">muškarac | poljubac | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac i svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: žena, muškarac, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, svijetla koža i ni svijetla ni tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏾">muškarac | poljubac | poljubac: žena, muškarac, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏾">muškarac | poljubac | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏿">muškarac | poljubac | poljubac: žena, muškarac, svijetla koža i tamna koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏿">muškarac | poljubac | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: žena, muškarac, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏻">muškarac | poljubac | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: žena, muškarac i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac i srednje svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏾">muškarac | poljubac | poljubac: žena, muškarac, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏾">muškarac | poljubac | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏿">muškarac | poljubac | poljubac: žena, muškarac, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏿">muškarac | poljubac | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏻">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, ni svijetla ni tamna koža i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏻">muškarac | ni svijetla ni tamna koža | poljubac | svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏼">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏼">muškarac | ni svijetla ni tamna koža | poljubac | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac i ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏾">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏾">muškarac | ni svijetla ni tamna koža | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏾" type="tts">poljubac: žena, muškarac, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏿">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, ni svijetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏿">muškarac | ni svijetla ni tamna koža | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏿" type="tts">poljubac: žena, muškarac, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: žena, muškarac, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏻">muškarac | poljubac | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: žena, muškarac, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏾">muškarac | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏿">muškarac | poljubac | srednje tamna koža | tamna koža | žena</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏻">muškarac | poljubac | poljubac: žena, muškarac, tamna koža i svijetla koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏻">muškarac | poljubac | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏻" type="tts">poljubac: žena, muškarac, tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏼">muškarac | poljubac | poljubac: žena, muškarac, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏼">muškarac | poljubac | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏼" type="tts">poljubac: žena, muškarac, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | poljubac: žena, muškarac, tamna koža i ni svijetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏽">muškarac | ni svijetla ni tamna koža | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏽" type="tts">poljubac: žena, muškarac, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏾">muškarac | poljubac | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏿">muškarac | poljubac | tamna koža | žena</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏻">poljubac | poljubac: žena, žena i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏻">poljubac | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena i svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏼">poljubac | poljubac: žena, žena, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏼">poljubac | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, svijetla koža i ni svijetla ni tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏾">poljubac | poljubac: žena, žena, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏾">poljubac | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏿">poljubac | poljubac: žena, žena, svijetla koža i tamna koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏿">poljubac | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏻">poljubac | poljubac: žena, žena, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏻">poljubac | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏼">poljubac | poljubac: žena, žena i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏼">poljubac | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena i srednje svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏾">poljubac | poljubac: žena, žena, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏾">poljubac | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏿">poljubac | poljubac: žena, žena, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏿">poljubac | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏻">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, ni svijetla ni tamna koža i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏻">ni svijetla ni tamna koža | poljubac | svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏼">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏼">ni svijetla ni tamna koža | poljubac | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena i ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏾">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏾">ni svijetla ni tamna koža | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏾" type="tts">poljubac: žena, žena, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏿">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, ni svijetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏿">ni svijetla ni tamna koža | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏿" type="tts">poljubac: žena, žena, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏻">poljubac | poljubac: žena, žena, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏻">poljubac | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏼">poljubac | poljubac: žena, žena, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏼">poljubac | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏾">poljubac | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏿">poljubac | srednje tamna koža | tamna koža | žena</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏻">poljubac | poljubac: žena, žena, tamna koža i svijetla koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏻">poljubac | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏻" type="tts">poljubac: žena, žena, tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏼">poljubac | poljubac: žena, žena, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏼">poljubac | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏼" type="tts">poljubac: žena, žena, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | poljubac: žena, žena, tamna koža i ni svijetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏽">ni svijetla ni tamna koža | poljubac | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏽" type="tts">poljubac: žena, žena, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏾">poljubac | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏿">poljubac | tamna koža | žena</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: žena, muškarac i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏻">muškarac | par sa srcem | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac i svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: žena, muškarac, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, svijetla koža i ni svijetla ni tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏾">muškarac | par sa srcem | par sa srcem: žena, muškarac, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏾">muškarac | par sa srcem | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏿">muškarac | par sa srcem | par sa srcem: žena, muškarac, svijetla koža i tamna koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏿">muškarac | par sa srcem | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: žena, muškarac, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏻">muškarac | par sa srcem | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: žena, muškarac i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac i srednje svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏾">muškarac | par sa srcem | par sa srcem: žena, muškarac, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏾">muškarac | par sa srcem | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏿">muškarac | par sa srcem | par sa srcem: žena, muškarac, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏿">muškarac | par sa srcem | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏻">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, ni svijetla ni tamna koža i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏻">muškarac | ni svijetla ni tamna koža | par sa srcem | svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏼">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏼">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac i ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏾">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏾">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏾" type="tts">par sa srcem: žena, muškarac, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏿">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, ni svijetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏿">muškarac | ni svijetla ni tamna koža | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏿" type="tts">par sa srcem: žena, muškarac, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏻">muškarac | par sa srcem | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏾">muškarac | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏿">muškarac | par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏻">muškarac | par sa srcem | par sa srcem: žena, muškarac, tamna koža i svijetla koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏻">muškarac | par sa srcem | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏻" type="tts">par sa srcem: žena, muškarac, tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏼">muškarac | par sa srcem | par sa srcem: žena, muškarac, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏼">muškarac | par sa srcem | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏼" type="tts">par sa srcem: žena, muškarac, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, muškarac, tamna koža i ni svijetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏽">muškarac | ni svijetla ni tamna koža | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏽" type="tts">par sa srcem: žena, muškarac, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏾">muškarac | par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏿">muškarac | par sa srcem | tamna koža | žena</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏻">par sa srcem | par sa srcem: žena, žena i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏻">par sa srcem | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏻" type="tts">par sa srcem: žena, žena i svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏼">par sa srcem | par sa srcem: žena, žena, svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏼">par sa srcem | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, svijetla koža i ni svijetla ni tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏾">par sa srcem | par sa srcem: žena, žena, svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏾">par sa srcem | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏿">par sa srcem | par sa srcem: žena, žena, svijetla koža i tamna koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏿">par sa srcem | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏻">par sa srcem | par sa srcem: žena, žena, srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏻">par sa srcem | srednje svijetla koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏼">par sa srcem | par sa srcem: žena, žena i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏼">par sa srcem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏼" type="tts">par sa srcem: žena, žena i srednje svijetla koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏾">par sa srcem | par sa srcem: žena, žena, srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏾">par sa srcem | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏿">par sa srcem | par sa srcem: žena, žena, srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏿">par sa srcem | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏻">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, ni svijetla ni tamna koža i svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏻">ni svijetla ni tamna koža | par sa srcem | svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏼">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏼">ni svijetla ni tamna koža | par sa srcem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena i ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏽" type="tts">par sa srcem: žena, žena i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏾">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏾">ni svijetla ni tamna koža | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏾" type="tts">par sa srcem: žena, žena, ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏿">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, ni svijetla ni tamna koža i tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏿">ni svijetla ni tamna koža | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏿" type="tts">par sa srcem: žena, žena, ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏻">par sa srcem | par sa srcem: žena, žena, srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏻">par sa srcem | srednje tamna koža | svijetla koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏼">par sa srcem | par sa srcem: žena, žena, srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏼">par sa srcem | srednje svijetla koža | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, srednje tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏾">par sa srcem | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏿">par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏻">par sa srcem | par sa srcem: žena, žena, tamna koža i svijetla koža | svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏻">par sa srcem | svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏻" type="tts">par sa srcem: žena, žena, tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏼">par sa srcem | par sa srcem: žena, žena, tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏼">par sa srcem | srednje svijetla koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏼" type="tts">par sa srcem: žena, žena, tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | par sa srcem: žena, žena, tamna koža i ni svijetla ni tamna koža | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏽">ni svijetla ni tamna koža | par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏽" type="tts">par sa srcem: žena, žena, tamna koža i ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏾">par sa srcem | srednje tamna koža | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏿">par sa srcem | tamna koža | žena</annotation>
 		<annotation cp="👩‍🦰">crvena kosa | odrasla osoba | žena</annotation>
-		<annotation cp="👩🏻‍🦰">crvena kosa | odrasla osoba | svijetla koža | žena | žena: svijetla koža i crvena kosa</annotation>
+		<annotation cp="👩🏻‍🦰">crvena kosa | odrasla osoba | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦰" type="tts">žena: svijetla koža i crvena kosa</annotation>
-		<annotation cp="👩🏼‍🦰">crvena kosa | odrasla osoba | srednje svijetla koža | žena | žena: srednje svijetla koža i crvena kosa</annotation>
+		<annotation cp="👩🏼‍🦰">crvena kosa | odrasla osoba | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦰" type="tts">žena: srednje svijetla koža i crvena kosa</annotation>
-		<annotation cp="👩🏽‍🦰">crvena kosa | ni svijetla ni tamna koža | odrasla osoba | žena | žena: ni svijetla ni tamna koža i crvena kosa</annotation>
+		<annotation cp="👩🏽‍🦰">crvena kosa | ni svijetla ni tamna koža | odrasla osoba | žena</annotation>
 		<annotation cp="👩🏽‍🦰" type="tts">žena: ni svijetla ni tamna koža i crvena kosa</annotation>
 		<annotation cp="👩🏾‍🦰">crvena kosa | odrasla osoba | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦰">crvena kosa | odrasla osoba | tamna koža | žena</annotation>
 		<annotation cp="👩‍🦱">kovrdžava kosa | odrasla osoba | žena</annotation>
-		<annotation cp="👩🏻‍🦱">kovrdžava kosa | odrasla osoba | svijetla koža | žena | žena: svijetla koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏻‍🦱">kovrdžava kosa | odrasla osoba | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦱" type="tts">žena: svijetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👩🏼‍🦱">kovrdžava kosa | odrasla osoba | srednje svijetla koža | žena | žena: srednje svijetla koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏼‍🦱">kovrdžava kosa | odrasla osoba | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦱" type="tts">žena: srednje svijetla koža i kovrdžava kosa</annotation>
-		<annotation cp="👩🏽‍🦱">kovrdžava kosa | ni svijetla ni tamna koža | odrasla osoba | žena | žena: ni svijetla ni tamna koža i kovrdžava kosa</annotation>
+		<annotation cp="👩🏽‍🦱">kovrdžava kosa | ni svijetla ni tamna koža | odrasla osoba | žena</annotation>
 		<annotation cp="👩🏽‍🦱" type="tts">žena: ni svijetla ni tamna koža i kovrdžava kosa</annotation>
 		<annotation cp="👩🏾‍🦱">kovrdžava kosa | odrasla osoba | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦱">kovrdžava kosa | odrasla osoba | tamna koža | žena</annotation>
-		<annotation cp="👩‍🦳">odrasla osoba | sijeda kosa | žena | žena: sijeda kosa</annotation>
+		<annotation cp="👩‍🦳">odrasla osoba | sijeda kosa | žena</annotation>
 		<annotation cp="👩‍🦳" type="tts">žena: sijeda kosa</annotation>
-		<annotation cp="👩🏻‍🦳">odrasla osoba | sijeda kosa | svijetla koža | žena | žena: svijetla koža i sijeda kosa</annotation>
+		<annotation cp="👩🏻‍🦳">odrasla osoba | sijeda kosa | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦳" type="tts">žena: svijetla koža i sijeda kosa</annotation>
-		<annotation cp="👩🏼‍🦳">odrasla osoba | sijeda kosa | srednje svijetla koža | žena | žena: srednje svijetla koža i sijeda kosa</annotation>
+		<annotation cp="👩🏼‍🦳">odrasla osoba | sijeda kosa | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦳" type="tts">žena: srednje svijetla koža i sijeda kosa</annotation>
-		<annotation cp="👩🏽‍🦳">ni svijetla ni tamna koža | odrasla osoba | sijeda kosa | žena | žena: ni svijetla ni tamna koža i sijeda kosa</annotation>
+		<annotation cp="👩🏽‍🦳">ni svijetla ni tamna koža | odrasla osoba | sijeda kosa | žena</annotation>
 		<annotation cp="👩🏽‍🦳" type="tts">žena: ni svijetla ni tamna koža i sijeda kosa</annotation>
-		<annotation cp="👩🏾‍🦳">odrasla osoba | sijeda kosa | srednje tamna koža | žena | žena: srednje tamna koža i sijeda kosa</annotation>
+		<annotation cp="👩🏾‍🦳">odrasla osoba | sijeda kosa | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🦳" type="tts">žena: srednje tamna koža i sijeda kosa</annotation>
-		<annotation cp="👩🏿‍🦳">odrasla osoba | sijeda kosa | tamna koža | žena | žena: tamna koža i sijeda kosa</annotation>
+		<annotation cp="👩🏿‍🦳">odrasla osoba | sijeda kosa | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦳" type="tts">žena: tamna koža i sijeda kosa</annotation>
 		<annotation cp="👩‍🦲">ćelav | odrasla osoba | žena</annotation>
-		<annotation cp="👩🏻‍🦲">ćelav | odrasla osoba | svijetla koža | žena | žena: svijetla koža i ćelav</annotation>
+		<annotation cp="👩🏻‍🦲">ćelav | odrasla osoba | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🦲" type="tts">žena: svijetla koža i ćelav</annotation>
-		<annotation cp="👩🏼‍🦲">ćelav | odrasla osoba | srednje svijetla koža | žena | žena: srednje svijetla koža i ćelav</annotation>
+		<annotation cp="👩🏼‍🦲">ćelav | odrasla osoba | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🦲" type="tts">žena: srednje svijetla koža i ćelav</annotation>
-		<annotation cp="👩🏽‍🦲">ćelav | ni svijetla ni tamna koža | odrasla osoba | žena | žena: ni svijetla ni tamna koža i ćelav</annotation>
+		<annotation cp="👩🏽‍🦲">ćelav | ni svijetla ni tamna koža | odrasla osoba | žena</annotation>
 		<annotation cp="👩🏽‍🦲" type="tts">žena: ni svijetla ni tamna koža i ćelav</annotation>
 		<annotation cp="👩🏾‍🦲">ćelav | odrasla osoba | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🦲">ćelav | odrasla osoba | tamna koža | žena</annotation>
-		<annotation cp="🧓🏻">neodređen rod | odrasla osoba | rodno neutralno | starija odrasla osoba | starija odrasla osoba: svijetla koža | starost | svijetla koža</annotation>
+		<annotation cp="🧓🏻">neodređen rod | odrasla osoba | rodno neutralno | starija odrasla osoba | starost | svijetla koža</annotation>
 		<annotation cp="🧓🏻" type="tts">starija odrasla osoba: svijetla koža</annotation>
-		<annotation cp="🧓🏼">neodređen rod | odrasla osoba | rodno neutralno | srednje svijetla koža | starija odrasla osoba | starija odrasla osoba: srednje svijetla koža | starost</annotation>
+		<annotation cp="🧓🏼">neodređen rod | odrasla osoba | rodno neutralno | srednje svijetla koža | starija odrasla osoba | starost</annotation>
 		<annotation cp="🧓🏼" type="tts">starija odrasla osoba: srednje svijetla koža</annotation>
-		<annotation cp="🧓🏽">neodređen rod | ni svijetla ni tamna koža | odrasla osoba | rodno neutralno | starija odrasla osoba | starija odrasla osoba: ni svijetla ni tamna koža | starost</annotation>
+		<annotation cp="🧓🏽">neodređen rod | ni svijetla ni tamna koža | odrasla osoba | rodno neutralno | starija odrasla osoba | starost</annotation>
 		<annotation cp="🧓🏽" type="tts">starija odrasla osoba: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧓🏾">neodređen rod | odrasla osoba | rodno neutralno | srednje tamna koža | starija odrasla osoba | starost</annotation>
 		<annotation cp="🧓🏿">neodređen rod | odrasla osoba | rodno neutralno | starija odrasla osoba | starost | tamna koža</annotation>
-		<annotation cp="👴🏻">muškarac | odrasla osoba | starac | starac: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👴🏻">muškarac | odrasla osoba | starac | svijetla koža</annotation>
 		<annotation cp="👴🏻" type="tts">starac: svijetla koža</annotation>
-		<annotation cp="👴🏼">muškarac | odrasla osoba | srednje svijetla koža | starac | starac: srednje svijetla koža</annotation>
+		<annotation cp="👴🏼">muškarac | odrasla osoba | srednje svijetla koža | starac</annotation>
 		<annotation cp="👴🏼" type="tts">starac: srednje svijetla koža</annotation>
-		<annotation cp="👴🏽">muškarac | ni svijetla ni tamna koža | odrasla osoba | starac | starac: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👴🏽">muškarac | ni svijetla ni tamna koža | odrasla osoba | starac</annotation>
 		<annotation cp="👴🏽" type="tts">starac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👵🏻">odrasla osoba | starica | starica: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👵🏻">odrasla osoba | starica | svijetla koža | žena</annotation>
 		<annotation cp="👵🏻" type="tts">starica: svijetla koža</annotation>
-		<annotation cp="👵🏼">odrasla osoba | srednje svijetla koža | starica | starica: srednje svijetla koža | žena</annotation>
+		<annotation cp="👵🏼">odrasla osoba | srednje svijetla koža | starica | žena</annotation>
 		<annotation cp="👵🏼" type="tts">starica: srednje svijetla koža</annotation>
-		<annotation cp="👵🏽">ni svijetla ni tamna koža | odrasla osoba | starica | starica: ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👵🏽">ni svijetla ni tamna koža | odrasla osoba | starica | žena</annotation>
 		<annotation cp="👵🏽" type="tts">starica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙍🏻">kretanje | mrštenje | namrštena osoba | namrštena osoba: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🙍🏻">kretanje | mrštenje | namrštena osoba | svijetla koža</annotation>
 		<annotation cp="🙍🏻" type="tts">namrštena osoba: svijetla koža</annotation>
-		<annotation cp="🙍🏼">kretanje | mrštenje | namrštena osoba | namrštena osoba: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🙍🏼">kretanje | mrštenje | namrštena osoba | srednje svijetla koža</annotation>
 		<annotation cp="🙍🏼" type="tts">namrštena osoba: srednje svijetla koža</annotation>
-		<annotation cp="🙍🏽">kretanje | mrštenje | namrštena osoba | namrštena osoba: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙍🏽">kretanje | mrštenje | namrštena osoba | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🙍🏽" type="tts">namrštena osoba: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙍🏻‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🙍🏻‍♂">mrštenje | muškarac | namršten muškarac | svijetla koža</annotation>
 		<annotation cp="🙍🏻‍♂" type="tts">namršten muškarac: svijetla koža</annotation>
-		<annotation cp="🙍🏼‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🙍🏼‍♂">mrštenje | muškarac | namršten muškarac | srednje svijetla koža</annotation>
 		<annotation cp="🙍🏼‍♂" type="tts">namršten muškarac: srednje svijetla koža</annotation>
-		<annotation cp="🙍🏽‍♂">mrštenje | muškarac | namršten muškarac | namršten muškarac: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙍🏽‍♂">mrštenje | muškarac | namršten muškarac | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🙍🏽‍♂" type="tts">namršten muškarac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙍🏻‍♀">mrštenje | namrštena žena | namrštena žena: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="🙍🏻‍♀">mrštenje | namrštena žena | svijetla koža | žena</annotation>
 		<annotation cp="🙍🏻‍♀" type="tts">namrštena žena: svijetla koža</annotation>
-		<annotation cp="🙍🏼‍♀">mrštenje | namrštena žena | namrštena žena: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="🙍🏼‍♀">mrštenje | namrštena žena | srednje svijetla koža | žena</annotation>
 		<annotation cp="🙍🏼‍♀" type="tts">namrštena žena: srednje svijetla koža</annotation>
-		<annotation cp="🙍🏽‍♀">mrštenje | namrštena žena | namrštena žena: ni svijetla ni tamna koža | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🙍🏽‍♀">mrštenje | namrštena žena | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="🙍🏽‍♀" type="tts">namrštena žena: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙎🏻">durenje | kretanje | nadurena osoba | nadurena osoba: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🙎🏻">durenje | kretanje | nadurena osoba | svijetla koža</annotation>
 		<annotation cp="🙎🏻" type="tts">nadurena osoba: svijetla koža</annotation>
-		<annotation cp="🙎🏼">durenje | kretanje | nadurena osoba | nadurena osoba: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🙎🏼">durenje | kretanje | nadurena osoba | srednje svijetla koža</annotation>
 		<annotation cp="🙎🏼" type="tts">nadurena osoba: srednje svijetla koža</annotation>
-		<annotation cp="🙎🏽">durenje | kretanje | nadurena osoba | nadurena osoba: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙎🏽">durenje | kretanje | nadurena osoba | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🙎🏽" type="tts">nadurena osoba: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙎🏻‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🙎🏻‍♂">durenje | muškarac | naduren muškarac | svijetla koža</annotation>
 		<annotation cp="🙎🏻‍♂" type="tts">naduren muškarac: svijetla koža</annotation>
-		<annotation cp="🙎🏼‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🙎🏼‍♂">durenje | muškarac | naduren muškarac | srednje svijetla koža</annotation>
 		<annotation cp="🙎🏼‍♂" type="tts">naduren muškarac: srednje svijetla koža</annotation>
-		<annotation cp="🙎🏽‍♂">durenje | muškarac | naduren muškarac | naduren muškarac: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙎🏽‍♂">durenje | muškarac | naduren muškarac | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🙎🏽‍♂" type="tts">naduren muškarac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙎🏻‍♀">durenje | nadurena žena | nadurena žena: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="🙎🏻‍♀">durenje | nadurena žena | svijetla koža | žena</annotation>
 		<annotation cp="🙎🏻‍♀" type="tts">nadurena žena: svijetla koža</annotation>
-		<annotation cp="🙎🏼‍♀">durenje | nadurena žena | nadurena žena: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="🙎🏼‍♀">durenje | nadurena žena | srednje svijetla koža | žena</annotation>
 		<annotation cp="🙎🏼‍♀" type="tts">nadurena žena: srednje svijetla koža</annotation>
-		<annotation cp="🙎🏽‍♀">durenje | nadurena žena | nadurena žena: ni svijetla ni tamna koža | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🙎🏽‍♀">durenje | nadurena žena | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="🙎🏽‍♀" type="tts">nadurena žena: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙅🏻">ne | nema | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: svijetla koža | pokret | ruka | svijetla koža | zabranjeno</annotation>
+		<annotation cp="🙅🏻">ne | nema | osoba koja pokazuje „ne“ | pokret | ruka | svijetla koža | zabranjeno</annotation>
 		<annotation cp="🙅🏻" type="tts">osoba koja pokazuje „ne“: svijetla koža</annotation>
-		<annotation cp="🙅🏼">ne | nema | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: srednje svijetla koža | pokret | ruka | srednje svijetla koža | zabranjeno</annotation>
+		<annotation cp="🙅🏼">ne | nema | osoba koja pokazuje „ne“ | pokret | ruka | srednje svijetla koža | zabranjeno</annotation>
 		<annotation cp="🙅🏼" type="tts">osoba koja pokazuje „ne“: srednje svijetla koža</annotation>
-		<annotation cp="🙅🏽">ne | nema | ni svijetla ni tamna koža | osoba koja pokazuje „ne“ | osoba koja pokazuje „ne“: ni svijetla ni tamna koža | pokret | ruka | zabranjeno</annotation>
+		<annotation cp="🙅🏽">ne | nema | ni svijetla ni tamna koža | osoba koja pokazuje „ne“ | pokret | ruka | zabranjeno</annotation>
 		<annotation cp="🙅🏽" type="tts">osoba koja pokazuje „ne“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙅🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: svijetla koža | ne | ruke | svijetla koža</annotation>
+		<annotation cp="🙅🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ruke | svijetla koža</annotation>
 		<annotation cp="🙅🏻‍♂" type="tts">muškarac pokazuje „ne“: svijetla koža</annotation>
-		<annotation cp="🙅🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: srednje svijetla koža | ne | ruke | srednje svijetla koža</annotation>
+		<annotation cp="🙅🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ruke | srednje svijetla koža</annotation>
 		<annotation cp="🙅🏼‍♂" type="tts">muškarac pokazuje „ne“: srednje svijetla koža</annotation>
-		<annotation cp="🙅🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | muškarac pokazuje „ne“: ni svijetla ni tamna koža | ne | ni svijetla ni tamna koža | ruke</annotation>
+		<annotation cp="🙅🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ne“ | ne | ni svijetla ni tamna koža | ruke</annotation>
 		<annotation cp="🙅🏽‍♂" type="tts">muškarac pokazuje „ne“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙅🏻‍♀">gestikulacija | ne | ruke | svijetla koža | žena | žena pokazuje „ne“ | žena pokazuje „ne“: svijetla koža</annotation>
+		<annotation cp="🙅🏻‍♀">gestikulacija | ne | ruke | svijetla koža | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏻‍♀" type="tts">žena pokazuje „ne“: svijetla koža</annotation>
-		<annotation cp="🙅🏼‍♀">gestikulacija | ne | ruke | srednje svijetla koža | žena | žena pokazuje „ne“ | žena pokazuje „ne“: srednje svijetla koža</annotation>
+		<annotation cp="🙅🏼‍♀">gestikulacija | ne | ruke | srednje svijetla koža | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏼‍♀" type="tts">žena pokazuje „ne“: srednje svijetla koža</annotation>
-		<annotation cp="🙅🏽‍♀">gestikulacija | ne | ni svijetla ni tamna koža | ruke | žena | žena pokazuje „ne“ | žena pokazuje „ne“: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙅🏽‍♀">gestikulacija | ne | ni svijetla ni tamna koža | ruke | žena | žena pokazuje „ne“</annotation>
 		<annotation cp="🙅🏽‍♀" type="tts">žena pokazuje „ne“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙆🏻">dobro | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: svijetla koža | pokret | ruka | svijetla koža | u redu</annotation>
+		<annotation cp="🙆🏻">dobro | ok | osoba koja pokazuje „u redu“ | pokret | ruka | svijetla koža | u redu</annotation>
 		<annotation cp="🙆🏻" type="tts">osoba koja pokazuje „u redu“: svijetla koža</annotation>
-		<annotation cp="🙆🏼">dobro | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: srednje svijetla koža | pokret | ruka | srednje svijetla koža | u redu</annotation>
+		<annotation cp="🙆🏼">dobro | ok | osoba koja pokazuje „u redu“ | pokret | ruka | srednje svijetla koža | u redu</annotation>
 		<annotation cp="🙆🏼" type="tts">osoba koja pokazuje „u redu“: srednje svijetla koža</annotation>
-		<annotation cp="🙆🏽">dobro | ni svijetla ni tamna koža | ok | osoba koja pokazuje „u redu“ | osoba koja pokazuje „u redu“: ni svijetla ni tamna koža | pokret | ruka | u redu</annotation>
+		<annotation cp="🙆🏽">dobro | ni svijetla ni tamna koža | ok | osoba koja pokazuje „u redu“ | pokret | ruka | u redu</annotation>
 		<annotation cp="🙆🏽" type="tts">osoba koja pokazuje „u redu“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙆🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: svijetla koža | ok | ruke | svijetla koža</annotation>
+		<annotation cp="🙆🏻‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ok | ruke | svijetla koža</annotation>
 		<annotation cp="🙆🏻‍♂" type="tts">muškarac pokazuje „ok“: svijetla koža</annotation>
-		<annotation cp="🙆🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: srednje svijetla koža | ok | ruke | srednje svijetla koža</annotation>
+		<annotation cp="🙆🏼‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ok | ruke | srednje svijetla koža</annotation>
 		<annotation cp="🙆🏼‍♂" type="tts">muškarac pokazuje „ok“: srednje svijetla koža</annotation>
-		<annotation cp="🙆🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | muškarac pokazuje „ok“: ni svijetla ni tamna koža | ni svijetla ni tamna koža | ok | ruke</annotation>
+		<annotation cp="🙆🏽‍♂">gestikulacija | muškarac | muškarac pokazuje „ok“ | ni svijetla ni tamna koža | ok | ruke</annotation>
 		<annotation cp="🙆🏽‍♂" type="tts">muškarac pokazuje „ok“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙆🏻‍♀">gestikulacija | ok | ruke | svijetla koža | žena | žena pokazuje „ok“ | žena pokazuje „ok“: svijetla koža</annotation>
+		<annotation cp="🙆🏻‍♀">gestikulacija | ok | ruke | svijetla koža | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏻‍♀" type="tts">žena pokazuje „ok“: svijetla koža</annotation>
-		<annotation cp="🙆🏼‍♀">gestikulacija | ok | ruke | srednje svijetla koža | žena | žena pokazuje „ok“ | žena pokazuje „ok“: srednje svijetla koža</annotation>
+		<annotation cp="🙆🏼‍♀">gestikulacija | ok | ruke | srednje svijetla koža | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏼‍♀" type="tts">žena pokazuje „ok“: srednje svijetla koža</annotation>
-		<annotation cp="🙆🏽‍♀">gestikulacija | ni svijetla ni tamna koža | ok | ruke | žena | žena pokazuje „ok“ | žena pokazuje „ok“: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙆🏽‍♀">gestikulacija | ni svijetla ni tamna koža | ok | ruke | žena | žena pokazuje „ok“</annotation>
 		<annotation cp="🙆🏽‍♀" type="tts">žena pokazuje „ok“: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💁🏻">elegantno | informacije | osoba koja daje informacije | osoba koja daje informacije: svijetla koža | pomoć | ruka | svijetla koža</annotation>
+		<annotation cp="💁🏻">elegantno | informacije | osoba koja daje informacije | pomoć | ruka | svijetla koža</annotation>
 		<annotation cp="💁🏻" type="tts">osoba koja daje informacije: svijetla koža</annotation>
-		<annotation cp="💁🏼">elegantno | informacije | osoba koja daje informacije | osoba koja daje informacije: srednje svijetla koža | pomoć | ruka | srednje svijetla koža</annotation>
+		<annotation cp="💁🏼">elegantno | informacije | osoba koja daje informacije | pomoć | ruka | srednje svijetla koža</annotation>
 		<annotation cp="💁🏼" type="tts">osoba koja daje informacije: srednje svijetla koža</annotation>
-		<annotation cp="💁🏽">elegantno | informacije | ni svijetla ni tamna koža | osoba koja daje informacije | osoba koja daje informacije: ni svijetla ni tamna koža | pomoć | ruka</annotation>
+		<annotation cp="💁🏽">elegantno | informacije | ni svijetla ni tamna koža | osoba koja daje informacije | pomoć | ruka</annotation>
 		<annotation cp="💁🏽" type="tts">osoba koja daje informacije: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💁🏾">elegantno | informacije | osoba koja daje informacije | pomoć | ruka | srednje tamna koža</annotation>
 		<annotation cp="💁🏿">elegantno | informacije | osoba koja daje informacije | pomoć | ruka | tamna koža</annotation>
-		<annotation cp="💁🏻‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | muškarac otkriva namjere: svijetla koža | ruke | svijetla koža</annotation>
+		<annotation cp="💁🏻‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | ruke | svijetla koža</annotation>
 		<annotation cp="💁🏻‍♂" type="tts">muškarac otkriva namjere: svijetla koža</annotation>
-		<annotation cp="💁🏼‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | muškarac otkriva namjere: srednje svijetla koža | ruke | srednje svijetla koža</annotation>
+		<annotation cp="💁🏼‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | ruke | srednje svijetla koža</annotation>
 		<annotation cp="💁🏼‍♂" type="tts">muškarac otkriva namjere: srednje svijetla koža</annotation>
-		<annotation cp="💁🏽‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | muškarac otkriva namjere: ni svijetla ni tamna koža | ni svijetla ni tamna koža | ruke</annotation>
+		<annotation cp="💁🏽‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | ni svijetla ni tamna koža | ruke</annotation>
 		<annotation cp="💁🏽‍♂" type="tts">muškarac otkriva namjere: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💁🏾‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | muškarac otkriva namjere: srednje tamna koža | ruke | srednje tamna koža</annotation>
+		<annotation cp="💁🏾‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | ruke | srednje tamna koža</annotation>
 		<annotation cp="💁🏾‍♂" type="tts">muškarac otkriva namjere: srednje tamna koža</annotation>
-		<annotation cp="💁🏿‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | muškarac otkriva namjere: tamna koža | ruke | tamna koža</annotation>
+		<annotation cp="💁🏿‍♂">gestikulacija | informacije | muškarac | muškarac otkriva namjere | ruke | tamna koža</annotation>
 		<annotation cp="💁🏿‍♂" type="tts">muškarac otkriva namjere: tamna koža</annotation>
-		<annotation cp="💁🏻‍♀">gestikulacija | informacije | ruke | svijetla koža | žena | žena otkriva namjere | žena otkriva namjere: svijetla koža</annotation>
+		<annotation cp="💁🏻‍♀">gestikulacija | informacije | ruke | svijetla koža | žena | žena otkriva namjere</annotation>
 		<annotation cp="💁🏻‍♀" type="tts">žena otkriva namjere: svijetla koža</annotation>
-		<annotation cp="💁🏼‍♀">gestikulacija | informacije | ruke | srednje svijetla koža | žena | žena otkriva namjere | žena otkriva namjere: srednje svijetla koža</annotation>
+		<annotation cp="💁🏼‍♀">gestikulacija | informacije | ruke | srednje svijetla koža | žena | žena otkriva namjere</annotation>
 		<annotation cp="💁🏼‍♀" type="tts">žena otkriva namjere: srednje svijetla koža</annotation>
-		<annotation cp="💁🏽‍♀">gestikulacija | informacije | ni svijetla ni tamna koža | ruke | žena | žena otkriva namjere | žena otkriva namjere: ni svijetla ni tamna koža</annotation>
+		<annotation cp="💁🏽‍♀">gestikulacija | informacije | ni svijetla ni tamna koža | ruke | žena | žena otkriva namjere</annotation>
 		<annotation cp="💁🏽‍♀" type="tts">žena otkriva namjere: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💁🏾‍♀">gestikulacija | informacije | ruke | srednje tamna koža | žena | žena otkriva namjere | žena otkriva namjere: srednje tamna koža</annotation>
+		<annotation cp="💁🏾‍♀">gestikulacija | informacije | ruke | srednje tamna koža | žena | žena otkriva namjere</annotation>
 		<annotation cp="💁🏾‍♀" type="tts">žena otkriva namjere: srednje tamna koža</annotation>
-		<annotation cp="💁🏿‍♀">gestikulacija | informacije | ruke | tamna koža | žena | žena otkriva namjere | žena otkriva namjere: tamna koža</annotation>
+		<annotation cp="💁🏿‍♀">gestikulacija | informacije | ruke | tamna koža | žena | žena otkriva namjere</annotation>
 		<annotation cp="💁🏿‍♀" type="tts">žena otkriva namjere: tamna koža</annotation>
-		<annotation cp="🙋🏻">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🙋🏻">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | svijetla koža</annotation>
 		<annotation cp="🙋🏻" type="tts">srećna osoba sa podignutom rukom: svijetla koža</annotation>
-		<annotation cp="🙋🏼">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🙋🏼">kretanje | podići | ruka | sreća | srećna osoba sa podignutom rukom | srednje svijetla koža</annotation>
 		<annotation cp="🙋🏼" type="tts">srećna osoba sa podignutom rukom: srednje svijetla koža</annotation>
-		<annotation cp="🙋🏽">kretanje | ni svijetla ni tamna koža | podići | ruka | sreća | srećna osoba sa podignutom rukom | srećna osoba sa podignutom rukom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙋🏽">kretanje | ni svijetla ni tamna koža | podići | ruka | sreća | srećna osoba sa podignutom rukom</annotation>
 		<annotation cp="🙋🏽" type="tts">srećna osoba sa podignutom rukom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙋🏻‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: svijetla koža | ruke | svijetla koža</annotation>
+		<annotation cp="🙋🏻‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ruke | svijetla koža</annotation>
 		<annotation cp="🙋🏻‍♂" type="tts">muškarac podiže ruku: svijetla koža</annotation>
-		<annotation cp="🙋🏼‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: srednje svijetla koža | ruke | srednje svijetla koža</annotation>
+		<annotation cp="🙋🏼‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ruke | srednje svijetla koža</annotation>
 		<annotation cp="🙋🏼‍♂" type="tts">muškarac podiže ruku: srednje svijetla koža</annotation>
-		<annotation cp="🙋🏽‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | muškarac podiže ruku: ni svijetla ni tamna koža | ni svijetla ni tamna koža | ruke</annotation>
+		<annotation cp="🙋🏽‍♂">gestikulacija | informacije | muškarac | muškarac podiže ruku | ni svijetla ni tamna koža | ruke</annotation>
 		<annotation cp="🙋🏽‍♂" type="tts">muškarac podiže ruku: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙋🏻‍♀">gestikulacija | informacije | ruke | svijetla koža | žena | žena podiže ruku | žena podiže ruku: svijetla koža</annotation>
+		<annotation cp="🙋🏻‍♀">gestikulacija | informacije | ruke | svijetla koža | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏻‍♀" type="tts">žena podiže ruku: svijetla koža</annotation>
-		<annotation cp="🙋🏼‍♀">gestikulacija | informacije | ruke | srednje svijetla koža | žena | žena podiže ruku | žena podiže ruku: srednje svijetla koža</annotation>
+		<annotation cp="🙋🏼‍♀">gestikulacija | informacije | ruke | srednje svijetla koža | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏼‍♀" type="tts">žena podiže ruku: srednje svijetla koža</annotation>
-		<annotation cp="🙋🏽‍♀">gestikulacija | informacije | ni svijetla ni tamna koža | ruke | žena | žena podiže ruku | žena podiže ruku: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙋🏽‍♀">gestikulacija | informacije | ni svijetla ni tamna koža | ruke | žena | žena podiže ruku</annotation>
 		<annotation cp="🙋🏽‍♀" type="tts">žena podiže ruku: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧏🏻">gluv | gluva osoba | gluva osoba: svijetla koža | pristupačnost | sluh | svijetla koža | uho</annotation>
+		<annotation cp="🧏🏻">gluv | gluva osoba | pristupačnost | sluh | svijetla koža | uho</annotation>
 		<annotation cp="🧏🏻" type="tts">gluva osoba: svijetla koža</annotation>
-		<annotation cp="🧏🏼">gluv | gluva osoba | gluva osoba: srednje svijetla koža | pristupačnost | sluh | srednje svijetla koža | uho</annotation>
+		<annotation cp="🧏🏼">gluv | gluva osoba | pristupačnost | sluh | srednje svijetla koža | uho</annotation>
 		<annotation cp="🧏🏼" type="tts">gluva osoba: srednje svijetla koža</annotation>
-		<annotation cp="🧏🏽">gluv | gluva osoba | gluva osoba: ni svijetla ni tamna koža | ni svijetla ni tamna koža | pristupačnost | sluh | uho</annotation>
+		<annotation cp="🧏🏽">gluv | gluva osoba | ni svijetla ni tamna koža | pristupačnost | sluh | uho</annotation>
 		<annotation cp="🧏🏽" type="tts">gluva osoba: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧏🏻‍♂">čovjek | gluv | gluv čovjek: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧏🏻‍♂">čovjek | gluv | svijetla koža</annotation>
 		<annotation cp="🧏🏻‍♂" type="tts">gluv čovjek: svijetla koža</annotation>
-		<annotation cp="🧏🏼‍♂">čovjek | gluv | gluv čovjek: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧏🏼‍♂">čovjek | gluv | srednje svijetla koža</annotation>
 		<annotation cp="🧏🏼‍♂" type="tts">gluv čovjek: srednje svijetla koža</annotation>
-		<annotation cp="🧏🏽‍♂">čovjek | gluv | gluv čovjek: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧏🏽‍♂">čovjek | gluv | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧏🏽‍♂" type="tts">gluv čovjek: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧏🏾‍♂">čovjek | gluv | gluv čovjek: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧏🏾‍♂">čovjek | gluv | srednje tamna koža</annotation>
 		<annotation cp="🧏🏾‍♂" type="tts">gluv čovjek: srednje tamna koža</annotation>
-		<annotation cp="🧏🏿‍♂">čovjek | gluv | gluv čovjek: tamna koža | tamna koža</annotation>
+		<annotation cp="🧏🏿‍♂">čovjek | gluv | tamna koža</annotation>
 		<annotation cp="🧏🏿‍♂" type="tts">gluv čovjek: tamna koža</annotation>
-		<annotation cp="🧏🏻‍♀">gluva | gluva žena: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="🧏🏻‍♀">gluva | svijetla koža | žena</annotation>
 		<annotation cp="🧏🏻‍♀" type="tts">gluva žena: svijetla koža</annotation>
-		<annotation cp="🧏🏼‍♀">gluva | gluva žena: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="🧏🏼‍♀">gluva | srednje svijetla koža | žena</annotation>
 		<annotation cp="🧏🏼‍♀" type="tts">gluva žena: srednje svijetla koža</annotation>
-		<annotation cp="🧏🏽‍♀">gluva | gluva žena: ni svijetla ni tamna koža | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🧏🏽‍♀">gluva | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="🧏🏽‍♀" type="tts">gluva žena: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙇🏻">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | osoba koja se klanja: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🙇🏻">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | svijetla koža</annotation>
 		<annotation cp="🙇🏻" type="tts">osoba koja se klanja: svijetla koža</annotation>
-		<annotation cp="🙇🏼">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | osoba koja se klanja: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🙇🏼">izvinjenje | klanjanje | kretanje | naklon | osoba koja se klanja | srednje svijetla koža</annotation>
 		<annotation cp="🙇🏼" type="tts">osoba koja se klanja: srednje svijetla koža</annotation>
-		<annotation cp="🙇🏽">izvinjenje | klanjanje | kretanje | naklon | ni svijetla ni tamna koža | osoba koja se klanja | osoba koja se klanja: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙇🏽">izvinjenje | klanjanje | kretanje | naklon | ni svijetla ni tamna koža | osoba koja se klanja</annotation>
 		<annotation cp="🙇🏽" type="tts">osoba koja se klanja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙇🏻‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: svijetla koža | naklon | svijetla koža</annotation>
+		<annotation cp="🙇🏻‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | svijetla koža</annotation>
 		<annotation cp="🙇🏻‍♂" type="tts">muški duboki naklon: svijetla koža</annotation>
-		<annotation cp="🙇🏼‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: srednje svijetla koža | naklon | srednje svijetla koža</annotation>
+		<annotation cp="🙇🏼‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | srednje svijetla koža</annotation>
 		<annotation cp="🙇🏼‍♂" type="tts">muški duboki naklon: srednje svijetla koža</annotation>
-		<annotation cp="🙇🏽‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | muški duboki naklon: ni svijetla ni tamna koža | naklon | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙇🏽‍♂">gestikulacija | izvinjenje | muškarac | muški duboki naklon | naklon | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🙇🏽‍♂" type="tts">muški duboki naklon: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🙇🏻‍♀">gestikulacija | izvinjenje | naklon | svijetla koža | žena | ženski duboki naklon | ženski duboki naklon: svijetla koža</annotation>
+		<annotation cp="🙇🏻‍♀">gestikulacija | izvinjenje | naklon | svijetla koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏻‍♀" type="tts">ženski duboki naklon: svijetla koža</annotation>
-		<annotation cp="🙇🏼‍♀">gestikulacija | izvinjenje | naklon | srednje svijetla koža | žena | ženski duboki naklon | ženski duboki naklon: srednje svijetla koža</annotation>
+		<annotation cp="🙇🏼‍♀">gestikulacija | izvinjenje | naklon | srednje svijetla koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏼‍♀" type="tts">ženski duboki naklon: srednje svijetla koža</annotation>
-		<annotation cp="🙇🏽‍♀">gestikulacija | izvinjenje | naklon | ni svijetla ni tamna koža | žena | ženski duboki naklon | ženski duboki naklon: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🙇🏽‍♀">gestikulacija | izvinjenje | naklon | ni svijetla ni tamna koža | žena | ženski duboki naklon</annotation>
 		<annotation cp="🙇🏽‍♀" type="tts">ženski duboki naklon: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤦🏻">čelo | glupost | kajanje | ogorčenje | šaka o čelo | šaka o čelo: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤦🏻">čelo | glupost | kajanje | ogorčenje | šaka o čelo | svijetla koža</annotation>
 		<annotation cp="🤦🏻" type="tts">šaka o čelo: svijetla koža</annotation>
-		<annotation cp="🤦🏼">čelo | glupost | kajanje | ogorčenje | šaka o čelo | šaka o čelo: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤦🏼">čelo | glupost | kajanje | ogorčenje | šaka o čelo | srednje svijetla koža</annotation>
 		<annotation cp="🤦🏼" type="tts">šaka o čelo: srednje svijetla koža</annotation>
-		<annotation cp="🤦🏽">čelo | glupost | kajanje | ni svijetla ni tamna koža | ogorčenje | šaka o čelo | šaka o čelo: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤦🏽">čelo | glupost | kajanje | ni svijetla ni tamna koža | ogorčenje | šaka o čelo</annotation>
 		<annotation cp="🤦🏽" type="tts">šaka o čelo: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤦🏾">čelo | glupost | kajanje | ogorčenje | šaka o čelo | srednje tamna koža</annotation>
 		<annotation cp="🤦🏿">čelo | glupost | kajanje | ogorčenje | šaka o čelo | tamna koža</annotation>
-		<annotation cp="🤦🏻‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤦🏻‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | svijetla koža</annotation>
 		<annotation cp="🤦🏻‍♂" type="tts">muškarac s rukom na čelu: svijetla koža</annotation>
-		<annotation cp="🤦🏼‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤦🏼‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | srednje svijetla koža</annotation>
 		<annotation cp="🤦🏼‍♂" type="tts">muškarac s rukom na čelu: srednje svijetla koža</annotation>
-		<annotation cp="🤦🏽‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | muškarac s rukom na čelu: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤦🏽‍♂">gestikulacija | glupost | kajanje | muškarac | muškarac s rukom na čelu | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤦🏽‍♂" type="tts">muškarac s rukom na čelu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤦🏻‍♀">gestikulacija | glupost | kajanje | svijetla koža | žena | žena s rukom na čelu | žena s rukom na čelu: svijetla koža</annotation>
+		<annotation cp="🤦🏻‍♀">gestikulacija | glupost | kajanje | svijetla koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏻‍♀" type="tts">žena s rukom na čelu: svijetla koža</annotation>
-		<annotation cp="🤦🏼‍♀">gestikulacija | glupost | kajanje | srednje svijetla koža | žena | žena s rukom na čelu | žena s rukom na čelu: srednje svijetla koža</annotation>
+		<annotation cp="🤦🏼‍♀">gestikulacija | glupost | kajanje | srednje svijetla koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏼‍♀" type="tts">žena s rukom na čelu: srednje svijetla koža</annotation>
-		<annotation cp="🤦🏽‍♀">gestikulacija | glupost | kajanje | ni svijetla ni tamna koža | žena | žena s rukom na čelu | žena s rukom na čelu: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤦🏽‍♀">gestikulacija | glupost | kajanje | ni svijetla ni tamna koža | žena | žena s rukom na čelu</annotation>
 		<annotation cp="🤦🏽‍♀" type="tts">žena s rukom na čelu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤷🏻">slijeganje ramenima | slijeganje ramenima: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤷🏻">slijeganje ramenima | svijetla koža</annotation>
 		<annotation cp="🤷🏻" type="tts">slijeganje ramenima: svijetla koža</annotation>
-		<annotation cp="🤷🏼">slijeganje ramenima | slijeganje ramenima: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤷🏼">slijeganje ramenima | srednje svijetla koža</annotation>
 		<annotation cp="🤷🏼" type="tts">slijeganje ramenima: srednje svijetla koža</annotation>
-		<annotation cp="🤷🏽">ni svijetla ni tamna koža | slijeganje ramenima | slijeganje ramenima: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤷🏽">ni svijetla ni tamna koža | slijeganje ramenima</annotation>
 		<annotation cp="🤷🏽" type="tts">slijeganje ramenima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤷🏾">slijeganje ramenima | slijeganje ramenima: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤷🏾">slijeganje ramenima | srednje tamna koža</annotation>
 		<annotation cp="🤷🏾" type="tts">slijeganje ramenima: srednje tamna koža</annotation>
-		<annotation cp="🤷🏿">slijeganje ramenima | slijeganje ramenima: tamna koža | tamna koža</annotation>
+		<annotation cp="🤷🏿">slijeganje ramenima | tamna koža</annotation>
 		<annotation cp="🤷🏿" type="tts">slijeganje ramenima: tamna koža</annotation>
-		<annotation cp="🤷🏻‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | muškarac sliježe ramenima: svijetla koža | neznanje | ravnodušnost | svijetla koža</annotation>
+		<annotation cp="🤷🏻‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | neznanje | ravnodušnost | svijetla koža</annotation>
 		<annotation cp="🤷🏻‍♂" type="tts">muškarac sliježe ramenima: svijetla koža</annotation>
-		<annotation cp="🤷🏼‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | muškarac sliježe ramenima: srednje svijetla koža | neznanje | ravnodušnost | srednje svijetla koža</annotation>
+		<annotation cp="🤷🏼‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | neznanje | ravnodušnost | srednje svijetla koža</annotation>
 		<annotation cp="🤷🏼‍♂" type="tts">muškarac sliježe ramenima: srednje svijetla koža</annotation>
-		<annotation cp="🤷🏽‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | muškarac sliježe ramenima: ni svijetla ni tamna koža | neznanje | ni svijetla ni tamna koža | ravnodušnost</annotation>
+		<annotation cp="🤷🏽‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | neznanje | ni svijetla ni tamna koža | ravnodušnost</annotation>
 		<annotation cp="🤷🏽‍♂" type="tts">muškarac sliježe ramenima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤷🏾‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | muškarac sliježe ramenima: srednje tamna koža | neznanje | ravnodušnost | srednje tamna koža</annotation>
+		<annotation cp="🤷🏾‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | neznanje | ravnodušnost | srednje tamna koža</annotation>
 		<annotation cp="🤷🏾‍♂" type="tts">muškarac sliježe ramenima: srednje tamna koža</annotation>
-		<annotation cp="🤷🏿‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | muškarac sliježe ramenima: tamna koža | neznanje | ravnodušnost | tamna koža</annotation>
+		<annotation cp="🤷🏿‍♂">gestikulacija | muškarac | muškarac sliježe ramenima | neznanje | ravnodušnost | tamna koža</annotation>
 		<annotation cp="🤷🏿‍♂" type="tts">muškarac sliježe ramenima: tamna koža</annotation>
-		<annotation cp="🤷🏻‍♀">gestikulacija | neznanje | ravnodušnost | svijetla koža | žena | žena sliježe ramenima | žena sliježe ramenima: svijetla koža</annotation>
+		<annotation cp="🤷🏻‍♀">gestikulacija | neznanje | ravnodušnost | svijetla koža | žena | žena sliježe ramenima</annotation>
 		<annotation cp="🤷🏻‍♀" type="tts">žena sliježe ramenima: svijetla koža</annotation>
-		<annotation cp="🤷🏼‍♀">gestikulacija | neznanje | ravnodušnost | srednje svijetla koža | žena | žena sliježe ramenima | žena sliježe ramenima: srednje svijetla koža</annotation>
+		<annotation cp="🤷🏼‍♀">gestikulacija | neznanje | ravnodušnost | srednje svijetla koža | žena | žena sliježe ramenima</annotation>
 		<annotation cp="🤷🏼‍♀" type="tts">žena sliježe ramenima: srednje svijetla koža</annotation>
-		<annotation cp="🤷🏽‍♀">gestikulacija | neznanje | ni svijetla ni tamna koža | ravnodušnost | žena | žena sliježe ramenima | žena sliježe ramenima: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤷🏽‍♀">gestikulacija | neznanje | ni svijetla ni tamna koža | ravnodušnost | žena | žena sliježe ramenima</annotation>
 		<annotation cp="🤷🏽‍♀" type="tts">žena sliježe ramenima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤷🏾‍♀">gestikulacija | neznanje | ravnodušnost | srednje tamna koža | žena | žena sliježe ramenima | žena sliježe ramenima: srednje tamna koža</annotation>
+		<annotation cp="🤷🏾‍♀">gestikulacija | neznanje | ravnodušnost | srednje tamna koža | žena | žena sliježe ramenima</annotation>
 		<annotation cp="🤷🏾‍♀" type="tts">žena sliježe ramenima: srednje tamna koža</annotation>
-		<annotation cp="🤷🏿‍♀">gestikulacija | neznanje | ravnodušnost | tamna koža | žena | žena sliježe ramenima | žena sliježe ramenima: tamna koža</annotation>
+		<annotation cp="🤷🏿‍♀">gestikulacija | neznanje | ravnodušnost | tamna koža | žena | žena sliježe ramenima</annotation>
 		<annotation cp="🤷🏿‍♀" type="tts">žena sliježe ramenima: tamna koža</annotation>
-		<annotation cp="🧑🏻‍⚕">doktor | ljekar | medicinska sestra | svijetla koža | zdravstveni radnik | zdravstveni radnik: svijetla koža | zdravstvo</annotation>
+		<annotation cp="🧑🏻‍⚕">doktor | ljekar | medicinska sestra | svijetla koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="🧑🏻‍⚕" type="tts">zdravstveni radnik: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍⚕">doktor | ljekar | medicinska sestra | srednje svijetla koža | zdravstveni radnik | zdravstveni radnik: srednje svijetla koža | zdravstvo</annotation>
+		<annotation cp="🧑🏼‍⚕">doktor | ljekar | medicinska sestra | srednje svijetla koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="🧑🏼‍⚕" type="tts">zdravstveni radnik: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍⚕">doktor | ljekar | medicinska sestra | ni svijetla ni tamna koža | zdravstveni radnik | zdravstveni radnik: ni svijetla ni tamna koža | zdravstvo</annotation>
+		<annotation cp="🧑🏽‍⚕">doktor | ljekar | medicinska sestra | ni svijetla ni tamna koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="🧑🏽‍⚕" type="tts">zdravstveni radnik: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏾‍⚕">doktor | ljekar | medicinska sestra | srednje tamna koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="🧑🏿‍⚕">doktor | ljekar | medicinska sestra | tamna koža | zdravstveni radnik | zdravstvo</annotation>
-		<annotation cp="👨🏻‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | muškarac zdravstveni radnik: svijetla koža | svijetla koža | zdravstveni radnik | zdravstvo</annotation>
+		<annotation cp="👨🏻‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | svijetla koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="👨🏻‍⚕" type="tts">muškarac zdravstveni radnik: svijetla koža</annotation>
-		<annotation cp="👨🏼‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | muškarac zdravstveni radnik: srednje svijetla koža | srednje svijetla koža | zdravstveni radnik | zdravstvo</annotation>
+		<annotation cp="👨🏼‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | srednje svijetla koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="👨🏼‍⚕" type="tts">muškarac zdravstveni radnik: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | muškarac zdravstveni radnik: ni svijetla ni tamna koža | ni svijetla ni tamna koža | zdravstveni radnik | zdravstvo</annotation>
+		<annotation cp="👨🏽‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | ni svijetla ni tamna koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="👨🏽‍⚕" type="tts">muškarac zdravstveni radnik: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏾‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | srednje tamna koža | zdravstveni radnik | zdravstvo</annotation>
 		<annotation cp="👨🏿‍⚕">doktor | ljekar | muškarac | muškarac zdravstveni radnik | tamna koža | zdravstveni radnik | zdravstvo</annotation>
-		<annotation cp="👩🏻‍⚕">doktor | ljekar | svijetla koža | zdravstvena radnica | zdravstvena radnica: svijetla koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏻‍⚕">doktor | ljekar | svijetla koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏻‍⚕" type="tts">zdravstvena radnica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍⚕">doktor | ljekar | srednje svijetla koža | zdravstvena radnica | zdravstvena radnica: srednje svijetla koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏼‍⚕">doktor | ljekar | srednje svijetla koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏼‍⚕" type="tts">zdravstvena radnica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍⚕">doktor | ljekar | ni svijetla ni tamna koža | zdravstvena radnica | zdravstvena radnica: ni svijetla ni tamna koža | zdravstvo | žena</annotation>
+		<annotation cp="👩🏽‍⚕">doktor | ljekar | ni svijetla ni tamna koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏽‍⚕" type="tts">zdravstvena radnica: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍⚕">doktor | ljekar | srednje tamna koža | zdravstvena radnica | zdravstvo | žena</annotation>
 		<annotation cp="👩🏿‍⚕">doktor | ljekar | tamna koža | zdravstvena radnica | zdravstvo | žena</annotation>
-		<annotation cp="🧑🏻‍🎓">diplomac | student(kinja) | student(kinja): svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🎓">diplomac | student(kinja) | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🎓" type="tts">student(kinja): svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🎓">diplomac | srednje svijetla koža | student(kinja) | student(kinja): srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🎓">diplomac | srednje svijetla koža | student(kinja)</annotation>
 		<annotation cp="🧑🏼‍🎓" type="tts">student(kinja): srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🎓">diplomac | ni svijetla ni tamna koža | student(kinja) | student(kinja): ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🎓">diplomac | ni svijetla ni tamna koža | student(kinja)</annotation>
 		<annotation cp="🧑🏽‍🎓" type="tts">student(kinja): ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎓">diplomac | srednje tamna koža | student(kinja) | student(kinja): srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🎓">diplomac | srednje tamna koža | student(kinja)</annotation>
 		<annotation cp="🧑🏾‍🎓" type="tts">student(kinja): srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎓">diplomac | student(kinja) | student(kinja): tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🎓">diplomac | student(kinja) | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🎓" type="tts">student(kinja): tamna koža</annotation>
-		<annotation cp="👨🏻‍🎓">diploma | matura | muškarac | student | student: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🎓">diploma | matura | muškarac | student | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🎓" type="tts">student: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🎓">diploma | matura | muškarac | srednje svijetla koža | student | student: srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🎓">diploma | matura | muškarac | srednje svijetla koža | student</annotation>
 		<annotation cp="👨🏼‍🎓" type="tts">student: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🎓">diploma | matura | muškarac | ni svijetla ni tamna koža | student | student: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🎓">diploma | matura | muškarac | ni svijetla ni tamna koža | student</annotation>
 		<annotation cp="👨🏽‍🎓" type="tts">student: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🎓">diploma | matura | student | studentkinja | studentkinja: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🎓">diploma | matura | student | studentkinja | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🎓" type="tts">studentkinja: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🎓">diploma | matura | srednje svijetla koža | student | studentkinja | studentkinja: srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🎓">diploma | matura | srednje svijetla koža | student | studentkinja | žena</annotation>
 		<annotation cp="👩🏼‍🎓" type="tts">studentkinja: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🎓">diploma | matura | ni svijetla ni tamna koža | student | studentkinja | studentkinja: ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🎓">diploma | matura | ni svijetla ni tamna koža | student | studentkinja | žena</annotation>
 		<annotation cp="👩🏽‍🎓" type="tts">studentkinja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🏫">instruktor | profesor | svijetla koža | učitelj | učitelj: svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🏫">instruktor | profesor | svijetla koža | učitelj</annotation>
 		<annotation cp="🧑🏻‍🏫" type="tts">učitelj: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🏫">instruktor | profesor | srednje svijetla koža | učitelj | učitelj: srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🏫">instruktor | profesor | srednje svijetla koža | učitelj</annotation>
 		<annotation cp="🧑🏼‍🏫" type="tts">učitelj: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🏫">instruktor | ni svijetla ni tamna koža | profesor | učitelj | učitelj: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🏫">instruktor | ni svijetla ni tamna koža | profesor | učitelj</annotation>
 		<annotation cp="🧑🏽‍🏫" type="tts">učitelj: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🏫">muškarac | profesor | profesor: svijetla koža | svijetla koža | učitelj</annotation>
+		<annotation cp="👨🏻‍🏫">muškarac | profesor | svijetla koža | učitelj</annotation>
 		<annotation cp="👨🏻‍🏫" type="tts">profesor: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🏫">muškarac | profesor | profesor: srednje svijetla koža | srednje svijetla koža | učitelj</annotation>
+		<annotation cp="👨🏼‍🏫">muškarac | profesor | srednje svijetla koža | učitelj</annotation>
 		<annotation cp="👨🏼‍🏫" type="tts">profesor: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🏫">muškarac | ni svijetla ni tamna koža | profesor | profesor: ni svijetla ni tamna koža | učitelj</annotation>
+		<annotation cp="👨🏽‍🏫">muškarac | ni svijetla ni tamna koža | profesor | učitelj</annotation>
 		<annotation cp="👨🏽‍🏫" type="tts">profesor: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🏫">profesor | profesorka | profesorka: svijetla koža | svijetla koža | učitelj | žena</annotation>
+		<annotation cp="👩🏻‍🏫">profesor | profesorka | svijetla koža | učitelj | žena</annotation>
 		<annotation cp="👩🏻‍🏫" type="tts">profesorka: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🏫">profesor | profesorka | profesorka: srednje svijetla koža | srednje svijetla koža | učitelj | žena</annotation>
+		<annotation cp="👩🏼‍🏫">profesor | profesorka | srednje svijetla koža | učitelj | žena</annotation>
 		<annotation cp="👩🏼‍🏫" type="tts">profesorka: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🏫">ni svijetla ni tamna koža | profesor | profesorka | profesorka: ni svijetla ni tamna koža | učitelj | žena</annotation>
+		<annotation cp="👩🏽‍🏫">ni svijetla ni tamna koža | profesor | profesorka | učitelj | žena</annotation>
 		<annotation cp="👩🏽‍🏫" type="tts">profesorka: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍⚖">pravda | sudija | sudija/nica | sudija/nica: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍⚖">pravda | sudija | sudija/nica | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍⚖" type="tts">sudija/nica: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍⚖">pravda | srednje svijetla koža | sudija | sudija/nica | sudija/nica: srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍⚖">pravda | srednje svijetla koža | sudija | sudija/nica</annotation>
 		<annotation cp="🧑🏼‍⚖" type="tts">sudija/nica: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍⚖">ni svijetla ni tamna koža | pravda | sudija | sudija/nica | sudija/nica: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍⚖">ni svijetla ni tamna koža | pravda | sudija | sudija/nica</annotation>
 		<annotation cp="🧑🏽‍⚖" type="tts">sudija/nica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍⚖">muškarac | muškarac sudija: svijetla koža | pravda | sudija | svijetla koža</annotation>
+		<annotation cp="👨🏻‍⚖">muškarac | pravda | sudija | svijetla koža</annotation>
 		<annotation cp="👨🏻‍⚖" type="tts">muškarac sudija: svijetla koža</annotation>
-		<annotation cp="👨🏼‍⚖">muškarac | muškarac sudija: srednje svijetla koža | pravda | srednje svijetla koža | sudija</annotation>
+		<annotation cp="👨🏼‍⚖">muškarac | pravda | srednje svijetla koža | sudija</annotation>
 		<annotation cp="👨🏼‍⚖" type="tts">muškarac sudija: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍⚖">muškarac | muškarac sudija: ni svijetla ni tamna koža | ni svijetla ni tamna koža | pravda | sudija</annotation>
+		<annotation cp="👨🏽‍⚖">muškarac | ni svijetla ni tamna koža | pravda | sudija</annotation>
 		<annotation cp="👨🏽‍⚖" type="tts">muškarac sudija: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍⚖">pravda | sudija | svijetla koža | žena | žena sudija: svijetla koža</annotation>
+		<annotation cp="👩🏻‍⚖">pravda | sudija | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍⚖" type="tts">žena sudija: svijetla koža</annotation>
-		<annotation cp="👩🏼‍⚖">pravda | srednje svijetla koža | sudija | žena | žena sudija: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍⚖">pravda | srednje svijetla koža | sudija | žena</annotation>
 		<annotation cp="👩🏼‍⚖" type="tts">žena sudija: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍⚖">ni svijetla ni tamna koža | pravda | sudija | žena | žena sudija: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍⚖">ni svijetla ni tamna koža | pravda | sudija | žena</annotation>
 		<annotation cp="👩🏽‍⚖" type="tts">žena sudija: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🌾">baštovan | poljoprivrednik | poljoprivrednik: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🌾">baštovan | poljoprivrednik | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🌾" type="tts">poljoprivrednik: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🌾">baštovan | poljoprivrednik | poljoprivrednik: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🌾">baštovan | poljoprivrednik | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🌾" type="tts">poljoprivrednik: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🌾">baštovan | ni svijetla ni tamna koža | poljoprivrednik | poljoprivrednik: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🌾">baštovan | ni svijetla ni tamna koža | poljoprivrednik</annotation>
 		<annotation cp="🧑🏽‍🌾" type="tts">poljoprivrednik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: svijetla koža | poljoprivrednik | selo | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🌾">bašta | farma | muškarac | poljoprivrednik | selo | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🌾" type="tts">muškarac poljoprivrednik: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: srednje svijetla koža | poljoprivrednik | selo | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🌾">bašta | farma | muškarac | poljoprivrednik | selo | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🌾" type="tts">muškarac poljoprivrednik: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🌾">bašta | farma | muškarac | muškarac poljoprivrednik: ni svijetla ni tamna koža | ni svijetla ni tamna koža | poljoprivrednik | selo</annotation>
+		<annotation cp="👨🏽‍🌾">bašta | farma | muškarac | ni svijetla ni tamna koža | poljoprivrednik | selo</annotation>
 		<annotation cp="👨🏽‍🌾" type="tts">muškarac poljoprivrednik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🌾">bašta | farma | poljoprivrednica | poljoprivrednica: svijetla koža | selo | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🌾">bašta | farma | poljoprivrednica | selo | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🌾" type="tts">poljoprivrednica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🌾">bašta | farma | poljoprivrednica | poljoprivrednica: srednje svijetla koža | selo | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🌾">bašta | farma | poljoprivrednica | selo | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🌾" type="tts">poljoprivrednica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🌾">bašta | farma | ni svijetla ni tamna koža | poljoprivrednica | poljoprivrednica: ni svijetla ni tamna koža | selo | žena</annotation>
+		<annotation cp="👩🏽‍🌾">bašta | farma | ni svijetla ni tamna koža | poljoprivrednica | selo | žena</annotation>
 		<annotation cp="👩🏽‍🌾" type="tts">poljoprivrednica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🍳">kuvar | kuvar: svijetla koža | šef | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🍳">kuvar | šef | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🍳" type="tts">kuvar: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🍳">kuvar | kuvar: srednje svijetla koža | šef | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🍳">kuvar | šef | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🍳" type="tts">kuvar: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🍳">kuvar | kuvar: ni svijetla ni tamna koža | ni svijetla ni tamna koža | šef</annotation>
+		<annotation cp="🧑🏽‍🍳">kuvar | ni svijetla ni tamna koža | šef</annotation>
 		<annotation cp="🧑🏽‍🍳" type="tts">kuvar: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: svijetla koža | šef | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🍳">kuhinja | kuvar | muškarac | šef | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🍳" type="tts">muškarac kuvar: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: srednje svijetla koža | šef | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🍳">kuhinja | kuvar | muškarac | šef | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🍳" type="tts">muškarac kuvar: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🍳">kuhinja | kuvar | muškarac | muškarac kuvar: ni svijetla ni tamna koža | ni svijetla ni tamna koža | šef</annotation>
+		<annotation cp="👨🏽‍🍳">kuhinja | kuvar | muškarac | ni svijetla ni tamna koža | šef</annotation>
 		<annotation cp="👨🏽‍🍳" type="tts">muškarac kuvar: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🍳">kuhinja | kuvar | kuvarica | kuvarica: svijetla koža | šef | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🍳">kuhinja | kuvar | kuvarica | šef | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🍳" type="tts">kuvarica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🍳">kuhinja | kuvar | kuvarica | kuvarica: srednje svijetla koža | šef | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🍳">kuhinja | kuvar | kuvarica | šef | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🍳" type="tts">kuvarica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🍳">kuhinja | kuvar | kuvarica | kuvarica: ni svijetla ni tamna koža | ni svijetla ni tamna koža | šef | žena</annotation>
+		<annotation cp="👩🏽‍🍳">kuhinja | kuvar | kuvarica | ni svijetla ni tamna koža | šef | žena</annotation>
 		<annotation cp="👩🏽‍🍳" type="tts">kuvarica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🔧">električar | majstor | mehaničar | mehaničar: svijetla koža | svijetla koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏻‍🔧">električar | majstor | mehaničar | svijetla koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏻‍🔧" type="tts">mehaničar: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🔧">električar | majstor | mehaničar | mehaničar: srednje svijetla koža | srednje svijetla koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏼‍🔧">električar | majstor | mehaničar | srednje svijetla koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏼‍🔧" type="tts">mehaničar: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🔧">električar | majstor | mehaničar | mehaničar: ni svijetla ni tamna koža | ni svijetla ni tamna koža | vodoinstalater</annotation>
+		<annotation cp="🧑🏽‍🔧">električar | majstor | mehaničar | ni svijetla ni tamna koža | vodoinstalater</annotation>
 		<annotation cp="🧑🏽‍🔧" type="tts">mehaničar: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🔧">alat | majstor | mehaničar | muškarac | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🔧" type="tts">muškarac mehaničar: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🔧">alat | majstor | mehaničar | muškarac | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🔧" type="tts">muškarac mehaničar: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🔧">alat | majstor | mehaničar | muškarac | muškarac mehaničar: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🔧">alat | majstor | mehaničar | muškarac | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🔧" type="tts">muškarac mehaničar: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🔧">alat | majstor | mehaničarka | mehaničarka: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🔧">alat | majstor | mehaničarka | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🔧" type="tts">mehaničarka: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🔧">alat | majstor | mehaničarka | mehaničarka: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🔧">alat | majstor | mehaničarka | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🔧" type="tts">mehaničarka: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🔧">alat | majstor | mehaničarka | mehaničarka: ni svijetla ni tamna koža | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🔧">alat | majstor | mehaničarka | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🔧" type="tts">mehaničarka: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🏭" type="tts">radnik u fabrici: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🏭">fabrika | industrija | proizvodna traka | radnik | radnik u fabrici | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🏭" type="tts">radnik u fabrici: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🏭">fabrika | industrija | ni svijetla ni tamna koža | proizvodna traka | radnik | radnik u fabrici | radnik u fabrici: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🏭">fabrika | industrija | ni svijetla ni tamna koža | proizvodna traka | radnik | radnik u fabrici</annotation>
 		<annotation cp="🧑🏽‍🏭" type="tts">radnik u fabrici: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🏭">fabrika | industrija | muškarac | radnik | radnik: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🏭">fabrika | industrija | muškarac | radnik | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🏭" type="tts">radnik: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🏭">fabrika | industrija | muškarac | radnik | radnik: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🏭">fabrika | industrija | muškarac | radnik | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🏭" type="tts">radnik: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🏭">fabrika | industrija | muškarac | ni svijetla ni tamna koža | radnik | radnik: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🏭">fabrika | industrija | muškarac | ni svijetla ni tamna koža | radnik</annotation>
 		<annotation cp="👨🏽‍🏭" type="tts">radnik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🏭">fabrika | industrija | radnica | radnica: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🏭">fabrika | industrija | radnica | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🏭" type="tts">radnica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🏭">fabrika | industrija | radnica | radnica: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🏭">fabrika | industrija | radnica | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🏭" type="tts">radnica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🏭">fabrika | industrija | ni svijetla ni tamna koža | radnica | radnica: ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🏭">fabrika | industrija | ni svijetla ni tamna koža | radnica | žena</annotation>
 		<annotation cp="👩🏽‍🏭" type="tts">radnica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: svijetla koža | menadžer | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍💼" type="tts">kancelarijski radnik: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: srednje svijetla koža | menadžer | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍💼" type="tts">kancelarijski radnik: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍💼">arhitekta | biznis | kancelarijski radnik | kancelarijski radnik: ni svijetla ni tamna koža | menadžer | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍💼">arhitekta | biznis | kancelarijski radnik | menadžer | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏽‍💼" type="tts">kancelarijski radnik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: svijetla koža | sekretarica | svijetla koža</annotation>
+		<annotation cp="👨🏻‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | sekretarica | svijetla koža</annotation>
 		<annotation cp="👨🏻‍💼" type="tts">muškarac u kancelariji: svijetla koža</annotation>
-		<annotation cp="👨🏼‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: srednje svijetla koža | sekretarica | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | sekretarica | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍💼" type="tts">muškarac u kancelariji: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | muškarac u kancelariji: ni svijetla ni tamna koža | ni svijetla ni tamna koža | sekretarica</annotation>
+		<annotation cp="👨🏽‍💼">asistent | kancelarija | muškarac | muškarac u kancelariji | ni svijetla ni tamna koža | sekretarica</annotation>
 		<annotation cp="👨🏽‍💼" type="tts">muškarac u kancelariji: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍💼">asistent | kancelarija | sekretarica | svijetla koža | žena | žena u kancelariji | žena u kancelariji: svijetla koža</annotation>
+		<annotation cp="👩🏻‍💼">asistent | kancelarija | sekretarica | svijetla koža | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏻‍💼" type="tts">žena u kancelariji: svijetla koža</annotation>
-		<annotation cp="👩🏼‍💼">asistent | kancelarija | sekretarica | srednje svijetla koža | žena | žena u kancelariji | žena u kancelariji: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍💼">asistent | kancelarija | sekretarica | srednje svijetla koža | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏼‍💼" type="tts">žena u kancelariji: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍💼">asistent | kancelarija | ni svijetla ni tamna koža | sekretarica | žena | žena u kancelariji | žena u kancelariji: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍💼">asistent | kancelarija | ni svijetla ni tamna koža | sekretarica | žena | žena u kancelariji</annotation>
 		<annotation cp="👩🏽‍💼" type="tts">žena u kancelariji: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🔬" type="tts">naučnik/ca: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🔬" type="tts">naučnik/ca: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | naučnik/ca: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🔬">biologičar | fizičar | hemičar | inženjer | naučnik | naučnik/ca | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏽‍🔬" type="tts">naučnik/ca: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🔬">biolog | hemičar | muškarac | naučnik | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🔬" type="tts">naučnik: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🔬">biolog | hemičar | muškarac | naučnik | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🔬" type="tts">naučnik: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🔬">biolog | hemičar | muškarac | naučnik | naučnik: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🔬">biolog | hemičar | muškarac | naučnik | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🔬" type="tts">naučnik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🔬">biolog | hemičar | naučnica | naučnica: svijetla koža | naučnik | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🔬">biolog | hemičar | naučnica | naučnik | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🔬" type="tts">naučnica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🔬">biolog | hemičar | naučnica | naučnica: srednje svijetla koža | naučnik | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🔬">biolog | hemičar | naučnica | naučnik | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🔬" type="tts">naučnica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🔬">biolog | hemičar | naučnica | naučnica: ni svijetla ni tamna koža | naučnik | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="👩🏽‍🔬">biolog | hemičar | naučnica | naučnik | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="👩🏽‍🔬" type="tts">naučnica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍💻">programer | pronalazač | softver | softveraš | svijetla koža | tehnolog | tehnolog: svijetla koža</annotation>
+		<annotation cp="🧑🏻‍💻">programer | pronalazač | softver | softveraš | svijetla koža | tehnolog</annotation>
 		<annotation cp="🧑🏻‍💻" type="tts">tehnolog: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍💻">programer | pronalazač | softver | softveraš | srednje svijetla koža | tehnolog | tehnolog: srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍💻">programer | pronalazač | softver | softveraš | srednje svijetla koža | tehnolog</annotation>
 		<annotation cp="🧑🏼‍💻" type="tts">tehnolog: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍💻">ni svijetla ni tamna koža | programer | pronalazač | softver | softveraš | tehnolog | tehnolog: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍💻">ni svijetla ni tamna koža | programer | pronalazač | softver | softveraš | tehnolog</annotation>
 		<annotation cp="🧑🏽‍💻" type="tts">tehnolog: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍💻">muškarac | muškarac tehnolog: svijetla koža | programer | pronalazač | softver | svijetla koža | tehnolog</annotation>
+		<annotation cp="👨🏻‍💻">muškarac | programer | pronalazač | softver | svijetla koža | tehnolog</annotation>
 		<annotation cp="👨🏻‍💻" type="tts">muškarac tehnolog: svijetla koža</annotation>
-		<annotation cp="👨🏼‍💻">muškarac | muškarac tehnolog: srednje svijetla koža | programer | pronalazač | softver | srednje svijetla koža | tehnolog</annotation>
+		<annotation cp="👨🏼‍💻">muškarac | programer | pronalazač | softver | srednje svijetla koža | tehnolog</annotation>
 		<annotation cp="👨🏼‍💻" type="tts">muškarac tehnolog: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍💻">muškarac | muškarac tehnolog: ni svijetla ni tamna koža | ni svijetla ni tamna koža | programer | pronalazač | softver | tehnolog</annotation>
+		<annotation cp="👨🏽‍💻">muškarac | ni svijetla ni tamna koža | programer | pronalazač | softver | tehnolog</annotation>
 		<annotation cp="👨🏽‍💻" type="tts">muškarac tehnolog: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍💻">programer | pronalazač | softver | svijetla koža | žena | žena tehnolog | žena tehnolog: svijetla koža</annotation>
+		<annotation cp="👩🏻‍💻">programer | pronalazač | softver | svijetla koža | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏻‍💻" type="tts">žena tehnolog: svijetla koža</annotation>
-		<annotation cp="👩🏼‍💻">programer | pronalazač | softver | srednje svijetla koža | žena | žena tehnolog | žena tehnolog: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍💻">programer | pronalazač | softver | srednje svijetla koža | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏼‍💻" type="tts">žena tehnolog: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍💻">ni svijetla ni tamna koža | programer | pronalazač | softver | žena | žena tehnolog | žena tehnolog: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍💻">ni svijetla ni tamna koža | programer | pronalazač | softver | žena | žena tehnolog</annotation>
 		<annotation cp="👩🏽‍💻" type="tts">žena tehnolog: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎤">glumac | pjevač | pjevač: svijetla koža | rok | svijetla koža | zabavljač | zvijezda</annotation>
+		<annotation cp="🧑🏻‍🎤">glumac | pjevač | rok | svijetla koža | zabavljač | zvijezda</annotation>
 		<annotation cp="🧑🏻‍🎤" type="tts">pjevač: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🎤">glumac | pjevač | pjevač: srednje svijetla koža | rok | srednje svijetla koža | zabavljač | zvijezda</annotation>
+		<annotation cp="🧑🏼‍🎤">glumac | pjevač | rok | srednje svijetla koža | zabavljač | zvijezda</annotation>
 		<annotation cp="🧑🏼‍🎤" type="tts">pjevač: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🎤">glumac | ni svijetla ni tamna koža | pjevač | pjevač: ni svijetla ni tamna koža | rok | zabavljač | zvijezda</annotation>
+		<annotation cp="🧑🏽‍🎤">glumac | ni svijetla ni tamna koža | pjevač | rok | zabavljač | zvijezda</annotation>
 		<annotation cp="🧑🏽‍🎤" type="tts">pjevač: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎤">glumac | pjevač | pjevač: srednje tamna koža | rok | srednje tamna koža | zabavljač | zvijezda</annotation>
+		<annotation cp="🧑🏾‍🎤">glumac | pjevač | rok | srednje tamna koža | zabavljač | zvijezda</annotation>
 		<annotation cp="🧑🏾‍🎤" type="tts">pjevač: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎤">glumac | pjevač | pjevač: tamna koža | rok | tamna koža | zabavljač | zvijezda</annotation>
+		<annotation cp="🧑🏿‍🎤">glumac | pjevač | rok | tamna koža | zabavljač | zvijezda</annotation>
 		<annotation cp="🧑🏿‍🎤" type="tts">pjevač: tamna koža</annotation>
-		<annotation cp="👨🏻‍🎤">glumac | muškarac | muškarac pjevač: svijetla koža | pjevač | rok | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🎤">glumac | muškarac | pjevač | rok | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🎤" type="tts">muškarac pjevač: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🎤">glumac | muškarac | muškarac pjevač: srednje svijetla koža | pjevač | rok | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🎤">glumac | muškarac | pjevač | rok | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🎤" type="tts">muškarac pjevač: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🎤">glumac | muškarac | muškarac pjevač: ni svijetla ni tamna koža | ni svijetla ni tamna koža | pjevač | rok</annotation>
+		<annotation cp="👨🏽‍🎤">glumac | muškarac | ni svijetla ni tamna koža | pjevač | rok</annotation>
 		<annotation cp="👨🏽‍🎤" type="tts">muškarac pjevač: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🎤">glumac | muškarac | muškarac pjevač: srednje tamna koža | pjevač | rok | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🎤">glumac | muškarac | pjevač | rok | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🎤" type="tts">muškarac pjevač: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🎤">glumac | muškarac | muškarac pjevač: tamna koža | pjevač | rok | tamna koža</annotation>
+		<annotation cp="👨🏿‍🎤">glumac | muškarac | pjevač | rok | tamna koža</annotation>
 		<annotation cp="👨🏿‍🎤" type="tts">muškarac pjevač: tamna koža</annotation>
-		<annotation cp="👩🏻‍🎤">glumica | pjevačica | pjevačica: svijetla koža | rok | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🎤">glumica | pjevačica | rok | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🎤" type="tts">pjevačica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🎤">glumica | pjevačica | pjevačica: srednje svijetla koža | rok | srednje svijetla koža | žena</annotation>
+		<annotation cp="👩🏼‍🎤">glumica | pjevačica | rok | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍🎤" type="tts">pjevačica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🎤">glumica | ni svijetla ni tamna koža | pjevačica | pjevačica: ni svijetla ni tamna koža | rok | žena</annotation>
+		<annotation cp="👩🏽‍🎤">glumica | ni svijetla ni tamna koža | pjevačica | rok | žena</annotation>
 		<annotation cp="👩🏽‍🎤" type="tts">pjevačica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🎤">glumica | pjevačica | pjevačica: srednje tamna koža | rok | srednje tamna koža | žena</annotation>
+		<annotation cp="👩🏾‍🎤">glumica | pjevačica | rok | srednje tamna koža | žena</annotation>
 		<annotation cp="👩🏾‍🎤" type="tts">pjevačica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🎤">glumica | pjevačica | pjevačica: tamna koža | rok | tamna koža | žena</annotation>
+		<annotation cp="👩🏿‍🎤">glumica | pjevačica | rok | tamna koža | žena</annotation>
 		<annotation cp="👩🏿‍🎤" type="tts">pjevačica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎨">slikar | svijetla koža | umjetnik | umjetnik: svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🎨">slikar | svijetla koža | umjetnik</annotation>
 		<annotation cp="🧑🏻‍🎨" type="tts">umjetnik: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🎨">slikar | srednje svijetla koža | umjetnik | umjetnik: srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🎨">slikar | srednje svijetla koža | umjetnik</annotation>
 		<annotation cp="🧑🏼‍🎨" type="tts">umjetnik: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🎨">ni svijetla ni tamna koža | slikar | umjetnik | umjetnik: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🎨">ni svijetla ni tamna koža | slikar | umjetnik</annotation>
 		<annotation cp="🧑🏽‍🎨" type="tts">umjetnik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍🎨">slikar | srednje tamna koža | umjetnik | umjetnik: srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🎨">slikar | srednje tamna koža | umjetnik</annotation>
 		<annotation cp="🧑🏾‍🎨" type="tts">umjetnik: srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍🎨">slikar | tamna koža | umjetnik | umjetnik: tamna koža</annotation>
+		<annotation cp="🧑🏿‍🎨">slikar | tamna koža | umjetnik</annotation>
 		<annotation cp="🧑🏿‍🎨" type="tts">umjetnik: tamna koža</annotation>
-		<annotation cp="👨🏻‍🎨">muškarac | muškarac umjetnik: svijetla koža | slikar | slikarstvo | svijetla koža | umjetnik</annotation>
+		<annotation cp="👨🏻‍🎨">muškarac | slikar | slikarstvo | svijetla koža | umjetnik</annotation>
 		<annotation cp="👨🏻‍🎨" type="tts">muškarac umjetnik: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🎨">muškarac | muškarac umjetnik: srednje svijetla koža | slikar | slikarstvo | srednje svijetla koža | umjetnik</annotation>
+		<annotation cp="👨🏼‍🎨">muškarac | slikar | slikarstvo | srednje svijetla koža | umjetnik</annotation>
 		<annotation cp="👨🏼‍🎨" type="tts">muškarac umjetnik: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🎨">muškarac | muškarac umjetnik: ni svijetla ni tamna koža | ni svijetla ni tamna koža | slikar | slikarstvo | umjetnik</annotation>
+		<annotation cp="👨🏽‍🎨">muškarac | ni svijetla ni tamna koža | slikar | slikarstvo | umjetnik</annotation>
 		<annotation cp="👨🏽‍🎨" type="tts">muškarac umjetnik: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🎨">muškarac | muškarac umjetnik: srednje tamna koža | slikar | slikarstvo | srednje tamna koža | umjetnik</annotation>
+		<annotation cp="👨🏾‍🎨">muškarac | slikar | slikarstvo | srednje tamna koža | umjetnik</annotation>
 		<annotation cp="👨🏾‍🎨" type="tts">muškarac umjetnik: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🎨">muškarac | muškarac umjetnik: tamna koža | slikar | slikarstvo | tamna koža | umjetnik</annotation>
+		<annotation cp="👨🏿‍🎨">muškarac | slikar | slikarstvo | tamna koža | umjetnik</annotation>
 		<annotation cp="👨🏿‍🎨" type="tts">muškarac umjetnik: tamna koža</annotation>
-		<annotation cp="👩🏻‍🎨">slikar | slikarstvo | svijetla koža | umjetnica | umjetnica: svijetla koža | umjetnik | žena</annotation>
+		<annotation cp="👩🏻‍🎨">slikar | slikarstvo | svijetla koža | umjetnica | umjetnik | žena</annotation>
 		<annotation cp="👩🏻‍🎨" type="tts">umjetnica: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🎨">slikar | slikarstvo | srednje svijetla koža | umjetnica | umjetnica: srednje svijetla koža | umjetnik | žena</annotation>
+		<annotation cp="👩🏼‍🎨">slikar | slikarstvo | srednje svijetla koža | umjetnica | umjetnik | žena</annotation>
 		<annotation cp="👩🏼‍🎨" type="tts">umjetnica: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🎨">ni svijetla ni tamna koža | slikar | slikarstvo | umjetnica | umjetnica: ni svijetla ni tamna koža | umjetnik | žena</annotation>
+		<annotation cp="👩🏽‍🎨">ni svijetla ni tamna koža | slikar | slikarstvo | umjetnica | umjetnik | žena</annotation>
 		<annotation cp="👩🏽‍🎨" type="tts">umjetnica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏾‍🎨">slikar | slikarstvo | srednje tamna koža | umjetnica | umjetnica: srednje tamna koža | umjetnik | žena</annotation>
+		<annotation cp="👩🏾‍🎨">slikar | slikarstvo | srednje tamna koža | umjetnica | umjetnik | žena</annotation>
 		<annotation cp="👩🏾‍🎨" type="tts">umjetnica: srednje tamna koža</annotation>
-		<annotation cp="👩🏿‍🎨">slikar | slikarstvo | tamna koža | umjetnica | umjetnica: tamna koža | umjetnik | žena</annotation>
+		<annotation cp="👩🏿‍🎨">slikar | slikarstvo | tamna koža | umjetnica | umjetnik | žena</annotation>
 		<annotation cp="👩🏿‍🎨" type="tts">umjetnica: tamna koža</annotation>
-		<annotation cp="🧑🏻‍✈">pilot(kinja) | pilot(kinja): svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍✈">pilot(kinja) | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍✈" type="tts">pilot(kinja): svijetla koža</annotation>
-		<annotation cp="🧑🏼‍✈">pilot(kinja) | pilot(kinja): srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍✈">pilot(kinja) | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍✈" type="tts">pilot(kinja): srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍✈">ni svijetla ni tamna koža | pilot(kinja) | pilot(kinja): ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍✈">ni svijetla ni tamna koža | pilot(kinja)</annotation>
 		<annotation cp="🧑🏽‍✈" type="tts">pilot(kinja): ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏾‍✈">pilot(kinja) | pilot(kinja): srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍✈">pilot(kinja) | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍✈" type="tts">pilot(kinja): srednje tamna koža</annotation>
-		<annotation cp="🧑🏿‍✈">pilot(kinja) | pilot(kinja): tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍✈">pilot(kinja) | tamna koža</annotation>
 		<annotation cp="🧑🏿‍✈" type="tts">pilot(kinja): tamna koža</annotation>
-		<annotation cp="👨🏻‍✈">avion | muškarac | pilot | pilot: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍✈">avion | muškarac | pilot | svijetla koža</annotation>
 		<annotation cp="👨🏻‍✈" type="tts">pilot: svijetla koža</annotation>
-		<annotation cp="👨🏼‍✈">avion | muškarac | pilot | pilot: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍✈">avion | muškarac | pilot | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍✈" type="tts">pilot: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍✈">avion | muškarac | ni svijetla ni tamna koža | pilot | pilot: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍✈">avion | muškarac | ni svijetla ni tamna koža | pilot</annotation>
 		<annotation cp="👨🏽‍✈" type="tts">pilot: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍✈">avion | pilot | svijetla koža | žena | žena pilot: svijetla koža</annotation>
+		<annotation cp="👩🏻‍✈">avion | pilot | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍✈" type="tts">žena pilot: svijetla koža</annotation>
-		<annotation cp="👩🏼‍✈">avion | pilot | srednje svijetla koža | žena | žena pilot: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍✈">avion | pilot | srednje svijetla koža | žena</annotation>
 		<annotation cp="👩🏼‍✈" type="tts">žena pilot: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍✈">avion | ni svijetla ni tamna koža | pilot | žena | žena pilot: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍✈">avion | ni svijetla ni tamna koža | pilot | žena</annotation>
 		<annotation cp="👩🏽‍✈" type="tts">žena pilot: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🚀">astronaut | astronaut: svijetla koža | raketa | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🚀">astronaut | raketa | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🚀" type="tts">astronaut: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🚀">astronaut | astronaut: srednje svijetla koža | raketa | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🚀">astronaut | raketa | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🚀" type="tts">astronaut: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🚀">astronaut | astronaut: ni svijetla ni tamna koža | ni svijetla ni tamna koža | raketa</annotation>
+		<annotation cp="🧑🏽‍🚀">astronaut | ni svijetla ni tamna koža | raketa</annotation>
 		<annotation cp="🧑🏽‍🚀" type="tts">astronaut: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🚀">astronaut | kosmonaut | kosmonaut: svijetla koža | muškarac | raketa | svemir | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🚀">astronaut | kosmonaut | muškarac | raketa | svemir | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🚀" type="tts">kosmonaut: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🚀">astronaut | kosmonaut | kosmonaut: srednje svijetla koža | muškarac | raketa | srednje svijetla koža | svemir</annotation>
+		<annotation cp="👨🏼‍🚀">astronaut | kosmonaut | muškarac | raketa | srednje svijetla koža | svemir</annotation>
 		<annotation cp="👨🏼‍🚀" type="tts">kosmonaut: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🚀">astronaut | kosmonaut | kosmonaut: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | raketa | svemir</annotation>
+		<annotation cp="👨🏽‍🚀">astronaut | kosmonaut | muškarac | ni svijetla ni tamna koža | raketa | svemir</annotation>
 		<annotation cp="👨🏽‍🚀" type="tts">kosmonaut: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🚀">astronaut | kosmonautkinja | kosmonautkinja: svijetla koža | raketa | svemir | svijetla koža | žena</annotation>
+		<annotation cp="👩🏻‍🚀">astronaut | kosmonautkinja | raketa | svemir | svijetla koža | žena</annotation>
 		<annotation cp="👩🏻‍🚀" type="tts">kosmonautkinja: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🚀">astronaut | kosmonautkinja | kosmonautkinja: srednje svijetla koža | raketa | srednje svijetla koža | svemir | žena</annotation>
+		<annotation cp="👩🏼‍🚀">astronaut | kosmonautkinja | raketa | srednje svijetla koža | svemir | žena</annotation>
 		<annotation cp="👩🏼‍🚀" type="tts">kosmonautkinja: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🚀">astronaut | kosmonautkinja | kosmonautkinja: ni svijetla ni tamna koža | ni svijetla ni tamna koža | raketa | svemir | žena</annotation>
+		<annotation cp="👩🏽‍🚀">astronaut | kosmonautkinja | ni svijetla ni tamna koža | raketa | svemir | žena</annotation>
 		<annotation cp="👩🏽‍🚀" type="tts">kosmonautkinja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🚒">svijetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: svijetla koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏻‍🚒">svijetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏻‍🚒" type="tts">vatrogasac / žena vatrogasac: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🚒">srednje svijetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: srednje svijetla koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏼‍🚒">srednje svijetla koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏼‍🚒" type="tts">vatrogasac / žena vatrogasac: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🚒">ni svijetla ni tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasac / žena vatrogasac: ni svijetla ni tamna koža | vatrogasno vozilo</annotation>
+		<annotation cp="🧑🏽‍🚒">ni svijetla ni tamna koža | vatrogasac | vatrogasac / žena vatrogasac | vatrogasno vozilo</annotation>
 		<annotation cp="🧑🏽‍🚒" type="tts">vatrogasac / žena vatrogasac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🚒">kamion | muškarac | svijetla koža | vatra | vatrogasac | vatrogasac: svijetla koža</annotation>
+		<annotation cp="👨🏻‍🚒">kamion | muškarac | svijetla koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏻‍🚒" type="tts">vatrogasac: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🚒">kamion | muškarac | srednje svijetla koža | vatra | vatrogasac | vatrogasac: srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🚒">kamion | muškarac | srednje svijetla koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏼‍🚒" type="tts">vatrogasac: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🚒">kamion | muškarac | ni svijetla ni tamna koža | vatra | vatrogasac | vatrogasac: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🚒">kamion | muškarac | ni svijetla ni tamna koža | vatra | vatrogasac</annotation>
 		<annotation cp="👨🏽‍🚒" type="tts">vatrogasac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🚒">kamion | svijetla koža | vatra | vatrogasac | žena | žena vatrogasac: svijetla koža</annotation>
+		<annotation cp="👩🏻‍🚒">kamion | svijetla koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏻‍🚒" type="tts">žena vatrogasac: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🚒">kamion | srednje svijetla koža | vatra | vatrogasac | žena | žena vatrogasac: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍🚒">kamion | srednje svijetla koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏼‍🚒" type="tts">žena vatrogasac: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🚒">kamion | ni svijetla ni tamna koža | vatra | vatrogasac | žena | žena vatrogasac: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🚒">kamion | ni svijetla ni tamna koža | vatra | vatrogasac | žena</annotation>
 		<annotation cp="👩🏽‍🚒" type="tts">žena vatrogasac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👮🏻">policajac | policija | pozornik | predstavnik policije | predstavnik policije: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👮🏻">policajac | policija | pozornik | predstavnik policije | svijetla koža</annotation>
 		<annotation cp="👮🏻" type="tts">predstavnik policije: svijetla koža</annotation>
-		<annotation cp="👮🏼">policajac | policija | pozornik | predstavnik policije | predstavnik policije: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👮🏼">policajac | policija | pozornik | predstavnik policije | srednje svijetla koža</annotation>
 		<annotation cp="👮🏼" type="tts">predstavnik policije: srednje svijetla koža</annotation>
-		<annotation cp="👮🏽">ni svijetla ni tamna koža | policajac | policija | pozornik | predstavnik policije | predstavnik policije: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👮🏽">ni svijetla ni tamna koža | policajac | policija | pozornik | predstavnik policije</annotation>
 		<annotation cp="👮🏽" type="tts">predstavnik policije: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👮🏻‍♂">muškarac | pandur | policajac | policajac: svijetla koža | policija | svijetla koža</annotation>
+		<annotation cp="👮🏻‍♂">muškarac | pandur | policajac | policija | svijetla koža</annotation>
 		<annotation cp="👮🏻‍♂" type="tts">policajac: svijetla koža</annotation>
-		<annotation cp="👮🏼‍♂">muškarac | pandur | policajac | policajac: srednje svijetla koža | policija | srednje svijetla koža</annotation>
+		<annotation cp="👮🏼‍♂">muškarac | pandur | policajac | policija | srednje svijetla koža</annotation>
 		<annotation cp="👮🏼‍♂" type="tts">policajac: srednje svijetla koža</annotation>
-		<annotation cp="👮🏽‍♂">muškarac | ni svijetla ni tamna koža | pandur | policajac | policajac: ni svijetla ni tamna koža | policija</annotation>
+		<annotation cp="👮🏽‍♂">muškarac | ni svijetla ni tamna koža | pandur | policajac | policija</annotation>
 		<annotation cp="👮🏽‍♂" type="tts">policajac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👮🏻‍♀">pandurka | policajka | policajka: svijetla koža | policija | svijetla koža | žena</annotation>
+		<annotation cp="👮🏻‍♀">pandurka | policajka | policija | svijetla koža | žena</annotation>
 		<annotation cp="👮🏻‍♀" type="tts">policajka: svijetla koža</annotation>
-		<annotation cp="👮🏼‍♀">pandurka | policajka | policajka: srednje svijetla koža | policija | srednje svijetla koža | žena</annotation>
+		<annotation cp="👮🏼‍♀">pandurka | policajka | policija | srednje svijetla koža | žena</annotation>
 		<annotation cp="👮🏼‍♀" type="tts">policajka: srednje svijetla koža</annotation>
-		<annotation cp="👮🏽‍♀">ni svijetla ni tamna koža | pandurka | policajka | policajka: ni svijetla ni tamna koža | policija | žena</annotation>
+		<annotation cp="👮🏽‍♀">ni svijetla ni tamna koža | pandurka | policajka | policija | žena</annotation>
 		<annotation cp="👮🏽‍♀" type="tts">policajka: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🕵🏻">detektiv | inspektor | inspektor: svijetla koža | špijun | svijetla koža</annotation>
+		<annotation cp="🕵🏻">detektiv | inspektor | špijun | svijetla koža</annotation>
 		<annotation cp="🕵🏻" type="tts">inspektor: svijetla koža</annotation>
-		<annotation cp="🕵🏼">detektiv | inspektor | inspektor: srednje svijetla koža | špijun | srednje svijetla koža</annotation>
+		<annotation cp="🕵🏼">detektiv | inspektor | špijun | srednje svijetla koža</annotation>
 		<annotation cp="🕵🏼" type="tts">inspektor: srednje svijetla koža</annotation>
-		<annotation cp="🕵🏽">detektiv | inspektor | inspektor: ni svijetla ni tamna koža | ni svijetla ni tamna koža | špijun</annotation>
+		<annotation cp="🕵🏽">detektiv | inspektor | ni svijetla ni tamna koža | špijun</annotation>
 		<annotation cp="🕵🏽" type="tts">inspektor: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🕵🏻‍♂">detektiv | detektiv: svijetla koža | muškarac | špijun | svijetla koža</annotation>
+		<annotation cp="🕵🏻‍♂">detektiv | muškarac | špijun | svijetla koža</annotation>
 		<annotation cp="🕵🏻‍♂" type="tts">detektiv: svijetla koža</annotation>
-		<annotation cp="🕵🏼‍♂">detektiv | detektiv: srednje svijetla koža | muškarac | špijun | srednje svijetla koža</annotation>
+		<annotation cp="🕵🏼‍♂">detektiv | muškarac | špijun | srednje svijetla koža</annotation>
 		<annotation cp="🕵🏼‍♂" type="tts">detektiv: srednje svijetla koža</annotation>
-		<annotation cp="🕵🏽‍♂">detektiv | detektiv: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | špijun</annotation>
+		<annotation cp="🕵🏽‍♂">detektiv | muškarac | ni svijetla ni tamna koža | špijun</annotation>
 		<annotation cp="🕵🏽‍♂" type="tts">detektiv: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🕵🏻‍♀">detektiv | detektivka | detektivka: svijetla koža | špijun | svijetla koža | žena</annotation>
+		<annotation cp="🕵🏻‍♀">detektiv | detektivka | špijun | svijetla koža | žena</annotation>
 		<annotation cp="🕵🏻‍♀" type="tts">detektivka: svijetla koža</annotation>
-		<annotation cp="🕵🏼‍♀">detektiv | detektivka | detektivka: srednje svijetla koža | špijun | srednje svijetla koža | žena</annotation>
+		<annotation cp="🕵🏼‍♀">detektiv | detektivka | špijun | srednje svijetla koža | žena</annotation>
 		<annotation cp="🕵🏼‍♀" type="tts">detektivka: srednje svijetla koža</annotation>
-		<annotation cp="🕵🏽‍♀">detektiv | detektivka | detektivka: ni svijetla ni tamna koža | ni svijetla ni tamna koža | špijun | žena</annotation>
+		<annotation cp="🕵🏽‍♀">detektiv | detektivka | ni svijetla ni tamna koža | špijun | žena</annotation>
 		<annotation cp="🕵🏽‍♀" type="tts">detektivka: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💂🏻">čuvar | čuvar: svijetla koža | stražar | svijetla koža</annotation>
+		<annotation cp="💂🏻">čuvar | stražar | svijetla koža</annotation>
 		<annotation cp="💂🏻" type="tts">čuvar: svijetla koža</annotation>
-		<annotation cp="💂🏼">čuvar | čuvar: srednje svijetla koža | srednje svijetla koža | stražar</annotation>
+		<annotation cp="💂🏼">čuvar | srednje svijetla koža | stražar</annotation>
 		<annotation cp="💂🏼" type="tts">čuvar: srednje svijetla koža</annotation>
-		<annotation cp="💂🏽">čuvar | čuvar: ni svijetla ni tamna koža | ni svijetla ni tamna koža | stražar</annotation>
+		<annotation cp="💂🏽">čuvar | ni svijetla ni tamna koža | stražar</annotation>
 		<annotation cp="💂🏽" type="tts">čuvar: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💂🏻‍♂">čuvar | gardista | gardista: svijetla koža | muškarac | stražar | svijetla koža</annotation>
+		<annotation cp="💂🏻‍♂">čuvar | gardista | muškarac | stražar | svijetla koža</annotation>
 		<annotation cp="💂🏻‍♂" type="tts">gardista: svijetla koža</annotation>
-		<annotation cp="💂🏼‍♂">čuvar | gardista | gardista: srednje svijetla koža | muškarac | srednje svijetla koža | stražar</annotation>
+		<annotation cp="💂🏼‍♂">čuvar | gardista | muškarac | srednje svijetla koža | stražar</annotation>
 		<annotation cp="💂🏼‍♂" type="tts">gardista: srednje svijetla koža</annotation>
-		<annotation cp="💂🏽‍♂">čuvar | gardista | gardista: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | stražar</annotation>
+		<annotation cp="💂🏽‍♂">čuvar | gardista | muškarac | ni svijetla ni tamna koža | stražar</annotation>
 		<annotation cp="💂🏽‍♂" type="tts">gardista: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💂🏻‍♀">čuvar | gardistkinja | gardistkinja: svijetla koža | stražar | svijetla koža | žena</annotation>
+		<annotation cp="💂🏻‍♀">čuvar | gardistkinja | stražar | svijetla koža | žena</annotation>
 		<annotation cp="💂🏻‍♀" type="tts">gardistkinja: svijetla koža</annotation>
-		<annotation cp="💂🏼‍♀">čuvar | gardistkinja | gardistkinja: srednje svijetla koža | srednje svijetla koža | stražar | žena</annotation>
+		<annotation cp="💂🏼‍♀">čuvar | gardistkinja | srednje svijetla koža | stražar | žena</annotation>
 		<annotation cp="💂🏼‍♀" type="tts">gardistkinja: srednje svijetla koža</annotation>
-		<annotation cp="💂🏽‍♀">čuvar | gardistkinja | gardistkinja: ni svijetla ni tamna koža | ni svijetla ni tamna koža | stražar | žena</annotation>
+		<annotation cp="💂🏽‍♀">čuvar | gardistkinja | ni svijetla ni tamna koža | stražar | žena</annotation>
 		<annotation cp="💂🏽‍♀" type="tts">gardistkinja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🥷🏻">borac | nevidljiv | nindža | nindža: svijetla koža | skriven | svijetla koža</annotation>
+		<annotation cp="🥷🏻">borac | nevidljiv | nindža | skriven | svijetla koža</annotation>
 		<annotation cp="🥷🏻" type="tts">nindža: svijetla koža</annotation>
-		<annotation cp="🥷🏼">borac | nevidljiv | nindža | nindža: srednje svijetla koža | skriven | srednje svijetla koža</annotation>
+		<annotation cp="🥷🏼">borac | nevidljiv | nindža | skriven | srednje svijetla koža</annotation>
 		<annotation cp="🥷🏼" type="tts">nindža: srednje svijetla koža</annotation>
-		<annotation cp="🥷🏽">borac | nevidljiv | ni svijetla ni tamna koža | nindža | nindža: ni svijetla ni tamna koža | skriven</annotation>
+		<annotation cp="🥷🏽">borac | nevidljiv | ni svijetla ni tamna koža | nindža | skriven</annotation>
 		<annotation cp="🥷🏽" type="tts">nindža: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👷🏻">građevinski radnik | građevinski radnik: svijetla koža | radnik | šljem | svijetla koža</annotation>
+		<annotation cp="👷🏻">građevinski radnik | radnik | šljem | svijetla koža</annotation>
 		<annotation cp="👷🏻" type="tts">građevinski radnik: svijetla koža</annotation>
-		<annotation cp="👷🏼">građevinski radnik | građevinski radnik: srednje svijetla koža | radnik | šljem | srednje svijetla koža</annotation>
+		<annotation cp="👷🏼">građevinski radnik | radnik | šljem | srednje svijetla koža</annotation>
 		<annotation cp="👷🏼" type="tts">građevinski radnik: srednje svijetla koža</annotation>
-		<annotation cp="👷🏽">građevinski radnik | građevinski radnik: ni svijetla ni tamna koža | ni svijetla ni tamna koža | radnik | šljem</annotation>
+		<annotation cp="👷🏽">građevinski radnik | ni svijetla ni tamna koža | radnik | šljem</annotation>
 		<annotation cp="👷🏽" type="tts">građevinski radnik: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👷🏾">građevinski radnik | radnik | šljem | srednje tamna koža</annotation>
 		<annotation cp="👷🏿">građevinski radnik | radnik | šljem | tamna koža</annotation>
-		<annotation cp="👷🏻‍♂">građevinar | građevinar: svijetla koža | muškarac | radnik | šljem | svijetla koža</annotation>
+		<annotation cp="👷🏻‍♂">građevinar | muškarac | radnik | šljem | svijetla koža</annotation>
 		<annotation cp="👷🏻‍♂" type="tts">građevinar: svijetla koža</annotation>
-		<annotation cp="👷🏼‍♂">građevinar | građevinar: srednje svijetla koža | muškarac | radnik | šljem | srednje svijetla koža</annotation>
+		<annotation cp="👷🏼‍♂">građevinar | muškarac | radnik | šljem | srednje svijetla koža</annotation>
 		<annotation cp="👷🏼‍♂" type="tts">građevinar: srednje svijetla koža</annotation>
-		<annotation cp="👷🏽‍♂">građevinar | građevinar: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | radnik | šljem</annotation>
+		<annotation cp="👷🏽‍♂">građevinar | muškarac | ni svijetla ni tamna koža | radnik | šljem</annotation>
 		<annotation cp="👷🏽‍♂" type="tts">građevinar: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👷🏾‍♂">građevinar | muškarac | radnik | šljem | srednje tamna koža</annotation>
 		<annotation cp="👷🏿‍♂">građevinar | muškarac | radnik | šljem | tamna koža</annotation>
-		<annotation cp="👷🏻‍♀">građevinar | građevinarka | građevinarka: svijetla koža | radnica | šljem | svijetla koža | žena</annotation>
+		<annotation cp="👷🏻‍♀">građevinar | građevinarka | radnica | šljem | svijetla koža | žena</annotation>
 		<annotation cp="👷🏻‍♀" type="tts">građevinarka: svijetla koža</annotation>
-		<annotation cp="👷🏼‍♀">građevinar | građevinarka | građevinarka: srednje svijetla koža | radnica | šljem | srednje svijetla koža | žena</annotation>
+		<annotation cp="👷🏼‍♀">građevinar | građevinarka | radnica | šljem | srednje svijetla koža | žena</annotation>
 		<annotation cp="👷🏼‍♀" type="tts">građevinarka: srednje svijetla koža</annotation>
-		<annotation cp="👷🏽‍♀">građevinar | građevinarka | građevinarka: ni svijetla ni tamna koža | ni svijetla ni tamna koža | radnica | šljem | žena</annotation>
+		<annotation cp="👷🏽‍♀">građevinar | građevinarka | ni svijetla ni tamna koža | radnica | šljem | žena</annotation>
 		<annotation cp="👷🏽‍♀" type="tts">građevinarka: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👷🏾‍♀">građevinar | građevinarka | radnica | šljem | srednje tamna koža | žena</annotation>
 		<annotation cp="👷🏿‍♀">građevinar | građevinarka | radnica | šljem | tamna koža | žena</annotation>
-		<annotation cp="🫅🏻">kraljevski | monarh | osoba sa krunom | osoba sa krunom: svijetla koža | plemenit | plemić | svijetla koža</annotation>
+		<annotation cp="🫅🏻">kraljevski | monarh | osoba sa krunom | plemenit | plemić | svijetla koža</annotation>
 		<annotation cp="🫅🏻" type="tts">osoba sa krunom: svijetla koža</annotation>
-		<annotation cp="🫅🏼">kraljevski | monarh | osoba sa krunom | osoba sa krunom: srednje svijetla koža | plemenit | plemić | srednje svijetla koža</annotation>
+		<annotation cp="🫅🏼">kraljevski | monarh | osoba sa krunom | plemenit | plemić | srednje svijetla koža</annotation>
 		<annotation cp="🫅🏼" type="tts">osoba sa krunom: srednje svijetla koža</annotation>
-		<annotation cp="🫅🏽">kraljevski | monarh | ni svijetla ni tamna koža | osoba sa krunom | osoba sa krunom: ni svijetla ni tamna koža | plemenit | plemić</annotation>
+		<annotation cp="🫅🏽">kraljevski | monarh | ni svijetla ni tamna koža | osoba sa krunom | plemenit | plemić</annotation>
 		<annotation cp="🫅🏽" type="tts">osoba sa krunom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤴🏻">princ | princ: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤴🏻">princ | svijetla koža</annotation>
 		<annotation cp="🤴🏻" type="tts">princ: svijetla koža</annotation>
-		<annotation cp="🤴🏼">princ | princ: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤴🏼">princ | srednje svijetla koža</annotation>
 		<annotation cp="🤴🏼" type="tts">princ: srednje svijetla koža</annotation>
-		<annotation cp="🤴🏽">ni svijetla ni tamna koža | princ | princ: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤴🏽">ni svijetla ni tamna koža | princ</annotation>
 		<annotation cp="🤴🏽" type="tts">princ: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👸🏻">bajka | mašta | princeza | princeza: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👸🏻">bajka | mašta | princeza | svijetla koža</annotation>
 		<annotation cp="👸🏻" type="tts">princeza: svijetla koža</annotation>
-		<annotation cp="👸🏼">bajka | mašta | princeza | princeza: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👸🏼">bajka | mašta | princeza | srednje svijetla koža</annotation>
 		<annotation cp="👸🏼" type="tts">princeza: srednje svijetla koža</annotation>
-		<annotation cp="👸🏽">bajka | mašta | ni svijetla ni tamna koža | princeza | princeza: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👸🏽">bajka | mašta | ni svijetla ni tamna koža | princeza</annotation>
 		<annotation cp="👸🏽" type="tts">princeza: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👳🏻">osoba sa turbanom | osoba sa turbanom: svijetla koža | svijetla koža | turban</annotation>
+		<annotation cp="👳🏻">osoba sa turbanom | svijetla koža | turban</annotation>
 		<annotation cp="👳🏻" type="tts">osoba sa turbanom: svijetla koža</annotation>
-		<annotation cp="👳🏼">osoba sa turbanom | osoba sa turbanom: srednje svijetla koža | srednje svijetla koža | turban</annotation>
+		<annotation cp="👳🏼">osoba sa turbanom | srednje svijetla koža | turban</annotation>
 		<annotation cp="👳🏼" type="tts">osoba sa turbanom: srednje svijetla koža</annotation>
-		<annotation cp="👳🏽">ni svijetla ni tamna koža | osoba sa turbanom | osoba sa turbanom: ni svijetla ni tamna koža | turban</annotation>
+		<annotation cp="👳🏽">ni svijetla ni tamna koža | osoba sa turbanom | turban</annotation>
 		<annotation cp="👳🏽" type="tts">osoba sa turbanom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👳🏻‍♂">čovjek sa turbanom | čovjek sa turbanom: svijetla koža | muškarac | svijetla koža | turban</annotation>
+		<annotation cp="👳🏻‍♂">čovjek sa turbanom | muškarac | svijetla koža | turban</annotation>
 		<annotation cp="👳🏻‍♂" type="tts">čovjek sa turbanom: svijetla koža</annotation>
-		<annotation cp="👳🏼‍♂">čovjek sa turbanom | čovjek sa turbanom: srednje svijetla koža | muškarac | srednje svijetla koža | turban</annotation>
+		<annotation cp="👳🏼‍♂">čovjek sa turbanom | muškarac | srednje svijetla koža | turban</annotation>
 		<annotation cp="👳🏼‍♂" type="tts">čovjek sa turbanom: srednje svijetla koža</annotation>
-		<annotation cp="👳🏽‍♂">čovjek sa turbanom | čovjek sa turbanom: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | turban</annotation>
+		<annotation cp="👳🏽‍♂">čovjek sa turbanom | muškarac | ni svijetla ni tamna koža | turban</annotation>
 		<annotation cp="👳🏽‍♂" type="tts">čovjek sa turbanom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👳🏾‍♂">čovjek sa turbanom | čovjek sa turbanom: srednje tamna koža | muškarac | srednje tamna koža | turban</annotation>
+		<annotation cp="👳🏾‍♂">čovjek sa turbanom | muškarac | srednje tamna koža | turban</annotation>
 		<annotation cp="👳🏾‍♂" type="tts">čovjek sa turbanom: srednje tamna koža</annotation>
-		<annotation cp="👳🏿‍♂">čovjek sa turbanom | čovjek sa turbanom: tamna koža | muškarac | tamna koža | turban</annotation>
+		<annotation cp="👳🏿‍♂">čovjek sa turbanom | muškarac | tamna koža | turban</annotation>
 		<annotation cp="👳🏿‍♂" type="tts">čovjek sa turbanom: tamna koža</annotation>
-		<annotation cp="👳🏻‍♀">svijetla koža | turban | žena | žena sa turbanom | žena sa turbanom: svijetla koža</annotation>
+		<annotation cp="👳🏻‍♀">svijetla koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏻‍♀" type="tts">žena sa turbanom: svijetla koža</annotation>
-		<annotation cp="👳🏼‍♀">srednje svijetla koža | turban | žena | žena sa turbanom | žena sa turbanom: srednje svijetla koža</annotation>
+		<annotation cp="👳🏼‍♀">srednje svijetla koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏼‍♀" type="tts">žena sa turbanom: srednje svijetla koža</annotation>
-		<annotation cp="👳🏽‍♀">ni svijetla ni tamna koža | turban | žena | žena sa turbanom | žena sa turbanom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👳🏽‍♀">ni svijetla ni tamna koža | turban | žena | žena sa turbanom</annotation>
 		<annotation cp="👳🏽‍♀" type="tts">žena sa turbanom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👲🏻">čovjek sa kineskom kapom | čovjek sa kineskom kapom: svijetla koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | svijetla koža</annotation>
+		<annotation cp="👲🏻">čovjek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | svijetla koža</annotation>
 		<annotation cp="👲🏻" type="tts">čovjek sa kineskom kapom: svijetla koža</annotation>
-		<annotation cp="👲🏼">čovjek sa kineskom kapom | čovjek sa kineskom kapom: srednje svijetla koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje svijetla koža</annotation>
+		<annotation cp="👲🏼">čovjek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje svijetla koža</annotation>
 		<annotation cp="👲🏼" type="tts">čovjek sa kineskom kapom: srednje svijetla koža</annotation>
-		<annotation cp="👲🏽">čovjek sa kineskom kapom | čovjek sa kineskom kapom: ni svijetla ni tamna koža | gua pi mao | kapa | kineska kapa | ni svijetla ni tamna koža | osoba | osoba sa kineskom kapom | šešir</annotation>
+		<annotation cp="👲🏽">čovjek sa kineskom kapom | gua pi mao | kapa | kineska kapa | ni svijetla ni tamna koža | osoba | osoba sa kineskom kapom | šešir</annotation>
 		<annotation cp="👲🏽" type="tts">čovjek sa kineskom kapom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👲🏾">čovjek sa kineskom kapom | čovjek sa kineskom kapom: srednje tamna koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje tamna koža</annotation>
+		<annotation cp="👲🏾">čovjek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | srednje tamna koža</annotation>
 		<annotation cp="👲🏾" type="tts">čovjek sa kineskom kapom: srednje tamna koža</annotation>
-		<annotation cp="👲🏿">čovjek sa kineskom kapom | čovjek sa kineskom kapom: tamna koža | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | tamna koža</annotation>
+		<annotation cp="👲🏿">čovjek sa kineskom kapom | gua pi mao | kapa | kineska kapa | osoba | osoba sa kineskom kapom | šešir | tamna koža</annotation>
 		<annotation cp="👲🏿" type="tts">čovjek sa kineskom kapom: tamna koža</annotation>
-		<annotation cp="🧕🏻">hidžab | marama | marama za na glavu | svijetla koža | tišel | žena sa maramom na glavi | žena sa maramom na glavi: svijetla koža</annotation>
+		<annotation cp="🧕🏻">hidžab | marama | marama za na glavu | svijetla koža | tišel | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏻" type="tts">žena sa maramom na glavi: svijetla koža</annotation>
-		<annotation cp="🧕🏼">hidžab | marama | marama za na glavu | srednje svijetla koža | tišel | žena sa maramom na glavi | žena sa maramom na glavi: srednje svijetla koža</annotation>
+		<annotation cp="🧕🏼">hidžab | marama | marama za na glavu | srednje svijetla koža | tišel | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏼" type="tts">žena sa maramom na glavi: srednje svijetla koža</annotation>
-		<annotation cp="🧕🏽">hidžab | marama | marama za na glavu | ni svijetla ni tamna koža | tišel | žena sa maramom na glavi | žena sa maramom na glavi: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧕🏽">hidžab | marama | marama za na glavu | ni svijetla ni tamna koža | tišel | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏽" type="tts">žena sa maramom na glavi: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧕🏾">hidžab | marama | marama za na glavu | srednje tamna koža | tišel | žena sa maramom na glavi</annotation>
 		<annotation cp="🧕🏿">hidžab | marama | marama za na glavu | tamna koža | tišel | žena sa maramom na glavi</annotation>
-		<annotation cp="🤵🏻">čovjek u smokingu | čovjek u smokingu: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤵🏻">čovjek u smokingu | svijetla koža</annotation>
 		<annotation cp="🤵🏻" type="tts">čovjek u smokingu: svijetla koža</annotation>
-		<annotation cp="🤵🏼">čovjek u smokingu | čovjek u smokingu: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤵🏼">čovjek u smokingu | srednje svijetla koža</annotation>
 		<annotation cp="🤵🏼" type="tts">čovjek u smokingu: srednje svijetla koža</annotation>
-		<annotation cp="🤵🏽">čovjek u smokingu | čovjek u smokingu: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤵🏽">čovjek u smokingu | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤵🏽" type="tts">čovjek u smokingu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤵🏾">čovjek u smokingu | čovjek u smokingu: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🤵🏾">čovjek u smokingu | srednje tamna koža</annotation>
 		<annotation cp="🤵🏾" type="tts">čovjek u smokingu: srednje tamna koža</annotation>
-		<annotation cp="🤵🏿">čovjek u smokingu | čovjek u smokingu: tamna koža | tamna koža</annotation>
+		<annotation cp="🤵🏿">čovjek u smokingu | tamna koža</annotation>
 		<annotation cp="🤵🏿" type="tts">čovjek u smokingu: tamna koža</annotation>
-		<annotation cp="🤵🏻‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: svijetla koža | smoking | svijetla koža</annotation>
+		<annotation cp="🤵🏻‍♂">muškarac | muškarac u smokingu | smoking | svijetla koža</annotation>
 		<annotation cp="🤵🏻‍♂" type="tts">muškarac u smokingu: svijetla koža</annotation>
-		<annotation cp="🤵🏼‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: srednje svijetla koža | smoking | srednje svijetla koža</annotation>
+		<annotation cp="🤵🏼‍♂">muškarac | muškarac u smokingu | smoking | srednje svijetla koža</annotation>
 		<annotation cp="🤵🏼‍♂" type="tts">muškarac u smokingu: srednje svijetla koža</annotation>
-		<annotation cp="🤵🏽‍♂">muškarac | muškarac u smokingu | muškarac u smokingu: ni svijetla ni tamna koža | ni svijetla ni tamna koža | smoking</annotation>
+		<annotation cp="🤵🏽‍♂">muškarac | muškarac u smokingu | ni svijetla ni tamna koža | smoking</annotation>
 		<annotation cp="🤵🏽‍♂" type="tts">muškarac u smokingu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤵🏻‍♀">smoking | svijetla koža | žena | žena u smokingu | žena u smokingu: svijetla koža</annotation>
+		<annotation cp="🤵🏻‍♀">smoking | svijetla koža | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏻‍♀" type="tts">žena u smokingu: svijetla koža</annotation>
-		<annotation cp="🤵🏼‍♀">smoking | srednje svijetla koža | žena | žena u smokingu | žena u smokingu: srednje svijetla koža</annotation>
+		<annotation cp="🤵🏼‍♀">smoking | srednje svijetla koža | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏼‍♀" type="tts">žena u smokingu: srednje svijetla koža</annotation>
-		<annotation cp="🤵🏽‍♀">ni svijetla ni tamna koža | smoking | žena | žena u smokingu | žena u smokingu: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤵🏽‍♀">ni svijetla ni tamna koža | smoking | žena | žena u smokingu</annotation>
 		<annotation cp="🤵🏽‍♀" type="tts">žena u smokingu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👰🏻">nevjesta sa velom | nevjesta sa velom: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👰🏻">nevjesta sa velom | svijetla koža</annotation>
 		<annotation cp="👰🏻" type="tts">nevjesta sa velom: svijetla koža</annotation>
-		<annotation cp="👰🏼">nevjesta sa velom | nevjesta sa velom: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👰🏼">nevjesta sa velom | srednje svijetla koža</annotation>
 		<annotation cp="👰🏼" type="tts">nevjesta sa velom: srednje svijetla koža</annotation>
-		<annotation cp="👰🏽">nevjesta sa velom | nevjesta sa velom: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👰🏽">nevjesta sa velom | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👰🏽" type="tts">nevjesta sa velom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👰🏾">nevjesta sa velom | nevjesta sa velom: srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="👰🏾">nevjesta sa velom | srednje tamna koža</annotation>
 		<annotation cp="👰🏾" type="tts">nevjesta sa velom: srednje tamna koža</annotation>
-		<annotation cp="👰🏿">nevjesta sa velom | nevjesta sa velom: tamna koža | tamna koža</annotation>
+		<annotation cp="👰🏿">nevjesta sa velom | tamna koža</annotation>
 		<annotation cp="👰🏿" type="tts">nevjesta sa velom: tamna koža</annotation>
-		<annotation cp="👰🏻‍♂">muškarac | muškarac sa velom | muškarac sa velom: svijetla koža | svijetla koža | veo</annotation>
+		<annotation cp="👰🏻‍♂">muškarac | muškarac sa velom | svijetla koža | veo</annotation>
 		<annotation cp="👰🏻‍♂" type="tts">muškarac sa velom: svijetla koža</annotation>
-		<annotation cp="👰🏼‍♂">muškarac | muškarac sa velom | muškarac sa velom: srednje svijetla koža | srednje svijetla koža | veo</annotation>
+		<annotation cp="👰🏼‍♂">muškarac | muškarac sa velom | srednje svijetla koža | veo</annotation>
 		<annotation cp="👰🏼‍♂" type="tts">muškarac sa velom: srednje svijetla koža</annotation>
-		<annotation cp="👰🏽‍♂">muškarac | muškarac sa velom | muškarac sa velom: ni svijetla ni tamna koža | ni svijetla ni tamna koža | veo</annotation>
+		<annotation cp="👰🏽‍♂">muškarac | muškarac sa velom | ni svijetla ni tamna koža | veo</annotation>
 		<annotation cp="👰🏽‍♂" type="tts">muškarac sa velom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👰🏻‍♀">svijetla koža | veo | žena | žena sa velom | žena sa velom: svijetla koža</annotation>
+		<annotation cp="👰🏻‍♀">svijetla koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏻‍♀" type="tts">žena sa velom: svijetla koža</annotation>
-		<annotation cp="👰🏼‍♀">srednje svijetla koža | veo | žena | žena sa velom | žena sa velom: srednje svijetla koža</annotation>
+		<annotation cp="👰🏼‍♀">srednje svijetla koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏼‍♀" type="tts">žena sa velom: srednje svijetla koža</annotation>
-		<annotation cp="👰🏽‍♀">ni svijetla ni tamna koža | veo | žena | žena sa velom | žena sa velom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👰🏽‍♀">ni svijetla ni tamna koža | veo | žena | žena sa velom</annotation>
 		<annotation cp="👰🏽‍♀" type="tts">žena sa velom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤰🏻">svijetla koža | trudnica | trudnica: svijetla koža | žena</annotation>
+		<annotation cp="🤰🏻">svijetla koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏻" type="tts">trudnica: svijetla koža</annotation>
-		<annotation cp="🤰🏼">srednje svijetla koža | trudnica | trudnica: srednje svijetla koža | žena</annotation>
+		<annotation cp="🤰🏼">srednje svijetla koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏼" type="tts">trudnica: srednje svijetla koža</annotation>
-		<annotation cp="🤰🏽">ni svijetla ni tamna koža | trudnica | trudnica: ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🤰🏽">ni svijetla ni tamna koža | trudnica | žena</annotation>
 		<annotation cp="🤰🏽" type="tts">trudnica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫃🏻">nadut | pun | stomak | svijetla koža | trudan | trudni muškarac | trudni muškarac: svijetla koža</annotation>
+		<annotation cp="🫃🏻">nadut | pun | stomak | svijetla koža | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏻" type="tts">trudni muškarac: svijetla koža</annotation>
-		<annotation cp="🫃🏼">nadut | pun | srednje svijetla koža | stomak | trudan | trudni muškarac | trudni muškarac: srednje svijetla koža</annotation>
+		<annotation cp="🫃🏼">nadut | pun | srednje svijetla koža | stomak | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏼" type="tts">trudni muškarac: srednje svijetla koža</annotation>
-		<annotation cp="🫃🏽">nadut | ni svijetla ni tamna koža | pun | stomak | trudan | trudni muškarac | trudni muškarac: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🫃🏽">nadut | ni svijetla ni tamna koža | pun | stomak | trudan | trudni muškarac</annotation>
 		<annotation cp="🫃🏽" type="tts">trudni muškarac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🫄🏻">nadut | pun | stomak | svijetla koža | trudan | trudna osoba | trudna osoba: svijetla koža</annotation>
+		<annotation cp="🫄🏻">nadut | pun | stomak | svijetla koža | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏻" type="tts">trudna osoba: svijetla koža</annotation>
-		<annotation cp="🫄🏼">nadut | pun | srednje svijetla koža | stomak | trudan | trudna osoba | trudna osoba: srednje svijetla koža</annotation>
+		<annotation cp="🫄🏼">nadut | pun | srednje svijetla koža | stomak | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏼" type="tts">trudna osoba: srednje svijetla koža</annotation>
-		<annotation cp="🫄🏽">nadut | ni svijetla ni tamna koža | pun | stomak | trudan | trudna osoba | trudna osoba: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🫄🏽">nadut | ni svijetla ni tamna koža | pun | stomak | trudan | trudna osoba</annotation>
 		<annotation cp="🫄🏽" type="tts">trudna osoba: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤱🏻">dojenje | dojenje: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤱🏻">dojenje | svijetla koža</annotation>
 		<annotation cp="🤱🏻" type="tts">dojenje: svijetla koža</annotation>
-		<annotation cp="🤱🏼">dojenje | dojenje: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤱🏼">dojenje | srednje svijetla koža</annotation>
 		<annotation cp="🤱🏼" type="tts">dojenje: srednje svijetla koža</annotation>
-		<annotation cp="🤱🏽">dojenje | dojenje: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤱🏽">dojenje | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤱🏽" type="tts">dojenje: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤱🏾">dojenje | srednje tamna koža</annotation>
 		<annotation cp="🤱🏿">dojenje | tamna koža</annotation>
-		<annotation cp="👩🏻‍🍼">beba | dojenje | hranjenje | svijetla koža | žena | žena hrani bebu | žena hrani bebu: svijetla koža</annotation>
+		<annotation cp="👩🏻‍🍼">beba | dojenje | hranjenje | svijetla koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏻‍🍼" type="tts">žena hrani bebu: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🍼">beba | dojenje | hranjenje | srednje svijetla koža | žena | žena hrani bebu | žena hrani bebu: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍🍼">beba | dojenje | hranjenje | srednje svijetla koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏼‍🍼" type="tts">žena hrani bebu: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🍼">beba | dojenje | hranjenje | ni svijetla ni tamna koža | žena | žena hrani bebu | žena hrani bebu: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🍼">beba | dojenje | hranjenje | ni svijetla ni tamna koža | žena | žena hrani bebu</annotation>
 		<annotation cp="👩🏽‍🍼" type="tts">žena hrani bebu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: svijetla koža | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🍼" type="tts">muškarac hrani bebu: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🍼" type="tts">muškarac hrani bebu: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | muškarac hrani bebu: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👨🏽‍🍼">beba | dojenje | hranjenje | muškarac | muškarac hrani bebu | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👨🏽‍🍼" type="tts">muškarac hrani bebu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | osoba hrani bebu: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🍼" type="tts">osoba hrani bebu: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | osoba hrani bebu: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🍼">beba | dojenje | hranjenje | muškarac | osoba hrani bebu | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🍼" type="tts">osoba hrani bebu: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🍼">beba | dojenje | hranjenje | muškarac | ni svijetla ni tamna koža | osoba hrani bebu | osoba hrani bebu: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🍼">beba | dojenje | hranjenje | muškarac | ni svijetla ni tamna koža | osoba hrani bebu</annotation>
 		<annotation cp="🧑🏽‍🍼" type="tts">osoba hrani bebu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👼🏻">anđeo | bajka | beba | beba anđeo: svijetla koža | lice | mašta | svijetla koža</annotation>
+		<annotation cp="👼🏻">anđeo | bajka | beba | lice | mašta | svijetla koža</annotation>
 		<annotation cp="👼🏻" type="tts">beba anđeo: svijetla koža</annotation>
-		<annotation cp="👼🏼">anđeo | bajka | beba | beba anđeo: srednje svijetla koža | lice | mašta | srednje svijetla koža</annotation>
+		<annotation cp="👼🏼">anđeo | bajka | beba | lice | mašta | srednje svijetla koža</annotation>
 		<annotation cp="👼🏼" type="tts">beba anđeo: srednje svijetla koža</annotation>
-		<annotation cp="👼🏽">anđeo | bajka | beba | beba anđeo: ni svijetla ni tamna koža | lice | mašta | ni svijetla ni tamna koža</annotation>
+		<annotation cp="👼🏽">anđeo | bajka | beba | lice | mašta | ni svijetla ni tamna koža</annotation>
 		<annotation cp="👼🏽" type="tts">beba anđeo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🎅🏻">bajka | božić | božić bata | djed mraz | Djed Mraz | Djed Mraz: svijetla koža | proslava | svijetla koža</annotation>
+		<annotation cp="🎅🏻">bajka | božić | božić bata | djed mraz | Djed Mraz | proslava | svijetla koža</annotation>
 		<annotation cp="🎅🏻" type="tts">Djed Mraz: svijetla koža</annotation>
-		<annotation cp="🎅🏼">bajka | božić | božić bata | djed mraz | Djed Mraz | Djed Mraz: srednje svijetla koža | proslava | srednje svijetla koža</annotation>
+		<annotation cp="🎅🏼">bajka | božić | božić bata | djed mraz | Djed Mraz | proslava | srednje svijetla koža</annotation>
 		<annotation cp="🎅🏼" type="tts">Djed Mraz: srednje svijetla koža</annotation>
-		<annotation cp="🎅🏽">bajka | božić | božić bata | djed mraz | Djed Mraz | Djed Mraz: ni svijetla ni tamna koža | ni svijetla ni tamna koža | proslava</annotation>
+		<annotation cp="🎅🏽">bajka | božić | božić bata | djed mraz | Djed Mraz | ni svijetla ni tamna koža | proslava</annotation>
 		<annotation cp="🎅🏽" type="tts">Djed Mraz: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🎅🏾">bajka | božić | božić bata | djed mraz | Djed Mraz | Djed Mraz: srednje tamna koža | proslava | srednje tamna koža</annotation>
+		<annotation cp="🎅🏾">bajka | božić | božić bata | djed mraz | Djed Mraz | proslava | srednje tamna koža</annotation>
 		<annotation cp="🎅🏾" type="tts">Djed Mraz: srednje tamna koža</annotation>
-		<annotation cp="🎅🏿">bajka | božić | božić bata | djed mraz | Djed Mraz | Djed Mraz: tamna koža | proslava | tamna koža</annotation>
+		<annotation cp="🎅🏿">bajka | božić | božić bata | djed mraz | Djed Mraz | proslava | tamna koža</annotation>
 		<annotation cp="🎅🏿" type="tts">Djed Mraz: tamna koža</annotation>
-		<annotation cp="🤶🏻">baka | baka Mraz: svijetla koža | božić | mraz | proslava | svijetla koža</annotation>
+		<annotation cp="🤶🏻">baka | božić | mraz | proslava | svijetla koža</annotation>
 		<annotation cp="🤶🏻" type="tts">baka Mraz: svijetla koža</annotation>
-		<annotation cp="🤶🏼">baka | baka Mraz: srednje svijetla koža | božić | mraz | proslava | srednje svijetla koža</annotation>
+		<annotation cp="🤶🏼">baka | božić | mraz | proslava | srednje svijetla koža</annotation>
 		<annotation cp="🤶🏼" type="tts">baka Mraz: srednje svijetla koža</annotation>
-		<annotation cp="🤶🏽">baka | baka Mraz: ni svijetla ni tamna koža | božić | mraz | ni svijetla ni tamna koža | proslava</annotation>
+		<annotation cp="🤶🏽">baka | božić | mraz | ni svijetla ni tamna koža | proslava</annotation>
 		<annotation cp="🤶🏽" type="tts">baka Mraz: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤶🏾">baka | božić | mraz | proslava | srednje tamna koža</annotation>
 		<annotation cp="🤶🏿">baka | božić | mraz | proslava | tamna koža</annotation>
-		<annotation cp="🧑🏻‍🎄">Božić | Mraz | osoba Mraz | osoba Mraz: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🎄">Božić | Mraz | osoba Mraz | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🎄" type="tts">osoba Mraz: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🎄">Božić | Mraz | osoba Mraz | osoba Mraz: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🎄">Božić | Mraz | osoba Mraz | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🎄" type="tts">osoba Mraz: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🎄">Božić | Mraz | ni svijetla ni tamna koža | osoba Mraz | osoba Mraz: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🎄">Božić | Mraz | ni svijetla ni tamna koža | osoba Mraz</annotation>
 		<annotation cp="🧑🏽‍🎄" type="tts">osoba Mraz: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦸🏻">dobro | heroina | heroj | superheroj | superheroj: svijetla koža | supermoć | svijetla koža</annotation>
+		<annotation cp="🦸🏻">dobro | heroina | heroj | superheroj | supermoć | svijetla koža</annotation>
 		<annotation cp="🦸🏻" type="tts">superheroj: svijetla koža</annotation>
-		<annotation cp="🦸🏼">dobro | heroina | heroj | srednje svijetla koža | superheroj | superheroj: srednje svijetla koža | supermoć</annotation>
+		<annotation cp="🦸🏼">dobro | heroina | heroj | srednje svijetla koža | superheroj | supermoć</annotation>
 		<annotation cp="🦸🏼" type="tts">superheroj: srednje svijetla koža</annotation>
-		<annotation cp="🦸🏽">dobro | heroina | heroj | ni svijetla ni tamna koža | superheroj | superheroj: ni svijetla ni tamna koža | supermoć</annotation>
+		<annotation cp="🦸🏽">dobro | heroina | heroj | ni svijetla ni tamna koža | superheroj | supermoć</annotation>
 		<annotation cp="🦸🏽" type="tts">superheroj: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦸🏾">dobro | heroina | heroj | srednje tamna koža | superheroj | superheroj: srednje tamna koža | supermoć</annotation>
+		<annotation cp="🦸🏾">dobro | heroina | heroj | srednje tamna koža | superheroj | supermoć</annotation>
 		<annotation cp="🦸🏾" type="tts">superheroj: srednje tamna koža</annotation>
-		<annotation cp="🦸🏿">dobro | heroina | heroj | superheroj | superheroj: tamna koža | supermoć | tamna koža</annotation>
+		<annotation cp="🦸🏿">dobro | heroina | heroj | superheroj | supermoć | tamna koža</annotation>
 		<annotation cp="🦸🏿" type="tts">superheroj: tamna koža</annotation>
-		<annotation cp="🦸🏻‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | muškarac superheroj: svijetla koža | super moć | svijetla koža</annotation>
+		<annotation cp="🦸🏻‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | super moć | svijetla koža</annotation>
 		<annotation cp="🦸🏻‍♂" type="tts">muškarac superheroj: svijetla koža</annotation>
-		<annotation cp="🦸🏼‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | muškarac superheroj: srednje svijetla koža | srednje svijetla koža | super moć</annotation>
+		<annotation cp="🦸🏼‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | srednje svijetla koža | super moć</annotation>
 		<annotation cp="🦸🏼‍♂" type="tts">muškarac superheroj: srednje svijetla koža</annotation>
-		<annotation cp="🦸🏽‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | muškarac superheroj: ni svijetla ni tamna koža | ni svijetla ni tamna koža | super moć</annotation>
+		<annotation cp="🦸🏽‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | ni svijetla ni tamna koža | super moć</annotation>
 		<annotation cp="🦸🏽‍♂" type="tts">muškarac superheroj: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦸🏾‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | muškarac superheroj: srednje tamna koža | srednje tamna koža | super moć</annotation>
+		<annotation cp="🦸🏾‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | srednje tamna koža | super moć</annotation>
 		<annotation cp="🦸🏾‍♂" type="tts">muškarac superheroj: srednje tamna koža</annotation>
-		<annotation cp="🦸🏿‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | muškarac superheroj: tamna koža | super moć | tamna koža</annotation>
+		<annotation cp="🦸🏿‍♂">dobro | heroj | muškarac | muškarac super heroj | muškarac superheroj | super moć | tamna koža</annotation>
 		<annotation cp="🦸🏿‍♂" type="tts">muškarac superheroj: tamna koža</annotation>
-		<annotation cp="🦸🏻‍♀">dobro | heroina | super moć | svijetla koža | žena | žena super heroj | žena super heroj: svijetla koža</annotation>
+		<annotation cp="🦸🏻‍♀">dobro | heroina | super moć | svijetla koža | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏻‍♀" type="tts">žena super heroj: svijetla koža</annotation>
-		<annotation cp="🦸🏼‍♀">dobro | heroina | srednje svijetla koža | super moć | žena | žena super heroj | žena super heroj: srednje svijetla koža</annotation>
+		<annotation cp="🦸🏼‍♀">dobro | heroina | srednje svijetla koža | super moć | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏼‍♀" type="tts">žena super heroj: srednje svijetla koža</annotation>
-		<annotation cp="🦸🏽‍♀">dobro | heroina | ni svijetla ni tamna koža | super moć | žena | žena super heroj | žena super heroj: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🦸🏽‍♀">dobro | heroina | ni svijetla ni tamna koža | super moć | žena | žena super heroj</annotation>
 		<annotation cp="🦸🏽‍♀" type="tts">žena super heroj: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦹🏻">kriminal | negativac | negativac: svijetla koža | super moć | svijetla koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏻">kriminal | negativac | super moć | svijetla koža | zlo | zločinac</annotation>
 		<annotation cp="🦹🏻" type="tts">negativac: svijetla koža</annotation>
-		<annotation cp="🦹🏼">kriminal | negativac | negativac: srednje svijetla koža | srednje svijetla koža | super moć | zlo | zločinac</annotation>
+		<annotation cp="🦹🏼">kriminal | negativac | srednje svijetla koža | super moć | zlo | zločinac</annotation>
 		<annotation cp="🦹🏼" type="tts">negativac: srednje svijetla koža</annotation>
-		<annotation cp="🦹🏽">kriminal | negativac | negativac: ni svijetla ni tamna koža | ni svijetla ni tamna koža | super moć | zlo | zločinac</annotation>
+		<annotation cp="🦹🏽">kriminal | negativac | ni svijetla ni tamna koža | super moć | zlo | zločinac</annotation>
 		<annotation cp="🦹🏽" type="tts">negativac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦹🏻‍♂">kriminal | muškarac | muškarac negativac: svijetla koža | negativac | super moć | svijetla koža | zlo</annotation>
+		<annotation cp="🦹🏻‍♂">kriminal | muškarac | negativac | super moć | svijetla koža | zlo</annotation>
 		<annotation cp="🦹🏻‍♂" type="tts">muškarac negativac: svijetla koža</annotation>
-		<annotation cp="🦹🏼‍♂">kriminal | muškarac | muškarac negativac: srednje svijetla koža | negativac | srednje svijetla koža | super moć | zlo</annotation>
+		<annotation cp="🦹🏼‍♂">kriminal | muškarac | negativac | srednje svijetla koža | super moć | zlo</annotation>
 		<annotation cp="🦹🏼‍♂" type="tts">muškarac negativac: srednje svijetla koža</annotation>
-		<annotation cp="🦹🏽‍♂">kriminal | muškarac | muškarac negativac: ni svijetla ni tamna koža | negativac | ni svijetla ni tamna koža | super moć | zlo</annotation>
+		<annotation cp="🦹🏽‍♂">kriminal | muškarac | negativac | ni svijetla ni tamna koža | super moć | zlo</annotation>
 		<annotation cp="🦹🏽‍♂" type="tts">muškarac negativac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🦹🏻‍♀">kriminal | super moć | svijetla koža | žena | žena negativac | žena negativac: svijetla koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏻‍♀">kriminal | super moć | svijetla koža | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏻‍♀" type="tts">žena negativac: svijetla koža</annotation>
-		<annotation cp="🦹🏼‍♀">kriminal | srednje svijetla koža | super moć | žena | žena negativac | žena negativac: srednje svijetla koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏼‍♀">kriminal | srednje svijetla koža | super moć | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏼‍♀" type="tts">žena negativac: srednje svijetla koža</annotation>
-		<annotation cp="🦹🏽‍♀">kriminal | ni svijetla ni tamna koža | super moć | žena | žena negativac | žena negativac: ni svijetla ni tamna koža | zlo | zločinac</annotation>
+		<annotation cp="🦹🏽‍♀">kriminal | ni svijetla ni tamna koža | super moć | žena | žena negativac | zlo | zločinac</annotation>
 		<annotation cp="🦹🏽‍♀" type="tts">žena negativac: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧙🏻">čarobnica | čarobnjak | mag | mag: svijetla koža | svijetla koža | vještica</annotation>
+		<annotation cp="🧙🏻">čarobnica | čarobnjak | mag | svijetla koža | vještica</annotation>
 		<annotation cp="🧙🏻" type="tts">mag: svijetla koža</annotation>
-		<annotation cp="🧙🏼">čarobnica | čarobnjak | mag | mag: srednje svijetla koža | srednje svijetla koža | vještica</annotation>
+		<annotation cp="🧙🏼">čarobnica | čarobnjak | mag | srednje svijetla koža | vještica</annotation>
 		<annotation cp="🧙🏼" type="tts">mag: srednje svijetla koža</annotation>
-		<annotation cp="🧙🏽">čarobnica | čarobnjak | mag | mag: ni svijetla ni tamna koža | ni svijetla ni tamna koža | vještica</annotation>
+		<annotation cp="🧙🏽">čarobnica | čarobnjak | mag | ni svijetla ni tamna koža | vještica</annotation>
 		<annotation cp="🧙🏽" type="tts">mag: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧙🏾">čarobnica | čarobnjak | mag | srednje tamna koža | vještica</annotation>
 		<annotation cp="🧙🏿">čarobnica | čarobnjak | mag | tamna koža | vještica</annotation>
-		<annotation cp="🧙🏻‍♂">čarobnjak | čarobnjak: svijetla koža | svijetla koža | vještac</annotation>
+		<annotation cp="🧙🏻‍♂">čarobnjak | svijetla koža | vještac</annotation>
 		<annotation cp="🧙🏻‍♂" type="tts">čarobnjak: svijetla koža</annotation>
-		<annotation cp="🧙🏼‍♂">čarobnjak | čarobnjak: srednje svijetla koža | srednje svijetla koža | vještac</annotation>
+		<annotation cp="🧙🏼‍♂">čarobnjak | srednje svijetla koža | vještac</annotation>
 		<annotation cp="🧙🏼‍♂" type="tts">čarobnjak: srednje svijetla koža</annotation>
-		<annotation cp="🧙🏽‍♂">čarobnjak | čarobnjak: ni svijetla ni tamna koža | ni svijetla ni tamna koža | vještac</annotation>
+		<annotation cp="🧙🏽‍♂">čarobnjak | ni svijetla ni tamna koža | vještac</annotation>
 		<annotation cp="🧙🏽‍♂" type="tts">čarobnjak: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧙🏾‍♂">čarobnjak | srednje tamna koža | vještac</annotation>
 		<annotation cp="🧙🏿‍♂">čarobnjak | tamna koža | vještac</annotation>
-		<annotation cp="🧙🏻‍♀">čarobnica | čarobnica: svijetla koža | svijetla koža | vještica</annotation>
+		<annotation cp="🧙🏻‍♀">čarobnica | svijetla koža | vještica</annotation>
 		<annotation cp="🧙🏻‍♀" type="tts">čarobnica: svijetla koža</annotation>
-		<annotation cp="🧙🏼‍♀">čarobnica | čarobnica: srednje svijetla koža | srednje svijetla koža | vještica</annotation>
+		<annotation cp="🧙🏼‍♀">čarobnica | srednje svijetla koža | vještica</annotation>
 		<annotation cp="🧙🏼‍♀" type="tts">čarobnica: srednje svijetla koža</annotation>
-		<annotation cp="🧙🏽‍♀">čarobnica | čarobnica: ni svijetla ni tamna koža | ni svijetla ni tamna koža | vještica</annotation>
+		<annotation cp="🧙🏽‍♀">čarobnica | ni svijetla ni tamna koža | vještica</annotation>
 		<annotation cp="🧙🏽‍♀" type="tts">čarobnica: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧙🏾‍♀">čarobnica | srednje tamna koža | vještica</annotation>
 		<annotation cp="🧙🏿‍♀">čarobnica | tamna koža | vještica</annotation>
-		<annotation cp="🧚🏻">Oberon | Pak | svijetla koža | Titanija | vila | vila: svijetla koža</annotation>
+		<annotation cp="🧚🏻">Oberon | Pak | svijetla koža | Titanija | vila</annotation>
 		<annotation cp="🧚🏻" type="tts">vila: svijetla koža</annotation>
-		<annotation cp="🧚🏼">Oberon | Pak | srednje svijetla koža | Titanija | vila | vila: srednje svijetla koža</annotation>
+		<annotation cp="🧚🏼">Oberon | Pak | srednje svijetla koža | Titanija | vila</annotation>
 		<annotation cp="🧚🏼" type="tts">vila: srednje svijetla koža</annotation>
-		<annotation cp="🧚🏽">ni svijetla ni tamna koža | Oberon | Pak | Titanija | vila | vila: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧚🏽">ni svijetla ni tamna koža | Oberon | Pak | Titanija | vila</annotation>
 		<annotation cp="🧚🏽" type="tts">vila: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧚🏻‍♂">Oberon | Pak | svijetla koža | vilenjak | vilenjak: svijetla koža</annotation>
+		<annotation cp="🧚🏻‍♂">Oberon | Pak | svijetla koža | vilenjak</annotation>
 		<annotation cp="🧚🏻‍♂" type="tts">vilenjak: svijetla koža</annotation>
-		<annotation cp="🧚🏼‍♂">Oberon | Pak | srednje svijetla koža | vilenjak | vilenjak: srednje svijetla koža</annotation>
+		<annotation cp="🧚🏼‍♂">Oberon | Pak | srednje svijetla koža | vilenjak</annotation>
 		<annotation cp="🧚🏼‍♂" type="tts">vilenjak: srednje svijetla koža</annotation>
-		<annotation cp="🧚🏽‍♂">ni svijetla ni tamna koža | Oberon | Pak | vilenjak | vilenjak: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧚🏽‍♂">ni svijetla ni tamna koža | Oberon | Pak | vilenjak</annotation>
 		<annotation cp="🧚🏽‍♂" type="tts">vilenjak: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧚🏻‍♀">svijetla koža | Titanija | žena vila | žena vila: svijetla koža</annotation>
+		<annotation cp="🧚🏻‍♀">svijetla koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏻‍♀" type="tts">žena vila: svijetla koža</annotation>
-		<annotation cp="🧚🏼‍♀">srednje svijetla koža | Titanija | žena vila | žena vila: srednje svijetla koža</annotation>
+		<annotation cp="🧚🏼‍♀">srednje svijetla koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏼‍♀" type="tts">žena vila: srednje svijetla koža</annotation>
-		<annotation cp="🧚🏽‍♀">ni svijetla ni tamna koža | Titanija | žena vila | žena vila: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧚🏽‍♀">ni svijetla ni tamna koža | Titanija | žena vila</annotation>
 		<annotation cp="🧚🏽‍♀" type="tts">žena vila: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧛🏻">Drakula | povampiren | svijetla koža | vampir | vampir: svijetla koža</annotation>
+		<annotation cp="🧛🏻">Drakula | povampiren | svijetla koža | vampir</annotation>
 		<annotation cp="🧛🏻" type="tts">vampir: svijetla koža</annotation>
-		<annotation cp="🧛🏼">Drakula | povampiren | srednje svijetla koža | vampir | vampir: srednje svijetla koža</annotation>
+		<annotation cp="🧛🏼">Drakula | povampiren | srednje svijetla koža | vampir</annotation>
 		<annotation cp="🧛🏼" type="tts">vampir: srednje svijetla koža</annotation>
-		<annotation cp="🧛🏽">Drakula | ni svijetla ni tamna koža | povampiren | vampir | vampir: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧛🏽">Drakula | ni svijetla ni tamna koža | povampiren | vampir</annotation>
 		<annotation cp="🧛🏽" type="tts">vampir: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧛🏻‍♂">Drakula | muški vampir | muški vampir: svijetla koža | povampiren | svijetla koža</annotation>
+		<annotation cp="🧛🏻‍♂">Drakula | muški vampir | povampiren | svijetla koža</annotation>
 		<annotation cp="🧛🏻‍♂" type="tts">muški vampir: svijetla koža</annotation>
-		<annotation cp="🧛🏼‍♂">Drakula | muški vampir | muški vampir: srednje svijetla koža | povampiren | srednje svijetla koža</annotation>
+		<annotation cp="🧛🏼‍♂">Drakula | muški vampir | povampiren | srednje svijetla koža</annotation>
 		<annotation cp="🧛🏼‍♂" type="tts">muški vampir: srednje svijetla koža</annotation>
-		<annotation cp="🧛🏽‍♂">Drakula | muški vampir | muški vampir: ni svijetla ni tamna koža | ni svijetla ni tamna koža | povampiren</annotation>
+		<annotation cp="🧛🏽‍♂">Drakula | muški vampir | ni svijetla ni tamna koža | povampiren</annotation>
 		<annotation cp="🧛🏽‍♂" type="tts">muški vampir: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧛🏻‍♀">povampiren | svijetla koža | ženski vampir | ženski vampir: svijetla koža</annotation>
+		<annotation cp="🧛🏻‍♀">povampiren | svijetla koža | ženski vampir</annotation>
 		<annotation cp="🧛🏻‍♀" type="tts">ženski vampir: svijetla koža</annotation>
-		<annotation cp="🧛🏼‍♀">povampiren | srednje svijetla koža | ženski vampir | ženski vampir: srednje svijetla koža</annotation>
+		<annotation cp="🧛🏼‍♀">povampiren | srednje svijetla koža | ženski vampir</annotation>
 		<annotation cp="🧛🏼‍♀" type="tts">ženski vampir: srednje svijetla koža</annotation>
-		<annotation cp="🧛🏽‍♀">ni svijetla ni tamna koža | povampiren | ženski vampir | ženski vampir: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧛🏽‍♀">ni svijetla ni tamna koža | povampiren | ženski vampir</annotation>
 		<annotation cp="🧛🏽‍♀" type="tts">ženski vampir: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧜🏻">osoba iz mora | osoba iz mora: svijetla koža | sirena | svijetla koža</annotation>
+		<annotation cp="🧜🏻">osoba iz mora | sirena | svijetla koža</annotation>
 		<annotation cp="🧜🏻" type="tts">osoba iz mora: svijetla koža</annotation>
-		<annotation cp="🧜🏼">osoba iz mora | osoba iz mora: srednje svijetla koža | sirena | srednje svijetla koža</annotation>
+		<annotation cp="🧜🏼">osoba iz mora | sirena | srednje svijetla koža</annotation>
 		<annotation cp="🧜🏼" type="tts">osoba iz mora: srednje svijetla koža</annotation>
-		<annotation cp="🧜🏽">ni svijetla ni tamna koža | osoba iz mora | osoba iz mora: ni svijetla ni tamna koža | sirena</annotation>
+		<annotation cp="🧜🏽">ni svijetla ni tamna koža | osoba iz mora | sirena</annotation>
 		<annotation cp="🧜🏽" type="tts">osoba iz mora: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧜🏻‍♂">muškarac iz mora | muškarac iz mora: svijetla koža | svijetla koža | Triton</annotation>
+		<annotation cp="🧜🏻‍♂">muškarac iz mora | svijetla koža | Triton</annotation>
 		<annotation cp="🧜🏻‍♂" type="tts">muškarac iz mora: svijetla koža</annotation>
-		<annotation cp="🧜🏼‍♂">muškarac iz mora | muškarac iz mora: srednje svijetla koža | srednje svijetla koža | Triton</annotation>
+		<annotation cp="🧜🏼‍♂">muškarac iz mora | srednje svijetla koža | Triton</annotation>
 		<annotation cp="🧜🏼‍♂" type="tts">muškarac iz mora: srednje svijetla koža</annotation>
-		<annotation cp="🧜🏽‍♂">muškarac iz mora | muškarac iz mora: ni svijetla ni tamna koža | ni svijetla ni tamna koža | Triton</annotation>
+		<annotation cp="🧜🏽‍♂">muškarac iz mora | ni svijetla ni tamna koža | Triton</annotation>
 		<annotation cp="🧜🏽‍♂" type="tts">muškarac iz mora: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧜🏻‍♀">sirena | sirena: svijetla koža | svijetla koža | žena iz mora</annotation>
+		<annotation cp="🧜🏻‍♀">sirena | svijetla koža | žena iz mora</annotation>
 		<annotation cp="🧜🏻‍♀" type="tts">sirena: svijetla koža</annotation>
-		<annotation cp="🧜🏼‍♀">sirena | sirena: srednje svijetla koža | srednje svijetla koža | žena iz mora</annotation>
+		<annotation cp="🧜🏼‍♀">sirena | srednje svijetla koža | žena iz mora</annotation>
 		<annotation cp="🧜🏼‍♀" type="tts">sirena: srednje svijetla koža</annotation>
-		<annotation cp="🧜🏽‍♀">ni svijetla ni tamna koža | sirena | sirena: ni svijetla ni tamna koža | žena iz mora</annotation>
+		<annotation cp="🧜🏽‍♀">ni svijetla ni tamna koža | sirena | žena iz mora</annotation>
 		<annotation cp="🧜🏽‍♀" type="tts">sirena: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧝🏻">magično | svijetla koža | vilovnjak | vilovnjak: svijetla koža</annotation>
+		<annotation cp="🧝🏻">magično | svijetla koža | vilovnjak</annotation>
 		<annotation cp="🧝🏻" type="tts">vilovnjak: svijetla koža</annotation>
-		<annotation cp="🧝🏼">magično | srednje svijetla koža | vilovnjak | vilovnjak: srednje svijetla koža</annotation>
+		<annotation cp="🧝🏼">magično | srednje svijetla koža | vilovnjak</annotation>
 		<annotation cp="🧝🏼" type="tts">vilovnjak: srednje svijetla koža</annotation>
-		<annotation cp="🧝🏽">magično | ni svijetla ni tamna koža | vilovnjak | vilovnjak: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧝🏽">magično | ni svijetla ni tamna koža | vilovnjak</annotation>
 		<annotation cp="🧝🏽" type="tts">vilovnjak: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧝🏻‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧝🏻‍♂">magičan muškarac | muškarac vilovnjak | svijetla koža</annotation>
 		<annotation cp="🧝🏻‍♂" type="tts">muškarac vilovnjak: svijetla koža</annotation>
-		<annotation cp="🧝🏼‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧝🏼‍♂">magičan muškarac | muškarac vilovnjak | srednje svijetla koža</annotation>
 		<annotation cp="🧝🏼‍♂" type="tts">muškarac vilovnjak: srednje svijetla koža</annotation>
-		<annotation cp="🧝🏽‍♂">magičan muškarac | muškarac vilovnjak | muškarac vilovnjak: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧝🏽‍♂">magičan muškarac | muškarac vilovnjak | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧝🏽‍♂" type="tts">muškarac vilovnjak: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧝🏻‍♀">magična žena | svijetla koža | žena vilovnjak | žena vilovnjak: svijetla koža</annotation>
+		<annotation cp="🧝🏻‍♀">magična žena | svijetla koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏻‍♀" type="tts">žena vilovnjak: svijetla koža</annotation>
-		<annotation cp="🧝🏼‍♀">magična žena | srednje svijetla koža | žena vilovnjak | žena vilovnjak: srednje svijetla koža</annotation>
+		<annotation cp="🧝🏼‍♀">magična žena | srednje svijetla koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏼‍♀" type="tts">žena vilovnjak: srednje svijetla koža</annotation>
-		<annotation cp="🧝🏽‍♀">magična žena | ni svijetla ni tamna koža | žena vilovnjak | žena vilovnjak: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧝🏽‍♀">magična žena | ni svijetla ni tamna koža | žena vilovnjak</annotation>
 		<annotation cp="🧝🏽‍♀" type="tts">žena vilovnjak: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💆🏻">lice | masaža | masaža lica | masaža lica: svijetla koža | salon | svijetla koža</annotation>
+		<annotation cp="💆🏻">lice | masaža | masaža lica | salon | svijetla koža</annotation>
 		<annotation cp="💆🏻" type="tts">masaža lica: svijetla koža</annotation>
-		<annotation cp="💆🏼">lice | masaža | masaža lica | masaža lica: srednje svijetla koža | salon | srednje svijetla koža</annotation>
+		<annotation cp="💆🏼">lice | masaža | masaža lica | salon | srednje svijetla koža</annotation>
 		<annotation cp="💆🏼" type="tts">masaža lica: srednje svijetla koža</annotation>
-		<annotation cp="💆🏽">lice | masaža | masaža lica | masaža lica: ni svijetla ni tamna koža | ni svijetla ni tamna koža | salon</annotation>
+		<annotation cp="💆🏽">lice | masaža | masaža lica | ni svijetla ni tamna koža | salon</annotation>
 		<annotation cp="💆🏽" type="tts">masaža lica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💆🏻‍♂">lice | masaža | muška masaža lica | muška masaža lica: svijetla koža | muškarac | salon | svijetla koža</annotation>
+		<annotation cp="💆🏻‍♂">lice | masaža | muška masaža lica | muškarac | salon | svijetla koža</annotation>
 		<annotation cp="💆🏻‍♂" type="tts">muška masaža lica: svijetla koža</annotation>
-		<annotation cp="💆🏼‍♂">lice | masaža | muška masaža lica | muška masaža lica: srednje svijetla koža | muškarac | salon | srednje svijetla koža</annotation>
+		<annotation cp="💆🏼‍♂">lice | masaža | muška masaža lica | muškarac | salon | srednje svijetla koža</annotation>
 		<annotation cp="💆🏼‍♂" type="tts">muška masaža lica: srednje svijetla koža</annotation>
-		<annotation cp="💆🏽‍♂">lice | masaža | muška masaža lica | muška masaža lica: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | salon</annotation>
+		<annotation cp="💆🏽‍♂">lice | masaža | muška masaža lica | muškarac | ni svijetla ni tamna koža | salon</annotation>
 		<annotation cp="💆🏽‍♂" type="tts">muška masaža lica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💆🏻‍♀">lice | masaža | salon | svijetla koža | žena | ženska masaža lica | ženska masaža lica: svijetla koža</annotation>
+		<annotation cp="💆🏻‍♀">lice | masaža | salon | svijetla koža | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏻‍♀" type="tts">ženska masaža lica: svijetla koža</annotation>
-		<annotation cp="💆🏼‍♀">lice | masaža | salon | srednje svijetla koža | žena | ženska masaža lica | ženska masaža lica: srednje svijetla koža</annotation>
+		<annotation cp="💆🏼‍♀">lice | masaža | salon | srednje svijetla koža | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏼‍♀" type="tts">ženska masaža lica: srednje svijetla koža</annotation>
-		<annotation cp="💆🏽‍♀">lice | masaža | ni svijetla ni tamna koža | salon | žena | ženska masaža lica | ženska masaža lica: ni svijetla ni tamna koža</annotation>
+		<annotation cp="💆🏽‍♀">lice | masaža | ni svijetla ni tamna koža | salon | žena | ženska masaža lica</annotation>
 		<annotation cp="💆🏽‍♀" type="tts">ženska masaža lica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💇🏻">frizer | osoba se šiša | salon | šišanje | šišanje kose | šišanje: svijetla koža | svijetla koža | uljepšavanje</annotation>
+		<annotation cp="💇🏻">frizer | osoba se šiša | salon | šišanje | šišanje kose | svijetla koža | uljepšavanje</annotation>
 		<annotation cp="💇🏻" type="tts">šišanje: svijetla koža</annotation>
-		<annotation cp="💇🏼">frizer | osoba se šiša | salon | šišanje | šišanje kose | šišanje: srednje svijetla koža | srednje svijetla koža | uljepšavanje</annotation>
+		<annotation cp="💇🏼">frizer | osoba se šiša | salon | šišanje | šišanje kose | srednje svijetla koža | uljepšavanje</annotation>
 		<annotation cp="💇🏼" type="tts">šišanje: srednje svijetla koža</annotation>
-		<annotation cp="💇🏽">frizer | ni svijetla ni tamna koža | osoba se šiša | salon | šišanje | šišanje kose | šišanje: ni svijetla ni tamna koža | uljepšavanje</annotation>
+		<annotation cp="💇🏽">frizer | ni svijetla ni tamna koža | osoba se šiša | salon | šišanje | šišanje kose | uljepšavanje</annotation>
 		<annotation cp="💇🏽" type="tts">šišanje: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💇🏾">frizer | osoba se šiša | salon | šišanje | šišanje kose | srednje tamna koža | uljepšavanje</annotation>
 		<annotation cp="💇🏿">frizer | osoba se šiša | salon | šišanje | šišanje kose | tamna koža | uljepšavanje</annotation>
-		<annotation cp="💇🏻‍♂">frizura | muškarac | muško šišanje | muško šišanje: svijetla koža | svijetla koža</annotation>
+		<annotation cp="💇🏻‍♂">frizura | muškarac | muško šišanje | svijetla koža</annotation>
 		<annotation cp="💇🏻‍♂" type="tts">muško šišanje: svijetla koža</annotation>
-		<annotation cp="💇🏼‍♂">frizura | muškarac | muško šišanje | muško šišanje: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="💇🏼‍♂">frizura | muškarac | muško šišanje | srednje svijetla koža</annotation>
 		<annotation cp="💇🏼‍♂" type="tts">muško šišanje: srednje svijetla koža</annotation>
-		<annotation cp="💇🏽‍♂">frizura | muškarac | muško šišanje | muško šišanje: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="💇🏽‍♂">frizura | muškarac | muško šišanje | ni svijetla ni tamna koža</annotation>
 		<annotation cp="💇🏽‍♂" type="tts">muško šišanje: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💇🏾‍♂">frizura | muškarac | muško šišanje | srednje tamna koža</annotation>
 		<annotation cp="💇🏿‍♂">frizura | muškarac | muško šišanje | tamna koža</annotation>
-		<annotation cp="💇🏻‍♀">frizura | svijetla koža | žena | žensko šišanje | žensko šišanje: svijetla koža</annotation>
+		<annotation cp="💇🏻‍♀">frizura | svijetla koža | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏻‍♀" type="tts">žensko šišanje: svijetla koža</annotation>
-		<annotation cp="💇🏼‍♀">frizura | srednje svijetla koža | žena | žensko šišanje | žensko šišanje: srednje svijetla koža</annotation>
+		<annotation cp="💇🏼‍♀">frizura | srednje svijetla koža | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏼‍♀" type="tts">žensko šišanje: srednje svijetla koža</annotation>
-		<annotation cp="💇🏽‍♀">frizura | ni svijetla ni tamna koža | žena | žensko šišanje | žensko šišanje: ni svijetla ni tamna koža</annotation>
+		<annotation cp="💇🏽‍♀">frizura | ni svijetla ni tamna koža | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏽‍♀" type="tts">žensko šišanje: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💇🏾‍♀">frizura | srednje tamna koža | žena | žensko šišanje</annotation>
 		<annotation cp="💇🏿‍♀">frizura | tamna koža | žena | žensko šišanje</annotation>
-		<annotation cp="🚶🏻">hodanje | pješak | pješak: svijetla koža | šetanje | svijetla koža</annotation>
+		<annotation cp="🚶🏻">hodanje | pješak | šetanje | svijetla koža</annotation>
 		<annotation cp="🚶🏻" type="tts">pješak: svijetla koža</annotation>
-		<annotation cp="🚶🏼">hodanje | pješak | pješak: srednje svijetla koža | šetanje | srednje svijetla koža</annotation>
+		<annotation cp="🚶🏼">hodanje | pješak | šetanje | srednje svijetla koža</annotation>
 		<annotation cp="🚶🏼" type="tts">pješak: srednje svijetla koža</annotation>
-		<annotation cp="🚶🏽">hodanje | ni svijetla ni tamna koža | pješak | pješak: ni svijetla ni tamna koža | šetanje</annotation>
+		<annotation cp="🚶🏽">hodanje | ni svijetla ni tamna koža | pješak | šetanje</annotation>
 		<annotation cp="🚶🏽" type="tts">pješak: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚶🏾">hodanje | pješak | pješak: srednje tamna koža | šetanje | srednje tamna koža</annotation>
+		<annotation cp="🚶🏾">hodanje | pješak | šetanje | srednje tamna koža</annotation>
 		<annotation cp="🚶🏾" type="tts">pješak: srednje tamna koža</annotation>
-		<annotation cp="🚶🏿">hodanje | pješak | pješak: tamna koža | šetanje | tamna koža</annotation>
+		<annotation cp="🚶🏿">hodanje | pješak | šetanje | tamna koža</annotation>
 		<annotation cp="🚶🏿" type="tts">pješak: tamna koža</annotation>
-		<annotation cp="🚶🏻‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: svijetla koža | šetanje | svijetla koža</annotation>
+		<annotation cp="🚶🏻‍♂">hodanje | muškarac | muškarac hoda | šetanje | svijetla koža</annotation>
 		<annotation cp="🚶🏻‍♂" type="tts">muškarac hoda: svijetla koža</annotation>
-		<annotation cp="🚶🏼‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: srednje svijetla koža | šetanje | srednje svijetla koža</annotation>
+		<annotation cp="🚶🏼‍♂">hodanje | muškarac | muškarac hoda | šetanje | srednje svijetla koža</annotation>
 		<annotation cp="🚶🏼‍♂" type="tts">muškarac hoda: srednje svijetla koža</annotation>
-		<annotation cp="🚶🏽‍♂">hodanje | muškarac | muškarac hoda | muškarac hoda: ni svijetla ni tamna koža | ni svijetla ni tamna koža | šetanje</annotation>
+		<annotation cp="🚶🏽‍♂">hodanje | muškarac | muškarac hoda | ni svijetla ni tamna koža | šetanje</annotation>
 		<annotation cp="🚶🏽‍♂" type="tts">muškarac hoda: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚶🏻‍♀">hodanje | šetanje | svijetla koža | žena | žena hoda | žena hoda: svijetla koža</annotation>
+		<annotation cp="🚶🏻‍♀">hodanje | šetanje | svijetla koža | žena | žena hoda</annotation>
 		<annotation cp="🚶🏻‍♀" type="tts">žena hoda: svijetla koža</annotation>
-		<annotation cp="🚶🏼‍♀">hodanje | šetanje | srednje svijetla koža | žena | žena hoda | žena hoda: srednje svijetla koža</annotation>
+		<annotation cp="🚶🏼‍♀">hodanje | šetanje | srednje svijetla koža | žena | žena hoda</annotation>
 		<annotation cp="🚶🏼‍♀" type="tts">žena hoda: srednje svijetla koža</annotation>
-		<annotation cp="🚶🏽‍♀">hodanje | ni svijetla ni tamna koža | šetanje | žena | žena hoda | žena hoda: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🚶🏽‍♀">hodanje | ni svijetla ni tamna koža | šetanje | žena | žena hoda</annotation>
 		<annotation cp="🚶🏽‍♀" type="tts">žena hoda: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧍🏻">osoba stoji | osoba stoji: svijetla koža | stajanje | stajati | svijetla koža</annotation>
+		<annotation cp="🧍🏻">osoba stoji | stajanje | stajati | svijetla koža</annotation>
 		<annotation cp="🧍🏻" type="tts">osoba stoji: svijetla koža</annotation>
-		<annotation cp="🧍🏼">osoba stoji | osoba stoji: srednje svijetla koža | srednje svijetla koža | stajanje | stajati</annotation>
+		<annotation cp="🧍🏼">osoba stoji | srednje svijetla koža | stajanje | stajati</annotation>
 		<annotation cp="🧍🏼" type="tts">osoba stoji: srednje svijetla koža</annotation>
-		<annotation cp="🧍🏽">ni svijetla ni tamna koža | osoba stoji | osoba stoji: ni svijetla ni tamna koža | stajanje | stajati</annotation>
+		<annotation cp="🧍🏽">ni svijetla ni tamna koža | osoba stoji | stajanje | stajati</annotation>
 		<annotation cp="🧍🏽" type="tts">osoba stoji: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧍🏻‍♂">čovjek | čovjek stoji: svijetla koža | stoji | svijetla koža</annotation>
+		<annotation cp="🧍🏻‍♂">čovjek | stoji | svijetla koža</annotation>
 		<annotation cp="🧍🏻‍♂" type="tts">čovjek stoji: svijetla koža</annotation>
-		<annotation cp="🧍🏼‍♂">čovjek | čovjek stoji: srednje svijetla koža | srednje svijetla koža | stoji</annotation>
+		<annotation cp="🧍🏼‍♂">čovjek | srednje svijetla koža | stoji</annotation>
 		<annotation cp="🧍🏼‍♂" type="tts">čovjek stoji: srednje svijetla koža</annotation>
-		<annotation cp="🧍🏽‍♂">čovjek | čovjek stoji: ni svijetla ni tamna koža | ni svijetla ni tamna koža | stoji</annotation>
+		<annotation cp="🧍🏽‍♂">čovjek | ni svijetla ni tamna koža | stoji</annotation>
 		<annotation cp="🧍🏽‍♂" type="tts">čovjek stoji: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧍🏾‍♂">čovjek | čovjek stoji: srednje tamna koža | srednje tamna koža | stoji</annotation>
+		<annotation cp="🧍🏾‍♂">čovjek | srednje tamna koža | stoji</annotation>
 		<annotation cp="🧍🏾‍♂" type="tts">čovjek stoji: srednje tamna koža</annotation>
-		<annotation cp="🧍🏿‍♂">čovjek | čovjek stoji: tamna koža | stoji | tamna koža</annotation>
+		<annotation cp="🧍🏿‍♂">čovjek | stoji | tamna koža</annotation>
 		<annotation cp="🧍🏿‍♂" type="tts">čovjek stoji: tamna koža</annotation>
-		<annotation cp="🧍🏻‍♀">stoji | svijetla koža | žena | žena stoji: svijetla koža</annotation>
+		<annotation cp="🧍🏻‍♀">stoji | svijetla koža | žena</annotation>
 		<annotation cp="🧍🏻‍♀" type="tts">žena stoji: svijetla koža</annotation>
-		<annotation cp="🧍🏼‍♀">srednje svijetla koža | stoji | žena | žena stoji: srednje svijetla koža</annotation>
+		<annotation cp="🧍🏼‍♀">srednje svijetla koža | stoji | žena</annotation>
 		<annotation cp="🧍🏼‍♀" type="tts">žena stoji: srednje svijetla koža</annotation>
-		<annotation cp="🧍🏽‍♀">ni svijetla ni tamna koža | stoji | žena | žena stoji: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧍🏽‍♀">ni svijetla ni tamna koža | stoji | žena</annotation>
 		<annotation cp="🧍🏽‍♀" type="tts">žena stoji: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧎🏻">klečanje | klečati | osoba kleči | osoba kleči: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧎🏻">klečanje | klečati | osoba kleči | svijetla koža</annotation>
 		<annotation cp="🧎🏻" type="tts">osoba kleči: svijetla koža</annotation>
-		<annotation cp="🧎🏼">klečanje | klečati | osoba kleči | osoba kleči: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧎🏼">klečanje | klečati | osoba kleči | srednje svijetla koža</annotation>
 		<annotation cp="🧎🏼" type="tts">osoba kleči: srednje svijetla koža</annotation>
-		<annotation cp="🧎🏽">klečanje | klečati | ni svijetla ni tamna koža | osoba kleči | osoba kleči: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧎🏽">klečanje | klečati | ni svijetla ni tamna koža | osoba kleči</annotation>
 		<annotation cp="🧎🏽" type="tts">osoba kleči: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧎🏻‍♂">čovek | čovek kleči: svijetla koža | kleči | svijetla koža</annotation>
+		<annotation cp="🧎🏻‍♂">čovek | kleči | svijetla koža</annotation>
 		<annotation cp="🧎🏻‍♂" type="tts">čovek kleči: svijetla koža</annotation>
-		<annotation cp="🧎🏼‍♂">čovek | čovek kleči: srednje svijetla koža | kleči | srednje svijetla koža</annotation>
+		<annotation cp="🧎🏼‍♂">čovek | kleči | srednje svijetla koža</annotation>
 		<annotation cp="🧎🏼‍♂" type="tts">čovek kleči: srednje svijetla koža</annotation>
-		<annotation cp="🧎🏽‍♂">čovek | čovek kleči: ni svijetla ni tamna koža | kleči | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧎🏽‍♂">čovek | kleči | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧎🏽‍♂" type="tts">čovek kleči: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧎🏻‍♀">kleči | svijetla koža | žena | žena kleči: svijetla koža</annotation>
+		<annotation cp="🧎🏻‍♀">kleči | svijetla koža | žena</annotation>
 		<annotation cp="🧎🏻‍♀" type="tts">žena kleči: svijetla koža</annotation>
-		<annotation cp="🧎🏼‍♀">kleči | srednje svijetla koža | žena | žena kleči: srednje svijetla koža</annotation>
+		<annotation cp="🧎🏼‍♀">kleči | srednje svijetla koža | žena</annotation>
 		<annotation cp="🧎🏼‍♀" type="tts">žena kleči: srednje svijetla koža</annotation>
-		<annotation cp="🧎🏽‍♀">kleči | ni svijetla ni tamna koža | žena | žena kleči: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧎🏽‍♀">kleči | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="🧎🏽‍♀" type="tts">žena kleči: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🦯">osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: svijetla koža | pristupačnost | slijep | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦯">osoba sa pomoćnim štapom | pristupačnost | slijep | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦯" type="tts">osoba sa pomoćnim štapom: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🦯">osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: srednje svijetla koža | pristupačnost | slijep | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦯">osoba sa pomoćnim štapom | pristupačnost | slijep | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦯" type="tts">osoba sa pomoćnim štapom: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🦯">ni svijetla ni tamna koža | osoba sa pomoćnim štapom | osoba sa pomoćnim štapom: ni svijetla ni tamna koža | pristupačnost | slijep</annotation>
+		<annotation cp="🧑🏽‍🦯">ni svijetla ni tamna koža | osoba sa pomoćnim štapom | pristupačnost | slijep</annotation>
 		<annotation cp="🧑🏽‍🦯" type="tts">osoba sa pomoćnim štapom: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧑🏾‍🦯">osoba sa pomoćnim štapom | pristupačnost | slijep | srednje tamna koža</annotation>
 		<annotation cp="🧑🏿‍🦯">osoba sa pomoćnim štapom | pristupačnost | slijep | tamna koža</annotation>
-		<annotation cp="👨🏻‍🦯">čovjek | čovjek sa pomoćnim štapom | čovjek sa pomoćnim štapom: svijetla koža | pristupačnost | slijep | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦯">čovjek | čovjek sa pomoćnim štapom | pristupačnost | slijep | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦯" type="tts">čovjek sa pomoćnim štapom: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🦯">čovjek | čovjek sa pomoćnim štapom | čovjek sa pomoćnim štapom: srednje svijetla koža | pristupačnost | slijep | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦯">čovjek | čovjek sa pomoćnim štapom | pristupačnost | slijep | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦯" type="tts">čovjek sa pomoćnim štapom: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🦯">čovjek | čovjek sa pomoćnim štapom | čovjek sa pomoćnim štapom: ni svijetla ni tamna koža | ni svijetla ni tamna koža | pristupačnost | slijep</annotation>
+		<annotation cp="👨🏽‍🦯">čovjek | čovjek sa pomoćnim štapom | ni svijetla ni tamna koža | pristupačnost | slijep</annotation>
 		<annotation cp="👨🏽‍🦯" type="tts">čovjek sa pomoćnim štapom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🦯">čovjek | čovjek sa pomoćnim štapom | čovjek sa pomoćnim štapom: srednje tamna koža | pristupačnost | slijep | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦯">čovjek | čovjek sa pomoćnim štapom | pristupačnost | slijep | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦯" type="tts">čovjek sa pomoćnim štapom: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🦯">čovjek | čovjek sa pomoćnim štapom | čovjek sa pomoćnim štapom: tamna koža | pristupačnost | slijep | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦯">čovjek | čovjek sa pomoćnim štapom | pristupačnost | slijep | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦯" type="tts">čovjek sa pomoćnim štapom: tamna koža</annotation>
-		<annotation cp="👩🏻‍🦯">pristupačnost | slijepa | svijetla koža | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: svijetla koža</annotation>
+		<annotation cp="👩🏻‍🦯">pristupačnost | slijepa | svijetla koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏻‍🦯" type="tts">žena sa pomoćnim štapom: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🦯">pristupačnost | slijepa | srednje svijetla koža | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍🦯">pristupačnost | slijepa | srednje svijetla koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏼‍🦯" type="tts">žena sa pomoćnim štapom: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🦯">ni svijetla ni tamna koža | pristupačnost | slijepa | žena | žena sa pomoćnim štapom | žena sa pomoćnim štapom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🦯">ni svijetla ni tamna koža | pristupačnost | slijepa | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏽‍🦯" type="tts">žena sa pomoćnim štapom: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍🦯">pristupačnost | slijepa | srednje tamna koža | žena | žena sa pomoćnim štapom</annotation>
 		<annotation cp="👩🏿‍🦯">pristupačnost | slijepa | tamna koža | žena | žena sa pomoćnim štapom</annotation>
-		<annotation cp="🧑🏻‍🦼">kolica | osoba u motornim kolicima | osoba u motornim kolicima: svijetla koža | pristupačnost | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦼">kolica | osoba u motornim kolicima | pristupačnost | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦼" type="tts">osoba u motornim kolicima: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🦼">kolica | osoba u motornim kolicima | osoba u motornim kolicima: srednje svijetla koža | pristupačnost | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦼">kolica | osoba u motornim kolicima | pristupačnost | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦼" type="tts">osoba u motornim kolicima: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🦼">kolica | ni svijetla ni tamna koža | osoba u motornim kolicima | osoba u motornim kolicima: ni svijetla ni tamna koža | pristupačnost</annotation>
+		<annotation cp="🧑🏽‍🦼">kolica | ni svijetla ni tamna koža | osoba u motornim kolicima | pristupačnost</annotation>
 		<annotation cp="🧑🏽‍🦼" type="tts">osoba u motornim kolicima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🦼">čovjek | čovjek u motornim kolicima | čovjek u motornim kolicima: svijetla koža | kolica | pristupačnost | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦼">čovjek | čovjek u motornim kolicima | kolica | pristupačnost | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦼" type="tts">čovjek u motornim kolicima: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🦼">čovjek | čovjek u motornim kolicima | čovjek u motornim kolicima: srednje svijetla koža | kolica | pristupačnost | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦼">čovjek | čovjek u motornim kolicima | kolica | pristupačnost | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦼" type="tts">čovjek u motornim kolicima: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🦼">čovjek | čovjek u motornim kolicima | čovjek u motornim kolicima: ni svijetla ni tamna koža | kolica | ni svijetla ni tamna koža | pristupačnost</annotation>
+		<annotation cp="👨🏽‍🦼">čovjek | čovjek u motornim kolicima | kolica | ni svijetla ni tamna koža | pristupačnost</annotation>
 		<annotation cp="👨🏽‍🦼" type="tts">čovjek u motornim kolicima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🦼">čovjek | čovjek u motornim kolicima | čovjek u motornim kolicima: srednje tamna koža | kolica | pristupačnost | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦼">čovjek | čovjek u motornim kolicima | kolica | pristupačnost | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦼" type="tts">čovjek u motornim kolicima: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🦼">čovjek | čovjek u motornim kolicima | čovjek u motornim kolicima: tamna koža | kolica | pristupačnost | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦼">čovjek | čovjek u motornim kolicima | kolica | pristupačnost | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦼" type="tts">čovjek u motornim kolicima: tamna koža</annotation>
-		<annotation cp="👩🏻‍🦼">kolica | pristupačnost | svijetla koža | žena | žena u motornim kolicima | žena u motornim kolicima: svijetla koža</annotation>
+		<annotation cp="👩🏻‍🦼">kolica | pristupačnost | svijetla koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏻‍🦼" type="tts">žena u motornim kolicima: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🦼">kolica | pristupačnost | srednje svijetla koža | žena | žena u motornim kolicima | žena u motornim kolicima: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍🦼">kolica | pristupačnost | srednje svijetla koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏼‍🦼" type="tts">žena u motornim kolicima: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🦼">kolica | ni svijetla ni tamna koža | pristupačnost | žena | žena u motornim kolicima | žena u motornim kolicima: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🦼">kolica | ni svijetla ni tamna koža | pristupačnost | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏽‍🦼" type="tts">žena u motornim kolicima: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍🦼">kolica | pristupačnost | srednje tamna koža | žena | žena u motornim kolicima</annotation>
 		<annotation cp="👩🏿‍🦼">kolica | pristupačnost | tamna koža | žena | žena u motornim kolicima</annotation>
-		<annotation cp="🧑🏻‍🦽">kolica | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: svijetla koža | pristupačnost | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🦽">kolica | osoba u mehaničkim kolicima | pristupačnost | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🦽" type="tts">osoba u mehaničkim kolicima: svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🦽">kolica | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: srednje svijetla koža | pristupačnost | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🦽">kolica | osoba u mehaničkim kolicima | pristupačnost | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🦽" type="tts">osoba u mehaničkim kolicima: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🦽">kolica | ni svijetla ni tamna koža | osoba u mehaničkim kolicima | osoba u mehaničkim kolicima: ni svijetla ni tamna koža | pristupačnost</annotation>
+		<annotation cp="🧑🏽‍🦽">kolica | ni svijetla ni tamna koža | osoba u mehaničkim kolicima | pristupačnost</annotation>
 		<annotation cp="🧑🏽‍🦽" type="tts">osoba u mehaničkim kolicima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🦽">čovjek | čovjek u mehaničkim kolicima | čovjek u mehaničkim kolicima: svijetla koža | kolica | pristupačnost | svijetla koža</annotation>
+		<annotation cp="👨🏻‍🦽">čovjek | čovjek u mehaničkim kolicima | kolica | pristupačnost | svijetla koža</annotation>
 		<annotation cp="👨🏻‍🦽" type="tts">čovjek u mehaničkim kolicima: svijetla koža</annotation>
-		<annotation cp="👨🏼‍🦽">čovjek | čovjek u mehaničkim kolicima | čovjek u mehaničkim kolicima: srednje svijetla koža | kolica | pristupačnost | srednje svijetla koža</annotation>
+		<annotation cp="👨🏼‍🦽">čovjek | čovjek u mehaničkim kolicima | kolica | pristupačnost | srednje svijetla koža</annotation>
 		<annotation cp="👨🏼‍🦽" type="tts">čovjek u mehaničkim kolicima: srednje svijetla koža</annotation>
-		<annotation cp="👨🏽‍🦽">čovjek | čovjek u mehaničkim kolicima | čovjek u mehaničkim kolicima: ni svijetla ni tamna koža | kolica | ni svijetla ni tamna koža | pristupačnost</annotation>
+		<annotation cp="👨🏽‍🦽">čovjek | čovjek u mehaničkim kolicima | kolica | ni svijetla ni tamna koža | pristupačnost</annotation>
 		<annotation cp="👨🏽‍🦽" type="tts">čovjek u mehaničkim kolicima: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏾‍🦽">čovjek | čovjek u mehaničkim kolicima | čovjek u mehaničkim kolicima: srednje tamna koža | kolica | pristupačnost | srednje tamna koža</annotation>
+		<annotation cp="👨🏾‍🦽">čovjek | čovjek u mehaničkim kolicima | kolica | pristupačnost | srednje tamna koža</annotation>
 		<annotation cp="👨🏾‍🦽" type="tts">čovjek u mehaničkim kolicima: srednje tamna koža</annotation>
-		<annotation cp="👨🏿‍🦽">čovjek | čovjek u mehaničkim kolicima | čovjek u mehaničkim kolicima: tamna koža | kolica | pristupačnost | tamna koža</annotation>
+		<annotation cp="👨🏿‍🦽">čovjek | čovjek u mehaničkim kolicima | kolica | pristupačnost | tamna koža</annotation>
 		<annotation cp="👨🏿‍🦽" type="tts">čovjek u mehaničkim kolicima: tamna koža</annotation>
-		<annotation cp="👩🏻‍🦽">kolica | pristupačnost | svijetla koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: svijetla koža</annotation>
+		<annotation cp="👩🏻‍🦽">kolica | pristupačnost | svijetla koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏻‍🦽" type="tts">žena u mehaničkim kolicima: svijetla koža</annotation>
-		<annotation cp="👩🏼‍🦽">kolica | pristupačnost | srednje svijetla koža | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: srednje svijetla koža</annotation>
+		<annotation cp="👩🏼‍🦽">kolica | pristupačnost | srednje svijetla koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏼‍🦽" type="tts">žena u mehaničkim kolicima: srednje svijetla koža</annotation>
-		<annotation cp="👩🏽‍🦽">kolica | ni svijetla ni tamna koža | pristupačnost | žena | žena u mehaničkim kolicima | žena u mehaničkim kolicima: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏽‍🦽">kolica | ni svijetla ni tamna koža | pristupačnost | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏽‍🦽" type="tts">žena u mehaničkim kolicima: ni svijetla ni tamna koža</annotation>
 		<annotation cp="👩🏾‍🦽">kolica | pristupačnost | srednje tamna koža | žena | žena u mehaničkim kolicima</annotation>
 		<annotation cp="👩🏿‍🦽">kolica | pristupačnost | tamna koža | žena | žena u mehaničkim kolicima</annotation>
-		<annotation cp="🏃🏻">maraton | svijetla koža | trčanje | trkač | trkač: svijetla koža</annotation>
+		<annotation cp="🏃🏻">maraton | svijetla koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏻" type="tts">trkač: svijetla koža</annotation>
-		<annotation cp="🏃🏼">maraton | srednje svijetla koža | trčanje | trkač | trkač: srednje svijetla koža</annotation>
+		<annotation cp="🏃🏼">maraton | srednje svijetla koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏼" type="tts">trkač: srednje svijetla koža</annotation>
-		<annotation cp="🏃🏽">maraton | ni svijetla ni tamna koža | trčanje | trkač | trkač: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🏃🏽">maraton | ni svijetla ni tamna koža | trčanje | trkač</annotation>
 		<annotation cp="🏃🏽" type="tts">trkač: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏃🏻‍♂">maraton | muškarac | muškarac trči | muškarac trči: svijetla koža | svijetla koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏻‍♂">maraton | muškarac | muškarac trči | svijetla koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏻‍♂" type="tts">muškarac trči: svijetla koža</annotation>
-		<annotation cp="🏃🏼‍♂">maraton | muškarac | muškarac trči | muškarac trči: srednje svijetla koža | srednje svijetla koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏼‍♂">maraton | muškarac | muškarac trči | srednje svijetla koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏼‍♂" type="tts">muškarac trči: srednje svijetla koža</annotation>
-		<annotation cp="🏃🏽‍♂">maraton | muškarac | muškarac trči | muškarac trči: ni svijetla ni tamna koža | ni svijetla ni tamna koža | trčanje | trka</annotation>
+		<annotation cp="🏃🏽‍♂">maraton | muškarac | muškarac trči | ni svijetla ni tamna koža | trčanje | trka</annotation>
 		<annotation cp="🏃🏽‍♂" type="tts">muškarac trči: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏃🏻‍♀">maraton | svijetla koža | trčanje | trka | žena | žena trči | žena trči: svijetla koža</annotation>
+		<annotation cp="🏃🏻‍♀">maraton | svijetla koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏻‍♀" type="tts">žena trči: svijetla koža</annotation>
-		<annotation cp="🏃🏼‍♀">maraton | srednje svijetla koža | trčanje | trka | žena | žena trči | žena trči: srednje svijetla koža</annotation>
+		<annotation cp="🏃🏼‍♀">maraton | srednje svijetla koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏼‍♀" type="tts">žena trči: srednje svijetla koža</annotation>
-		<annotation cp="🏃🏽‍♀">maraton | ni svijetla ni tamna koža | trčanje | trka | žena | žena trči | žena trči: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🏃🏽‍♀">maraton | ni svijetla ni tamna koža | trčanje | trka | žena | žena trči</annotation>
 		<annotation cp="🏃🏽‍♀" type="tts">žena trči: ni svijetla ni tamna koža</annotation>
-		<annotation cp="💃🏻">ples | plesačica | plesačica: svijetla koža | plesanje | svijetla koža | žena</annotation>
+		<annotation cp="💃🏻">ples | plesačica | plesanje | svijetla koža | žena</annotation>
 		<annotation cp="💃🏻" type="tts">plesačica: svijetla koža</annotation>
-		<annotation cp="💃🏼">ples | plesačica | plesačica: srednje svijetla koža | plesanje | srednje svijetla koža | žena</annotation>
+		<annotation cp="💃🏼">ples | plesačica | plesanje | srednje svijetla koža | žena</annotation>
 		<annotation cp="💃🏼" type="tts">plesačica: srednje svijetla koža</annotation>
-		<annotation cp="💃🏽">ni svijetla ni tamna koža | ples | plesačica | plesačica: ni svijetla ni tamna koža | plesanje | žena</annotation>
+		<annotation cp="💃🏽">ni svijetla ni tamna koža | ples | plesačica | plesanje | žena</annotation>
 		<annotation cp="💃🏽" type="tts">plesačica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🕺🏻">muškarac | ples | plesač | plesač: svijetla koža | plesanje | svijetla koža</annotation>
+		<annotation cp="🕺🏻">muškarac | ples | plesač | plesanje | svijetla koža</annotation>
 		<annotation cp="🕺🏻" type="tts">plesač: svijetla koža</annotation>
-		<annotation cp="🕺🏼">muškarac | ples | plesač | plesač: srednje svijetla koža | plesanje | srednje svijetla koža</annotation>
+		<annotation cp="🕺🏼">muškarac | ples | plesač | plesanje | srednje svijetla koža</annotation>
 		<annotation cp="🕺🏼" type="tts">plesač: srednje svijetla koža</annotation>
-		<annotation cp="🕺🏽">muškarac | ni svijetla ni tamna koža | ples | plesač | plesač: ni svijetla ni tamna koža | plesanje</annotation>
+		<annotation cp="🕺🏽">muškarac | ni svijetla ni tamna koža | ples | plesač | plesanje</annotation>
 		<annotation cp="🕺🏽" type="tts">plesač: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🕴🏻">muškarac u poslovnom odijelu koji lebdi | muškarac u poslovnom odijelu koji lebdi: svijetla koža | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | svijetla koža</annotation>
+		<annotation cp="🕴🏻">muškarac u poslovnom odijelu koji lebdi | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | svijetla koža</annotation>
 		<annotation cp="🕴🏻" type="tts">muškarac u poslovnom odijelu koji lebdi: svijetla koža</annotation>
-		<annotation cp="🕴🏼">muškarac u poslovnom odijelu koji lebdi | muškarac u poslovnom odijelu koji lebdi: srednje svijetla koža | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | srednje svijetla koža</annotation>
+		<annotation cp="🕴🏼">muškarac u poslovnom odijelu koji lebdi | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | srednje svijetla koža</annotation>
 		<annotation cp="🕴🏼" type="tts">muškarac u poslovnom odijelu koji lebdi: srednje svijetla koža</annotation>
-		<annotation cp="🕴🏽">muškarac u poslovnom odijelu koji lebdi | muškarac u poslovnom odijelu koji lebdi: ni svijetla ni tamna koža | ni svijetla ni tamna koža | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao</annotation>
+		<annotation cp="🕴🏽">muškarac u poslovnom odijelu koji lebdi | ni svijetla ni tamna koža | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao</annotation>
 		<annotation cp="🕴🏽" type="tts">muškarac u poslovnom odijelu koji lebdi: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🕴🏾">muškarac u poslovnom odijelu koji lebdi | muškarac u poslovnom odijelu koji lebdi: srednje tamna koža | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | srednje tamna koža</annotation>
+		<annotation cp="🕴🏾">muškarac u poslovnom odijelu koji lebdi | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | srednje tamna koža</annotation>
 		<annotation cp="🕴🏾" type="tts">muškarac u poslovnom odijelu koji lebdi: srednje tamna koža</annotation>
-		<annotation cp="🕴🏿">muškarac u poslovnom odijelu koji lebdi | muškarac u poslovnom odijelu koji lebdi: tamna koža | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | tamna koža</annotation>
+		<annotation cp="🕴🏿">muškarac u poslovnom odijelu koji lebdi | odijelo | osoba | osoba u poslovnom odijelu koja lebdi | posao | tamna koža</annotation>
 		<annotation cp="🕴🏿" type="tts">muškarac u poslovnom odijelu koji lebdi: tamna koža</annotation>
-		<annotation cp="🧖🏻">osoba u parnom kupatilu | osoba u parnom kupatilu: svijetla koža | parno kupatilo | sauna | svijetla koža</annotation>
+		<annotation cp="🧖🏻">osoba u parnom kupatilu | parno kupatilo | sauna | svijetla koža</annotation>
 		<annotation cp="🧖🏻" type="tts">osoba u parnom kupatilu: svijetla koža</annotation>
-		<annotation cp="🧖🏼">osoba u parnom kupatilu | osoba u parnom kupatilu: srednje svijetla koža | parno kupatilo | sauna | srednje svijetla koža</annotation>
+		<annotation cp="🧖🏼">osoba u parnom kupatilu | parno kupatilo | sauna | srednje svijetla koža</annotation>
 		<annotation cp="🧖🏼" type="tts">osoba u parnom kupatilu: srednje svijetla koža</annotation>
-		<annotation cp="🧖🏽">ni svijetla ni tamna koža | osoba u parnom kupatilu | osoba u parnom kupatilu: ni svijetla ni tamna koža | parno kupatilo | sauna</annotation>
+		<annotation cp="🧖🏽">ni svijetla ni tamna koža | osoba u parnom kupatilu | parno kupatilo | sauna</annotation>
 		<annotation cp="🧖🏽" type="tts">osoba u parnom kupatilu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧖🏻‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: svijetla koža | parno kupatilo | sauna | svijetla koža</annotation>
+		<annotation cp="🧖🏻‍♂">muškarac u parnom kupatilu | parno kupatilo | sauna | svijetla koža</annotation>
 		<annotation cp="🧖🏻‍♂" type="tts">muškarac u parnom kupatilu: svijetla koža</annotation>
-		<annotation cp="🧖🏼‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: srednje svijetla koža | parno kupatilo | sauna | srednje svijetla koža</annotation>
+		<annotation cp="🧖🏼‍♂">muškarac u parnom kupatilu | parno kupatilo | sauna | srednje svijetla koža</annotation>
 		<annotation cp="🧖🏼‍♂" type="tts">muškarac u parnom kupatilu: srednje svijetla koža</annotation>
-		<annotation cp="🧖🏽‍♂">muškarac u parnom kupatilu | muškarac u parnom kupatilu: ni svijetla ni tamna koža | ni svijetla ni tamna koža | parno kupatilo | sauna</annotation>
+		<annotation cp="🧖🏽‍♂">muškarac u parnom kupatilu | ni svijetla ni tamna koža | parno kupatilo | sauna</annotation>
 		<annotation cp="🧖🏽‍♂" type="tts">muškarac u parnom kupatilu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧖🏻‍♀">parno kupatilo | sauna | svijetla koža | žena u parnom kupatilu | žena u parnom kupatilu: svijetla koža</annotation>
+		<annotation cp="🧖🏻‍♀">parno kupatilo | sauna | svijetla koža | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏻‍♀" type="tts">žena u parnom kupatilu: svijetla koža</annotation>
-		<annotation cp="🧖🏼‍♀">parno kupatilo | sauna | srednje svijetla koža | žena u parnom kupatilu | žena u parnom kupatilu: srednje svijetla koža</annotation>
+		<annotation cp="🧖🏼‍♀">parno kupatilo | sauna | srednje svijetla koža | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏼‍♀" type="tts">žena u parnom kupatilu: srednje svijetla koža</annotation>
-		<annotation cp="🧖🏽‍♀">ni svijetla ni tamna koža | parno kupatilo | sauna | žena u parnom kupatilu | žena u parnom kupatilu: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧖🏽‍♀">ni svijetla ni tamna koža | parno kupatilo | sauna | žena u parnom kupatilu</annotation>
 		<annotation cp="🧖🏽‍♀" type="tts">žena u parnom kupatilu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧗🏻">penjač | penjanje | penjanje: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧗🏻">penjač | penjanje | svijetla koža</annotation>
 		<annotation cp="🧗🏻" type="tts">penjanje: svijetla koža</annotation>
-		<annotation cp="🧗🏼">penjač | penjanje | penjanje: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧗🏼">penjač | penjanje | srednje svijetla koža</annotation>
 		<annotation cp="🧗🏼" type="tts">penjanje: srednje svijetla koža</annotation>
-		<annotation cp="🧗🏽">ni svijetla ni tamna koža | penjač | penjanje | penjanje: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧗🏽">ni svijetla ni tamna koža | penjač | penjanje</annotation>
 		<annotation cp="🧗🏽" type="tts">penjanje: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧗🏻‍♂">muškarac se penje | muškarac se penje: svijetla koža | penjač | svijetla koža</annotation>
+		<annotation cp="🧗🏻‍♂">muškarac se penje | penjač | svijetla koža</annotation>
 		<annotation cp="🧗🏻‍♂" type="tts">muškarac se penje: svijetla koža</annotation>
-		<annotation cp="🧗🏼‍♂">muškarac se penje | muškarac se penje: srednje svijetla koža | penjač | srednje svijetla koža</annotation>
+		<annotation cp="🧗🏼‍♂">muškarac se penje | penjač | srednje svijetla koža</annotation>
 		<annotation cp="🧗🏼‍♂" type="tts">muškarac se penje: srednje svijetla koža</annotation>
-		<annotation cp="🧗🏽‍♂">muškarac se penje | muškarac se penje: ni svijetla ni tamna koža | ni svijetla ni tamna koža | penjač</annotation>
+		<annotation cp="🧗🏽‍♂">muškarac se penje | ni svijetla ni tamna koža | penjač</annotation>
 		<annotation cp="🧗🏽‍♂" type="tts">muškarac se penje: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧗🏻‍♀">penjačica | svijetla koža | žena se penje | žena se penje: svijetla koža</annotation>
+		<annotation cp="🧗🏻‍♀">penjačica | svijetla koža | žena se penje</annotation>
 		<annotation cp="🧗🏻‍♀" type="tts">žena se penje: svijetla koža</annotation>
-		<annotation cp="🧗🏼‍♀">penjačica | srednje svijetla koža | žena se penje | žena se penje: srednje svijetla koža</annotation>
+		<annotation cp="🧗🏼‍♀">penjačica | srednje svijetla koža | žena se penje</annotation>
 		<annotation cp="🧗🏼‍♀" type="tts">žena se penje: srednje svijetla koža</annotation>
-		<annotation cp="🧗🏽‍♀">ni svijetla ni tamna koža | penjačica | žena se penje | žena se penje: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧗🏽‍♀">ni svijetla ni tamna koža | penjačica | žena se penje</annotation>
 		<annotation cp="🧗🏽‍♀" type="tts">žena se penje: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏇🏻">džokej | konj | svijetla koža | trkaći konj | trke konja | trke konja: svijetla koža</annotation>
+		<annotation cp="🏇🏻">džokej | konj | svijetla koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏻" type="tts">trke konja: svijetla koža</annotation>
-		<annotation cp="🏇🏼">džokej | konj | srednje svijetla koža | trkaći konj | trke konja | trke konja: srednje svijetla koža</annotation>
+		<annotation cp="🏇🏼">džokej | konj | srednje svijetla koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏼" type="tts">trke konja: srednje svijetla koža</annotation>
-		<annotation cp="🏇🏽">džokej | konj | ni svijetla ni tamna koža | trkaći konj | trke konja | trke konja: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🏇🏽">džokej | konj | ni svijetla ni tamna koža | trkaći konj | trke konja</annotation>
 		<annotation cp="🏇🏽" type="tts">trke konja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏂🏻">svijetla koža | vozač snouborda | vozač snouborda: svijetla koža</annotation>
+		<annotation cp="🏂🏻">svijetla koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏻" type="tts">vozač snouborda: svijetla koža</annotation>
-		<annotation cp="🏂🏼">srednje svijetla koža | vozač snouborda | vozač snouborda: srednje svijetla koža</annotation>
+		<annotation cp="🏂🏼">srednje svijetla koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏼" type="tts">vozač snouborda: srednje svijetla koža</annotation>
-		<annotation cp="🏂🏽">ni svijetla ni tamna koža | vozač snouborda | vozač snouborda: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🏂🏽">ni svijetla ni tamna koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏽" type="tts">vozač snouborda: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🏂🏾">srednje tamna koža | vozač snouborda</annotation>
 		<annotation cp="🏂🏿">tamna koža | vozač snouborda</annotation>
-		<annotation cp="🏌🏻">golf | loptica | osoba igra golf | osoba igra golf: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🏌🏻">golf | loptica | osoba igra golf | svijetla koža</annotation>
 		<annotation cp="🏌🏻" type="tts">osoba igra golf: svijetla koža</annotation>
-		<annotation cp="🏌🏼">golf | loptica | osoba igra golf | osoba igra golf: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🏌🏼">golf | loptica | osoba igra golf | srednje svijetla koža</annotation>
 		<annotation cp="🏌🏼" type="tts">osoba igra golf: srednje svijetla koža</annotation>
-		<annotation cp="🏌🏽">golf | loptica | ni svijetla ni tamna koža | osoba igra golf | osoba igra golf: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🏌🏽">golf | loptica | ni svijetla ni tamna koža | osoba igra golf</annotation>
 		<annotation cp="🏌🏽" type="tts">osoba igra golf: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏌🏻‍♂">golf | golfer | golfer: svijetla koža | loptica | muškarac | svijetla koža</annotation>
+		<annotation cp="🏌🏻‍♂">golf | golfer | loptica | muškarac | svijetla koža</annotation>
 		<annotation cp="🏌🏻‍♂" type="tts">golfer: svijetla koža</annotation>
-		<annotation cp="🏌🏼‍♂">golf | golfer | golfer: srednje svijetla koža | loptica | muškarac | srednje svijetla koža</annotation>
+		<annotation cp="🏌🏼‍♂">golf | golfer | loptica | muškarac | srednje svijetla koža</annotation>
 		<annotation cp="🏌🏼‍♂" type="tts">golfer: srednje svijetla koža</annotation>
-		<annotation cp="🏌🏽‍♂">golf | golfer | golfer: ni svijetla ni tamna koža | loptica | muškarac | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🏌🏽‍♂">golf | golfer | loptica | muškarac | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🏌🏽‍♂" type="tts">golfer: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏌🏻‍♀">golf | golferka | golferka: svijetla koža | loptica | svijetla koža | žena</annotation>
+		<annotation cp="🏌🏻‍♀">golf | golferka | loptica | svijetla koža | žena</annotation>
 		<annotation cp="🏌🏻‍♀" type="tts">golferka: svijetla koža</annotation>
-		<annotation cp="🏌🏼‍♀">golf | golferka | golferka: srednje svijetla koža | loptica | srednje svijetla koža | žena</annotation>
+		<annotation cp="🏌🏼‍♀">golf | golferka | loptica | srednje svijetla koža | žena</annotation>
 		<annotation cp="🏌🏼‍♀" type="tts">golferka: srednje svijetla koža</annotation>
-		<annotation cp="🏌🏽‍♀">golf | golferka | golferka: ni svijetla ni tamna koža | loptica | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🏌🏽‍♀">golf | golferka | loptica | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="🏌🏽‍♀" type="tts">golferka: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏄🏻">osoba surfuje | osoba surfuje: svijetla koža | surfovanje | svijetla koža</annotation>
+		<annotation cp="🏄🏻">osoba surfuje | surfovanje | svijetla koža</annotation>
 		<annotation cp="🏄🏻" type="tts">osoba surfuje: svijetla koža</annotation>
-		<annotation cp="🏄🏼">osoba surfuje | osoba surfuje: srednje svijetla koža | srednje svijetla koža | surfovanje</annotation>
+		<annotation cp="🏄🏼">osoba surfuje | srednje svijetla koža | surfovanje</annotation>
 		<annotation cp="🏄🏼" type="tts">osoba surfuje: srednje svijetla koža</annotation>
-		<annotation cp="🏄🏽">ni svijetla ni tamna koža | osoba surfuje | osoba surfuje: ni svijetla ni tamna koža | surfovanje</annotation>
+		<annotation cp="🏄🏽">ni svijetla ni tamna koža | osoba surfuje | surfovanje</annotation>
 		<annotation cp="🏄🏽" type="tts">osoba surfuje: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏄🏻‍♂">muškarac | surfer | surfer: svijetla koža | surfovanje | svijetla koža</annotation>
+		<annotation cp="🏄🏻‍♂">muškarac | surfer | surfovanje | svijetla koža</annotation>
 		<annotation cp="🏄🏻‍♂" type="tts">surfer: svijetla koža</annotation>
-		<annotation cp="🏄🏼‍♂">muškarac | srednje svijetla koža | surfer | surfer: srednje svijetla koža | surfovanje</annotation>
+		<annotation cp="🏄🏼‍♂">muškarac | srednje svijetla koža | surfer | surfovanje</annotation>
 		<annotation cp="🏄🏼‍♂" type="tts">surfer: srednje svijetla koža</annotation>
-		<annotation cp="🏄🏽‍♂">muškarac | ni svijetla ni tamna koža | surfer | surfer: ni svijetla ni tamna koža | surfovanje</annotation>
+		<annotation cp="🏄🏽‍♂">muškarac | ni svijetla ni tamna koža | surfer | surfovanje</annotation>
 		<annotation cp="🏄🏽‍♂" type="tts">surfer: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏄🏻‍♀">surferka | surferka: svijetla koža | surfovanje | svijetla koža | žena</annotation>
+		<annotation cp="🏄🏻‍♀">surferka | surfovanje | svijetla koža | žena</annotation>
 		<annotation cp="🏄🏻‍♀" type="tts">surferka: svijetla koža</annotation>
-		<annotation cp="🏄🏼‍♀">srednje svijetla koža | surferka | surferka: srednje svijetla koža | surfovanje | žena</annotation>
+		<annotation cp="🏄🏼‍♀">srednje svijetla koža | surferka | surfovanje | žena</annotation>
 		<annotation cp="🏄🏼‍♀" type="tts">surferka: srednje svijetla koža</annotation>
-		<annotation cp="🏄🏽‍♀">ni svijetla ni tamna koža | surferka | surferka: ni svijetla ni tamna koža | surfovanje | žena</annotation>
+		<annotation cp="🏄🏽‍♀">ni svijetla ni tamna koža | surferka | surfovanje | žena</annotation>
 		<annotation cp="🏄🏽‍♀" type="tts">surferka: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚣🏻">čamac | čamac na vesla | čamac na vesla: svijetla koža | svijetla koža | vozilo</annotation>
+		<annotation cp="🚣🏻">čamac | čamac na vesla | svijetla koža | vozilo</annotation>
 		<annotation cp="🚣🏻" type="tts">čamac na vesla: svijetla koža</annotation>
-		<annotation cp="🚣🏼">čamac | čamac na vesla | čamac na vesla: srednje svijetla koža | srednje svijetla koža | vozilo</annotation>
+		<annotation cp="🚣🏼">čamac | čamac na vesla | srednje svijetla koža | vozilo</annotation>
 		<annotation cp="🚣🏼" type="tts">čamac na vesla: srednje svijetla koža</annotation>
-		<annotation cp="🚣🏽">čamac | čamac na vesla | čamac na vesla: ni svijetla ni tamna koža | ni svijetla ni tamna koža | vozilo</annotation>
+		<annotation cp="🚣🏽">čamac | čamac na vesla | ni svijetla ni tamna koža | vozilo</annotation>
 		<annotation cp="🚣🏽" type="tts">čamac na vesla: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚣🏻‍♂">čamac | muškarac | svijetla koža | veslač | veslač: svijetla koža | veslanje</annotation>
+		<annotation cp="🚣🏻‍♂">čamac | muškarac | svijetla koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏻‍♂" type="tts">veslač: svijetla koža</annotation>
-		<annotation cp="🚣🏼‍♂">čamac | muškarac | srednje svijetla koža | veslač | veslač: srednje svijetla koža | veslanje</annotation>
+		<annotation cp="🚣🏼‍♂">čamac | muškarac | srednje svijetla koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏼‍♂" type="tts">veslač: srednje svijetla koža</annotation>
-		<annotation cp="🚣🏽‍♂">čamac | muškarac | ni svijetla ni tamna koža | veslač | veslač: ni svijetla ni tamna koža | veslanje</annotation>
+		<annotation cp="🚣🏽‍♂">čamac | muškarac | ni svijetla ni tamna koža | veslač | veslanje</annotation>
 		<annotation cp="🚣🏽‍♂" type="tts">veslač: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚣🏻‍♀">čamac | svijetla koža | veslačica | veslačica: svijetla koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏻‍♀">čamac | svijetla koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏻‍♀" type="tts">veslačica: svijetla koža</annotation>
-		<annotation cp="🚣🏼‍♀">čamac | srednje svijetla koža | veslačica | veslačica: srednje svijetla koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏼‍♀">čamac | srednje svijetla koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏼‍♀" type="tts">veslačica: srednje svijetla koža</annotation>
-		<annotation cp="🚣🏽‍♀">čamac | ni svijetla ni tamna koža | veslačica | veslačica: ni svijetla ni tamna koža | veslanje | žena</annotation>
+		<annotation cp="🚣🏽‍♀">čamac | ni svijetla ni tamna koža | veslačica | veslanje | žena</annotation>
 		<annotation cp="🚣🏽‍♀" type="tts">veslačica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏊🏻">osoba pliva | osoba pliva: svijetla koža | plivanje | svijetla koža</annotation>
+		<annotation cp="🏊🏻">osoba pliva | plivanje | svijetla koža</annotation>
 		<annotation cp="🏊🏻" type="tts">osoba pliva: svijetla koža</annotation>
-		<annotation cp="🏊🏼">osoba pliva | osoba pliva: srednje svijetla koža | plivanje | srednje svijetla koža</annotation>
+		<annotation cp="🏊🏼">osoba pliva | plivanje | srednje svijetla koža</annotation>
 		<annotation cp="🏊🏼" type="tts">osoba pliva: srednje svijetla koža</annotation>
-		<annotation cp="🏊🏽">ni svijetla ni tamna koža | osoba pliva | osoba pliva: ni svijetla ni tamna koža | plivanje</annotation>
+		<annotation cp="🏊🏽">ni svijetla ni tamna koža | osoba pliva | plivanje</annotation>
 		<annotation cp="🏊🏽" type="tts">osoba pliva: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏊🏻‍♂">muškarac | plivač | plivač: svijetla koža | plivanje | svijetla koža</annotation>
+		<annotation cp="🏊🏻‍♂">muškarac | plivač | plivanje | svijetla koža</annotation>
 		<annotation cp="🏊🏻‍♂" type="tts">plivač: svijetla koža</annotation>
-		<annotation cp="🏊🏼‍♂">muškarac | plivač | plivač: srednje svijetla koža | plivanje | srednje svijetla koža</annotation>
+		<annotation cp="🏊🏼‍♂">muškarac | plivač | plivanje | srednje svijetla koža</annotation>
 		<annotation cp="🏊🏼‍♂" type="tts">plivač: srednje svijetla koža</annotation>
-		<annotation cp="🏊🏽‍♂">muškarac | ni svijetla ni tamna koža | plivač | plivač: ni svijetla ni tamna koža | plivanje</annotation>
+		<annotation cp="🏊🏽‍♂">muškarac | ni svijetla ni tamna koža | plivač | plivanje</annotation>
 		<annotation cp="🏊🏽‍♂" type="tts">plivač: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏊🏻‍♀">plivačica | plivačica: svijetla koža | plivanje | svijetla koža | žena</annotation>
+		<annotation cp="🏊🏻‍♀">plivačica | plivanje | svijetla koža | žena</annotation>
 		<annotation cp="🏊🏻‍♀" type="tts">plivačica: svijetla koža</annotation>
-		<annotation cp="🏊🏼‍♀">plivačica | plivačica: srednje svijetla koža | plivanje | srednje svijetla koža | žena</annotation>
+		<annotation cp="🏊🏼‍♀">plivačica | plivanje | srednje svijetla koža | žena</annotation>
 		<annotation cp="🏊🏼‍♀" type="tts">plivačica: srednje svijetla koža</annotation>
-		<annotation cp="🏊🏽‍♀">ni svijetla ni tamna koža | plivačica | plivačica: ni svijetla ni tamna koža | plivanje | žena</annotation>
+		<annotation cp="🏊🏽‍♀">ni svijetla ni tamna koža | plivačica | plivanje | žena</annotation>
 		<annotation cp="🏊🏽‍♀" type="tts">plivačica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="⛹🏻">lopta | osoba sa loptom | osoba sa loptom: svijetla koža | svijetla koža</annotation>
+		<annotation cp="⛹🏻">lopta | osoba sa loptom | svijetla koža</annotation>
 		<annotation cp="⛹🏻" type="tts">osoba sa loptom: svijetla koža</annotation>
-		<annotation cp="⛹🏼">lopta | osoba sa loptom | osoba sa loptom: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="⛹🏼">lopta | osoba sa loptom | srednje svijetla koža</annotation>
 		<annotation cp="⛹🏼" type="tts">osoba sa loptom: srednje svijetla koža</annotation>
-		<annotation cp="⛹🏽">lopta | ni svijetla ni tamna koža | osoba sa loptom | osoba sa loptom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="⛹🏽">lopta | ni svijetla ni tamna koža | osoba sa loptom</annotation>
 		<annotation cp="⛹🏽" type="tts">osoba sa loptom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="⛹🏻‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: svijetla koža | svijetla koža</annotation>
+		<annotation cp="⛹🏻‍♂">lopta | muškarac | muškarac sa loptom | svijetla koža</annotation>
 		<annotation cp="⛹🏻‍♂" type="tts">muškarac sa loptom: svijetla koža</annotation>
-		<annotation cp="⛹🏼‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="⛹🏼‍♂">lopta | muškarac | muškarac sa loptom | srednje svijetla koža</annotation>
 		<annotation cp="⛹🏼‍♂" type="tts">muškarac sa loptom: srednje svijetla koža</annotation>
-		<annotation cp="⛹🏽‍♂">lopta | muškarac | muškarac sa loptom | muškarac sa loptom: ni svijetla ni tamna koža | ni svijetla ni tamna koža</annotation>
+		<annotation cp="⛹🏽‍♂">lopta | muškarac | muškarac sa loptom | ni svijetla ni tamna koža</annotation>
 		<annotation cp="⛹🏽‍♂" type="tts">muškarac sa loptom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="⛹🏻‍♀">lopta | svijetla koža | žena | žena sa loptom | žena sa loptom: svijetla koža</annotation>
+		<annotation cp="⛹🏻‍♀">lopta | svijetla koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏻‍♀" type="tts">žena sa loptom: svijetla koža</annotation>
-		<annotation cp="⛹🏼‍♀">lopta | srednje svijetla koža | žena | žena sa loptom | žena sa loptom: srednje svijetla koža</annotation>
+		<annotation cp="⛹🏼‍♀">lopta | srednje svijetla koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏼‍♀" type="tts">žena sa loptom: srednje svijetla koža</annotation>
-		<annotation cp="⛹🏽‍♀">lopta | ni svijetla ni tamna koža | žena | žena sa loptom | žena sa loptom: ni svijetla ni tamna koža</annotation>
+		<annotation cp="⛹🏽‍♀">lopta | ni svijetla ni tamna koža | žena | žena sa loptom</annotation>
 		<annotation cp="⛹🏽‍♀" type="tts">žena sa loptom: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏋🏻">dizač | osoba diže tegove | osoba diže tegove: svijetla koža | svijetla koža | tegovi</annotation>
+		<annotation cp="🏋🏻">dizač | osoba diže tegove | svijetla koža | tegovi</annotation>
 		<annotation cp="🏋🏻" type="tts">osoba diže tegove: svijetla koža</annotation>
-		<annotation cp="🏋🏼">dizač | osoba diže tegove | osoba diže tegove: srednje svijetla koža | srednje svijetla koža | tegovi</annotation>
+		<annotation cp="🏋🏼">dizač | osoba diže tegove | srednje svijetla koža | tegovi</annotation>
 		<annotation cp="🏋🏼" type="tts">osoba diže tegove: srednje svijetla koža</annotation>
-		<annotation cp="🏋🏽">dizač | ni svijetla ni tamna koža | osoba diže tegove | osoba diže tegove: ni svijetla ni tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏽">dizač | ni svijetla ni tamna koža | osoba diže tegove | tegovi</annotation>
 		<annotation cp="🏋🏽" type="tts">osoba diže tegove: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏋🏻‍♂">dizač tegova | dizač tegova: svijetla koža | dizanje | muškarac | svijetla koža | tegovi</annotation>
+		<annotation cp="🏋🏻‍♂">dizač tegova | dizanje | muškarac | svijetla koža | tegovi</annotation>
 		<annotation cp="🏋🏻‍♂" type="tts">dizač tegova: svijetla koža</annotation>
-		<annotation cp="🏋🏼‍♂">dizač tegova | dizač tegova: srednje svijetla koža | dizanje | muškarac | srednje svijetla koža | tegovi</annotation>
+		<annotation cp="🏋🏼‍♂">dizač tegova | dizanje | muškarac | srednje svijetla koža | tegovi</annotation>
 		<annotation cp="🏋🏼‍♂" type="tts">dizač tegova: srednje svijetla koža</annotation>
-		<annotation cp="🏋🏽‍♂">dizač tegova | dizač tegova: ni svijetla ni tamna koža | dizanje | muškarac | ni svijetla ni tamna koža | tegovi</annotation>
+		<annotation cp="🏋🏽‍♂">dizač tegova | dizanje | muškarac | ni svijetla ni tamna koža | tegovi</annotation>
 		<annotation cp="🏋🏽‍♂" type="tts">dizač tegova: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🏋🏻‍♀">dizačica tegova | dizačica tegova: svijetla koža | dizanje | svijetla koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏻‍♀">dizačica tegova | dizanje | svijetla koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏻‍♀" type="tts">dizačica tegova: svijetla koža</annotation>
-		<annotation cp="🏋🏼‍♀">dizačica tegova | dizačica tegova: srednje svijetla koža | dizanje | srednje svijetla koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏼‍♀">dizačica tegova | dizanje | srednje svijetla koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏼‍♀" type="tts">dizačica tegova: srednje svijetla koža</annotation>
-		<annotation cp="🏋🏽‍♀">dizačica tegova | dizačica tegova: ni svijetla ni tamna koža | dizanje | ni svijetla ni tamna koža | tegovi | žena</annotation>
+		<annotation cp="🏋🏽‍♀">dizačica tegova | dizanje | ni svijetla ni tamna koža | tegovi | žena</annotation>
 		<annotation cp="🏋🏽‍♀" type="tts">dizačica tegova: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚴🏻">bicikl | biciklista | biciklizam | osoba na biciklu | osoba na biciklu: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🚴🏻">bicikl | biciklista | biciklizam | osoba na biciklu | svijetla koža</annotation>
 		<annotation cp="🚴🏻" type="tts">osoba na biciklu: svijetla koža</annotation>
-		<annotation cp="🚴🏼">bicikl | biciklista | biciklizam | osoba na biciklu | osoba na biciklu: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🚴🏼">bicikl | biciklista | biciklizam | osoba na biciklu | srednje svijetla koža</annotation>
 		<annotation cp="🚴🏼" type="tts">osoba na biciklu: srednje svijetla koža</annotation>
-		<annotation cp="🚴🏽">bicikl | biciklista | biciklizam | ni svijetla ni tamna koža | osoba na biciklu | osoba na biciklu: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🚴🏽">bicikl | biciklista | biciklizam | ni svijetla ni tamna koža | osoba na biciklu</annotation>
 		<annotation cp="🚴🏽" type="tts">osoba na biciklu: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🚴🏾">bicikl | biciklista | biciklizam | osoba na biciklu | srednje tamna koža</annotation>
 		<annotation cp="🚴🏿">bicikl | biciklista | biciklizam | osoba na biciklu | tamna koža</annotation>
-		<annotation cp="🚴🏻‍♂">bicikl | biciklista | biciklista: svijetla koža | muškarac | svijetla koža</annotation>
+		<annotation cp="🚴🏻‍♂">bicikl | biciklista | muškarac | svijetla koža</annotation>
 		<annotation cp="🚴🏻‍♂" type="tts">biciklista: svijetla koža</annotation>
-		<annotation cp="🚴🏼‍♂">bicikl | biciklista | biciklista: srednje svijetla koža | muškarac | srednje svijetla koža</annotation>
+		<annotation cp="🚴🏼‍♂">bicikl | biciklista | muškarac | srednje svijetla koža</annotation>
 		<annotation cp="🚴🏼‍♂" type="tts">biciklista: srednje svijetla koža</annotation>
-		<annotation cp="🚴🏽‍♂">bicikl | biciklista | biciklista: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🚴🏽‍♂">bicikl | biciklista | muškarac | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🚴🏽‍♂" type="tts">biciklista: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚴🏻‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="🚴🏻‍♀">bicikl | biciklista | biciklistkinja | svijetla koža | žena</annotation>
 		<annotation cp="🚴🏻‍♀" type="tts">biciklistkinja: svijetla koža</annotation>
-		<annotation cp="🚴🏼‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="🚴🏼‍♀">bicikl | biciklista | biciklistkinja | srednje svijetla koža | žena</annotation>
 		<annotation cp="🚴🏼‍♀" type="tts">biciklistkinja: srednje svijetla koža</annotation>
-		<annotation cp="🚴🏽‍♀">bicikl | biciklista | biciklistkinja | biciklistkinja: ni svijetla ni tamna koža | ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🚴🏽‍♀">bicikl | biciklista | biciklistkinja | ni svijetla ni tamna koža | žena</annotation>
 		<annotation cp="🚴🏽‍♀" type="tts">biciklistkinja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚵🏻">bicikl | biciklista | brdo | osoba na brdskom biciklu | osoba na brdskom biciklu: svijetla koža | planina | svijetla koža</annotation>
+		<annotation cp="🚵🏻">bicikl | biciklista | brdo | osoba na brdskom biciklu | planina | svijetla koža</annotation>
 		<annotation cp="🚵🏻" type="tts">osoba na brdskom biciklu: svijetla koža</annotation>
-		<annotation cp="🚵🏼">bicikl | biciklista | brdo | osoba na brdskom biciklu | osoba na brdskom biciklu: srednje svijetla koža | planina | srednje svijetla koža</annotation>
+		<annotation cp="🚵🏼">bicikl | biciklista | brdo | osoba na brdskom biciklu | planina | srednje svijetla koža</annotation>
 		<annotation cp="🚵🏼" type="tts">osoba na brdskom biciklu: srednje svijetla koža</annotation>
-		<annotation cp="🚵🏽">bicikl | biciklista | brdo | ni svijetla ni tamna koža | osoba na brdskom biciklu | osoba na brdskom biciklu: ni svijetla ni tamna koža | planina</annotation>
+		<annotation cp="🚵🏽">bicikl | biciklista | brdo | ni svijetla ni tamna koža | osoba na brdskom biciklu | planina</annotation>
 		<annotation cp="🚵🏽" type="tts">osoba na brdskom biciklu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚵🏻‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: svijetla koža | muškarac | planina | svijetla koža</annotation>
+		<annotation cp="🚵🏻‍♂">bicikl | biciklista | brdski biciklista | muškarac | planina | svijetla koža</annotation>
 		<annotation cp="🚵🏻‍♂" type="tts">brdski biciklista: svijetla koža</annotation>
-		<annotation cp="🚵🏼‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: srednje svijetla koža | muškarac | planina | srednje svijetla koža</annotation>
+		<annotation cp="🚵🏼‍♂">bicikl | biciklista | brdski biciklista | muškarac | planina | srednje svijetla koža</annotation>
 		<annotation cp="🚵🏼‍♂" type="tts">brdski biciklista: srednje svijetla koža</annotation>
-		<annotation cp="🚵🏽‍♂">bicikl | biciklista | brdski biciklista | brdski biciklista: ni svijetla ni tamna koža | muškarac | ni svijetla ni tamna koža | planina</annotation>
+		<annotation cp="🚵🏽‍♂">bicikl | biciklista | brdski biciklista | muškarac | ni svijetla ni tamna koža | planina</annotation>
 		<annotation cp="🚵🏽‍♂" type="tts">brdski biciklista: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🚵🏻‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: svijetla koža | planina | svijetla koža | žena</annotation>
+		<annotation cp="🚵🏻‍♀">bicikl | biciklista | brdska biciklistkinja | planina | svijetla koža | žena</annotation>
 		<annotation cp="🚵🏻‍♀" type="tts">brdska biciklistkinja: svijetla koža</annotation>
-		<annotation cp="🚵🏼‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: srednje svijetla koža | planina | srednje svijetla koža | žena</annotation>
+		<annotation cp="🚵🏼‍♀">bicikl | biciklista | brdska biciklistkinja | planina | srednje svijetla koža | žena</annotation>
 		<annotation cp="🚵🏼‍♀" type="tts">brdska biciklistkinja: srednje svijetla koža</annotation>
-		<annotation cp="🚵🏽‍♀">bicikl | biciklista | brdska biciklistkinja | brdska biciklistkinja: ni svijetla ni tamna koža | ni svijetla ni tamna koža | planina | žena</annotation>
+		<annotation cp="🚵🏽‍♀">bicikl | biciklista | brdska biciklistkinja | ni svijetla ni tamna koža | planina | žena</annotation>
 		<annotation cp="🚵🏽‍♀" type="tts">brdska biciklistkinja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤸🏻">gimnastičarska zvezda | gimnastičarska zvezda: svijetla koža | gimnastičarska zvijezda | gimnastika | svijetla koža | zvijezda</annotation>
+		<annotation cp="🤸🏻">gimnastičarska zvezda | gimnastičarska zvijezda | gimnastika | svijetla koža | zvijezda</annotation>
 		<annotation cp="🤸🏻" type="tts">gimnastičarska zvezda: svijetla koža</annotation>
-		<annotation cp="🤸🏼">gimnastičarska zvezda | gimnastičarska zvezda: srednje svijetla koža | gimnastičarska zvijezda | gimnastika | srednje svijetla koža | zvijezda</annotation>
+		<annotation cp="🤸🏼">gimnastičarska zvezda | gimnastičarska zvijezda | gimnastika | srednje svijetla koža | zvijezda</annotation>
 		<annotation cp="🤸🏼" type="tts">gimnastičarska zvezda: srednje svijetla koža</annotation>
-		<annotation cp="🤸🏽">gimnastičarska zvezda | gimnastičarska zvezda: ni svijetla ni tamna koža | gimnastičarska zvijezda | gimnastika | ni svijetla ni tamna koža | zvijezda</annotation>
+		<annotation cp="🤸🏽">gimnastičarska zvezda | gimnastičarska zvijezda | gimnastika | ni svijetla ni tamna koža | zvijezda</annotation>
 		<annotation cp="🤸🏽" type="tts">gimnastičarska zvezda: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤸🏾">gimnastičarska zvezda | gimnastičarska zvijezda | gimnastika | srednje tamna koža | zvijezda</annotation>
 		<annotation cp="🤸🏿">gimnastičarska zvezda | gimnastičarska zvijezda | gimnastika | tamna koža | zvijezda</annotation>
-		<annotation cp="🤸🏻‍♂">akrobata | gimnastičar | gimnastičar: svijetla koža | gimnastika | muškarac | svijetla koža | zvijezda</annotation>
+		<annotation cp="🤸🏻‍♂">akrobata | gimnastičar | gimnastika | muškarac | svijetla koža | zvijezda</annotation>
 		<annotation cp="🤸🏻‍♂" type="tts">gimnastičar: svijetla koža</annotation>
-		<annotation cp="🤸🏼‍♂">akrobata | gimnastičar | gimnastičar: srednje svijetla koža | gimnastika | muškarac | srednje svijetla koža | zvijezda</annotation>
+		<annotation cp="🤸🏼‍♂">akrobata | gimnastičar | gimnastika | muškarac | srednje svijetla koža | zvijezda</annotation>
 		<annotation cp="🤸🏼‍♂" type="tts">gimnastičar: srednje svijetla koža</annotation>
-		<annotation cp="🤸🏽‍♂">akrobata | gimnastičar | gimnastičar: ni svijetla ni tamna koža | gimnastika | muškarac | ni svijetla ni tamna koža | zvijezda</annotation>
+		<annotation cp="🤸🏽‍♂">akrobata | gimnastičar | gimnastika | muškarac | ni svijetla ni tamna koža | zvijezda</annotation>
 		<annotation cp="🤸🏽‍♂" type="tts">gimnastičar: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤸🏾‍♂">akrobata | gimnastičar | gimnastika | muškarac | srednje tamna koža | zvijezda</annotation>
 		<annotation cp="🤸🏿‍♂">akrobata | gimnastičar | gimnastika | muškarac | tamna koža | zvijezda</annotation>
-		<annotation cp="🤸🏻‍♀">akrobata | gimnastičarka | gimnastičarka: svijetla koža | gimnastika | svijetla koža | žena | zvijezda</annotation>
+		<annotation cp="🤸🏻‍♀">akrobata | gimnastičarka | gimnastika | svijetla koža | žena | zvijezda</annotation>
 		<annotation cp="🤸🏻‍♀" type="tts">gimnastičarka: svijetla koža</annotation>
-		<annotation cp="🤸🏼‍♀">akrobata | gimnastičarka | gimnastičarka: srednje svijetla koža | gimnastika | srednje svijetla koža | žena | zvijezda</annotation>
+		<annotation cp="🤸🏼‍♀">akrobata | gimnastičarka | gimnastika | srednje svijetla koža | žena | zvijezda</annotation>
 		<annotation cp="🤸🏼‍♀" type="tts">gimnastičarka: srednje svijetla koža</annotation>
-		<annotation cp="🤸🏽‍♀">akrobata | gimnastičarka | gimnastičarka: ni svijetla ni tamna koža | gimnastika | ni svijetla ni tamna koža | žena | zvijezda</annotation>
+		<annotation cp="🤸🏽‍♀">akrobata | gimnastičarka | gimnastika | ni svijetla ni tamna koža | žena | zvijezda</annotation>
 		<annotation cp="🤸🏽‍♀" type="tts">gimnastičarka: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤸🏾‍♀">akrobata | gimnastičarka | gimnastika | srednje tamna koža | žena | zvijezda</annotation>
 		<annotation cp="🤸🏿‍♀">akrobata | gimnastičarka | gimnastika | tamna koža | žena | zvijezda</annotation>
-		<annotation cp="🤽🏻">bazen | sport | svijetla koža | vaterpolo | vaterpolo: svijetla koža | voda</annotation>
+		<annotation cp="🤽🏻">bazen | sport | svijetla koža | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏻" type="tts">vaterpolo: svijetla koža</annotation>
-		<annotation cp="🤽🏼">bazen | sport | srednje svijetla koža | vaterpolo | vaterpolo: srednje svijetla koža | voda</annotation>
+		<annotation cp="🤽🏼">bazen | sport | srednje svijetla koža | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏼" type="tts">vaterpolo: srednje svijetla koža</annotation>
-		<annotation cp="🤽🏽">bazen | ni svijetla ni tamna koža | sport | vaterpolo | vaterpolo: ni svijetla ni tamna koža | voda</annotation>
+		<annotation cp="🤽🏽">bazen | ni svijetla ni tamna koža | sport | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏽" type="tts">vaterpolo: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤽🏻‍♂">bazen | muškarac | svijetla koža | vaterpolista | vaterpolista: svijetla koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏻‍♂">bazen | muškarac | svijetla koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏻‍♂" type="tts">vaterpolista: svijetla koža</annotation>
-		<annotation cp="🤽🏼‍♂">bazen | muškarac | srednje svijetla koža | vaterpolista | vaterpolista: srednje svijetla koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏼‍♂">bazen | muškarac | srednje svijetla koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏼‍♂" type="tts">vaterpolista: srednje svijetla koža</annotation>
-		<annotation cp="🤽🏽‍♂">bazen | muškarac | ni svijetla ni tamna koža | vaterpolista | vaterpolista: ni svijetla ni tamna koža | vaterpolo | voda</annotation>
+		<annotation cp="🤽🏽‍♂">bazen | muškarac | ni svijetla ni tamna koža | vaterpolista | vaterpolo | voda</annotation>
 		<annotation cp="🤽🏽‍♂" type="tts">vaterpolista: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤽🏻‍♀">bazen | svijetla koža | vaterpolistkinja | vaterpolistkinja: svijetla koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏻‍♀">bazen | svijetla koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏻‍♀" type="tts">vaterpolistkinja: svijetla koža</annotation>
-		<annotation cp="🤽🏼‍♀">bazen | srednje svijetla koža | vaterpolistkinja | vaterpolistkinja: srednje svijetla koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏼‍♀">bazen | srednje svijetla koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏼‍♀" type="tts">vaterpolistkinja: srednje svijetla koža</annotation>
-		<annotation cp="🤽🏽‍♀">bazen | ni svijetla ni tamna koža | vaterpolistkinja | vaterpolistkinja: ni svijetla ni tamna koža | vaterpolo | voda | žena</annotation>
+		<annotation cp="🤽🏽‍♀">bazen | ni svijetla ni tamna koža | vaterpolistkinja | vaterpolo | voda | žena</annotation>
 		<annotation cp="🤽🏽‍♀" type="tts">vaterpolistkinja: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤾🏻">lopta | osoba igra rukomet | rukomet | rukomet: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤾🏻">lopta | osoba igra rukomet | rukomet | svijetla koža</annotation>
 		<annotation cp="🤾🏻" type="tts">rukomet: svijetla koža</annotation>
-		<annotation cp="🤾🏼">lopta | osoba igra rukomet | rukomet | rukomet: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤾🏼">lopta | osoba igra rukomet | rukomet | srednje svijetla koža</annotation>
 		<annotation cp="🤾🏼" type="tts">rukomet: srednje svijetla koža</annotation>
-		<annotation cp="🤾🏽">lopta | ni svijetla ni tamna koža | osoba igra rukomet | rukomet | rukomet: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤾🏽">lopta | ni svijetla ni tamna koža | osoba igra rukomet | rukomet</annotation>
 		<annotation cp="🤾🏽" type="tts">rukomet: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤾🏾">lopta | osoba igra rukomet | rukomet | srednje tamna koža</annotation>
 		<annotation cp="🤾🏿">lopta | osoba igra rukomet | rukomet | tamna koža</annotation>
-		<annotation cp="🤾🏻‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | rukometaš: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🤾🏻‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | svijetla koža</annotation>
 		<annotation cp="🤾🏻‍♂" type="tts">rukometaš: svijetla koža</annotation>
-		<annotation cp="🤾🏼‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | rukometaš: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🤾🏼‍♂">bacanje | lopta | muškarac | rukomet | rukometaš | srednje svijetla koža</annotation>
 		<annotation cp="🤾🏼‍♂" type="tts">rukometaš: srednje svijetla koža</annotation>
-		<annotation cp="🤾🏽‍♂">bacanje | lopta | muškarac | ni svijetla ni tamna koža | rukomet | rukometaš | rukometaš: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🤾🏽‍♂">bacanje | lopta | muškarac | ni svijetla ni tamna koža | rukomet | rukometaš</annotation>
 		<annotation cp="🤾🏽‍♂" type="tts">rukometaš: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤾🏻‍♀">bacanje | lopta | rukomet | rukometašica | rukometašica: svijetla koža | svijetla koža | žena</annotation>
+		<annotation cp="🤾🏻‍♀">bacanje | lopta | rukomet | rukometašica | svijetla koža | žena</annotation>
 		<annotation cp="🤾🏻‍♀" type="tts">rukometašica: svijetla koža</annotation>
-		<annotation cp="🤾🏼‍♀">bacanje | lopta | rukomet | rukometašica | rukometašica: srednje svijetla koža | srednje svijetla koža | žena</annotation>
+		<annotation cp="🤾🏼‍♀">bacanje | lopta | rukomet | rukometašica | srednje svijetla koža | žena</annotation>
 		<annotation cp="🤾🏼‍♀" type="tts">rukometašica: srednje svijetla koža</annotation>
-		<annotation cp="🤾🏽‍♀">bacanje | lopta | ni svijetla ni tamna koža | rukomet | rukometašica | rukometašica: ni svijetla ni tamna koža | žena</annotation>
+		<annotation cp="🤾🏽‍♀">bacanje | lopta | ni svijetla ni tamna koža | rukomet | rukometašica | žena</annotation>
 		<annotation cp="🤾🏽‍♀" type="tts">rukometašica: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🤹🏻">cirkus | osoba žonglira | osoba žonglira: svijetla koža | ravnoteža | svijetla koža | vještina | žongliranje</annotation>
+		<annotation cp="🤹🏻">cirkus | osoba žonglira | ravnoteža | svijetla koža | vještina | žongliranje</annotation>
 		<annotation cp="🤹🏻" type="tts">osoba žonglira: svijetla koža</annotation>
-		<annotation cp="🤹🏼">cirkus | osoba žonglira | osoba žonglira: srednje svijetla koža | ravnoteža | srednje svijetla koža | vještina | žongliranje</annotation>
+		<annotation cp="🤹🏼">cirkus | osoba žonglira | ravnoteža | srednje svijetla koža | vještina | žongliranje</annotation>
 		<annotation cp="🤹🏼" type="tts">osoba žonglira: srednje svijetla koža</annotation>
-		<annotation cp="🤹🏽">cirkus | ni svijetla ni tamna koža | osoba žonglira | osoba žonglira: ni svijetla ni tamna koža | ravnoteža | vještina | žongliranje</annotation>
+		<annotation cp="🤹🏽">cirkus | ni svijetla ni tamna koža | osoba žonglira | ravnoteža | vještina | žongliranje</annotation>
 		<annotation cp="🤹🏽" type="tts">osoba žonglira: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤹🏾">cirkus | osoba žonglira | ravnoteža | srednje tamna koža | vještina | žongliranje</annotation>
 		<annotation cp="🤹🏿">cirkus | osoba žonglira | ravnoteža | tamna koža | vještina | žongliranje</annotation>
-		<annotation cp="🤹🏻‍♂">cirkus | muškarac | svijetla koža | vještina | žongler | žongler: svijetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏻‍♂">cirkus | muškarac | svijetla koža | vještina | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏻‍♂" type="tts">žongler: svijetla koža</annotation>
-		<annotation cp="🤹🏼‍♂">cirkus | muškarac | srednje svijetla koža | vještina | žongler | žongler: srednje svijetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏼‍♂">cirkus | muškarac | srednje svijetla koža | vještina | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏼‍♂" type="tts">žongler: srednje svijetla koža</annotation>
-		<annotation cp="🤹🏽‍♂">cirkus | muškarac | ni svijetla ni tamna koža | vještina | žongler | žongler: ni svijetla ni tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏽‍♂">cirkus | muškarac | ni svijetla ni tamna koža | vještina | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏽‍♂" type="tts">žongler: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤹🏾‍♂">cirkus | muškarac | srednje tamna koža | vještina | žongler | žongliranje</annotation>
 		<annotation cp="🤹🏿‍♂">cirkus | muškarac | tamna koža | vještina | žongler | žongliranje</annotation>
-		<annotation cp="🤹🏻‍♀">cirkus | svijetla koža | vještina | žena | žonglerka | žonglerka: svijetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏻‍♀">cirkus | svijetla koža | vještina | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏻‍♀" type="tts">žonglerka: svijetla koža</annotation>
-		<annotation cp="🤹🏼‍♀">cirkus | srednje svijetla koža | vještina | žena | žonglerka | žonglerka: srednje svijetla koža | žongliranje</annotation>
+		<annotation cp="🤹🏼‍♀">cirkus | srednje svijetla koža | vještina | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏼‍♀" type="tts">žonglerka: srednje svijetla koža</annotation>
-		<annotation cp="🤹🏽‍♀">cirkus | ni svijetla ni tamna koža | vještina | žena | žonglerka | žonglerka: ni svijetla ni tamna koža | žongliranje</annotation>
+		<annotation cp="🤹🏽‍♀">cirkus | ni svijetla ni tamna koža | vještina | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏽‍♀" type="tts">žonglerka: ni svijetla ni tamna koža</annotation>
 		<annotation cp="🤹🏾‍♀">cirkus | srednje tamna koža | vještina | žena | žonglerka | žongliranje</annotation>
 		<annotation cp="🤹🏿‍♀">cirkus | tamna koža | vještina | žena | žonglerka | žongliranje</annotation>
-		<annotation cp="🧘🏻">joga | lotos poza | lotos poza: svijetla koža | meditacija | svijetla koža</annotation>
+		<annotation cp="🧘🏻">joga | lotos poza | meditacija | svijetla koža</annotation>
 		<annotation cp="🧘🏻" type="tts">lotos poza: svijetla koža</annotation>
-		<annotation cp="🧘🏼">joga | lotos poza | lotos poza: srednje svijetla koža | meditacija | srednje svijetla koža</annotation>
+		<annotation cp="🧘🏼">joga | lotos poza | meditacija | srednje svijetla koža</annotation>
 		<annotation cp="🧘🏼" type="tts">lotos poza: srednje svijetla koža</annotation>
-		<annotation cp="🧘🏽">joga | lotos poza | lotos poza: ni svijetla ni tamna koža | meditacija | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧘🏽">joga | lotos poza | meditacija | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧘🏽" type="tts">lotos poza: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧘🏻‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: svijetla koža | muškarac u lotus pozi | svijetla koža</annotation>
+		<annotation cp="🧘🏻‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | svijetla koža</annotation>
 		<annotation cp="🧘🏻‍♂" type="tts">muškarac u lotos pozi: svijetla koža</annotation>
-		<annotation cp="🧘🏼‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: srednje svijetla koža | muškarac u lotus pozi | srednje svijetla koža</annotation>
+		<annotation cp="🧘🏼‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | srednje svijetla koža</annotation>
 		<annotation cp="🧘🏼‍♂" type="tts">muškarac u lotos pozi: srednje svijetla koža</annotation>
-		<annotation cp="🧘🏽‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotos pozi: ni svijetla ni tamna koža | muškarac u lotus pozi | ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧘🏽‍♂">joga | meditacija | muškarac u lotos pozi | muškarac u lotus pozi | ni svijetla ni tamna koža</annotation>
 		<annotation cp="🧘🏽‍♂" type="tts">muškarac u lotos pozi: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧘🏻‍♀">joga | meditacija | svijetla koža | žena u lotos pozi | žena u lotos pozi: svijetla koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏻‍♀">joga | meditacija | svijetla koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏻‍♀" type="tts">žena u lotos pozi: svijetla koža</annotation>
-		<annotation cp="🧘🏼‍♀">joga | meditacija | srednje svijetla koža | žena u lotos pozi | žena u lotos pozi: srednje svijetla koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏼‍♀">joga | meditacija | srednje svijetla koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏼‍♀" type="tts">žena u lotos pozi: srednje svijetla koža</annotation>
-		<annotation cp="🧘🏽‍♀">joga | meditacija | ni svijetla ni tamna koža | žena u lotos pozi | žena u lotos pozi: ni svijetla ni tamna koža | žena u lotus pozi</annotation>
+		<annotation cp="🧘🏽‍♀">joga | meditacija | ni svijetla ni tamna koža | žena u lotos pozi | žena u lotus pozi</annotation>
 		<annotation cp="🧘🏽‍♀" type="tts">žena u lotos pozi: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🛀🏻">kada | kupanje | osoba koja se kupa | osoba koja se kupa: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🛀🏻">kada | kupanje | osoba koja se kupa | svijetla koža</annotation>
 		<annotation cp="🛀🏻" type="tts">osoba koja se kupa: svijetla koža</annotation>
-		<annotation cp="🛀🏼">kada | kupanje | osoba koja se kupa | osoba koja se kupa: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🛀🏼">kada | kupanje | osoba koja se kupa | srednje svijetla koža</annotation>
 		<annotation cp="🛀🏼" type="tts">osoba koja se kupa: srednje svijetla koža</annotation>
-		<annotation cp="🛀🏽">kada | kupanje | ni svijetla ni tamna koža | osoba koja se kupa | osoba koja se kupa: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🛀🏽">kada | kupanje | ni svijetla ni tamna koža | osoba koja se kupa</annotation>
 		<annotation cp="🛀🏽" type="tts">osoba koja se kupa: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🛌🏻">hotel | osoba u krevetu | osoba u krevetu: svijetla koža | spavanje | svijetla koža</annotation>
+		<annotation cp="🛌🏻">hotel | osoba u krevetu | spavanje | svijetla koža</annotation>
 		<annotation cp="🛌🏻" type="tts">osoba u krevetu: svijetla koža</annotation>
-		<annotation cp="🛌🏼">hotel | osoba u krevetu | osoba u krevetu: srednje svijetla koža | spavanje | srednje svijetla koža</annotation>
+		<annotation cp="🛌🏼">hotel | osoba u krevetu | spavanje | srednje svijetla koža</annotation>
 		<annotation cp="🛌🏼" type="tts">osoba u krevetu: srednje svijetla koža</annotation>
-		<annotation cp="🛌🏽">hotel | ni svijetla ni tamna koža | osoba u krevetu | osoba u krevetu: ni svijetla ni tamna koža | spavanje</annotation>
+		<annotation cp="🛌🏽">hotel | ni svijetla ni tamna koža | osoba u krevetu | spavanje</annotation>
 		<annotation cp="🛌🏽" type="tts">osoba u krevetu: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏻">osobe se drže za ruke | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: svijetla koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: svijetla koža i srednje svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏼">osobe se drže za ruke | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: svijetla koža i ni svijetla ni tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏾">osobe se drže za ruke | osobe se drže za ruke: svijetla koža i srednje tamna koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏾">osobe se drže za ruke | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏿">osobe se drže za ruke | osobe se drže za ruke: svijetla koža i tamna koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏿">osobe se drže za ruke | svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: svijetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: srednje svijetla koža i svijetla koža | srednje svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏻">osobe se drže za ruke | srednje svijetla koža | svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏼">osobe se drže za ruke | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: srednje svijetla koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏾">osobe se drže za ruke | osobe se drže za ruke: srednje svijetla koža i srednje tamna koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏾">osobe se drže za ruke | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏿">osobe se drže za ruke | osobe se drže za ruke: srednje svijetla koža i tamna koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏿">osobe se drže za ruke | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏻">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svijetla ni tamna koža i svijetla koža | svijetla koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏻">ni svijetla ni tamna koža | osobe se drže za ruke | svijetla koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏼">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏼">ni svijetla ni tamna koža | osobe se drže za ruke | srednje svijetla koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svijetla ni tamna koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏾">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏾">ni svijetla ni tamna koža | osobe se drže za ruke | srednje tamna koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏾" type="tts">osobe se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏿">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: ni svijetla ni tamna koža i tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏿">ni svijetla ni tamna koža | osobe se drže za ruke | tamna koža</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏿" type="tts">osobe se drže za ruke: ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i svijetla koža | srednje tamna koža | svijetla koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏻">osobe se drže za ruke | srednje tamna koža | svijetla koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i srednje svijetla koža | srednje svijetla koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏼">osobe se drže za ruke | srednje svijetla koža | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža | srednje tamna koža</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | srednje tamna koža</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏻">osobe se drže za ruke | osobe se drže za ruke: tamna koža i svijetla koža | svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏻">osobe se drže za ruke | svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏻" type="tts">osobe se drže za ruke: tamna koža i svijetla koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏼">osobe se drže za ruke | osobe se drže za ruke: tamna koža i srednje svijetla koža | srednje svijetla koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏼">osobe se drže za ruke | srednje svijetla koža | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏼" type="tts">osobe se drže za ruke: tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | osobe se drže za ruke: tamna koža i ni svijetla ni tamna koža | tamna koža</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏽">ni svijetla ni tamna koža | osobe se drže za ruke | tamna koža</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏽" type="tts">osobe se drže za ruke: tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👭🏻">držanje za ruke | par | ruka | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: svijetla koža</annotation>
+		<annotation cp="👭🏻">držanje za ruke | par | ruka | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏻" type="tts">žene se drže za ruke: svijetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svijetla koža | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: svijetla koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svijetla koža | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏼" type="tts">žene se drže za ruke: svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: svijetla koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏽" type="tts">žene se drže za ruke: svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje tamna koža | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: svijetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje tamna koža | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏾" type="tts">žene se drže za ruke: svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏿">držanje za ruke | par | ruka | svijetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: svijetla koža i tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏿">držanje za ruke | par | ruka | svijetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏿" type="tts">žene se drže za ruke: svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje svijetla koža | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svijetla koža i svijetla koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje svijetla koža | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏻" type="tts">žene se drže za ruke: srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👭🏼">držanje za ruke | par | ruka | srednje svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svijetla koža</annotation>
+		<annotation cp="👭🏼">držanje za ruke | par | ruka | srednje svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏼" type="tts">žene se drže za ruke: srednje svijetla koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏽" type="tts">žene se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje svijetla koža | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svijetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏾">držanje za ruke | par | ruka | srednje svijetla koža | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏾" type="tts">žene se drže za ruke: srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏿">držanje za ruke | par | ruka | srednje svijetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje svijetla koža i tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏿">držanje za ruke | par | ruka | srednje svijetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏿" type="tts">žene se drže za ruke: srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏻">držanje za ruke | ni svijetla ni tamna koža | par | ruka | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: ni svijetla ni tamna koža i svijetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏻">držanje za ruke | ni svijetla ni tamna koža | par | ruka | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏻" type="tts">žene se drže za ruke: ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏼">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏼">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏼" type="tts">žene se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👭🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | žene | žene se drže za ruke | žene se drže za ruke: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👭🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | žene | žene se drže za ruke</annotation>
 		<annotation cp="👭🏽" type="tts">žene se drže za ruke: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏾">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏾">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏾" type="tts">žene se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏿">držanje za ruke | ni svijetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: ni svijetla ni tamna koža i tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏿">držanje za ruke | ni svijetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏿" type="tts">žene se drže za ruke: ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje tamna koža | svijetla koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i svijetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏻">držanje za ruke | par | ruka | srednje tamna koža | svijetla koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏻" type="tts">žene se drže za ruke: srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svijetla koža | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svijetla koža | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏼" type="tts">žene se drže za ruke: srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke | žene se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | srednje tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏽" type="tts">žene se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏻">držanje za ruke | par | ruka | svijetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i svijetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏻">držanje za ruke | par | ruka | svijetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏻" type="tts">žene se drže za ruke: tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svijetla koža | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏼">držanje za ruke | par | ruka | srednje svijetla koža | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏼" type="tts">žene se drže za ruke: tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke | žene se drže za ruke: tamna koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏽">držanje za ruke | ni svijetla ni tamna koža | par | ruka | tamna koža | žene | žene se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏽" type="tts">žene se drže za ruke: tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👫🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svijetla koža</annotation>
+		<annotation cp="👫🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏻" type="tts">žena i muškarac se drže za ruke: svijetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svijetla koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svijetla koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svijetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: svijetla koža i tamna koža</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svijetla koža i svijetla koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👫🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svijetla koža</annotation>
+		<annotation cp="👫🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏼" type="tts">žena i muškarac se drže za ruke: srednje svijetla koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svijetla koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje svijetla koža i tamna koža</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svijetla ni tamna koža i svijetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👫🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svijetla ni tamna koža</annotation>
+		<annotation cp="👫🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👫🏽" type="tts">žena i muškarac se drže za ruke: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏾">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏾" type="tts">žena i muškarac se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: ni svijetla ni tamna koža i tamna koža</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏿">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏿" type="tts">žena i muškarac se drže za ruke: ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svijetla koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i svijetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje tamna koža | svijetla koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i svijetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏻">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏻" type="tts">žena i muškarac se drže za ruke: tamna koža i svijetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i srednje svijetla koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏼">držanje | muškarac | muškarac i žena se drže za ruke | par | ruke | srednje svijetla koža | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏼" type="tts">žena i muškarac se drže za ruke: tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke | žena i muškarac se drže za ruke: tamna koža i ni svijetla ni tamna koža</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏽">držanje | muškarac | muškarac i žena se drže za ruke | ni svijetla ni tamna koža | par | ruke | tamna koža | žena | žena i muškarac se drže za ruke</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏽" type="tts">žena i muškarac se drže za ruke: tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👬🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svijetla koža | par | ruke | svijetla koža | zodijak</annotation>
+		<annotation cp="👬🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | svijetla koža | zodijak</annotation>
 		<annotation cp="👬🏻" type="tts">muškarci se drže za ruke: svijetla koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svijetla koža i srednje svijetla koža | par | ruke | srednje svijetla koža | svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: svijetla koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svijetla koža i ni svijetla ni tamna koža | ni svijetla ni tamna koža | par | ruke | svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svijetla koža i srednje tamna koža | par | ruke | srednje tamna koža | svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: svijetla koža i tamna koža | par | ruke | svijetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | svijetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: svijetla koža i tamna koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svijetla koža i svijetla koža | par | ruke | srednje svijetla koža | svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: srednje svijetla koža i svijetla koža</annotation>
-		<annotation cp="👬🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svijetla koža | par | ruke | srednje svijetla koža | zodijak</annotation>
+		<annotation cp="👬🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | zodijak</annotation>
 		<annotation cp="👬🏼" type="tts">muškarci se drže za ruke: srednje svijetla koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: srednje svijetla koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svijetla koža i srednje tamna koža | par | ruke | srednje svijetla koža | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: srednje svijetla koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje svijetla koža i tamna koža | par | ruke | srednje svijetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: srednje svijetla koža i tamna koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svijetla ni tamna koža i svijetla koža | ni svijetla ni tamna koža | par | ruke | svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: ni svijetla ni tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: ni svijetla ni tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👬🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svijetla ni tamna koža | ni svijetla ni tamna koža | par | ruke | zodijak</annotation>
+		<annotation cp="👬🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | zodijak</annotation>
 		<annotation cp="👬🏽" type="tts">muškarci se drže za ruke: ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏾">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏾" type="tts">muškarci se drže za ruke: ni svijetla ni tamna koža i srednje tamna koža</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: ni svijetla ni tamna koža i tamna koža | ni svijetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏿">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏿" type="tts">muškarci se drže za ruke: ni svijetla ni tamna koža i tamna koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i svijetla koža | par | ruke | srednje tamna koža | svijetla koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje tamna koža | svijetla koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: srednje tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i srednje svijetla koža | par | ruke | srednje svijetla koža | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: srednje tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | srednje tamna koža | zodijak</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: srednje tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i svijetla koža | par | ruke | svijetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏻">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | svijetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏻" type="tts">muškarci se drže za ruke: tamna koža i svijetla koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i srednje svijetla koža | par | ruke | srednje svijetla koža | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏼">blizanci | držanje | muškarac | muškarci se drže za ruke | par | ruke | srednje svijetla koža | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏼" type="tts">muškarci se drže za ruke: tamna koža i srednje svijetla koža</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | muškarci se drže za ruke: tamna koža i ni svijetla ni tamna koža | ni svijetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏽">blizanci | držanje | muškarac | muškarci se drže za ruke | ni svijetla ni tamna koža | par | ruke | tamna koža | zodijak</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏽" type="tts">muškarci se drže za ruke: tamna koža i ni svijetla ni tamna koža</annotation>
-		<annotation cp="💏🏻">poljubac | poljubac: svijetla koža | svijetla koža</annotation>
+		<annotation cp="💏🏻">poljubac | svijetla koža</annotation>
 		<annotation cp="💏🏻" type="tts">poljubac: svijetla koža</annotation>
-		<annotation cp="💏🏼">poljubac | poljubac: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="💏🏼">poljubac | srednje svijetla koža</annotation>
 		<annotation cp="💏🏼" type="tts">poljubac: srednje svijetla koža</annotation>
-		<annotation cp="💏🏽">ni svijetla ni tamna koža | poljubac | poljubac: ni svijetla ni tamna koža</annotation>
+		<annotation cp="💏🏽">ni svijetla ni tamna koža | poljubac</annotation>
 		<annotation cp="💏🏽" type="tts">poljubac: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💏🏾">poljubac | srednje tamna koža</annotation>
 		<annotation cp="💏🏿">poljubac | tamna koža</annotation>
 		<annotation cp="👩‍❤‍💋‍👨">muškarac | poljubac | žena</annotation>
 		<annotation cp="👨‍❤‍💋‍👨">muškarac | poljubac</annotation>
 		<annotation cp="👩‍❤‍💋‍👩">poljubac | žena</annotation>
-		<annotation cp="💑🏻">par sa srcem | par sa srcem: svijetla koža | svijetla koža</annotation>
+		<annotation cp="💑🏻">par sa srcem | svijetla koža</annotation>
 		<annotation cp="💑🏻" type="tts">par sa srcem: svijetla koža</annotation>
-		<annotation cp="💑🏼">par sa srcem | par sa srcem: srednje svijetla koža | srednje svijetla koža</annotation>
+		<annotation cp="💑🏼">par sa srcem | srednje svijetla koža</annotation>
 		<annotation cp="💑🏼" type="tts">par sa srcem: srednje svijetla koža</annotation>
-		<annotation cp="💑🏽">ni svijetla ni tamna koža | par sa srcem | par sa srcem: ni svijetla ni tamna koža</annotation>
+		<annotation cp="💑🏽">ni svijetla ni tamna koža | par sa srcem</annotation>
 		<annotation cp="💑🏽" type="tts">par sa srcem: ni svijetla ni tamna koža</annotation>
 		<annotation cp="💑🏾">par sa srcem | srednje tamna koža</annotation>
 		<annotation cp="💑🏿">par sa srcem | tamna koža</annotation>
 		<annotation cp="👩‍❤‍👨">muškarac | par sa srcem | žena</annotation>
 		<annotation cp="👨‍❤‍👨">muškarac | par sa srcem</annotation>
 		<annotation cp="👩‍❤‍👩">par sa srcem | žena</annotation>
-		<annotation cp="👨‍👩‍👦">dječak | muškarac | porodica | porodica: muškarac, žena i dječak | žena</annotation>
+		<annotation cp="👨‍👩‍👦">dječak | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👦" type="tts">porodica: muškarac, žena i dječak</annotation>
-		<annotation cp="👨‍👩‍👧">djevojčica | muškarac | porodica | porodica: muškarac, žena i djevojčica | žena</annotation>
+		<annotation cp="👨‍👩‍👧">djevojčica | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👧" type="tts">porodica: muškarac, žena i djevojčica</annotation>
-		<annotation cp="👨‍👩‍👧‍👦">dječak | djevojčica | muškarac | porodica | porodica: muškarac, žena, djevojčica i dječak | žena</annotation>
+		<annotation cp="👨‍👩‍👧‍👦">dječak | djevojčica | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👧‍👦" type="tts">porodica: muškarac, žena, djevojčica i dječak</annotation>
-		<annotation cp="👨‍👩‍👦‍👦">dječak | muškarac | porodica | porodica: muškarac, žena, dječak i dječak | žena</annotation>
+		<annotation cp="👨‍👩‍👦‍👦">dječak | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👦‍👦" type="tts">porodica: muškarac, žena, dječak i dječak</annotation>
-		<annotation cp="👨‍👩‍👧‍👧">djevojčica | muškarac | porodica | porodica: muškarac, žena, djevojčica i djevojčica | žena</annotation>
+		<annotation cp="👨‍👩‍👧‍👧">djevojčica | muškarac | porodica | žena</annotation>
 		<annotation cp="👨‍👩‍👧‍👧" type="tts">porodica: muškarac, žena, djevojčica i djevojčica</annotation>
-		<annotation cp="👨‍👨‍👦">dječak | muškarac | porodica | porodica: muškarac, muškarac i dječak</annotation>
+		<annotation cp="👨‍👨‍👦">dječak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👦" type="tts">porodica: muškarac, muškarac i dječak</annotation>
-		<annotation cp="👨‍👨‍👧">djevojčica | muškarac | porodica | porodica: muškarac, muškarac i djevojčica</annotation>
+		<annotation cp="👨‍👨‍👧">djevojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👧" type="tts">porodica: muškarac, muškarac i djevojčica</annotation>
-		<annotation cp="👨‍👨‍👧‍👦">dječak | djevojčica | muškarac | porodica | porodica: muškarac, muškarac, djevojčica i dječak</annotation>
+		<annotation cp="👨‍👨‍👧‍👦">dječak | djevojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👧‍👦" type="tts">porodica: muškarac, muškarac, djevojčica i dječak</annotation>
-		<annotation cp="👨‍👨‍👦‍👦">dječak | muškarac | porodica | porodica: muškarac, muškarac, dječak i dječak</annotation>
+		<annotation cp="👨‍👨‍👦‍👦">dječak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👦‍👦" type="tts">porodica: muškarac, muškarac, dječak i dječak</annotation>
-		<annotation cp="👨‍👨‍👧‍👧">djevojčica | muškarac | porodica | porodica: muškarac, muškarac, djevojčica i djevojčica</annotation>
+		<annotation cp="👨‍👨‍👧‍👧">djevojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👨‍👧‍👧" type="tts">porodica: muškarac, muškarac, djevojčica i djevojčica</annotation>
-		<annotation cp="👩‍👩‍👦">dječak | porodica | porodica: žena, žena i dječak | žena</annotation>
+		<annotation cp="👩‍👩‍👦">dječak | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👦" type="tts">porodica: žena, žena i dječak</annotation>
-		<annotation cp="👩‍👩‍👧">djevojčica | porodica | porodica: žena, žena i djevojčica | žena</annotation>
+		<annotation cp="👩‍👩‍👧">djevojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👧" type="tts">porodica: žena, žena i djevojčica</annotation>
-		<annotation cp="👩‍👩‍👧‍👦">dječak | djevojčica | porodica | porodica: žena, žena, djevojčica i dječak | žena</annotation>
+		<annotation cp="👩‍👩‍👧‍👦">dječak | djevojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👧‍👦" type="tts">porodica: žena, žena, djevojčica i dječak</annotation>
-		<annotation cp="👩‍👩‍👦‍👦">dječak | porodica | porodica: žena, žena, dječak i dječak | žena</annotation>
+		<annotation cp="👩‍👩‍👦‍👦">dječak | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👦‍👦" type="tts">porodica: žena, žena, dječak i dječak</annotation>
-		<annotation cp="👩‍👩‍👧‍👧">djevojčica | porodica | porodica: žena, žena, djevojčica i djevojčica | žena</annotation>
+		<annotation cp="👩‍👩‍👧‍👧">djevojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👩‍👧‍👧" type="tts">porodica: žena, žena, djevojčica i djevojčica</annotation>
-		<annotation cp="👨‍👦">dječak | muškarac | porodica | porodica: muškarac i dječak</annotation>
+		<annotation cp="👨‍👦">dječak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👦" type="tts">porodica: muškarac i dječak</annotation>
-		<annotation cp="👨‍👦‍👦">dječak | muškarac | porodica | porodica: muškarac, dječak i dječak</annotation>
+		<annotation cp="👨‍👦‍👦">dječak | muškarac | porodica</annotation>
 		<annotation cp="👨‍👦‍👦" type="tts">porodica: muškarac, dječak i dječak</annotation>
-		<annotation cp="👨‍👧">djevojčica | muškarac | porodica | porodica: muškarac i djevojčica</annotation>
+		<annotation cp="👨‍👧">djevojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👧" type="tts">porodica: muškarac i djevojčica</annotation>
-		<annotation cp="👨‍👧‍👦">dječak | djevojčica | muškarac | porodica | porodica: muškarac, djevojčica i dječak</annotation>
+		<annotation cp="👨‍👧‍👦">dječak | djevojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👧‍👦" type="tts">porodica: muškarac, djevojčica i dječak</annotation>
-		<annotation cp="👨‍👧‍👧">djevojčica | muškarac | porodica | porodica: muškarac, djevojčica i djevojčica</annotation>
+		<annotation cp="👨‍👧‍👧">djevojčica | muškarac | porodica</annotation>
 		<annotation cp="👨‍👧‍👧" type="tts">porodica: muškarac, djevojčica i djevojčica</annotation>
-		<annotation cp="👩‍👦">dječak | porodica | porodica: žena i dječak | žena</annotation>
+		<annotation cp="👩‍👦">dječak | porodica | žena</annotation>
 		<annotation cp="👩‍👦" type="tts">porodica: žena i dječak</annotation>
-		<annotation cp="👩‍👦‍👦">dječak | porodica | porodica: žena, dječak i dječak | žena</annotation>
+		<annotation cp="👩‍👦‍👦">dječak | porodica | žena</annotation>
 		<annotation cp="👩‍👦‍👦" type="tts">porodica: žena, dječak i dječak</annotation>
-		<annotation cp="👩‍👧">djevojčica | porodica | porodica: žena i djevojčica | žena</annotation>
+		<annotation cp="👩‍👧">djevojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👧" type="tts">porodica: žena i djevojčica</annotation>
-		<annotation cp="👩‍👧‍👦">dječak | djevojčica | porodica | porodica: žena, djevojčica i dječak | žena</annotation>
+		<annotation cp="👩‍👧‍👦">dječak | djevojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👧‍👦" type="tts">porodica: žena, djevojčica i dječak</annotation>
-		<annotation cp="👩‍👧‍👧">djevojčica | porodica | porodica: žena, djevojčica i djevojčica | žena</annotation>
+		<annotation cp="👩‍👧‍👧">djevojčica | porodica | žena</annotation>
 		<annotation cp="👩‍👧‍👧" type="tts">porodica: žena, djevojčica i djevojčica</annotation>
-		<annotation cp="🇦🇨">zastava | zastava: ostrvo Asension</annotation>
 		<annotation cp="🇦🇨" type="tts">zastava: ostrvo Asension</annotation>
-		<annotation cp="🇦🇽">zastava | zastava: Olandska ostrva</annotation>
 		<annotation cp="🇦🇽" type="tts">zastava: Olandska ostrva</annotation>
-		<annotation cp="🇧🇱">zastava | zastava: Sen Bartelemi</annotation>
 		<annotation cp="🇧🇱" type="tts">zastava: Sen Bartelemi</annotation>
-		<annotation cp="🇧🇳">zastava | zastava: Bruneji</annotation>
 		<annotation cp="🇧🇳" type="tts">zastava: Bruneji</annotation>
-		<annotation cp="🇧🇻">zastava | zastava: ostrvo Buve</annotation>
 		<annotation cp="🇧🇻" type="tts">zastava: ostrvo Buve</annotation>
-		<annotation cp="🇧🇾">zastava | zastava: Bjelorusija</annotation>
 		<annotation cp="🇧🇾" type="tts">zastava: Bjelorusija</annotation>
-		<annotation cp="🇨🇨">zastava | zastava: Kokosova (Kiling) ostrva</annotation>
 		<annotation cp="🇨🇨" type="tts">zastava: Kokosova (Kiling) ostrva</annotation>
-		<annotation cp="🇨🇵">zastava | zastava: ostrvo Kliperton</annotation>
 		<annotation cp="🇨🇵" type="tts">zastava: ostrvo Kliperton</annotation>
-		<annotation cp="🇨🇿">zastava | zastava: Češka Republika</annotation>
 		<annotation cp="🇨🇿" type="tts">zastava: Češka Republika</annotation>
-		<annotation cp="🇩🇪">zastava | zastava: Njemačka</annotation>
 		<annotation cp="🇩🇪" type="tts">zastava: Njemačka</annotation>
-		<annotation cp="🇫🇰">zastava | zastava: Foklandska ostrva</annotation>
 		<annotation cp="🇫🇰" type="tts">zastava: Foklandska ostrva</annotation>
-		<annotation cp="🇫🇴">zastava | zastava: Farska ostrva</annotation>
 		<annotation cp="🇫🇴" type="tts">zastava: Farska ostrva</annotation>
-		<annotation cp="🇬🇸">zastava | zastava: Južna Džordžija i Južna Sendvička ostrva</annotation>
 		<annotation cp="🇬🇸" type="tts">zastava: Južna Džordžija i Južna Sendvička ostrva</annotation>
-		<annotation cp="🇬🇺">zastava | zastava: Gvam</annotation>
 		<annotation cp="🇬🇺" type="tts">zastava: Gvam</annotation>
-		<annotation cp="🇬🇼">zastava | zastava: Gvineja Bisao</annotation>
 		<annotation cp="🇬🇼" type="tts">zastava: Gvineja Bisao</annotation>
-		<annotation cp="🇭🇰">zastava | zastava: Hongkong (SAO Kine)</annotation>
 		<annotation cp="🇭🇰" type="tts">zastava: Hongkong (SAO Kine)</annotation>
-		<annotation cp="🇭🇲">zastava | zastava: ostrvo Herd i ostrva Makdonald</annotation>
 		<annotation cp="🇭🇲" type="tts">zastava: ostrvo Herd i ostrva Makdonald</annotation>
-		<annotation cp="🇰🇲">zastava | zastava: Komori</annotation>
 		<annotation cp="🇰🇲" type="tts">zastava: Komori</annotation>
-		<annotation cp="🇰🇵">zastava | zastava: Sjeverna Koreja</annotation>
 		<annotation cp="🇰🇵" type="tts">zastava: Sjeverna Koreja</annotation>
-		<annotation cp="🇲🇰">zastava | zastava: Sjeverna Makedonija</annotation>
 		<annotation cp="🇲🇰" type="tts">zastava: Sjeverna Makedonija</annotation>
-		<annotation cp="🇲🇲">zastava | zastava: Mjanmar (Burma)</annotation>
 		<annotation cp="🇲🇲" type="tts">zastava: Mjanmar (Burma)</annotation>
-		<annotation cp="🇲🇵">zastava | zastava: Sjeverna Marijanska ostrva</annotation>
 		<annotation cp="🇲🇵" type="tts">zastava: Sjeverna Marijanska ostrva</annotation>
-		<annotation cp="🇳🇫">zastava | zastava: ostrvo Norfok</annotation>
 		<annotation cp="🇳🇫" type="tts">zastava: ostrvo Norfok</annotation>
-		<annotation cp="🇳🇺">zastava | zastava: Nijue</annotation>
 		<annotation cp="🇳🇺" type="tts">zastava: Nijue</annotation>
-		<annotation cp="🇵🇸">zastava | zastava: palestinske teritorije</annotation>
 		<annotation cp="🇵🇸" type="tts">zastava: palestinske teritorije</annotation>
-		<annotation cp="🇷🇪">zastava | zastava: Reunion</annotation>
 		<annotation cp="🇷🇪" type="tts">zastava: Reunion</annotation>
-		<annotation cp="🇹🇫">zastava | zastava: Francuske južne teritorije</annotation>
 		<annotation cp="🇹🇫" type="tts">zastava: Francuske južne teritorije</annotation>
-		<annotation cp="🇺🇲">zastava | zastava: Spoljna ostrva SAD</annotation>
 		<annotation cp="🇺🇲" type="tts">zastava: Spoljna ostrva SAD</annotation>
-		<annotation cp="🇻🇨">zastava | zastava: Sveti Vinsent i Grenadini</annotation>
 		<annotation cp="🇻🇨" type="tts">zastava: Sveti Vinsent i Grenadini</annotation>
-		<annotation cp="🇻🇬">zastava | zastava: Britanska Djevičanska ostrva</annotation>
 		<annotation cp="🇻🇬" type="tts">zastava: Britanska Djevičanska ostrva</annotation>
-		<annotation cp="🇻🇮">zastava | zastava: Američka Djevičanska ostrva</annotation>
 		<annotation cp="🇻🇮" type="tts">zastava: Američka Djevičanska ostrva</annotation>
 	</annotations>
 </ldml>

--- a/common/annotationsDerived/yo_BJ.xml
+++ b/common/annotationsDerived/yo_BJ.xml
@@ -14,3834 +14,3743 @@ Derived short names and annotations, using GenerateDerivedAnnotations.java. See 
 		<territory type="BJ"/>
 	</identity>
 	<annotations>
-		<annotation cp="👋🏻">amɔ́lára | juwɔ́ | N Juwɔ | ń juwɔ́ | N Juwɔ: amɔ́lára | ɔwɔ́</annotation>
+		<annotation cp="👋🏻">amɔ́lára | juwɔ́ | N Juwɔ | ń juwɔ́ | ɔwɔ́</annotation>
 		<annotation cp="👋🏻" type="tts">N Juwɔ: amɔ́lára</annotation>
-		<annotation cp="👋🏼">amɔ́lára díɛ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | N Juwɔ: amɔ́lára díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👋🏼">amɔ́lára díɛ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | ɔwɔ́</annotation>
 		<annotation cp="👋🏼" type="tts">N Juwɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👋🏽">amɔ́láwɔ̀ díɛ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | N Juwɔ: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👋🏽">amɔ́láwɔ̀ díɛ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | ɔwɔ́</annotation>
 		<annotation cp="👋🏽" type="tts">N Juwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👋🏾">adúláwɔ̀ díɛ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | N Juwɔ: adúláwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👋🏾">adúláwɔ̀ díɛ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | ɔwɔ́</annotation>
 		<annotation cp="👋🏾" type="tts">N Juwɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👋🏿">adúláwɔ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | N Juwɔ: adúláwɔ̀ | ɔwɔ́</annotation>
+		<annotation cp="👋🏿">adúláwɔ̀ | juwɔ́ | N Juwɔ | ń juwɔ́ | ɔwɔ́</annotation>
 		<annotation cp="👋🏿" type="tts">N Juwɔ: adúláwɔ̀</annotation>
-		<annotation cp="🤚🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | Na Ɛhin Ɔwɔ Soke: amɔ́lára | nà sókè</annotation>
+		<annotation cp="🤚🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | nà sókè</annotation>
 		<annotation cp="🤚🏻" type="tts">Na Ɛhin Ɔwɔ Soke: amɔ́lára</annotation>
-		<annotation cp="🤚🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | Na Ɛhin Ɔwɔ Soke: amɔ́lára díɛ̀ | nà sókè</annotation>
+		<annotation cp="🤚🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | nà sókè</annotation>
 		<annotation cp="🤚🏼" type="tts">Na Ɛhin Ɔwɔ Soke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤚🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | Na Ɛhin Ɔwɔ Soke: amɔ́láwɔ̀ díɛ̀ | nà sókè</annotation>
+		<annotation cp="🤚🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | nà sókè</annotation>
 		<annotation cp="🤚🏽" type="tts">Na Ɛhin Ɔwɔ Soke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤚🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | Na Ɛhin Ɔwɔ Soke: adúláwɔ̀ díɛ̀ | nà sókè</annotation>
+		<annotation cp="🤚🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | nà sókè</annotation>
 		<annotation cp="🤚🏾" type="tts">Na Ɛhin Ɔwɔ Soke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤚🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | Na Ɛhin Ɔwɔ Soke: adúláwɔ̀ | nà sókè</annotation>
+		<annotation cp="🤚🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Na Ɛhin Ɔwɔ Soke | nà sókè</annotation>
 		<annotation cp="🤚🏿" type="tts">Na Ɛhin Ɔwɔ Soke: adúláwɔ̀</annotation>
-		<annotation cp="🖐🏻">amɔ́lára | ìka | nawɔ́ sókè pɛ̀lú ìyàka | nawɔ́ sókè pɛ̀lú ìyàka: amɔ́lára | ɔwɔ́ | yàka</annotation>
+		<annotation cp="🖐🏻">amɔ́lára | ìka | nawɔ́ sókè pɛ̀lú ìyàka | ɔwɔ́ | yàka</annotation>
 		<annotation cp="🖐🏻" type="tts">nawɔ́ sókè pɛ̀lú ìyàka: amɔ́lára</annotation>
-		<annotation cp="🖐🏼">amɔ́lára díɛ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | nawɔ́ sókè pɛ̀lú ìyàka: amɔ́lára díɛ̀ | ɔwɔ́ | yàka</annotation>
+		<annotation cp="🖐🏼">amɔ́lára díɛ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | ɔwɔ́ | yàka</annotation>
 		<annotation cp="🖐🏼" type="tts">nawɔ́ sókè pɛ̀lú ìyàka: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🖐🏽">amɔ́láwɔ̀ díɛ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | nawɔ́ sókè pɛ̀lú ìyàka: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | yàka</annotation>
+		<annotation cp="🖐🏽">amɔ́láwɔ̀ díɛ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | ɔwɔ́ | yàka</annotation>
 		<annotation cp="🖐🏽" type="tts">nawɔ́ sókè pɛ̀lú ìyàka: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🖐🏾">adúláwɔ̀ díɛ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | nawɔ́ sókè pɛ̀lú ìyàka: adúláwɔ̀ díɛ̀ | ɔwɔ́ | yàka</annotation>
+		<annotation cp="🖐🏾">adúláwɔ̀ díɛ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | ɔwɔ́ | yàka</annotation>
 		<annotation cp="🖐🏾" type="tts">nawɔ́ sókè pɛ̀lú ìyàka: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🖐🏿">adúláwɔ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | nawɔ́ sókè pɛ̀lú ìyàka: adúláwɔ̀ | ɔwɔ́ | yàka</annotation>
+		<annotation cp="🖐🏿">adúláwɔ̀ | ìka | nawɔ́ sókè pɛ̀lú ìyàka | ɔwɔ́ | yàka</annotation>
 		<annotation cp="🖐🏿" type="tts">nawɔ́ sókè pɛ̀lú ìyàka: adúláwɔ̀</annotation>
-		<annotation cp="✋🏻">amɔ́lára | ɔwɔ́ | Ɔwɔ Nina Soke | Ɔwɔ Nina Soke: amɔ́lára</annotation>
+		<annotation cp="✋🏻">amɔ́lára | ɔwɔ́ | Ɔwɔ Nina Soke</annotation>
 		<annotation cp="✋🏻" type="tts">Ɔwɔ Nina Soke: amɔ́lára</annotation>
-		<annotation cp="✋🏼">amɔ́lára díɛ̀ | ɔwɔ́ | Ɔwɔ Nina Soke | Ɔwɔ Nina Soke: amɔ́lára díɛ̀</annotation>
+		<annotation cp="✋🏼">amɔ́lára díɛ̀ | ɔwɔ́ | Ɔwɔ Nina Soke</annotation>
 		<annotation cp="✋🏼" type="tts">Ɔwɔ Nina Soke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="✋🏽">amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | Ɔwɔ Nina Soke | Ɔwɔ Nina Soke: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="✋🏽">amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | Ɔwɔ Nina Soke</annotation>
 		<annotation cp="✋🏽" type="tts">Ɔwɔ Nina Soke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="✋🏾">adúláwɔ̀ díɛ̀ | ɔwɔ́ | Ɔwɔ Nina Soke | Ɔwɔ Nina Soke: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="✋🏾">adúláwɔ̀ díɛ̀ | ɔwɔ́ | Ɔwɔ Nina Soke</annotation>
 		<annotation cp="✋🏾" type="tts">Ɔwɔ Nina Soke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="✋🏿">adúláwɔ̀ | ɔwɔ́ | Ɔwɔ Nina Soke | Ɔwɔ Nina Soke: adúláwɔ̀</annotation>
+		<annotation cp="✋🏿">adúláwɔ̀ | ɔwɔ́ | Ɔwɔ Nina Soke</annotation>
 		<annotation cp="✋🏿" type="tts">Ɔwɔ Nina Soke: adúláwɔ̀</annotation>
-		<annotation cp="🖖🏻">amɔ́lára | ìka | Kiki Ibɛri Funni | Kiki Ibɛri Funni: amɔ́lára | ɔwɔ́ | spock | vulcan</annotation>
+		<annotation cp="🖖🏻">amɔ́lára | ìka | Kiki Ibɛri Funni | ɔwɔ́ | spock | vulcan</annotation>
 		<annotation cp="🖖🏻" type="tts">Kiki Ibɛri Funni: amɔ́lára</annotation>
-		<annotation cp="🖖🏼">amɔ́lára díɛ̀ | ìka | Kiki Ibɛri Funni | Kiki Ibɛri Funni: amɔ́lára díɛ̀ | ɔwɔ́ | spock | vulcan</annotation>
+		<annotation cp="🖖🏼">amɔ́lára díɛ̀ | ìka | Kiki Ibɛri Funni | ɔwɔ́ | spock | vulcan</annotation>
 		<annotation cp="🖖🏼" type="tts">Kiki Ibɛri Funni: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🖖🏽">amɔ́láwɔ̀ díɛ̀ | ìka | Kiki Ibɛri Funni | Kiki Ibɛri Funni: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | spock | vulcan</annotation>
+		<annotation cp="🖖🏽">amɔ́láwɔ̀ díɛ̀ | ìka | Kiki Ibɛri Funni | ɔwɔ́ | spock | vulcan</annotation>
 		<annotation cp="🖖🏽" type="tts">Kiki Ibɛri Funni: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🖖🏾">adúláwɔ̀ díɛ̀ | ìka | Kiki Ibɛri Funni | Kiki Ibɛri Funni: adúláwɔ̀ díɛ̀ | ɔwɔ́ | spock | vulcan</annotation>
+		<annotation cp="🖖🏾">adúláwɔ̀ díɛ̀ | ìka | Kiki Ibɛri Funni | ɔwɔ́ | spock | vulcan</annotation>
 		<annotation cp="🖖🏾" type="tts">Kiki Ibɛri Funni: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🖖🏿">adúláwɔ̀ | ìka | Kiki Ibɛri Funni | Kiki Ibɛri Funni: adúláwɔ̀ | ɔwɔ́ | spock | vulcan</annotation>
+		<annotation cp="🖖🏿">adúláwɔ̀ | ìka | Kiki Ibɛri Funni | ɔwɔ́ | spock | vulcan</annotation>
 		<annotation cp="🖖🏿" type="tts">Kiki Ibɛri Funni: adúláwɔ̀</annotation>
-		<annotation cp="🫱🏻">amɔ́lára | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún | ɔwɔ́ ɔ̀tún: amɔ́lára</annotation>
+		<annotation cp="🫱🏻">amɔ́lára | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún</annotation>
 		<annotation cp="🫱🏻" type="tts">ɔwɔ́ ɔ̀tún: amɔ́lára</annotation>
-		<annotation cp="🫱🏼">amɔ́lára díɛ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún | ɔwɔ́ ɔ̀tún: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🫱🏼">amɔ́lára díɛ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún</annotation>
 		<annotation cp="🫱🏼" type="tts">ɔwɔ́ ɔ̀tún: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫱🏽">amɔ́láwɔ̀ díɛ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún | ɔwɔ́ ɔ̀tún: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫱🏽">amɔ́láwɔ̀ díɛ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún</annotation>
 		<annotation cp="🫱🏽" type="tts">ɔwɔ́ ɔ̀tún: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏾">adúláwɔ̀ díɛ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún | ɔwɔ́ ɔ̀tún: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫱🏾">adúláwɔ̀ díɛ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún</annotation>
 		<annotation cp="🫱🏾" type="tts">ɔwɔ́ ɔ̀tún: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏿">adúláwɔ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún | ɔwɔ́ ɔ̀tún: adúláwɔ̀</annotation>
+		<annotation cp="🫱🏿">adúláwɔ̀ | apá ɔtún | owɔ́ | ɔtún | ɔwɔ́ ɔ̀tún</annotation>
 		<annotation cp="🫱🏿" type="tts">ɔwɔ́ ɔ̀tún: adúláwɔ̀</annotation>
-		<annotation cp="🫱🏻‍🫲🏼">amɔ́lára | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára, amɔ́lára díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏻‍🫲🏼">amɔ́lára | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏻‍🫲🏼" type="tts">Ìbɔwɔ́: amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫱🏻‍🫲🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára, amɔ́láwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏻‍🫲🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏻‍🫲🏽" type="tts">Ìbɔwɔ́: amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏻‍🫲🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára, adúláwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏻‍🫲🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏻‍🫲🏾" type="tts">Ìbɔwɔ́: amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏻‍🫲🏿">adúláwɔ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára, adúláwɔ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏻‍🫲🏿">adúláwɔ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏻‍🫲🏿" type="tts">Ìbɔwɔ́: amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="🫱🏼‍🫲🏻">amɔ́lára | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára díɛ̀, amɔ́lára | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏼‍🫲🏻">amɔ́lára | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏼‍🫲🏻" type="tts">Ìbɔwɔ́: amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🫱🏼‍🫲🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏼‍🫲🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏼‍🫲🏽" type="tts">Ìbɔwɔ́: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏼‍🫲🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏼‍🫲🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏼‍🫲🏾" type="tts">Ìbɔwɔ́: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏼‍🫲🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára díɛ̀, adúláwɔ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏼‍🫲🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏼‍🫲🏿" type="tts">Ìbɔwɔ́: amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🫱🏽‍🫲🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, amɔ́lára | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏽‍🫲🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏽‍🫲🏻" type="tts">Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🫱🏽‍🫲🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏽‍🫲🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏽‍🫲🏼" type="tts">Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫱🏽‍🫲🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏽‍🫲🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏽‍🫲🏾" type="tts">Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏽‍🫲🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏽‍🫲🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏽‍🫲🏿" type="tts">Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🫱🏾‍🫲🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀ díɛ̀, amɔ́lára | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏾‍🫲🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏾‍🫲🏻" type="tts">Ìbɔwɔ́: adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🫱🏾‍🫲🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏾‍🫲🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏾‍🫲🏼" type="tts">Ìbɔwɔ́: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫱🏾‍🫲🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏾‍🫲🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏾‍🫲🏽" type="tts">Ìbɔwɔ́: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏾‍🫲🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀ díɛ̀, adúláwɔ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏾‍🫲🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏾‍🫲🏿" type="tts">Ìbɔwɔ́: adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🫱🏿‍🫲🏻">adúláwɔ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀, amɔ́lára | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏿‍🫲🏻">adúláwɔ̀ | amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏿‍🫲🏻" type="tts">Ìbɔwɔ́: adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="🫱🏿‍🫲🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀, amɔ́lára díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏿‍🫲🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏿‍🫲🏼" type="tts">Ìbɔwɔ́: adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫱🏿‍🫲🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏿‍🫲🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏿‍🫲🏽" type="tts">Ìbɔwɔ́: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫱🏿‍🫲🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀, adúláwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🫱🏿‍🫲🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🫱🏿‍🫲🏾" type="tts">Ìbɔwɔ́: adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫲🏻">amɔ́lára | apa [posí | òsì | owo | ɔwɔ́ òsì | ɔwɔ́ òsì: amɔ́lára</annotation>
+		<annotation cp="🫲🏻">amɔ́lára | apa [posí | òsì | owo | ɔwɔ́ òsì</annotation>
 		<annotation cp="🫲🏻" type="tts">ɔwɔ́ òsì: amɔ́lára</annotation>
-		<annotation cp="🫲🏼">amɔ́lára díɛ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì | ɔwɔ́ òsì: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🫲🏼">amɔ́lára díɛ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì</annotation>
 		<annotation cp="🫲🏼" type="tts">ɔwɔ́ òsì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫲🏽">amɔ́láwɔ̀ díɛ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì | ɔwɔ́ òsì: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫲🏽">amɔ́láwɔ̀ díɛ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì</annotation>
 		<annotation cp="🫲🏽" type="tts">ɔwɔ́ òsì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫲🏾">adúláwɔ̀ díɛ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì | ɔwɔ́ òsì: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫲🏾">adúláwɔ̀ díɛ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì</annotation>
 		<annotation cp="🫲🏾" type="tts">ɔwɔ́ òsì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫲🏿">adúláwɔ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì | ɔwɔ́ òsì: adúláwɔ̀</annotation>
+		<annotation cp="🫲🏿">adúláwɔ̀ | apa [posí | òsì | owo | ɔwɔ́ òsì</annotation>
 		<annotation cp="🫲🏿" type="tts">ɔwɔ́ òsì: adúláwɔ̀</annotation>
-		<annotation cp="🫳🏻">amɔ́lára | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀: amɔ́lára | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
+		<annotation cp="🫳🏻">amɔ́lára | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
 		<annotation cp="🫳🏻" type="tts">àtɛ́lɛ̀wɔ́ ìsàlɛ̀: amɔ́lára</annotation>
-		<annotation cp="🫳🏼">amɔ́lára díɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀: amɔ́lára díɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
+		<annotation cp="🫳🏼">amɔ́lára díɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
 		<annotation cp="🫳🏼" type="tts">àtɛ́lɛ̀wɔ́ ìsàlɛ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫳🏽">amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀: amɔ́láwɔ̀ díɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
+		<annotation cp="🫳🏽">amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
 		<annotation cp="🫳🏽" type="tts">àtɛ́lɛ̀wɔ́ ìsàlɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫳🏾">adúláwɔ̀ díɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀: adúláwɔ̀ díɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
+		<annotation cp="🫳🏾">adúláwɔ̀ díɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
 		<annotation cp="🫳🏾" type="tts">àtɛ́lɛ̀wɔ́ ìsàlɛ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫳🏿">adúláwɔ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀: adúláwɔ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
+		<annotation cp="🫳🏿">adúláwɔ̀ | àtɛ́lɛ̀wɔ́ ìsàlɛ̀ | jabɔ̀ | lé lɔ | ɔwɔ́ ìsàlɛ̀ | shoo</annotation>
 		<annotation cp="🫳🏿" type="tts">àtɛ́lɛ̀wɔ́ ìsàlɛ̀: adúláwɔ̀</annotation>
-		<annotation cp="🫴🏻">amɔ́lára | àtɛ́lɛwɔ́ òkè | àtɛ́lɛwɔ́ òkè: amɔ́lára | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
+		<annotation cp="🫴🏻">amɔ́lára | àtɛ́lɛwɔ́ òkè | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
 		<annotation cp="🫴🏻" type="tts">àtɛ́lɛwɔ́ òkè: amɔ́lára</annotation>
-		<annotation cp="🫴🏼">amɔ́lára díɛ̀ | àtɛ́lɛwɔ́ òkè | àtɛ́lɛwɔ́ òkè: amɔ́lára díɛ̀ | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
+		<annotation cp="🫴🏼">amɔ́lára díɛ̀ | àtɛ́lɛwɔ́ òkè | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
 		<annotation cp="🫴🏼" type="tts">àtɛ́lɛwɔ́ òkè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫴🏽">amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛwɔ́ òkè | àtɛ́lɛwɔ́ òkè: amɔ́láwɔ̀ díɛ̀ | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
+		<annotation cp="🫴🏽">amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛwɔ́ òkè | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
 		<annotation cp="🫴🏽" type="tts">àtɛ́lɛwɔ́ òkè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫴🏾">adúláwɔ̀ díɛ̀ | àtɛ́lɛwɔ́ òkè | àtɛ́lɛwɔ́ òkè: adúláwɔ̀ díɛ̀ | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
+		<annotation cp="🫴🏾">adúláwɔ̀ díɛ̀ | àtɛ́lɛwɔ́ òkè | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
 		<annotation cp="🫴🏾" type="tts">àtɛ́lɛwɔ́ òkè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫴🏿">adúláwɔ̀ | àtɛ́lɛwɔ́ òkè | àtɛ́lɛwɔ́ òkè: adúláwɔ̀ | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
+		<annotation cp="🫴🏿">adúláwɔ̀ | àtɛ́lɛwɔ́ òkè | fún | mú | ɔwɔ́ òkè | pè | wá</annotation>
 		<annotation cp="🫴🏿" type="tts">àtɛ́lɛwɔ́ òkè: adúláwɔ̀</annotation>
-		<annotation cp="🫷🏻">amɔ́lára | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì | títi ɔwɔ́ sɔ́sì: amɔ́lára</annotation>
+		<annotation cp="🫷🏻">amɔ́lára | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì</annotation>
 		<annotation cp="🫷🏻" type="tts">títi ɔwɔ́ sɔ́sì: amɔ́lára</annotation>
-		<annotation cp="🫷🏼">amɔ́lára díɛ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì | títi ɔwɔ́ sɔ́sì: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🫷🏼">amɔ́lára díɛ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì</annotation>
 		<annotation cp="🫷🏼" type="tts">títi ɔwɔ́ sɔ́sì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫷🏽">amɔ́láwɔ̀ díɛ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì | títi ɔwɔ́ sɔ́sì: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫷🏽">amɔ́láwɔ̀ díɛ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì</annotation>
 		<annotation cp="🫷🏽" type="tts">títi ɔwɔ́ sɔ́sì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫷🏾">adúláwɔ̀ díɛ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì | títi ɔwɔ́ sɔ́sì: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫷🏾">adúláwɔ̀ díɛ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì</annotation>
 		<annotation cp="🫷🏾" type="tts">títi ɔwɔ́ sɔ́sì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫷🏿">adúláwɔ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì | títi ɔwɔ́ sɔ́sì: adúláwɔ̀</annotation>
+		<annotation cp="🫷🏿">adúláwɔ̀ | apa osi | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́sì</annotation>
 		<annotation cp="🫷🏿" type="tts">títi ɔwɔ́ sɔ́sì: adúláwɔ̀</annotation>
-		<annotation cp="🫸🏻">amɔ́lára | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun | títi ɔwɔ́ sɔ́tun: amɔ́lára</annotation>
+		<annotation cp="🫸🏻">amɔ́lára | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun</annotation>
 		<annotation cp="🫸🏻" type="tts">títi ɔwɔ́ sɔ́tun: amɔ́lára</annotation>
-		<annotation cp="🫸🏼">amɔ́lára díɛ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun | títi ɔwɔ́ sɔ́tun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🫸🏼">amɔ́lára díɛ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun</annotation>
 		<annotation cp="🫸🏼" type="tts">títi ɔwɔ́ sɔ́tun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫸🏽">amɔ́láwɔ̀ díɛ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun | títi ɔwɔ́ sɔ́tun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫸🏽">amɔ́láwɔ̀ díɛ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun</annotation>
 		<annotation cp="🫸🏽" type="tts">títi ɔwɔ́ sɔ́tun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫸🏾">adúláwɔ̀ díɛ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun | títi ɔwɔ́ sɔ́tun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫸🏾">adúláwɔ̀ díɛ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun</annotation>
 		<annotation cp="🫸🏾" type="tts">títi ɔwɔ́ sɔ́tun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫸🏿">adúláwɔ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun | títi ɔwɔ́ sɔ́tun: adúláwɔ̀</annotation>
+		<annotation cp="🫸🏿">adúláwɔ̀ | apa ɔ̀tún | duro | ìka ɔwɔ́ márùn | kùnà | ti | títi ɔwɔ́ sɔ́tun</annotation>
 		<annotation cp="🫸🏿" type="tts">títi ɔwɔ́ sɔ́tun: adúláwɔ̀</annotation>
-		<annotation cp="👌🏻">amɔ́lára | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA | Ɔwɔ ODARA: amɔ́lára</annotation>
+		<annotation cp="👌🏻">amɔ́lára | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA</annotation>
 		<annotation cp="👌🏻" type="tts">Ɔwɔ ODARA: amɔ́lára</annotation>
-		<annotation cp="👌🏼">amɔ́lára díɛ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA | Ɔwɔ ODARA: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👌🏼">amɔ́lára díɛ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA</annotation>
 		<annotation cp="👌🏼" type="tts">Ɔwɔ ODARA: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👌🏽">amɔ́láwɔ̀ díɛ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA | Ɔwɔ ODARA: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👌🏽">amɔ́láwɔ̀ díɛ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA</annotation>
 		<annotation cp="👌🏽" type="tts">Ɔwɔ ODARA: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👌🏾">adúláwɔ̀ díɛ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA | Ɔwɔ ODARA: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👌🏾">adúláwɔ̀ díɛ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA</annotation>
 		<annotation cp="👌🏾" type="tts">Ɔwɔ ODARA: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👌🏿">adúláwɔ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA | Ɔwɔ ODARA: adúláwɔ̀</annotation>
+		<annotation cp="👌🏿">adúláwɔ̀ | ÓDÁRA | ɔwɔ́ | Ɔwɔ ODARA</annotation>
 		<annotation cp="👌🏿" type="tts">Ɔwɔ ODARA: adúláwɔ̀</annotation>
-		<annotation cp="🤌🏻">amɔ́lára | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìka kíkákò: amɔ́lára | ìwanulɛ́nuwò | yín</annotation>
+		<annotation cp="🤌🏻">amɔ́lára | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìwanulɛ́nuwò | yín</annotation>
 		<annotation cp="🤌🏻" type="tts">ìka kíkákò: amɔ́lára</annotation>
-		<annotation cp="🤌🏼">amɔ́lára díɛ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìka kíkákò: amɔ́lára díɛ̀ | ìwanulɛ́nuwò | yín</annotation>
+		<annotation cp="🤌🏼">amɔ́lára díɛ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìwanulɛ́nuwò | yín</annotation>
 		<annotation cp="🤌🏼" type="tts">ìka kíkákò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤌🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìka kíkákò: amɔ́láwɔ̀ díɛ̀ | ìwanulɛ́nuwò | yín</annotation>
+		<annotation cp="🤌🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìwanulɛ́nuwò | yín</annotation>
 		<annotation cp="🤌🏽" type="tts">ìka kíkákò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤌🏾">adúláwɔ̀ díɛ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìka kíkákò: adúláwɔ̀ díɛ̀ | ìwanulɛ́nuwò | yín</annotation>
+		<annotation cp="🤌🏾">adúláwɔ̀ díɛ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìwanulɛ́nuwò | yín</annotation>
 		<annotation cp="🤌🏾" type="tts">ìka kíkákò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤌🏿">adúláwɔ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìka kíkákò: adúláwɔ̀ | ìwanulɛ́nuwò | yín</annotation>
+		<annotation cp="🤌🏿">adúláwɔ̀ | ɛ̀fɛ̀ | ìfiwɔ́ sɔ̀rɔ̀ | ìka | ìka kíkákò | ìwanulɛ́nuwò | yín</annotation>
 		<annotation cp="🤌🏿" type="tts">ìka kíkákò: adúláwɔ̀</annotation>
-		<annotation cp="🤏🏻">amɔ́lára | ìka kíká | ìka kíká: amɔ́lára | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
+		<annotation cp="🤏🏻">amɔ́lára | ìka kíká | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
 		<annotation cp="🤏🏻" type="tts">ìka kíká: amɔ́lára</annotation>
-		<annotation cp="🤏🏼">amɔ́lára díɛ̀ | ìka kíká | ìka kíká: amɔ́lára díɛ̀ | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
+		<annotation cp="🤏🏼">amɔ́lára díɛ̀ | ìka kíká | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
 		<annotation cp="🤏🏼" type="tts">ìka kíká: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤏🏽">amɔ́láwɔ̀ díɛ̀ | ìka kíká | ìka kíká: amɔ́láwɔ̀ díɛ̀ | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
+		<annotation cp="🤏🏽">amɔ́láwɔ̀ díɛ̀ | ìka kíká | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
 		<annotation cp="🤏🏽" type="tts">ìka kíká: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤏🏾">adúláwɔ̀ díɛ̀ | ìka kíká | ìka kíká: adúláwɔ̀ díɛ̀ | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
+		<annotation cp="🤏🏾">adúláwɔ̀ díɛ̀ | ìka kíká | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
 		<annotation cp="🤏🏾" type="tts">ìka kíká: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤏🏿">adúláwɔ̀ | ìka kíká | ìka kíká: adúláwɔ̀ | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
+		<annotation cp="🤏🏿">adúláwɔ̀ | ìka kíká | owó kɛ̀keré | ɔwɔ́ yínyín</annotation>
 		<annotation cp="🤏🏿" type="tts">ìka kíká: adúláwɔ̀</annotation>
-		<annotation cp="✌🏻">amɔ́lára | asheyɔrí | asheyɔrí ɔwɔ́: amɔ́lára | ɔwɔ́ | v</annotation>
+		<annotation cp="✌🏻">amɔ́lára | asheyɔrí | ɔwɔ́ | v</annotation>
 		<annotation cp="✌🏻" type="tts">asheyɔrí ɔwɔ́: amɔ́lára</annotation>
-		<annotation cp="✌🏼">amɔ́lára díɛ̀ | asheyɔrí | asheyɔrí ɔwɔ́: amɔ́lára díɛ̀ | ɔwɔ́ | v</annotation>
+		<annotation cp="✌🏼">amɔ́lára díɛ̀ | asheyɔrí | ɔwɔ́ | v</annotation>
 		<annotation cp="✌🏼" type="tts">asheyɔrí ɔwɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="✌🏽">amɔ́láwɔ̀ díɛ̀ | asheyɔrí | asheyɔrí ɔwɔ́: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | v</annotation>
+		<annotation cp="✌🏽">amɔ́láwɔ̀ díɛ̀ | asheyɔrí | ɔwɔ́ | v</annotation>
 		<annotation cp="✌🏽" type="tts">asheyɔrí ɔwɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="✌🏾">adúláwɔ̀ díɛ̀ | asheyɔrí | asheyɔrí ɔwɔ́: adúláwɔ̀ díɛ̀ | ɔwɔ́ | v</annotation>
+		<annotation cp="✌🏾">adúláwɔ̀ díɛ̀ | asheyɔrí | ɔwɔ́ | v</annotation>
 		<annotation cp="✌🏾" type="tts">asheyɔrí ɔwɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="✌🏿">adúláwɔ̀ | asheyɔrí | asheyɔrí ɔwɔ́: adúláwɔ̀ | ɔwɔ́ | v</annotation>
+		<annotation cp="✌🏿">adúláwɔ̀ | asheyɔrí | ɔwɔ́ | v</annotation>
 		<annotation cp="✌🏿" type="tts">asheyɔrí ɔwɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🤞🏻">amɔ́lára | dábùú | Igbekalera | Igbekalera: amɔ́lára | ìka | orírere | ɔwɔ́</annotation>
+		<annotation cp="🤞🏻">amɔ́lára | dábùú | Igbekalera | ìka | orírere | ɔwɔ́</annotation>
 		<annotation cp="🤞🏻" type="tts">Igbekalera: amɔ́lára</annotation>
-		<annotation cp="🤞🏼">amɔ́lára díɛ̀ | dábùú | Igbekalera | Igbekalera: amɔ́lára díɛ̀ | ìka | orírere | ɔwɔ́</annotation>
+		<annotation cp="🤞🏼">amɔ́lára díɛ̀ | dábùú | Igbekalera | ìka | orírere | ɔwɔ́</annotation>
 		<annotation cp="🤞🏼" type="tts">Igbekalera: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤞🏽">amɔ́láwɔ̀ díɛ̀ | dábùú | Igbekalera | Igbekalera: amɔ́láwɔ̀ díɛ̀ | ìka | orírere | ɔwɔ́</annotation>
+		<annotation cp="🤞🏽">amɔ́láwɔ̀ díɛ̀ | dábùú | Igbekalera | ìka | orírere | ɔwɔ́</annotation>
 		<annotation cp="🤞🏽" type="tts">Igbekalera: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤞🏾">adúláwɔ̀ díɛ̀ | dábùú | Igbekalera | Igbekalera: adúláwɔ̀ díɛ̀ | ìka | orírere | ɔwɔ́</annotation>
+		<annotation cp="🤞🏾">adúláwɔ̀ díɛ̀ | dábùú | Igbekalera | ìka | orírere | ɔwɔ́</annotation>
 		<annotation cp="🤞🏾" type="tts">Igbekalera: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤞🏿">adúláwɔ̀ | dábùú | Igbekalera | Igbekalera: adúláwɔ̀ | ìka | orírere | ɔwɔ́</annotation>
+		<annotation cp="🤞🏿">adúláwɔ̀ | dábùú | Igbekalera | ìka | orírere | ɔwɔ́</annotation>
 		<annotation cp="🤞🏿" type="tts">Igbekalera: adúláwɔ̀</annotation>
-		<annotation cp="🫰🏻">amɔ́lára | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: amɔ́lára | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
+		<annotation cp="🫰🏻">amɔ́lára | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
 		<annotation cp="🫰🏻" type="tts">ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: amɔ́lára</annotation>
-		<annotation cp="🫰🏼">amɔ́lára díɛ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: amɔ́lára díɛ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
+		<annotation cp="🫰🏼">amɔ́lára díɛ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
 		<annotation cp="🫰🏼" type="tts">ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫰🏽">amɔ́láwɔ̀ díɛ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: amɔ́láwɔ̀ díɛ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
+		<annotation cp="🫰🏽">amɔ́láwɔ̀ díɛ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
 		<annotation cp="🫰🏽" type="tts">ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫰🏾">adúláwɔ̀ díɛ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: adúláwɔ̀ díɛ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
+		<annotation cp="🫰🏾">adúláwɔ̀ díɛ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
 		<annotation cp="🫰🏾" type="tts">ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫰🏿">adúláwɔ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: adúláwɔ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
+		<annotation cp="🫰🏿">adúláwɔ̀ | heart | ìfɛ́ | owó | ɔwɔ́ pɛ̀lú ìka kekeré | ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀ | snap àti atanpako to wà papɔ̀ | wɔ́n</annotation>
 		<annotation cp="🫰🏿" type="tts">ɔwɔ́ pɛ̀lú ìka kɛ́keré àti ìka ńlá ní pípapɔ̀: adúláwɔ̀</annotation>
-		<annotation cp="🤟🏻">amɔ́lára | ìfɔwɔ́júwè mo ní ìfɛ́ | ìfɔwɔ́júwè mo ní ìfɛ́: amɔ́lára | ILY | Ɔwɔ́</annotation>
+		<annotation cp="🤟🏻">amɔ́lára | ìfɔwɔ́júwè mo ní ìfɛ́ | ILY | Ɔwɔ́</annotation>
 		<annotation cp="🤟🏻" type="tts">ìfɔwɔ́júwè mo ní ìfɛ́: amɔ́lára</annotation>
-		<annotation cp="🤟🏼">amɔ́lára díɛ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ìfɔwɔ́júwè mo ní ìfɛ́: amɔ́lára díɛ̀ | ILY | Ɔwɔ́</annotation>
+		<annotation cp="🤟🏼">amɔ́lára díɛ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ILY | Ɔwɔ́</annotation>
 		<annotation cp="🤟🏼" type="tts">ìfɔwɔ́júwè mo ní ìfɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤟🏽">amɔ́láwɔ̀ díɛ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ìfɔwɔ́júwè mo ní ìfɛ́: amɔ́láwɔ̀ díɛ̀ | ILY | Ɔwɔ́</annotation>
+		<annotation cp="🤟🏽">amɔ́láwɔ̀ díɛ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ILY | Ɔwɔ́</annotation>
 		<annotation cp="🤟🏽" type="tts">ìfɔwɔ́júwè mo ní ìfɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤟🏾">adúláwɔ̀ díɛ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ìfɔwɔ́júwè mo ní ìfɛ́: adúláwɔ̀ díɛ̀ | ILY | Ɔwɔ́</annotation>
+		<annotation cp="🤟🏾">adúláwɔ̀ díɛ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ILY | Ɔwɔ́</annotation>
 		<annotation cp="🤟🏾" type="tts">ìfɔwɔ́júwè mo ní ìfɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤟🏿">adúláwɔ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ìfɔwɔ́júwè mo ní ìfɛ́: adúláwɔ̀ | ILY | Ɔwɔ́</annotation>
+		<annotation cp="🤟🏿">adúláwɔ̀ | ìfɔwɔ́júwè mo ní ìfɛ́ | ILY | Ɔwɔ́</annotation>
 		<annotation cp="🤟🏿" type="tts">ìfɔwɔ́júwè mo ní ìfɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🤘🏻">19900 | Aami Awɔn Iwo | Aami Awɔn Iwo: amɔ́lára | amɔ́lára | ìka | ìwo | ɔwɔ́</annotation>
+		<annotation cp="🤘🏻">19900 | Aami Awɔn Iwo | amɔ́lára | ìka | ìwo | ɔwɔ́</annotation>
 		<annotation cp="🤘🏻" type="tts">Aami Awɔn Iwo: amɔ́lára</annotation>
-		<annotation cp="🤘🏼">19900 | Aami Awɔn Iwo | Aami Awɔn Iwo: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ìka | ìwo | ɔwɔ́</annotation>
+		<annotation cp="🤘🏼">19900 | Aami Awɔn Iwo | amɔ́lára díɛ̀ | ìka | ìwo | ɔwɔ́</annotation>
 		<annotation cp="🤘🏼" type="tts">Aami Awɔn Iwo: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤘🏽">19900 | Aami Awɔn Iwo | Aami Awɔn Iwo: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìka | ìwo | ɔwɔ́</annotation>
+		<annotation cp="🤘🏽">19900 | Aami Awɔn Iwo | amɔ́láwɔ̀ díɛ̀ | ìka | ìwo | ɔwɔ́</annotation>
 		<annotation cp="🤘🏽" type="tts">Aami Awɔn Iwo: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤘🏾">19900 | Aami Awɔn Iwo | Aami Awɔn Iwo: adúláwɔ̀ díɛ̀ | adúláwɔ̀ díɛ̀ | ìka | ìwo | ɔwɔ́</annotation>
+		<annotation cp="🤘🏾">19900 | Aami Awɔn Iwo | adúláwɔ̀ díɛ̀ | ìka | ìwo | ɔwɔ́</annotation>
 		<annotation cp="🤘🏾" type="tts">Aami Awɔn Iwo: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤘🏿">19900 | Aami Awɔn Iwo | Aami Awɔn Iwo: adúláwɔ̀ | adúláwɔ̀ | ìka | ìwo | ɔwɔ́</annotation>
+		<annotation cp="🤘🏿">19900 | Aami Awɔn Iwo | adúláwɔ̀ | ìka | ìwo | ɔwɔ́</annotation>
 		<annotation cp="🤘🏿" type="tts">Aami Awɔn Iwo: adúláwɔ̀</annotation>
-		<annotation cp="🤙🏻">amɔ́lára | ìpè | ɔwɔ́ | Ɔwɔ Ipeni | Ɔwɔ Ipeni: amɔ́lára</annotation>
+		<annotation cp="🤙🏻">amɔ́lára | ìpè | ɔwɔ́ | Ɔwɔ Ipeni</annotation>
 		<annotation cp="🤙🏻" type="tts">Ɔwɔ Ipeni: amɔ́lára</annotation>
-		<annotation cp="🤙🏼">amɔ́lára díɛ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni | Ɔwɔ Ipeni: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤙🏼">amɔ́lára díɛ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni</annotation>
 		<annotation cp="🤙🏼" type="tts">Ɔwɔ Ipeni: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤙🏽">amɔ́láwɔ̀ díɛ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni | Ɔwɔ Ipeni: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤙🏽">amɔ́láwɔ̀ díɛ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni</annotation>
 		<annotation cp="🤙🏽" type="tts">Ɔwɔ Ipeni: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤙🏾">adúláwɔ̀ díɛ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni | Ɔwɔ Ipeni: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤙🏾">adúláwɔ̀ díɛ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni</annotation>
 		<annotation cp="🤙🏾" type="tts">Ɔwɔ Ipeni: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤙🏿">adúláwɔ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni | Ɔwɔ Ipeni: adúláwɔ̀</annotation>
+		<annotation cp="🤙🏿">adúláwɔ̀ | ìpè | ɔwɔ́ | Ɔwɔ Ipeni</annotation>
 		<annotation cp="🤙🏿" type="tts">Ɔwɔ Ipeni: adúláwɔ̀</annotation>
-		<annotation cp="👈🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: amɔ́lára | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👈🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👈🏻" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: amɔ́lára</annotation>
-		<annotation cp="👈🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: amɔ́lára díɛ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👈🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👈🏼" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👈🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: amɔ́láwɔ̀ díɛ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👈🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👈🏽" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👈🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: adúláwɔ̀ díɛ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👈🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👈🏾" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👈🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: adúláwɔ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👈🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👈🏿" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Osi: adúláwɔ̀</annotation>
-		<annotation cp="👉🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: amɔ́lára | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👉🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👉🏻" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: amɔ́lára</annotation>
-		<annotation cp="👉🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: amɔ́lára díɛ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👉🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👉🏼" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👉🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: amɔ́láwɔ̀ díɛ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👉🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👉🏽" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👉🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: adúláwɔ̀ díɛ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👉🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👉🏾" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👉🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: adúláwɔ̀ | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
+		<annotation cp="👉🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun | ìka | ìka kékeré | ɔ̀gángán | ɔwɔ́</annotation>
 		<annotation cp="👉🏿" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Apa Ɔtun: adúláwɔ̀</annotation>
-		<annotation cp="👆🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | Ɛyin Ɔwɔ Ti O Tɔka Si Oke: amɔ́lára | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="👆🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="👆🏻" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Oke: amɔ́lára</annotation>
-		<annotation cp="👆🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | Ɛyin Ɔwɔ Ti O Tɔka Si Oke: amɔ́lára díɛ̀ | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="👆🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="👆🏼" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Oke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👆🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | Ɛyin Ɔwɔ Ti O Tɔka Si Oke: amɔ́láwɔ̀ díɛ̀ | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="👆🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="👆🏽" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Oke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👆🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | Ɛyin Ɔwɔ Ti O Tɔka Si Oke: adúláwɔ̀ díɛ̀ | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="👆🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="👆🏾" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Oke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👆🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | Ɛyin Ɔwɔ Ti O Tɔka Si Oke: adúláwɔ̀ | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="👆🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Oke | ìka | ìka kékeré | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="👆🏿" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Oke: adúláwɔ̀</annotation>
-		<annotation cp="🖕🏻">amɔ́lára | ìka | ìka àárín | ìka àárín: amɔ́lára | ɔwɔ́</annotation>
+		<annotation cp="🖕🏻">amɔ́lára | ìka | ìka àárín | ɔwɔ́</annotation>
 		<annotation cp="🖕🏻" type="tts">ìka àárín: amɔ́lára</annotation>
-		<annotation cp="🖕🏼">amɔ́lára díɛ̀ | ìka | ìka àárín | ìka àárín: amɔ́lára díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="🖕🏼">amɔ́lára díɛ̀ | ìka | ìka àárín | ɔwɔ́</annotation>
 		<annotation cp="🖕🏼" type="tts">ìka àárín: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🖕🏽">amɔ́láwɔ̀ díɛ̀ | ìka | ìka àárín | ìka àárín: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="🖕🏽">amɔ́láwɔ̀ díɛ̀ | ìka | ìka àárín | ɔwɔ́</annotation>
 		<annotation cp="🖕🏽" type="tts">ìka àárín: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🖕🏾">adúláwɔ̀ díɛ̀ | ìka | ìka àárín | ìka àárín: adúláwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="🖕🏾">adúláwɔ̀ díɛ̀ | ìka | ìka àárín | ɔwɔ́</annotation>
 		<annotation cp="🖕🏾" type="tts">ìka àárín: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🖕🏿">adúláwɔ̀ | ìka | ìka àárín | ìka àárín: adúláwɔ̀ | ɔwɔ́</annotation>
+		<annotation cp="🖕🏿">adúláwɔ̀ | ìka | ìka àárín | ɔwɔ́</annotation>
 		<annotation cp="🖕🏿" type="tts">ìka àárín: adúláwɔ̀</annotation>
-		<annotation cp="👇🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: amɔ́lára | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="👇🏻">amɔ́lára | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="👇🏻" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: amɔ́lára</annotation>
-		<annotation cp="👇🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: amɔ́lára díɛ̀ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="👇🏼">amɔ́lára díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="👇🏼" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👇🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: amɔ́láwɔ̀ díɛ̀ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="👇🏽">amɔ́láwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="👇🏽" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👇🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: adúláwɔ̀ díɛ̀ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="👇🏾">adúláwɔ̀ díɛ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="👇🏾" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👇🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: adúláwɔ̀ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="👇🏿">adúláwɔ̀ | ɛ̀yìn ɔwɔ́ | Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ | ìka | ìka kékeré | ìsàlɛ̀ | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="👇🏿" type="tts">Ɛyin Ɔwɔ Ti O Tɔka Si Isalɛ: adúláwɔ̀</annotation>
-		<annotation cp="☝🏻">amɔ́lára | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ìka kékeré tí ń tɔ́ka sókè: amɔ́lára | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="☝🏻">amɔ́lára | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="☝🏻" type="tts">ìka kékeré tí ń tɔ́ka sókè: amɔ́lára</annotation>
-		<annotation cp="☝🏼">amɔ́lára díɛ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ìka kékeré tí ń tɔ́ka sókè: amɔ́lára díɛ̀ | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="☝🏼">amɔ́lára díɛ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="☝🏼" type="tts">ìka kékeré tí ń tɔ́ka sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="☝🏽">amɔ́láwɔ̀ díɛ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ìka kékeré tí ń tɔ́ka sókè: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="☝🏽">amɔ́láwɔ̀ díɛ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="☝🏽" type="tts">ìka kékeré tí ń tɔ́ka sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="☝🏾">adúláwɔ̀ díɛ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ìka kékeré tí ń tɔ́ka sókè: adúláwɔ̀ díɛ̀ | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="☝🏾">adúláwɔ̀ díɛ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="☝🏾" type="tts">ìka kékeré tí ń tɔ́ka sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="☝🏿">adúláwɔ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ìka kékeré tí ń tɔ́ka sókè: adúláwɔ̀ | ɔwɔ́ | sókè | tɔ́ka</annotation>
+		<annotation cp="☝🏿">adúláwɔ̀ | ìka | ìka kékeré | ìka kékeré tí ń tɔ́ka sókè | ɔwɔ́ | sókè | tɔ́ka</annotation>
 		<annotation cp="☝🏿" type="tts">ìka kékeré tí ń tɔ́ka sókè: adúláwɔ̀</annotation>
-		<annotation cp="🫵🏻">amɔ́lára | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran | títɔ́ka sí olùwòran: amɔ́lára</annotation>
+		<annotation cp="🫵🏻">amɔ́lára | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran</annotation>
 		<annotation cp="🫵🏻" type="tts">títɔ́ka sí olùwòran: amɔ́lára</annotation>
-		<annotation cp="🫵🏼">amɔ́lára díɛ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran | títɔ́ka sí olùwòran: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🫵🏼">amɔ́lára díɛ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran</annotation>
 		<annotation cp="🫵🏼" type="tts">títɔ́ka sí olùwòran: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫵🏽">amɔ́láwɔ̀ díɛ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran | títɔ́ka sí olùwòran: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫵🏽">amɔ́láwɔ̀ díɛ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran</annotation>
 		<annotation cp="🫵🏽" type="tts">títɔ́ka sí olùwòran: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫵🏾">adúláwɔ̀ díɛ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran | títɔ́ka sí olùwòran: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫵🏾">adúláwɔ̀ díɛ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran</annotation>
 		<annotation cp="🫵🏾" type="tts">títɔ́ka sí olùwòran: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫵🏿">adúláwɔ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran | títɔ́ka sí olùwòran: adúláwɔ̀</annotation>
+		<annotation cp="🫵🏿">adúláwɔ̀ | idi | iwo | nina owo kekere si oluworan | títɔ́ka sí olùwòran</annotation>
 		<annotation cp="🫵🏿" type="tts">títɔ́ka sí olùwòran: adúláwɔ̀</annotation>
-		<annotation cp="👍🏻">+1 | amɔ́lára | àtànpàkò | Atanpako Loke | Atanpako Loke: amɔ́lára | òkè | ɔwɔ́</annotation>
+		<annotation cp="👍🏻">+1 | amɔ́lára | àtànpàkò | Atanpako Loke | òkè | ɔwɔ́</annotation>
 		<annotation cp="👍🏻" type="tts">Atanpako Loke: amɔ́lára</annotation>
-		<annotation cp="👍🏼">+1 | amɔ́lára díɛ̀ | àtànpàkò | Atanpako Loke | Atanpako Loke: amɔ́lára díɛ̀ | òkè | ɔwɔ́</annotation>
+		<annotation cp="👍🏼">+1 | amɔ́lára díɛ̀ | àtànpàkò | Atanpako Loke | òkè | ɔwɔ́</annotation>
 		<annotation cp="👍🏼" type="tts">Atanpako Loke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👍🏽">+1 | amɔ́láwɔ̀ díɛ̀ | àtànpàkò | Atanpako Loke | Atanpako Loke: amɔ́láwɔ̀ díɛ̀ | òkè | ɔwɔ́</annotation>
+		<annotation cp="👍🏽">+1 | amɔ́láwɔ̀ díɛ̀ | àtànpàkò | Atanpako Loke | òkè | ɔwɔ́</annotation>
 		<annotation cp="👍🏽" type="tts">Atanpako Loke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👍🏾">+1 | adúláwɔ̀ díɛ̀ | àtànpàkò | Atanpako Loke | Atanpako Loke: adúláwɔ̀ díɛ̀ | òkè | ɔwɔ́</annotation>
+		<annotation cp="👍🏾">+1 | adúláwɔ̀ díɛ̀ | àtànpàkò | Atanpako Loke | òkè | ɔwɔ́</annotation>
 		<annotation cp="👍🏾" type="tts">Atanpako Loke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👍🏿">+1 | adúláwɔ̀ | àtànpàkò | Atanpako Loke | Atanpako Loke: adúláwɔ̀ | òkè | ɔwɔ́</annotation>
+		<annotation cp="👍🏿">+1 | adúláwɔ̀ | àtànpàkò | Atanpako Loke | òkè | ɔwɔ́</annotation>
 		<annotation cp="👍🏿" type="tts">Atanpako Loke: adúláwɔ̀</annotation>
-		<annotation cp="👎🏻">-1 | amɔ́lára | àtànpàkò | Atanpako Nisalɛ | Atanpako Nisalɛ: amɔ́lára | ìsàlɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👎🏻">-1 | amɔ́lára | àtànpàkò | Atanpako Nisalɛ | ìsàlɛ̀ | ɔwɔ́</annotation>
 		<annotation cp="👎🏻" type="tts">Atanpako Nisalɛ: amɔ́lára</annotation>
-		<annotation cp="👎🏼">-1 | amɔ́lára díɛ̀ | àtànpàkò | Atanpako Nisalɛ | Atanpako Nisalɛ: amɔ́lára díɛ̀ | ìsàlɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👎🏼">-1 | amɔ́lára díɛ̀ | àtànpàkò | Atanpako Nisalɛ | ìsàlɛ̀ | ɔwɔ́</annotation>
 		<annotation cp="👎🏼" type="tts">Atanpako Nisalɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👎🏽">-1 | amɔ́láwɔ̀ díɛ̀ | àtànpàkò | Atanpako Nisalɛ | Atanpako Nisalɛ: amɔ́láwɔ̀ díɛ̀ | ìsàlɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👎🏽">-1 | amɔ́láwɔ̀ díɛ̀ | àtànpàkò | Atanpako Nisalɛ | ìsàlɛ̀ | ɔwɔ́</annotation>
 		<annotation cp="👎🏽" type="tts">Atanpako Nisalɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👎🏾">-1 | adúláwɔ̀ díɛ̀ | àtànpàkò | Atanpako Nisalɛ | Atanpako Nisalɛ: adúláwɔ̀ díɛ̀ | ìsàlɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👎🏾">-1 | adúláwɔ̀ díɛ̀ | àtànpàkò | Atanpako Nisalɛ | ìsàlɛ̀ | ɔwɔ́</annotation>
 		<annotation cp="👎🏾" type="tts">Atanpako Nisalɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👎🏿">-1 | adúláwɔ̀ | àtànpàkò | Atanpako Nisalɛ | Atanpako Nisalɛ: adúláwɔ̀ | ìsàlɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="👎🏿">-1 | adúláwɔ̀ | àtànpàkò | Atanpako Nisalɛ | ìsàlɛ̀ | ɔwɔ́</annotation>
 		<annotation cp="👎🏿" type="tts">Atanpako Nisalɛ: adúláwɔ̀</annotation>
-		<annotation cp="✊🏻">amɔ́lára | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | Nashɛ Soke: amɔ́lára | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="✊🏻">amɔ́lára | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="✊🏻" type="tts">Nashɛ Soke: amɔ́lára</annotation>
-		<annotation cp="✊🏼">amɔ́lára díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | Nashɛ Soke: amɔ́lára díɛ̀ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="✊🏼">amɔ́lára díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="✊🏼" type="tts">Nashɛ Soke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="✊🏽">amɔ́láwɔ̀ díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | Nashɛ Soke: amɔ́láwɔ̀ díɛ̀ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="✊🏽">amɔ́láwɔ̀ díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="✊🏽" type="tts">Nashɛ Soke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="✊🏾">adúláwɔ̀ díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | Nashɛ Soke: adúláwɔ̀ díɛ̀ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="✊🏾">adúláwɔ̀ díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="✊🏾" type="tts">Nashɛ Soke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="✊🏿">adúláwɔ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | Nashɛ Soke: adúláwɔ̀ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="✊🏿">adúláwɔ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | Nashɛ Soke | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="✊🏿" type="tts">Nashɛ Soke: adúláwɔ̀</annotation>
-		<annotation cp="👊🏻">amɔ́lára | Ɛshɛ Ti o Nbɔ | Ɛshɛ Ti o Nbɔ: amɔ́lára | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="👊🏻">amɔ́lára | Ɛshɛ Ti o Nbɔ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="👊🏻" type="tts">Ɛshɛ Ti o Nbɔ: amɔ́lára</annotation>
-		<annotation cp="👊🏼">amɔ́lára díɛ̀ | Ɛshɛ Ti o Nbɔ | Ɛshɛ Ti o Nbɔ: amɔ́lára díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="👊🏼">amɔ́lára díɛ̀ | Ɛshɛ Ti o Nbɔ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="👊🏼" type="tts">Ɛshɛ Ti o Nbɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👊🏽">amɔ́láwɔ̀ díɛ̀ | Ɛshɛ Ti o Nbɔ | Ɛshɛ Ti o Nbɔ: amɔ́láwɔ̀ díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="👊🏽">amɔ́láwɔ̀ díɛ̀ | Ɛshɛ Ti o Nbɔ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="👊🏽" type="tts">Ɛshɛ Ti o Nbɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👊🏾">adúláwɔ̀ díɛ̀ | Ɛshɛ Ti o Nbɔ | Ɛshɛ Ti o Nbɔ: adúláwɔ̀ díɛ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="👊🏾">adúláwɔ̀ díɛ̀ | Ɛshɛ Ti o Nbɔ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="👊🏾" type="tts">Ɛshɛ Ti o Nbɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👊🏿">adúláwɔ̀ | Ɛshɛ Ti o Nbɔ | Ɛshɛ Ti o Nbɔ: adúláwɔ̀ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
+		<annotation cp="👊🏿">adúláwɔ̀ | Ɛshɛ Ti o Nbɔ | fún ɔwɔ́ pɔ̀ | ìshɛ́ | òwɔ́ ɛ̀shɛ́</annotation>
 		<annotation cp="👊🏿" type="tts">Ɛshɛ Ti o Nbɔ: adúláwɔ̀</annotation>
-		<annotation cp="🤛🏻">amɔ́lára | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | Ɛsɛ ti O Kɔju sosi: amɔ́lára | ɛ̀shɛ́</annotation>
+		<annotation cp="🤛🏻">amɔ́lára | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | ɛ̀shɛ́</annotation>
 		<annotation cp="🤛🏻" type="tts">Ɛsɛ ti O Kɔju sosi: amɔ́lára</annotation>
-		<annotation cp="🤛🏼">amɔ́lára díɛ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | Ɛsɛ ti O Kɔju sosi: amɔ́lára díɛ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤛🏼">amɔ́lára díɛ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | ɛ̀shɛ́</annotation>
 		<annotation cp="🤛🏼" type="tts">Ɛsɛ ti O Kɔju sosi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤛🏽">amɔ́láwɔ̀ díɛ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | Ɛsɛ ti O Kɔju sosi: amɔ́láwɔ̀ díɛ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤛🏽">amɔ́láwɔ̀ díɛ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | ɛ̀shɛ́</annotation>
 		<annotation cp="🤛🏽" type="tts">Ɛsɛ ti O Kɔju sosi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤛🏾">adúláwɔ̀ díɛ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | Ɛsɛ ti O Kɔju sosi: adúláwɔ̀ díɛ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤛🏾">adúláwɔ̀ díɛ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | ɛ̀shɛ́</annotation>
 		<annotation cp="🤛🏾" type="tts">Ɛsɛ ti O Kɔju sosi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤛🏿">adúláwɔ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | Ɛsɛ ti O Kɔju sosi: adúláwɔ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤛🏿">adúláwɔ̀ | apá ɔ̀sì | Ɛsɛ ti O Kɔju sosi | ɛ̀shɛ́</annotation>
 		<annotation cp="🤛🏿" type="tts">Ɛsɛ ti O Kɔju sosi: adúláwɔ̀</annotation>
-		<annotation cp="🤜🏻">amɔ́lára | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | Ɛsɛ ti O Kɔju sɔtun: amɔ́lára | ɛ̀shɛ́</annotation>
+		<annotation cp="🤜🏻">amɔ́lára | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | ɛ̀shɛ́</annotation>
 		<annotation cp="🤜🏻" type="tts">Ɛsɛ ti O Kɔju sɔtun: amɔ́lára</annotation>
-		<annotation cp="🤜🏼">amɔ́lára díɛ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | Ɛsɛ ti O Kɔju sɔtun: amɔ́lára díɛ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤜🏼">amɔ́lára díɛ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | ɛ̀shɛ́</annotation>
 		<annotation cp="🤜🏼" type="tts">Ɛsɛ ti O Kɔju sɔtun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤜🏽">amɔ́láwɔ̀ díɛ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | Ɛsɛ ti O Kɔju sɔtun: amɔ́láwɔ̀ díɛ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤜🏽">amɔ́láwɔ̀ díɛ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | ɛ̀shɛ́</annotation>
 		<annotation cp="🤜🏽" type="tts">Ɛsɛ ti O Kɔju sɔtun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤜🏾">adúláwɔ̀ díɛ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | Ɛsɛ ti O Kɔju sɔtun: adúláwɔ̀ díɛ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤜🏾">adúláwɔ̀ díɛ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | ɛ̀shɛ́</annotation>
 		<annotation cp="🤜🏾" type="tts">Ɛsɛ ti O Kɔju sɔtun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤜🏿">adúláwɔ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | Ɛsɛ ti O Kɔju sɔtun: adúláwɔ̀ | ɛ̀shɛ́</annotation>
+		<annotation cp="🤜🏿">adúláwɔ̀ | apá ɔ̀tún | Ɛsɛ ti O Kɔju sɔtun | ɛ̀shɛ́</annotation>
 		<annotation cp="🤜🏿" type="tts">Ɛsɛ ti O Kɔju sɔtun: adúláwɔ̀</annotation>
-		<annotation cp="👏🏻">amɔ́lára | N Patɛwɔ | N Patɛwɔ: amɔ́lára | ɔwɔ́ | pàtɛ́wɔ́</annotation>
+		<annotation cp="👏🏻">amɔ́lára | N Patɛwɔ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
 		<annotation cp="👏🏻" type="tts">N Patɛwɔ: amɔ́lára</annotation>
-		<annotation cp="👏🏼">amɔ́lára díɛ̀ | N Patɛwɔ | N Patɛwɔ: amɔ́lára díɛ̀ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
+		<annotation cp="👏🏼">amɔ́lára díɛ̀ | N Patɛwɔ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
 		<annotation cp="👏🏼" type="tts">N Patɛwɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👏🏽">amɔ́láwɔ̀ díɛ̀ | N Patɛwɔ | N Patɛwɔ: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
+		<annotation cp="👏🏽">amɔ́láwɔ̀ díɛ̀ | N Patɛwɔ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
 		<annotation cp="👏🏽" type="tts">N Patɛwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👏🏾">adúláwɔ̀ díɛ̀ | N Patɛwɔ | N Patɛwɔ: adúláwɔ̀ díɛ̀ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
+		<annotation cp="👏🏾">adúláwɔ̀ díɛ̀ | N Patɛwɔ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
 		<annotation cp="👏🏾" type="tts">N Patɛwɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👏🏿">adúláwɔ̀ | N Patɛwɔ | N Patɛwɔ: adúláwɔ̀ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
+		<annotation cp="👏🏿">adúláwɔ̀ | N Patɛwɔ | ɔwɔ́ | pàtɛ́wɔ́</annotation>
 		<annotation cp="👏🏿" type="tts">N Patɛwɔ: adúláwɔ̀</annotation>
-		<annotation cp="🙌🏻">amɔ́lára | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | Ina Awɔn Ɔwɔ: amɔ́lára | nawɔ́ | ɔwɔ́</annotation>
+		<annotation cp="🙌🏻">amɔ́lára | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | nawɔ́ | ɔwɔ́</annotation>
 		<annotation cp="🙌🏻" type="tts">Ina Awɔn Ɔwɔ: amɔ́lára</annotation>
-		<annotation cp="🙌🏼">amɔ́lára díɛ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | Ina Awɔn Ɔwɔ: amɔ́lára díɛ̀ | nawɔ́ | ɔwɔ́</annotation>
+		<annotation cp="🙌🏼">amɔ́lára díɛ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | nawɔ́ | ɔwɔ́</annotation>
 		<annotation cp="🙌🏼" type="tts">Ina Awɔn Ɔwɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙌🏽">amɔ́láwɔ̀ díɛ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | Ina Awɔn Ɔwɔ: amɔ́láwɔ̀ díɛ̀ | nawɔ́ | ɔwɔ́</annotation>
+		<annotation cp="🙌🏽">amɔ́láwɔ̀ díɛ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | nawɔ́ | ɔwɔ́</annotation>
 		<annotation cp="🙌🏽" type="tts">Ina Awɔn Ɔwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙌🏾">adúláwɔ̀ díɛ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | Ina Awɔn Ɔwɔ: adúláwɔ̀ díɛ̀ | nawɔ́ | ɔwɔ́</annotation>
+		<annotation cp="🙌🏾">adúláwɔ̀ díɛ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | nawɔ́ | ɔwɔ́</annotation>
 		<annotation cp="🙌🏾" type="tts">Ina Awɔn Ɔwɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙌🏿">adúláwɔ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | Ina Awɔn Ɔwɔ: adúláwɔ̀ | nawɔ́ | ɔwɔ́</annotation>
+		<annotation cp="🙌🏿">adúláwɔ̀ | ayɛyɛ | fɔwɔ́júwè | hooray | Ina Awɔn Ɔwɔ | nawɔ́ | ɔwɔ́</annotation>
 		<annotation cp="🙌🏿" type="tts">Ina Awɔn Ɔwɔ: adúláwɔ̀</annotation>
-		<annotation cp="🫶🏻">amɔ́lára | ìfɛ́ | ɔwɔ́ ɔkàn | ɔwɔ́ ɔkàn: amɔ́lára</annotation>
+		<annotation cp="🫶🏻">amɔ́lára | ìfɛ́ | ɔwɔ́ ɔkàn</annotation>
 		<annotation cp="🫶🏻" type="tts">ɔwɔ́ ɔkàn: amɔ́lára</annotation>
-		<annotation cp="🫶🏼">amɔ́lára díɛ̀ | ìfɛ́ | ɔwɔ́ ɔkàn | ɔwɔ́ ɔkàn: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🫶🏼">amɔ́lára díɛ̀ | ìfɛ́ | ɔwɔ́ ɔkàn</annotation>
 		<annotation cp="🫶🏼" type="tts">ɔwɔ́ ɔkàn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫶🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | ɔwɔ́ ɔkàn | ɔwɔ́ ɔkàn: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫶🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | ɔwɔ́ ɔkàn</annotation>
 		<annotation cp="🫶🏽" type="tts">ɔwɔ́ ɔkàn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫶🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | ɔwɔ́ ɔkàn | ɔwɔ́ ɔkàn: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🫶🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | ɔwɔ́ ɔkàn</annotation>
 		<annotation cp="🫶🏾" type="tts">ɔwɔ́ ɔkàn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫶🏿">adúláwɔ̀ | ìfɛ́ | ɔwɔ́ ɔkàn | ɔwɔ́ ɔkàn: adúláwɔ̀</annotation>
+		<annotation cp="🫶🏿">adúláwɔ̀ | ìfɛ́ | ɔwɔ́ ɔkàn</annotation>
 		<annotation cp="🫶🏿" type="tts">ɔwɔ́ ɔkàn: adúláwɔ̀</annotation>
-		<annotation cp="👐🏻">amɔ́lára | Awɔn Ɔwɔ Shishi | Awɔn Ɔwɔ Shishi: amɔ́lára | ɔwɔ́ | shí</annotation>
+		<annotation cp="👐🏻">amɔ́lára | Awɔn Ɔwɔ Shishi | ɔwɔ́ | shí</annotation>
 		<annotation cp="👐🏻" type="tts">Awɔn Ɔwɔ Shishi: amɔ́lára</annotation>
-		<annotation cp="👐🏼">amɔ́lára díɛ̀ | Awɔn Ɔwɔ Shishi | Awɔn Ɔwɔ Shishi: amɔ́lára díɛ̀ | ɔwɔ́ | shí</annotation>
+		<annotation cp="👐🏼">amɔ́lára díɛ̀ | Awɔn Ɔwɔ Shishi | ɔwɔ́ | shí</annotation>
 		<annotation cp="👐🏼" type="tts">Awɔn Ɔwɔ Shishi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👐🏽">amɔ́láwɔ̀ díɛ̀ | Awɔn Ɔwɔ Shishi | Awɔn Ɔwɔ Shishi: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | shí</annotation>
+		<annotation cp="👐🏽">amɔ́láwɔ̀ díɛ̀ | Awɔn Ɔwɔ Shishi | ɔwɔ́ | shí</annotation>
 		<annotation cp="👐🏽" type="tts">Awɔn Ɔwɔ Shishi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👐🏾">adúláwɔ̀ díɛ̀ | Awɔn Ɔwɔ Shishi | Awɔn Ɔwɔ Shishi: adúláwɔ̀ díɛ̀ | ɔwɔ́ | shí</annotation>
+		<annotation cp="👐🏾">adúláwɔ̀ díɛ̀ | Awɔn Ɔwɔ Shishi | ɔwɔ́ | shí</annotation>
 		<annotation cp="👐🏾" type="tts">Awɔn Ɔwɔ Shishi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👐🏿">adúláwɔ̀ | Awɔn Ɔwɔ Shishi | Awɔn Ɔwɔ Shishi: adúláwɔ̀ | ɔwɔ́ | shí</annotation>
+		<annotation cp="👐🏿">adúláwɔ̀ | Awɔn Ɔwɔ Shishi | ɔwɔ́ | shí</annotation>
 		<annotation cp="👐🏿" type="tts">Awɔn Ɔwɔ Shishi: adúláwɔ̀</annotation>
-		<annotation cp="🤲🏻">àdúrà | amɔ́lára | àtɛ́lɛ́ɔwɔ́ papɔ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀: amɔ́lára</annotation>
+		<annotation cp="🤲🏻">àdúrà | amɔ́lára | àtɛ́lɛ́ɔwɔ́ papɔ̀</annotation>
 		<annotation cp="🤲🏻" type="tts">àtɛ́lɛ́ɔwɔ́ papɔ̀: amɔ́lára</annotation>
-		<annotation cp="🤲🏼">àdúrà | amɔ́lára díɛ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤲🏼">àdúrà | amɔ́lára díɛ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀</annotation>
 		<annotation cp="🤲🏼" type="tts">àtɛ́lɛ́ɔwɔ́ papɔ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤲🏽">àdúrà | amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤲🏽">àdúrà | amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀</annotation>
 		<annotation cp="🤲🏽" type="tts">àtɛ́lɛ́ɔwɔ́ papɔ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤲🏾">adúláwɔ̀ díɛ̀ | àdúrà | àtɛ́lɛ́ɔwɔ́ papɔ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤲🏾">adúláwɔ̀ díɛ̀ | àdúrà | àtɛ́lɛ́ɔwɔ́ papɔ̀</annotation>
 		<annotation cp="🤲🏾" type="tts">àtɛ́lɛ́ɔwɔ́ papɔ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤲🏿">adúláwɔ̀ | àdúrà | àtɛ́lɛ́ɔwɔ́ papɔ̀ | àtɛ́lɛ́ɔwɔ́ papɔ̀: adúláwɔ̀</annotation>
+		<annotation cp="🤲🏿">adúláwɔ̀ | àdúrà | àtɛ́lɛ́ɔwɔ́ papɔ̀</annotation>
 		<annotation cp="🤲🏿" type="tts">àtɛ́lɛ́ɔwɔ́ papɔ̀: adúláwɔ̀</annotation>
-		<annotation cp="🤝🏻">amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🤝🏻">amɔ́lára | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🤝🏻" type="tts">Ìbɔwɔ́: amɔ́lára</annotation>
-		<annotation cp="🤝🏼">amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́lára díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🤝🏼">amɔ́lára díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🤝🏼" type="tts">Ìbɔwɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤝🏽">amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🤝🏽">amɔ́láwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🤝🏽" type="tts">Ìbɔwɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤝🏾">adúláwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀ díɛ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🤝🏾">adúláwɔ̀ díɛ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🤝🏾" type="tts">Ìbɔwɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤝🏿">adúláwɔ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | Ìbɔwɔ́: adúláwɔ̀ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
+		<annotation cp="🤝🏿">adúláwɔ̀ | gbɔn | ìbɔwɔ́ | Ìbɔwɔ́ | ìfaramɔ́ | ìpàdé | ɔwɔ</annotation>
 		<annotation cp="🤝🏿" type="tts">Ìbɔwɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🙏🏻">adúpé | amɔ́lára | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | Ika Awɔn Ɔwɔ: amɔ́lára | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
+		<annotation cp="🙏🏻">adúpé | amɔ́lára | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
 		<annotation cp="🙏🏻" type="tts">Ika Awɔn Ɔwɔ: amɔ́lára</annotation>
-		<annotation cp="🙏🏼">adúpé | amɔ́lára díɛ̀ | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | Ika Awɔn Ɔwɔ: amɔ́lára díɛ̀ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
+		<annotation cp="🙏🏼">adúpé | amɔ́lára díɛ̀ | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
 		<annotation cp="🙏🏼" type="tts">Ika Awɔn Ɔwɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙏🏽">adúpé | amɔ́láwɔ̀ díɛ̀ | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | Ika Awɔn Ɔwɔ: amɔ́láwɔ̀ díɛ̀ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
+		<annotation cp="🙏🏽">adúpé | amɔ́láwɔ̀ díɛ̀ | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
 		<annotation cp="🙏🏽" type="tts">Ika Awɔn Ɔwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙏🏾">adúláwɔ̀ díɛ̀ | adúpé | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | Ika Awɔn Ɔwɔ: adúláwɔ̀ díɛ̀ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
+		<annotation cp="🙏🏾">adúláwɔ̀ díɛ̀ | adúpé | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
 		<annotation cp="🙏🏾" type="tts">Ika Awɔn Ɔwɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙏🏿">adúláwɔ̀ | adúpé | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | Ika Awɔn Ɔwɔ: adúláwɔ̀ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
+		<annotation cp="🙏🏿">adúláwɔ̀ | adúpé | bèrè | fɔwɔ́júwè | gbèdúrà | Ika Awɔn Ɔwɔ | jɔ̀wɔ́ | kákò | ɔwɔ́ | tɛríba</annotation>
 		<annotation cp="🙏🏿" type="tts">Ika Awɔn Ɔwɔ: adúláwɔ̀</annotation>
-		<annotation cp="✍🏻">amɔ́lára | kɔ̀wé | ńkɔ́wé | ńkɔ́wé: amɔ́lára | ɔwɔ́</annotation>
+		<annotation cp="✍🏻">amɔ́lára | kɔ̀wé | ńkɔ́wé | ɔwɔ́</annotation>
 		<annotation cp="✍🏻" type="tts">ńkɔ́wé: amɔ́lára</annotation>
-		<annotation cp="✍🏼">amɔ́lára díɛ̀ | kɔ̀wé | ńkɔ́wé | ńkɔ́wé: amɔ́lára díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="✍🏼">amɔ́lára díɛ̀ | kɔ̀wé | ńkɔ́wé | ɔwɔ́</annotation>
 		<annotation cp="✍🏼" type="tts">ńkɔ́wé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="✍🏽">amɔ́láwɔ̀ díɛ̀ | kɔ̀wé | ńkɔ́wé | ńkɔ́wé: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="✍🏽">amɔ́láwɔ̀ díɛ̀ | kɔ̀wé | ńkɔ́wé | ɔwɔ́</annotation>
 		<annotation cp="✍🏽" type="tts">ńkɔ́wé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="✍🏾">adúláwɔ̀ díɛ̀ | kɔ̀wé | ńkɔ́wé | ńkɔ́wé: adúláwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="✍🏾">adúláwɔ̀ díɛ̀ | kɔ̀wé | ńkɔ́wé | ɔwɔ́</annotation>
 		<annotation cp="✍🏾" type="tts">ńkɔ́wé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="✍🏿">adúláwɔ̀ | kɔ̀wé | ńkɔ́wé | ńkɔ́wé: adúláwɔ̀ | ɔwɔ́</annotation>
+		<annotation cp="✍🏿">adúláwɔ̀ | kɔ̀wé | ńkɔ́wé | ɔwɔ́</annotation>
 		<annotation cp="✍🏿" type="tts">ńkɔ́wé: adúláwɔ̀</annotation>
-		<annotation cp="💅🏻">àkun ojú | amɔ́lára | asharalóge | èékánná | Ikun Eekanna | Ikun Eekanna: amɔ́lára | ìtɔ́jú | kíkùn</annotation>
+		<annotation cp="💅🏻">àkun ojú | amɔ́lára | asharalóge | èékánná | Ikun Eekanna | ìtɔ́jú | kíkùn</annotation>
 		<annotation cp="💅🏻" type="tts">Ikun Eekanna: amɔ́lára</annotation>
-		<annotation cp="💅🏼">àkun ojú | amɔ́lára díɛ̀ | asharalóge | èékánná | Ikun Eekanna | Ikun Eekanna: amɔ́lára díɛ̀ | ìtɔ́jú | kíkùn</annotation>
+		<annotation cp="💅🏼">àkun ojú | amɔ́lára díɛ̀ | asharalóge | èékánná | Ikun Eekanna | ìtɔ́jú | kíkùn</annotation>
 		<annotation cp="💅🏼" type="tts">Ikun Eekanna: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💅🏽">àkun ojú | amɔ́láwɔ̀ díɛ̀ | asharalóge | èékánná | Ikun Eekanna | Ikun Eekanna: amɔ́láwɔ̀ díɛ̀ | ìtɔ́jú | kíkùn</annotation>
+		<annotation cp="💅🏽">àkun ojú | amɔ́láwɔ̀ díɛ̀ | asharalóge | èékánná | Ikun Eekanna | ìtɔ́jú | kíkùn</annotation>
 		<annotation cp="💅🏽" type="tts">Ikun Eekanna: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💅🏾">adúláwɔ̀ díɛ̀ | àkun ojú | asharalóge | èékánná | Ikun Eekanna | Ikun Eekanna: adúláwɔ̀ díɛ̀ | ìtɔ́jú | kíkùn</annotation>
+		<annotation cp="💅🏾">adúláwɔ̀ díɛ̀ | àkun ojú | asharalóge | èékánná | Ikun Eekanna | ìtɔ́jú | kíkùn</annotation>
 		<annotation cp="💅🏾" type="tts">Ikun Eekanna: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💅🏿">adúláwɔ̀ | àkun ojú | asharalóge | èékánná | Ikun Eekanna | Ikun Eekanna: adúláwɔ̀ | ìtɔ́jú | kíkùn</annotation>
+		<annotation cp="💅🏿">adúláwɔ̀ | àkun ojú | asharalóge | èékánná | Ikun Eekanna | ìtɔ́jú | kíkùn</annotation>
 		<annotation cp="💅🏿" type="tts">Ikun Eekanna: adúláwɔ̀</annotation>
-		<annotation cp="🤳🏻">amɔ́lára | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni | Yiya Ara ɛni: amɔ́lára</annotation>
+		<annotation cp="🤳🏻">amɔ́lára | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni</annotation>
 		<annotation cp="🤳🏻" type="tts">Yiya Ara ɛni: amɔ́lára</annotation>
-		<annotation cp="🤳🏼">amɔ́lára díɛ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni | Yiya Ara ɛni: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤳🏼">amɔ́lára díɛ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni</annotation>
 		<annotation cp="🤳🏼" type="tts">Yiya Ara ɛni: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤳🏽">amɔ́láwɔ̀ díɛ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni | Yiya Ara ɛni: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤳🏽">amɔ́láwɔ̀ díɛ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni</annotation>
 		<annotation cp="🤳🏽" type="tts">Yiya Ara ɛni: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤳🏾">adúláwɔ̀ díɛ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni | Yiya Ara ɛni: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤳🏾">adúláwɔ̀ díɛ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni</annotation>
 		<annotation cp="🤳🏾" type="tts">Yiya Ara ɛni: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤳🏿">adúláwɔ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni | Yiya Ara ɛni: adúláwɔ̀</annotation>
+		<annotation cp="🤳🏿">adúláwɔ̀ | fóònù | fɔ́tò àdáyà | kámɛ́rà | Yiya Ara ɛni</annotation>
 		<annotation cp="🤳🏿" type="tts">Yiya Ara ɛni: adúláwɔ̀</annotation>
-		<annotation cp="💪🏻">amɔ́lára | àwàdà | Aya Fifɛ | Aya Fifɛ: amɔ́lára | egun ɔwɔ́ | ishan | nà</annotation>
+		<annotation cp="💪🏻">amɔ́lára | àwàdà | Aya Fifɛ | egun ɔwɔ́ | ishan | nà</annotation>
 		<annotation cp="💪🏻" type="tts">Aya Fifɛ: amɔ́lára</annotation>
-		<annotation cp="💪🏼">amɔ́lára díɛ̀ | àwàdà | Aya Fifɛ | Aya Fifɛ: amɔ́lára díɛ̀ | egun ɔwɔ́ | ishan | nà</annotation>
+		<annotation cp="💪🏼">amɔ́lára díɛ̀ | àwàdà | Aya Fifɛ | egun ɔwɔ́ | ishan | nà</annotation>
 		<annotation cp="💪🏼" type="tts">Aya Fifɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💪🏽">amɔ́láwɔ̀ díɛ̀ | àwàdà | Aya Fifɛ | Aya Fifɛ: amɔ́láwɔ̀ díɛ̀ | egun ɔwɔ́ | ishan | nà</annotation>
+		<annotation cp="💪🏽">amɔ́láwɔ̀ díɛ̀ | àwàdà | Aya Fifɛ | egun ɔwɔ́ | ishan | nà</annotation>
 		<annotation cp="💪🏽" type="tts">Aya Fifɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💪🏾">adúláwɔ̀ díɛ̀ | àwàdà | Aya Fifɛ | Aya Fifɛ: adúláwɔ̀ díɛ̀ | egun ɔwɔ́ | ishan | nà</annotation>
+		<annotation cp="💪🏾">adúláwɔ̀ díɛ̀ | àwàdà | Aya Fifɛ | egun ɔwɔ́ | ishan | nà</annotation>
 		<annotation cp="💪🏾" type="tts">Aya Fifɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💪🏿">adúláwɔ̀ | àwàdà | Aya Fifɛ | Aya Fifɛ: adúláwɔ̀ | egun ɔwɔ́ | ishan | nà</annotation>
+		<annotation cp="💪🏿">adúláwɔ̀ | àwàdà | Aya Fifɛ | egun ɔwɔ́ | ishan | nà</annotation>
 		<annotation cp="💪🏿" type="tts">Aya Fifɛ: adúláwɔ̀</annotation>
-		<annotation cp="🦵🏻">amɔ́lára | ese | ese: amɔ́lára | ɛ́sɛ | gbá</annotation>
+		<annotation cp="🦵🏻">amɔ́lára | ese | ɛ́sɛ | gbá</annotation>
 		<annotation cp="🦵🏻" type="tts">ese: amɔ́lára</annotation>
-		<annotation cp="🦵🏼">amɔ́lára díɛ̀ | ese | ese: amɔ́lára díɛ̀ | ɛ́sɛ | gbá</annotation>
+		<annotation cp="🦵🏼">amɔ́lára díɛ̀ | ese | ɛ́sɛ | gbá</annotation>
 		<annotation cp="🦵🏼" type="tts">ese: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦵🏽">amɔ́láwɔ̀ díɛ̀ | ese | ese: amɔ́láwɔ̀ díɛ̀ | ɛ́sɛ | gbá</annotation>
+		<annotation cp="🦵🏽">amɔ́láwɔ̀ díɛ̀ | ese | ɛ́sɛ | gbá</annotation>
 		<annotation cp="🦵🏽" type="tts">ese: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦵🏾">adúláwɔ̀ díɛ̀ | ese | ese: adúláwɔ̀ díɛ̀ | ɛ́sɛ | gbá</annotation>
+		<annotation cp="🦵🏾">adúláwɔ̀ díɛ̀ | ese | ɛ́sɛ | gbá</annotation>
 		<annotation cp="🦵🏾" type="tts">ese: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦵🏿">adúláwɔ̀ | ese | ese: adúláwɔ̀ | ɛ́sɛ | gbá</annotation>
+		<annotation cp="🦵🏿">adúláwɔ̀ | ese | ɛ́sɛ | gbá</annotation>
 		<annotation cp="🦵🏿" type="tts">ese: adúláwɔ̀</annotation>
-		<annotation cp="🦶🏻">amɔ́lára | ese | ɛsɛ̀ | ɛsɛ̀: amɔ́lára | gba | idiurop</annotation>
+		<annotation cp="🦶🏻">amɔ́lára | ese | ɛsɛ̀ | gba | idiurop</annotation>
 		<annotation cp="🦶🏻" type="tts">ɛsɛ̀: amɔ́lára</annotation>
-		<annotation cp="🦶🏼">amɔ́lára díɛ̀ | ese | ɛsɛ̀ | ɛsɛ̀: amɔ́lára díɛ̀ | gba | idiurop</annotation>
+		<annotation cp="🦶🏼">amɔ́lára díɛ̀ | ese | ɛsɛ̀ | gba | idiurop</annotation>
 		<annotation cp="🦶🏼" type="tts">ɛsɛ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦶🏽">amɔ́láwɔ̀ díɛ̀ | ese | ɛsɛ̀ | ɛsɛ̀: amɔ́láwɔ̀ díɛ̀ | gba | idiurop</annotation>
+		<annotation cp="🦶🏽">amɔ́láwɔ̀ díɛ̀ | ese | ɛsɛ̀ | gba | idiurop</annotation>
 		<annotation cp="🦶🏽" type="tts">ɛsɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦶🏾">adúláwɔ̀ díɛ̀ | ese | ɛsɛ̀ | ɛsɛ̀: adúláwɔ̀ díɛ̀ | gba | idiurop</annotation>
+		<annotation cp="🦶🏾">adúláwɔ̀ díɛ̀ | ese | ɛsɛ̀ | gba | idiurop</annotation>
 		<annotation cp="🦶🏾" type="tts">ɛsɛ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦶🏿">adúláwɔ̀ | ese | ɛsɛ̀ | ɛsɛ̀: adúláwɔ̀ | gba | idiurop</annotation>
+		<annotation cp="🦶🏿">adúláwɔ̀ | ese | ɛsɛ̀ | gba | idiurop</annotation>
 		<annotation cp="🦶🏿" type="tts">ɛsɛ̀: adúláwɔ̀</annotation>
-		<annotation cp="👂🏻">amɔ́lára | Ara | Etí | Etí: amɔ́lára</annotation>
+		<annotation cp="👂🏻">amɔ́lára | Ara | Etí</annotation>
 		<annotation cp="👂🏻" type="tts">Etí: amɔ́lára</annotation>
-		<annotation cp="👂🏼">amɔ́lára díɛ̀ | Ara | Etí | Etí: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👂🏼">amɔ́lára díɛ̀ | Ara | Etí</annotation>
 		<annotation cp="👂🏼" type="tts">Etí: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👂🏽">amɔ́láwɔ̀ díɛ̀ | Ara | Etí | Etí: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👂🏽">amɔ́láwɔ̀ díɛ̀ | Ara | Etí</annotation>
 		<annotation cp="👂🏽" type="tts">Etí: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👂🏾">adúláwɔ̀ díɛ̀ | Ara | Etí | Etí: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👂🏾">adúláwɔ̀ díɛ̀ | Ara | Etí</annotation>
 		<annotation cp="👂🏾" type="tts">Etí: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👂🏿">adúláwɔ̀ | Ara | Etí | Etí: adúláwɔ̀</annotation>
+		<annotation cp="👂🏿">adúláwɔ̀ | Ara | Etí</annotation>
 		<annotation cp="👂🏿" type="tts">Etí: adúláwɔ̀</annotation>
-		<annotation cp="🦻🏻">amɔ́lára | etí pɛ̀lú ohun ìgbɔ́ràn | etí pɛ̀lú ohun ìgbɔ́ràn: amɔ́lára | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
+		<annotation cp="🦻🏻">amɔ́lára | etí pɛ̀lú ohun ìgbɔ́ràn | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
 		<annotation cp="🦻🏻" type="tts">etí pɛ̀lú ohun ìgbɔ́ràn: amɔ́lára</annotation>
-		<annotation cp="🦻🏼">amɔ́lára díɛ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | etí pɛ̀lú ohun ìgbɔ́ràn: amɔ́lára díɛ̀ | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
+		<annotation cp="🦻🏼">amɔ́lára díɛ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
 		<annotation cp="🦻🏼" type="tts">etí pɛ̀lú ohun ìgbɔ́ràn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦻🏽">amɔ́láwɔ̀ díɛ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | etí pɛ̀lú ohun ìgbɔ́ràn: amɔ́láwɔ̀ díɛ̀ | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
+		<annotation cp="🦻🏽">amɔ́láwɔ̀ díɛ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
 		<annotation cp="🦻🏽" type="tts">etí pɛ̀lú ohun ìgbɔ́ràn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦻🏾">adúláwɔ̀ díɛ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | etí pɛ̀lú ohun ìgbɔ́ràn: adúláwɔ̀ díɛ̀ | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
+		<annotation cp="🦻🏾">adúláwɔ̀ díɛ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
 		<annotation cp="🦻🏾" type="tts">etí pɛ̀lú ohun ìgbɔ́ràn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦻🏿">adúláwɔ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | etí pɛ̀lú ohun ìgbɔ́ràn: adúláwɔ̀ | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
+		<annotation cp="🦻🏿">adúláwɔ̀ | etí pɛ̀lú ohun ìgbɔ́ràn | gbɔ̀ pɛ̀lu elo | ona igba</annotation>
 		<annotation cp="🦻🏿" type="tts">etí pɛ̀lú ohun ìgbɔ́ràn: adúláwɔ̀</annotation>
-		<annotation cp="👃🏻">amɔ́lára | Ara | Imu | Imu: amɔ́lára</annotation>
+		<annotation cp="👃🏻">amɔ́lára | Ara | Imu</annotation>
 		<annotation cp="👃🏻" type="tts">Imu: amɔ́lára</annotation>
-		<annotation cp="👃🏼">amɔ́lára díɛ̀ | Ara | Imu | Imu: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👃🏼">amɔ́lára díɛ̀ | Ara | Imu</annotation>
 		<annotation cp="👃🏼" type="tts">Imu: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👃🏽">amɔ́láwɔ̀ díɛ̀ | Ara | Imu | Imu: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👃🏽">amɔ́láwɔ̀ díɛ̀ | Ara | Imu</annotation>
 		<annotation cp="👃🏽" type="tts">Imu: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👃🏾">adúláwɔ̀ díɛ̀ | Ara | Imu | Imu: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👃🏾">adúláwɔ̀ díɛ̀ | Ara | Imu</annotation>
 		<annotation cp="👃🏾" type="tts">Imu: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👃🏿">adúláwɔ̀ | Ara | Imu | Imu: adúláwɔ̀</annotation>
+		<annotation cp="👃🏿">adúláwɔ̀ | Ara | Imu</annotation>
 		<annotation cp="👃🏿" type="tts">Imu: adúláwɔ̀</annotation>
-		<annotation cp="👶🏻">amɔ́lára | ìkókó | ìkókó: amɔ́lára | ɔ̀dɔ́</annotation>
+		<annotation cp="👶🏻">amɔ́lára | ìkókó | ɔ̀dɔ́</annotation>
 		<annotation cp="👶🏻" type="tts">ìkókó: amɔ́lára</annotation>
-		<annotation cp="👶🏼">amɔ́lára díɛ̀ | ìkókó | ìkókó: amɔ́lára díɛ̀ | ɔ̀dɔ́</annotation>
+		<annotation cp="👶🏼">amɔ́lára díɛ̀ | ìkókó | ɔ̀dɔ́</annotation>
 		<annotation cp="👶🏼" type="tts">ìkókó: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👶🏽">amɔ́láwɔ̀ díɛ̀ | ìkókó | ìkókó: amɔ́láwɔ̀ díɛ̀ | ɔ̀dɔ́</annotation>
+		<annotation cp="👶🏽">amɔ́láwɔ̀ díɛ̀ | ìkókó | ɔ̀dɔ́</annotation>
 		<annotation cp="👶🏽" type="tts">ìkókó: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👶🏾">adúláwɔ̀ díɛ̀ | ìkókó | ìkókó: adúláwɔ̀ díɛ̀ | ɔ̀dɔ́</annotation>
+		<annotation cp="👶🏾">adúláwɔ̀ díɛ̀ | ìkókó | ɔ̀dɔ́</annotation>
 		<annotation cp="👶🏾" type="tts">ìkókó: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👶🏿">adúláwɔ̀ | ìkókó | ìkókó: adúláwɔ̀ | ɔ̀dɔ́</annotation>
+		<annotation cp="👶🏿">adúláwɔ̀ | ìkókó | ɔ̀dɔ́</annotation>
 		<annotation cp="👶🏿" type="tts">ìkókó: adúláwɔ̀</annotation>
-		<annotation cp="🧒🏻">amɔ́lára | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ | ɔmɔ: amɔ́lára</annotation>
+		<annotation cp="🧒🏻">amɔ́lára | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ</annotation>
 		<annotation cp="🧒🏻" type="tts">ɔmɔ: amɔ́lára</annotation>
-		<annotation cp="🧒🏼">amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ | ɔmɔ: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧒🏼">amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ</annotation>
 		<annotation cp="🧒🏼" type="tts">ɔmɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧒🏽">amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ | ɔmɔ: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧒🏽">amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ</annotation>
 		<annotation cp="🧒🏽" type="tts">ɔmɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧒🏾">adúláwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ | ɔmɔ: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧒🏾">adúláwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ</annotation>
 		<annotation cp="🧒🏾" type="tts">ɔmɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧒🏿">adúláwɔ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ | ɔmɔ: adúláwɔ̀</annotation>
+		<annotation cp="🧒🏿">adúláwɔ̀ | gé̩ndà-shekushɛyɛ | màjèsín | ɔmɔ</annotation>
 		<annotation cp="🧒🏿" type="tts">ɔmɔ: adúláwɔ̀</annotation>
-		<annotation cp="👦🏻">amɔ́lára | ɔ̀dɔ́ | ɔmɔkùnrin | ɔmɔkùnrin: amɔ́lára</annotation>
+		<annotation cp="👦🏻">amɔ́lára | ɔ̀dɔ́ | ɔmɔkùnrin</annotation>
 		<annotation cp="👦🏻" type="tts">ɔmɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="👦🏼">amɔ́lára díɛ̀ | ɔ̀dɔ́ | ɔmɔkùnrin | ɔmɔkùnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👦🏼">amɔ́lára díɛ̀ | ɔ̀dɔ́ | ɔmɔkùnrin</annotation>
 		<annotation cp="👦🏼" type="tts">ɔmɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👦🏽">amɔ́láwɔ̀ díɛ̀ | ɔ̀dɔ́ | ɔmɔkùnrin | ɔmɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👦🏽">amɔ́láwɔ̀ díɛ̀ | ɔ̀dɔ́ | ɔmɔkùnrin</annotation>
 		<annotation cp="👦🏽" type="tts">ɔmɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👦🏾">adúláwɔ̀ díɛ̀ | ɔ̀dɔ́ | ɔmɔkùnrin | ɔmɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👦🏾">adúláwɔ̀ díɛ̀ | ɔ̀dɔ́ | ɔmɔkùnrin</annotation>
 		<annotation cp="👦🏾" type="tts">ɔmɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👦🏿">adúláwɔ̀ | ɔ̀dɔ́ | ɔmɔkùnrin | ɔmɔkùnrin: adúláwɔ̀</annotation>
+		<annotation cp="👦🏿">adúláwɔ̀ | ɔ̀dɔ́ | ɔmɔkùnrin</annotation>
 		<annotation cp="👦🏿" type="tts">ɔmɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="👧🏻">àmi oshù ìbí | amɔ́lára | ɔ̀dɔ́ | ɔmɔbìrin | ɔmɔbìrin: amɔ́lára | Virgo</annotation>
+		<annotation cp="👧🏻">àmi oshù ìbí | amɔ́lára | ɔ̀dɔ́ | ɔmɔbìrin | Virgo</annotation>
 		<annotation cp="👧🏻" type="tts">ɔmɔbìrin: amɔ́lára</annotation>
-		<annotation cp="👧🏼">àmi oshù ìbí | amɔ́lára díɛ̀ | ɔ̀dɔ́ | ɔmɔbìrin | ɔmɔbìrin: amɔ́lára díɛ̀ | Virgo</annotation>
+		<annotation cp="👧🏼">àmi oshù ìbí | amɔ́lára díɛ̀ | ɔ̀dɔ́ | ɔmɔbìrin | Virgo</annotation>
 		<annotation cp="👧🏼" type="tts">ɔmɔbìrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👧🏽">àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | ɔ̀dɔ́ | ɔmɔbìrin | ɔmɔbìrin: amɔ́láwɔ̀ díɛ̀ | Virgo</annotation>
+		<annotation cp="👧🏽">àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | ɔ̀dɔ́ | ɔmɔbìrin | Virgo</annotation>
 		<annotation cp="👧🏽" type="tts">ɔmɔbìrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👧🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | ɔ̀dɔ́ | ɔmɔbìrin | ɔmɔbìrin: adúláwɔ̀ díɛ̀ | Virgo</annotation>
+		<annotation cp="👧🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | ɔ̀dɔ́ | ɔmɔbìrin | Virgo</annotation>
 		<annotation cp="👧🏾" type="tts">ɔmɔbìrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👧🏿">adúláwɔ̀ | àmi oshù ìbí | ɔ̀dɔ́ | ɔmɔbìrin | ɔmɔbìrin: adúláwɔ̀ | Virgo</annotation>
+		<annotation cp="👧🏿">adúláwɔ̀ | àmi oshù ìbí | ɔ̀dɔ́ | ɔmɔbìrin | Virgo</annotation>
 		<annotation cp="👧🏿" type="tts">ɔmɔbìrin: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻">àgbà | àgbà: amɔ́lára | amɔ́lára | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧑🏻">àgbà | amɔ́lára | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧑🏻" type="tts">àgbà: amɔ́lára</annotation>
-		<annotation cp="🧑🏼">àgbà | àgbà: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧑🏼">àgbà | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧑🏼" type="tts">àgbà: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽">àgbà | àgbà: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧑🏽">àgbà | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧑🏽" type="tts">àgbà: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | àgbà: adúláwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧑🏾" type="tts">àgbà: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿">adúláwɔ̀ | àgbà | àgbà: adúláwɔ̀ | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧑🏿">adúláwɔ̀ | àgbà | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧑🏿" type="tts">àgbà: adúláwɔ̀</annotation>
-		<annotation cp="👱🏻">amɔ́lára | Eniyan Onirun funfun | Eniyan Onirun funfun: amɔ́lára | oníru funfun</annotation>
+		<annotation cp="👱🏻">amɔ́lára | Eniyan Onirun funfun | oníru funfun</annotation>
 		<annotation cp="👱🏻" type="tts">Eniyan Onirun funfun: amɔ́lára</annotation>
-		<annotation cp="👱🏼">amɔ́lára díɛ̀ | Eniyan Onirun funfun | Eniyan Onirun funfun: amɔ́lára díɛ̀ | oníru funfun</annotation>
+		<annotation cp="👱🏼">amɔ́lára díɛ̀ | Eniyan Onirun funfun | oníru funfun</annotation>
 		<annotation cp="👱🏼" type="tts">Eniyan Onirun funfun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👱🏽">amɔ́láwɔ̀ díɛ̀ | Eniyan Onirun funfun | Eniyan Onirun funfun: amɔ́láwɔ̀ díɛ̀ | oníru funfun</annotation>
+		<annotation cp="👱🏽">amɔ́láwɔ̀ díɛ̀ | Eniyan Onirun funfun | oníru funfun</annotation>
 		<annotation cp="👱🏽" type="tts">Eniyan Onirun funfun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👱🏾">adúláwɔ̀ díɛ̀ | Eniyan Onirun funfun | Eniyan Onirun funfun: adúláwɔ̀ díɛ̀ | oníru funfun</annotation>
+		<annotation cp="👱🏾">adúláwɔ̀ díɛ̀ | Eniyan Onirun funfun | oníru funfun</annotation>
 		<annotation cp="👱🏾" type="tts">Eniyan Onirun funfun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👱🏿">adúláwɔ̀ | Eniyan Onirun funfun | Eniyan Onirun funfun: adúláwɔ̀ | oníru funfun</annotation>
+		<annotation cp="👱🏿">adúláwɔ̀ | Eniyan Onirun funfun | oníru funfun</annotation>
 		<annotation cp="👱🏿" type="tts">Eniyan Onirun funfun: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">àgbà | amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼">àgbà | amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏼" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏽" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏾" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍💋‍🧑🏿" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">àgbà | amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻">àgbà | amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏻" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏽" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏾" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍💋‍🧑🏿" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏻" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏼" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏾" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍💋‍🧑🏿" type="tts">Ifɛnuko: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏻" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏼" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏽" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍💋‍🧑🏿" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">adúláwɔ̀ | àgbà | amɔ́lára | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻">adúláwɔ̀ | àgbà | amɔ́lára | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏻" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏼" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏽" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | Ifɛnuko | Ifɛnuko: àgbà, àgbà, adúláwɔ̀, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍💋‍🧑🏾" type="tts">Ifɛnuko: àgbà, àgbà, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏼">àgbà | amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏼">àgbà | amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏽">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏽">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍❤‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍❤‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍❤‍🧑🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏻">àgbà | amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏻">àgbà | amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏽">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏽">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏼‍❤‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍❤‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍❤‍🧑🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏻">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏻">àgbà | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏼">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏼">àgbà | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏾">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏽‍❤‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍❤‍🧑🏿">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍❤‍🧑🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏻">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏻">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏼">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏼">adúláwɔ̀ díɛ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏽">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏽">adúláwɔ̀ díɛ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍❤‍🧑🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍❤‍🧑🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍❤‍🧑🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏻">adúláwɔ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏻">adúláwɔ̀ | àgbà | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏼">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏼">adúláwɔ̀ | àgbà | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏽">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏽">adúláwɔ̀ | àgbà | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍❤‍🧑🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍❤‍🧑🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àgbà | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍❤‍🧑🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: àgbà, àgbà, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
 		<annotation cp="🧑‍🦰">àgbà | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
-		<annotation cp="🧑🏻‍🦰">àgbà | àgbà: amɔ́lára, irun pupa | amɔ́lára | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
+		<annotation cp="🧑🏻‍🦰">àgbà | amɔ́lára | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
 		<annotation cp="🧑🏻‍🦰" type="tts">àgbà: amɔ́lára, irun pupa</annotation>
-		<annotation cp="🧑🏼‍🦰">àgbà | àgbà: amɔ́lára díɛ̀, irun pupa | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
+		<annotation cp="🧑🏼‍🦰">àgbà | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
 		<annotation cp="🧑🏼‍🦰" type="tts">àgbà: amɔ́lára díɛ̀, irun pupa</annotation>
-		<annotation cp="🧑🏽‍🦰">àgbà | àgbà: amɔ́láwɔ̀ díɛ̀, irun pupa | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
+		<annotation cp="🧑🏽‍🦰">àgbà | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
 		<annotation cp="🧑🏽‍🦰" type="tts">àgbà: amɔ́láwɔ̀ díɛ̀, irun pupa</annotation>
-		<annotation cp="🧑🏾‍🦰">adúláwɔ̀ díɛ̀ | àgbà | àgbà: adúláwɔ̀ díɛ̀, irun pupa | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
+		<annotation cp="🧑🏾‍🦰">adúláwɔ̀ díɛ̀ | àgbà | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
 		<annotation cp="🧑🏾‍🦰" type="tts">àgbà: adúláwɔ̀ díɛ̀, irun pupa</annotation>
-		<annotation cp="🧑🏿‍🦰">adúláwɔ̀ | àgbà | àgbà: adúláwɔ̀, irun pupa | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
+		<annotation cp="🧑🏿‍🦰">adúláwɔ̀ | àgbà | gé̩ndà-shekushɛyɛ | irun pupa</annotation>
 		<annotation cp="🧑🏿‍🦰" type="tts">àgbà: adúláwɔ̀, irun pupa</annotation>
-		<annotation cp="🧑‍🦱">àgbà | àgbà: irun rírɔ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
+		<annotation cp="🧑‍🦱">àgbà | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
 		<annotation cp="🧑‍🦱" type="tts">àgbà: irun rírɔ̀</annotation>
-		<annotation cp="🧑🏻‍🦱">àgbà | àgbà: amɔ́lára, irun rírɔ̀ | amɔ́lára | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
+		<annotation cp="🧑🏻‍🦱">àgbà | amɔ́lára | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
 		<annotation cp="🧑🏻‍🦱" type="tts">àgbà: amɔ́lára, irun rírɔ̀</annotation>
-		<annotation cp="🧑🏼‍🦱">àgbà | àgbà: amɔ́lára díɛ̀, irun rírɔ̀ | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
+		<annotation cp="🧑🏼‍🦱">àgbà | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
 		<annotation cp="🧑🏼‍🦱" type="tts">àgbà: amɔ́lára díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="🧑🏽‍🦱">àgbà | àgbà: amɔ́láwɔ̀ díɛ̀, irun rírɔ̀ | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
+		<annotation cp="🧑🏽‍🦱">àgbà | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
 		<annotation cp="🧑🏽‍🦱" type="tts">àgbà: amɔ́láwɔ̀ díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="🧑🏾‍🦱">adúláwɔ̀ díɛ̀ | àgbà | àgbà: adúláwɔ̀ díɛ̀, irun rírɔ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
+		<annotation cp="🧑🏾‍🦱">adúláwɔ̀ díɛ̀ | àgbà | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
 		<annotation cp="🧑🏾‍🦱" type="tts">àgbà: adúláwɔ̀ díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="🧑🏿‍🦱">adúláwɔ̀ | àgbà | àgbà: adúláwɔ̀, irun rírɔ̀ | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
+		<annotation cp="🧑🏿‍🦱">adúláwɔ̀ | àgbà | gé̩ndà-shekushɛyɛ | irun rírɔ̀</annotation>
 		<annotation cp="🧑🏿‍🦱" type="tts">àgbà: adúláwɔ̀, irun rírɔ̀</annotation>
 		<annotation cp="🧑‍🦳">àgbà | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
-		<annotation cp="🧑🏻‍🦳">àgbà | àgbà: amɔ́lára, irun funfun | amɔ́lára | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
+		<annotation cp="🧑🏻‍🦳">àgbà | amɔ́lára | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
 		<annotation cp="🧑🏻‍🦳" type="tts">àgbà: amɔ́lára, irun funfun</annotation>
-		<annotation cp="🧑🏼‍🦳">àgbà | àgbà: amɔ́lára díɛ̀, irun funfun | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
+		<annotation cp="🧑🏼‍🦳">àgbà | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
 		<annotation cp="🧑🏼‍🦳" type="tts">àgbà: amɔ́lára díɛ̀, irun funfun</annotation>
-		<annotation cp="🧑🏽‍🦳">àgbà | àgbà: amɔ́láwɔ̀ díɛ̀, irun funfun | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
+		<annotation cp="🧑🏽‍🦳">àgbà | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
 		<annotation cp="🧑🏽‍🦳" type="tts">àgbà: amɔ́láwɔ̀ díɛ̀, irun funfun</annotation>
-		<annotation cp="🧑🏾‍🦳">adúláwɔ̀ díɛ̀ | àgbà | àgbà: adúláwɔ̀ díɛ̀, irun funfun | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
+		<annotation cp="🧑🏾‍🦳">adúláwɔ̀ díɛ̀ | àgbà | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
 		<annotation cp="🧑🏾‍🦳" type="tts">àgbà: adúláwɔ̀ díɛ̀, irun funfun</annotation>
-		<annotation cp="🧑🏿‍🦳">adúláwɔ̀ | àgbà | àgbà: adúláwɔ̀, irun funfun | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
+		<annotation cp="🧑🏿‍🦳">adúláwɔ̀ | àgbà | gé̩ndà-shekushɛyɛ | irun funfun</annotation>
 		<annotation cp="🧑🏿‍🦳" type="tts">àgbà: adúláwɔ̀, irun funfun</annotation>
 		<annotation cp="🧑‍🦲">àgbà | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
-		<annotation cp="🧑🏻‍🦲">àgbà | àgbà: amɔ́lára, orí pípá | amɔ́lára | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
+		<annotation cp="🧑🏻‍🦲">àgbà | amɔ́lára | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
 		<annotation cp="🧑🏻‍🦲" type="tts">àgbà: amɔ́lára, orí pípá</annotation>
-		<annotation cp="🧑🏼‍🦲">àgbà | àgbà: amɔ́lára díɛ̀, orí pípá | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
+		<annotation cp="🧑🏼‍🦲">àgbà | amɔ́lára díɛ̀ | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
 		<annotation cp="🧑🏼‍🦲" type="tts">àgbà: amɔ́lára díɛ̀, orí pípá</annotation>
-		<annotation cp="🧑🏽‍🦲">àgbà | àgbà: amɔ́láwɔ̀ díɛ̀, orí pípá | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
+		<annotation cp="🧑🏽‍🦲">àgbà | amɔ́láwɔ̀ díɛ̀ | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
 		<annotation cp="🧑🏽‍🦲" type="tts">àgbà: amɔ́láwɔ̀ díɛ̀, orí pípá</annotation>
-		<annotation cp="🧑🏾‍🦲">adúláwɔ̀ díɛ̀ | àgbà | àgbà: adúláwɔ̀ díɛ̀, orí pípá | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
+		<annotation cp="🧑🏾‍🦲">adúláwɔ̀ díɛ̀ | àgbà | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
 		<annotation cp="🧑🏾‍🦲" type="tts">àgbà: adúláwɔ̀ díɛ̀, orí pípá</annotation>
-		<annotation cp="🧑🏿‍🦲">adúláwɔ̀ | àgbà | àgbà: adúláwɔ̀, orí pípá | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
+		<annotation cp="🧑🏿‍🦲">adúláwɔ̀ | àgbà | gé̩ndà-shekushɛyɛ | orí pípá</annotation>
 		<annotation cp="🧑🏿‍🦲" type="tts">àgbà: adúláwɔ̀, orí pípá</annotation>
-		<annotation cp="👨🏻">amɔ́lára | Ɔkùnrin | Ɔkùnrin: amɔ́lára</annotation>
+		<annotation cp="👨🏻">amɔ́lára | Ɔkùnrin</annotation>
 		<annotation cp="👨🏻" type="tts">Ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="👨🏼">amɔ́lára díɛ̀ | Ɔkùnrin | Ɔkùnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼">amɔ́lára díɛ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏼" type="tts">Ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽">amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | Ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽">amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏽" type="tts">Ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾">adúláwɔ̀ díɛ̀ | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾">adúláwɔ̀ díɛ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏾" type="tts">Ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿">adúláwɔ̀ | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿">adúláwɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏿" type="tts">Ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧔🏻">amɔ́lára | apárí | apárí: amɔ́lára | irùngbɔ̀n</annotation>
+		<annotation cp="🧔🏻">amɔ́lára | apárí | irùngbɔ̀n</annotation>
 		<annotation cp="🧔🏻" type="tts">apárí: amɔ́lára</annotation>
-		<annotation cp="🧔🏼">amɔ́lára díɛ̀ | apárí | apárí: amɔ́lára díɛ̀ | irùngbɔ̀n</annotation>
+		<annotation cp="🧔🏼">amɔ́lára díɛ̀ | apárí | irùngbɔ̀n</annotation>
 		<annotation cp="🧔🏼" type="tts">apárí: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧔🏽">amɔ́láwɔ̀ díɛ̀ | apárí | apárí: amɔ́láwɔ̀ díɛ̀ | irùngbɔ̀n</annotation>
+		<annotation cp="🧔🏽">amɔ́láwɔ̀ díɛ̀ | apárí | irùngbɔ̀n</annotation>
 		<annotation cp="🧔🏽" type="tts">apárí: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧔🏾">adúláwɔ̀ díɛ̀ | apárí | apárí: adúláwɔ̀ díɛ̀ | irùngbɔ̀n</annotation>
+		<annotation cp="🧔🏾">adúláwɔ̀ díɛ̀ | apárí | irùngbɔ̀n</annotation>
 		<annotation cp="🧔🏾" type="tts">apárí: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧔🏿">adúláwɔ̀ | apárí | apárí: adúláwɔ̀ | irùngbɔ̀n</annotation>
+		<annotation cp="🧔🏿">adúláwɔ̀ | apárí | irùngbɔ̀n</annotation>
 		<annotation cp="🧔🏿" type="tts">apárí: adúláwɔ̀</annotation>
-		<annotation cp="🧔🏻‍♂">amɔ́lára | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: amɔ́lára, irùgbɔ̀n | ɔkùnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏻‍♂">amɔ́lára | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏻‍♂" type="tts">ɔkùnrin: amɔ́lára, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏼‍♂">amɔ́lára díɛ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: amɔ́lára díɛ̀, irùgbɔ̀n | ɔkùnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏼‍♂">amɔ́lára díɛ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏼‍♂" type="tts">ɔkùnrin: amɔ́lára díɛ̀, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏽‍♂">amɔ́láwɔ̀ díɛ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irùgbɔ̀n | ɔkùnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏽‍♂">amɔ́láwɔ̀ díɛ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏽‍♂" type="tts">ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏾‍♂">adúláwɔ̀ díɛ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: adúláwɔ̀ díɛ̀, irùgbɔ̀n | ɔkùnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏾‍♂">adúláwɔ̀ díɛ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏾‍♂" type="tts">ɔkùnrin: adúláwɔ̀ díɛ̀, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏿‍♂">adúláwɔ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: adúláwɔ̀, irùgbɔ̀n | ɔkùnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏿‍♂">adúláwɔ̀ | irùgbɔ̀n | ɔkùnrin | ɔkùnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏿‍♂" type="tts">ɔkùnrin: adúláwɔ̀, irùgbɔ̀n</annotation>
-		<annotation cp="👱🏻‍♂">amɔ́lára | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun | ɔkùnrin onírun funfun: amɔ́lára</annotation>
+		<annotation cp="👱🏻‍♂">amɔ́lára | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun</annotation>
 		<annotation cp="👱🏻‍♂" type="tts">ɔkùnrin onírun funfun: amɔ́lára</annotation>
-		<annotation cp="👱🏼‍♂">amɔ́lára díɛ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun | ɔkùnrin onírun funfun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👱🏼‍♂">amɔ́lára díɛ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun</annotation>
 		<annotation cp="👱🏼‍♂" type="tts">ɔkùnrin onírun funfun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👱🏽‍♂">amɔ́láwɔ̀ díɛ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun | ɔkùnrin onírun funfun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👱🏽‍♂">amɔ́láwɔ̀ díɛ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun</annotation>
 		<annotation cp="👱🏽‍♂" type="tts">ɔkùnrin onírun funfun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👱🏾‍♂">adúláwɔ̀ díɛ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun | ɔkùnrin onírun funfun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👱🏾‍♂">adúláwɔ̀ díɛ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun</annotation>
 		<annotation cp="👱🏾‍♂" type="tts">ɔkùnrin onírun funfun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👱🏿‍♂">adúláwɔ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun | ɔkùnrin onírun funfun: adúláwɔ̀</annotation>
+		<annotation cp="👱🏿‍♂">adúláwɔ̀ | onírun funfun | ɔkùnrin | ɔkùnrin onírun funfun</annotation>
 		<annotation cp="👱🏿‍♂" type="tts">ɔkùnrin onírun funfun: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏻">amɔ́lára | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏻">amɔ́lára | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏻‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏼‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏽‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍❤‍💋‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍💋‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏻">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏻">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍❤‍💋‍👨🏿">adúláwɔ̀ | Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍💋‍👨🏿">adúláwɔ̀ | Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏻‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏼‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏽‍❤‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍❤‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍❤‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍❤‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏻">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏻">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍❤‍👨🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀ | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍❤‍👨🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin, adúláwɔ̀</annotation>
-		<annotation cp="👨‍🦰">irun pupa | Ɔkùnrin | Ɔkùnrin: irun pupa</annotation>
+		<annotation cp="👨‍🦰">irun pupa | Ɔkùnrin</annotation>
 		<annotation cp="👨‍🦰" type="tts">Ɔkùnrin: irun pupa</annotation>
-		<annotation cp="👨🏻‍🦰">amɔ́lára | irun pupa | Ɔkùnrin | Ɔkùnrin: amɔ́lára, irun pupa</annotation>
+		<annotation cp="👨🏻‍🦰">amɔ́lára | irun pupa | Ɔkùnrin</annotation>
 		<annotation cp="👨🏻‍🦰" type="tts">Ɔkùnrin: amɔ́lára, irun pupa</annotation>
-		<annotation cp="👨🏼‍🦰">amɔ́lára díɛ̀ | irun pupa | Ɔkùnrin | Ɔkùnrin: amɔ́lára díɛ̀, irun pupa</annotation>
+		<annotation cp="👨🏼‍🦰">amɔ́lára díɛ̀ | irun pupa | Ɔkùnrin</annotation>
 		<annotation cp="👨🏼‍🦰" type="tts">Ɔkùnrin: amɔ́lára díɛ̀, irun pupa</annotation>
-		<annotation cp="👨🏽‍🦰">amɔ́láwɔ̀ díɛ̀ | irun pupa | Ɔkùnrin | Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irun pupa</annotation>
+		<annotation cp="👨🏽‍🦰">amɔ́láwɔ̀ díɛ̀ | irun pupa | Ɔkùnrin</annotation>
 		<annotation cp="👨🏽‍🦰" type="tts">Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irun pupa</annotation>
-		<annotation cp="👨🏾‍🦰">adúláwɔ̀ díɛ̀ | irun pupa | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀ díɛ̀, irun pupa</annotation>
+		<annotation cp="👨🏾‍🦰">adúláwɔ̀ díɛ̀ | irun pupa | Ɔkùnrin</annotation>
 		<annotation cp="👨🏾‍🦰" type="tts">Ɔkùnrin: adúláwɔ̀ díɛ̀, irun pupa</annotation>
-		<annotation cp="👨🏿‍🦰">adúláwɔ̀ | irun pupa | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀, irun pupa</annotation>
+		<annotation cp="👨🏿‍🦰">adúláwɔ̀ | irun pupa | Ɔkùnrin</annotation>
 		<annotation cp="👨🏿‍🦰" type="tts">Ɔkùnrin: adúláwɔ̀, irun pupa</annotation>
-		<annotation cp="👨‍🦱">irun rírɔ̀ | Ɔkùnrin | Ɔkùnrin: irun rírɔ̀</annotation>
+		<annotation cp="👨‍🦱">irun rírɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨‍🦱" type="tts">Ɔkùnrin: irun rírɔ̀</annotation>
-		<annotation cp="👨🏻‍🦱">amɔ́lára | irun rírɔ̀ | Ɔkùnrin | Ɔkùnrin: amɔ́lára, irun rírɔ̀</annotation>
+		<annotation cp="👨🏻‍🦱">amɔ́lára | irun rírɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏻‍🦱" type="tts">Ɔkùnrin: amɔ́lára, irun rírɔ̀</annotation>
-		<annotation cp="👨🏼‍🦱">amɔ́lára díɛ̀ | irun rírɔ̀ | Ɔkùnrin | Ɔkùnrin: amɔ́lára díɛ̀, irun rírɔ̀</annotation>
+		<annotation cp="👨🏼‍🦱">amɔ́lára díɛ̀ | irun rírɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏼‍🦱" type="tts">Ɔkùnrin: amɔ́lára díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="👨🏽‍🦱">amɔ́láwɔ̀ díɛ̀ | irun rírɔ̀ | Ɔkùnrin | Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irun rírɔ̀</annotation>
+		<annotation cp="👨🏽‍🦱">amɔ́láwɔ̀ díɛ̀ | irun rírɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏽‍🦱" type="tts">Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="👨🏾‍🦱">adúláwɔ̀ díɛ̀ | irun rírɔ̀ | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀ díɛ̀, irun rírɔ̀</annotation>
+		<annotation cp="👨🏾‍🦱">adúláwɔ̀ díɛ̀ | irun rírɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏾‍🦱" type="tts">Ɔkùnrin: adúláwɔ̀ díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="👨🏿‍🦱">adúláwɔ̀ | irun rírɔ̀ | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀, irun rírɔ̀</annotation>
+		<annotation cp="👨🏿‍🦱">adúláwɔ̀ | irun rírɔ̀ | Ɔkùnrin</annotation>
 		<annotation cp="👨🏿‍🦱" type="tts">Ɔkùnrin: adúláwɔ̀, irun rírɔ̀</annotation>
-		<annotation cp="👨‍🦳">irun funfun | Ɔkùnrin | Ɔkùnrin: irun funfun</annotation>
+		<annotation cp="👨‍🦳">irun funfun | Ɔkùnrin</annotation>
 		<annotation cp="👨‍🦳" type="tts">Ɔkùnrin: irun funfun</annotation>
-		<annotation cp="👨🏻‍🦳">amɔ́lára | irun funfun | Ɔkùnrin | Ɔkùnrin: amɔ́lára, irun funfun</annotation>
+		<annotation cp="👨🏻‍🦳">amɔ́lára | irun funfun | Ɔkùnrin</annotation>
 		<annotation cp="👨🏻‍🦳" type="tts">Ɔkùnrin: amɔ́lára, irun funfun</annotation>
-		<annotation cp="👨🏼‍🦳">amɔ́lára díɛ̀ | irun funfun | Ɔkùnrin | Ɔkùnrin: amɔ́lára díɛ̀, irun funfun</annotation>
+		<annotation cp="👨🏼‍🦳">amɔ́lára díɛ̀ | irun funfun | Ɔkùnrin</annotation>
 		<annotation cp="👨🏼‍🦳" type="tts">Ɔkùnrin: amɔ́lára díɛ̀, irun funfun</annotation>
-		<annotation cp="👨🏽‍🦳">amɔ́láwɔ̀ díɛ̀ | irun funfun | Ɔkùnrin | Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irun funfun</annotation>
+		<annotation cp="👨🏽‍🦳">amɔ́láwɔ̀ díɛ̀ | irun funfun | Ɔkùnrin</annotation>
 		<annotation cp="👨🏽‍🦳" type="tts">Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, irun funfun</annotation>
-		<annotation cp="👨🏾‍🦳">adúláwɔ̀ díɛ̀ | irun funfun | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀ díɛ̀, irun funfun</annotation>
+		<annotation cp="👨🏾‍🦳">adúláwɔ̀ díɛ̀ | irun funfun | Ɔkùnrin</annotation>
 		<annotation cp="👨🏾‍🦳" type="tts">Ɔkùnrin: adúláwɔ̀ díɛ̀, irun funfun</annotation>
-		<annotation cp="👨🏿‍🦳">adúláwɔ̀ | irun funfun | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀, irun funfun</annotation>
+		<annotation cp="👨🏿‍🦳">adúláwɔ̀ | irun funfun | Ɔkùnrin</annotation>
 		<annotation cp="👨🏿‍🦳" type="tts">Ɔkùnrin: adúláwɔ̀, irun funfun</annotation>
-		<annotation cp="👨‍🦲">orí pípá | Ɔkùnrin | Ɔkùnrin: orí pípá</annotation>
+		<annotation cp="👨‍🦲">orí pípá | Ɔkùnrin</annotation>
 		<annotation cp="👨‍🦲" type="tts">Ɔkùnrin: orí pípá</annotation>
-		<annotation cp="👨🏻‍🦲">amɔ́lára | orí pípá | Ɔkùnrin | Ɔkùnrin: amɔ́lára, orí pípá</annotation>
+		<annotation cp="👨🏻‍🦲">amɔ́lára | orí pípá | Ɔkùnrin</annotation>
 		<annotation cp="👨🏻‍🦲" type="tts">Ɔkùnrin: amɔ́lára, orí pípá</annotation>
-		<annotation cp="👨🏼‍🦲">amɔ́lára díɛ̀ | orí pípá | Ɔkùnrin | Ɔkùnrin: amɔ́lára díɛ̀, orí pípá</annotation>
+		<annotation cp="👨🏼‍🦲">amɔ́lára díɛ̀ | orí pípá | Ɔkùnrin</annotation>
 		<annotation cp="👨🏼‍🦲" type="tts">Ɔkùnrin: amɔ́lára díɛ̀, orí pípá</annotation>
-		<annotation cp="👨🏽‍🦲">amɔ́láwɔ̀ díɛ̀ | orí pípá | Ɔkùnrin | Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, orí pípá</annotation>
+		<annotation cp="👨🏽‍🦲">amɔ́láwɔ̀ díɛ̀ | orí pípá | Ɔkùnrin</annotation>
 		<annotation cp="👨🏽‍🦲" type="tts">Ɔkùnrin: amɔ́láwɔ̀ díɛ̀, orí pípá</annotation>
-		<annotation cp="👨🏾‍🦲">adúláwɔ̀ díɛ̀ | orí pípá | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀ díɛ̀, orí pípá</annotation>
+		<annotation cp="👨🏾‍🦲">adúláwɔ̀ díɛ̀ | orí pípá | Ɔkùnrin</annotation>
 		<annotation cp="👨🏾‍🦲" type="tts">Ɔkùnrin: adúláwɔ̀ díɛ̀, orí pípá</annotation>
-		<annotation cp="👨🏿‍🦲">adúláwɔ̀ | orí pípá | Ɔkùnrin | Ɔkùnrin: adúláwɔ̀, orí pípá</annotation>
+		<annotation cp="👨🏿‍🦲">adúláwɔ̀ | orí pípá | Ɔkùnrin</annotation>
 		<annotation cp="👨🏿‍🦲" type="tts">Ɔkùnrin: adúláwɔ̀, orí pípá</annotation>
-		<annotation cp="👩🏻">amɔ́lára | Obìnrin | Obìnrin: amɔ́lára</annotation>
+		<annotation cp="👩🏻">amɔ́lára | Obìnrin</annotation>
 		<annotation cp="👩🏻" type="tts">Obìnrin: amɔ́lára</annotation>
-		<annotation cp="👩🏼">amɔ́lára díɛ̀ | Obìnrin | Obìnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👩🏼">amɔ́lára díɛ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏼" type="tts">Obìnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽">amɔ́láwɔ̀ díɛ̀ | Obìnrin | Obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏽">amɔ́láwɔ̀ díɛ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏽" type="tts">Obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾">adúláwɔ̀ díɛ̀ | Obìnrin | Obìnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏾">adúláwɔ̀ díɛ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏾" type="tts">Obìnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿">adúláwɔ̀ | Obìnrin | Obìnrin: adúláwɔ̀</annotation>
+		<annotation cp="👩🏿">adúláwɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏿" type="tts">Obìnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧔🏻‍♀">amɔ́lára | irùgbɔ̀n | obìnrin | obìnrin: amɔ́lára, irùgbɔ̀n | obìnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏻‍♀">amɔ́lára | irùgbɔ̀n | obìnrin | obìnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏻‍♀" type="tts">obìnrin: amɔ́lára, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏼‍♀">amɔ́lára díɛ̀ | irùgbɔ̀n | obìnrin | obìnrin: amɔ́lára díɛ̀, irùgbɔ̀n | obìnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏼‍♀">amɔ́lára díɛ̀ | irùgbɔ̀n | obìnrin | obìnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏼‍♀" type="tts">obìnrin: amɔ́lára díɛ̀, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏽‍♀">amɔ́láwɔ̀ díɛ̀ | irùgbɔ̀n | obìnrin | obìnrin: amɔ́láwɔ̀ díɛ̀, irùgbɔ̀n | obìnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏽‍♀">amɔ́láwɔ̀ díɛ̀ | irùgbɔ̀n | obìnrin | obìnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏽‍♀" type="tts">obìnrin: amɔ́láwɔ̀ díɛ̀, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏾‍♀">adúláwɔ̀ díɛ̀ | irùgbɔ̀n | obìnrin | obìnrin: adúláwɔ̀ díɛ̀, irùgbɔ̀n | obìnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏾‍♀">adúláwɔ̀ díɛ̀ | irùgbɔ̀n | obìnrin | obìnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏾‍♀" type="tts">obìnrin: adúláwɔ̀ díɛ̀, irùgbɔ̀n</annotation>
-		<annotation cp="🧔🏿‍♀">adúláwɔ̀ | irùgbɔ̀n | obìnrin | obìnrin: adúláwɔ̀, irùgbɔ̀n | obìnrin: irùgbɔ̀n</annotation>
+		<annotation cp="🧔🏿‍♀">adúláwɔ̀ | irùgbɔ̀n | obìnrin | obìnrin: irùgbɔ̀n</annotation>
 		<annotation cp="🧔🏿‍♀" type="tts">obìnrin: adúláwɔ̀, irùgbɔ̀n</annotation>
-		<annotation cp="👱🏻‍♀">amɔ́lára | obìnrin | obìnrin onírun funfun | obìnrin onírun funfun: amɔ́lára | onírun funfun</annotation>
+		<annotation cp="👱🏻‍♀">amɔ́lára | obìnrin | obìnrin onírun funfun | onírun funfun</annotation>
 		<annotation cp="👱🏻‍♀" type="tts">obìnrin onírun funfun: amɔ́lára</annotation>
-		<annotation cp="👱🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin onírun funfun | obìnrin onírun funfun: amɔ́lára díɛ̀ | onírun funfun</annotation>
+		<annotation cp="👱🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin onírun funfun | onírun funfun</annotation>
 		<annotation cp="👱🏼‍♀" type="tts">obìnrin onírun funfun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👱🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin onírun funfun | obìnrin onírun funfun: amɔ́láwɔ̀ díɛ̀ | onírun funfun</annotation>
+		<annotation cp="👱🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin onírun funfun | onírun funfun</annotation>
 		<annotation cp="👱🏽‍♀" type="tts">obìnrin onírun funfun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👱🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin onírun funfun | obìnrin onírun funfun: adúláwɔ̀ díɛ̀ | onírun funfun</annotation>
+		<annotation cp="👱🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin onírun funfun | onírun funfun</annotation>
 		<annotation cp="👱🏾‍♀" type="tts">obìnrin onírun funfun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👱🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin onírun funfun | obìnrin onírun funfun: adúláwɔ̀ | onírun funfun</annotation>
+		<annotation cp="👱🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin onírun funfun | onírun funfun</annotation>
 		<annotation cp="👱🏿‍♀" type="tts">obìnrin onírun funfun: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏻">amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏻">amɔ́lára | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏻">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏻">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏻" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏼" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏽" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏾" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👨🏿">adúláwɔ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👨🏿">adúláwɔ̀ | Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👨🏿" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin, adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏻">amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏻">amɔ́lára | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏻" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏼">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏼">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏼" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏽" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏾" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍💋‍👩🏿">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍💋‍👩🏿">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍💋‍👩🏿" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏻">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏻">amɔ́lára | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏻" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏼">amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏼">amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏼" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏽" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏾" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍💋‍👩🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍💋‍👩🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍💋‍👩🏿" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏻" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏼" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏽" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏾" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍💋‍👩🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍💋‍👩🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍💋‍👩🏿" type="tts">Ifɛnuko: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏻" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏼" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏽" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏾" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍💋‍👩🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍💋‍👩🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍💋‍👩🏿" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏻">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏻">adúláwɔ̀ | amɔ́lára | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏻" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏼" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏽" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏾" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍💋‍👩🏿">adúláwɔ̀ | Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍💋‍👩🏿">adúláwɔ̀ | Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍💋‍👩🏿" type="tts">Ifɛnuko: Obìnrin, Obìnrin, adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏻">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏻">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👨🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀ | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👨🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👨🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin, adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏼">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏼">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍❤‍👩🏿">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍❤‍👩🏿">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍❤‍👩🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏻">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏻">amɔ́lára | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍❤‍👩🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍❤‍👩🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍❤‍👩🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍❤‍👩🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍❤‍👩🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍❤‍👩🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍❤‍👩🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍❤‍👩🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍❤‍👩🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏻">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏻">adúláwɔ̀ | amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍❤‍👩🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀ | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍❤‍👩🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍❤‍👩🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin, adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🦰">amɔ́lára | irun pupa | Obìnrin | Obìnrin: amɔ́lára, irun pupa</annotation>
+		<annotation cp="👩🏻‍🦰">amɔ́lára | irun pupa | Obìnrin</annotation>
 		<annotation cp="👩🏻‍🦰" type="tts">Obìnrin: amɔ́lára, irun pupa</annotation>
-		<annotation cp="👩🏼‍🦰">amɔ́lára díɛ̀ | irun pupa | Obìnrin | Obìnrin: amɔ́lára díɛ̀, irun pupa</annotation>
+		<annotation cp="👩🏼‍🦰">amɔ́lára díɛ̀ | irun pupa | Obìnrin</annotation>
 		<annotation cp="👩🏼‍🦰" type="tts">Obìnrin: amɔ́lára díɛ̀, irun pupa</annotation>
-		<annotation cp="👩🏽‍🦰">amɔ́láwɔ̀ díɛ̀ | irun pupa | Obìnrin | Obìnrin: amɔ́láwɔ̀ díɛ̀, irun pupa</annotation>
+		<annotation cp="👩🏽‍🦰">amɔ́láwɔ̀ díɛ̀ | irun pupa | Obìnrin</annotation>
 		<annotation cp="👩🏽‍🦰" type="tts">Obìnrin: amɔ́láwɔ̀ díɛ̀, irun pupa</annotation>
-		<annotation cp="👩🏾‍🦰">adúláwɔ̀ díɛ̀ | irun pupa | Obìnrin | Obìnrin: adúláwɔ̀ díɛ̀, irun pupa</annotation>
+		<annotation cp="👩🏾‍🦰">adúláwɔ̀ díɛ̀ | irun pupa | Obìnrin</annotation>
 		<annotation cp="👩🏾‍🦰" type="tts">Obìnrin: adúláwɔ̀ díɛ̀, irun pupa</annotation>
-		<annotation cp="👩🏿‍🦰">adúláwɔ̀ | irun pupa | Obìnrin | Obìnrin: adúláwɔ̀, irun pupa</annotation>
+		<annotation cp="👩🏿‍🦰">adúláwɔ̀ | irun pupa | Obìnrin</annotation>
 		<annotation cp="👩🏿‍🦰" type="tts">Obìnrin: adúláwɔ̀, irun pupa</annotation>
-		<annotation cp="👩‍🦱">irun rírɔ̀ | Obìnrin | Obìnrin: irun rírɔ̀</annotation>
+		<annotation cp="👩‍🦱">irun rírɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩‍🦱" type="tts">Obìnrin: irun rírɔ̀</annotation>
-		<annotation cp="👩🏻‍🦱">amɔ́lára | irun rírɔ̀ | Obìnrin | Obìnrin: amɔ́lára, irun rírɔ̀</annotation>
+		<annotation cp="👩🏻‍🦱">amɔ́lára | irun rírɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏻‍🦱" type="tts">Obìnrin: amɔ́lára, irun rírɔ̀</annotation>
-		<annotation cp="👩🏼‍🦱">amɔ́lára díɛ̀ | irun rírɔ̀ | Obìnrin | Obìnrin: amɔ́lára díɛ̀, irun rírɔ̀</annotation>
+		<annotation cp="👩🏼‍🦱">amɔ́lára díɛ̀ | irun rírɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏼‍🦱" type="tts">Obìnrin: amɔ́lára díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="👩🏽‍🦱">amɔ́láwɔ̀ díɛ̀ | irun rírɔ̀ | Obìnrin | Obìnrin: amɔ́láwɔ̀ díɛ̀, irun rírɔ̀</annotation>
+		<annotation cp="👩🏽‍🦱">amɔ́láwɔ̀ díɛ̀ | irun rírɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏽‍🦱" type="tts">Obìnrin: amɔ́láwɔ̀ díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="👩🏾‍🦱">adúláwɔ̀ díɛ̀ | irun rírɔ̀ | Obìnrin | Obìnrin: adúláwɔ̀ díɛ̀, irun rírɔ̀</annotation>
+		<annotation cp="👩🏾‍🦱">adúláwɔ̀ díɛ̀ | irun rírɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏾‍🦱" type="tts">Obìnrin: adúláwɔ̀ díɛ̀, irun rírɔ̀</annotation>
-		<annotation cp="👩🏿‍🦱">adúláwɔ̀ | irun rírɔ̀ | Obìnrin | Obìnrin: adúláwɔ̀, irun rírɔ̀</annotation>
+		<annotation cp="👩🏿‍🦱">adúláwɔ̀ | irun rírɔ̀ | Obìnrin</annotation>
 		<annotation cp="👩🏿‍🦱" type="tts">Obìnrin: adúláwɔ̀, irun rírɔ̀</annotation>
-		<annotation cp="👩🏻‍🦳">amɔ́lára | irun funfun | Obìnrin | Obìnrin: amɔ́lára, irun funfun</annotation>
+		<annotation cp="👩🏻‍🦳">amɔ́lára | irun funfun | Obìnrin</annotation>
 		<annotation cp="👩🏻‍🦳" type="tts">Obìnrin: amɔ́lára, irun funfun</annotation>
-		<annotation cp="👩🏼‍🦳">amɔ́lára díɛ̀ | irun funfun | Obìnrin | Obìnrin: amɔ́lára díɛ̀, irun funfun</annotation>
+		<annotation cp="👩🏼‍🦳">amɔ́lára díɛ̀ | irun funfun | Obìnrin</annotation>
 		<annotation cp="👩🏼‍🦳" type="tts">Obìnrin: amɔ́lára díɛ̀, irun funfun</annotation>
-		<annotation cp="👩🏽‍🦳">amɔ́láwɔ̀ díɛ̀ | irun funfun | Obìnrin | Obìnrin: amɔ́láwɔ̀ díɛ̀, irun funfun</annotation>
+		<annotation cp="👩🏽‍🦳">amɔ́láwɔ̀ díɛ̀ | irun funfun | Obìnrin</annotation>
 		<annotation cp="👩🏽‍🦳" type="tts">Obìnrin: amɔ́láwɔ̀ díɛ̀, irun funfun</annotation>
-		<annotation cp="👩🏾‍🦳">adúláwɔ̀ díɛ̀ | irun funfun | Obìnrin | Obìnrin: adúláwɔ̀ díɛ̀, irun funfun</annotation>
+		<annotation cp="👩🏾‍🦳">adúláwɔ̀ díɛ̀ | irun funfun | Obìnrin</annotation>
 		<annotation cp="👩🏾‍🦳" type="tts">Obìnrin: adúláwɔ̀ díɛ̀, irun funfun</annotation>
-		<annotation cp="👩🏿‍🦳">adúláwɔ̀ | irun funfun | Obìnrin | Obìnrin: adúláwɔ̀, irun funfun</annotation>
+		<annotation cp="👩🏿‍🦳">adúláwɔ̀ | irun funfun | Obìnrin</annotation>
 		<annotation cp="👩🏿‍🦳" type="tts">Obìnrin: adúláwɔ̀, irun funfun</annotation>
-		<annotation cp="👩🏻‍🦲">amɔ́lára | Obìnrin | Obìnrin: amɔ́lára, orí pípá | orí pípá</annotation>
+		<annotation cp="👩🏻‍🦲">amɔ́lára | Obìnrin | orí pípá</annotation>
 		<annotation cp="👩🏻‍🦲" type="tts">Obìnrin: amɔ́lára, orí pípá</annotation>
-		<annotation cp="👩🏼‍🦲">amɔ́lára díɛ̀ | Obìnrin | Obìnrin: amɔ́lára díɛ̀, orí pípá | orí pípá</annotation>
+		<annotation cp="👩🏼‍🦲">amɔ́lára díɛ̀ | Obìnrin | orí pípá</annotation>
 		<annotation cp="👩🏼‍🦲" type="tts">Obìnrin: amɔ́lára díɛ̀, orí pípá</annotation>
-		<annotation cp="👩🏽‍🦲">amɔ́láwɔ̀ díɛ̀ | Obìnrin | Obìnrin: amɔ́láwɔ̀ díɛ̀, orí pípá | orí pípá</annotation>
+		<annotation cp="👩🏽‍🦲">amɔ́láwɔ̀ díɛ̀ | Obìnrin | orí pípá</annotation>
 		<annotation cp="👩🏽‍🦲" type="tts">Obìnrin: amɔ́láwɔ̀ díɛ̀, orí pípá</annotation>
-		<annotation cp="👩🏾‍🦲">adúláwɔ̀ díɛ̀ | Obìnrin | Obìnrin: adúláwɔ̀ díɛ̀, orí pípá | orí pípá</annotation>
+		<annotation cp="👩🏾‍🦲">adúláwɔ̀ díɛ̀ | Obìnrin | orí pípá</annotation>
 		<annotation cp="👩🏾‍🦲" type="tts">Obìnrin: adúláwɔ̀ díɛ̀, orí pípá</annotation>
-		<annotation cp="👩🏿‍🦲">adúláwɔ̀ | Obìnrin | Obìnrin: adúláwɔ̀, orí pípá | orí pípá</annotation>
+		<annotation cp="👩🏿‍🦲">adúláwɔ̀ | Obìnrin | orí pípá</annotation>
 		<annotation cp="👩🏿‍🦲" type="tts">Obìnrin: adúláwɔ̀, orí pípá</annotation>
-		<annotation cp="🧓🏻">àgbàlagbà | àgbàlagbà: amɔ́lára | amɔ́lára | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧓🏻">àgbàlagbà | amɔ́lára | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧓🏻" type="tts">àgbàlagbà: amɔ́lára</annotation>
-		<annotation cp="🧓🏼">àgbàlagbà | àgbàlagbà: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧓🏼">àgbàlagbà | amɔ́lára díɛ̀ | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧓🏼" type="tts">àgbàlagbà: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧓🏽">àgbàlagbà | àgbàlagbà: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧓🏽">àgbàlagbà | amɔ́láwɔ̀ díɛ̀ | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧓🏽" type="tts">àgbàlagbà: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧓🏾">adúláwɔ̀ díɛ̀ | àgbàlagbà | àgbàlagbà: adúláwɔ̀ díɛ̀ | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧓🏾">adúláwɔ̀ díɛ̀ | àgbàlagbà | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧓🏾" type="tts">àgbàlagbà: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧓🏿">adúláwɔ̀ | àgbàlagbà | àgbàlagbà: adúláwɔ̀ | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
+		<annotation cp="🧓🏿">adúláwɔ̀ | àgbàlagbà | arúgbó | gé̩ndà-shekushɛyɛ</annotation>
 		<annotation cp="🧓🏿" type="tts">àgbàlagbà: adúláwɔ̀</annotation>
-		<annotation cp="👴🏻">àgbàlagbà | Agbalagba Ɔkunrin | Agbalagba Ɔkunrin: amɔ́lára | amɔ́lára | ɔkùnrin</annotation>
+		<annotation cp="👴🏻">àgbàlagbà | Agbalagba Ɔkunrin | amɔ́lára | ɔkùnrin</annotation>
 		<annotation cp="👴🏻" type="tts">Agbalagba Ɔkunrin: amɔ́lára</annotation>
-		<annotation cp="👴🏼">àgbàlagbà | Agbalagba Ɔkunrin | Agbalagba Ɔkunrin: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ɔkùnrin</annotation>
+		<annotation cp="👴🏼">àgbàlagbà | Agbalagba Ɔkunrin | amɔ́lára díɛ̀ | ɔkùnrin</annotation>
 		<annotation cp="👴🏼" type="tts">Agbalagba Ɔkunrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👴🏽">àgbàlagbà | Agbalagba Ɔkunrin | Agbalagba Ɔkunrin: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ɔkùnrin</annotation>
+		<annotation cp="👴🏽">àgbàlagbà | Agbalagba Ɔkunrin | amɔ́láwɔ̀ díɛ̀ | ɔkùnrin</annotation>
 		<annotation cp="👴🏽" type="tts">Agbalagba Ɔkunrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👴🏾">adúláwɔ̀ díɛ̀ | àgbàlagbà | Agbalagba Ɔkunrin | Agbalagba Ɔkunrin: adúláwɔ̀ díɛ̀ | ɔkùnrin</annotation>
+		<annotation cp="👴🏾">adúláwɔ̀ díɛ̀ | àgbàlagbà | Agbalagba Ɔkunrin | ɔkùnrin</annotation>
 		<annotation cp="👴🏾" type="tts">Agbalagba Ɔkunrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👴🏿">adúláwɔ̀ | àgbàlagbà | Agbalagba Ɔkunrin | Agbalagba Ɔkunrin: adúláwɔ̀ | ɔkùnrin</annotation>
+		<annotation cp="👴🏿">adúláwɔ̀ | àgbàlagbà | Agbalagba Ɔkunrin | ɔkùnrin</annotation>
 		<annotation cp="👴🏿" type="tts">Agbalagba Ɔkunrin: adúláwɔ̀</annotation>
-		<annotation cp="👵🏻">agbalagba | Agbalagba Obinrin: amɔ́lára | amɔ́lára | obinrin</annotation>
+		<annotation cp="👵🏻">agbalagba | amɔ́lára | obinrin</annotation>
 		<annotation cp="👵🏻" type="tts">Agbalagba Obinrin: amɔ́lára</annotation>
-		<annotation cp="👵🏼">agbalagba | Agbalagba Obinrin: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | obinrin</annotation>
+		<annotation cp="👵🏼">agbalagba | amɔ́lára díɛ̀ | obinrin</annotation>
 		<annotation cp="👵🏼" type="tts">Agbalagba Obinrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👵🏽">agbalagba | Agbalagba Obinrin: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | obinrin</annotation>
+		<annotation cp="👵🏽">agbalagba | amɔ́láwɔ̀ díɛ̀ | obinrin</annotation>
 		<annotation cp="👵🏽" type="tts">Agbalagba Obinrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👵🏾">adúláwɔ̀ díɛ̀ | agbalagba | Agbalagba Obinrin: adúláwɔ̀ díɛ̀ | obinrin</annotation>
+		<annotation cp="👵🏾">adúláwɔ̀ díɛ̀ | agbalagba | obinrin</annotation>
 		<annotation cp="👵🏾" type="tts">Agbalagba Obinrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👵🏿">adúláwɔ̀ | agbalagba | Agbalagba Obinrin: adúláwɔ̀ | obinrin</annotation>
+		<annotation cp="👵🏿">adúláwɔ̀ | agbalagba | obinrin</annotation>
 		<annotation cp="👵🏿" type="tts">Agbalagba Obinrin: adúláwɔ̀</annotation>
-		<annotation cp="🙍🏻">amɔ́lára | Ɛni N Bojujɛ | Ɛni N Bojujɛ: amɔ́lára | fajúro | fɔwɔ́júwè</annotation>
+		<annotation cp="🙍🏻">amɔ́lára | Ɛni N Bojujɛ | fajúro | fɔwɔ́júwè</annotation>
 		<annotation cp="🙍🏻" type="tts">Ɛni N Bojujɛ: amɔ́lára</annotation>
-		<annotation cp="🙍🏼">amɔ́lára díɛ̀ | Ɛni N Bojujɛ | Ɛni N Bojujɛ: amɔ́lára díɛ̀ | fajúro | fɔwɔ́júwè</annotation>
+		<annotation cp="🙍🏼">amɔ́lára díɛ̀ | Ɛni N Bojujɛ | fajúro | fɔwɔ́júwè</annotation>
 		<annotation cp="🙍🏼" type="tts">Ɛni N Bojujɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙍🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Bojujɛ | Ɛni N Bojujɛ: amɔ́láwɔ̀ díɛ̀ | fajúro | fɔwɔ́júwè</annotation>
+		<annotation cp="🙍🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Bojujɛ | fajúro | fɔwɔ́júwè</annotation>
 		<annotation cp="🙍🏽" type="tts">Ɛni N Bojujɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙍🏾">adúláwɔ̀ díɛ̀ | Ɛni N Bojujɛ | Ɛni N Bojujɛ: adúláwɔ̀ díɛ̀ | fajúro | fɔwɔ́júwè</annotation>
+		<annotation cp="🙍🏾">adúláwɔ̀ díɛ̀ | Ɛni N Bojujɛ | fajúro | fɔwɔ́júwè</annotation>
 		<annotation cp="🙍🏾" type="tts">Ɛni N Bojujɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙍🏿">adúláwɔ̀ | Ɛni N Bojujɛ | Ɛni N Bojujɛ: adúláwɔ̀ | fajúro | fɔwɔ́júwè</annotation>
+		<annotation cp="🙍🏿">adúláwɔ̀ | Ɛni N Bojujɛ | fajúro | fɔwɔ́júwè</annotation>
 		<annotation cp="🙍🏿" type="tts">Ɛni N Bojujɛ: adúláwɔ̀</annotation>
-		<annotation cp="🙍🏻‍♂">amɔ́lára | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro | ɔkùnrin tí ń fajúro: amɔ́lára</annotation>
+		<annotation cp="🙍🏻‍♂">amɔ́lára | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏻‍♂" type="tts">ɔkùnrin tí ń fajúro: amɔ́lára</annotation>
-		<annotation cp="🙍🏼‍♂">amɔ́lára díɛ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro | ɔkùnrin tí ń fajúro: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🙍🏼‍♂">amɔ́lára díɛ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏼‍♂" type="tts">ɔkùnrin tí ń fajúro: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙍🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro | ɔkùnrin tí ń fajúro: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙍🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏽‍♂" type="tts">ɔkùnrin tí ń fajúro: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙍🏾‍♂">adúláwɔ̀ díɛ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro | ɔkùnrin tí ń fajúro: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙍🏾‍♂">adúláwɔ̀ díɛ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏾‍♂" type="tts">ɔkùnrin tí ń fajúro: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙍🏿‍♂">adúláwɔ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro | ɔkùnrin tí ń fajúro: adúláwɔ̀</annotation>
+		<annotation cp="🙍🏿‍♂">adúláwɔ̀ | fífajúro | fífowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏿‍♂" type="tts">ɔkùnrin tí ń fajúro: adúláwɔ̀</annotation>
-		<annotation cp="🙍🏻‍♀">amɔ́lára | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro | obìnrin tí ń fajúro: amɔ́lára</annotation>
+		<annotation cp="🙍🏻‍♀">amɔ́lára | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏻‍♀" type="tts">obìnrin tí ń fajúro: amɔ́lára</annotation>
-		<annotation cp="🙍🏼‍♀">amɔ́lára díɛ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro | obìnrin tí ń fajúro: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🙍🏼‍♀">amɔ́lára díɛ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏼‍♀" type="tts">obìnrin tí ń fajúro: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙍🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro | obìnrin tí ń fajúro: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙍🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏽‍♀" type="tts">obìnrin tí ń fajúro: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙍🏾‍♀">adúláwɔ̀ díɛ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro | obìnrin tí ń fajúro: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙍🏾‍♀">adúláwɔ̀ díɛ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏾‍♀" type="tts">obìnrin tí ń fajúro: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙍🏿‍♀">adúláwɔ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro | obìnrin tí ń fajúro: adúláwɔ̀</annotation>
+		<annotation cp="🙍🏿‍♀">adúláwɔ̀ | fífajúro | fɔwɔ́júwè | obìnrin | obìnrin tí ń fajúro</annotation>
 		<annotation cp="🙍🏿‍♀" type="tts">obìnrin tí ń fajúro: adúláwɔ̀</annotation>
-		<annotation cp="🙎🏻">amɔ́lára | Ɛni Yahɔn sita | Ɛni Yahɔn sita: amɔ́lára | fífowɔ́júwè | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏻">amɔ́lára | Ɛni Yahɔn sita | fífowɔ́júwè | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏻" type="tts">Ɛni Yahɔn sita: amɔ́lára</annotation>
-		<annotation cp="🙎🏼">amɔ́lára díɛ̀ | Ɛni Yahɔn sita | Ɛni Yahɔn sita: amɔ́lára díɛ̀ | fífowɔ́júwè | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏼">amɔ́lára díɛ̀ | Ɛni Yahɔn sita | fífowɔ́júwè | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏼" type="tts">Ɛni Yahɔn sita: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙎🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni Yahɔn sita | Ɛni Yahɔn sita: amɔ́láwɔ̀ díɛ̀ | fífowɔ́júwè | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni Yahɔn sita | fífowɔ́júwè | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏽" type="tts">Ɛni Yahɔn sita: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙎🏾">adúláwɔ̀ díɛ̀ | Ɛni Yahɔn sita | Ɛni Yahɔn sita: adúláwɔ̀ díɛ̀ | fífowɔ́júwè | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏾">adúláwɔ̀ díɛ̀ | Ɛni Yahɔn sita | fífowɔ́júwè | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏾" type="tts">Ɛni Yahɔn sita: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙎🏿">adúláwɔ̀ | Ɛni Yahɔn sita | Ɛni Yahɔn sita: adúláwɔ̀ | fífowɔ́júwè | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏿">adúláwɔ̀ | Ɛni Yahɔn sita | fífowɔ́júwè | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏿" type="tts">Ɛni Yahɔn sita: adúláwɔ̀</annotation>
-		<annotation cp="🙎🏻‍♂">amɔ́lára | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | ɔkùnrin tí ń shíshù ètè síta: amɔ́lára | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏻‍♂">amɔ́lára | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏻‍♂" type="tts">ɔkùnrin tí ń shíshù ètè síta: amɔ́lára</annotation>
-		<annotation cp="🙎🏼‍♂">amɔ́lára díɛ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | ɔkùnrin tí ń shíshù ètè síta: amɔ́lára díɛ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏼‍♂">amɔ́lára díɛ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏼‍♂" type="tts">ɔkùnrin tí ń shíshù ètè síta: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙎🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | ɔkùnrin tí ń shíshù ètè síta: amɔ́láwɔ̀ díɛ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏽‍♂" type="tts">ɔkùnrin tí ń shíshù ètè síta: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙎🏾‍♂">adúláwɔ̀ díɛ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | ɔkùnrin tí ń shíshù ètè síta: adúláwɔ̀ díɛ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏾‍♂">adúláwɔ̀ díɛ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏾‍♂" type="tts">ɔkùnrin tí ń shíshù ètè síta: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙎🏿‍♂">adúláwɔ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | ɔkùnrin tí ń shíshù ètè síta: adúláwɔ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏿‍♂">adúláwɔ̀ | fowɔ́júwè | ɔkùnrin | ɔkùnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏿‍♂" type="tts">ɔkùnrin tí ń shíshù ètè síta: adúláwɔ̀</annotation>
-		<annotation cp="🙎🏻‍♀">amɔ́lára | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | obìnrin tí ń shíshù ètè síta: amɔ́lára | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏻‍♀">amɔ́lára | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏻‍♀" type="tts">obìnrin tí ń shíshù ètè síta: amɔ́lára</annotation>
-		<annotation cp="🙎🏼‍♀">amɔ́lára díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | obìnrin tí ń shíshù ètè síta: amɔ́lára díɛ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏼‍♀">amɔ́lára díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏼‍♀" type="tts">obìnrin tí ń shíshù ètè síta: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙎🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | obìnrin tí ń shíshù ètè síta: amɔ́láwɔ̀ díɛ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏽‍♀" type="tts">obìnrin tí ń shíshù ètè síta: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙎🏾‍♀">adúláwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | obìnrin tí ń shíshù ètè síta: adúláwɔ̀ díɛ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏾‍♀">adúláwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏾‍♀" type="tts">obìnrin tí ń shíshù ètè síta: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙎🏿‍♀">adúláwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | obìnrin tí ń shíshù ètè síta: adúláwɔ̀ | shíshù ètè síta</annotation>
+		<annotation cp="🙎🏿‍♀">adúláwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń shíshù ètè síta | shíshù ètè síta</annotation>
 		<annotation cp="🙎🏿‍♀" type="tts">obìnrin tí ń shíshù ètè síta: adúláwɔ̀</annotation>
-		<annotation cp="🙅🏻">amɔ́lára | èwɔ̀ | Ɛni Nsɔ RARA | Ɛni Nsɔ RARA: amɔ́lára | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏻">amɔ́lára | èwɔ̀ | Ɛni Nsɔ RARA | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏻" type="tts">Ɛni Nsɔ RARA: amɔ́lára</annotation>
-		<annotation cp="🙅🏼">amɔ́lára díɛ̀ | èwɔ̀ | Ɛni Nsɔ RARA | Ɛni Nsɔ RARA: amɔ́lára díɛ̀ | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏼">amɔ́lára díɛ̀ | èwɔ̀ | Ɛni Nsɔ RARA | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏼" type="tts">Ɛni Nsɔ RARA: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙅🏽">amɔ́láwɔ̀ díɛ̀ | èwɔ̀ | Ɛni Nsɔ RARA | Ɛni Nsɔ RARA: amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏽">amɔ́láwɔ̀ díɛ̀ | èwɔ̀ | Ɛni Nsɔ RARA | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏽" type="tts">Ɛni Nsɔ RARA: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙅🏾">adúláwɔ̀ díɛ̀ | èwɔ̀ | Ɛni Nsɔ RARA | Ɛni Nsɔ RARA: adúláwɔ̀ díɛ̀ | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏾">adúláwɔ̀ díɛ̀ | èwɔ̀ | Ɛni Nsɔ RARA | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏾" type="tts">Ɛni Nsɔ RARA: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙅🏿">adúláwɔ̀ | èwɔ̀ | Ɛni Nsɔ RARA | Ɛni Nsɔ RARA: adúláwɔ̀ | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏿">adúláwɔ̀ | èwɔ̀ | Ɛni Nsɔ RARA | fowɔ́júwè | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏿" type="tts">Ɛni Nsɔ RARA: adúláwɔ̀</annotation>
-		<annotation cp="🙅🏻‍♂">amɔ́lára | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔkùnrin tí ń sɔ RÁRÁ: amɔ́lára | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏻‍♂">amɔ́lára | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏻‍♂" type="tts">ɔkùnrin tí ń sɔ RÁRÁ: amɔ́lára</annotation>
-		<annotation cp="🙅🏼‍♂">amɔ́lára díɛ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔkùnrin tí ń sɔ RÁRÁ: amɔ́lára díɛ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏼‍♂">amɔ́lára díɛ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏼‍♂" type="tts">ɔkùnrin tí ń sɔ RÁRÁ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙅🏽‍♂">amɔ́láwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔkùnrin tí ń sɔ RÁRÁ: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏽‍♂">amɔ́láwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏽‍♂" type="tts">ɔkùnrin tí ń sɔ RÁRÁ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙅🏾‍♂">adúláwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔkùnrin tí ń sɔ RÁRÁ: adúláwɔ̀ díɛ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏾‍♂">adúláwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏾‍♂" type="tts">ɔkùnrin tí ń sɔ RÁRÁ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙅🏿‍♂">adúláwɔ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔkùnrin tí ń sɔ RÁRÁ: adúláwɔ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏿‍♂">adúláwɔ̀ | èwɔ̀ | fowɔ́júwè | ɔkùnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏿‍♂" type="tts">ɔkùnrin tí ń sɔ RÁRÁ: adúláwɔ̀</annotation>
-		<annotation cp="🙅🏻‍♀">amɔ́lára | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | obìnrin tí ń sɔ RÁRÁ: amɔ́lára | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏻‍♀">amɔ́lára | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏻‍♀" type="tts">obìnrin tí ń sɔ RÁRÁ: amɔ́lára</annotation>
-		<annotation cp="🙅🏼‍♀">amɔ́lára díɛ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | obìnrin tí ń sɔ RÁRÁ: amɔ́lára díɛ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏼‍♀">amɔ́lára díɛ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏼‍♀" type="tts">obìnrin tí ń sɔ RÁRÁ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙅🏽‍♀">amɔ́láwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | obìnrin tí ń sɔ RÁRÁ: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏽‍♀">amɔ́láwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏽‍♀" type="tts">obìnrin tí ń sɔ RÁRÁ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙅🏾‍♀">adúláwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | obìnrin tí ń sɔ RÁRÁ: adúláwɔ̀ díɛ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏾‍♀">adúláwɔ̀ díɛ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏾‍♀" type="tts">obìnrin tí ń sɔ RÁRÁ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙅🏿‍♀">adúláwɔ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | obìnrin tí ń sɔ RÁRÁ: adúláwɔ̀ | ɔwɔ́ | rárá</annotation>
+		<annotation cp="🙅🏿‍♀">adúláwɔ̀ | èwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ RÁRÁ | ɔwɔ́ | rárá</annotation>
 		<annotation cp="🙅🏿‍♀" type="tts">obìnrin tí ń sɔ RÁRÁ: adúláwɔ̀</annotation>
-		<annotation cp="🙆🏻">amɔ́lára | Ɛni Nsɔ O DARA | Ɛni Nsɔ O DARA: amɔ́lára | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏻">amɔ́lára | Ɛni Nsɔ O DARA | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏻" type="tts">Ɛni Nsɔ O DARA: amɔ́lára</annotation>
-		<annotation cp="🙆🏼">amɔ́lára díɛ̀ | Ɛni Nsɔ O DARA | Ɛni Nsɔ O DARA: amɔ́lára díɛ̀ | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏼">amɔ́lára díɛ̀ | Ɛni Nsɔ O DARA | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏼" type="tts">Ɛni Nsɔ O DARA: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙆🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni Nsɔ O DARA | Ɛni Nsɔ O DARA: amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni Nsɔ O DARA | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏽" type="tts">Ɛni Nsɔ O DARA: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙆🏾">adúláwɔ̀ díɛ̀ | Ɛni Nsɔ O DARA | Ɛni Nsɔ O DARA: adúláwɔ̀ díɛ̀ | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏾">adúláwɔ̀ díɛ̀ | Ɛni Nsɔ O DARA | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏾" type="tts">Ɛni Nsɔ O DARA: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙆🏿">adúláwɔ̀ | Ɛni Nsɔ O DARA | Ɛni Nsɔ O DARA: adúláwɔ̀ | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏿">adúláwɔ̀ | Ɛni Nsɔ O DARA | fowɔ́júwè | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏿" type="tts">Ɛni Nsɔ O DARA: adúláwɔ̀</annotation>
-		<annotation cp="🙆🏻‍♂">amɔ́lára | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔkùnrin tí ń sɔ ÓDÁRA: amɔ́lára | ɔwɔ́</annotation>
+		<annotation cp="🙆🏻‍♂">amɔ́lára | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏻‍♂" type="tts">ɔkùnrin tí ń sɔ ÓDÁRA: amɔ́lára</annotation>
-		<annotation cp="🙆🏼‍♂">amɔ́lára díɛ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔkùnrin tí ń sɔ ÓDÁRA: amɔ́lára díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="🙆🏼‍♂">amɔ́lára díɛ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏼‍♂" type="tts">ɔkùnrin tí ń sɔ ÓDÁRA: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙆🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔkùnrin tí ń sɔ ÓDÁRA: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="🙆🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏽‍♂" type="tts">ɔkùnrin tí ń sɔ ÓDÁRA: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙆🏾‍♂">adúláwɔ̀ díɛ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔkùnrin tí ń sɔ ÓDÁRA: adúláwɔ̀ díɛ̀ | ɔwɔ́</annotation>
+		<annotation cp="🙆🏾‍♂">adúláwɔ̀ díɛ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏾‍♂" type="tts">ɔkùnrin tí ń sɔ ÓDÁRA: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙆🏿‍♂">adúláwɔ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔkùnrin tí ń sɔ ÓDÁRA: adúláwɔ̀ | ɔwɔ́</annotation>
+		<annotation cp="🙆🏿‍♂">adúláwɔ̀ | fowɔ́júwé | ÓDÁRA | ɔkùnrin | ɔkùnrin tí ń sɔ ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏿‍♂" type="tts">ɔkùnrin tí ń sɔ ÓDÁRA: adúláwɔ̀</annotation>
-		<annotation cp="🙆🏻‍♀">amɔ́lára | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | obìnrin tí ń sɔ ÓDÁRA: amɔ́lára | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏻‍♀">amɔ́lára | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏻‍♀" type="tts">obìnrin tí ń sɔ ÓDÁRA: amɔ́lára</annotation>
-		<annotation cp="🙆🏼‍♀">amɔ́lára díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | obìnrin tí ń sɔ ÓDÁRA: amɔ́lára díɛ̀ | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏼‍♀">amɔ́lára díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏼‍♀" type="tts">obìnrin tí ń sɔ ÓDÁRA: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙆🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | obìnrin tí ń sɔ ÓDÁRA: amɔ́láwɔ̀ díɛ̀ | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏽‍♀" type="tts">obìnrin tí ń sɔ ÓDÁRA: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙆🏾‍♀">adúláwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | obìnrin tí ń sɔ ÓDÁRA: adúláwɔ̀ díɛ̀ | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏾‍♀">adúláwɔ̀ díɛ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏾‍♀" type="tts">obìnrin tí ń sɔ ÓDÁRA: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙆🏿‍♀">adúláwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | obìnrin tí ń sɔ ÓDÁRA: adúláwɔ̀ | ÓDÁRA | ɔwɔ́</annotation>
+		<annotation cp="🙆🏿‍♀">adúláwɔ̀ | fowɔ́júwè | obìnrin | obìnrin tí ń sɔ ÓDÁRA | ÓDÁRA | ɔwɔ́</annotation>
 		<annotation cp="🙆🏿‍♀" type="tts">obìnrin tí ń sɔ ÓDÁRA: adúláwɔ̀</annotation>
-		<annotation cp="💁🏻">amɔ́lára | Ɛni N Tɔka Ɔwɔ | Ɛni N Tɔka Ɔwɔ: amɔ́lára | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="💁🏻">amɔ́lára | Ɛni N Tɔka Ɔwɔ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="💁🏻" type="tts">Ɛni N Tɔka Ɔwɔ: amɔ́lára</annotation>
-		<annotation cp="💁🏼">amɔ́lára díɛ̀ | Ɛni N Tɔka Ɔwɔ | Ɛni N Tɔka Ɔwɔ: amɔ́lára díɛ̀ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="💁🏼">amɔ́lára díɛ̀ | Ɛni N Tɔka Ɔwɔ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="💁🏼" type="tts">Ɛni N Tɔka Ɔwɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💁🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Tɔka Ɔwɔ | Ɛni N Tɔka Ɔwɔ: amɔ́láwɔ̀ díɛ̀ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="💁🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Tɔka Ɔwɔ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="💁🏽" type="tts">Ɛni N Tɔka Ɔwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💁🏾">adúláwɔ̀ díɛ̀ | Ɛni N Tɔka Ɔwɔ | Ɛni N Tɔka Ɔwɔ: adúláwɔ̀ díɛ̀ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="💁🏾">adúláwɔ̀ díɛ̀ | Ɛni N Tɔka Ɔwɔ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="💁🏾" type="tts">Ɛni N Tɔka Ɔwɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💁🏿">adúláwɔ̀ | Ɛni N Tɔka Ɔwɔ | Ɛni N Tɔka Ɔwɔ: adúláwɔ̀ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
+		<annotation cp="💁🏿">adúláwɔ̀ | Ɛni N Tɔka Ɔwɔ | ìrànwɔ́ | ìròyìn | ɔlɔyaya | ɔwɔ́ | tɔ́ka</annotation>
 		<annotation cp="💁🏿" type="tts">Ɛni N Tɔka Ɔwɔ: adúláwɔ̀</annotation>
-		<annotation cp="💁🏻‍♂">amɔ́lára | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | ɔkùnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára | sassy | taka ɔwɔ́</annotation>
+		<annotation cp="💁🏻‍♂">amɔ́lára | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | sassy | taka ɔwɔ́</annotation>
 		<annotation cp="💁🏻‍♂" type="tts">ɔkùnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára</annotation>
-		<annotation cp="💁🏼‍♂">amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | ɔkùnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára díɛ̀ | sassy | taka ɔwɔ́</annotation>
+		<annotation cp="💁🏼‍♂">amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | sassy | taka ɔwɔ́</annotation>
 		<annotation cp="💁🏼‍♂" type="tts">ɔkùnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💁🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | ɔkùnrin tí ń tɔ́ka ɔwɔ́: amɔ́láwɔ̀ díɛ̀ | sassy | taka ɔwɔ́</annotation>
+		<annotation cp="💁🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | sassy | taka ɔwɔ́</annotation>
 		<annotation cp="💁🏽‍♂" type="tts">ɔkùnrin tí ń tɔ́ka ɔwɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💁🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | ɔkùnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀ díɛ̀ | sassy | taka ɔwɔ́</annotation>
+		<annotation cp="💁🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | sassy | taka ɔwɔ́</annotation>
 		<annotation cp="💁🏾‍♂" type="tts">ɔkùnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💁🏿‍♂">adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | ɔkùnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀ | sassy | taka ɔwɔ́</annotation>
+		<annotation cp="💁🏿‍♂">adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń tɔ́ka ɔwɔ́ | sassy | taka ɔwɔ́</annotation>
 		<annotation cp="💁🏿‍♂" type="tts">ɔkùnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀</annotation>
-		<annotation cp="💁🏻‍♀">amɔ́lára | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | obìnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára | sassy | tɔ́ka ɔwɔ́</annotation>
+		<annotation cp="💁🏻‍♀">amɔ́lára | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | sassy | tɔ́ka ɔwɔ́</annotation>
 		<annotation cp="💁🏻‍♀" type="tts">obìnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára</annotation>
-		<annotation cp="💁🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | obìnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára díɛ̀ | sassy | tɔ́ka ɔwɔ́</annotation>
+		<annotation cp="💁🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | sassy | tɔ́ka ɔwɔ́</annotation>
 		<annotation cp="💁🏼‍♀" type="tts">obìnrin tí ń tɔ́ka ɔwɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💁🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | obìnrin tí ń tɔ́ka ɔwɔ́: amɔ́láwɔ̀ díɛ̀ | sassy | tɔ́ka ɔwɔ́</annotation>
+		<annotation cp="💁🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | sassy | tɔ́ka ɔwɔ́</annotation>
 		<annotation cp="💁🏽‍♀" type="tts">obìnrin tí ń tɔ́ka ɔwɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💁🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | obìnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀ díɛ̀ | sassy | tɔ́ka ɔwɔ́</annotation>
+		<annotation cp="💁🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | sassy | tɔ́ka ɔwɔ́</annotation>
 		<annotation cp="💁🏾‍♀" type="tts">obìnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💁🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | obìnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀ | sassy | tɔ́ka ɔwɔ́</annotation>
+		<annotation cp="💁🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin tí ń tɔ́ka ɔwɔ́ | sassy | tɔ́ka ɔwɔ́</annotation>
 		<annotation cp="💁🏿‍♀" type="tts">obìnrin tí ń tɔ́ka ɔwɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🙋🏻">amɔ́lára | Ɛni N Nawɔ Soke | Ɛni N Nawɔ Soke: amɔ́lára | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
+		<annotation cp="🙋🏻">amɔ́lára | Ɛni N Nawɔ Soke | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
 		<annotation cp="🙋🏻" type="tts">Ɛni N Nawɔ Soke: amɔ́lára</annotation>
-		<annotation cp="🙋🏼">amɔ́lára díɛ̀ | Ɛni N Nawɔ Soke | Ɛni N Nawɔ Soke: amɔ́lára díɛ̀ | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
+		<annotation cp="🙋🏼">amɔ́lára díɛ̀ | Ɛni N Nawɔ Soke | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
 		<annotation cp="🙋🏼" type="tts">Ɛni N Nawɔ Soke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙋🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Nawɔ Soke | Ɛni N Nawɔ Soke: amɔ́láwɔ̀ díɛ̀ | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
+		<annotation cp="🙋🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Nawɔ Soke | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
 		<annotation cp="🙋🏽" type="tts">Ɛni N Nawɔ Soke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙋🏾">adúláwɔ̀ díɛ̀ | Ɛni N Nawɔ Soke | Ɛni N Nawɔ Soke: adúláwɔ̀ díɛ̀ | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
+		<annotation cp="🙋🏾">adúláwɔ̀ díɛ̀ | Ɛni N Nawɔ Soke | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
 		<annotation cp="🙋🏾" type="tts">Ɛni N Nawɔ Soke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙋🏿">adúláwɔ̀ | Ɛni N Nawɔ Soke | Ɛni N Nawɔ Soke: adúláwɔ̀ | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
+		<annotation cp="🙋🏿">adúláwɔ̀ | Ɛni N Nawɔ Soke | fɔwɔ́júwè | gbéga | ìdùnú | ɔwɔ́</annotation>
 		<annotation cp="🙋🏿" type="tts">Ɛni N Nawɔ Soke: adúláwɔ̀</annotation>
-		<annotation cp="🙋🏻‍♂">amɔ́lára | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè | ɔkùnrintí ń nawɔ́ sókè: amɔ́lára</annotation>
+		<annotation cp="🙋🏻‍♂">amɔ́lára | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏻‍♂" type="tts">ɔkùnrintí ń nawɔ́ sókè: amɔ́lára</annotation>
-		<annotation cp="🙋🏼‍♂">amɔ́lára díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè | ɔkùnrintí ń nawɔ́ sókè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🙋🏼‍♂">amɔ́lára díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏼‍♂" type="tts">ɔkùnrintí ń nawɔ́ sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙋🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè | ɔkùnrintí ń nawɔ́ sókè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙋🏽‍♂">amɔ́láwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏽‍♂" type="tts">ɔkùnrintí ń nawɔ́ sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙋🏾‍♂">adúláwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè | ɔkùnrintí ń nawɔ́ sókè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙋🏾‍♂">adúláwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏾‍♂" type="tts">ɔkùnrintí ń nawɔ́ sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙋🏿‍♂">adúláwɔ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè | ɔkùnrintí ń nawɔ́ sókè: adúláwɔ̀</annotation>
+		<annotation cp="🙋🏿‍♂">adúláwɔ̀ | fɔwɔ́júwè | nawɔ́ sókè | ɔkùnrin | ɔkùnrintí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏿‍♂" type="tts">ɔkùnrintí ń nawɔ́ sókè: adúláwɔ̀</annotation>
-		<annotation cp="🙋🏻‍♀">amɔ́lára | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè | obìnrin tí ń nawɔ́ sókè: amɔ́lára</annotation>
+		<annotation cp="🙋🏻‍♀">amɔ́lára | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏻‍♀" type="tts">obìnrin tí ń nawɔ́ sókè: amɔ́lára</annotation>
-		<annotation cp="🙋🏼‍♀">amɔ́lára díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè | obìnrin tí ń nawɔ́ sókè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🙋🏼‍♀">amɔ́lára díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏼‍♀" type="tts">obìnrin tí ń nawɔ́ sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙋🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè | obìnrin tí ń nawɔ́ sókè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙋🏽‍♀">amɔ́láwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏽‍♀" type="tts">obìnrin tí ń nawɔ́ sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙋🏾‍♀">adúláwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè | obìnrin tí ń nawɔ́ sókè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🙋🏾‍♀">adúláwɔ̀ díɛ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏾‍♀" type="tts">obìnrin tí ń nawɔ́ sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙋🏿‍♀">adúláwɔ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè | obìnrin tí ń nawɔ́ sókè: adúláwɔ̀</annotation>
+		<annotation cp="🙋🏿‍♀">adúláwɔ̀ | fɔwɔ́júwè | nawɔ́ sókè | obìnrin | obìnrin tí ń nawɔ́ sókè</annotation>
 		<annotation cp="🙋🏿‍♀" type="tts">obìnrin tí ń nawɔ́ sókè: adúláwɔ̀</annotation>
-		<annotation cp="🧏🏻">amɔ́lára | etí | gbɔ́ | odi | odí ènìyàn | odi: amɔ́lára</annotation>
+		<annotation cp="🧏🏻">amɔ́lára | etí | gbɔ́ | odi | odí ènìyàn</annotation>
 		<annotation cp="🧏🏻" type="tts">odi: amɔ́lára</annotation>
-		<annotation cp="🧏🏼">amɔ́lára díɛ̀ | etí | gbɔ́ | odi | odí ènìyàn | odi: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧏🏼">amɔ́lára díɛ̀ | etí | gbɔ́ | odi | odí ènìyàn</annotation>
 		<annotation cp="🧏🏼" type="tts">odi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧏🏽">amɔ́láwɔ̀ díɛ̀ | etí | gbɔ́ | odi | odí ènìyàn | odi: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧏🏽">amɔ́láwɔ̀ díɛ̀ | etí | gbɔ́ | odi | odí ènìyàn</annotation>
 		<annotation cp="🧏🏽" type="tts">odi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧏🏾">adúláwɔ̀ díɛ̀ | etí | gbɔ́ | odi | odí ènìyàn | odi: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧏🏾">adúláwɔ̀ díɛ̀ | etí | gbɔ́ | odi | odí ènìyàn</annotation>
 		<annotation cp="🧏🏾" type="tts">odi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧏🏿">adúláwɔ̀ | etí | gbɔ́ | odi | odí ènìyàn | odi: adúláwɔ̀</annotation>
+		<annotation cp="🧏🏿">adúláwɔ̀ | etí | gbɔ́ | odi | odí ènìyàn</annotation>
 		<annotation cp="🧏🏿" type="tts">odi: adúláwɔ̀</annotation>
-		<annotation cp="🧏🏻‍♂">adití | amɔ́lára | ɔkùnrin | ɔkùnrin adití: amɔ́lára</annotation>
+		<annotation cp="🧏🏻‍♂">adití | amɔ́lára | ɔkùnrin</annotation>
 		<annotation cp="🧏🏻‍♂" type="tts">ɔkùnrin adití: amɔ́lára</annotation>
-		<annotation cp="🧏🏼‍♂">adití | amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin adití: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧏🏼‍♂">adití | amɔ́lára díɛ̀ | ɔkùnrin</annotation>
 		<annotation cp="🧏🏼‍♂" type="tts">ɔkùnrin adití: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧏🏽‍♂">adití | amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin adití: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧏🏽‍♂">adití | amɔ́láwɔ̀ díɛ̀ | ɔkùnrin</annotation>
 		<annotation cp="🧏🏽‍♂" type="tts">ɔkùnrin adití: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧏🏾‍♂">adití | adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin adití: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧏🏾‍♂">adití | adúláwɔ̀ díɛ̀ | ɔkùnrin</annotation>
 		<annotation cp="🧏🏾‍♂" type="tts">ɔkùnrin adití: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧏🏿‍♂">adití | adúláwɔ̀ | ɔkùnrin | ɔkùnrin adití: adúláwɔ̀</annotation>
+		<annotation cp="🧏🏿‍♂">adití | adúláwɔ̀ | ɔkùnrin</annotation>
 		<annotation cp="🧏🏿‍♂" type="tts">ɔkùnrin adití: adúláwɔ̀</annotation>
-		<annotation cp="🧏🏻‍♀">adití | amɔ́lára | obìnrin | obìnrin adití: amɔ́lára</annotation>
+		<annotation cp="🧏🏻‍♀">adití | amɔ́lára | obìnrin</annotation>
 		<annotation cp="🧏🏻‍♀" type="tts">obìnrin adití: amɔ́lára</annotation>
-		<annotation cp="🧏🏼‍♀">adití | amɔ́lára díɛ̀ | obìnrin | obìnrin adití: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧏🏼‍♀">adití | amɔ́lára díɛ̀ | obìnrin</annotation>
 		<annotation cp="🧏🏼‍♀" type="tts">obìnrin adití: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧏🏽‍♀">adití | amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin adití: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧏🏽‍♀">adití | amɔ́láwɔ̀ díɛ̀ | obìnrin</annotation>
 		<annotation cp="🧏🏽‍♀" type="tts">obìnrin adití: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧏🏾‍♀">adití | adúláwɔ̀ díɛ̀ | obìnrin | obìnrin adití: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧏🏾‍♀">adití | adúláwɔ̀ díɛ̀ | obìnrin</annotation>
 		<annotation cp="🧏🏾‍♀" type="tts">obìnrin adití: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧏🏿‍♀">adití | adúláwɔ̀ | obìnrin | obìnrin adití: adúláwɔ̀</annotation>
+		<annotation cp="🧏🏿‍♀">adití | adúláwɔ̀ | obìnrin</annotation>
 		<annotation cp="🧏🏿‍♀" type="tts">obìnrin adití: adúláwɔ̀</annotation>
-		<annotation cp="🙇🏻">amɔ́lára | bɛ̀bɛ̀ | Ɛni N Tɛriba | Ɛni N Tɛriba: amɔ́lára | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
+		<annotation cp="🙇🏻">amɔ́lára | bɛ̀bɛ̀ | Ɛni N Tɛriba | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
 		<annotation cp="🙇🏻" type="tts">Ɛni N Tɛriba: amɔ́lára</annotation>
-		<annotation cp="🙇🏼">amɔ́lára díɛ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | Ɛni N Tɛriba: amɔ́lára díɛ̀ | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
+		<annotation cp="🙇🏼">amɔ́lára díɛ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
 		<annotation cp="🙇🏼" type="tts">Ɛni N Tɛriba: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙇🏽">amɔ́láwɔ̀ díɛ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | Ɛni N Tɛriba: amɔ́láwɔ̀ díɛ̀ | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
+		<annotation cp="🙇🏽">amɔ́láwɔ̀ díɛ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
 		<annotation cp="🙇🏽" type="tts">Ɛni N Tɛriba: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙇🏾">adúláwɔ̀ díɛ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | Ɛni N Tɛriba: adúláwɔ̀ díɛ̀ | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
+		<annotation cp="🙇🏾">adúláwɔ̀ díɛ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
 		<annotation cp="🙇🏾" type="tts">Ɛni N Tɛriba: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙇🏿">adúláwɔ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | Ɛni N Tɛriba: adúláwɔ̀ | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
+		<annotation cp="🙇🏿">adúláwɔ̀ | bɛ̀bɛ̀ | Ɛni N Tɛriba | fɔwɔ́júwè | pɛ̀lɛ́ | tɛríba</annotation>
 		<annotation cp="🙇🏿" type="tts">Ɛni N Tɛriba: adúláwɔ̀</annotation>
-		<annotation cp="🙇🏻‍♂">àànú | amɔ́lára | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | ɔkùnrin tí ń tɛríba: amɔ́lára | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏻‍♂">àànú | amɔ́lára | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏻‍♂" type="tts">ɔkùnrin tí ń tɛríba: amɔ́lára</annotation>
-		<annotation cp="🙇🏼‍♂">àànú | amɔ́lára díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | ɔkùnrin tí ń tɛríba: amɔ́lára díɛ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏼‍♂">àànú | amɔ́lára díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏼‍♂" type="tts">ɔkùnrin tí ń tɛríba: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙇🏽‍♂">àànú | amɔ́láwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | ɔkùnrin tí ń tɛríba: amɔ́láwɔ̀ díɛ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏽‍♂">àànú | amɔ́láwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏽‍♂" type="tts">ɔkùnrin tí ń tɛríba: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙇🏾‍♂">àànú | adúláwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | ɔkùnrin tí ń tɛríba: adúláwɔ̀ díɛ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏾‍♂">àànú | adúláwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏾‍♂" type="tts">ɔkùnrin tí ń tɛríba: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙇🏿‍♂">àànú | adúláwɔ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | ɔkùnrin tí ń tɛríba: adúláwɔ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏿‍♂">àànú | adúláwɔ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | ɔkùnrin | ɔkùnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏿‍♂" type="tts">ɔkùnrin tí ń tɛríba: adúláwɔ̀</annotation>
-		<annotation cp="🙇🏻‍♀">àànú | amɔ́lára | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | obìnrin tí ń tɛríba: amɔ́lára | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏻‍♀">àànú | amɔ́lára | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏻‍♀" type="tts">obìnrin tí ń tɛríba: amɔ́lára</annotation>
-		<annotation cp="🙇🏼‍♀">àànú | amɔ́lára díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | obìnrin tí ń tɛríba: amɔ́lára díɛ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏼‍♀">àànú | amɔ́lára díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏼‍♀" type="tts">obìnrin tí ń tɛríba: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🙇🏽‍♀">àànú | amɔ́láwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | obìnrin tí ń tɛríba: amɔ́láwɔ̀ díɛ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏽‍♀">àànú | amɔ́láwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏽‍♀" type="tts">obìnrin tí ń tɛríba: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙇🏾‍♀">àànú | adúláwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | obìnrin tí ń tɛríba: adúláwɔ̀ díɛ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏾‍♀">àànú | adúláwɔ̀ díɛ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏾‍♀" type="tts">obìnrin tí ń tɛríba: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🙇🏿‍♀">àànú | adúláwɔ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | obìnrin tí ń tɛríba: adúláwɔ̀ | pɛ̀lɛ́ | títɛríba</annotation>
+		<annotation cp="🙇🏿‍♀">àànú | adúláwɔ̀ | bɛ̀bɛ̀ | fɔwɔ́júwè | obìnrin | obìnrin tí ń tɛríba | pɛ̀lɛ́ | títɛríba</annotation>
 		<annotation cp="🙇🏿‍♀" type="tts">obìnrin tí ń tɛríba: adúláwɔ̀</annotation>
-		<annotation cp="🤦🏻">àìgbàgbɔ́ | amɔ́lára | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | Ɛni Fɔwɔ Boju: amɔ́lára | ìkórira | ojú</annotation>
+		<annotation cp="🤦🏻">àìgbàgbɔ́ | amɔ́lára | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | ìkórira | ojú</annotation>
 		<annotation cp="🤦🏻" type="tts">Ɛni Fɔwɔ Boju: amɔ́lára</annotation>
-		<annotation cp="🤦🏼">àìgbàgbɔ́ | amɔ́lára díɛ̀ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | Ɛni Fɔwɔ Boju: amɔ́lára díɛ̀ | ìkórira | ojú</annotation>
+		<annotation cp="🤦🏼">àìgbàgbɔ́ | amɔ́lára díɛ̀ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | ìkórira | ojú</annotation>
 		<annotation cp="🤦🏼" type="tts">Ɛni Fɔwɔ Boju: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤦🏽">àìgbàgbɔ́ | amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | Ɛni Fɔwɔ Boju: amɔ́láwɔ̀ díɛ̀ | ìkórira | ojú</annotation>
+		<annotation cp="🤦🏽">àìgbàgbɔ́ | amɔ́láwɔ̀ díɛ̀ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | ìkórira | ojú</annotation>
 		<annotation cp="🤦🏽" type="tts">Ɛni Fɔwɔ Boju: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤦🏾">adúláwɔ̀ díɛ̀ | àìgbàgbɔ́ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | Ɛni Fɔwɔ Boju: adúláwɔ̀ díɛ̀ | ìkórira | ojú</annotation>
+		<annotation cp="🤦🏾">adúláwɔ̀ díɛ̀ | àìgbàgbɔ́ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | ìkórira | ojú</annotation>
 		<annotation cp="🤦🏾" type="tts">Ɛni Fɔwɔ Boju: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤦🏿">adúláwɔ̀ | àìgbàgbɔ́ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | Ɛni Fɔwɔ Boju: adúláwɔ̀ | ìkórira | ojú</annotation>
+		<annotation cp="🤦🏿">adúláwɔ̀ | àìgbàgbɔ́ | àtɛ́lɛ́ ɔwa | Ɛni Fɔwɔ Boju | ìkórira | ojú</annotation>
 		<annotation cp="🤦🏿" type="tts">Ɛni Fɔwɔ Boju: adúláwɔ̀</annotation>
-		<annotation cp="🤦🏻‍♂">àìgbàgbɔ́ | amɔ́lára | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú | ɔkùnrin tín fɔwɔ́bojú: amɔ́lára</annotation>
+		<annotation cp="🤦🏻‍♂">àìgbàgbɔ́ | amɔ́lára | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú</annotation>
 		<annotation cp="🤦🏻‍♂" type="tts">ɔkùnrin tín fɔwɔ́bojú: amɔ́lára</annotation>
-		<annotation cp="🤦🏼‍♂">àìgbàgbɔ́ | amɔ́lára díɛ̀ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú | ɔkùnrin tín fɔwɔ́bojú: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤦🏼‍♂">àìgbàgbɔ́ | amɔ́lára díɛ̀ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú</annotation>
 		<annotation cp="🤦🏼‍♂" type="tts">ɔkùnrin tín fɔwɔ́bojú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤦🏽‍♂">àìgbàgbɔ́ | amɔ́láwɔ̀ díɛ̀ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú | ɔkùnrin tín fɔwɔ́bojú: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤦🏽‍♂">àìgbàgbɔ́ | amɔ́láwɔ̀ díɛ̀ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú</annotation>
 		<annotation cp="🤦🏽‍♂" type="tts">ɔkùnrin tín fɔwɔ́bojú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤦🏾‍♂">adúláwɔ̀ díɛ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú | ɔkùnrin tín fɔwɔ́bojú: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤦🏾‍♂">adúláwɔ̀ díɛ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú</annotation>
 		<annotation cp="🤦🏾‍♂" type="tts">ɔkùnrin tín fɔwɔ́bojú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤦🏿‍♂">adúláwɔ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú | ɔkùnrin tín fɔwɔ́bojú: adúláwɔ̀</annotation>
+		<annotation cp="🤦🏿‍♂">adúláwɔ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | okùnrin | ɔkùnrin tín fɔwɔ́bojú</annotation>
 		<annotation cp="🤦🏿‍♂" type="tts">ɔkùnrin tín fɔwɔ́bojú: adúláwɔ̀</annotation>
-		<annotation cp="🤦🏻‍♀">àìgbàgbɔ́ | amɔ́lára | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrí tín fɔwɔ́bojú: amɔ́lára | obìnrin</annotation>
+		<annotation cp="🤦🏻‍♀">àìgbàgbɔ́ | amɔ́lára | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrin</annotation>
 		<annotation cp="🤦🏻‍♀" type="tts">obìnrí tín fɔwɔ́bojú: amɔ́lára</annotation>
-		<annotation cp="🤦🏼‍♀">àìgbàgbɔ́ | amɔ́lára díɛ̀ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrí tín fɔwɔ́bojú: amɔ́lára díɛ̀ | obìnrin</annotation>
+		<annotation cp="🤦🏼‍♀">àìgbàgbɔ́ | amɔ́lára díɛ̀ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrin</annotation>
 		<annotation cp="🤦🏼‍♀" type="tts">obìnrí tín fɔwɔ́bojú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤦🏽‍♀">àìgbàgbɔ́ | amɔ́láwɔ̀ díɛ̀ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrí tín fɔwɔ́bojú: amɔ́láwɔ̀ díɛ̀ | obìnrin</annotation>
+		<annotation cp="🤦🏽‍♀">àìgbàgbɔ́ | amɔ́láwɔ̀ díɛ̀ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrin</annotation>
 		<annotation cp="🤦🏽‍♀" type="tts">obìnrí tín fɔwɔ́bojú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤦🏾‍♀">adúláwɔ̀ díɛ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrí tín fɔwɔ́bojú: adúláwɔ̀ díɛ̀ | obìnrin</annotation>
+		<annotation cp="🤦🏾‍♀">adúláwɔ̀ díɛ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrin</annotation>
 		<annotation cp="🤦🏾‍♀" type="tts">obìnrí tín fɔwɔ́bojú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤦🏿‍♀">adúláwɔ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrí tín fɔwɔ́bojú: adúláwɔ̀ | obìnrin</annotation>
+		<annotation cp="🤦🏿‍♀">adúláwɔ̀ | àìgbàgbɔ́ | fɔwɔ́bojú | ìkórira | obìnrí tín fɔwɔ́bojú | obìnrin</annotation>
 		<annotation cp="🤦🏿‍♀" type="tts">obìnrí tín fɔwɔ́bojú: adúláwɔ̀</annotation>
-		<annotation cp="🤷🏻">àìmɔ̀kan | àìnání | amɔ́lára | Ɛni N Gunpa | Ɛni N Gunpa: amɔ́lára | gúnpá | iyèméjì</annotation>
+		<annotation cp="🤷🏻">àìmɔ̀kan | àìnání | amɔ́lára | Ɛni N Gunpa | gúnpá | iyèméjì</annotation>
 		<annotation cp="🤷🏻" type="tts">Ɛni N Gunpa: amɔ́lára</annotation>
-		<annotation cp="🤷🏼">àìmɔ̀kan | àìnání | amɔ́lára díɛ̀ | Ɛni N Gunpa | Ɛni N Gunpa: amɔ́lára díɛ̀ | gúnpá | iyèméjì</annotation>
+		<annotation cp="🤷🏼">àìmɔ̀kan | àìnání | amɔ́lára díɛ̀ | Ɛni N Gunpa | gúnpá | iyèméjì</annotation>
 		<annotation cp="🤷🏼" type="tts">Ɛni N Gunpa: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤷🏽">àìmɔ̀kan | àìnání | amɔ́láwɔ̀ díɛ̀ | Ɛni N Gunpa | Ɛni N Gunpa: amɔ́láwɔ̀ díɛ̀ | gúnpá | iyèméjì</annotation>
+		<annotation cp="🤷🏽">àìmɔ̀kan | àìnání | amɔ́láwɔ̀ díɛ̀ | Ɛni N Gunpa | gúnpá | iyèméjì</annotation>
 		<annotation cp="🤷🏽" type="tts">Ɛni N Gunpa: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤷🏾">adúláwɔ̀ díɛ̀ | àìmɔ̀kan | àìnání | Ɛni N Gunpa | Ɛni N Gunpa: adúláwɔ̀ díɛ̀ | gúnpá | iyèméjì</annotation>
+		<annotation cp="🤷🏾">adúláwɔ̀ díɛ̀ | àìmɔ̀kan | àìnání | Ɛni N Gunpa | gúnpá | iyèméjì</annotation>
 		<annotation cp="🤷🏾" type="tts">Ɛni N Gunpa: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤷🏿">adúláwɔ̀ | àìmɔ̀kan | àìnání | Ɛni N Gunpa | Ɛni N Gunpa: adúláwɔ̀ | gúnpá | iyèméjì</annotation>
+		<annotation cp="🤷🏿">adúláwɔ̀ | àìmɔ̀kan | àìnání | Ɛni N Gunpa | gúnpá | iyèméjì</annotation>
 		<annotation cp="🤷🏿" type="tts">Ɛni N Gunpa: adúláwɔ̀</annotation>
-		<annotation cp="🤷🏻‍♂">àìmɔ̀kan | àìnání | amɔ́lára | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá | ɔkùnrin tí ń gúnpá: amɔ́lára</annotation>
+		<annotation cp="🤷🏻‍♂">àìmɔ̀kan | àìnání | amɔ́lára | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá</annotation>
 		<annotation cp="🤷🏻‍♂" type="tts">ɔkùnrin tí ń gúnpá: amɔ́lára</annotation>
-		<annotation cp="🤷🏼‍♂">àìmɔ̀kan | àìnání | amɔ́lára díɛ̀ | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá | ɔkùnrin tí ń gúnpá: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤷🏼‍♂">àìmɔ̀kan | àìnání | amɔ́lára díɛ̀ | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá</annotation>
 		<annotation cp="🤷🏼‍♂" type="tts">ɔkùnrin tí ń gúnpá: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤷🏽‍♂">àìmɔ̀kan | àìnání | amɔ́láwɔ̀ díɛ̀ | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá | ɔkùnrin tí ń gúnpá: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤷🏽‍♂">àìmɔ̀kan | àìnání | amɔ́láwɔ̀ díɛ̀ | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá</annotation>
 		<annotation cp="🤷🏽‍♂" type="tts">ɔkùnrin tí ń gúnpá: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤷🏾‍♂">adúláwɔ̀ díɛ̀ | àìmɔ̀kan | àìnání | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá | ɔkùnrin tí ń gúnpá: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤷🏾‍♂">adúláwɔ̀ díɛ̀ | àìmɔ̀kan | àìnání | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá</annotation>
 		<annotation cp="🤷🏾‍♂" type="tts">ɔkùnrin tí ń gúnpá: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤷🏿‍♂">adúláwɔ̀ | àìmɔ̀kan | àìnání | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá | ɔkùnrin tí ń gúnpá: adúláwɔ̀</annotation>
+		<annotation cp="🤷🏿‍♂">adúláwɔ̀ | àìmɔ̀kan | àìnání | gúnpá | iyèméjì | ɔkùnrin | ɔkùnrin tí ń gúnpá</annotation>
 		<annotation cp="🤷🏿‍♂" type="tts">ɔkùnrin tí ń gúnpá: adúláwɔ̀</annotation>
-		<annotation cp="🤷🏻‍♀">àìmɔ̀kan | àìnánní | amɔ́lára | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa | obìǹrin tí ń gúnpa: amɔ́lára</annotation>
+		<annotation cp="🤷🏻‍♀">àìmɔ̀kan | àìnánní | amɔ́lára | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa</annotation>
 		<annotation cp="🤷🏻‍♀" type="tts">obìǹrin tí ń gúnpa: amɔ́lára</annotation>
-		<annotation cp="🤷🏼‍♀">àìmɔ̀kan | àìnánní | amɔ́lára díɛ̀ | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa | obìǹrin tí ń gúnpa: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤷🏼‍♀">àìmɔ̀kan | àìnánní | amɔ́lára díɛ̀ | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa</annotation>
 		<annotation cp="🤷🏼‍♀" type="tts">obìǹrin tí ń gúnpa: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤷🏽‍♀">àìmɔ̀kan | àìnánní | amɔ́láwɔ̀ díɛ̀ | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa | obìǹrin tí ń gúnpa: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤷🏽‍♀">àìmɔ̀kan | àìnánní | amɔ́láwɔ̀ díɛ̀ | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa</annotation>
 		<annotation cp="🤷🏽‍♀" type="tts">obìǹrin tí ń gúnpa: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤷🏾‍♀">adúláwɔ̀ díɛ̀ | àìmɔ̀kan | àìnánní | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa | obìǹrin tí ń gúnpa: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤷🏾‍♀">adúláwɔ̀ díɛ̀ | àìmɔ̀kan | àìnánní | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa</annotation>
 		<annotation cp="🤷🏾‍♀" type="tts">obìǹrin tí ń gúnpa: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤷🏿‍♀">adúláwɔ̀ | àìmɔ̀kan | àìnánní | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa | obìǹrin tí ń gúnpa: adúláwɔ̀</annotation>
+		<annotation cp="🤷🏿‍♀">adúláwɔ̀ | àìmɔ̀kan | àìnánní | gúnpá | iyèméjì | obìnrin | obìǹrin tí ń gúnpa</annotation>
 		<annotation cp="🤷🏿‍♀" type="tts">obìǹrin tí ń gúnpa: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍⚕">amɔ́lára | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera | òshìshɛ́ ìlera: amɔ́lára</annotation>
+		<annotation cp="🧑🏻‍⚕">amɔ́lára | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera</annotation>
 		<annotation cp="🧑🏻‍⚕" type="tts">òshìshɛ́ ìlera: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍⚕">amɔ́lára díɛ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera | òshìshɛ́ ìlera: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧑🏼‍⚕">amɔ́lára díɛ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera</annotation>
 		<annotation cp="🧑🏼‍⚕" type="tts">òshìshɛ́ ìlera: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍⚕">amɔ́láwɔ̀ díɛ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera | òshìshɛ́ ìlera: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏽‍⚕">amɔ́láwɔ̀ díɛ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera</annotation>
 		<annotation cp="🧑🏽‍⚕" type="tts">òshìshɛ́ ìlera: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍⚕">adúláwɔ̀ díɛ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera | òshìshɛ́ ìlera: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏾‍⚕">adúláwɔ̀ díɛ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera</annotation>
 		<annotation cp="🧑🏾‍⚕" type="tts">òshìshɛ́ ìlera: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍⚕">adúláwɔ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera | òshìshɛ́ ìlera: adúláwɔ̀</annotation>
+		<annotation cp="🧑🏿‍⚕">adúláwɔ̀ | ashèwòsàn nípasɛ̀ ìmɔ̀ràn | dɔ̀kítà | ìtɔ́jú ìlera | nɔ́ɔ̀sì | òshìshɛ́ ìlera</annotation>
 		<annotation cp="🧑🏿‍⚕" type="tts">òshìshɛ́ ìlera: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍⚕">ajɔ ìlera | amɔ́lára | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera | ɔkùnrín òshìshɛ́ ètò ìlera: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍⚕">ajɔ ìlera | amɔ́lára | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera</annotation>
 		<annotation cp="👨🏻‍⚕" type="tts">ɔkùnrín òshìshɛ́ ètò ìlera: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍⚕">ajɔ ìlera | amɔ́lára díɛ̀ | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera | ɔkùnrín òshìshɛ́ ètò ìlera: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍⚕">ajɔ ìlera | amɔ́lára díɛ̀ | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera</annotation>
 		<annotation cp="👨🏼‍⚕" type="tts">ɔkùnrín òshìshɛ́ ètò ìlera: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍⚕">ajɔ ìlera | amɔ́láwɔ̀ díɛ̀ | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera | ɔkùnrín òshìshɛ́ ètò ìlera: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍⚕">ajɔ ìlera | amɔ́láwɔ̀ díɛ̀ | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera</annotation>
 		<annotation cp="👨🏽‍⚕" type="tts">ɔkùnrín òshìshɛ́ ètò ìlera: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍⚕">adúláwɔ̀ díɛ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera | ɔkùnrín òshìshɛ́ ètò ìlera: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍⚕">adúláwɔ̀ díɛ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera</annotation>
 		<annotation cp="👨🏾‍⚕" type="tts">ɔkùnrín òshìshɛ́ ètò ìlera: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍⚕">adúláwɔ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera | ɔkùnrín òshìshɛ́ ètò ìlera: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍⚕">adúláwɔ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | olùdámɔ̀ràn | ɔkùnrin | ɔkùnrín òshìshɛ́ ètò ìlera</annotation>
 		<annotation cp="👨🏿‍⚕" type="tts">ɔkùnrín òshìshɛ́ ètò ìlera: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍⚕">ajɔ ìlera | amɔ́lára | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | obìrin òshìshɛ́ ètò ìlera: amɔ́lára | olùdámɔ̀ràn</annotation>
+		<annotation cp="👩🏻‍⚕">ajɔ ìlera | amɔ́lára | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | olùdámɔ̀ràn</annotation>
 		<annotation cp="👩🏻‍⚕" type="tts">obìrin òshìshɛ́ ètò ìlera: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍⚕">ajɔ ìlera | amɔ́lára díɛ̀ | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | obìrin òshìshɛ́ ètò ìlera: amɔ́lára díɛ̀ | olùdámɔ̀ràn</annotation>
+		<annotation cp="👩🏼‍⚕">ajɔ ìlera | amɔ́lára díɛ̀ | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | olùdámɔ̀ràn</annotation>
 		<annotation cp="👩🏼‍⚕" type="tts">obìrin òshìshɛ́ ètò ìlera: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍⚕">ajɔ ìlera | amɔ́láwɔ̀ díɛ̀ | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | obìrin òshìshɛ́ ètò ìlera: amɔ́láwɔ̀ díɛ̀ | olùdámɔ̀ràn</annotation>
+		<annotation cp="👩🏽‍⚕">ajɔ ìlera | amɔ́láwɔ̀ díɛ̀ | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | olùdámɔ̀ràn</annotation>
 		<annotation cp="👩🏽‍⚕" type="tts">obìrin òshìshɛ́ ètò ìlera: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍⚕">adúláwɔ̀ díɛ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | obìrin òshìshɛ́ ètò ìlera: adúláwɔ̀ díɛ̀ | olùdámɔ̀ràn</annotation>
+		<annotation cp="👩🏾‍⚕">adúláwɔ̀ díɛ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | olùdámɔ̀ràn</annotation>
 		<annotation cp="👩🏾‍⚕" type="tts">obìrin òshìshɛ́ ètò ìlera: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍⚕">adúláwɔ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | obìrin òshìshɛ́ ètò ìlera: adúláwɔ̀ | olùdámɔ̀ràn</annotation>
+		<annotation cp="👩🏿‍⚕">adúláwɔ̀ | ajɔ ìlera | dókítà | nɔ́ɔ̀sì | obìrin | obìrin òshìshɛ́ ètò ìlera | olùdámɔ̀ràn</annotation>
 		<annotation cp="👩🏿‍⚕" type="tts">obìrin òshìshɛ́ ètò ìlera: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🎓">akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́: amɔ́lára | akɛ́kɔ̀ɔ́gboyè | amɔ́lára</annotation>
+		<annotation cp="🧑🏻‍🎓">akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́gboyè | amɔ́lára</annotation>
 		<annotation cp="🧑🏻‍🎓" type="tts">akɛ́kɔ̀ɔ́: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🎓">akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́: amɔ́lára díɛ̀ | akɛ́kɔ̀ɔ́gboyè | amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧑🏼‍🎓">akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́gboyè | amɔ́lára díɛ̀</annotation>
 		<annotation cp="🧑🏼‍🎓" type="tts">akɛ́kɔ̀ɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🎓">akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́: amɔ́láwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́gboyè | amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏽‍🎓">akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́gboyè | amɔ́láwɔ̀ díɛ̀</annotation>
 		<annotation cp="🧑🏽‍🎓" type="tts">akɛ́kɔ̀ɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🎓">adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́: adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́gboyè</annotation>
+		<annotation cp="🧑🏾‍🎓">adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́gboyè</annotation>
 		<annotation cp="🧑🏾‍🎓" type="tts">akɛ́kɔ̀ɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🎓">adúláwɔ̀ | akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́: adúláwɔ̀ | akɛ́kɔ̀ɔ́gboyè</annotation>
+		<annotation cp="🧑🏿‍🎓">adúláwɔ̀ | akɛ́kɔ̀ɔ́ | akɛ́kɔ̀ɔ́gboyè</annotation>
 		<annotation cp="🧑🏿‍🎓" type="tts">akɛ́kɔ̀ɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára | kàwégboyè | ɔkùnrin | ɔkùnrin akɛ́kɔ̀ɔ́: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára | kàwégboyè | ɔkùnrin</annotation>
 		<annotation cp="👨🏻‍🎓" type="tts">ɔkùnrin akɛ́kɔ̀ɔ́: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára díɛ̀ | kàwégboyè | ɔkùnrin | ɔkùnrin akɛ́kɔ̀ɔ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára díɛ̀ | kàwégboyè | ɔkùnrin</annotation>
 		<annotation cp="👨🏼‍🎓" type="tts">ɔkùnrin akɛ́kɔ̀ɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🎓">akɛ́kɔ̀ɔ́ | amɔ́láwɔ̀ díɛ̀ | kàwégboyè | ɔkùnrin | ɔkùnrin akɛ́kɔ̀ɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🎓">akɛ́kɔ̀ɔ́ | amɔ́láwɔ̀ díɛ̀ | kàwégboyè | ɔkùnrin</annotation>
 		<annotation cp="👨🏽‍🎓" type="tts">ɔkùnrin akɛ́kɔ̀ɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🎓">adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | ɔkùnrin | ɔkùnrin akɛ́kɔ̀ɔ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🎓">adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | ɔkùnrin</annotation>
 		<annotation cp="👨🏾‍🎓" type="tts">ɔkùnrin akɛ́kɔ̀ɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🎓">adúláwɔ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | ɔkùnrin | ɔkùnrin akɛ́kɔ̀ɔ́: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🎓">adúláwɔ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | ɔkùnrin</annotation>
 		<annotation cp="👨🏿‍🎓" type="tts">ɔkùnrin akɛ́kɔ̀ɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára | kàwégboyè | obìrin | obìrin akɛ́kɔ̀ɔ́: amɔ́lára</annotation>
+		<annotation cp="👩🏻‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára | kàwégboyè | obìrin</annotation>
 		<annotation cp="👩🏻‍🎓" type="tts">obìrin akɛ́kɔ̀ɔ́: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára díɛ̀ | kàwégboyè | obìrin | obìrin akɛ́kɔ̀ɔ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👩🏼‍🎓">akɛ́kɔ̀ɔ́ | amɔ́lára díɛ̀ | kàwégboyè | obìrin</annotation>
 		<annotation cp="👩🏼‍🎓" type="tts">obìrin akɛ́kɔ̀ɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🎓">akɛ́kɔ̀ɔ́ | amɔ́láwɔ̀ díɛ̀ | kàwégboyè | obìrin | obìrin akɛ́kɔ̀ɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏽‍🎓">akɛ́kɔ̀ɔ́ | amɔ́láwɔ̀ díɛ̀ | kàwégboyè | obìrin</annotation>
 		<annotation cp="👩🏽‍🎓" type="tts">obìrin akɛ́kɔ̀ɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🎓">adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | obìrin | obìrin akɛ́kɔ̀ɔ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏾‍🎓">adúláwɔ̀ díɛ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | obìrin</annotation>
 		<annotation cp="👩🏾‍🎓" type="tts">obìrin akɛ́kɔ̀ɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🎓">adúláwɔ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | obìrin | obìrin akɛ́kɔ̀ɔ́: adúláwɔ̀</annotation>
+		<annotation cp="👩🏿‍🎓">adúláwɔ̀ | akɛ́kɔ̀ɔ́ | kàwégboyè | obìrin</annotation>
 		<annotation cp="👩🏿‍🎓" type="tts">obìrin akɛ́kɔ̀ɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🏫">amɔ́lára | olùkɔ́ | olùkɔ́: amɔ́lára | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
+		<annotation cp="🧑🏻‍🏫">amɔ́lára | olùkɔ́ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
 		<annotation cp="🧑🏻‍🏫" type="tts">olùkɔ́: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🏫">amɔ́lára díɛ̀ | olùkɔ́ | olùkɔ́: amɔ́lára díɛ̀ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
+		<annotation cp="🧑🏼‍🏫">amɔ́lára díɛ̀ | olùkɔ́ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
 		<annotation cp="🧑🏼‍🏫" type="tts">olùkɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🏫">amɔ́láwɔ̀ díɛ̀ | olùkɔ́ | olùkɔ́: amɔ́láwɔ̀ díɛ̀ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
+		<annotation cp="🧑🏽‍🏫">amɔ́láwɔ̀ díɛ̀ | olùkɔ́ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
 		<annotation cp="🧑🏽‍🏫" type="tts">olùkɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🏫">adúláwɔ̀ díɛ̀ | olùkɔ́ | olùkɔ́: adúláwɔ̀ díɛ̀ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
+		<annotation cp="🧑🏾‍🏫">adúláwɔ̀ díɛ̀ | olùkɔ́ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
 		<annotation cp="🧑🏾‍🏫" type="tts">olùkɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🏫">adúláwɔ̀ | olùkɔ́ | olùkɔ́: adúláwɔ̀ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
+		<annotation cp="🧑🏿‍🏫">adúláwɔ̀ | olùkɔ́ | olùtɔ́sɔ́nà | ɔ̀jɔ̀gbɔ́n</annotation>
 		<annotation cp="🧑🏿‍🏫" type="tts">olùkɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🏫">amɔ́lára | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔkùnrin olùkɔ́: amɔ́lára | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👨🏻‍🏫">amɔ́lára | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👨🏻‍🏫" type="tts">ɔkùnrin olùkɔ́: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🏫">amɔ́lára díɛ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔkùnrin olùkɔ́: amɔ́lára díɛ̀ | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👨🏼‍🏫">amɔ́lára díɛ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👨🏼‍🏫" type="tts">ɔkùnrin olùkɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🏫">amɔ́láwɔ̀ díɛ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔkùnrin olùkɔ́: amɔ́láwɔ̀ díɛ̀ | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👨🏽‍🏫">amɔ́láwɔ̀ díɛ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👨🏽‍🏫" type="tts">ɔkùnrin olùkɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🏫">adúláwɔ̀ díɛ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔkùnrin olùkɔ́: adúláwɔ̀ díɛ̀ | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👨🏾‍🏫">adúláwɔ̀ díɛ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👨🏾‍🏫" type="tts">ɔkùnrin olùkɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🏫">adúláwɔ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔkùnrin olùkɔ́: adúláwɔ̀ | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👨🏿‍🏫">adúláwɔ̀ | olùkɔ́ | olùtanisɔ́nà | ɔkùnrin | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👨🏿‍🏫" type="tts">ɔkùnrin olùkɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🏫">amɔ́lára | obìnrin olùkɔ́ | obìnrin olùkɔ́: amɔ́lára | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👩🏻‍🏫">amɔ́lára | obìnrin olùkɔ́ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👩🏻‍🏫" type="tts">obìnrin olùkɔ́: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🏫">amɔ́lára díɛ̀ | obìnrin olùkɔ́ | obìnrin olùkɔ́: amɔ́lára díɛ̀ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👩🏼‍🏫">amɔ́lára díɛ̀ | obìnrin olùkɔ́ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👩🏼‍🏫" type="tts">obìnrin olùkɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🏫">amɔ́láwɔ̀ díɛ̀ | obìnrin olùkɔ́ | obìnrin olùkɔ́: amɔ́láwɔ̀ díɛ̀ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👩🏽‍🏫">amɔ́láwɔ̀ díɛ̀ | obìnrin olùkɔ́ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👩🏽‍🏫" type="tts">obìnrin olùkɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🏫">adúláwɔ̀ díɛ̀ | obìnrin olùkɔ́ | obìnrin olùkɔ́: adúláwɔ̀ díɛ̀ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👩🏾‍🏫">adúláwɔ̀ díɛ̀ | obìnrin olùkɔ́ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👩🏾‍🏫" type="tts">obìnrin olùkɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🏫">adúláwɔ̀ | obìnrin olùkɔ́ | obìnrin olùkɔ́: adúláwɔ̀ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
+		<annotation cp="👩🏿‍🏫">adúláwɔ̀ | obìnrin olùkɔ́ | obìrin | olùkɔ́ | olùtanisɔ́nà | ɔ̀mɔ̀wé àgbà</annotation>
 		<annotation cp="👩🏿‍🏫" type="tts">obìnrin olùkɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍⚖">adájɔ́ | adájɔ́: amɔ́lára | amɔ́lára | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
+		<annotation cp="🧑🏻‍⚖">adájɔ́ | amɔ́lára | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
 		<annotation cp="🧑🏻‍⚖" type="tts">adájɔ́: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍⚖">adájɔ́ | adájɔ́: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
+		<annotation cp="🧑🏼‍⚖">adájɔ́ | amɔ́lára díɛ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
 		<annotation cp="🧑🏼‍⚖" type="tts">adájɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍⚖">adájɔ́ | adájɔ́: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
+		<annotation cp="🧑🏽‍⚖">adájɔ́ | amɔ́láwɔ̀ díɛ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
 		<annotation cp="🧑🏽‍⚖" type="tts">adájɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍⚖">adájɔ́ | adájɔ́: adúláwɔ̀ díɛ̀ | adúláwɔ̀ díɛ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
+		<annotation cp="🧑🏾‍⚖">adájɔ́ | adúláwɔ̀ díɛ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
 		<annotation cp="🧑🏾‍⚖" type="tts">adájɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍⚖">adájɔ́ | adájɔ́: adúláwɔ̀ | adúláwɔ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
+		<annotation cp="🧑🏿‍⚖">adájɔ́ | adúláwɔ̀ | ìdájɔ́ òdodo | ìwɔ̀n</annotation>
 		<annotation cp="🧑🏿‍⚖" type="tts">adájɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍⚖">amɔ́lára | òdodo onídajɔ | ɔkùnrin adájɔ́ | ɔkùnrin adájɔ́: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍⚖">amɔ́lára | òdodo onídajɔ | ɔkùnrin adájɔ́</annotation>
 		<annotation cp="👨🏻‍⚖" type="tts">ɔkùnrin adájɔ́: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍⚖">amɔ́lára díɛ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́ | ɔkùnrin adájɔ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍⚖">amɔ́lára díɛ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́</annotation>
 		<annotation cp="👨🏼‍⚖" type="tts">ɔkùnrin adájɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍⚖">amɔ́láwɔ̀ díɛ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́ | ɔkùnrin adájɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍⚖">amɔ́láwɔ̀ díɛ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́</annotation>
 		<annotation cp="👨🏽‍⚖" type="tts">ɔkùnrin adájɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍⚖">adúláwɔ̀ díɛ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́ | ɔkùnrin adájɔ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍⚖">adúláwɔ̀ díɛ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́</annotation>
 		<annotation cp="👨🏾‍⚖" type="tts">ɔkùnrin adájɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍⚖">adúláwɔ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́ | ɔkùnrin adájɔ́: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍⚖">adúláwɔ̀ | òdodo onídajɔ | ɔkùnrin adájɔ́</annotation>
 		<annotation cp="👨🏿‍⚖" type="tts">ɔkùnrin adájɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍⚖">adájɔ́ | amɔ́lára | obìnrin adájɔ́ | obìnrin adájɔ́: amɔ́lára | obìrin síkélì</annotation>
+		<annotation cp="👩🏻‍⚖">adájɔ́ | amɔ́lára | obìnrin adájɔ́ | obìrin síkélì</annotation>
 		<annotation cp="👩🏻‍⚖" type="tts">obìnrin adájɔ́: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍⚖">adájɔ́ | amɔ́lára díɛ̀ | obìnrin adájɔ́ | obìnrin adájɔ́: amɔ́lára díɛ̀ | obìrin síkélì</annotation>
+		<annotation cp="👩🏼‍⚖">adájɔ́ | amɔ́lára díɛ̀ | obìnrin adájɔ́ | obìrin síkélì</annotation>
 		<annotation cp="👩🏼‍⚖" type="tts">obìnrin adájɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍⚖">adájɔ́ | amɔ́láwɔ̀ díɛ̀ | obìnrin adájɔ́ | obìnrin adájɔ́: amɔ́láwɔ̀ díɛ̀ | obìrin síkélì</annotation>
+		<annotation cp="👩🏽‍⚖">adájɔ́ | amɔ́láwɔ̀ díɛ̀ | obìnrin adájɔ́ | obìrin síkélì</annotation>
 		<annotation cp="👩🏽‍⚖" type="tts">obìnrin adájɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍⚖">adájɔ́ | adúláwɔ̀ díɛ̀ | obìnrin adájɔ́ | obìnrin adájɔ́: adúláwɔ̀ díɛ̀ | obìrin síkélì</annotation>
+		<annotation cp="👩🏾‍⚖">adájɔ́ | adúláwɔ̀ díɛ̀ | obìnrin adájɔ́ | obìrin síkélì</annotation>
 		<annotation cp="👩🏾‍⚖" type="tts">obìnrin adájɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍⚖">adájɔ́ | adúláwɔ̀ | obìnrin adájɔ́ | obìnrin adájɔ́: adúláwɔ̀ | obìrin síkélì</annotation>
+		<annotation cp="👩🏿‍⚖">adájɔ́ | adúláwɔ̀ | obìnrin adájɔ́ | obìrin síkélì</annotation>
 		<annotation cp="👩🏿‍⚖" type="tts">obìnrin adájɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🌾">àgbɛ̀ | àgbɛ̀: amɔ́lára | àgbɛɛ̀ | amɔ́lára | darandaran | olùtɔ́jú ɔgbà</annotation>
+		<annotation cp="🧑🏻‍🌾">àgbɛ̀ | àgbɛɛ̀ | amɔ́lára | darandaran | olùtɔ́jú ɔgbà</annotation>
 		<annotation cp="🧑🏻‍🌾" type="tts">àgbɛ̀: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🌾">àgbɛ̀ | àgbɛ̀: amɔ́lára díɛ̀ | àgbɛɛ̀ | amɔ́lára díɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
+		<annotation cp="🧑🏼‍🌾">àgbɛ̀ | àgbɛɛ̀ | amɔ́lára díɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
 		<annotation cp="🧑🏼‍🌾" type="tts">àgbɛ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🌾">àgbɛ̀ | àgbɛ̀: amɔ́láwɔ̀ díɛ̀ | àgbɛɛ̀ | amɔ́láwɔ̀ díɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
+		<annotation cp="🧑🏽‍🌾">àgbɛ̀ | àgbɛɛ̀ | amɔ́láwɔ̀ díɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
 		<annotation cp="🧑🏽‍🌾" type="tts">àgbɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🌾">adúláwɔ̀ díɛ̀ | àgbɛ̀ | àgbɛ̀: adúláwɔ̀ díɛ̀ | àgbɛɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
+		<annotation cp="🧑🏾‍🌾">adúláwɔ̀ díɛ̀ | àgbɛ̀ | àgbɛɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
 		<annotation cp="🧑🏾‍🌾" type="tts">àgbɛ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🌾">adúláwɔ̀ | àgbɛ̀ | àgbɛ̀: adúláwɔ̀ | àgbɛɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
+		<annotation cp="🧑🏿‍🌾">adúláwɔ̀ | àgbɛ̀ | àgbɛɛ̀ | darandaran | olùtɔ́jú ɔgbà</annotation>
 		<annotation cp="🧑🏿‍🌾" type="tts">àgbɛ̀: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🌾">àgbɛ́ | amɔ́lára | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin | ɔkùnrin àgbɛ́: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🌾">àgbɛ́ | amɔ́lára | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin</annotation>
 		<annotation cp="👨🏻‍🌾" type="tts">ɔkùnrin àgbɛ́: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🌾">àgbɛ́ | amɔ́lára díɛ̀ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin | ɔkùnrin àgbɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🌾">àgbɛ́ | amɔ́lára díɛ̀ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin</annotation>
 		<annotation cp="👨🏼‍🌾" type="tts">ɔkùnrin àgbɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🌾">àgbɛ́ | amɔ́láwɔ̀ díɛ̀ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin | ɔkùnrin àgbɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🌾">àgbɛ́ | amɔ́láwɔ̀ díɛ̀ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin</annotation>
 		<annotation cp="👨🏽‍🌾" type="tts">ɔkùnrin àgbɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🌾">adúláwɔ̀ díɛ̀ | àgbɛ́ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin | ɔkùnrin àgbɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🌾">adúláwɔ̀ díɛ̀ | àgbɛ́ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin</annotation>
 		<annotation cp="👨🏾‍🌾" type="tts">ɔkùnrin àgbɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🌾">adúláwɔ̀ | àgbɛ́ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin | ɔkùnrin àgbɛ́: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🌾">adúláwɔ̀ | àgbɛ́ | ashɔ́gbà | olùtɔ́jú màlùú | ɔkùnrin</annotation>
 		<annotation cp="👨🏿‍🌾" type="tts">ɔkùnrin àgbɛ́: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🌾">àgbɛ́ | amɔ́lára | ashɔ́gbà | obìrin | obìrinàgbɛ́ | obìrinàgbɛ́: amɔ́lára | olùtɔ́jú màlùú</annotation>
+		<annotation cp="👩🏻‍🌾">àgbɛ́ | amɔ́lára | ashɔ́gbà | obìrin | obìrinàgbɛ́ | olùtɔ́jú màlùú</annotation>
 		<annotation cp="👩🏻‍🌾" type="tts">obìrinàgbɛ́: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🌾">àgbɛ́ | amɔ́lára díɛ̀ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | obìrinàgbɛ́: amɔ́lára díɛ̀ | olùtɔ́jú màlùú</annotation>
+		<annotation cp="👩🏼‍🌾">àgbɛ́ | amɔ́lára díɛ̀ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | olùtɔ́jú màlùú</annotation>
 		<annotation cp="👩🏼‍🌾" type="tts">obìrinàgbɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🌾">àgbɛ́ | amɔ́láwɔ̀ díɛ̀ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | obìrinàgbɛ́: amɔ́láwɔ̀ díɛ̀ | olùtɔ́jú màlùú</annotation>
+		<annotation cp="👩🏽‍🌾">àgbɛ́ | amɔ́láwɔ̀ díɛ̀ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | olùtɔ́jú màlùú</annotation>
 		<annotation cp="👩🏽‍🌾" type="tts">obìrinàgbɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🌾">adúláwɔ̀ díɛ̀ | àgbɛ́ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | obìrinàgbɛ́: adúláwɔ̀ díɛ̀ | olùtɔ́jú màlùú</annotation>
+		<annotation cp="👩🏾‍🌾">adúláwɔ̀ díɛ̀ | àgbɛ́ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | olùtɔ́jú màlùú</annotation>
 		<annotation cp="👩🏾‍🌾" type="tts">obìrinàgbɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🌾">adúláwɔ̀ | àgbɛ́ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | obìrinàgbɛ́: adúláwɔ̀ | olùtɔ́jú màlùú</annotation>
+		<annotation cp="👩🏿‍🌾">adúláwɔ̀ | àgbɛ́ | ashɔ́gbà | obìrin | obìrinàgbɛ́ | olùtɔ́jú màlùú</annotation>
 		<annotation cp="👩🏿‍🌾" type="tts">obìrinàgbɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🍳">alásè | alásè: amɔ́lára | amɔ́lára | olórí alásè</annotation>
+		<annotation cp="🧑🏻‍🍳">alásè | amɔ́lára | olórí alásè</annotation>
 		<annotation cp="🧑🏻‍🍳" type="tts">alásè: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🍳">alásè | alásè: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | olórí alásè</annotation>
+		<annotation cp="🧑🏼‍🍳">alásè | amɔ́lára díɛ̀ | olórí alásè</annotation>
 		<annotation cp="🧑🏼‍🍳" type="tts">alásè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🍳">alásè | alásè: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | olórí alásè</annotation>
+		<annotation cp="🧑🏽‍🍳">alásè | amɔ́láwɔ̀ díɛ̀ | olórí alásè</annotation>
 		<annotation cp="🧑🏽‍🍳" type="tts">alásè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🍳">adúláwɔ̀ díɛ̀ | alásè | alásè: adúláwɔ̀ díɛ̀ | olórí alásè</annotation>
+		<annotation cp="🧑🏾‍🍳">adúláwɔ̀ díɛ̀ | alásè | olórí alásè</annotation>
 		<annotation cp="🧑🏾‍🍳" type="tts">alásè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🍳">adúláwɔ̀ | alásè | alásè: adúláwɔ̀ | olórí alásè</annotation>
+		<annotation cp="🧑🏿‍🍳">adúláwɔ̀ | alásè | olórí alásè</annotation>
 		<annotation cp="🧑🏿‍🍳" type="tts">alásè: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🍳">amɔ́lára | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ | ɔkùnrin olùse ónjɛ: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🍳">amɔ́lára | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ</annotation>
 		<annotation cp="👨🏻‍🍳" type="tts">ɔkùnrin olùse ónjɛ: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🍳">amɔ́lára díɛ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ | ɔkùnrin olùse ónjɛ: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🍳">amɔ́lára díɛ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ</annotation>
 		<annotation cp="👨🏼‍🍳" type="tts">ɔkùnrin olùse ónjɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🍳">amɔ́láwɔ̀ díɛ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ | ɔkùnrin olùse ónjɛ: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🍳">amɔ́láwɔ̀ díɛ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ</annotation>
 		<annotation cp="👨🏽‍🍳" type="tts">ɔkùnrin olùse ónjɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🍳">adúláwɔ̀ díɛ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ | ɔkùnrin olùse ónjɛ: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🍳">adúláwɔ̀ díɛ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ</annotation>
 		<annotation cp="👨🏾‍🍳" type="tts">ɔkùnrin olùse ónjɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🍳">adúláwɔ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ | ɔkùnrin olùse ónjɛ: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🍳">adúláwɔ̀ | olúse ónjɛ | olùse ónjɛ | ɔkùnrin | ɔkùnrin olùse ónjɛ</annotation>
 		<annotation cp="👨🏿‍🍳" type="tts">ɔkùnrin olùse ónjɛ: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🍳">amɔ́lára | obìrin | obìrin olùse ónjɛ | obìrin olùse ónjɛ: amɔ́lára | olúse ónjɛ | olùse ónjɛ</annotation>
+		<annotation cp="👩🏻‍🍳">amɔ́lára | obìrin | obìrin olùse ónjɛ | olúse ónjɛ | olùse ónjɛ</annotation>
 		<annotation cp="👩🏻‍🍳" type="tts">obìrin olùse ónjɛ: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🍳">amɔ́lára díɛ̀ | obìrin | obìrin olùse ónjɛ | obìrin olùse ónjɛ: amɔ́lára díɛ̀ | olúse ónjɛ | olùse ónjɛ</annotation>
+		<annotation cp="👩🏼‍🍳">amɔ́lára díɛ̀ | obìrin | obìrin olùse ónjɛ | olúse ónjɛ | olùse ónjɛ</annotation>
 		<annotation cp="👩🏼‍🍳" type="tts">obìrin olùse ónjɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🍳">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrin olùse ónjɛ | obìrin olùse ónjɛ: amɔ́láwɔ̀ díɛ̀ | olúse ónjɛ | olùse ónjɛ</annotation>
+		<annotation cp="👩🏽‍🍳">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrin olùse ónjɛ | olúse ónjɛ | olùse ónjɛ</annotation>
 		<annotation cp="👩🏽‍🍳" type="tts">obìrin olùse ónjɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🍳">adúláwɔ̀ díɛ̀ | obìrin | obìrin olùse ónjɛ | obìrin olùse ónjɛ: adúláwɔ̀ díɛ̀ | olúse ónjɛ | olùse ónjɛ</annotation>
+		<annotation cp="👩🏾‍🍳">adúláwɔ̀ díɛ̀ | obìrin | obìrin olùse ónjɛ | olúse ónjɛ | olùse ónjɛ</annotation>
 		<annotation cp="👩🏾‍🍳" type="tts">obìrin olùse ónjɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🍳">adúláwɔ̀ | obìrin | obìrin olùse ónjɛ | obìrin olùse ónjɛ: adúláwɔ̀ | olúse ónjɛ | olùse ónjɛ</annotation>
+		<annotation cp="👩🏿‍🍳">adúláwɔ̀ | obìrin | obìrin olùse ónjɛ | olúse ónjɛ | olùse ónjɛ</annotation>
 		<annotation cp="👩🏿‍🍳" type="tts">obìrin olùse ónjɛ: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🔧">amɔ́lára | arólélópòó | mɛkáníìkì | mɛkáníìkì: amɔ́lára | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
+		<annotation cp="🧑🏻‍🔧">amɔ́lára | arólélópòó | mɛkáníìkì | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
 		<annotation cp="🧑🏻‍🔧" type="tts">mɛkáníìkì: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🔧">amɔ́lára díɛ̀ | arólélópòó | mɛkáníìkì | mɛkáníìkì: amɔ́lára díɛ̀ | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
+		<annotation cp="🧑🏼‍🔧">amɔ́lára díɛ̀ | arólélópòó | mɛkáníìkì | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
 		<annotation cp="🧑🏼‍🔧" type="tts">mɛkáníìkì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🔧">amɔ́láwɔ̀ díɛ̀ | arólélópòó | mɛkáníìkì | mɛkáníìkì: amɔ́láwɔ̀ díɛ̀ | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
+		<annotation cp="🧑🏽‍🔧">amɔ́láwɔ̀ díɛ̀ | arólélópòó | mɛkáníìkì | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
 		<annotation cp="🧑🏽‍🔧" type="tts">mɛkáníìkì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🔧">adúláwɔ̀ díɛ̀ | arólélópòó | mɛkáníìkì | mɛkáníìkì: adúláwɔ̀ díɛ̀ | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
+		<annotation cp="🧑🏾‍🔧">adúláwɔ̀ díɛ̀ | arólélópòó | mɛkáníìkì | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
 		<annotation cp="🧑🏾‍🔧" type="tts">mɛkáníìkì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🔧">adúláwɔ̀ | arólélópòó | mɛkáníìkì | mɛkáníìkì: adúláwɔ̀ | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
+		<annotation cp="🧑🏿‍🔧">adúláwɔ̀ | arólélópòó | mɛkáníìkì | oníshɛ́-ɛ̀lɛ́tíríìkì | oníshɛ́-ɔwɔ́</annotation>
 		<annotation cp="🧑🏿‍🔧" type="tts">mɛkáníìkì: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🔧">amɔ́lára | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | ɔkùnrin atún ɔkɔ̀ she: amɔ́lára | pílɔ́bà</annotation>
+		<annotation cp="👨🏻‍🔧">amɔ́lára | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👨🏻‍🔧" type="tts">ɔkùnrin atún ɔkɔ̀ she: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🔧">amɔ́lára díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | ɔkùnrin atún ɔkɔ̀ she: amɔ́lára díɛ̀ | pílɔ́bà</annotation>
+		<annotation cp="👨🏼‍🔧">amɔ́lára díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👨🏼‍🔧" type="tts">ɔkùnrin atún ɔkɔ̀ she: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🔧">amɔ́láwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | ɔkùnrin atún ɔkɔ̀ she: amɔ́láwɔ̀ díɛ̀ | pílɔ́bà</annotation>
+		<annotation cp="👨🏽‍🔧">amɔ́láwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👨🏽‍🔧" type="tts">ɔkùnrin atún ɔkɔ̀ she: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🔧">adúláwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | ɔkùnrin atún ɔkɔ̀ she: adúláwɔ̀ díɛ̀ | pílɔ́bà</annotation>
+		<annotation cp="👨🏾‍🔧">adúláwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👨🏾‍🔧" type="tts">ɔkùnrin atún ɔkɔ̀ she: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🔧">adúláwɔ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | ɔkùnrin atún ɔkɔ̀ she: adúláwɔ̀ | pílɔ́bà</annotation>
+		<annotation cp="👨🏿‍🔧">adúláwɔ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | ɔkùnrin | ɔkùnrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👨🏿‍🔧" type="tts">ɔkùnrin atún ɔkɔ̀ she: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🔧">amɔ́lára | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | obìrin atún ɔkɔ̀ she: amɔ́lára | pílɔ́bà</annotation>
+		<annotation cp="👩🏻‍🔧">amɔ́lára | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👩🏻‍🔧" type="tts">obìrin atún ɔkɔ̀ she: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🔧">amɔ́lára díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | obìrin atún ɔkɔ̀ she: amɔ́lára díɛ̀ | pílɔ́bà</annotation>
+		<annotation cp="👩🏼‍🔧">amɔ́lára díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👩🏼‍🔧" type="tts">obìrin atún ɔkɔ̀ she: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🔧">amɔ́láwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | obìrin atún ɔkɔ̀ she: amɔ́láwɔ̀ díɛ̀ | pílɔ́bà</annotation>
+		<annotation cp="👩🏽‍🔧">amɔ́láwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👩🏽‍🔧" type="tts">obìrin atún ɔkɔ̀ she: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🔧">adúláwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | obìrin atún ɔkɔ̀ she: adúláwɔ̀ díɛ̀ | pílɔ́bà</annotation>
+		<annotation cp="👩🏾‍🔧">adúláwɔ̀ díɛ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👩🏾‍🔧" type="tts">obìrin atún ɔkɔ̀ she: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🔧">adúláwɔ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | obìrin atún ɔkɔ̀ she: adúláwɔ̀ | pílɔ́bà</annotation>
+		<annotation cp="👩🏿‍🔧">adúláwɔ̀ | atún ináshe | atún ɔkɔ̀ she | ɛni shòwò | obìrin | obìrin atún ɔkɔ̀ she | pílɔ́bà</annotation>
 		<annotation cp="👩🏿‍🔧" type="tts">obìrin atún ɔkɔ̀ she: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🏭">amɔ́lára | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: amɔ́lára | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="🧑🏻‍🏭">amɔ́lára | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="🧑🏻‍🏭" type="tts">òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🏭">amɔ́lára díɛ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: amɔ́lára díɛ̀ | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="🧑🏼‍🏭">amɔ́lára díɛ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="🧑🏼‍🏭" type="tts">òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🏭">amɔ́láwɔ̀ díɛ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: amɔ́láwɔ̀ díɛ̀ | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="🧑🏽‍🏭">amɔ́láwɔ̀ díɛ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="🧑🏽‍🏭" type="tts">òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🏭">adúláwɔ̀ díɛ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: adúláwɔ̀ díɛ̀ | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="🧑🏾‍🏭">adúláwɔ̀ díɛ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="🧑🏾‍🏭" type="tts">òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🏭">adúláwɔ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: adúláwɔ̀ | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="🧑🏿‍🏭">adúláwɔ̀ | ilé-ishɛ́ ashàgbéjáde ɔjà | nípa àkójɔpɔ̀ àwɔn ilé-ishɛ́ oníshòwò ɔjà | òshìshɛ́ | òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà | shíshe àtòpɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="🧑🏿‍🏭" type="tts">òshìshɛ́ ilé-ishɛ́ ashàgbéjáde ɔjà: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🏭">amɔ́lára | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́ | ɔkùnrin òshìshɛ́ ilé-ishɛ́: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🏭">amɔ́lára | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́</annotation>
 		<annotation cp="👨🏻‍🏭" type="tts">ɔkùnrin òshìshɛ́ ilé-ishɛ́: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🏭">amɔ́lára díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́ | ɔkùnrin òshìshɛ́ ilé-ishɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🏭">amɔ́lára díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́</annotation>
 		<annotation cp="👨🏼‍🏭" type="tts">ɔkùnrin òshìshɛ́ ilé-ishɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🏭">amɔ́láwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́ | ɔkùnrin òshìshɛ́ ilé-ishɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🏭">amɔ́láwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́</annotation>
 		<annotation cp="👨🏽‍🏭" type="tts">ɔkùnrin òshìshɛ́ ilé-ishɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🏭">adúláwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́ | ɔkùnrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🏭">adúláwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́</annotation>
 		<annotation cp="👨🏾‍🏭" type="tts">ɔkùnrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🏭">adúláwɔ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́ | ɔkùnrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🏭">adúláwɔ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin òshìshɛ́ ilé-ishɛ́</annotation>
 		<annotation cp="👨🏿‍🏭" type="tts">ɔkùnrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🏭">amɔ́lára | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | obìrin òshìshɛ́ ilé-ishɛ́: amɔ́lára | òshìshɛ́</annotation>
+		<annotation cp="👩🏻‍🏭">amɔ́lára | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | òshìshɛ́</annotation>
 		<annotation cp="👩🏻‍🏭" type="tts">obìrin òshìshɛ́ ilé-ishɛ́: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🏭">amɔ́lára díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | obìrin òshìshɛ́ ilé-ishɛ́: amɔ́lára díɛ̀ | òshìshɛ́</annotation>
+		<annotation cp="👩🏼‍🏭">amɔ́lára díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | òshìshɛ́</annotation>
 		<annotation cp="👩🏼‍🏭" type="tts">obìrin òshìshɛ́ ilé-ishɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🏭">amɔ́láwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | obìrin òshìshɛ́ ilé-ishɛ́: amɔ́láwɔ̀ díɛ̀ | òshìshɛ́</annotation>
+		<annotation cp="👩🏽‍🏭">amɔ́láwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | òshìshɛ́</annotation>
 		<annotation cp="👩🏽‍🏭" type="tts">obìrin òshìshɛ́ ilé-ishɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🏭">adúláwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | obìrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀ díɛ̀ | òshìshɛ́</annotation>
+		<annotation cp="👩🏾‍🏭">adúláwɔ̀ díɛ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | òshìshɛ́</annotation>
 		<annotation cp="👩🏾‍🏭" type="tts">obìrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🏭">adúláwɔ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | obìrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀ | òshìshɛ́</annotation>
+		<annotation cp="👩🏿‍🏭">adúláwɔ̀ | ilé ishɛ́ | ìpéjɔpɔ̀ | obìrin | obìrin òshìshɛ́ ilé-ishɛ́ | òshìshɛ́</annotation>
 		<annotation cp="👩🏿‍🏭" type="tts">obìrin òshìshɛ́ ilé-ishɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍💼">amɔ́lára | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | òshìshɛ́ ɔ́fíìsì: amɔ́lára | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
+		<annotation cp="🧑🏻‍💼">amɔ́lára | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
 		<annotation cp="🧑🏻‍💼" type="tts">òshìshɛ́ ɔ́fíìsì: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍💼">amɔ́lára díɛ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | òshìshɛ́ ɔ́fíìsì: amɔ́lára díɛ̀ | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
+		<annotation cp="🧑🏼‍💼">amɔ́lára díɛ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
 		<annotation cp="🧑🏼‍💼" type="tts">òshìshɛ́ ɔ́fíìsì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍💼">amɔ́láwɔ̀ díɛ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | òshìshɛ́ ɔ́fíìsì: amɔ́láwɔ̀ díɛ̀ | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
+		<annotation cp="🧑🏽‍💼">amɔ́láwɔ̀ díɛ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
 		<annotation cp="🧑🏽‍💼" type="tts">òshìshɛ́ ɔ́fíìsì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍💼">adúláwɔ̀ díɛ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | òshìshɛ́ ɔ́fíìsì: adúláwɔ̀ díɛ̀ | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
+		<annotation cp="🧑🏾‍💼">adúláwɔ̀ díɛ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
 		<annotation cp="🧑🏾‍💼" type="tts">òshìshɛ́ ɔ́fíìsì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍💼">adúláwɔ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | òshìshɛ́ ɔ́fíìsì: adúláwɔ̀ | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
+		<annotation cp="🧑🏿‍💼">adúláwɔ̀ | ayàwòrán ilé-kíkɔ́ | okòwò | olùshàkóso | òshìshɛ́ ɔ́fíìsì | tó jɛ mɔ́ ishɛ́ ɔ́fíìsì</annotation>
 		<annotation cp="🧑🏿‍💼" type="tts">òshìshɛ́ ɔ́fíìsì: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍💼">alábóòjútò | amɔ́lára | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì | ɔkùnrin òshìshɛ́ ɔ́físì: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍💼">alábóòjútò | amɔ́lára | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì</annotation>
 		<annotation cp="👨🏻‍💼" type="tts">ɔkùnrin òshìshɛ́ ɔ́físì: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍💼">alábóòjútò | amɔ́lára díɛ̀ | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì | ɔkùnrin òshìshɛ́ ɔ́físì: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍💼">alábóòjútò | amɔ́lára díɛ̀ | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì</annotation>
 		<annotation cp="👨🏼‍💼" type="tts">ɔkùnrin òshìshɛ́ ɔ́físì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍💼">alábóòjútò | amɔ́láwɔ̀ díɛ̀ | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì | ɔkùnrin òshìshɛ́ ɔ́físì: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍💼">alábóòjútò | amɔ́láwɔ̀ díɛ̀ | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì</annotation>
 		<annotation cp="👨🏽‍💼" type="tts">ɔkùnrin òshìshɛ́ ɔ́físì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍💼">adúláwɔ̀ díɛ̀ | alábóòjútò | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì | ɔkùnrin òshìshɛ́ ɔ́físì: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍💼">adúláwɔ̀ díɛ̀ | alábóòjútò | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì</annotation>
 		<annotation cp="👨🏾‍💼" type="tts">ɔkùnrin òshìshɛ́ ɔ́físì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍💼">adúláwɔ̀ | alábóòjútò | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì | ɔkùnrin òshìshɛ́ ɔ́físì: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍💼">adúláwɔ̀ | alábóòjútò | ishɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì | ɔkùnrin | ɔkùnrin òshìshɛ́ ɔ́físì</annotation>
 		<annotation cp="👨🏿‍💼" type="tts">ɔkùnrin òshìshɛ́ ɔ́físì: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍💼">alábóòjútò | amɔ́lára | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | obìrin òshìshɛ́ ɔ́físì: amɔ́lára | olùyà ilé | òwò | ɔ́físì</annotation>
+		<annotation cp="👩🏻‍💼">alábóòjútò | amɔ́lára | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì</annotation>
 		<annotation cp="👩🏻‍💼" type="tts">obìrin òshìshɛ́ ɔ́físì: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍💼">alábóòjútò | amɔ́lára díɛ̀ | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | obìrin òshìshɛ́ ɔ́físì: amɔ́lára díɛ̀ | olùyà ilé | òwò | ɔ́físì</annotation>
+		<annotation cp="👩🏼‍💼">alábóòjútò | amɔ́lára díɛ̀ | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì</annotation>
 		<annotation cp="👩🏼‍💼" type="tts">obìrin òshìshɛ́ ɔ́físì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍💼">alábóòjútò | amɔ́láwɔ̀ díɛ̀ | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | obìrin òshìshɛ́ ɔ́físì: amɔ́láwɔ̀ díɛ̀ | olùyà ilé | òwò | ɔ́físì</annotation>
+		<annotation cp="👩🏽‍💼">alábóòjútò | amɔ́láwɔ̀ díɛ̀ | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì</annotation>
 		<annotation cp="👩🏽‍💼" type="tts">obìrin òshìshɛ́ ɔ́físì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍💼">adúláwɔ̀ díɛ̀ | alábóòjútò | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | obìrin òshìshɛ́ ɔ́físì: adúláwɔ̀ díɛ̀ | olùyà ilé | òwò | ɔ́físì</annotation>
+		<annotation cp="👩🏾‍💼">adúláwɔ̀ díɛ̀ | alábóòjútò | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì</annotation>
 		<annotation cp="👩🏾‍💼" type="tts">obìrin òshìshɛ́ ɔ́físì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍💼">adúláwɔ̀ | alábóòjútò | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | obìrin òshìshɛ́ ɔ́físì: adúláwɔ̀ | olùyà ilé | òwò | ɔ́físì</annotation>
+		<annotation cp="👩🏿‍💼">adúláwɔ̀ | alábóòjútò | ishɛ́ ɔ́físì | obìrin | obìrin òshìshɛ́ ɔ́físì | olùyà ilé | òwò | ɔ́físì</annotation>
 		<annotation cp="👩🏿‍💼" type="tts">obìrin òshìshɛ́ ɔ́físì: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🔬">amɔ́lára | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà | onímɔ̀ sáyɛ́ǹsì: amɔ́lára</annotation>
+		<annotation cp="🧑🏻‍🔬">amɔ́lára | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà</annotation>
 		<annotation cp="🧑🏻‍🔬" type="tts">onímɔ̀ sáyɛ́ǹsì: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🔬">amɔ́lára díɛ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà | onímɔ̀ sáyɛ́ǹsì: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧑🏼‍🔬">amɔ́lára díɛ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà</annotation>
 		<annotation cp="🧑🏼‍🔬" type="tts">onímɔ̀ sáyɛ́ǹsì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🔬">amɔ́láwɔ̀ díɛ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà | onímɔ̀ sáyɛ́ǹsì: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏽‍🔬">amɔ́láwɔ̀ díɛ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà</annotation>
 		<annotation cp="🧑🏽‍🔬" type="tts">onímɔ̀ sáyɛ́ǹsì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🔬">adúláwɔ̀ díɛ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà | onímɔ̀ sáyɛ́ǹsì: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏾‍🔬">adúláwɔ̀ díɛ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà</annotation>
 		<annotation cp="🧑🏾‍🔬" type="tts">onímɔ̀ sáyɛ́ǹsì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🔬">adúláwɔ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà | onímɔ̀ sáyɛ́ǹsì: adúláwɔ̀</annotation>
+		<annotation cp="🧑🏿‍🔬">adúláwɔ̀ | onímɔ̀ ɛ̀rɔ | onímɔ̀ sáyɛ́ǹsì | onímɔ̀ sáyɛ́ǹsì àwɔn ohun alààyè | onímɔ̀ sáyɛ́ǹsì ìshɛ̀dá àti àwɔn ohun àdáyébá | onímɔ̀ sáyɛ́ǹsì nípa kɛ́míkà</annotation>
 		<annotation cp="🧑🏿‍🔬" type="tts">onímɔ̀ sáyɛ́ǹsì: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🔬">amɔ́lára | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì | ɔkùnrín síyɛ́nsì: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🔬">amɔ́lára | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì</annotation>
 		<annotation cp="👨🏻‍🔬" type="tts">ɔkùnrín síyɛ́nsì: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🔬">amɔ́lára díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì | ɔkùnrín síyɛ́nsì: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🔬">amɔ́lára díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì</annotation>
 		<annotation cp="👨🏼‍🔬" type="tts">ɔkùnrín síyɛ́nsì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🔬">amɔ́láwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì | ɔkùnrín síyɛ́nsì: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🔬">amɔ́láwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì</annotation>
 		<annotation cp="👨🏽‍🔬" type="tts">ɔkùnrín síyɛ́nsì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🔬">adúláwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì | ɔkùnrín síyɛ́nsì: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🔬">adúláwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì</annotation>
 		<annotation cp="👨🏾‍🔬" type="tts">ɔkùnrín síyɛ́nsì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🔬">adúláwɔ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì | ɔkùnrín síyɛ́nsì: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🔬">adúláwɔ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì | ɔkùnrin | ɔkùnrín síyɛ́nsì</annotation>
 		<annotation cp="👨🏿‍🔬" type="tts">ɔkùnrín síyɛ́nsì: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🔬">amɔ́lára | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | obìrin síyɛ́nsì: amɔ́lára | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
+		<annotation cp="👩🏻‍🔬">amɔ́lára | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
 		<annotation cp="👩🏻‍🔬" type="tts">obìrin síyɛ́nsì: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🔬">amɔ́lára díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | obìrin síyɛ́nsì: amɔ́lára díɛ̀ | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
+		<annotation cp="👩🏼‍🔬">amɔ́lára díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
 		<annotation cp="👩🏼‍🔬" type="tts">obìrin síyɛ́nsì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🔬">amɔ́láwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | obìrin síyɛ́nsì: amɔ́láwɔ̀ díɛ̀ | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
+		<annotation cp="👩🏽‍🔬">amɔ́láwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
 		<annotation cp="👩🏽‍🔬" type="tts">obìrin síyɛ́nsì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🔬">adúláwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | obìrin síyɛ́nsì: adúláwɔ̀ díɛ̀ | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
+		<annotation cp="👩🏾‍🔬">adúláwɔ̀ díɛ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
 		<annotation cp="👩🏾‍🔬" type="tts">obìrin síyɛ́nsì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🔬">adúláwɔ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | obìrin síyɛ́nsì: adúláwɔ̀ | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
+		<annotation cp="👩🏿‍🔬">adúláwɔ̀ | bìyólɔ́gì | físísítì | kɛ́mísítì | obìrin | obìrin síyɛ́nsì | onímɔ̀ ìshirò | onímɔ̀ lrɔ | onímɔ̀ síyɛ́nsì</annotation>
 		<annotation cp="👩🏿‍🔬" type="tts">obìrin síyɛ́nsì: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍💻">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: amɔ́lára | aláròshe ohun tuntun | amɔ́lára | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
+		<annotation cp="🧑🏻‍💻">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | aláròshe ohun tuntun | amɔ́lára | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
 		<annotation cp="🧑🏻‍💻" type="tts">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍💻">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: amɔ́lára díɛ̀ | aláròshe ohun tuntun | amɔ́lára díɛ̀ | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
+		<annotation cp="🧑🏼‍💻">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | aláròshe ohun tuntun | amɔ́lára díɛ̀ | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
 		<annotation cp="🧑🏼‍💻" type="tts">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍💻">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: amɔ́láwɔ̀ díɛ̀ | aláròshe ohun tuntun | amɔ́láwɔ̀ díɛ̀ | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
+		<annotation cp="🧑🏽‍💻">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | aláròshe ohun tuntun | amɔ́láwɔ̀ díɛ̀ | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
 		<annotation cp="🧑🏽‍💻" type="tts">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍💻">adúláwɔ̀ díɛ̀ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: adúláwɔ̀ díɛ̀ | aláròshe ohun tuntun | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
+		<annotation cp="🧑🏾‍💻">adúláwɔ̀ díɛ̀ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | aláròshe ohun tuntun | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
 		<annotation cp="🧑🏾‍💻" type="tts">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍💻">adúláwɔ̀ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: adúláwɔ̀ | aláròshe ohun tuntun | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
+		<annotation cp="🧑🏿‍💻">adúláwɔ̀ | akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ | aláròshe ohun tuntun | ɛ̀yà àìrídìmú inú ɛ̀rɔ | olúkɔ-kóòdù | onímɔ̀ kóòdù</annotation>
 		<annotation cp="🧑🏿‍💻" type="tts">akɔ́shɛ́mɔshɛ́ ìmɔ̀-ɛ̀rɔ: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍💻">amɔ́lára | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ | ɔkùnrin oníms ɛ̀rɔ: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍💻">amɔ́lára | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ</annotation>
 		<annotation cp="👨🏻‍💻" type="tts">ɔkùnrin oníms ɛ̀rɔ: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍💻">amɔ́lára díɛ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ | ɔkùnrin oníms ɛ̀rɔ: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍💻">amɔ́lára díɛ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ</annotation>
 		<annotation cp="👨🏼‍💻" type="tts">ɔkùnrin oníms ɛ̀rɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍💻">amɔ́láwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ | ɔkùnrin oníms ɛ̀rɔ: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍💻">amɔ́láwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ</annotation>
 		<annotation cp="👨🏽‍💻" type="tts">ɔkùnrin oníms ɛ̀rɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍💻">adúláwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ | ɔkùnrin oníms ɛ̀rɔ: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍💻">adúláwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ</annotation>
 		<annotation cp="👨🏾‍💻" type="tts">ɔkùnrin oníms ɛ̀rɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍💻">adúláwɔ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ | ɔkùnrin oníms ɛ̀rɔ: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍💻">adúláwɔ̀ | ɛ̀yà àrídimú | kódà | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ | ɔkùnrin | ɔkùnrin oníms ɛ̀rɔ</annotation>
 		<annotation cp="👨🏿‍💻" type="tts">ɔkùnrin oníms ɛ̀rɔ: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍💻">amɔ́lára | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | obìrin onímɔ̀ ɛ̀rɔ: amɔ́lára | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="👩🏻‍💻">amɔ́lára | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="👩🏻‍💻" type="tts">obìrin onímɔ̀ ɛ̀rɔ: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍💻">amɔ́lára díɛ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | obìrin onímɔ̀ ɛ̀rɔ: amɔ́lára díɛ̀ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="👩🏼‍💻">amɔ́lára díɛ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="👩🏼‍💻" type="tts">obìrin onímɔ̀ ɛ̀rɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍💻">amɔ́láwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | obìrin onímɔ̀ ɛ̀rɔ: amɔ́láwɔ̀ díɛ̀ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="👩🏽‍💻">amɔ́láwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="👩🏽‍💻" type="tts">obìrin onímɔ̀ ɛ̀rɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍💻">adúláwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | obìrin onímɔ̀ ɛ̀rɔ: adúláwɔ̀ díɛ̀ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="👩🏾‍💻">adúláwɔ̀ díɛ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="👩🏾‍💻" type="tts">obìrin onímɔ̀ ɛ̀rɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍💻">adúláwɔ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | obìrin onímɔ̀ ɛ̀rɔ: adúláwɔ̀ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
+		<annotation cp="👩🏿‍💻">adúláwɔ̀ | ɛ̀yà àrídimú | kódà | obìrin | obìrin onímɔ̀ ɛ̀rɔ | olùdásílɛ̀ | olùmúgbɛ́rù | onímɔ̀ ɛ̀rɔ</annotation>
 		<annotation cp="👩🏿‍💻" type="tts">obìrin onímɔ̀ ɛ̀rɔ: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🎤">adánilárayá | akɔrin | akɔrin: amɔ́lára | amɔ́lára | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
+		<annotation cp="🧑🏻‍🎤">adánilárayá | akɔrin | amɔ́lára | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
 		<annotation cp="🧑🏻‍🎤" type="tts">akɔrin: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🎤">adánilárayá | akɔrin | akɔrin: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
+		<annotation cp="🧑🏼‍🎤">adánilárayá | akɔrin | amɔ́lára díɛ̀ | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
 		<annotation cp="🧑🏼‍🎤" type="tts">akɔrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🎤">adánilárayá | akɔrin | akɔrin: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
+		<annotation cp="🧑🏽‍🎤">adánilárayá | akɔrin | amɔ́láwɔ̀ díɛ̀ | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
 		<annotation cp="🧑🏽‍🎤" type="tts">akɔrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🎤">adánilárayá | adúláwɔ̀ díɛ̀ | akɔrin | akɔrin: adúláwɔ̀ díɛ̀ | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
+		<annotation cp="🧑🏾‍🎤">adánilárayá | adúláwɔ̀ díɛ̀ | akɔrin | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
 		<annotation cp="🧑🏾‍🎤" type="tts">akɔrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🎤">adánilárayá | adúláwɔ̀ | akɔrin | akɔrin: adúláwɔ̀ | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
+		<annotation cp="🧑🏿‍🎤">adánilárayá | adúláwɔ̀ | akɔrin | ìràwɔ̀ | jó lɛ́sɔ̀lɛ́sɔ̀ sí orin | òshèré</annotation>
 		<annotation cp="🧑🏿‍🎤" type="tts">akɔrin: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🎤">adánirárayá | akɔrin | amɔ́lára | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔkùnrin olórin: amɔ́lára | ɔshèré</annotation>
+		<annotation cp="👨🏻‍🎤">adánirárayá | akɔrin | amɔ́lára | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔshèré</annotation>
 		<annotation cp="👨🏻‍🎤" type="tts">ɔkùnrin olórin: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🎤">adánirárayá | akɔrin | amɔ́lára díɛ̀ | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔkùnrin olórin: amɔ́lára díɛ̀ | ɔshèré</annotation>
+		<annotation cp="👨🏼‍🎤">adánirárayá | akɔrin | amɔ́lára díɛ̀ | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔshèré</annotation>
 		<annotation cp="👨🏼‍🎤" type="tts">ɔkùnrin olórin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🎤">adánirárayá | akɔrin | amɔ́láwɔ̀ díɛ̀ | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔkùnrin olórin: amɔ́láwɔ̀ díɛ̀ | ɔshèré</annotation>
+		<annotation cp="👨🏽‍🎤">adánirárayá | akɔrin | amɔ́láwɔ̀ díɛ̀ | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔshèré</annotation>
 		<annotation cp="👨🏽‍🎤" type="tts">ɔkùnrin olórin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🎤">adánirárayá | adúláwɔ̀ díɛ̀ | akɔrin | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔkùnrin olórin: adúláwɔ̀ díɛ̀ | ɔshèré</annotation>
+		<annotation cp="👨🏾‍🎤">adánirárayá | adúláwɔ̀ díɛ̀ | akɔrin | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔshèré</annotation>
 		<annotation cp="👨🏾‍🎤" type="tts">ɔkùnrin olórin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🎤">adánirárayá | adúláwɔ̀ | akɔrin | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔkùnrin olórin: adúláwɔ̀ | ɔshèré</annotation>
+		<annotation cp="👨🏿‍🎤">adánirárayá | adúláwɔ̀ | akɔrin | àpáta | ìràwɔ̀ | ɔkùnrin | ɔkùnrin olórin | ɔshèré</annotation>
 		<annotation cp="👨🏿‍🎤" type="tts">ɔkùnrin olórin: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🎤">adánirárayá | akɔrin | amɔ́lára | àpáta | ìràwɔ̀ | obìnrin olórin | obìnrin olórin: amɔ́lára | obìrin | ɔshèré</annotation>
+		<annotation cp="👩🏻‍🎤">adánirárayá | akɔrin | amɔ́lára | àpáta | ìràwɔ̀ | obìnrin olórin | obìrin | ɔshèré</annotation>
 		<annotation cp="👩🏻‍🎤" type="tts">obìnrin olórin: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🎤">adánirárayá | akɔrin | amɔ́lára díɛ̀ | àpáta | ìràwɔ̀ | obìnrin olórin | obìnrin olórin: amɔ́lára díɛ̀ | obìrin | ɔshèré</annotation>
+		<annotation cp="👩🏼‍🎤">adánirárayá | akɔrin | amɔ́lára díɛ̀ | àpáta | ìràwɔ̀ | obìnrin olórin | obìrin | ɔshèré</annotation>
 		<annotation cp="👩🏼‍🎤" type="tts">obìnrin olórin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🎤">adánirárayá | akɔrin | amɔ́láwɔ̀ díɛ̀ | àpáta | ìràwɔ̀ | obìnrin olórin | obìnrin olórin: amɔ́láwɔ̀ díɛ̀ | obìrin | ɔshèré</annotation>
+		<annotation cp="👩🏽‍🎤">adánirárayá | akɔrin | amɔ́láwɔ̀ díɛ̀ | àpáta | ìràwɔ̀ | obìnrin olórin | obìrin | ɔshèré</annotation>
 		<annotation cp="👩🏽‍🎤" type="tts">obìnrin olórin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🎤">adánirárayá | adúláwɔ̀ díɛ̀ | akɔrin | àpáta | ìràwɔ̀ | obìnrin olórin | obìnrin olórin: adúláwɔ̀ díɛ̀ | obìrin | ɔshèré</annotation>
+		<annotation cp="👩🏾‍🎤">adánirárayá | adúláwɔ̀ díɛ̀ | akɔrin | àpáta | ìràwɔ̀ | obìnrin olórin | obìrin | ɔshèré</annotation>
 		<annotation cp="👩🏾‍🎤" type="tts">obìnrin olórin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🎤">adánirárayá | adúláwɔ̀ | akɔrin | àpáta | ìràwɔ̀ | obìnrin olórin | obìnrin olórin: adúláwɔ̀ | obìrin | ɔshèré</annotation>
+		<annotation cp="👩🏿‍🎤">adánirárayá | adúláwɔ̀ | akɔrin | àpáta | ìràwɔ̀ | obìnrin olórin | obìrin | ɔshèré</annotation>
 		<annotation cp="👩🏿‍🎤" type="tts">obìnrin olórin: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🎨">amɔ́lára | ashɛ̀dá àwòrán | ashɛ̀dá àwòrán: amɔ́lára | àtɛ àwɔ̀ ìyàwòrán</annotation>
+		<annotation cp="🧑🏻‍🎨">amɔ́lára | ashɛ̀dá àwòrán | àtɛ àwɔ̀ ìyàwòrán</annotation>
 		<annotation cp="🧑🏻‍🎨" type="tts">ashɛ̀dá àwòrán: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🎨">amɔ́lára díɛ̀ | ashɛ̀dá àwòrán | ashɛ̀dá àwòrán: amɔ́lára díɛ̀ | àtɛ àwɔ̀ ìyàwòrán</annotation>
+		<annotation cp="🧑🏼‍🎨">amɔ́lára díɛ̀ | ashɛ̀dá àwòrán | àtɛ àwɔ̀ ìyàwòrán</annotation>
 		<annotation cp="🧑🏼‍🎨" type="tts">ashɛ̀dá àwòrán: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🎨">amɔ́láwɔ̀ díɛ̀ | ashɛ̀dá àwòrán | ashɛ̀dá àwòrán: amɔ́láwɔ̀ díɛ̀ | àtɛ àwɔ̀ ìyàwòrán</annotation>
+		<annotation cp="🧑🏽‍🎨">amɔ́láwɔ̀ díɛ̀ | ashɛ̀dá àwòrán | àtɛ àwɔ̀ ìyàwòrán</annotation>
 		<annotation cp="🧑🏽‍🎨" type="tts">ashɛ̀dá àwòrán: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🎨">adúláwɔ̀ díɛ̀ | ashɛ̀dá àwòrán | ashɛ̀dá àwòrán: adúláwɔ̀ díɛ̀ | àtɛ àwɔ̀ ìyàwòrán</annotation>
+		<annotation cp="🧑🏾‍🎨">adúláwɔ̀ díɛ̀ | ashɛ̀dá àwòrán | àtɛ àwɔ̀ ìyàwòrán</annotation>
 		<annotation cp="🧑🏾‍🎨" type="tts">ashɛ̀dá àwòrán: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🎨">adúláwɔ̀ | ashɛ̀dá àwòrán | ashɛ̀dá àwòrán: adúláwɔ̀ | àtɛ àwɔ̀ ìyàwòrán</annotation>
+		<annotation cp="🧑🏿‍🎨">adúláwɔ̀ | ashɛ̀dá àwòrán | àtɛ àwɔ̀ ìyàwòrán</annotation>
 		<annotation cp="🧑🏿‍🎨" type="tts">ashɛ̀dá àwòrán: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🎨">amɔ́lára | òshèré | ɔkùnrin | ɔkùnrin òshèré: amɔ́lára | páalɛ́ttì</annotation>
+		<annotation cp="👨🏻‍🎨">amɔ́lára | òshèré | ɔkùnrin | páalɛ́ttì</annotation>
 		<annotation cp="👨🏻‍🎨" type="tts">ɔkùnrin òshèré: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🎨">amɔ́lára díɛ̀ | òshèré | ɔkùnrin | ɔkùnrin òshèré: amɔ́lára díɛ̀ | páalɛ́ttì</annotation>
+		<annotation cp="👨🏼‍🎨">amɔ́lára díɛ̀ | òshèré | ɔkùnrin | páalɛ́ttì</annotation>
 		<annotation cp="👨🏼‍🎨" type="tts">ɔkùnrin òshèré: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🎨">amɔ́láwɔ̀ díɛ̀ | òshèré | ɔkùnrin | ɔkùnrin òshèré: amɔ́láwɔ̀ díɛ̀ | páalɛ́ttì</annotation>
+		<annotation cp="👨🏽‍🎨">amɔ́láwɔ̀ díɛ̀ | òshèré | ɔkùnrin | páalɛ́ttì</annotation>
 		<annotation cp="👨🏽‍🎨" type="tts">ɔkùnrin òshèré: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🎨">adúláwɔ̀ díɛ̀ | òshèré | ɔkùnrin | ɔkùnrin òshèré: adúláwɔ̀ díɛ̀ | páalɛ́ttì</annotation>
+		<annotation cp="👨🏾‍🎨">adúláwɔ̀ díɛ̀ | òshèré | ɔkùnrin | páalɛ́ttì</annotation>
 		<annotation cp="👨🏾‍🎨" type="tts">ɔkùnrin òshèré: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🎨">adúláwɔ̀ | òshèré | ɔkùnrin | ɔkùnrin òshèré: adúláwɔ̀ | páalɛ́ttì</annotation>
+		<annotation cp="👨🏿‍🎨">adúláwɔ̀ | òshèré | ɔkùnrin | páalɛ́ttì</annotation>
 		<annotation cp="👨🏿‍🎨" type="tts">ɔkùnrin òshèré: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🎨">amɔ́lára | obìrin | obìrin òshèré | obìrin òshèré: amɔ́lára | òshèré pálɛ́ttì</annotation>
+		<annotation cp="👩🏻‍🎨">amɔ́lára | obìrin | obìrin òshèré | òshèré pálɛ́ttì</annotation>
 		<annotation cp="👩🏻‍🎨" type="tts">obìrin òshèré: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🎨">amɔ́lára díɛ̀ | obìrin | obìrin òshèré | obìrin òshèré: amɔ́lára díɛ̀ | òshèré pálɛ́ttì</annotation>
+		<annotation cp="👩🏼‍🎨">amɔ́lára díɛ̀ | obìrin | obìrin òshèré | òshèré pálɛ́ttì</annotation>
 		<annotation cp="👩🏼‍🎨" type="tts">obìrin òshèré: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🎨">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrin òshèré | obìrin òshèré: amɔ́láwɔ̀ díɛ̀ | òshèré pálɛ́ttì</annotation>
+		<annotation cp="👩🏽‍🎨">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrin òshèré | òshèré pálɛ́ttì</annotation>
 		<annotation cp="👩🏽‍🎨" type="tts">obìrin òshèré: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🎨">adúláwɔ̀ díɛ̀ | obìrin | obìrin òshèré | obìrin òshèré: adúláwɔ̀ díɛ̀ | òshèré pálɛ́ttì</annotation>
+		<annotation cp="👩🏾‍🎨">adúláwɔ̀ díɛ̀ | obìrin | obìrin òshèré | òshèré pálɛ́ttì</annotation>
 		<annotation cp="👩🏾‍🎨" type="tts">obìrin òshèré: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🎨">adúláwɔ̀ | obìrin | obìrin òshèré | obìrin òshèré: adúláwɔ̀ | òshèré pálɛ́ttì</annotation>
+		<annotation cp="👩🏿‍🎨">adúláwɔ̀ | obìrin | obìrin òshèré | òshèré pálɛ́ttì</annotation>
 		<annotation cp="👩🏿‍🎨" type="tts">obìrin òshèré: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍✈">amɔ́lára | atukɔ̀-òfurufú | atukɔ̀-òfurufú: amɔ́lára | ɔkɔ̀-òfurufú</annotation>
+		<annotation cp="🧑🏻‍✈">amɔ́lára | atukɔ̀-òfurufú | ɔkɔ̀-òfurufú</annotation>
 		<annotation cp="🧑🏻‍✈" type="tts">atukɔ̀-òfurufú: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍✈">amɔ́lára díɛ̀ | atukɔ̀-òfurufú | atukɔ̀-òfurufú: amɔ́lára díɛ̀ | ɔkɔ̀-òfurufú</annotation>
+		<annotation cp="🧑🏼‍✈">amɔ́lára díɛ̀ | atukɔ̀-òfurufú | ɔkɔ̀-òfurufú</annotation>
 		<annotation cp="🧑🏼‍✈" type="tts">atukɔ̀-òfurufú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍✈">amɔ́láwɔ̀ díɛ̀ | atukɔ̀-òfurufú | atukɔ̀-òfurufú: amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀-òfurufú</annotation>
+		<annotation cp="🧑🏽‍✈">amɔ́láwɔ̀ díɛ̀ | atukɔ̀-òfurufú | ɔkɔ̀-òfurufú</annotation>
 		<annotation cp="🧑🏽‍✈" type="tts">atukɔ̀-òfurufú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍✈">adúláwɔ̀ díɛ̀ | atukɔ̀-òfurufú | atukɔ̀-òfurufú: adúláwɔ̀ díɛ̀ | ɔkɔ̀-òfurufú</annotation>
+		<annotation cp="🧑🏾‍✈">adúláwɔ̀ díɛ̀ | atukɔ̀-òfurufú | ɔkɔ̀-òfurufú</annotation>
 		<annotation cp="🧑🏾‍✈" type="tts">atukɔ̀-òfurufú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍✈">adúláwɔ̀ | atukɔ̀-òfurufú | atukɔ̀-òfurufú: adúláwɔ̀ | ɔkɔ̀-òfurufú</annotation>
+		<annotation cp="🧑🏿‍✈">adúláwɔ̀ | atukɔ̀-òfurufú | ɔkɔ̀-òfurufú</annotation>
 		<annotation cp="🧑🏿‍✈" type="tts">atukɔ̀-òfurufú: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍✈">amɔ́lára | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú | ɔkùnrin awa ɔkɔ́ bàlú: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍✈">amɔ́lára | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👨🏻‍✈" type="tts">ɔkùnrin awa ɔkɔ́ bàlú: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍✈">amɔ́lára díɛ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú | ɔkùnrin awa ɔkɔ́ bàlú: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍✈">amɔ́lára díɛ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👨🏼‍✈" type="tts">ɔkùnrin awa ɔkɔ́ bàlú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍✈">amɔ́láwɔ̀ díɛ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú | ɔkùnrin awa ɔkɔ́ bàlú: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍✈">amɔ́láwɔ̀ díɛ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👨🏽‍✈" type="tts">ɔkùnrin awa ɔkɔ́ bàlú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍✈">adúláwɔ̀ díɛ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú | ɔkùnrin awa ɔkɔ́ bàlú: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍✈">adúláwɔ̀ díɛ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👨🏾‍✈" type="tts">ɔkùnrin awa ɔkɔ́ bàlú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍✈">adúláwɔ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú | ɔkùnrin awa ɔkɔ́ bàlú: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍✈">adúláwɔ̀ | awa ɔks bálú | bàlú | ɔkùnrin | ɔkùnrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👨🏿‍✈" type="tts">ɔkùnrin awa ɔkɔ́ bàlú: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍✈">amɔ́lára | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú | obìrin awa ɔkɔ́ bàlú: amɔ́lára</annotation>
+		<annotation cp="👩🏻‍✈">amɔ́lára | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👩🏻‍✈" type="tts">obìrin awa ɔkɔ́ bàlú: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍✈">amɔ́lára díɛ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú | obìrin awa ɔkɔ́ bàlú: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👩🏼‍✈">amɔ́lára díɛ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👩🏼‍✈" type="tts">obìrin awa ɔkɔ́ bàlú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍✈">amɔ́láwɔ̀ díɛ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú | obìrin awa ɔkɔ́ bàlú: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏽‍✈">amɔ́láwɔ̀ díɛ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👩🏽‍✈" type="tts">obìrin awa ɔkɔ́ bàlú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍✈">adúláwɔ̀ díɛ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú | obìrin awa ɔkɔ́ bàlú: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏾‍✈">adúláwɔ̀ díɛ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👩🏾‍✈" type="tts">obìrin awa ɔkɔ́ bàlú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍✈">adúláwɔ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú | obìrin awa ɔkɔ́ bàlú: adúláwɔ̀</annotation>
+		<annotation cp="👩🏿‍✈">adúláwɔ̀ | awa ɔkɔ̀ bálú | bàlú | obìrin | obìrin awa ɔkɔ́ bàlú</annotation>
 		<annotation cp="👩🏿‍✈" type="tts">obìrin awa ɔkɔ́ bàlú: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🚀">amɔ́lára | arìnrìn-àjò lɔ sí ayé mìíràn | arìnrìn-àjò lɔ sí ayé mìíràn: amɔ́lára | rɔ́kɛ́ɛ̀tì</annotation>
+		<annotation cp="🧑🏻‍🚀">amɔ́lára | arìnrìn-àjò lɔ sí ayé mìíràn | rɔ́kɛ́ɛ̀tì</annotation>
 		<annotation cp="🧑🏻‍🚀" type="tts">arìnrìn-àjò lɔ sí ayé mìíràn: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🚀">amɔ́lára díɛ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | arìnrìn-àjò lɔ sí ayé mìíràn: amɔ́lára díɛ̀ | rɔ́kɛ́ɛ̀tì</annotation>
+		<annotation cp="🧑🏼‍🚀">amɔ́lára díɛ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | rɔ́kɛ́ɛ̀tì</annotation>
 		<annotation cp="🧑🏼‍🚀" type="tts">arìnrìn-àjò lɔ sí ayé mìíràn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🚀">amɔ́láwɔ̀ díɛ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | arìnrìn-àjò lɔ sí ayé mìíràn: amɔ́láwɔ̀ díɛ̀ | rɔ́kɛ́ɛ̀tì</annotation>
+		<annotation cp="🧑🏽‍🚀">amɔ́láwɔ̀ díɛ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | rɔ́kɛ́ɛ̀tì</annotation>
 		<annotation cp="🧑🏽‍🚀" type="tts">arìnrìn-àjò lɔ sí ayé mìíràn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🚀">adúláwɔ̀ díɛ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | arìnrìn-àjò lɔ sí ayé mìíràn: adúláwɔ̀ díɛ̀ | rɔ́kɛ́ɛ̀tì</annotation>
+		<annotation cp="🧑🏾‍🚀">adúláwɔ̀ díɛ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | rɔ́kɛ́ɛ̀tì</annotation>
 		<annotation cp="🧑🏾‍🚀" type="tts">arìnrìn-àjò lɔ sí ayé mìíràn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🚀">adúláwɔ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | arìnrìn-àjò lɔ sí ayé mìíràn: adúláwɔ̀ | rɔ́kɛ́ɛ̀tì</annotation>
+		<annotation cp="🧑🏿‍🚀">adúláwɔ̀ | arìnrìn-àjò lɔ sí ayé mìíràn | rɔ́kɛ́ɛ̀tì</annotation>
 		<annotation cp="🧑🏿‍🚀" type="tts">arìnrìn-àjò lɔ sí ayé mìíràn: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🚀">amɔ́lára | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: amɔ́lára | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👨🏻‍🚀">amɔ́lára | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👨🏻‍🚀" type="tts">ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🚀">amɔ́lára díɛ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: amɔ́lára díɛ̀ | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👨🏼‍🚀">amɔ́lára díɛ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👨🏼‍🚀" type="tts">ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🚀">amɔ́láwɔ̀ díɛ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: amɔ́láwɔ̀ díɛ̀ | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👨🏽‍🚀">amɔ́láwɔ̀ díɛ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👨🏽‍🚀" type="tts">ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🚀">adúláwɔ̀ díɛ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: adúláwɔ̀ díɛ̀ | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👨🏾‍🚀">adúláwɔ̀ díɛ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👨🏾‍🚀" type="tts">ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🚀">adúláwɔ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: adúláwɔ̀ | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👨🏿‍🚀">adúláwɔ̀ | òkùnrin | olùwádìí inú òshùpá | ɔkùnrin olùwádìí inú òshùpá ɔkùnrin | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👨🏿‍🚀" type="tts">ɔkùnrin olùwádìí inú òshùpá ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🚀">amɔ́lára | obìrin | obìrinolùwádìí inú òshùpá | obìrinolùwádìí inú òshùpá: amɔ́lára | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👩🏻‍🚀">amɔ́lára | obìrin | obìrinolùwádìí inú òshùpá | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👩🏻‍🚀" type="tts">obìrinolùwádìí inú òshùpá: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🚀">amɔ́lára díɛ̀ | obìrin | obìrinolùwádìí inú òshùpá | obìrinolùwádìí inú òshùpá: amɔ́lára díɛ̀ | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👩🏼‍🚀">amɔ́lára díɛ̀ | obìrin | obìrinolùwádìí inú òshùpá | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👩🏼‍🚀" type="tts">obìrinolùwádìí inú òshùpá: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🚀">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrinolùwádìí inú òshùpá | obìrinolùwádìí inú òshùpá: amɔ́láwɔ̀ díɛ̀ | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👩🏽‍🚀">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrinolùwádìí inú òshùpá | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👩🏽‍🚀" type="tts">obìrinolùwádìí inú òshùpá: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🚀">adúláwɔ̀ díɛ̀ | obìrin | obìrinolùwádìí inú òshùpá | obìrinolùwádìí inú òshùpá: adúláwɔ̀ díɛ̀ | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👩🏾‍🚀">adúláwɔ̀ díɛ̀ | obìrin | obìrinolùwádìí inú òshùpá | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👩🏾‍🚀" type="tts">obìrinolùwádìí inú òshùpá: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🚀">adúláwɔ̀ | obìrin | obìrinolùwádìí inú òshùpá | obìrinolùwádìí inú òshùpá: adúláwɔ̀ | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
+		<annotation cp="👩🏿‍🚀">adúláwɔ̀ | obìrin | obìrinolùwádìí inú òshùpá | olùwádìí inú òshùpá | rɔ́kɛ̀tì</annotation>
 		<annotation cp="👩🏿‍🚀" type="tts">obìrinolùwádìí inú òshùpá: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🚒">amɔ́lára | ɔkɔ̀ panápaná | panápaná | panápaná: amɔ́lára</annotation>
+		<annotation cp="🧑🏻‍🚒">amɔ́lára | ɔkɔ̀ panápaná | panápaná</annotation>
 		<annotation cp="🧑🏻‍🚒" type="tts">panápaná: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🚒">amɔ́lára díɛ̀ | ɔkɔ̀ panápaná | panápaná | panápaná: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧑🏼‍🚒">amɔ́lára díɛ̀ | ɔkɔ̀ panápaná | panápaná</annotation>
 		<annotation cp="🧑🏼‍🚒" type="tts">panápaná: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🚒">amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ panápaná | panápaná | panápaná: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏽‍🚒">amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ panápaná | panápaná</annotation>
 		<annotation cp="🧑🏽‍🚒" type="tts">panápaná: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🚒">adúláwɔ̀ díɛ̀ | ɔkɔ̀ panápaná | panápaná | panápaná: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏾‍🚒">adúláwɔ̀ díɛ̀ | ɔkɔ̀ panápaná | panápaná</annotation>
 		<annotation cp="🧑🏾‍🚒" type="tts">panápaná: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🚒">adúláwɔ̀ | ɔkɔ̀ panápaná | panápaná | panápaná: adúláwɔ̀</annotation>
+		<annotation cp="🧑🏿‍🚒">adúláwɔ̀ | ɔkɔ̀ panápaná | panápaná</annotation>
 		<annotation cp="🧑🏿‍🚒" type="tts">panápaná: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🚒">amɔ́lára | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | ɔkùnrin panapanɔ́: amɔ́lára | panɔ́panɔ́</annotation>
+		<annotation cp="👨🏻‍🚒">amɔ́lára | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👨🏻‍🚒" type="tts">ɔkùnrin panapanɔ́: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🚒">amɔ́lára díɛ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | ɔkùnrin panapanɔ́: amɔ́lára díɛ̀ | panɔ́panɔ́</annotation>
+		<annotation cp="👨🏼‍🚒">amɔ́lára díɛ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👨🏼‍🚒" type="tts">ɔkùnrin panapanɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🚒">amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | ɔkùnrin panapanɔ́: amɔ́láwɔ̀ díɛ̀ | panɔ́panɔ́</annotation>
+		<annotation cp="👨🏽‍🚒">amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👨🏽‍🚒" type="tts">ɔkùnrin panapanɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🚒">adúláwɔ̀ díɛ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | ɔkùnrin panapanɔ́: adúláwɔ̀ díɛ̀ | panɔ́panɔ́</annotation>
+		<annotation cp="👨🏾‍🚒">adúláwɔ̀ díɛ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👨🏾‍🚒" type="tts">ɔkùnrin panapanɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🚒">adúláwɔ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | ɔkùnrin panapanɔ́: adúláwɔ̀ | panɔ́panɔ́</annotation>
+		<annotation cp="👨🏿‍🚒">adúláwɔ̀ | ɔkɔ̀ panapanɔ́ | ɔkùnrin | ɔkùnrin panapanɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👨🏿‍🚒" type="tts">ɔkùnrin panapanɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🚒">amɔ́lára | obìrin | obìrin panapanɔ́ | obìrin panapanɔ́: amɔ́lára | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
+		<annotation cp="👩🏻‍🚒">amɔ́lára | obìrin | obìrin panapanɔ́ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👩🏻‍🚒" type="tts">obìrin panapanɔ́: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🚒">amɔ́lára díɛ̀ | obìrin | obìrin panapanɔ́ | obìrin panapanɔ́: amɔ́lára díɛ̀ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
+		<annotation cp="👩🏼‍🚒">amɔ́lára díɛ̀ | obìrin | obìrin panapanɔ́ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👩🏼‍🚒" type="tts">obìrin panapanɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🚒">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrin panapanɔ́ | obìrin panapanɔ́: amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
+		<annotation cp="👩🏽‍🚒">amɔ́láwɔ̀ díɛ̀ | obìrin | obìrin panapanɔ́ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👩🏽‍🚒" type="tts">obìrin panapanɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🚒">adúláwɔ̀ díɛ̀ | obìrin | obìrin panapanɔ́ | obìrin panapanɔ́: adúláwɔ̀ díɛ̀ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
+		<annotation cp="👩🏾‍🚒">adúláwɔ̀ díɛ̀ | obìrin | obìrin panapanɔ́ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👩🏾‍🚒" type="tts">obìrin panapanɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🚒">adúláwɔ̀ | obìrin | obìrin panapanɔ́ | obìrin panapanɔ́: adúláwɔ̀ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
+		<annotation cp="👩🏿‍🚒">adúláwɔ̀ | obìrin | obìrin panapanɔ́ | ɔkɔ̀ panɔ́pnɔ́ | panɔ́panɔ́</annotation>
 		<annotation cp="👩🏿‍🚒" type="tts">obìrin panapanɔ́: adúláwɔ̀</annotation>
-		<annotation cp="👮🏻">amɔ́lára | òshìshɛ́ | Ɔlɔpa | Ɔlɔpa: amɔ́lára | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏻">amɔ́lára | òshìshɛ́ | Ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏻" type="tts">Ɔlɔpa: amɔ́lára</annotation>
-		<annotation cp="👮🏼">amɔ́lára díɛ̀ | òshìshɛ́ | Ɔlɔpa | Ɔlɔpa: amɔ́lára díɛ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏼">amɔ́lára díɛ̀ | òshìshɛ́ | Ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏼" type="tts">Ɔlɔpa: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👮🏽">amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | Ɔlɔpa | Ɔlɔpa: amɔ́láwɔ̀ díɛ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏽">amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | Ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏽" type="tts">Ɔlɔpa: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👮🏾">adúláwɔ̀ díɛ̀ | òshìshɛ́ | Ɔlɔpa | Ɔlɔpa: adúláwɔ̀ díɛ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏾">adúláwɔ̀ díɛ̀ | òshìshɛ́ | Ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏾" type="tts">Ɔlɔpa: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👮🏿">adúláwɔ̀ | òshìshɛ́ | Ɔlɔpa | Ɔlɔpa: adúláwɔ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏿">adúláwɔ̀ | òshìshɛ́ | Ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏿" type="tts">Ɔlɔpa: adúláwɔ̀</annotation>
-		<annotation cp="👮🏻‍♂">amɔ́lára | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔkùnrin ɔlɔpa: amɔ́lára | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏻‍♂">amɔ́lára | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏻‍♂" type="tts">ɔkùnrin ɔlɔpa: amɔ́lára</annotation>
-		<annotation cp="👮🏼‍♂">amɔ́lára díɛ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔkùnrin ɔlɔpa: amɔ́lára díɛ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏼‍♂">amɔ́lára díɛ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏼‍♂" type="tts">ɔkùnrin ɔlɔpa: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👮🏽‍♂">amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔkùnrin ɔlɔpa: amɔ́láwɔ̀ díɛ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏽‍♂">amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏽‍♂" type="tts">ɔkùnrin ɔlɔpa: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👮🏾‍♂">adúláwɔ̀ díɛ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔkùnrin ɔlɔpa: adúláwɔ̀ díɛ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏾‍♂">adúláwɔ̀ díɛ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏾‍♂" type="tts">ɔkùnrin ɔlɔpa: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👮🏿‍♂">adúláwɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔkùnrin ɔlɔpa: adúláwɔ̀ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏿‍♂">adúláwɔ̀ | òshìshɛ́ | ɔkùnrin | ɔkùnrin ɔlɔpa | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏿‍♂" type="tts">ɔkùnrin ɔlɔpa: adúláwɔ̀</annotation>
-		<annotation cp="👮🏻‍♀">amɔ́lára | obìnrin | obìnrin ɔlɔpa | obìnrin ɔlɔpa: amɔ́lára | òshìshɛ́ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏻‍♀">amɔ́lára | obìnrin | obìnrin ɔlɔpa | òshìshɛ́ | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏻‍♀" type="tts">obìnrin ɔlɔpa: amɔ́lára</annotation>
-		<annotation cp="👮🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin ɔlɔpa | obìnrin ɔlɔpa: amɔ́lára díɛ̀ | òshìshɛ́ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin ɔlɔpa | òshìshɛ́ | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏼‍♀" type="tts">obìnrin ɔlɔpa: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👮🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin ɔlɔpa | obìnrin ɔlɔpa: amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin ɔlɔpa | òshìshɛ́ | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏽‍♀" type="tts">obìnrin ɔlɔpa: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👮🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin ɔlɔpa | obìnrin ɔlɔpa: adúláwɔ̀ díɛ̀ | òshìshɛ́ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin ɔlɔpa | òshìshɛ́ | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏾‍♀" type="tts">obìnrin ɔlɔpa: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👮🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin ɔlɔpa | obìnrin ɔlɔpa: adúláwɔ̀ | òshìshɛ́ | ɔlɔ́pàá</annotation>
+		<annotation cp="👮🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin ɔlɔpa | òshìshɛ́ | ɔlɔ́pàá</annotation>
 		<annotation cp="👮🏿‍♀" type="tts">obìnrin ɔlɔpa: adúláwɔ̀</annotation>
-		<annotation cp="🕵🏻">amɔ́lára | ashèwádìí | ɔ̀tɛlèmúyé | ɔ̀tɛlèmúyé: amɔ́lára</annotation>
+		<annotation cp="🕵🏻">amɔ́lára | ashèwádìí | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏻" type="tts">ɔ̀tɛlèmúyé: amɔ́lára</annotation>
-		<annotation cp="🕵🏼">amɔ́lára díɛ̀ | ashèwádìí | ɔ̀tɛlèmúyé | ɔ̀tɛlèmúyé: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🕵🏼">amɔ́lára díɛ̀ | ashèwádìí | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏼" type="tts">ɔ̀tɛlèmúyé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🕵🏽">amɔ́láwɔ̀ díɛ̀ | ashèwádìí | ɔ̀tɛlèmúyé | ɔ̀tɛlèmúyé: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🕵🏽">amɔ́láwɔ̀ díɛ̀ | ashèwádìí | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏽" type="tts">ɔ̀tɛlèmúyé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕵🏾">adúláwɔ̀ díɛ̀ | ashèwádìí | ɔ̀tɛlèmúyé | ɔ̀tɛlèmúyé: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🕵🏾">adúláwɔ̀ díɛ̀ | ashèwádìí | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏾" type="tts">ɔ̀tɛlèmúyé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕵🏿">adúláwɔ̀ | ashèwádìí | ɔ̀tɛlèmúyé | ɔ̀tɛlèmúyé: adúláwɔ̀</annotation>
+		<annotation cp="🕵🏿">adúláwɔ̀ | ashèwádìí | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏿" type="tts">ɔ̀tɛlèmúyé: adúláwɔ̀</annotation>
-		<annotation cp="🕵🏻‍♂">amɔ́lára | ashèwádìí | ɔkùnrin | ɔkùnrin ɔ̀tɛlèmúyé: amɔ́lára | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏻‍♂">amɔ́lára | ashèwádìí | ɔkùnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏻‍♂" type="tts">ɔkùnrin ɔ̀tɛlèmúyé: amɔ́lára</annotation>
-		<annotation cp="🕵🏼‍♂">amɔ́lára díɛ̀ | ashèwádìí | ɔkùnrin | ɔkùnrin ɔ̀tɛlèmúyé: amɔ́lára díɛ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏼‍♂">amɔ́lára díɛ̀ | ashèwádìí | ɔkùnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏼‍♂" type="tts">ɔkùnrin ɔ̀tɛlèmúyé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🕵🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ashèwádìí | ɔkùnrin | ɔkùnrin ɔ̀tɛlèmúyé: amɔ́láwɔ̀ díɛ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ashèwádìí | ɔkùnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏽‍♂" type="tts">ɔkùnrin ɔ̀tɛlèmúyé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕵🏾‍♂">adúláwɔ̀ díɛ̀ | ashèwádìí | ɔkùnrin | ɔkùnrin ɔ̀tɛlèmúyé: adúláwɔ̀ díɛ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏾‍♂">adúláwɔ̀ díɛ̀ | ashèwádìí | ɔkùnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏾‍♂" type="tts">ɔkùnrin ɔ̀tɛlèmúyé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕵🏿‍♂">adúláwɔ̀ | ashèwádìí | ɔkùnrin | ɔkùnrin ɔ̀tɛlèmúyé: adúláwɔ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏿‍♂">adúláwɔ̀ | ashèwádìí | ɔkùnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏿‍♂" type="tts">ɔkùnrin ɔ̀tɛlèmúyé: adúláwɔ̀</annotation>
-		<annotation cp="🕵🏻‍♀">amɔ́lára | ashèwádìí | obìnrin | obìnrin ɔ̀tɛlèmúyé: amɔ́lára | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏻‍♀">amɔ́lára | ashèwádìí | obìnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏻‍♀" type="tts">obìnrin ɔ̀tɛlèmúyé: amɔ́lára</annotation>
-		<annotation cp="🕵🏼‍♀">amɔ́lára díɛ̀ | ashèwádìí | obìnrin | obìnrin ɔ̀tɛlèmúyé: amɔ́lára díɛ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏼‍♀">amɔ́lára díɛ̀ | ashèwádìí | obìnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏼‍♀" type="tts">obìnrin ɔ̀tɛlèmúyé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🕵🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ashèwádìí | obìnrin | obìnrin ɔ̀tɛlèmúyé: amɔ́láwɔ̀ díɛ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ashèwádìí | obìnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏽‍♀" type="tts">obìnrin ɔ̀tɛlèmúyé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕵🏾‍♀">adúláwɔ̀ díɛ̀ | ashèwádìí | obìnrin | obìnrin ɔ̀tɛlèmúyé: adúláwɔ̀ díɛ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏾‍♀">adúláwɔ̀ díɛ̀ | ashèwádìí | obìnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏾‍♀" type="tts">obìnrin ɔ̀tɛlèmúyé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕵🏿‍♀">adúláwɔ̀ | ashèwádìí | obìnrin | obìnrin ɔ̀tɛlèmúyé: adúláwɔ̀ | ɔ̀tɛlèmúyé</annotation>
+		<annotation cp="🕵🏿‍♀">adúláwɔ̀ | ashèwádìí | obìnrin | ɔ̀tɛlèmúyé</annotation>
 		<annotation cp="🕵🏿‍♀" type="tts">obìnrin ɔ̀tɛlèmúyé: adúláwɔ̀</annotation>
-		<annotation cp="💂🏻">amɔ́lára | Olushɔ | Olushɔ: amɔ́lára</annotation>
+		<annotation cp="💂🏻">amɔ́lára | Olushɔ</annotation>
 		<annotation cp="💂🏻" type="tts">Olushɔ: amɔ́lára</annotation>
-		<annotation cp="💂🏼">amɔ́lára díɛ̀ | Olushɔ | Olushɔ: amɔ́lára díɛ̀</annotation>
+		<annotation cp="💂🏼">amɔ́lára díɛ̀ | Olushɔ</annotation>
 		<annotation cp="💂🏼" type="tts">Olushɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💂🏽">amɔ́láwɔ̀ díɛ̀ | Olushɔ | Olushɔ: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="💂🏽">amɔ́láwɔ̀ díɛ̀ | Olushɔ</annotation>
 		<annotation cp="💂🏽" type="tts">Olushɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💂🏾">adúláwɔ̀ díɛ̀ | Olushɔ | Olushɔ: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="💂🏾">adúláwɔ̀ díɛ̀ | Olushɔ</annotation>
 		<annotation cp="💂🏾" type="tts">Olushɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💂🏿">adúláwɔ̀ | Olushɔ | Olushɔ: adúláwɔ̀</annotation>
+		<annotation cp="💂🏿">adúláwɔ̀ | Olushɔ</annotation>
 		<annotation cp="💂🏿" type="tts">Olushɔ: adúláwɔ̀</annotation>
-		<annotation cp="💂🏻‍♂">amɔ́lára | olùshɔ́ | ɔkùnrin | ɔkùnrin olùshɔ́: amɔ́lára</annotation>
+		<annotation cp="💂🏻‍♂">amɔ́lára | olùshɔ́ | ɔkùnrin</annotation>
 		<annotation cp="💂🏻‍♂" type="tts">ɔkùnrin olùshɔ́: amɔ́lára</annotation>
-		<annotation cp="💂🏼‍♂">amɔ́lára díɛ̀ | olùshɔ́ | ɔkùnrin | ɔkùnrin olùshɔ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="💂🏼‍♂">amɔ́lára díɛ̀ | olùshɔ́ | ɔkùnrin</annotation>
 		<annotation cp="💂🏼‍♂" type="tts">ɔkùnrin olùshɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💂🏽‍♂">amɔ́láwɔ̀ díɛ̀ | olùshɔ́ | ɔkùnrin | ɔkùnrin olùshɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="💂🏽‍♂">amɔ́láwɔ̀ díɛ̀ | olùshɔ́ | ɔkùnrin</annotation>
 		<annotation cp="💂🏽‍♂" type="tts">ɔkùnrin olùshɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💂🏾‍♂">adúláwɔ̀ díɛ̀ | olùshɔ́ | ɔkùnrin | ɔkùnrin olùshɔ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="💂🏾‍♂">adúláwɔ̀ díɛ̀ | olùshɔ́ | ɔkùnrin</annotation>
 		<annotation cp="💂🏾‍♂" type="tts">ɔkùnrin olùshɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💂🏿‍♂">adúláwɔ̀ | olùshɔ́ | ɔkùnrin | ɔkùnrin olùshɔ́: adúláwɔ̀</annotation>
+		<annotation cp="💂🏿‍♂">adúláwɔ̀ | olùshɔ́ | ɔkùnrin</annotation>
 		<annotation cp="💂🏿‍♂" type="tts">ɔkùnrin olùshɔ́: adúláwɔ̀</annotation>
-		<annotation cp="💂🏻‍♀">amɔ́lára | obìnrin | obìnrin olùshɔ́: amɔ́lára | olùshɔ́</annotation>
+		<annotation cp="💂🏻‍♀">amɔ́lára | obìnrin | olùshɔ́</annotation>
 		<annotation cp="💂🏻‍♀" type="tts">obìnrin olùshɔ́: amɔ́lára</annotation>
-		<annotation cp="💂🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin olùshɔ́: amɔ́lára díɛ̀ | olùshɔ́</annotation>
+		<annotation cp="💂🏼‍♀">amɔ́lára díɛ̀ | obìnrin | olùshɔ́</annotation>
 		<annotation cp="💂🏼‍♀" type="tts">obìnrin olùshɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💂🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin olùshɔ́: amɔ́láwɔ̀ díɛ̀ | olùshɔ́</annotation>
+		<annotation cp="💂🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | olùshɔ́</annotation>
 		<annotation cp="💂🏽‍♀" type="tts">obìnrin olùshɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💂🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin olùshɔ́: adúláwɔ̀ díɛ̀ | olùshɔ́</annotation>
+		<annotation cp="💂🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | olùshɔ́</annotation>
 		<annotation cp="💂🏾‍♀" type="tts">obìnrin olùshɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💂🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin olùshɔ́: adúláwɔ̀ | olùshɔ́</annotation>
+		<annotation cp="💂🏿‍♀">adúláwɔ̀ | obìnrin | olùshɔ́</annotation>
 		<annotation cp="💂🏿‍♀" type="tts">obìnrin olùshɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🥷🏻">ajagun | amɔ́lára | ninja | nínjà | nínjà: amɔ́lára | oja | sápamɔ́</annotation>
+		<annotation cp="🥷🏻">ajagun | amɔ́lára | ninja | nínjà | oja | sápamɔ́</annotation>
 		<annotation cp="🥷🏻" type="tts">nínjà: amɔ́lára</annotation>
-		<annotation cp="🥷🏼">ajagun | amɔ́lára díɛ̀ | ninja | nínjà | nínjà: amɔ́lára díɛ̀ | oja | sápamɔ́</annotation>
+		<annotation cp="🥷🏼">ajagun | amɔ́lára díɛ̀ | ninja | nínjà | oja | sápamɔ́</annotation>
 		<annotation cp="🥷🏼" type="tts">nínjà: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🥷🏽">ajagun | amɔ́láwɔ̀ díɛ̀ | ninja | nínjà | nínjà: amɔ́láwɔ̀ díɛ̀ | oja | sápamɔ́</annotation>
+		<annotation cp="🥷🏽">ajagun | amɔ́láwɔ̀ díɛ̀ | ninja | nínjà | oja | sápamɔ́</annotation>
 		<annotation cp="🥷🏽" type="tts">nínjà: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🥷🏾">adúláwɔ̀ díɛ̀ | ajagun | ninja | nínjà | nínjà: adúláwɔ̀ díɛ̀ | oja | sápamɔ́</annotation>
+		<annotation cp="🥷🏾">adúláwɔ̀ díɛ̀ | ajagun | ninja | nínjà | oja | sápamɔ́</annotation>
 		<annotation cp="🥷🏾" type="tts">nínjà: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🥷🏿">adúláwɔ̀ | ajagun | ninja | nínjà | nínjà: adúláwɔ̀ | oja | sápamɔ́</annotation>
+		<annotation cp="🥷🏿">adúláwɔ̀ | ajagun | ninja | nínjà | oja | sápamɔ́</annotation>
 		<annotation cp="🥷🏿" type="tts">nínjà: adúláwɔ̀</annotation>
-		<annotation cp="👷🏻">amɔ́lára | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle | Oshishɛ Ikɔle: amɔ́lára</annotation>
+		<annotation cp="👷🏻">amɔ́lára | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle</annotation>
 		<annotation cp="👷🏻" type="tts">Oshishɛ Ikɔle: amɔ́lára</annotation>
-		<annotation cp="👷🏼">amɔ́lára díɛ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle | Oshishɛ Ikɔle: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👷🏼">amɔ́lára díɛ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle</annotation>
 		<annotation cp="👷🏼" type="tts">Oshishɛ Ikɔle: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👷🏽">amɔ́láwɔ̀ díɛ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle | Oshishɛ Ikɔle: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👷🏽">amɔ́láwɔ̀ díɛ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle</annotation>
 		<annotation cp="👷🏽" type="tts">Oshishɛ Ikɔle: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👷🏾">adúláwɔ̀ díɛ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle | Oshishɛ Ikɔle: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👷🏾">adúláwɔ̀ díɛ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle</annotation>
 		<annotation cp="👷🏾" type="tts">Oshishɛ Ikɔle: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👷🏿">adúláwɔ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle | Oshishɛ Ikɔle: adúláwɔ̀</annotation>
+		<annotation cp="👷🏿">adúláwɔ̀ | fìlà | òshìshɛ́ | Oshishɛ Ikɔle | òshishɛ́ ìkɔle</annotation>
 		<annotation cp="👷🏿" type="tts">Oshishɛ Ikɔle: adúláwɔ̀</annotation>
-		<annotation cp="👷🏻‍♂">amɔ́lára | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | òshishɛ́ ìkɔ́lé ɔkùnrin: amɔ́lára | ɔkùnrin</annotation>
+		<annotation cp="👷🏻‍♂">amɔ́lára | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | ɔkùnrin</annotation>
 		<annotation cp="👷🏻‍♂" type="tts">òshishɛ́ ìkɔ́lé ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="👷🏼‍♂">amɔ́lára díɛ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | òshishɛ́ ìkɔ́lé ɔkùnrin: amɔ́lára díɛ̀ | ɔkùnrin</annotation>
+		<annotation cp="👷🏼‍♂">amɔ́lára díɛ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | ɔkùnrin</annotation>
 		<annotation cp="👷🏼‍♂" type="tts">òshishɛ́ ìkɔ́lé ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👷🏽‍♂">amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | òshishɛ́ ìkɔ́lé ɔkùnrin: amɔ́láwɔ̀ díɛ̀ | ɔkùnrin</annotation>
+		<annotation cp="👷🏽‍♂">amɔ́láwɔ̀ díɛ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | ɔkùnrin</annotation>
 		<annotation cp="👷🏽‍♂" type="tts">òshishɛ́ ìkɔ́lé ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👷🏾‍♂">adúláwɔ̀ díɛ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | òshishɛ́ ìkɔ́lé ɔkùnrin: adúláwɔ̀ díɛ̀ | ɔkùnrin</annotation>
+		<annotation cp="👷🏾‍♂">adúláwɔ̀ díɛ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | ɔkùnrin</annotation>
 		<annotation cp="👷🏾‍♂" type="tts">òshishɛ́ ìkɔ́lé ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👷🏿‍♂">adúláwɔ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | òshishɛ́ ìkɔ́lé ɔkùnrin: adúláwɔ̀ | ɔkùnrin</annotation>
+		<annotation cp="👷🏿‍♂">adúláwɔ̀ | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé ɔkùnrin | ɔkùnrin</annotation>
 		<annotation cp="👷🏿‍♂" type="tts">òshishɛ́ ìkɔ́lé ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="👷🏻‍♀">amɔ́lára | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin | òshishɛ́ ìkɔ́lé obìnrin: amɔ́lára</annotation>
+		<annotation cp="👷🏻‍♀">amɔ́lára | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin</annotation>
 		<annotation cp="👷🏻‍♀" type="tts">òshishɛ́ ìkɔ́lé obìnrin: amɔ́lára</annotation>
-		<annotation cp="👷🏼‍♀">amɔ́lára díɛ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin | òshishɛ́ ìkɔ́lé obìnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👷🏼‍♀">amɔ́lára díɛ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin</annotation>
 		<annotation cp="👷🏼‍♀" type="tts">òshishɛ́ ìkɔ́lé obìnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👷🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin | òshishɛ́ ìkɔ́lé obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👷🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin</annotation>
 		<annotation cp="👷🏽‍♀" type="tts">òshishɛ́ ìkɔ́lé obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👷🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin | òshishɛ́ ìkɔ́lé obìnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👷🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin</annotation>
 		<annotation cp="👷🏾‍♀" type="tts">òshishɛ́ ìkɔ́lé obìnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👷🏿‍♀">adúláwɔ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin | òshishɛ́ ìkɔ́lé obìnrin: adúláwɔ̀</annotation>
+		<annotation cp="👷🏿‍♀">adúláwɔ̀ | obìnrin | òshìshɛ́ | òshishɛ́ ìkɔle | òshishɛ́ ìkɔ́lé obìnrin</annotation>
 		<annotation cp="👷🏿‍♀" type="tts">òshishɛ́ ìkɔ́lé obìnrin: adúláwɔ̀</annotation>
-		<annotation cp="🫅🏻">amɔ́lára | ènìyàn pɛ̀lú adé | ènìyàn pɛ̀lú adé: amɔ́lára | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
+		<annotation cp="🫅🏻">amɔ́lára | ènìyàn pɛ̀lú adé | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
 		<annotation cp="🫅🏻" type="tts">ènìyàn pɛ̀lú adé: amɔ́lára</annotation>
-		<annotation cp="🫅🏼">amɔ́lára díɛ̀ | ènìyàn pɛ̀lú adé | ènìyàn pɛ̀lú adé: amɔ́lára díɛ̀ | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
+		<annotation cp="🫅🏼">amɔ́lára díɛ̀ | ènìyàn pɛ̀lú adé | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
 		<annotation cp="🫅🏼" type="tts">ènìyàn pɛ̀lú adé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫅🏽">amɔ́láwɔ̀ díɛ̀ | ènìyàn pɛ̀lú adé | ènìyàn pɛ̀lú adé: amɔ́láwɔ̀ díɛ̀ | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
+		<annotation cp="🫅🏽">amɔ́láwɔ̀ díɛ̀ | ènìyàn pɛ̀lú adé | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
 		<annotation cp="🫅🏽" type="tts">ènìyàn pɛ̀lú adé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫅🏾">adúláwɔ̀ díɛ̀ | ènìyàn pɛ̀lú adé | ènìyàn pɛ̀lú adé: adúláwɔ̀ díɛ̀ | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
+		<annotation cp="🫅🏾">adúláwɔ̀ díɛ̀ | ènìyàn pɛ̀lú adé | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
 		<annotation cp="🫅🏾" type="tts">ènìyàn pɛ̀lú adé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫅🏿">adúláwɔ̀ | ènìyàn pɛ̀lú adé | ènìyàn pɛ̀lú adé: adúláwɔ̀ | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
+		<annotation cp="🫅🏿">adúláwɔ̀ | ènìyàn pɛ̀lú adé | idile oba | idíle oba | ɔmɔ idile ɔba</annotation>
 		<annotation cp="🫅🏿" type="tts">ènìyàn pɛ̀lú adé: adúláwɔ̀</annotation>
-		<annotation cp="🤴🏻">amɔ́lára | Ɔmɔkunrin Alade | Ɔmɔkunrin Alade: amɔ́lára</annotation>
+		<annotation cp="🤴🏻">amɔ́lára | Ɔmɔkunrin Alade</annotation>
 		<annotation cp="🤴🏻" type="tts">Ɔmɔkunrin Alade: amɔ́lára</annotation>
-		<annotation cp="🤴🏼">amɔ́lára díɛ̀ | Ɔmɔkunrin Alade | Ɔmɔkunrin Alade: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤴🏼">amɔ́lára díɛ̀ | Ɔmɔkunrin Alade</annotation>
 		<annotation cp="🤴🏼" type="tts">Ɔmɔkunrin Alade: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤴🏽">amɔ́láwɔ̀ díɛ̀ | Ɔmɔkunrin Alade | Ɔmɔkunrin Alade: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤴🏽">amɔ́láwɔ̀ díɛ̀ | Ɔmɔkunrin Alade</annotation>
 		<annotation cp="🤴🏽" type="tts">Ɔmɔkunrin Alade: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤴🏾">adúláwɔ̀ díɛ̀ | Ɔmɔkunrin Alade | Ɔmɔkunrin Alade: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤴🏾">adúláwɔ̀ díɛ̀ | Ɔmɔkunrin Alade</annotation>
 		<annotation cp="🤴🏾" type="tts">Ɔmɔkunrin Alade: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤴🏿">adúláwɔ̀ | Ɔmɔkunrin Alade | Ɔmɔkunrin Alade: adúláwɔ̀</annotation>
+		<annotation cp="🤴🏿">adúláwɔ̀ | Ɔmɔkunrin Alade</annotation>
 		<annotation cp="🤴🏿" type="tts">Ɔmɔkunrin Alade: adúláwɔ̀</annotation>
-		<annotation cp="👸🏻">àlá | amɔ́lára | ìtàn ɔmɔdé | Ɔmɔbinrin Alade | Ɔmɔbinrin Alade: amɔ́lára</annotation>
+		<annotation cp="👸🏻">àlá | amɔ́lára | ìtàn ɔmɔdé | Ɔmɔbinrin Alade</annotation>
 		<annotation cp="👸🏻" type="tts">Ɔmɔbinrin Alade: amɔ́lára</annotation>
-		<annotation cp="👸🏼">àlá | amɔ́lára díɛ̀ | ìtàn ɔmɔdé | Ɔmɔbinrin Alade | Ɔmɔbinrin Alade: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👸🏼">àlá | amɔ́lára díɛ̀ | ìtàn ɔmɔdé | Ɔmɔbinrin Alade</annotation>
 		<annotation cp="👸🏼" type="tts">Ɔmɔbinrin Alade: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👸🏽">àlá | amɔ́láwɔ̀ díɛ̀ | ìtàn ɔmɔdé | Ɔmɔbinrin Alade | Ɔmɔbinrin Alade: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👸🏽">àlá | amɔ́láwɔ̀ díɛ̀ | ìtàn ɔmɔdé | Ɔmɔbinrin Alade</annotation>
 		<annotation cp="👸🏽" type="tts">Ɔmɔbinrin Alade: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👸🏾">adúláwɔ̀ díɛ̀ | àlá | ìtàn ɔmɔdé | Ɔmɔbinrin Alade | Ɔmɔbinrin Alade: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👸🏾">adúláwɔ̀ díɛ̀ | àlá | ìtàn ɔmɔdé | Ɔmɔbinrin Alade</annotation>
 		<annotation cp="👸🏾" type="tts">Ɔmɔbinrin Alade: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👸🏿">adúláwɔ̀ | àlá | ìtàn ɔmɔdé | Ɔmɔbinrin Alade | Ɔmɔbinrin Alade: adúláwɔ̀</annotation>
+		<annotation cp="👸🏿">adúláwɔ̀ | àlá | ìtàn ɔmɔdé | Ɔmɔbinrin Alade</annotation>
 		<annotation cp="👸🏿" type="tts">Ɔmɔbinrin Alade: adúláwɔ̀</annotation>
-		<annotation cp="👳🏻">amɔ́lára | Ɛni wɔ Lawani | Ɛni wɔ Lawani: amɔ́lára | láwàní</annotation>
+		<annotation cp="👳🏻">amɔ́lára | Ɛni wɔ Lawani | láwàní</annotation>
 		<annotation cp="👳🏻" type="tts">Ɛni wɔ Lawani: amɔ́lára</annotation>
-		<annotation cp="👳🏼">amɔ́lára díɛ̀ | Ɛni wɔ Lawani | Ɛni wɔ Lawani: amɔ́lára díɛ̀ | láwàní</annotation>
+		<annotation cp="👳🏼">amɔ́lára díɛ̀ | Ɛni wɔ Lawani | láwàní</annotation>
 		<annotation cp="👳🏼" type="tts">Ɛni wɔ Lawani: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👳🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni wɔ Lawani | Ɛni wɔ Lawani: amɔ́láwɔ̀ díɛ̀ | láwàní</annotation>
+		<annotation cp="👳🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni wɔ Lawani | láwàní</annotation>
 		<annotation cp="👳🏽" type="tts">Ɛni wɔ Lawani: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👳🏾">adúláwɔ̀ díɛ̀ | Ɛni wɔ Lawani | Ɛni wɔ Lawani: adúláwɔ̀ díɛ̀ | láwàní</annotation>
+		<annotation cp="👳🏾">adúláwɔ̀ díɛ̀ | Ɛni wɔ Lawani | láwàní</annotation>
 		<annotation cp="👳🏾" type="tts">Ɛni wɔ Lawani: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👳🏿">adúláwɔ̀ | Ɛni wɔ Lawani | Ɛni wɔ Lawani: adúláwɔ̀ | láwàní</annotation>
+		<annotation cp="👳🏿">adúláwɔ̀ | Ɛni wɔ Lawani | láwàní</annotation>
 		<annotation cp="👳🏿" type="tts">Ɛni wɔ Lawani: adúláwɔ̀</annotation>
-		<annotation cp="👳🏻‍♂">amɔ́lára | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní | ɔkùnrin tó dé láwàní: amɔ́lára</annotation>
+		<annotation cp="👳🏻‍♂">amɔ́lára | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏻‍♂" type="tts">ɔkùnrin tó dé láwàní: amɔ́lára</annotation>
-		<annotation cp="👳🏼‍♂">amɔ́lára díɛ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní | ɔkùnrin tó dé láwàní: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👳🏼‍♂">amɔ́lára díɛ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏼‍♂" type="tts">ɔkùnrin tó dé láwàní: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👳🏽‍♂">amɔ́láwɔ̀ díɛ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní | ɔkùnrin tó dé láwàní: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👳🏽‍♂">amɔ́láwɔ̀ díɛ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏽‍♂" type="tts">ɔkùnrin tó dé láwàní: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👳🏾‍♂">adúláwɔ̀ díɛ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní | ɔkùnrin tó dé láwàní: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👳🏾‍♂">adúláwɔ̀ díɛ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏾‍♂" type="tts">ɔkùnrin tó dé láwàní: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👳🏿‍♂">adúláwɔ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní | ɔkùnrin tó dé láwàní: adúláwɔ̀</annotation>
+		<annotation cp="👳🏿‍♂">adúláwɔ̀ | láwàní | ɔkùnrin | ɔkùnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏿‍♂" type="tts">ɔkùnrin tó dé láwàní: adúláwɔ̀</annotation>
-		<annotation cp="👳🏻‍♀">amɔ́lára | láwàní | obìnrin | obìnrin tó dé láwàní | obìnrin tó dé láwàní: amɔ́lára</annotation>
+		<annotation cp="👳🏻‍♀">amɔ́lára | láwàní | obìnrin | obìnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏻‍♀" type="tts">obìnrin tó dé láwàní: amɔ́lára</annotation>
-		<annotation cp="👳🏼‍♀">amɔ́lára díɛ̀ | láwàní | obìnrin | obìnrin tó dé láwàní | obìnrin tó dé láwàní: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👳🏼‍♀">amɔ́lára díɛ̀ | láwàní | obìnrin | obìnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏼‍♀" type="tts">obìnrin tó dé láwàní: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👳🏽‍♀">amɔ́láwɔ̀ díɛ̀ | láwàní | obìnrin | obìnrin tó dé láwàní | obìnrin tó dé láwàní: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👳🏽‍♀">amɔ́láwɔ̀ díɛ̀ | láwàní | obìnrin | obìnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏽‍♀" type="tts">obìnrin tó dé láwàní: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👳🏾‍♀">adúláwɔ̀ díɛ̀ | láwàní | obìnrin | obìnrin tó dé láwàní | obìnrin tó dé láwàní: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👳🏾‍♀">adúláwɔ̀ díɛ̀ | láwàní | obìnrin | obìnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏾‍♀" type="tts">obìnrin tó dé láwàní: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👳🏿‍♀">adúláwɔ̀ | láwàní | obìnrin | obìnrin tó dé láwàní | obìnrin tó dé láwàní: adúláwɔ̀</annotation>
+		<annotation cp="👳🏿‍♀">adúláwɔ̀ | láwàní | obìnrin | obìnrin tó dé láwàní</annotation>
 		<annotation cp="👳🏿‍♀" type="tts">obìnrin tó dé láwàní: adúláwɔ̀</annotation>
-		<annotation cp="👲🏻">amɔ́lára | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi | Ɔkunrin Pɛlu Fila Shainisi: amɔ́lára</annotation>
+		<annotation cp="👲🏻">amɔ́lára | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi</annotation>
 		<annotation cp="👲🏻" type="tts">Ɔkunrin Pɛlu Fila Shainisi: amɔ́lára</annotation>
-		<annotation cp="👲🏼">amɔ́lára díɛ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi | Ɔkunrin Pɛlu Fila Shainisi: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👲🏼">amɔ́lára díɛ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi</annotation>
 		<annotation cp="👲🏼" type="tts">Ɔkunrin Pɛlu Fila Shainisi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👲🏽">amɔ́láwɔ̀ díɛ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi | Ɔkunrin Pɛlu Fila Shainisi: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👲🏽">amɔ́láwɔ̀ díɛ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi</annotation>
 		<annotation cp="👲🏽" type="tts">Ɔkunrin Pɛlu Fila Shainisi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👲🏾">adúláwɔ̀ díɛ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi | Ɔkunrin Pɛlu Fila Shainisi: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👲🏾">adúláwɔ̀ díɛ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi</annotation>
 		<annotation cp="👲🏾" type="tts">Ɔkunrin Pɛlu Fila Shainisi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👲🏿">adúláwɔ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi | Ɔkunrin Pɛlu Fila Shainisi: adúláwɔ̀</annotation>
+		<annotation cp="👲🏿">adúláwɔ̀ | fìlà | gua pi mao | ɔkùnrin | Ɔkunrin Pɛlu Fila Shainisi</annotation>
 		<annotation cp="👲🏿" type="tts">Ɔkunrin Pɛlu Fila Shainisi: adúláwɔ̀</annotation>
-		<annotation cp="🧕🏻">amɔ́lára | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè | obinrin tó wé gèlè: amɔ́lára</annotation>
+		<annotation cp="🧕🏻">amɔ́lára | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè</annotation>
 		<annotation cp="🧕🏻" type="tts">obinrin tó wé gèlè: amɔ́lára</annotation>
-		<annotation cp="🧕🏼">amɔ́lára díɛ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè | obinrin tó wé gèlè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧕🏼">amɔ́lára díɛ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè</annotation>
 		<annotation cp="🧕🏼" type="tts">obinrin tó wé gèlè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧕🏽">amɔ́láwɔ̀ díɛ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè | obinrin tó wé gèlè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧕🏽">amɔ́láwɔ̀ díɛ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè</annotation>
 		<annotation cp="🧕🏽" type="tts">obinrin tó wé gèlè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧕🏾">adúláwɔ̀ díɛ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè | obinrin tó wé gèlè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧕🏾">adúláwɔ̀ díɛ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè</annotation>
 		<annotation cp="🧕🏾" type="tts">obinrin tó wé gèlè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧕🏿">adúláwɔ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè | obinrin tó wé gèlè: adúláwɔ̀</annotation>
+		<annotation cp="🧕🏿">adúláwɔ̀ | Gèlè | gèlè àwɔn sípánì | ìbòrí | ìbòrí àwɔn júù | obinrin tó wé gèlè</annotation>
 		<annotation cp="🧕🏿" type="tts">obinrin tó wé gèlè: adúláwɔ̀</annotation>
-		<annotation cp="🤵🏻">amɔ́lára | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu | Ɔkunrin Pɛlu Kootu: amɔ́lára</annotation>
+		<annotation cp="🤵🏻">amɔ́lára | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu</annotation>
 		<annotation cp="🤵🏻" type="tts">Ɔkunrin Pɛlu Kootu: amɔ́lára</annotation>
-		<annotation cp="🤵🏼">amɔ́lára díɛ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu | Ɔkunrin Pɛlu Kootu: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤵🏼">amɔ́lára díɛ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu</annotation>
 		<annotation cp="🤵🏼" type="tts">Ɔkunrin Pɛlu Kootu: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤵🏽">amɔ́láwɔ̀ díɛ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu | Ɔkunrin Pɛlu Kootu: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤵🏽">amɔ́láwɔ̀ díɛ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu</annotation>
 		<annotation cp="🤵🏽" type="tts">Ɔkunrin Pɛlu Kootu: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤵🏾">adúláwɔ̀ díɛ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu | Ɔkunrin Pɛlu Kootu: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤵🏾">adúláwɔ̀ díɛ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu</annotation>
 		<annotation cp="🤵🏾" type="tts">Ɔkunrin Pɛlu Kootu: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤵🏿">adúláwɔ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu | Ɔkunrin Pɛlu Kootu: adúláwɔ̀</annotation>
+		<annotation cp="🤵🏿">adúláwɔ̀ | kóòtù | ɔkɔ ìyàwó | ɔkùnrin | Ɔkunrin Pɛlu Kootu</annotation>
 		<annotation cp="🤵🏿" type="tts">Ɔkunrin Pɛlu Kootu: adúláwɔ̀</annotation>
-		<annotation cp="🤵🏻‍♂">amɔ́lára | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára</annotation>
+		<annotation cp="🤵🏻‍♂">amɔ́lára | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏻‍♂" type="tts">ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára</annotation>
-		<annotation cp="🤵🏼‍♂">amɔ́lára díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤵🏼‍♂">amɔ́lára díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏼‍♂" type="tts">ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤵🏽‍♂">amɔ́láwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤵🏽‍♂">amɔ́láwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏽‍♂" type="tts">ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤵🏾‍♂">adúláwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤵🏾‍♂">adúláwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏾‍♂" type="tts">ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤵🏿‍♂">adúláwɔ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀</annotation>
+		<annotation cp="🤵🏿‍♂">adúláwɔ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | ɔkùnrin | ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏿‍♂" type="tts">ɔkùnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🤵🏻‍♀">amɔ́lára | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára</annotation>
+		<annotation cp="🤵🏻‍♀">amɔ́lára | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏻‍♀" type="tts">obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára</annotation>
-		<annotation cp="🤵🏼‍♀">amɔ́lára díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤵🏼‍♀">amɔ́lára díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏼‍♀" type="tts">obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤵🏽‍♀">amɔ́láwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤵🏽‍♀">amɔ́láwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏽‍♀" type="tts">obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤵🏾‍♀">adúláwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤵🏾‍♀">adúláwɔ̀ díɛ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏾‍♀" type="tts">obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤵🏿‍♀">adúláwɔ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́ | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀</annotation>
+		<annotation cp="🤵🏿‍♀">adúláwɔ̀ | kóòtù àwɔ̀lɔsóde ìrɔ̀lɛ́ | obìnrin | obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́</annotation>
 		<annotation cp="🤵🏿‍♀" type="tts">obìnrin tó wɔ kóòtù ìlɔsóde ìrɔ̀lɛ́: adúláwɔ̀</annotation>
-		<annotation cp="👰🏻">amɔ́lára | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju | Iyawo Pɛlu Iboju: amɔ́lára</annotation>
+		<annotation cp="👰🏻">amɔ́lára | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju</annotation>
 		<annotation cp="👰🏻" type="tts">Iyawo Pɛlu Iboju: amɔ́lára</annotation>
-		<annotation cp="👰🏼">amɔ́lára díɛ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju | Iyawo Pɛlu Iboju: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👰🏼">amɔ́lára díɛ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju</annotation>
 		<annotation cp="👰🏼" type="tts">Iyawo Pɛlu Iboju: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👰🏽">amɔ́láwɔ̀ díɛ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju | Iyawo Pɛlu Iboju: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👰🏽">amɔ́láwɔ̀ díɛ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju</annotation>
 		<annotation cp="👰🏽" type="tts">Iyawo Pɛlu Iboju: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👰🏾">adúláwɔ̀ díɛ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju | Iyawo Pɛlu Iboju: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👰🏾">adúláwɔ̀ díɛ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju</annotation>
 		<annotation cp="👰🏾" type="tts">Iyawo Pɛlu Iboju: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👰🏿">adúláwɔ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju | Iyawo Pɛlu Iboju: adúláwɔ̀</annotation>
+		<annotation cp="👰🏿">adúláwɔ̀ | ìbòjú | ìgbéyàwó | ìyàwó | Iyawo Pɛlu Iboju</annotation>
 		<annotation cp="👰🏿" type="tts">Iyawo Pɛlu Iboju: adúláwɔ̀</annotation>
-		<annotation cp="👰🏻‍♂">amɔ́lára | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú | ɔkùnrin tó fi ashɔ bojú: amɔ́lára</annotation>
+		<annotation cp="👰🏻‍♂">amɔ́lára | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏻‍♂" type="tts">ɔkùnrin tó fi ashɔ bojú: amɔ́lára</annotation>
-		<annotation cp="👰🏼‍♂">amɔ́lára díɛ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú | ɔkùnrin tó fi ashɔ bojú: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👰🏼‍♂">amɔ́lára díɛ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏼‍♂" type="tts">ɔkùnrin tó fi ashɔ bojú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👰🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú | ɔkùnrin tó fi ashɔ bojú: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👰🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏽‍♂" type="tts">ɔkùnrin tó fi ashɔ bojú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👰🏾‍♂">adúláwɔ̀ díɛ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú | ɔkùnrin tó fi ashɔ bojú: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👰🏾‍♂">adúláwɔ̀ díɛ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏾‍♂" type="tts">ɔkùnrin tó fi ashɔ bojú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👰🏿‍♂">adúláwɔ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú | ɔkùnrin tó fi ashɔ bojú: adúláwɔ̀</annotation>
+		<annotation cp="👰🏿‍♂">adúláwɔ̀ | ashɔ ìbojú | ɔkùnrin | ɔkùnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏿‍♂" type="tts">ɔkùnrin tó fi ashɔ bojú: adúláwɔ̀</annotation>
-		<annotation cp="👰🏻‍♀">amɔ́lára | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú | obìnrin tó fi ashɔ bojú: amɔ́lára</annotation>
+		<annotation cp="👰🏻‍♀">amɔ́lára | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏻‍♀" type="tts">obìnrin tó fi ashɔ bojú: amɔ́lára</annotation>
-		<annotation cp="👰🏼‍♀">amɔ́lára díɛ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú | obìnrin tó fi ashɔ bojú: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👰🏼‍♀">amɔ́lára díɛ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏼‍♀" type="tts">obìnrin tó fi ashɔ bojú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👰🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú | obìnrin tó fi ashɔ bojú: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👰🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏽‍♀" type="tts">obìnrin tó fi ashɔ bojú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👰🏾‍♀">adúláwɔ̀ díɛ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú | obìnrin tó fi ashɔ bojú: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👰🏾‍♀">adúláwɔ̀ díɛ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏾‍♀" type="tts">obìnrin tó fi ashɔ bojú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👰🏿‍♀">adúláwɔ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú | obìnrin tó fi ashɔ bojú: adúláwɔ̀</annotation>
+		<annotation cp="👰🏿‍♀">adúláwɔ̀ | ashɔ ìbojú | obìnrin | obìnrin tó fi ashɔ bojú</annotation>
 		<annotation cp="👰🏿‍♀" type="tts">obìnrin tó fi ashɔ bojú: adúláwɔ̀</annotation>
-		<annotation cp="🤰🏻">alaboyun | amɔ́lára | obinrin | obinrin alaboyun: amɔ́lára</annotation>
+		<annotation cp="🤰🏻">alaboyun | amɔ́lára | obinrin</annotation>
 		<annotation cp="🤰🏻" type="tts">obinrin alaboyun: amɔ́lára</annotation>
-		<annotation cp="🤰🏼">alaboyun | amɔ́lára díɛ̀ | obinrin | obinrin alaboyun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤰🏼">alaboyun | amɔ́lára díɛ̀ | obinrin</annotation>
 		<annotation cp="🤰🏼" type="tts">obinrin alaboyun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤰🏽">alaboyun | amɔ́láwɔ̀ díɛ̀ | obinrin | obinrin alaboyun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤰🏽">alaboyun | amɔ́láwɔ̀ díɛ̀ | obinrin</annotation>
 		<annotation cp="🤰🏽" type="tts">obinrin alaboyun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤰🏾">adúláwɔ̀ díɛ̀ | alaboyun | obinrin | obinrin alaboyun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤰🏾">adúláwɔ̀ díɛ̀ | alaboyun | obinrin</annotation>
 		<annotation cp="🤰🏾" type="tts">obinrin alaboyun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤰🏿">adúláwɔ̀ | alaboyun | obinrin | obinrin alaboyun: adúláwɔ̀</annotation>
+		<annotation cp="🤰🏿">adúláwɔ̀ | alaboyun | obinrin</annotation>
 		<annotation cp="🤰🏿" type="tts">obinrin alaboyun: adúláwɔ̀</annotation>
-		<annotation cp="🫃🏻">aláboyún ɔkùnrin | aláboyún ɔkùnrin: amɔ́lára | amɔ́lára | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
+		<annotation cp="🫃🏻">aláboyún ɔkùnrin | amɔ́lára | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
 		<annotation cp="🫃🏻" type="tts">aláboyún ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="🫃🏼">aláboyún ɔkùnrin | aláboyún ɔkùnrin: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
+		<annotation cp="🫃🏼">aláboyún ɔkùnrin | amɔ́lára díɛ̀ | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
 		<annotation cp="🫃🏼" type="tts">aláboyún ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫃🏽">aláboyún ɔkùnrin | aláboyún ɔkùnrin: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
+		<annotation cp="🫃🏽">aláboyún ɔkùnrin | amɔ́láwɔ̀ díɛ̀ | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
 		<annotation cp="🫃🏽" type="tts">aláboyún ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫃🏾">adúláwɔ̀ díɛ̀ | aláboyún ɔkùnrin | aláboyún ɔkùnrin: adúláwɔ̀ díɛ̀ | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
+		<annotation cp="🫃🏾">adúláwɔ̀ díɛ̀ | aláboyún ɔkùnrin | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
 		<annotation cp="🫃🏾" type="tts">aláboyún ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫃🏿">adúláwɔ̀ | aláboyún ɔkùnrin | aláboyún ɔkùnrin: adúláwɔ̀ | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
+		<annotation cp="🫃🏿">adúláwɔ̀ | aláboyún ɔkùnrin | ikù | kún | lóyún ɔkùnrin | tobi</annotation>
 		<annotation cp="🫃🏿" type="tts">aláboyún ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="🫄🏻">aláboyún | aláboyún ɔkùnrin | aláboyún: amɔ́lára | amɔ́lára | ikù | kún | lóyún | tobi</annotation>
+		<annotation cp="🫄🏻">aláboyún | aláboyún ɔkùnrin | amɔ́lára | ikù | kún | lóyún | tobi</annotation>
 		<annotation cp="🫄🏻" type="tts">aláboyún: amɔ́lára</annotation>
-		<annotation cp="🫄🏼">aláboyún | aláboyún ɔkùnrin | aláboyún: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ikù | kún | lóyún | tobi</annotation>
+		<annotation cp="🫄🏼">aláboyún | aláboyún ɔkùnrin | amɔ́lára díɛ̀ | ikù | kún | lóyún | tobi</annotation>
 		<annotation cp="🫄🏼" type="tts">aláboyún: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🫄🏽">aláboyún | aláboyún ɔkùnrin | aláboyún: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ikù | kún | lóyún | tobi</annotation>
+		<annotation cp="🫄🏽">aláboyún | aláboyún ɔkùnrin | amɔ́láwɔ̀ díɛ̀ | ikù | kún | lóyún | tobi</annotation>
 		<annotation cp="🫄🏽" type="tts">aláboyún: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫄🏾">adúláwɔ̀ díɛ̀ | aláboyún | aláboyún ɔkùnrin | aláboyún: adúláwɔ̀ díɛ̀ | ikù | kún | lóyún | tobi</annotation>
+		<annotation cp="🫄🏾">adúláwɔ̀ díɛ̀ | aláboyún | aláboyún ɔkùnrin | ikù | kún | lóyún | tobi</annotation>
 		<annotation cp="🫄🏾" type="tts">aláboyún: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🫄🏿">adúláwɔ̀ | aláboyún | aláboyún ɔkùnrin | aláboyún: adúláwɔ̀ | ikù | kún | lóyún | tobi</annotation>
+		<annotation cp="🫄🏿">adúláwɔ̀ | aláboyún | aláboyún ɔkùnrin | ikù | kún | lóyún | tobi</annotation>
 		<annotation cp="🫄🏿" type="tts">aláboyún: adúláwɔ̀</annotation>
-		<annotation cp="🤱🏻">amɔ́lára | ìfɔ́mɔlɔ́yàn | ìfɔ́mɔlɔ́yàn: amɔ́lára | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
+		<annotation cp="🤱🏻">amɔ́lára | ìfɔ́mɔlɔ́yàn | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
 		<annotation cp="🤱🏻" type="tts">ìfɔ́mɔlɔ́yàn: amɔ́lára</annotation>
-		<annotation cp="🤱🏼">amɔ́lára díɛ̀ | ìfɔ́mɔlɔ́yàn | ìfɔ́mɔlɔ́yàn: amɔ́lára díɛ̀ | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
+		<annotation cp="🤱🏼">amɔ́lára díɛ̀ | ìfɔ́mɔlɔ́yàn | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
 		<annotation cp="🤱🏼" type="tts">ìfɔ́mɔlɔ́yàn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤱🏽">amɔ́láwɔ̀ díɛ̀ | ìfɔ́mɔlɔ́yàn | ìfɔ́mɔlɔ́yàn: amɔ́láwɔ̀ díɛ̀ | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
+		<annotation cp="🤱🏽">amɔ́láwɔ̀ díɛ̀ | ìfɔ́mɔlɔ́yàn | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
 		<annotation cp="🤱🏽" type="tts">ìfɔ́mɔlɔ́yàn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤱🏾">adúláwɔ̀ díɛ̀ | ìfɔ́mɔlɔ́yàn | ìfɔ́mɔlɔ́yàn: adúláwɔ̀ díɛ̀ | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
+		<annotation cp="🤱🏾">adúláwɔ̀ díɛ̀ | ìfɔ́mɔlɔ́yàn | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
 		<annotation cp="🤱🏾" type="tts">ìfɔ́mɔlɔ́yàn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤱🏿">adúláwɔ̀ | ìfɔ́mɔlɔ́yàn | ìfɔ́mɔlɔ́yàn: adúláwɔ̀ | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
+		<annotation cp="🤱🏿">adúláwɔ̀ | ìfɔ́mɔlɔ́yàn | ìkókó | ìtɔ́jú ɔmɔ | ɔyɔ̀n</annotation>
 		<annotation cp="🤱🏿" type="tts">ìfɔ́mɔlɔ́yàn: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🍼">amɔ́lára | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | obìnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👩🏻‍🍼">amɔ́lára | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👩🏻‍🍼" type="tts">obìnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🍼">amɔ́lára díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | obìnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára díɛ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👩🏼‍🍼">amɔ́lára díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👩🏼‍🍼" type="tts">obìnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🍼">amɔ́láwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | obìnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́láwɔ̀ díɛ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👩🏽‍🍼">amɔ́láwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👩🏽‍🍼" type="tts">obìnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🍼">adúláwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | obìnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ díɛ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👩🏾‍🍼">adúláwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👩🏾‍🍼" type="tts">obìnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🍼">adúláwɔ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | obìnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👩🏿‍🍼">adúláwɔ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | obìnrin | obìnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👩🏿‍🍼" type="tts">obìnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🍼">amɔ́lára | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👨🏻‍🍼">amɔ́lára | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👨🏻‍🍼" type="tts">ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🍼">amɔ́lára díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára díɛ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👨🏼‍🍼">amɔ́lára díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👨🏼‍🍼" type="tts">ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🍼">amɔ́láwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́láwɔ̀ díɛ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👨🏽‍🍼">amɔ́láwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👨🏽‍🍼" type="tts">ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🍼">adúláwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ díɛ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👨🏾‍🍼">adúláwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👨🏾‍🍼" type="tts">ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🍼">adúláwɔ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="👨🏿‍🍼">adúláwɔ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔkùnrin | ɔkùnrin tó ń fɔ́mɔ lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="👨🏿‍🍼" type="tts">ɔkùnrin tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🍼">amɔ́lára | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | ɛnìkan tó ń fɔ́mɔ lóúnjɛ: amɔ́lára | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="🧑🏻‍🍼">amɔ́lára | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="🧑🏻‍🍼" type="tts">ɛnìkan tó ń fɔ́mɔ lóúnjɛ: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🍼">amɔ́lára díɛ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | ɛnìkan tó ń fɔ́mɔ lóúnjɛ: amɔ́lára díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="🧑🏼‍🍼">amɔ́lára díɛ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="🧑🏼‍🍼" type="tts">ɛnìkan tó ń fɔ́mɔ lóúnjɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🍼">amɔ́láwɔ̀ díɛ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | ɛnìkan tó ń fɔ́mɔ lóúnjɛ: amɔ́láwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="🧑🏽‍🍼">amɔ́láwɔ̀ díɛ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="🧑🏽‍🍼" type="tts">ɛnìkan tó ń fɔ́mɔ lóúnjɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🍼">adúláwɔ̀ díɛ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | ɛnìkan tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ díɛ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="🧑🏾‍🍼">adúláwɔ̀ díɛ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="🧑🏾‍🍼" type="tts">ɛnìkan tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🍼">adúláwɔ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | ɛnìkan tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
+		<annotation cp="🧑🏿‍🍼">adúláwɔ̀ | ɛnìkan | ɛnìkan tó ń fɔ́mɔ lóúnjɛ | fífɔ́mɔ lɔ́yàn | fífúni lóúnjɛ | ɔmɔ-ɔwɔ́</annotation>
 		<annotation cp="🧑🏿‍🍼" type="tts">ɛnìkan tó ń fɔ́mɔ lóúnjɛ: adúláwɔ̀</annotation>
-		<annotation cp="👼🏻">àlá | amɔ́lára | áńgɛ́lì | ángɛli ìkókó | ángɛli ìkókó: amɔ́lára | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
+		<annotation cp="👼🏻">àlá | amɔ́lára | áńgɛ́lì | ángɛli ìkókó | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
 		<annotation cp="👼🏻" type="tts">ángɛli ìkókó: amɔ́lára</annotation>
-		<annotation cp="👼🏼">àlá | amɔ́lára díɛ̀ | áńgɛ́lì | ángɛli ìkókó | ángɛli ìkókó: amɔ́lára díɛ̀ | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
+		<annotation cp="👼🏼">àlá | amɔ́lára díɛ̀ | áńgɛ́lì | ángɛli ìkókó | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
 		<annotation cp="👼🏼" type="tts">ángɛli ìkókó: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👼🏽">àlá | amɔ́láwɔ̀ díɛ̀ | áńgɛ́lì | ángɛli ìkókó | ángɛli ìkókó: amɔ́láwɔ̀ díɛ̀ | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
+		<annotation cp="👼🏽">àlá | amɔ́láwɔ̀ díɛ̀ | áńgɛ́lì | ángɛli ìkókó | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
 		<annotation cp="👼🏽" type="tts">ángɛli ìkókó: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👼🏾">adúláwɔ̀ díɛ̀ | àlá | áńgɛ́lì | ángɛli ìkókó | ángɛli ìkókó: adúláwɔ̀ díɛ̀ | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
+		<annotation cp="👼🏾">adúláwɔ̀ díɛ̀ | àlá | áńgɛ́lì | ángɛli ìkókó | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
 		<annotation cp="👼🏾" type="tts">ángɛli ìkókó: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👼🏿">adúláwɔ̀ | àlá | áńgɛ́lì | ángɛli ìkókó | ángɛli ìkókó: adúláwɔ̀ | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
+		<annotation cp="👼🏿">adúláwɔ̀ | àlá | áńgɛ́lì | ángɛli ìkókó | ìkókó | ìtàn ɔmɔdé | ojú</annotation>
 		<annotation cp="👼🏿" type="tts">ángɛli ìkókó: adúláwɔ̀</annotation>
-		<annotation cp="🎅🏻">amɔ́lára | ayɛyɛ | baba | Baba Keresi | Baba Keresi: amɔ́lára | kérésì</annotation>
+		<annotation cp="🎅🏻">amɔ́lára | ayɛyɛ | baba | Baba Keresi | kérésì</annotation>
 		<annotation cp="🎅🏻" type="tts">Baba Keresi: amɔ́lára</annotation>
-		<annotation cp="🎅🏼">amɔ́lára díɛ̀ | ayɛyɛ | baba | Baba Keresi | Baba Keresi: amɔ́lára díɛ̀ | kérésì</annotation>
+		<annotation cp="🎅🏼">amɔ́lára díɛ̀ | ayɛyɛ | baba | Baba Keresi | kérésì</annotation>
 		<annotation cp="🎅🏼" type="tts">Baba Keresi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🎅🏽">amɔ́láwɔ̀ díɛ̀ | ayɛyɛ | baba | Baba Keresi | Baba Keresi: amɔ́láwɔ̀ díɛ̀ | kérésì</annotation>
+		<annotation cp="🎅🏽">amɔ́láwɔ̀ díɛ̀ | ayɛyɛ | baba | Baba Keresi | kérésì</annotation>
 		<annotation cp="🎅🏽" type="tts">Baba Keresi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🎅🏾">adúláwɔ̀ díɛ̀ | ayɛyɛ | baba | Baba Keresi | Baba Keresi: adúláwɔ̀ díɛ̀ | kérésì</annotation>
+		<annotation cp="🎅🏾">adúláwɔ̀ díɛ̀ | ayɛyɛ | baba | Baba Keresi | kérésì</annotation>
 		<annotation cp="🎅🏾" type="tts">Baba Keresi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🎅🏿">adúláwɔ̀ | ayɛyɛ | baba | Baba Keresi | Baba Keresi: adúláwɔ̀ | kérésì</annotation>
+		<annotation cp="🎅🏿">adúláwɔ̀ | ayɛyɛ | baba | Baba Keresi | kérésì</annotation>
 		<annotation cp="🎅🏿" type="tts">Baba Keresi: adúláwɔ̀</annotation>
-		<annotation cp="🤶🏻">[kɛrɛsí | amɔ́lára | Arabinrin Keresi | Arabinrin Keresi: amɔ́lára | ayɛyɛ | ìyá | kérésì | omidan</annotation>
+		<annotation cp="🤶🏻">[kɛrɛsí | amɔ́lára | Arabinrin Keresi | ayɛyɛ | ìyá | kérésì | omidan</annotation>
 		<annotation cp="🤶🏻" type="tts">Arabinrin Keresi: amɔ́lára</annotation>
-		<annotation cp="🤶🏼">[kɛrɛsí | amɔ́lára díɛ̀ | Arabinrin Keresi | Arabinrin Keresi: amɔ́lára díɛ̀ | ayɛyɛ | ìyá | kérésì | omidan</annotation>
+		<annotation cp="🤶🏼">[kɛrɛsí | amɔ́lára díɛ̀ | Arabinrin Keresi | ayɛyɛ | ìyá | kérésì | omidan</annotation>
 		<annotation cp="🤶🏼" type="tts">Arabinrin Keresi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤶🏽">[kɛrɛsí | amɔ́láwɔ̀ díɛ̀ | Arabinrin Keresi | Arabinrin Keresi: amɔ́láwɔ̀ díɛ̀ | ayɛyɛ | ìyá | kérésì | omidan</annotation>
+		<annotation cp="🤶🏽">[kɛrɛsí | amɔ́láwɔ̀ díɛ̀ | Arabinrin Keresi | ayɛyɛ | ìyá | kérésì | omidan</annotation>
 		<annotation cp="🤶🏽" type="tts">Arabinrin Keresi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤶🏾">[kɛrɛsí | adúláwɔ̀ díɛ̀ | Arabinrin Keresi | Arabinrin Keresi: adúláwɔ̀ díɛ̀ | ayɛyɛ | ìyá | kérésì | omidan</annotation>
+		<annotation cp="🤶🏾">[kɛrɛsí | adúláwɔ̀ díɛ̀ | Arabinrin Keresi | ayɛyɛ | ìyá | kérésì | omidan</annotation>
 		<annotation cp="🤶🏾" type="tts">Arabinrin Keresi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤶🏿">[kɛrɛsí | adúláwɔ̀ | Arabinrin Keresi | Arabinrin Keresi: adúláwɔ̀ | ayɛyɛ | ìyá | kérésì | omidan</annotation>
+		<annotation cp="🤶🏿">[kɛrɛsí | adúláwɔ̀ | Arabinrin Keresi | ayɛyɛ | ìyá | kérésì | omidan</annotation>
 		<annotation cp="🤶🏿" type="tts">Arabinrin Keresi: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🎄">amɔ́lára | claus | kérésìmesì | mx claus | mx claus: amɔ́lára</annotation>
+		<annotation cp="🧑🏻‍🎄">amɔ́lára | claus | kérésìmesì | mx claus</annotation>
 		<annotation cp="🧑🏻‍🎄" type="tts">mx claus: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🎄">amɔ́lára díɛ̀ | claus | kérésìmesì | mx claus | mx claus: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧑🏼‍🎄">amɔ́lára díɛ̀ | claus | kérésìmesì | mx claus</annotation>
 		<annotation cp="🧑🏼‍🎄" type="tts">mx claus: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🎄">amɔ́láwɔ̀ díɛ̀ | claus | kérésìmesì | mx claus | mx claus: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏽‍🎄">amɔ́láwɔ̀ díɛ̀ | claus | kérésìmesì | mx claus</annotation>
 		<annotation cp="🧑🏽‍🎄" type="tts">mx claus: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🎄">adúláwɔ̀ díɛ̀ | claus | kérésìmesì | mx claus | mx claus: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧑🏾‍🎄">adúláwɔ̀ díɛ̀ | claus | kérésìmesì | mx claus</annotation>
 		<annotation cp="🧑🏾‍🎄" type="tts">mx claus: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🎄">adúláwɔ̀ | claus | kérésìmesì | mx claus | mx claus: adúláwɔ̀</annotation>
+		<annotation cp="🧑🏿‍🎄">adúláwɔ̀ | claus | kérésìmesì | mx claus</annotation>
 		<annotation cp="🧑🏿‍🎄" type="tts">mx claus: adúláwɔ̀</annotation>
-		<annotation cp="🦸🏻">akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | akɔni alágbára: amɔ́lára | alágbára ńla | amɔ́lára | dára</annotation>
+		<annotation cp="🦸🏻">akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | alágbára ńla | amɔ́lára | dára</annotation>
 		<annotation cp="🦸🏻" type="tts">akɔni alágbára: amɔ́lára</annotation>
-		<annotation cp="🦸🏼">akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | akɔni alágbára: amɔ́lára díɛ̀ | alágbára ńla | amɔ́lára díɛ̀ | dára</annotation>
+		<annotation cp="🦸🏼">akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | alágbára ńla | amɔ́lára díɛ̀ | dára</annotation>
 		<annotation cp="🦸🏼" type="tts">akɔni alágbára: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦸🏽">akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | akɔni alágbára: amɔ́láwɔ̀ díɛ̀ | alágbára ńla | amɔ́láwɔ̀ díɛ̀ | dára</annotation>
+		<annotation cp="🦸🏽">akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | alágbára ńla | amɔ́láwɔ̀ díɛ̀ | dára</annotation>
 		<annotation cp="🦸🏽" type="tts">akɔni alágbára: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦸🏾">adúláwɔ̀ díɛ̀ | akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | akɔni alágbára: adúláwɔ̀ díɛ̀ | alágbára ńla | dára</annotation>
+		<annotation cp="🦸🏾">adúláwɔ̀ díɛ̀ | akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | alágbára ńla | dára</annotation>
 		<annotation cp="🦸🏾" type="tts">akɔni alágbára: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦸🏿">adúláwɔ̀ | akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | akɔni alágbára: adúláwɔ̀ | alágbára ńla | dára</annotation>
+		<annotation cp="🦸🏿">adúláwɔ̀ | akin nlá | akin obìnrin | akin ɔ̀kùnrin | akɔni alágbára | alágbára ńla | dára</annotation>
 		<annotation cp="🦸🏿" type="tts">akɔni alágbára: adúláwɔ̀</annotation>
-		<annotation cp="🦸🏻‍♂">agbára ńlá | akɔni | amɔ́lára | dára | ɔkùnrin | ɔkùnrin akɔni ńlá | ɔkùnrin akɔni ńlá: amɔ́lára</annotation>
+		<annotation cp="🦸🏻‍♂">agbára ńlá | akɔni | amɔ́lára | dára | ɔkùnrin | ɔkùnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏻‍♂" type="tts">ɔkùnrin akɔni ńlá: amɔ́lára</annotation>
-		<annotation cp="🦸🏼‍♂">agbára ńlá | akɔni | amɔ́lára díɛ̀ | dára | ɔkùnrin | ɔkùnrin akɔni ńlá | ɔkùnrin akɔni ńlá: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🦸🏼‍♂">agbára ńlá | akɔni | amɔ́lára díɛ̀ | dára | ɔkùnrin | ɔkùnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏼‍♂" type="tts">ɔkùnrin akɔni ńlá: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦸🏽‍♂">agbára ńlá | akɔni | amɔ́láwɔ̀ díɛ̀ | dára | ɔkùnrin | ɔkùnrin akɔni ńlá | ɔkùnrin akɔni ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🦸🏽‍♂">agbára ńlá | akɔni | amɔ́láwɔ̀ díɛ̀ | dára | ɔkùnrin | ɔkùnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏽‍♂" type="tts">ɔkùnrin akɔni ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦸🏾‍♂">adúláwɔ̀ díɛ̀ | agbára ńlá | akɔni | dára | ɔkùnrin | ɔkùnrin akɔni ńlá | ɔkùnrin akɔni ńlá: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🦸🏾‍♂">adúláwɔ̀ díɛ̀ | agbára ńlá | akɔni | dára | ɔkùnrin | ɔkùnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏾‍♂" type="tts">ɔkùnrin akɔni ńlá: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦸🏿‍♂">adúláwɔ̀ | agbára ńlá | akɔni | dára | ɔkùnrin | ɔkùnrin akɔni ńlá | ɔkùnrin akɔni ńlá: adúláwɔ̀</annotation>
+		<annotation cp="🦸🏿‍♂">adúláwɔ̀ | agbára ńlá | akɔni | dára | ɔkùnrin | ɔkùnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏿‍♂" type="tts">ɔkùnrin akɔni ńlá: adúláwɔ̀</annotation>
-		<annotation cp="🦸🏻‍♀">agbára ńlá | akɔni | amɔ́lára | dára | obìnrin | obìnrin akɔni ńlá | obìnrin akɔni ńlá: amɔ́lára</annotation>
+		<annotation cp="🦸🏻‍♀">agbára ńlá | akɔni | amɔ́lára | dára | obìnrin | obìnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏻‍♀" type="tts">obìnrin akɔni ńlá: amɔ́lára</annotation>
-		<annotation cp="🦸🏼‍♀">agbára ńlá | akɔni | amɔ́lára díɛ̀ | dára | obìnrin | obìnrin akɔni ńlá | obìnrin akɔni ńlá: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🦸🏼‍♀">agbára ńlá | akɔni | amɔ́lára díɛ̀ | dára | obìnrin | obìnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏼‍♀" type="tts">obìnrin akɔni ńlá: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦸🏽‍♀">agbára ńlá | akɔni | amɔ́láwɔ̀ díɛ̀ | dára | obìnrin | obìnrin akɔni ńlá | obìnrin akɔni ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🦸🏽‍♀">agbára ńlá | akɔni | amɔ́láwɔ̀ díɛ̀ | dára | obìnrin | obìnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏽‍♀" type="tts">obìnrin akɔni ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦸🏾‍♀">adúláwɔ̀ díɛ̀ | agbára ńlá | akɔni | dára | obìnrin | obìnrin akɔni ńlá | obìnrin akɔni ńlá: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🦸🏾‍♀">adúláwɔ̀ díɛ̀ | agbára ńlá | akɔni | dára | obìnrin | obìnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏾‍♀" type="tts">obìnrin akɔni ńlá: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦸🏿‍♀">adúláwɔ̀ | agbára ńlá | akɔni | dára | obìnrin | obìnrin akɔni ńlá | obìnrin akɔni ńlá: adúláwɔ̀</annotation>
+		<annotation cp="🦸🏿‍♀">adúláwɔ̀ | agbára ńlá | akɔni | dára | obìnrin | obìnrin akɔni ńlá</annotation>
 		<annotation cp="🦸🏿‍♀" type="tts">obìnrin akɔni ńlá: adúláwɔ̀</annotation>
-		<annotation cp="🦹🏻">[búburú | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | alátakɔ̀ alágbára: amɔ́lára | amɔ́lára | ɔ̀dàran</annotation>
+		<annotation cp="🦹🏻">[búburú | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | amɔ́lára | ɔ̀dàran</annotation>
 		<annotation cp="🦹🏻" type="tts">alátakɔ̀ alágbára: amɔ́lára</annotation>
-		<annotation cp="🦹🏼">[búburú | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | alátakɔ̀ alágbára: amɔ́lára díɛ̀ | amɔ́lára díɛ̀ | ɔ̀dàran</annotation>
+		<annotation cp="🦹🏼">[búburú | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | amɔ́lára díɛ̀ | ɔ̀dàran</annotation>
 		<annotation cp="🦹🏼" type="tts">alátakɔ̀ alágbára: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦹🏽">[búburú | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | alátakɔ̀ alágbára: amɔ́láwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | ɔ̀dàran</annotation>
+		<annotation cp="🦹🏽">[búburú | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | amɔ́láwɔ̀ díɛ̀ | ɔ̀dàran</annotation>
 		<annotation cp="🦹🏽" type="tts">alátakɔ̀ alágbára: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦹🏾">[búburú | adúláwɔ̀ díɛ̀ | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | alátakɔ̀ alágbára: adúláwɔ̀ díɛ̀ | ɔ̀dàran</annotation>
+		<annotation cp="🦹🏾">[búburú | adúláwɔ̀ díɛ̀ | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | ɔ̀dàran</annotation>
 		<annotation cp="🦹🏾" type="tts">alátakɔ̀ alágbára: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦹🏿">[búburú | adúláwɔ̀ | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | alátakɔ̀ alágbára: adúláwɔ̀ | ɔ̀dàran</annotation>
+		<annotation cp="🦹🏿">[búburú | adúláwɔ̀ | alágbára nlá | alátakɔ̀ | alátakɔ̀ alágbára | ɔ̀dàran</annotation>
 		<annotation cp="🦹🏿" type="tts">alátakɔ̀ alágbára: adúláwɔ̀</annotation>
-		<annotation cp="🦹🏻‍♂">agbára ńlá | amɔ́lára | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá | ɔkùnrin ashèbàjɛ́ ńlá: amɔ́lára</annotation>
+		<annotation cp="🦹🏻‍♂">agbára ńlá | amɔ́lára | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá</annotation>
 		<annotation cp="🦹🏻‍♂" type="tts">ɔkùnrin ashèbàjɛ́ ńlá: amɔ́lára</annotation>
-		<annotation cp="🦹🏼‍♂">agbára ńlá | amɔ́lára díɛ̀ | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá | ɔkùnrin ashèbàjɛ́ ńlá: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🦹🏼‍♂">agbára ńlá | amɔ́lára díɛ̀ | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá</annotation>
 		<annotation cp="🦹🏼‍♂" type="tts">ɔkùnrin ashèbàjɛ́ ńlá: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦹🏽‍♂">agbára ńlá | amɔ́láwɔ̀ díɛ̀ | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá | ɔkùnrin ashèbàjɛ́ ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🦹🏽‍♂">agbára ńlá | amɔ́láwɔ̀ díɛ̀ | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá</annotation>
 		<annotation cp="🦹🏽‍♂" type="tts">ɔkùnrin ashèbàjɛ́ ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦹🏾‍♂">adúláwɔ̀ díɛ̀ | agbára ńlá | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá | ɔkùnrin ashèbàjɛ́ ńlá: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🦹🏾‍♂">adúláwɔ̀ díɛ̀ | agbára ńlá | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá</annotation>
 		<annotation cp="🦹🏾‍♂" type="tts">ɔkùnrin ashèbàjɛ́ ńlá: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦹🏿‍♂">adúláwɔ̀ | agbára ńlá | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá | ɔkùnrin ashèbàjɛ́ ńlá: adúláwɔ̀</annotation>
+		<annotation cp="🦹🏿‍♂">adúláwɔ̀ | agbára ńlá | ashèbájɛ́ | ibi | ɔ̀daràn | ɔkùnrin | ɔkùnrin ashèbàjɛ́ ńlá</annotation>
 		<annotation cp="🦹🏿‍♂" type="tts">ɔkùnrin ashèbàjɛ́ ńlá: adúláwɔ̀</annotation>
-		<annotation cp="🦹🏻‍♀">agbára ńlá | amɔ́lára | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | obìnrin ashèbàjɛ́ ńlá: amɔ́lára | ɔbìnrin | ɔ̀daràn</annotation>
+		<annotation cp="🦹🏻‍♀">agbára ńlá | amɔ́lára | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | ɔbìnrin | ɔ̀daràn</annotation>
 		<annotation cp="🦹🏻‍♀" type="tts">obìnrin ashèbàjɛ́ ńlá: amɔ́lára</annotation>
-		<annotation cp="🦹🏼‍♀">agbára ńlá | amɔ́lára díɛ̀ | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | obìnrin ashèbàjɛ́ ńlá: amɔ́lára díɛ̀ | ɔbìnrin | ɔ̀daràn</annotation>
+		<annotation cp="🦹🏼‍♀">agbára ńlá | amɔ́lára díɛ̀ | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | ɔbìnrin | ɔ̀daràn</annotation>
 		<annotation cp="🦹🏼‍♀" type="tts">obìnrin ashèbàjɛ́ ńlá: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🦹🏽‍♀">agbára ńlá | amɔ́láwɔ̀ díɛ̀ | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | obìnrin ashèbàjɛ́ ńlá: amɔ́láwɔ̀ díɛ̀ | ɔbìnrin | ɔ̀daràn</annotation>
+		<annotation cp="🦹🏽‍♀">agbára ńlá | amɔ́láwɔ̀ díɛ̀ | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | ɔbìnrin | ɔ̀daràn</annotation>
 		<annotation cp="🦹🏽‍♀" type="tts">obìnrin ashèbàjɛ́ ńlá: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦹🏾‍♀">adúláwɔ̀ díɛ̀ | agbára ńlá | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | obìnrin ashèbàjɛ́ ńlá: adúláwɔ̀ díɛ̀ | ɔbìnrin | ɔ̀daràn</annotation>
+		<annotation cp="🦹🏾‍♀">adúláwɔ̀ díɛ̀ | agbára ńlá | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | ɔbìnrin | ɔ̀daràn</annotation>
 		<annotation cp="🦹🏾‍♀" type="tts">obìnrin ashèbàjɛ́ ńlá: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🦹🏿‍♀">adúláwɔ̀ | agbára ńlá | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | obìnrin ashèbàjɛ́ ńlá: adúláwɔ̀ | ɔbìnrin | ɔ̀daràn</annotation>
+		<annotation cp="🦹🏿‍♀">adúláwɔ̀ | agbára ńlá | ashèbàjɛ́ | ibi | obìnrin ashèbàjɛ́ ńlá | ɔbìnrin | ɔ̀daràn</annotation>
 		<annotation cp="🦹🏿‍♀" type="tts">obìnrin ashèbàjɛ́ ńlá: adúláwɔ̀</annotation>
-		<annotation cp="🧙🏻">àjɛ́ | amɔ́lára | onídán | onídán: amɔ́lára | oshó</annotation>
+		<annotation cp="🧙🏻">àjɛ́ | amɔ́lára | onídán | oshó</annotation>
 		<annotation cp="🧙🏻" type="tts">onídán: amɔ́lára</annotation>
-		<annotation cp="🧙🏼">àjɛ́ | amɔ́lára díɛ̀ | onídán | onídán: amɔ́lára díɛ̀ | oshó</annotation>
+		<annotation cp="🧙🏼">àjɛ́ | amɔ́lára díɛ̀ | onídán | oshó</annotation>
 		<annotation cp="🧙🏼" type="tts">onídán: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧙🏽">àjɛ́ | amɔ́láwɔ̀ díɛ̀ | onídán | onídán: amɔ́láwɔ̀ díɛ̀ | oshó</annotation>
+		<annotation cp="🧙🏽">àjɛ́ | amɔ́láwɔ̀ díɛ̀ | onídán | oshó</annotation>
 		<annotation cp="🧙🏽" type="tts">onídán: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧙🏾">adúláwɔ̀ díɛ̀ | àjɛ́ | onídán | onídán: adúláwɔ̀ díɛ̀ | oshó</annotation>
+		<annotation cp="🧙🏾">adúláwɔ̀ díɛ̀ | àjɛ́ | onídán | oshó</annotation>
 		<annotation cp="🧙🏾" type="tts">onídán: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧙🏿">adúláwɔ̀ | àjɛ́ | onídán | onídán: adúláwɔ̀ | oshó</annotation>
+		<annotation cp="🧙🏿">adúláwɔ̀ | àjɛ́ | onídán | oshó</annotation>
 		<annotation cp="🧙🏿" type="tts">onídán: adúláwɔ̀</annotation>
-		<annotation cp="🧙🏻‍♂">amɔ́lára | Oshó | Ɔkùnrin onídán | Ɔkùnrin onídán: amɔ́lára</annotation>
+		<annotation cp="🧙🏻‍♂">amɔ́lára | Oshó | Ɔkùnrin onídán</annotation>
 		<annotation cp="🧙🏻‍♂" type="tts">Ɔkùnrin onídán: amɔ́lára</annotation>
-		<annotation cp="🧙🏼‍♂">amɔ́lára díɛ̀ | Oshó | Ɔkùnrin onídán | Ɔkùnrin onídán: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧙🏼‍♂">amɔ́lára díɛ̀ | Oshó | Ɔkùnrin onídán</annotation>
 		<annotation cp="🧙🏼‍♂" type="tts">Ɔkùnrin onídán: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧙🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Oshó | Ɔkùnrin onídán | Ɔkùnrin onídán: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧙🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Oshó | Ɔkùnrin onídán</annotation>
 		<annotation cp="🧙🏽‍♂" type="tts">Ɔkùnrin onídán: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧙🏾‍♂">adúláwɔ̀ díɛ̀ | Oshó | Ɔkùnrin onídán | Ɔkùnrin onídán: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧙🏾‍♂">adúláwɔ̀ díɛ̀ | Oshó | Ɔkùnrin onídán</annotation>
 		<annotation cp="🧙🏾‍♂" type="tts">Ɔkùnrin onídán: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧙🏿‍♂">adúláwɔ̀ | Oshó | Ɔkùnrin onídán | Ɔkùnrin onídán: adúláwɔ̀</annotation>
+		<annotation cp="🧙🏿‍♂">adúláwɔ̀ | Oshó | Ɔkùnrin onídán</annotation>
 		<annotation cp="🧙🏿‍♂" type="tts">Ɔkùnrin onídán: adúláwɔ̀</annotation>
-		<annotation cp="🧙🏻‍♀">àjé̩ | àjɛ́ | amɔ́lára | Obìnrin onídán | Obìnrin onídán: amɔ́lára</annotation>
+		<annotation cp="🧙🏻‍♀">àjé̩ | àjɛ́ | amɔ́lára | Obìnrin onídán</annotation>
 		<annotation cp="🧙🏻‍♀" type="tts">Obìnrin onídán: amɔ́lára</annotation>
-		<annotation cp="🧙🏼‍♀">àjé̩ | àjɛ́ | amɔ́lára díɛ̀ | Obìnrin onídán | Obìnrin onídán: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧙🏼‍♀">àjé̩ | àjɛ́ | amɔ́lára díɛ̀ | Obìnrin onídán</annotation>
 		<annotation cp="🧙🏼‍♀" type="tts">Obìnrin onídán: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧙🏽‍♀">àjé̩ | àjɛ́ | amɔ́láwɔ̀ díɛ̀ | Obìnrin onídán | Obìnrin onídán: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧙🏽‍♀">àjé̩ | àjɛ́ | amɔ́láwɔ̀ díɛ̀ | Obìnrin onídán</annotation>
 		<annotation cp="🧙🏽‍♀" type="tts">Obìnrin onídán: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧙🏾‍♀">adúláwɔ̀ díɛ̀ | àjé̩ | àjɛ́ | Obìnrin onídán | Obìnrin onídán: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧙🏾‍♀">adúláwɔ̀ díɛ̀ | àjé̩ | àjɛ́ | Obìnrin onídán</annotation>
 		<annotation cp="🧙🏾‍♀" type="tts">Obìnrin onídán: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧙🏿‍♀">adúláwɔ̀ | àjé̩ | àjɛ́ | Obìnrin onídán | Obìnrin onídán: adúláwɔ̀</annotation>
+		<annotation cp="🧙🏿‍♀">adúláwɔ̀ | àjé̩ | àjɛ́ | Obìnrin onídán</annotation>
 		<annotation cp="🧙🏿‍♀" type="tts">Obìnrin onídán: adúláwɔ̀</annotation>
-		<annotation cp="🧚🏻">amɔ́lára | Iwin | Iwin: amɔ́lára | Oberon | Puck | Titania</annotation>
+		<annotation cp="🧚🏻">amɔ́lára | Iwin | Oberon | Puck | Titania</annotation>
 		<annotation cp="🧚🏻" type="tts">Iwin: amɔ́lára</annotation>
-		<annotation cp="🧚🏼">amɔ́lára díɛ̀ | Iwin | Iwin: amɔ́lára díɛ̀ | Oberon | Puck | Titania</annotation>
+		<annotation cp="🧚🏼">amɔ́lára díɛ̀ | Iwin | Oberon | Puck | Titania</annotation>
 		<annotation cp="🧚🏼" type="tts">Iwin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧚🏽">amɔ́láwɔ̀ díɛ̀ | Iwin | Iwin: amɔ́láwɔ̀ díɛ̀ | Oberon | Puck | Titania</annotation>
+		<annotation cp="🧚🏽">amɔ́láwɔ̀ díɛ̀ | Iwin | Oberon | Puck | Titania</annotation>
 		<annotation cp="🧚🏽" type="tts">Iwin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧚🏾">adúláwɔ̀ díɛ̀ | Iwin | Iwin: adúláwɔ̀ díɛ̀ | Oberon | Puck | Titania</annotation>
+		<annotation cp="🧚🏾">adúláwɔ̀ díɛ̀ | Iwin | Oberon | Puck | Titania</annotation>
 		<annotation cp="🧚🏾" type="tts">Iwin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧚🏿">adúláwɔ̀ | Iwin | Iwin: adúláwɔ̀ | Oberon | Puck | Titania</annotation>
+		<annotation cp="🧚🏿">adúláwɔ̀ | Iwin | Oberon | Puck | Titania</annotation>
 		<annotation cp="🧚🏿" type="tts">Iwin: adúláwɔ̀</annotation>
-		<annotation cp="🧚🏻‍♂">amɔ́lára | Iwin ɔkùnrin | Iwin ɔkùnrin: amɔ́lára | Oberon | Puck</annotation>
+		<annotation cp="🧚🏻‍♂">amɔ́lára | Iwin ɔkùnrin | Oberon | Puck</annotation>
 		<annotation cp="🧚🏻‍♂" type="tts">Iwin ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="🧚🏼‍♂">amɔ́lára díɛ̀ | Iwin ɔkùnrin | Iwin ɔkùnrin: amɔ́lára díɛ̀ | Oberon | Puck</annotation>
+		<annotation cp="🧚🏼‍♂">amɔ́lára díɛ̀ | Iwin ɔkùnrin | Oberon | Puck</annotation>
 		<annotation cp="🧚🏼‍♂" type="tts">Iwin ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧚🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Iwin ɔkùnrin | Iwin ɔkùnrin: amɔ́láwɔ̀ díɛ̀ | Oberon | Puck</annotation>
+		<annotation cp="🧚🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Iwin ɔkùnrin | Oberon | Puck</annotation>
 		<annotation cp="🧚🏽‍♂" type="tts">Iwin ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧚🏾‍♂">adúláwɔ̀ díɛ̀ | Iwin ɔkùnrin | Iwin ɔkùnrin: adúláwɔ̀ díɛ̀ | Oberon | Puck</annotation>
+		<annotation cp="🧚🏾‍♂">adúláwɔ̀ díɛ̀ | Iwin ɔkùnrin | Oberon | Puck</annotation>
 		<annotation cp="🧚🏾‍♂" type="tts">Iwin ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧚🏿‍♂">adúláwɔ̀ | Iwin ɔkùnrin | Iwin ɔkùnrin: adúláwɔ̀ | Oberon | Puck</annotation>
+		<annotation cp="🧚🏿‍♂">adúláwɔ̀ | Iwin ɔkùnrin | Oberon | Puck</annotation>
 		<annotation cp="🧚🏿‍♂" type="tts">Iwin ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧚🏻‍♀">amɔ́lára | Iwin obìnrin | Iwin obìnrin: amɔ́lára | Tìtàníà</annotation>
+		<annotation cp="🧚🏻‍♀">amɔ́lára | Iwin obìnrin | Tìtàníà</annotation>
 		<annotation cp="🧚🏻‍♀" type="tts">Iwin obìnrin: amɔ́lára</annotation>
-		<annotation cp="🧚🏼‍♀">amɔ́lára díɛ̀ | Iwin obìnrin | Iwin obìnrin: amɔ́lára díɛ̀ | Tìtàníà</annotation>
+		<annotation cp="🧚🏼‍♀">amɔ́lára díɛ̀ | Iwin obìnrin | Tìtàníà</annotation>
 		<annotation cp="🧚🏼‍♀" type="tts">Iwin obìnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧚🏽‍♀">amɔ́láwɔ̀ díɛ̀ | Iwin obìnrin | Iwin obìnrin: amɔ́láwɔ̀ díɛ̀ | Tìtàníà</annotation>
+		<annotation cp="🧚🏽‍♀">amɔ́láwɔ̀ díɛ̀ | Iwin obìnrin | Tìtàníà</annotation>
 		<annotation cp="🧚🏽‍♀" type="tts">Iwin obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧚🏾‍♀">adúláwɔ̀ díɛ̀ | Iwin obìnrin | Iwin obìnrin: adúláwɔ̀ díɛ̀ | Tìtàníà</annotation>
+		<annotation cp="🧚🏾‍♀">adúláwɔ̀ díɛ̀ | Iwin obìnrin | Tìtàníà</annotation>
 		<annotation cp="🧚🏾‍♀" type="tts">Iwin obìnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧚🏿‍♀">adúláwɔ̀ | Iwin obìnrin | Iwin obìnrin: adúláwɔ̀ | Tìtàníà</annotation>
+		<annotation cp="🧚🏿‍♀">adúláwɔ̀ | Iwin obìnrin | Tìtàníà</annotation>
 		<annotation cp="🧚🏿‍♀" type="tts">Iwin obìnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧛🏻">àìkú | amɔ́lára | Dàràkúlà | Fánpáyà | Fánpáyà: amɔ́lára</annotation>
+		<annotation cp="🧛🏻">àìkú | amɔ́lára | Dàràkúlà | Fánpáyà</annotation>
 		<annotation cp="🧛🏻" type="tts">Fánpáyà: amɔ́lára</annotation>
-		<annotation cp="🧛🏼">àìkú | amɔ́lára díɛ̀ | Dàràkúlà | Fánpáyà | Fánpáyà: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧛🏼">àìkú | amɔ́lára díɛ̀ | Dàràkúlà | Fánpáyà</annotation>
 		<annotation cp="🧛🏼" type="tts">Fánpáyà: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧛🏽">àìkú | amɔ́láwɔ̀ díɛ̀ | Dàràkúlà | Fánpáyà | Fánpáyà: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧛🏽">àìkú | amɔ́láwɔ̀ díɛ̀ | Dàràkúlà | Fánpáyà</annotation>
 		<annotation cp="🧛🏽" type="tts">Fánpáyà: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧛🏾">adúláwɔ̀ díɛ̀ | àìkú | Dàràkúlà | Fánpáyà | Fánpáyà: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧛🏾">adúláwɔ̀ díɛ̀ | àìkú | Dàràkúlà | Fánpáyà</annotation>
 		<annotation cp="🧛🏾" type="tts">Fánpáyà: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧛🏿">adúláwɔ̀ | àìkú | Dàràkúlà | Fánpáyà | Fánpáyà: adúláwɔ̀</annotation>
+		<annotation cp="🧛🏿">adúláwɔ̀ | àìkú | Dàràkúlà | Fánpáyà</annotation>
 		<annotation cp="🧛🏿" type="tts">Fánpáyà: adúláwɔ̀</annotation>
-		<annotation cp="🧛🏻‍♂">àìkú | amɔ́lára | Dàràkúlà | Fánpáyà ɔkùnrin | Fánpáyà ɔkùnrin: amɔ́lára</annotation>
+		<annotation cp="🧛🏻‍♂">àìkú | amɔ́lára | Dàràkúlà | Fánpáyà ɔkùnrin</annotation>
 		<annotation cp="🧛🏻‍♂" type="tts">Fánpáyà ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="🧛🏼‍♂">àìkú | amɔ́lára díɛ̀ | Dàràkúlà | Fánpáyà ɔkùnrin | Fánpáyà ɔkùnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧛🏼‍♂">àìkú | amɔ́lára díɛ̀ | Dàràkúlà | Fánpáyà ɔkùnrin</annotation>
 		<annotation cp="🧛🏼‍♂" type="tts">Fánpáyà ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧛🏽‍♂">àìkú | amɔ́láwɔ̀ díɛ̀ | Dàràkúlà | Fánpáyà ɔkùnrin | Fánpáyà ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧛🏽‍♂">àìkú | amɔ́láwɔ̀ díɛ̀ | Dàràkúlà | Fánpáyà ɔkùnrin</annotation>
 		<annotation cp="🧛🏽‍♂" type="tts">Fánpáyà ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧛🏾‍♂">adúláwɔ̀ díɛ̀ | àìkú | Dàràkúlà | Fánpáyà ɔkùnrin | Fánpáyà ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧛🏾‍♂">adúláwɔ̀ díɛ̀ | àìkú | Dàràkúlà | Fánpáyà ɔkùnrin</annotation>
 		<annotation cp="🧛🏾‍♂" type="tts">Fánpáyà ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧛🏿‍♂">adúláwɔ̀ | àìkú | Dàràkúlà | Fánpáyà ɔkùnrin | Fánpáyà ɔkùnrin: adúláwɔ̀</annotation>
+		<annotation cp="🧛🏿‍♂">adúláwɔ̀ | àìkú | Dàràkúlà | Fánpáyà ɔkùnrin</annotation>
 		<annotation cp="🧛🏿‍♂" type="tts">Fánpáyà ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧛🏻‍♀">àìlèkú | amɔ́lára | Fánpáyà obìnrin | Fánpáyà obìnrin: amɔ́lára</annotation>
+		<annotation cp="🧛🏻‍♀">àìlèkú | amɔ́lára | Fánpáyà obìnrin</annotation>
 		<annotation cp="🧛🏻‍♀" type="tts">Fánpáyà obìnrin: amɔ́lára</annotation>
-		<annotation cp="🧛🏼‍♀">àìlèkú | amɔ́lára díɛ̀ | Fánpáyà obìnrin | Fánpáyà obìnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧛🏼‍♀">àìlèkú | amɔ́lára díɛ̀ | Fánpáyà obìnrin</annotation>
 		<annotation cp="🧛🏼‍♀" type="tts">Fánpáyà obìnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧛🏽‍♀">àìlèkú | amɔ́láwɔ̀ díɛ̀ | Fánpáyà obìnrin | Fánpáyà obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧛🏽‍♀">àìlèkú | amɔ́láwɔ̀ díɛ̀ | Fánpáyà obìnrin</annotation>
 		<annotation cp="🧛🏽‍♀" type="tts">Fánpáyà obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧛🏾‍♀">adúláwɔ̀ díɛ̀ | àìlèkú | Fánpáyà obìnrin | Fánpáyà obìnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧛🏾‍♀">adúláwɔ̀ díɛ̀ | àìlèkú | Fánpáyà obìnrin</annotation>
 		<annotation cp="🧛🏾‍♀" type="tts">Fánpáyà obìnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧛🏿‍♀">adúláwɔ̀ | àìlèkú | Fánpáyà obìnrin | Fánpáyà obìnrin: adúláwɔ̀</annotation>
+		<annotation cp="🧛🏿‍♀">adúláwɔ̀ | àìlèkú | Fánpáyà obìnrin</annotation>
 		<annotation cp="🧛🏿‍♀" type="tts">Fánpáyà obìnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧜🏻">amɔ́lára | Yemɔja | Yemɔja ènìyàn | Yemɔja ènìyàn: amɔ́lára</annotation>
+		<annotation cp="🧜🏻">amɔ́lára | Yemɔja | Yemɔja ènìyàn</annotation>
 		<annotation cp="🧜🏻" type="tts">Yemɔja ènìyàn: amɔ́lára</annotation>
-		<annotation cp="🧜🏼">amɔ́lára díɛ̀ | Yemɔja | Yemɔja ènìyàn | Yemɔja ènìyàn: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧜🏼">amɔ́lára díɛ̀ | Yemɔja | Yemɔja ènìyàn</annotation>
 		<annotation cp="🧜🏼" type="tts">Yemɔja ènìyàn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧜🏽">amɔ́láwɔ̀ díɛ̀ | Yemɔja | Yemɔja ènìyàn | Yemɔja ènìyàn: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧜🏽">amɔ́láwɔ̀ díɛ̀ | Yemɔja | Yemɔja ènìyàn</annotation>
 		<annotation cp="🧜🏽" type="tts">Yemɔja ènìyàn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧜🏾">adúláwɔ̀ díɛ̀ | Yemɔja | Yemɔja ènìyàn | Yemɔja ènìyàn: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧜🏾">adúláwɔ̀ díɛ̀ | Yemɔja | Yemɔja ènìyàn</annotation>
 		<annotation cp="🧜🏾" type="tts">Yemɔja ènìyàn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧜🏿">adúláwɔ̀ | Yemɔja | Yemɔja ènìyàn | Yemɔja ènìyàn: adúláwɔ̀</annotation>
+		<annotation cp="🧜🏿">adúláwɔ̀ | Yemɔja | Yemɔja ènìyàn</annotation>
 		<annotation cp="🧜🏿" type="tts">Yemɔja ènìyàn: adúláwɔ̀</annotation>
-		<annotation cp="🧜🏻‍♂">amɔ́lára | Triton | Yemɔja ɔkùnrin | Yemɔja ɔkùnrin: amɔ́lára</annotation>
+		<annotation cp="🧜🏻‍♂">amɔ́lára | Triton | Yemɔja ɔkùnrin</annotation>
 		<annotation cp="🧜🏻‍♂" type="tts">Yemɔja ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="🧜🏼‍♂">amɔ́lára díɛ̀ | Triton | Yemɔja ɔkùnrin | Yemɔja ɔkùnrin: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧜🏼‍♂">amɔ́lára díɛ̀ | Triton | Yemɔja ɔkùnrin</annotation>
 		<annotation cp="🧜🏼‍♂" type="tts">Yemɔja ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧜🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Triton | Yemɔja ɔkùnrin | Yemɔja ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧜🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Triton | Yemɔja ɔkùnrin</annotation>
 		<annotation cp="🧜🏽‍♂" type="tts">Yemɔja ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧜🏾‍♂">adúláwɔ̀ díɛ̀ | Triton | Yemɔja ɔkùnrin | Yemɔja ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧜🏾‍♂">adúláwɔ̀ díɛ̀ | Triton | Yemɔja ɔkùnrin</annotation>
 		<annotation cp="🧜🏾‍♂" type="tts">Yemɔja ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧜🏿‍♂">adúláwɔ̀ | Triton | Yemɔja ɔkùnrin | Yemɔja ɔkùnrin: adúláwɔ̀</annotation>
+		<annotation cp="🧜🏿‍♂">adúláwɔ̀ | Triton | Yemɔja ɔkùnrin</annotation>
 		<annotation cp="🧜🏿‍♂" type="tts">Yemɔja ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧜🏻‍♀">amɔ́lára | iyemɔja | iyemɔja: amɔ́lára | Yemɔja obìnrin</annotation>
+		<annotation cp="🧜🏻‍♀">amɔ́lára | iyemɔja | Yemɔja obìnrin</annotation>
 		<annotation cp="🧜🏻‍♀" type="tts">iyemɔja: amɔ́lára</annotation>
-		<annotation cp="🧜🏼‍♀">amɔ́lára díɛ̀ | iyemɔja | iyemɔja: amɔ́lára díɛ̀ | Yemɔja obìnrin</annotation>
+		<annotation cp="🧜🏼‍♀">amɔ́lára díɛ̀ | iyemɔja | Yemɔja obìnrin</annotation>
 		<annotation cp="🧜🏼‍♀" type="tts">iyemɔja: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧜🏽‍♀">amɔ́láwɔ̀ díɛ̀ | iyemɔja | iyemɔja: amɔ́láwɔ̀ díɛ̀ | Yemɔja obìnrin</annotation>
+		<annotation cp="🧜🏽‍♀">amɔ́láwɔ̀ díɛ̀ | iyemɔja | Yemɔja obìnrin</annotation>
 		<annotation cp="🧜🏽‍♀" type="tts">iyemɔja: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧜🏾‍♀">adúláwɔ̀ díɛ̀ | iyemɔja | iyemɔja: adúláwɔ̀ díɛ̀ | Yemɔja obìnrin</annotation>
+		<annotation cp="🧜🏾‍♀">adúláwɔ̀ díɛ̀ | iyemɔja | Yemɔja obìnrin</annotation>
 		<annotation cp="🧜🏾‍♀" type="tts">iyemɔja: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧜🏿‍♀">adúláwɔ̀ | iyemɔja | iyemɔja: adúláwɔ̀ | Yemɔja obìnrin</annotation>
+		<annotation cp="🧜🏿‍♀">adúláwɔ̀ | iyemɔja | Yemɔja obìnrin</annotation>
 		<annotation cp="🧜🏿‍♀" type="tts">iyemɔja: adúláwɔ̀</annotation>
-		<annotation cp="🧝🏻">amɔ́lára | Egbére | Egbére: amɔ́lára | ìdán</annotation>
+		<annotation cp="🧝🏻">amɔ́lára | Egbére | ìdán</annotation>
 		<annotation cp="🧝🏻" type="tts">Egbére: amɔ́lára</annotation>
-		<annotation cp="🧝🏼">amɔ́lára díɛ̀ | Egbére | Egbére: amɔ́lára díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏼">amɔ́lára díɛ̀ | Egbére | ìdán</annotation>
 		<annotation cp="🧝🏼" type="tts">Egbére: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧝🏽">amɔ́láwɔ̀ díɛ̀ | Egbére | Egbére: amɔ́láwɔ̀ díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏽">amɔ́láwɔ̀ díɛ̀ | Egbére | ìdán</annotation>
 		<annotation cp="🧝🏽" type="tts">Egbére: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧝🏾">adúláwɔ̀ díɛ̀ | Egbére | Egbére: adúláwɔ̀ díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏾">adúláwɔ̀ díɛ̀ | Egbére | ìdán</annotation>
 		<annotation cp="🧝🏾" type="tts">Egbére: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧝🏿">adúláwɔ̀ | Egbére | Egbére: adúláwɔ̀ | ìdán</annotation>
+		<annotation cp="🧝🏿">adúláwɔ̀ | Egbére | ìdán</annotation>
 		<annotation cp="🧝🏿" type="tts">Egbére: adúláwɔ̀</annotation>
-		<annotation cp="🧝🏻‍♂">amɔ́lára | egbére ɔkùnrin | egbére ɔkùnrin: amɔ́lára | ìdán</annotation>
+		<annotation cp="🧝🏻‍♂">amɔ́lára | egbére ɔkùnrin | ìdán</annotation>
 		<annotation cp="🧝🏻‍♂" type="tts">egbére ɔkùnrin: amɔ́lára</annotation>
-		<annotation cp="🧝🏼‍♂">amɔ́lára díɛ̀ | egbére ɔkùnrin | egbére ɔkùnrin: amɔ́lára díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏼‍♂">amɔ́lára díɛ̀ | egbére ɔkùnrin | ìdán</annotation>
 		<annotation cp="🧝🏼‍♂" type="tts">egbére ɔkùnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧝🏽‍♂">amɔ́láwɔ̀ díɛ̀ | egbére ɔkùnrin | egbére ɔkùnrin: amɔ́láwɔ̀ díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏽‍♂">amɔ́láwɔ̀ díɛ̀ | egbére ɔkùnrin | ìdán</annotation>
 		<annotation cp="🧝🏽‍♂" type="tts">egbére ɔkùnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧝🏾‍♂">adúláwɔ̀ díɛ̀ | egbére ɔkùnrin | egbére ɔkùnrin: adúláwɔ̀ díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏾‍♂">adúláwɔ̀ díɛ̀ | egbére ɔkùnrin | ìdán</annotation>
 		<annotation cp="🧝🏾‍♂" type="tts">egbére ɔkùnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧝🏿‍♂">adúláwɔ̀ | egbére ɔkùnrin | egbére ɔkùnrin: adúláwɔ̀ | ìdán</annotation>
+		<annotation cp="🧝🏿‍♂">adúláwɔ̀ | egbére ɔkùnrin | ìdán</annotation>
 		<annotation cp="🧝🏿‍♂" type="tts">egbére ɔkùnrin: adúláwɔ̀</annotation>
-		<annotation cp="🧝🏻‍♀">amɔ́lára | egbére obìnrin | egbére obìnrin: amɔ́lára | ìdán</annotation>
+		<annotation cp="🧝🏻‍♀">amɔ́lára | egbére obìnrin | ìdán</annotation>
 		<annotation cp="🧝🏻‍♀" type="tts">egbére obìnrin: amɔ́lára</annotation>
-		<annotation cp="🧝🏼‍♀">amɔ́lára díɛ̀ | egbére obìnrin | egbére obìnrin: amɔ́lára díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏼‍♀">amɔ́lára díɛ̀ | egbére obìnrin | ìdán</annotation>
 		<annotation cp="🧝🏼‍♀" type="tts">egbére obìnrin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧝🏽‍♀">amɔ́láwɔ̀ díɛ̀ | egbére obìnrin | egbére obìnrin: amɔ́láwɔ̀ díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏽‍♀">amɔ́láwɔ̀ díɛ̀ | egbére obìnrin | ìdán</annotation>
 		<annotation cp="🧝🏽‍♀" type="tts">egbére obìnrin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧝🏾‍♀">adúláwɔ̀ díɛ̀ | egbére obìnrin | egbére obìnrin: adúláwɔ̀ díɛ̀ | ìdán</annotation>
+		<annotation cp="🧝🏾‍♀">adúláwɔ̀ díɛ̀ | egbére obìnrin | ìdán</annotation>
 		<annotation cp="🧝🏾‍♀" type="tts">egbére obìnrin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧝🏿‍♀">adúláwɔ̀ | egbére obìnrin | egbére obìnrin: adúláwɔ̀ | ìdán</annotation>
+		<annotation cp="🧝🏿‍♀">adúláwɔ̀ | egbére obìnrin | ìdán</annotation>
 		<annotation cp="🧝🏿‍♀" type="tts">egbére obìnrin: adúláwɔ̀</annotation>
-		<annotation cp="💆🏻">amɔ́lára | ɛni N gba Ishɛ | ɛni N gba Ishɛ: amɔ́lára | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
+		<annotation cp="💆🏻">amɔ́lára | ɛni N gba Ishɛ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
 		<annotation cp="💆🏻" type="tts">ɛni N gba Ishɛ: amɔ́lára</annotation>
-		<annotation cp="💆🏼">amɔ́lára díɛ̀ | ɛni N gba Ishɛ | ɛni N gba Ishɛ: amɔ́lára díɛ̀ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
+		<annotation cp="💆🏼">amɔ́lára díɛ̀ | ɛni N gba Ishɛ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
 		<annotation cp="💆🏼" type="tts">ɛni N gba Ishɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💆🏽">amɔ́láwɔ̀ díɛ̀ | ɛni N gba Ishɛ | ɛni N gba Ishɛ: amɔ́láwɔ̀ díɛ̀ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
+		<annotation cp="💆🏽">amɔ́láwɔ̀ díɛ̀ | ɛni N gba Ishɛ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
 		<annotation cp="💆🏽" type="tts">ɛni N gba Ishɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💆🏾">adúláwɔ̀ díɛ̀ | ɛni N gba Ishɛ | ɛni N gba Ishɛ: adúláwɔ̀ díɛ̀ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
+		<annotation cp="💆🏾">adúláwɔ̀ díɛ̀ | ɛni N gba Ishɛ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
 		<annotation cp="💆🏾" type="tts">ɛni N gba Ishɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💆🏿">adúláwɔ̀ | ɛni N gba Ishɛ | ɛni N gba Ishɛ: adúláwɔ̀ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
+		<annotation cp="💆🏿">adúláwɔ̀ | ɛni N gba Ishɛ | ìfiránshɛ́ | ilé onídìrí | ojú</annotation>
 		<annotation cp="💆🏿" type="tts">ɛni N gba Ishɛ: adúláwɔ̀</annotation>
-		<annotation cp="💆🏻‍♂">amɔ́lára | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́ | ɔkùnrin tí ń gba ìfiránshɛ́: amɔ́lára</annotation>
+		<annotation cp="💆🏻‍♂">amɔ́lára | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́</annotation>
 		<annotation cp="💆🏻‍♂" type="tts">ɔkùnrin tí ń gba ìfiránshɛ́: amɔ́lára</annotation>
-		<annotation cp="💆🏼‍♂">amɔ́lára díɛ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́ | ɔkùnrin tí ń gba ìfiránshɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="💆🏼‍♂">amɔ́lára díɛ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́</annotation>
 		<annotation cp="💆🏼‍♂" type="tts">ɔkùnrin tí ń gba ìfiránshɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💆🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́ | ɔkùnrin tí ń gba ìfiránshɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="💆🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́</annotation>
 		<annotation cp="💆🏽‍♂" type="tts">ɔkùnrin tí ń gba ìfiránshɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💆🏾‍♂">adúláwɔ̀ díɛ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́ | ɔkùnrin tí ń gba ìfiránshɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="💆🏾‍♂">adúláwɔ̀ díɛ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́</annotation>
 		<annotation cp="💆🏾‍♂" type="tts">ɔkùnrin tí ń gba ìfiránshɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💆🏿‍♂">adúláwɔ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́ | ɔkùnrin tí ń gba ìfiránshɛ́: adúláwɔ̀</annotation>
+		<annotation cp="💆🏿‍♂">adúláwɔ̀ | ìfiránshɛ́ | ojú | ɔkùnrin | ɔkùnrin tí ń gba ìfiránshɛ́</annotation>
 		<annotation cp="💆🏿‍♂" type="tts">ɔkùnrin tí ń gba ìfiránshɛ́: adúláwɔ̀</annotation>
-		<annotation cp="💆🏻‍♀">amɔ́lára | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | obìnrin tí ń gba ìfiránshɛ́: amɔ́lára | ojú</annotation>
+		<annotation cp="💆🏻‍♀">amɔ́lára | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | ojú</annotation>
 		<annotation cp="💆🏻‍♀" type="tts">obìnrin tí ń gba ìfiránshɛ́: amɔ́lára</annotation>
-		<annotation cp="💆🏼‍♀">amɔ́lára díɛ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | obìnrin tí ń gba ìfiránshɛ́: amɔ́lára díɛ̀ | ojú</annotation>
+		<annotation cp="💆🏼‍♀">amɔ́lára díɛ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | ojú</annotation>
 		<annotation cp="💆🏼‍♀" type="tts">obìnrin tí ń gba ìfiránshɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💆🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | obìnrin tí ń gba ìfiránshɛ́: amɔ́láwɔ̀ díɛ̀ | ojú</annotation>
+		<annotation cp="💆🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | ojú</annotation>
 		<annotation cp="💆🏽‍♀" type="tts">obìnrin tí ń gba ìfiránshɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💆🏾‍♀">adúláwɔ̀ díɛ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | obìnrin tí ń gba ìfiránshɛ́: adúláwɔ̀ díɛ̀ | ojú</annotation>
+		<annotation cp="💆🏾‍♀">adúláwɔ̀ díɛ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | ojú</annotation>
 		<annotation cp="💆🏾‍♀" type="tts">obìnrin tí ń gba ìfiránshɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💆🏿‍♀">adúláwɔ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | obìnrin tí ń gba ìfiránshɛ́: adúláwɔ̀ | ojú</annotation>
+		<annotation cp="💆🏿‍♀">adúláwɔ̀ | ìfiránshɛ́ | obìnrin | obìnrin tí ń gba ìfiránshɛ́ | ojú</annotation>
 		<annotation cp="💆🏿‍♀" type="tts">obìnrin tí ń gba ìfiránshɛ́: adúláwɔ̀</annotation>
-		<annotation cp="💇🏻">agɛrun | amɔ́lára | Ɛni N Gɛrun | Ɛni N Gɛrun: amɔ́lára | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
+		<annotation cp="💇🏻">agɛrun | amɔ́lára | Ɛni N Gɛrun | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
 		<annotation cp="💇🏻" type="tts">Ɛni N Gɛrun: amɔ́lára</annotation>
-		<annotation cp="💇🏼">agɛrun | amɔ́lára díɛ̀ | Ɛni N Gɛrun | Ɛni N Gɛrun: amɔ́lára díɛ̀ | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
+		<annotation cp="💇🏼">agɛrun | amɔ́lára díɛ̀ | Ɛni N Gɛrun | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
 		<annotation cp="💇🏼" type="tts">Ɛni N Gɛrun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💇🏽">agɛrun | amɔ́láwɔ̀ díɛ̀ | Ɛni N Gɛrun | Ɛni N Gɛrun: amɔ́láwɔ̀ díɛ̀ | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
+		<annotation cp="💇🏽">agɛrun | amɔ́láwɔ̀ díɛ̀ | Ɛni N Gɛrun | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
 		<annotation cp="💇🏽" type="tts">Ɛni N Gɛrun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💇🏾">adúláwɔ̀ díɛ̀ | agɛrun | Ɛni N Gɛrun | Ɛni N Gɛrun: adúláwɔ̀ díɛ̀ | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
+		<annotation cp="💇🏾">adúláwɔ̀ díɛ̀ | agɛrun | Ɛni N Gɛrun | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
 		<annotation cp="💇🏾" type="tts">Ɛni N Gɛrun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💇🏿">adúláwɔ̀ | agɛrun | Ɛni N Gɛrun | Ɛni N Gɛrun: adúláwɔ̀ | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
+		<annotation cp="💇🏿">adúláwɔ̀ | agɛrun | Ɛni N Gɛrun | ɛwà | gérun | ìyàrá ìgbàlejò</annotation>
 		<annotation cp="💇🏿" type="tts">Ɛni N Gɛrun: adúláwɔ̀</annotation>
-		<annotation cp="💇🏻‍♂">amɔ́lára | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun | ɔkùnrin tí ń gɛrun: amɔ́lára</annotation>
+		<annotation cp="💇🏻‍♂">amɔ́lára | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏻‍♂" type="tts">ɔkùnrin tí ń gɛrun: amɔ́lára</annotation>
-		<annotation cp="💇🏼‍♂">amɔ́lára díɛ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun | ɔkùnrin tí ń gɛrun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="💇🏼‍♂">amɔ́lára díɛ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏼‍♂" type="tts">ɔkùnrin tí ń gɛrun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💇🏽‍♂">amɔ́láwɔ̀ díɛ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun | ɔkùnrin tí ń gɛrun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="💇🏽‍♂">amɔ́láwɔ̀ díɛ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏽‍♂" type="tts">ɔkùnrin tí ń gɛrun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💇🏾‍♂">adúláwɔ̀ díɛ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun | ɔkùnrin tí ń gɛrun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="💇🏾‍♂">adúláwɔ̀ díɛ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏾‍♂" type="tts">ɔkùnrin tí ń gɛrun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💇🏿‍♂">adúláwɔ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun | ɔkùnrin tí ń gɛrun: adúláwɔ̀</annotation>
+		<annotation cp="💇🏿‍♂">adúláwɔ̀ | gɛrun | ɔkùnrin | ɔkùnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏿‍♂" type="tts">ɔkùnrin tí ń gɛrun: adúláwɔ̀</annotation>
-		<annotation cp="💇🏻‍♀">amɔ́lára | gɛrun | obìnrin | obìnrin tí ń gɛrun | obìnrin tí ń gɛrun: amɔ́lára</annotation>
+		<annotation cp="💇🏻‍♀">amɔ́lára | gɛrun | obìnrin | obìnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏻‍♀" type="tts">obìnrin tí ń gɛrun: amɔ́lára</annotation>
-		<annotation cp="💇🏼‍♀">amɔ́lára díɛ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun | obìnrin tí ń gɛrun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="💇🏼‍♀">amɔ́lára díɛ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏼‍♀" type="tts">obìnrin tí ń gɛrun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💇🏽‍♀">amɔ́láwɔ̀ díɛ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun | obìnrin tí ń gɛrun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="💇🏽‍♀">amɔ́láwɔ̀ díɛ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏽‍♀" type="tts">obìnrin tí ń gɛrun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💇🏾‍♀">adúláwɔ̀ díɛ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun | obìnrin tí ń gɛrun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="💇🏾‍♀">adúláwɔ̀ díɛ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏾‍♀" type="tts">obìnrin tí ń gɛrun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💇🏿‍♀">adúláwɔ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun | obìnrin tí ń gɛrun: adúláwɔ̀</annotation>
+		<annotation cp="💇🏿‍♀">adúláwɔ̀ | gɛrun | obìnrin | obìnrin tí ń gɛrun</annotation>
 		<annotation cp="💇🏿‍♀" type="tts">obìnrin tí ń gɛrun: adúláwɔ̀</annotation>
-		<annotation cp="🚶🏻">amɔ́lára | Ɛni N Rin | Ɛni N Rin: amɔ́lára | ìrìn | ń rìn</annotation>
+		<annotation cp="🚶🏻">amɔ́lára | Ɛni N Rin | ìrìn | ń rìn</annotation>
 		<annotation cp="🚶🏻" type="tts">Ɛni N Rin: amɔ́lára</annotation>
-		<annotation cp="🚶🏼">amɔ́lára díɛ̀ | Ɛni N Rin | Ɛni N Rin: amɔ́lára díɛ̀ | ìrìn | ń rìn</annotation>
+		<annotation cp="🚶🏼">amɔ́lára díɛ̀ | Ɛni N Rin | ìrìn | ń rìn</annotation>
 		<annotation cp="🚶🏼" type="tts">Ɛni N Rin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚶🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Rin | Ɛni N Rin: amɔ́láwɔ̀ díɛ̀ | ìrìn | ń rìn</annotation>
+		<annotation cp="🚶🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Rin | ìrìn | ń rìn</annotation>
 		<annotation cp="🚶🏽" type="tts">Ɛni N Rin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚶🏾">adúláwɔ̀ díɛ̀ | Ɛni N Rin | Ɛni N Rin: adúláwɔ̀ díɛ̀ | ìrìn | ń rìn</annotation>
+		<annotation cp="🚶🏾">adúláwɔ̀ díɛ̀ | Ɛni N Rin | ìrìn | ń rìn</annotation>
 		<annotation cp="🚶🏾" type="tts">Ɛni N Rin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚶🏿">adúláwɔ̀ | Ɛni N Rin | Ɛni N Rin: adúláwɔ̀ | ìrìn | ń rìn</annotation>
+		<annotation cp="🚶🏿">adúláwɔ̀ | Ɛni N Rin | ìrìn | ń rìn</annotation>
 		<annotation cp="🚶🏿" type="tts">Ɛni N Rin: adúláwɔ̀</annotation>
-		<annotation cp="🚶🏻‍♂">amɔ́lára | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn | ɔkùnrin tí ń rìn: amɔ́lára</annotation>
+		<annotation cp="🚶🏻‍♂">amɔ́lára | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏻‍♂" type="tts">ɔkùnrin tí ń rìn: amɔ́lára</annotation>
-		<annotation cp="🚶🏼‍♂">amɔ́lára díɛ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn | ɔkùnrin tí ń rìn: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🚶🏼‍♂">amɔ́lára díɛ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏼‍♂" type="tts">ɔkùnrin tí ń rìn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚶🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn | ɔkùnrin tí ń rìn: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚶🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏽‍♂" type="tts">ɔkùnrin tí ń rìn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚶🏾‍♂">adúláwɔ̀ díɛ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn | ɔkùnrin tí ń rìn: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚶🏾‍♂">adúláwɔ̀ díɛ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏾‍♂" type="tts">ɔkùnrin tí ń rìn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚶🏿‍♂">adúláwɔ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn | ɔkùnrin tí ń rìn: adúláwɔ̀</annotation>
+		<annotation cp="🚶🏿‍♂">adúláwɔ̀ | ìrìn | ɔkùnrin | ɔkùnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏿‍♂" type="tts">ɔkùnrin tí ń rìn: adúláwɔ̀</annotation>
-		<annotation cp="🚶🏻‍♀">amɔ́lára | ìrìn | obìnrin | obìnrin tí ń rìn | obìnrin tí ń rìn: amɔ́lára</annotation>
+		<annotation cp="🚶🏻‍♀">amɔ́lára | ìrìn | obìnrin | obìnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏻‍♀" type="tts">obìnrin tí ń rìn: amɔ́lára</annotation>
-		<annotation cp="🚶🏼‍♀">amɔ́lára díɛ̀ | ìrìn | obìnrin | obìnrin tí ń rìn | obìnrin tí ń rìn: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🚶🏼‍♀">amɔ́lára díɛ̀ | ìrìn | obìnrin | obìnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏼‍♀" type="tts">obìnrin tí ń rìn: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚶🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ìrìn | obìnrin | obìnrin tí ń rìn | obìnrin tí ń rìn: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚶🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ìrìn | obìnrin | obìnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏽‍♀" type="tts">obìnrin tí ń rìn: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚶🏾‍♀">adúláwɔ̀ díɛ̀ | ìrìn | obìnrin | obìnrin tí ń rìn | obìnrin tí ń rìn: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚶🏾‍♀">adúláwɔ̀ díɛ̀ | ìrìn | obìnrin | obìnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏾‍♀" type="tts">obìnrin tí ń rìn: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚶🏿‍♀">adúláwɔ̀ | ìrìn | obìnrin | obìnrin tí ń rìn | obìnrin tí ń rìn: adúláwɔ̀</annotation>
+		<annotation cp="🚶🏿‍♀">adúláwɔ̀ | ìrìn | obìnrin | obìnrin tí ń rìn</annotation>
 		<annotation cp="🚶🏿‍♀" type="tts">obìnrin tí ń rìn: adúláwɔ̀</annotation>
-		<annotation cp="🧍🏻">amɔ́lára | dídúró | dúró | ènìyàn dídúró | ènìyàn dídúró: amɔ́lára</annotation>
+		<annotation cp="🧍🏻">amɔ́lára | dídúró | dúró | ènìyàn dídúró</annotation>
 		<annotation cp="🧍🏻" type="tts">ènìyàn dídúró: amɔ́lára</annotation>
-		<annotation cp="🧍🏼">amɔ́lára díɛ̀ | dídúró | dúró | ènìyàn dídúró | ènìyàn dídúró: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧍🏼">amɔ́lára díɛ̀ | dídúró | dúró | ènìyàn dídúró</annotation>
 		<annotation cp="🧍🏼" type="tts">ènìyàn dídúró: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧍🏽">amɔ́láwɔ̀ díɛ̀ | dídúró | dúró | ènìyàn dídúró | ènìyàn dídúró: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧍🏽">amɔ́láwɔ̀ díɛ̀ | dídúró | dúró | ènìyàn dídúró</annotation>
 		<annotation cp="🧍🏽" type="tts">ènìyàn dídúró: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧍🏾">adúláwɔ̀ díɛ̀ | dídúró | dúró | ènìyàn dídúró | ènìyàn dídúró: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧍🏾">adúláwɔ̀ díɛ̀ | dídúró | dúró | ènìyàn dídúró</annotation>
 		<annotation cp="🧍🏾" type="tts">ènìyàn dídúró: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧍🏿">adúláwɔ̀ | dídúró | dúró | ènìyàn dídúró | ènìyàn dídúró: adúláwɔ̀</annotation>
+		<annotation cp="🧍🏿">adúláwɔ̀ | dídúró | dúró | ènìyàn dídúró</annotation>
 		<annotation cp="🧍🏿" type="tts">ènìyàn dídúró: adúláwɔ̀</annotation>
-		<annotation cp="🧍🏻‍♂">amɔ́lára | ń dúró | ɔkùnrin | ɔkùnrin tó dúró | ɔkùnrin tó dúró: amɔ́lára</annotation>
+		<annotation cp="🧍🏻‍♂">amɔ́lára | ń dúró | ɔkùnrin | ɔkùnrin tó dúró</annotation>
 		<annotation cp="🧍🏻‍♂" type="tts">ɔkùnrin tó dúró: amɔ́lára</annotation>
-		<annotation cp="🧍🏼‍♂">amɔ́lára díɛ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró | ɔkùnrin tó dúró: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧍🏼‍♂">amɔ́lára díɛ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró</annotation>
 		<annotation cp="🧍🏼‍♂" type="tts">ɔkùnrin tó dúró: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧍🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró | ɔkùnrin tó dúró: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧍🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró</annotation>
 		<annotation cp="🧍🏽‍♂" type="tts">ɔkùnrin tó dúró: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧍🏾‍♂">adúláwɔ̀ díɛ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró | ɔkùnrin tó dúró: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧍🏾‍♂">adúláwɔ̀ díɛ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró</annotation>
 		<annotation cp="🧍🏾‍♂" type="tts">ɔkùnrin tó dúró: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧍🏿‍♂">adúláwɔ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró | ɔkùnrin tó dúró: adúláwɔ̀</annotation>
+		<annotation cp="🧍🏿‍♂">adúláwɔ̀ | ń dúró | ɔkùnrin | ɔkùnrin tó dúró</annotation>
 		<annotation cp="🧍🏿‍♂" type="tts">ɔkùnrin tó dúró: adúláwɔ̀</annotation>
-		<annotation cp="🧍🏻‍♀">amɔ́lára | ń dúró | obìnrin | obìnrin tó dúró | obìnrin tó dúró: amɔ́lára</annotation>
+		<annotation cp="🧍🏻‍♀">amɔ́lára | ń dúró | obìnrin | obìnrin tó dúró</annotation>
 		<annotation cp="🧍🏻‍♀" type="tts">obìnrin tó dúró: amɔ́lára</annotation>
-		<annotation cp="🧍🏼‍♀">amɔ́lára díɛ̀ | ń dúró | obìnrin | obìnrin tó dúró | obìnrin tó dúró: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧍🏼‍♀">amɔ́lára díɛ̀ | ń dúró | obìnrin | obìnrin tó dúró</annotation>
 		<annotation cp="🧍🏼‍♀" type="tts">obìnrin tó dúró: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧍🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ń dúró | obìnrin | obìnrin tó dúró | obìnrin tó dúró: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧍🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ń dúró | obìnrin | obìnrin tó dúró</annotation>
 		<annotation cp="🧍🏽‍♀" type="tts">obìnrin tó dúró: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧍🏾‍♀">adúláwɔ̀ díɛ̀ | ń dúró | obìnrin | obìnrin tó dúró | obìnrin tó dúró: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧍🏾‍♀">adúláwɔ̀ díɛ̀ | ń dúró | obìnrin | obìnrin tó dúró</annotation>
 		<annotation cp="🧍🏾‍♀" type="tts">obìnrin tó dúró: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧍🏿‍♀">adúláwɔ̀ | ń dúró | obìnrin | obìnrin tó dúró | obìnrin tó dúró: adúláwɔ̀</annotation>
+		<annotation cp="🧍🏿‍♀">adúláwɔ̀ | ń dúró | obìnrin | obìnrin tó dúró</annotation>
 		<annotation cp="🧍🏿‍♀" type="tts">obìnrin tó dúró: adúláwɔ̀</annotation>
-		<annotation cp="🧎🏻">amɔ́lára | ènìyàn kíkúnlɛ̀ | ènìyàn kíkúnlɛ̀: amɔ́lára | kíkúnlɛ̀ | kúnlɛ̀</annotation>
+		<annotation cp="🧎🏻">amɔ́lára | ènìyàn kíkúnlɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
 		<annotation cp="🧎🏻" type="tts">ènìyàn kíkúnlɛ̀: amɔ́lára</annotation>
-		<annotation cp="🧎🏼">amɔ́lára díɛ̀ | ènìyàn kíkúnlɛ̀ | ènìyàn kíkúnlɛ̀: amɔ́lára díɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
+		<annotation cp="🧎🏼">amɔ́lára díɛ̀ | ènìyàn kíkúnlɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
 		<annotation cp="🧎🏼" type="tts">ènìyàn kíkúnlɛ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧎🏽">amɔ́láwɔ̀ díɛ̀ | ènìyàn kíkúnlɛ̀ | ènìyàn kíkúnlɛ̀: amɔ́láwɔ̀ díɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
+		<annotation cp="🧎🏽">amɔ́láwɔ̀ díɛ̀ | ènìyàn kíkúnlɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
 		<annotation cp="🧎🏽" type="tts">ènìyàn kíkúnlɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧎🏾">adúláwɔ̀ díɛ̀ | ènìyàn kíkúnlɛ̀ | ènìyàn kíkúnlɛ̀: adúláwɔ̀ díɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
+		<annotation cp="🧎🏾">adúláwɔ̀ díɛ̀ | ènìyàn kíkúnlɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
 		<annotation cp="🧎🏾" type="tts">ènìyàn kíkúnlɛ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧎🏿">adúláwɔ̀ | ènìyàn kíkúnlɛ̀ | ènìyàn kíkúnlɛ̀: adúláwɔ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
+		<annotation cp="🧎🏿">adúláwɔ̀ | ènìyàn kíkúnlɛ̀ | kíkúnlɛ̀ | kúnlɛ̀</annotation>
 		<annotation cp="🧎🏿" type="tts">ènìyàn kíkúnlɛ̀: adúláwɔ̀</annotation>
-		<annotation cp="🧎🏻‍♂">amɔ́lára | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀ | ɔkùnrin tó kúnlɛ̀: amɔ́lára</annotation>
+		<annotation cp="🧎🏻‍♂">amɔ́lára | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏻‍♂" type="tts">ɔkùnrin tó kúnlɛ̀: amɔ́lára</annotation>
-		<annotation cp="🧎🏼‍♂">amɔ́lára díɛ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀ | ɔkùnrin tó kúnlɛ̀: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧎🏼‍♂">amɔ́lára díɛ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏼‍♂" type="tts">ɔkùnrin tó kúnlɛ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧎🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀ | ɔkùnrin tó kúnlɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧎🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏽‍♂" type="tts">ɔkùnrin tó kúnlɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧎🏾‍♂">adúláwɔ̀ díɛ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀ | ɔkùnrin tó kúnlɛ̀: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧎🏾‍♂">adúláwɔ̀ díɛ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏾‍♂" type="tts">ɔkùnrin tó kúnlɛ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧎🏿‍♂">adúláwɔ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀ | ɔkùnrin tó kúnlɛ̀: adúláwɔ̀</annotation>
+		<annotation cp="🧎🏿‍♂">adúláwɔ̀ | ń kúnlɛ̀ | ɔkùnrin | ɔkùnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏿‍♂" type="tts">ɔkùnrin tó kúnlɛ̀: adúláwɔ̀</annotation>
-		<annotation cp="🧎🏻‍♀">amɔ́lára | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀ | obìnrin tó kúnlɛ̀: amɔ́lára</annotation>
+		<annotation cp="🧎🏻‍♀">amɔ́lára | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏻‍♀" type="tts">obìnrin tó kúnlɛ̀: amɔ́lára</annotation>
-		<annotation cp="🧎🏼‍♀">amɔ́lára díɛ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀ | obìnrin tó kúnlɛ̀: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧎🏼‍♀">amɔ́lára díɛ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏼‍♀" type="tts">obìnrin tó kúnlɛ̀: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧎🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀ | obìnrin tó kúnlɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧎🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏽‍♀" type="tts">obìnrin tó kúnlɛ̀: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧎🏾‍♀">adúláwɔ̀ díɛ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀ | obìnrin tó kúnlɛ̀: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧎🏾‍♀">adúláwɔ̀ díɛ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏾‍♀" type="tts">obìnrin tó kúnlɛ̀: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧎🏿‍♀">adúláwɔ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀ | obìnrin tó kúnlɛ̀: adúláwɔ̀</annotation>
+		<annotation cp="🧎🏿‍♀">adúláwɔ̀ | ń kúnlɛ̀ | obìnrin | obìnrin tó kúnlɛ̀</annotation>
 		<annotation cp="🧎🏿‍♀" type="tts">obìnrin tó kúnlɛ̀: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🦯">afɔ́jú | amɔ́lára | ènìyàn pɛ̀lú ɔ̀pá funfun | ènìyàn pɛ̀lú ɔ̀pá funfun: amɔ́lára | ìráàyèsí</annotation>
+		<annotation cp="🧑🏻‍🦯">afɔ́jú | amɔ́lára | ènìyàn pɛ̀lú ɔ̀pá funfun | ìráàyèsí</annotation>
 		<annotation cp="🧑🏻‍🦯" type="tts">ènìyàn pɛ̀lú ɔ̀pá funfun: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🦯">afɔ́jú | amɔ́lára díɛ̀ | ènìyàn pɛ̀lú ɔ̀pá funfun | ènìyàn pɛ̀lú ɔ̀pá funfun: amɔ́lára díɛ̀ | ìráàyèsí</annotation>
+		<annotation cp="🧑🏼‍🦯">afɔ́jú | amɔ́lára díɛ̀ | ènìyàn pɛ̀lú ɔ̀pá funfun | ìráàyèsí</annotation>
 		<annotation cp="🧑🏼‍🦯" type="tts">ènìyàn pɛ̀lú ɔ̀pá funfun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🦯">afɔ́jú | amɔ́láwɔ̀ díɛ̀ | ènìyàn pɛ̀lú ɔ̀pá funfun | ènìyàn pɛ̀lú ɔ̀pá funfun: amɔ́láwɔ̀ díɛ̀ | ìráàyèsí</annotation>
+		<annotation cp="🧑🏽‍🦯">afɔ́jú | amɔ́láwɔ̀ díɛ̀ | ènìyàn pɛ̀lú ɔ̀pá funfun | ìráàyèsí</annotation>
 		<annotation cp="🧑🏽‍🦯" type="tts">ènìyàn pɛ̀lú ɔ̀pá funfun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🦯">adúláwɔ̀ díɛ̀ | afɔ́jú | ènìyàn pɛ̀lú ɔ̀pá funfun | ènìyàn pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ díɛ̀ | ìráàyèsí</annotation>
+		<annotation cp="🧑🏾‍🦯">adúláwɔ̀ díɛ̀ | afɔ́jú | ènìyàn pɛ̀lú ɔ̀pá funfun | ìráàyèsí</annotation>
 		<annotation cp="🧑🏾‍🦯" type="tts">ènìyàn pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🦯">adúláwɔ̀ | afɔ́jú | ènìyàn pɛ̀lú ɔ̀pá funfun | ènìyàn pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ | ìráàyèsí</annotation>
+		<annotation cp="🧑🏿‍🦯">adúláwɔ̀ | afɔ́jú | ènìyàn pɛ̀lú ɔ̀pá funfun | ìráàyèsí</annotation>
 		<annotation cp="🧑🏿‍🦯" type="tts">ènìyàn pɛ̀lú ɔ̀pá funfun: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🦯">afɔ́jú | amɔ́lára | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun | ɔkùnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🦯">afɔ́jú | amɔ́lára | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👨🏻‍🦯" type="tts">ɔkùnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🦯">afɔ́jú | amɔ́lára díɛ̀ | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun | ɔkùnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🦯">afɔ́jú | amɔ́lára díɛ̀ | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👨🏼‍🦯" type="tts">ɔkùnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🦯">afɔ́jú | amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun | ɔkùnrin pɛ̀lú ɔ̀pá funfun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🦯">afɔ́jú | amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👨🏽‍🦯" type="tts">ɔkùnrin pɛ̀lú ɔ̀pá funfun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🦯">adúláwɔ̀ díɛ̀ | afɔ́jú | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun | ɔkùnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🦯">adúláwɔ̀ díɛ̀ | afɔ́jú | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👨🏾‍🦯" type="tts">ɔkùnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🦯">adúláwɔ̀ | afɔ́jú | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun | ɔkùnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🦯">adúláwɔ̀ | afɔ́jú | ìráàyèsí | ɔkùnrin | ɔkùnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👨🏿‍🦯" type="tts">ɔkùnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🦯">afɔ́jú | amɔ́lára | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun | obìnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára</annotation>
+		<annotation cp="👩🏻‍🦯">afɔ́jú | amɔ́lára | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👩🏻‍🦯" type="tts">obìnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🦯">afɔ́jú | amɔ́lára díɛ̀ | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun | obìnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👩🏼‍🦯">afɔ́jú | amɔ́lára díɛ̀ | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👩🏼‍🦯" type="tts">obìnrin pɛ̀lú ɔ̀pá funfun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🦯">afɔ́jú | amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun | obìnrin pɛ̀lú ɔ̀pá funfun: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏽‍🦯">afɔ́jú | amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👩🏽‍🦯" type="tts">obìnrin pɛ̀lú ɔ̀pá funfun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🦯">adúláwɔ̀ díɛ̀ | afɔ́jú | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun | obìnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏾‍🦯">adúláwɔ̀ díɛ̀ | afɔ́jú | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👩🏾‍🦯" type="tts">obìnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🦯">adúláwɔ̀ | afɔ́jú | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun | obìnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀</annotation>
+		<annotation cp="👩🏿‍🦯">adúláwɔ̀ | afɔ́jú | ìráàyèsí | obìnrin | obìnrin pɛ̀lú ɔ̀pá funfun</annotation>
 		<annotation cp="👩🏿‍🦯" type="tts">obìnrin pɛ̀lú ɔ̀pá funfun: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🦼">amɔ́lára | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏻‍🦼">amɔ́lára | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏻‍🦼" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🦼">amɔ́lára díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏼‍🦼">amɔ́lára díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏼‍🦼" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🦼">amɔ́láwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏽‍🦼">amɔ́láwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏽‍🦼" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🦼">adúláwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏾‍🦼">adúláwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏾‍🦼" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🦼">adúláwɔ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏿‍🦼">adúláwɔ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏿‍🦼" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🦼">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🦼">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👨🏻‍🦼" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🦼">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🦼">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👨🏼‍🦼" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🦼">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🦼">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👨🏽‍🦼" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🦼">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🦼">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👨🏾‍🦼" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🦼">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🦼">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👨🏿‍🦼" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🦼">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára</annotation>
+		<annotation cp="👩🏻‍🦼">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👩🏻‍🦼" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🦼">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👩🏼‍🦼">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👩🏼‍🦼" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🦼">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏽‍🦼">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👩🏽‍🦼" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🦼">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏾‍🦼">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👩🏾‍🦼" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🦼">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀</annotation>
+		<annotation cp="👩🏿‍🦼">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò</annotation>
 		<annotation cp="👩🏿‍🦼" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn ɛlɛ́rɔ-mɔ́tò: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🦽">amɔ́lára | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏻‍🦽">amɔ́lára | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏻‍🦽" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🦽">amɔ́lára díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏼‍🦽">amɔ́lára díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏼‍🦽" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🦽">amɔ́láwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏽‍🦽">amɔ́láwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏽‍🦽" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🦽">adúláwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏾‍🦽">adúláwɔ̀ díɛ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏾‍🦽" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🦽">adúláwɔ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
+		<annotation cp="🧑🏿‍🦽">adúláwɔ̀ | ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ìráàyèsí | kɛ̀kɛ́ abirùn</annotation>
 		<annotation cp="🧑🏿‍🦽" type="tts">ènìyàn nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀</annotation>
-		<annotation cp="👨🏻‍🦽">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára</annotation>
+		<annotation cp="👨🏻‍🦽">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👨🏻‍🦽" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára</annotation>
-		<annotation cp="👨🏼‍🦽">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👨🏼‍🦽">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👨🏼‍🦽" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏽‍🦽">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏽‍🦽">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👨🏽‍🦽" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🦽">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👨🏾‍🦽">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👨🏾‍🦽" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🦽">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀</annotation>
+		<annotation cp="👨🏿‍🦽">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | ɔkùnrin | ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👨🏿‍🦽" type="tts">ɔkùnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀</annotation>
-		<annotation cp="👩🏻‍🦽">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára</annotation>
+		<annotation cp="👩🏻‍🦽">amɔ́lára | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👩🏻‍🦽" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára</annotation>
-		<annotation cp="👩🏼‍🦽">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára díɛ̀</annotation>
+		<annotation cp="👩🏼‍🦽">amɔ́lára díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👩🏼‍🦽" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏽‍🦽">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏽‍🦽">amɔ́láwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👩🏽‍🦽" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🦽">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="👩🏾‍🦽">adúláwɔ̀ díɛ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👩🏾‍🦽" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🦽">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀</annotation>
+		<annotation cp="👩🏿‍🦽">adúláwɔ̀ | ìráàyèsí | kɛ̀kɛ́ abirùn | obìnrin | obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí</annotation>
 		<annotation cp="👩🏿‍🦽" type="tts">obìnrin nínú kɛ̀kɛ́-abirùn aláfɔwɔ́yí: adúláwɔ̀</annotation>
-		<annotation cp="🏃🏻">amɔ́lára | eré | Ɛni N Sare | Ɛni N Sare: amɔ́lára | sáré</annotation>
+		<annotation cp="🏃🏻">amɔ́lára | eré | Ɛni N Sare | sáré</annotation>
 		<annotation cp="🏃🏻" type="tts">Ɛni N Sare: amɔ́lára</annotation>
-		<annotation cp="🏃🏼">amɔ́lára díɛ̀ | eré | Ɛni N Sare | Ɛni N Sare: amɔ́lára díɛ̀ | sáré</annotation>
+		<annotation cp="🏃🏼">amɔ́lára díɛ̀ | eré | Ɛni N Sare | sáré</annotation>
 		<annotation cp="🏃🏼" type="tts">Ɛni N Sare: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏃🏽">amɔ́láwɔ̀ díɛ̀ | eré | Ɛni N Sare | Ɛni N Sare: amɔ́láwɔ̀ díɛ̀ | sáré</annotation>
+		<annotation cp="🏃🏽">amɔ́láwɔ̀ díɛ̀ | eré | Ɛni N Sare | sáré</annotation>
 		<annotation cp="🏃🏽" type="tts">Ɛni N Sare: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏃🏾">adúláwɔ̀ díɛ̀ | eré | Ɛni N Sare | Ɛni N Sare: adúláwɔ̀ díɛ̀ | sáré</annotation>
+		<annotation cp="🏃🏾">adúláwɔ̀ díɛ̀ | eré | Ɛni N Sare | sáré</annotation>
 		<annotation cp="🏃🏾" type="tts">Ɛni N Sare: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏃🏿">adúláwɔ̀ | eré | Ɛni N Sare | Ɛni N Sare: adúláwɔ̀ | sáré</annotation>
+		<annotation cp="🏃🏿">adúláwɔ̀ | eré | Ɛni N Sare | sáré</annotation>
 		<annotation cp="🏃🏿" type="tts">Ɛni N Sare: adúláwɔ̀</annotation>
-		<annotation cp="🏃🏻‍♂">amɔ́lára | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | ɔkùnrin tí ń sáré: amɔ́lára | sáré</annotation>
+		<annotation cp="🏃🏻‍♂">amɔ́lára | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | sáré</annotation>
 		<annotation cp="🏃🏻‍♂" type="tts">ɔkùnrin tí ń sáré: amɔ́lára</annotation>
-		<annotation cp="🏃🏼‍♂">amɔ́lára díɛ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | ɔkùnrin tí ń sáré: amɔ́lára díɛ̀ | sáré</annotation>
+		<annotation cp="🏃🏼‍♂">amɔ́lára díɛ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | sáré</annotation>
 		<annotation cp="🏃🏼‍♂" type="tts">ɔkùnrin tí ń sáré: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏃🏽‍♂">amɔ́láwɔ̀ díɛ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | ɔkùnrin tí ń sáré: amɔ́láwɔ̀ díɛ̀ | sáré</annotation>
+		<annotation cp="🏃🏽‍♂">amɔ́láwɔ̀ díɛ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | sáré</annotation>
 		<annotation cp="🏃🏽‍♂" type="tts">ɔkùnrin tí ń sáré: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏃🏾‍♂">adúláwɔ̀ díɛ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | ɔkùnrin tí ń sáré: adúláwɔ̀ díɛ̀ | sáré</annotation>
+		<annotation cp="🏃🏾‍♂">adúláwɔ̀ díɛ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | sáré</annotation>
 		<annotation cp="🏃🏾‍♂" type="tts">ɔkùnrin tí ń sáré: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏃🏿‍♂">adúláwɔ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | ɔkùnrin tí ń sáré: adúláwɔ̀ | sáré</annotation>
+		<annotation cp="🏃🏿‍♂">adúláwɔ̀ | eré | eré ìdíjɛ | ɔkùnrin | ɔkùnrin tí ń sáré | sáré</annotation>
 		<annotation cp="🏃🏿‍♂" type="tts">ɔkùnrin tí ń sáré: adúláwɔ̀</annotation>
-		<annotation cp="🏃🏻‍♀">amɔ́lára | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré | obìrin tí ń sáré: amɔ́lára</annotation>
+		<annotation cp="🏃🏻‍♀">amɔ́lára | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré</annotation>
 		<annotation cp="🏃🏻‍♀" type="tts">obìrin tí ń sáré: amɔ́lára</annotation>
-		<annotation cp="🏃🏼‍♀">amɔ́lára díɛ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré | obìrin tí ń sáré: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🏃🏼‍♀">amɔ́lára díɛ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré</annotation>
 		<annotation cp="🏃🏼‍♀" type="tts">obìrin tí ń sáré: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏃🏽‍♀">amɔ́láwɔ̀ díɛ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré | obìrin tí ń sáré: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏃🏽‍♀">amɔ́láwɔ̀ díɛ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré</annotation>
 		<annotation cp="🏃🏽‍♀" type="tts">obìrin tí ń sáré: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏃🏾‍♀">adúláwɔ̀ díɛ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré | obìrin tí ń sáré: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏃🏾‍♀">adúláwɔ̀ díɛ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré</annotation>
 		<annotation cp="🏃🏾‍♀" type="tts">obìrin tí ń sáré: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏃🏿‍♀">adúláwɔ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré | obìrin tí ń sáré: adúláwɔ̀</annotation>
+		<annotation cp="🏃🏿‍♀">adúláwɔ̀ | eré | eré ìdíje | ń sáré | obìnrin | obìrin tí ń sáré</annotation>
 		<annotation cp="🏃🏿‍♀" type="tts">obìrin tí ń sáré: adúláwɔ̀</annotation>
-		<annotation cp="💃🏻">amɔ́lára | obinrin | Obinrin Ti Njo | Obinrin Ti Njo: amɔ́lára | Ti Njo</annotation>
+		<annotation cp="💃🏻">amɔ́lára | obinrin | Obinrin Ti Njo | Ti Njo</annotation>
 		<annotation cp="💃🏻" type="tts">Obinrin Ti Njo: amɔ́lára</annotation>
-		<annotation cp="💃🏼">amɔ́lára díɛ̀ | obinrin | Obinrin Ti Njo | Obinrin Ti Njo: amɔ́lára díɛ̀ | Ti Njo</annotation>
+		<annotation cp="💃🏼">amɔ́lára díɛ̀ | obinrin | Obinrin Ti Njo | Ti Njo</annotation>
 		<annotation cp="💃🏼" type="tts">Obinrin Ti Njo: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💃🏽">amɔ́láwɔ̀ díɛ̀ | obinrin | Obinrin Ti Njo | Obinrin Ti Njo: amɔ́láwɔ̀ díɛ̀ | Ti Njo</annotation>
+		<annotation cp="💃🏽">amɔ́láwɔ̀ díɛ̀ | obinrin | Obinrin Ti Njo | Ti Njo</annotation>
 		<annotation cp="💃🏽" type="tts">Obinrin Ti Njo: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💃🏾">adúláwɔ̀ díɛ̀ | obinrin | Obinrin Ti Njo | Obinrin Ti Njo: adúláwɔ̀ díɛ̀ | Ti Njo</annotation>
+		<annotation cp="💃🏾">adúláwɔ̀ díɛ̀ | obinrin | Obinrin Ti Njo | Ti Njo</annotation>
 		<annotation cp="💃🏾" type="tts">Obinrin Ti Njo: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💃🏿">adúláwɔ̀ | obinrin | Obinrin Ti Njo | Obinrin Ti Njo: adúláwɔ̀ | Ti Njo</annotation>
+		<annotation cp="💃🏿">adúláwɔ̀ | obinrin | Obinrin Ti Njo | Ti Njo</annotation>
 		<annotation cp="💃🏿" type="tts">Obinrin Ti Njo: adúláwɔ̀</annotation>
-		<annotation cp="🕺🏻">amɔ́lára | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo | Ɔkunrin Ti Njo: amɔ́lára</annotation>
+		<annotation cp="🕺🏻">amɔ́lára | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo</annotation>
 		<annotation cp="🕺🏻" type="tts">Ɔkunrin Ti Njo: amɔ́lára</annotation>
-		<annotation cp="🕺🏼">amɔ́lára díɛ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo | Ɔkunrin Ti Njo: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🕺🏼">amɔ́lára díɛ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo</annotation>
 		<annotation cp="🕺🏼" type="tts">Ɔkunrin Ti Njo: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🕺🏽">amɔ́láwɔ̀ díɛ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo | Ɔkunrin Ti Njo: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🕺🏽">amɔ́láwɔ̀ díɛ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo</annotation>
 		<annotation cp="🕺🏽" type="tts">Ɔkunrin Ti Njo: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕺🏾">adúláwɔ̀ díɛ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo | Ɔkunrin Ti Njo: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🕺🏾">adúláwɔ̀ díɛ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo</annotation>
 		<annotation cp="🕺🏾" type="tts">Ɔkunrin Ti Njo: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕺🏿">adúláwɔ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo | Ɔkunrin Ti Njo: adúláwɔ̀</annotation>
+		<annotation cp="🕺🏿">adúláwɔ̀ | ijɔ́ | ɔkùnrin | Ɔkunrin Ti Njo</annotation>
 		<annotation cp="🕺🏿" type="tts">Ɔkunrin Ti Njo: adúláwɔ̀</annotation>
-		<annotation cp="🕴🏻">amɔ́lára | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò | ɔkùnrin nínu kóòtú òwò: amɔ́lára</annotation>
+		<annotation cp="🕴🏻">amɔ́lára | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò</annotation>
 		<annotation cp="🕴🏻" type="tts">ɔkùnrin nínu kóòtú òwò: amɔ́lára</annotation>
-		<annotation cp="🕴🏼">amɔ́lára díɛ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò | ɔkùnrin nínu kóòtú òwò: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🕴🏼">amɔ́lára díɛ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò</annotation>
 		<annotation cp="🕴🏼" type="tts">ɔkùnrin nínu kóòtú òwò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🕴🏽">amɔ́láwɔ̀ díɛ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò | ɔkùnrin nínu kóòtú òwò: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🕴🏽">amɔ́láwɔ̀ díɛ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò</annotation>
 		<annotation cp="🕴🏽" type="tts">ɔkùnrin nínu kóòtú òwò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕴🏾">adúláwɔ̀ díɛ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò | ɔkùnrin nínu kóòtú òwò: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🕴🏾">adúláwɔ̀ díɛ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò</annotation>
 		<annotation cp="🕴🏾" type="tts">ɔkùnrin nínu kóòtú òwò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🕴🏿">adúláwɔ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò | ɔkùnrin nínu kóòtú òwò: adúláwɔ̀</annotation>
+		<annotation cp="🕴🏿">adúláwɔ̀ | kóòtù | òwò | ɔkùnrin | ɔkùnrin nínu kóòtú òwò</annotation>
 		<annotation cp="🕴🏿" type="tts">ɔkùnrin nínu kóòtú òwò: adúláwɔ̀</annotation>
-		<annotation cp="🧖🏻">amɔ́lára | Ènìyàn nínú Ìyàrá tó n gbóná | Ènìyàn nínú Ìyàrá tó n gbóná: amɔ́lára | Ìyàrá tó n gbóná</annotation>
+		<annotation cp="🧖🏻">amɔ́lára | Ènìyàn nínú Ìyàrá tó n gbóná | Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏻" type="tts">Ènìyàn nínú Ìyàrá tó n gbóná: amɔ́lára</annotation>
-		<annotation cp="🧖🏼">amɔ́lára díɛ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ènìyàn nínú Ìyàrá tó n gbóná: amɔ́lára díɛ̀ | Ìyàrá tó n gbóná</annotation>
+		<annotation cp="🧖🏼">amɔ́lára díɛ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏼" type="tts">Ènìyàn nínú Ìyàrá tó n gbóná: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧖🏽">amɔ́láwɔ̀ díɛ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ènìyàn nínú Ìyàrá tó n gbóná: amɔ́láwɔ̀ díɛ̀ | Ìyàrá tó n gbóná</annotation>
+		<annotation cp="🧖🏽">amɔ́láwɔ̀ díɛ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏽" type="tts">Ènìyàn nínú Ìyàrá tó n gbóná: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧖🏾">adúláwɔ̀ díɛ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ènìyàn nínú Ìyàrá tó n gbóná: adúláwɔ̀ díɛ̀ | Ìyàrá tó n gbóná</annotation>
+		<annotation cp="🧖🏾">adúláwɔ̀ díɛ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏾" type="tts">Ènìyàn nínú Ìyàrá tó n gbóná: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧖🏿">adúláwɔ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ènìyàn nínú Ìyàrá tó n gbóná: adúláwɔ̀ | Ìyàrá tó n gbóná</annotation>
+		<annotation cp="🧖🏿">adúláwɔ̀ | Ènìyàn nínú Ìyàrá tó n gbóná | Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏿" type="tts">Ènìyàn nínú Ìyàrá tó n gbóná: adúláwɔ̀</annotation>
-		<annotation cp="🧖🏻‍♂">amɔ́lára | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná: amɔ́lára</annotation>
+		<annotation cp="🧖🏻‍♂">amɔ́lára | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏻‍♂" type="tts">Ɔkùnrin nínú Ìyàrá tó n gbóná: amɔ́lára</annotation>
-		<annotation cp="🧖🏼‍♂">amɔ́lára díɛ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧖🏼‍♂">amɔ́lára díɛ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏼‍♂" type="tts">Ɔkùnrin nínú Ìyàrá tó n gbóná: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧖🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧖🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏽‍♂" type="tts">Ɔkùnrin nínú Ìyàrá tó n gbóná: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧖🏾‍♂">adúláwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧖🏾‍♂">adúláwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏾‍♂" type="tts">Ɔkùnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧖🏿‍♂">adúláwɔ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀</annotation>
+		<annotation cp="🧖🏿‍♂">adúláwɔ̀ | Ìyàrá tó n gbóná | Ɔkùnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏿‍♂" type="tts">Ɔkùnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀</annotation>
-		<annotation cp="🧖🏻‍♀">amɔ́lára | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná: amɔ́lára</annotation>
+		<annotation cp="🧖🏻‍♀">amɔ́lára | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏻‍♀" type="tts">Obìnrin nínú Ìyàrá tó n gbóná: amɔ́lára</annotation>
-		<annotation cp="🧖🏼‍♀">amɔ́lára díɛ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧖🏼‍♀">amɔ́lára díɛ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏼‍♀" type="tts">Obìnrin nínú Ìyàrá tó n gbóná: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧖🏽‍♀">amɔ́láwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧖🏽‍♀">amɔ́láwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏽‍♀" type="tts">Obìnrin nínú Ìyàrá tó n gbóná: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧖🏾‍♀">adúláwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧖🏾‍♀">adúláwɔ̀ díɛ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏾‍♀" type="tts">Obìnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧖🏿‍♀">adúláwɔ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀</annotation>
+		<annotation cp="🧖🏿‍♀">adúláwɔ̀ | Ìyàrá tó n gbóná | Obìnrin nínú Ìyàrá tó n gbóná</annotation>
 		<annotation cp="🧖🏿‍♀" type="tts">Obìnrin nínú Ìyàrá tó n gbóná: adúláwɔ̀</annotation>
-		<annotation cp="🧗🏻">agùnkè | amɔ́lára | Ènìyàn tó n gòkè | Ènìyàn tó n gòkè: amɔ́lára</annotation>
+		<annotation cp="🧗🏻">agùnkè | amɔ́lára | Ènìyàn tó n gòkè</annotation>
 		<annotation cp="🧗🏻" type="tts">Ènìyàn tó n gòkè: amɔ́lára</annotation>
-		<annotation cp="🧗🏼">agùnkè | amɔ́lára díɛ̀ | Ènìyàn tó n gòkè | Ènìyàn tó n gòkè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧗🏼">agùnkè | amɔ́lára díɛ̀ | Ènìyàn tó n gòkè</annotation>
 		<annotation cp="🧗🏼" type="tts">Ènìyàn tó n gòkè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧗🏽">agùnkè | amɔ́láwɔ̀ díɛ̀ | Ènìyàn tó n gòkè | Ènìyàn tó n gòkè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧗🏽">agùnkè | amɔ́láwɔ̀ díɛ̀ | Ènìyàn tó n gòkè</annotation>
 		<annotation cp="🧗🏽" type="tts">Ènìyàn tó n gòkè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧗🏾">adúláwɔ̀ díɛ̀ | agùnkè | Ènìyàn tó n gòkè | Ènìyàn tó n gòkè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧗🏾">adúláwɔ̀ díɛ̀ | agùnkè | Ènìyàn tó n gòkè</annotation>
 		<annotation cp="🧗🏾" type="tts">Ènìyàn tó n gòkè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧗🏿">adúláwɔ̀ | agùnkè | Ènìyàn tó n gòkè | Ènìyàn tó n gòkè: adúláwɔ̀</annotation>
+		<annotation cp="🧗🏿">adúláwɔ̀ | agùnkè | Ènìyàn tó n gòkè</annotation>
 		<annotation cp="🧗🏿" type="tts">Ènìyàn tó n gòkè: adúláwɔ̀</annotation>
-		<annotation cp="🧗🏻‍♂">agùnkè | amɔ́lára | O̩kùnrin tó n gòkè | O̩kùnrin tó n gòkè: amɔ́lára</annotation>
+		<annotation cp="🧗🏻‍♂">agùnkè | amɔ́lára | O̩kùnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏻‍♂" type="tts">O̩kùnrin tó n gòkè: amɔ́lára</annotation>
-		<annotation cp="🧗🏼‍♂">agùnkè | amɔ́lára díɛ̀ | O̩kùnrin tó n gòkè | O̩kùnrin tó n gòkè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧗🏼‍♂">agùnkè | amɔ́lára díɛ̀ | O̩kùnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏼‍♂" type="tts">O̩kùnrin tó n gòkè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧗🏽‍♂">agùnkè | amɔ́láwɔ̀ díɛ̀ | O̩kùnrin tó n gòkè | O̩kùnrin tó n gòkè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧗🏽‍♂">agùnkè | amɔ́láwɔ̀ díɛ̀ | O̩kùnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏽‍♂" type="tts">O̩kùnrin tó n gòkè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧗🏾‍♂">adúláwɔ̀ díɛ̀ | agùnkè | O̩kùnrin tó n gòkè | O̩kùnrin tó n gòkè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧗🏾‍♂">adúláwɔ̀ díɛ̀ | agùnkè | O̩kùnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏾‍♂" type="tts">O̩kùnrin tó n gòkè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧗🏿‍♂">adúláwɔ̀ | agùnkè | O̩kùnrin tó n gòkè | O̩kùnrin tó n gòkè: adúláwɔ̀</annotation>
+		<annotation cp="🧗🏿‍♂">adúláwɔ̀ | agùnkè | O̩kùnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏿‍♂" type="tts">O̩kùnrin tó n gòkè: adúláwɔ̀</annotation>
-		<annotation cp="🧗🏻‍♀">agùnkè | amɔ́lára | Obìnrin tó n gòkè | Obìnrin tó n gòkè: amɔ́lára</annotation>
+		<annotation cp="🧗🏻‍♀">agùnkè | amɔ́lára | Obìnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏻‍♀" type="tts">Obìnrin tó n gòkè: amɔ́lára</annotation>
-		<annotation cp="🧗🏼‍♀">agùnkè | amɔ́lára díɛ̀ | Obìnrin tó n gòkè | Obìnrin tó n gòkè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🧗🏼‍♀">agùnkè | amɔ́lára díɛ̀ | Obìnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏼‍♀" type="tts">Obìnrin tó n gòkè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧗🏽‍♀">agùnkè | amɔ́láwɔ̀ díɛ̀ | Obìnrin tó n gòkè | Obìnrin tó n gòkè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧗🏽‍♀">agùnkè | amɔ́láwɔ̀ díɛ̀ | Obìnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏽‍♀" type="tts">Obìnrin tó n gòkè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧗🏾‍♀">adúláwɔ̀ díɛ̀ | agùnkè | Obìnrin tó n gòkè | Obìnrin tó n gòkè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🧗🏾‍♀">adúláwɔ̀ díɛ̀ | agùnkè | Obìnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏾‍♀" type="tts">Obìnrin tó n gòkè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧗🏿‍♀">adúláwɔ̀ | agùnkè | Obìnrin tó n gòkè | Obìnrin tó n gòkè: adúláwɔ̀</annotation>
+		<annotation cp="🧗🏿‍♀">adúláwɔ̀ | agùnkè | Obìnrin tó n gòkè</annotation>
 		<annotation cp="🧗🏿‍♀" type="tts">Obìnrin tó n gòkè: adúláwɔ̀</annotation>
-		<annotation cp="🏇🏻">amɔ́lára | eré ɛlɛ́shin | Ereje Ɛlɛsin | Ereje Ɛlɛsin: amɔ́lára | ɛshin | ìdíje eré</annotation>
+		<annotation cp="🏇🏻">amɔ́lára | eré ɛlɛ́shin | Ereje Ɛlɛsin | ɛshin | ìdíje eré</annotation>
 		<annotation cp="🏇🏻" type="tts">Ereje Ɛlɛsin: amɔ́lára</annotation>
-		<annotation cp="🏇🏼">amɔ́lára díɛ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | Ereje Ɛlɛsin: amɔ́lára díɛ̀ | ɛshin | ìdíje eré</annotation>
+		<annotation cp="🏇🏼">amɔ́lára díɛ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | ɛshin | ìdíje eré</annotation>
 		<annotation cp="🏇🏼" type="tts">Ereje Ɛlɛsin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏇🏽">amɔ́láwɔ̀ díɛ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | Ereje Ɛlɛsin: amɔ́láwɔ̀ díɛ̀ | ɛshin | ìdíje eré</annotation>
+		<annotation cp="🏇🏽">amɔ́láwɔ̀ díɛ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | ɛshin | ìdíje eré</annotation>
 		<annotation cp="🏇🏽" type="tts">Ereje Ɛlɛsin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏇🏾">adúláwɔ̀ díɛ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | Ereje Ɛlɛsin: adúláwɔ̀ díɛ̀ | ɛshin | ìdíje eré</annotation>
+		<annotation cp="🏇🏾">adúláwɔ̀ díɛ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | ɛshin | ìdíje eré</annotation>
 		<annotation cp="🏇🏾" type="tts">Ereje Ɛlɛsin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏇🏿">adúláwɔ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | Ereje Ɛlɛsin: adúláwɔ̀ | ɛshin | ìdíje eré</annotation>
+		<annotation cp="🏇🏿">adúláwɔ̀ | eré ɛlɛ́shin | Ereje Ɛlɛsin | ɛshin | ìdíje eré</annotation>
 		<annotation cp="🏇🏿" type="tts">Ereje Ɛlɛsin: adúláwɔ̀</annotation>
-		<annotation cp="🏂🏻">amɔ́lára | ìsheré orí yìnyín | Ishere Ori Yiyin | Ishere Ori Yiyin: amɔ́lára | síkì | yìnyín</annotation>
+		<annotation cp="🏂🏻">amɔ́lára | ìsheré orí yìnyín | Ishere Ori Yiyin | síkì | yìnyín</annotation>
 		<annotation cp="🏂🏻" type="tts">Ishere Ori Yiyin: amɔ́lára</annotation>
-		<annotation cp="🏂🏼">amɔ́lára díɛ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | Ishere Ori Yiyin: amɔ́lára díɛ̀ | síkì | yìnyín</annotation>
+		<annotation cp="🏂🏼">amɔ́lára díɛ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | síkì | yìnyín</annotation>
 		<annotation cp="🏂🏼" type="tts">Ishere Ori Yiyin: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏂🏽">amɔ́láwɔ̀ díɛ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | Ishere Ori Yiyin: amɔ́láwɔ̀ díɛ̀ | síkì | yìnyín</annotation>
+		<annotation cp="🏂🏽">amɔ́láwɔ̀ díɛ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | síkì | yìnyín</annotation>
 		<annotation cp="🏂🏽" type="tts">Ishere Ori Yiyin: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏂🏾">adúláwɔ̀ díɛ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | Ishere Ori Yiyin: adúláwɔ̀ díɛ̀ | síkì | yìnyín</annotation>
+		<annotation cp="🏂🏾">adúláwɔ̀ díɛ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | síkì | yìnyín</annotation>
 		<annotation cp="🏂🏾" type="tts">Ishere Ori Yiyin: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏂🏿">adúláwɔ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | Ishere Ori Yiyin: adúláwɔ̀ | síkì | yìnyín</annotation>
+		<annotation cp="🏂🏿">adúláwɔ̀ | ìsheré orí yìnyín | Ishere Ori Yiyin | síkì | yìnyín</annotation>
 		<annotation cp="🏂🏿" type="tts">Ishere Ori Yiyin: adúláwɔ̀</annotation>
-		<annotation cp="🏌🏻">amɔ́lára | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | ɛni gɔ́ɔ̀fù: amɔ́lára | gɔ́ɔ̀fù</annotation>
+		<annotation cp="🏌🏻">amɔ́lára | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏻" type="tts">ɛni gɔ́ɔ̀fù: amɔ́lára</annotation>
-		<annotation cp="🏌🏼">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | ɛni gɔ́ɔ̀fù: amɔ́lára díɛ̀ | gɔ́ɔ̀fù</annotation>
+		<annotation cp="🏌🏼">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏼" type="tts">ɛni gɔ́ɔ̀fù: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏌🏽">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | ɛni gɔ́ɔ̀fù: amɔ́láwɔ̀ díɛ̀ | gɔ́ɔ̀fù</annotation>
+		<annotation cp="🏌🏽">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏽" type="tts">ɛni gɔ́ɔ̀fù: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏌🏾">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | ɛni gɔ́ɔ̀fù: adúláwɔ̀ díɛ̀ | gɔ́ɔ̀fù</annotation>
+		<annotation cp="🏌🏾">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏾" type="tts">ɛni gɔ́ɔ̀fù: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏌🏿">adúláwɔ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | ɛni gɔ́ɔ̀fù: adúláwɔ̀ | gɔ́ɔ̀fù</annotation>
+		<annotation cp="🏌🏿">adúláwɔ̀ | bɔ́ɔ̀lù | ɛni gɔ́ɔ̀fù | gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏿" type="tts">ɛni gɔ́ɔ̀fù: adúláwɔ̀</annotation>
-		<annotation cp="🏌🏻‍♂">amɔ́lára | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù | ɔkùnrin tí ń gɔ́ɔ̀fù: amɔ́lára</annotation>
+		<annotation cp="🏌🏻‍♂">amɔ́lára | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏻‍♂" type="tts">ɔkùnrin tí ń gɔ́ɔ̀fù: amɔ́lára</annotation>
-		<annotation cp="🏌🏼‍♂">amɔ́lára díɛ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù | ɔkùnrin tí ń gɔ́ɔ̀fù: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🏌🏼‍♂">amɔ́lára díɛ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏼‍♂" type="tts">ɔkùnrin tí ń gɔ́ɔ̀fù: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏌🏽‍♂">amɔ́láwɔ̀ díɛ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù | ɔkùnrin tí ń gɔ́ɔ̀fù: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏌🏽‍♂">amɔ́láwɔ̀ díɛ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏽‍♂" type="tts">ɔkùnrin tí ń gɔ́ɔ̀fù: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏌🏾‍♂">adúláwɔ̀ díɛ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù | ɔkùnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏌🏾‍♂">adúláwɔ̀ díɛ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏾‍♂" type="tts">ɔkùnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏌🏿‍♂">adúláwɔ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù | ɔkùnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀</annotation>
+		<annotation cp="🏌🏿‍♂">adúláwɔ̀ | gɔ́ɔ̀fù | ɔkùnrin | ɔkùnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏿‍♂" type="tts">ɔkùnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀</annotation>
-		<annotation cp="🏌🏻‍♀">amɔ́lára | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù | obìnrin tí ń gɔ́ɔ̀fù: amɔ́lára</annotation>
+		<annotation cp="🏌🏻‍♀">amɔ́lára | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏻‍♀" type="tts">obìnrin tí ń gɔ́ɔ̀fù: amɔ́lára</annotation>
-		<annotation cp="🏌🏼‍♀">amɔ́lára díɛ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù | obìnrin tí ń gɔ́ɔ̀fù: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🏌🏼‍♀">amɔ́lára díɛ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏼‍♀" type="tts">obìnrin tí ń gɔ́ɔ̀fù: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏌🏽‍♀">amɔ́láwɔ̀ díɛ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù | obìnrin tí ń gɔ́ɔ̀fù: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏌🏽‍♀">amɔ́láwɔ̀ díɛ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏽‍♀" type="tts">obìnrin tí ń gɔ́ɔ̀fù: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏌🏾‍♀">adúláwɔ̀ díɛ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù | obìnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏌🏾‍♀">adúláwɔ̀ díɛ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏾‍♀" type="tts">obìnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏌🏿‍♀">adúláwɔ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù | obìnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀</annotation>
+		<annotation cp="🏌🏿‍♀">adúláwɔ̀ | gɔ́ɔ̀fù | obìnrin | obìnrin tí ń gɔ́ɔ̀fù</annotation>
 		<annotation cp="🏌🏿‍♀" type="tts">obìnrin tí ń gɔ́ɔ̀fù: adúláwɔ̀</annotation>
-		<annotation cp="🏄🏻">amɔ́lára | Ɛni N Gun Iji | Ɛni N Gun Iji: amɔ́lára | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏻">amɔ́lára | Ɛni N Gun Iji | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏻" type="tts">Ɛni N Gun Iji: amɔ́lára</annotation>
-		<annotation cp="🏄🏼">amɔ́lára díɛ̀ | Ɛni N Gun Iji | Ɛni N Gun Iji: amɔ́lára díɛ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏼">amɔ́lára díɛ̀ | Ɛni N Gun Iji | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏼" type="tts">Ɛni N Gun Iji: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏄🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Gun Iji | Ɛni N Gun Iji: amɔ́láwɔ̀ díɛ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N Gun Iji | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏽" type="tts">Ɛni N Gun Iji: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏄🏾">adúláwɔ̀ díɛ̀ | Ɛni N Gun Iji | Ɛni N Gun Iji: adúláwɔ̀ díɛ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏾">adúláwɔ̀ díɛ̀ | Ɛni N Gun Iji | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏾" type="tts">Ɛni N Gun Iji: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏄🏿">adúláwɔ̀ | Ɛni N Gun Iji | Ɛni N Gun Iji: adúláwɔ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏿">adúláwɔ̀ | Ɛni N Gun Iji | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏿" type="tts">Ɛni N Gun Iji: adúláwɔ̀</annotation>
-		<annotation cp="🏄🏻‍♂">amɔ́lára | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | ɔkùnrin tí ń wá íńtánɛ́tì: amɔ́lára | tí ń wá íńtánɛ́tì</annotation>
+		<annotation cp="🏄🏻‍♂">amɔ́lára | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | tí ń wá íńtánɛ́tì</annotation>
 		<annotation cp="🏄🏻‍♂" type="tts">ɔkùnrin tí ń wá íńtánɛ́tì: amɔ́lára</annotation>
-		<annotation cp="🏄🏼‍♂">amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | ɔkùnrin tí ń wá íńtánɛ́tì: amɔ́lára díɛ̀ | tí ń wá íńtánɛ́tì</annotation>
+		<annotation cp="🏄🏼‍♂">amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | tí ń wá íńtánɛ́tì</annotation>
 		<annotation cp="🏄🏼‍♂" type="tts">ɔkùnrin tí ń wá íńtánɛ́tì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏄🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | ɔkùnrin tí ń wá íńtánɛ́tì: amɔ́láwɔ̀ díɛ̀ | tí ń wá íńtánɛ́tì</annotation>
+		<annotation cp="🏄🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | tí ń wá íńtánɛ́tì</annotation>
 		<annotation cp="🏄🏽‍♂" type="tts">ɔkùnrin tí ń wá íńtánɛ́tì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏄🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | ɔkùnrin tí ń wá íńtánɛ́tì: adúláwɔ̀ díɛ̀ | tí ń wá íńtánɛ́tì</annotation>
+		<annotation cp="🏄🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | tí ń wá íńtánɛ́tì</annotation>
 		<annotation cp="🏄🏾‍♂" type="tts">ɔkùnrin tí ń wá íńtánɛ́tì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏄🏿‍♂">adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | ɔkùnrin tí ń wá íńtánɛ́tì: adúláwɔ̀ | tí ń wá íńtánɛ́tì</annotation>
+		<annotation cp="🏄🏿‍♂">adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń wá íńtánɛ́tì | tí ń wá íńtánɛ́tì</annotation>
 		<annotation cp="🏄🏿‍♂" type="tts">ɔkùnrin tí ń wá íńtánɛ́tì: adúláwɔ̀</annotation>
-		<annotation cp="🏄🏻‍♀">amɔ́lára | obìnrín | obìnrín tí ń wá íńtánɛ́tì | obìnrín tí ń wá íńtánɛ́tì: amɔ́lára | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏻‍♀">amɔ́lára | obìnrín | obìnrín tí ń wá íńtánɛ́tì | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏻‍♀" type="tts">obìnrín tí ń wá íńtánɛ́tì: amɔ́lára</annotation>
-		<annotation cp="🏄🏼‍♀">amɔ́lára díɛ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | obìnrín tí ń wá íńtánɛ́tì: amɔ́lára díɛ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏼‍♀">amɔ́lára díɛ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏼‍♀" type="tts">obìnrín tí ń wá íńtánɛ́tì: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏄🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | obìnrín tí ń wá íńtánɛ́tì: amɔ́láwɔ̀ díɛ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏽‍♀" type="tts">obìnrín tí ń wá íńtánɛ́tì: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏄🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | obìnrín tí ń wá íńtánɛ́tì: adúláwɔ̀ díɛ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏾‍♀" type="tts">obìnrín tí ń wá íńtánɛ́tì: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏄🏿‍♀">adúláwɔ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | obìnrín tí ń wá íńtánɛ́tì: adúláwɔ̀ | wíwáìtanɛti</annotation>
+		<annotation cp="🏄🏿‍♀">adúláwɔ̀ | obìnrín | obìnrín tí ń wá íńtánɛ́tì | wíwáìtanɛti</annotation>
 		<annotation cp="🏄🏿‍♀" type="tts">obìnrín tí ń wá íńtánɛ́tì: adúláwɔ̀</annotation>
-		<annotation cp="🚣🏻">amɔ́lára | Ɛni N wa Ɔkɔ | Ɛni N wa Ɔkɔ: amɔ́lára | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
+		<annotation cp="🚣🏻">amɔ́lára | Ɛni N wa Ɔkɔ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
 		<annotation cp="🚣🏻" type="tts">Ɛni N wa Ɔkɔ: amɔ́lára</annotation>
-		<annotation cp="🚣🏼">amɔ́lára díɛ̀ | Ɛni N wa Ɔkɔ | Ɛni N wa Ɔkɔ: amɔ́lára díɛ̀ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
+		<annotation cp="🚣🏼">amɔ́lára díɛ̀ | Ɛni N wa Ɔkɔ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
 		<annotation cp="🚣🏼" type="tts">Ɛni N wa Ɔkɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚣🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N wa Ɔkɔ | Ɛni N wa Ɔkɔ: amɔ́láwɔ̀ díɛ̀ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
+		<annotation cp="🚣🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N wa Ɔkɔ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
 		<annotation cp="🚣🏽" type="tts">Ɛni N wa Ɔkɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚣🏾">adúláwɔ̀ díɛ̀ | Ɛni N wa Ɔkɔ | Ɛni N wa Ɔkɔ: adúláwɔ̀ díɛ̀ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
+		<annotation cp="🚣🏾">adúláwɔ̀ díɛ̀ | Ɛni N wa Ɔkɔ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
 		<annotation cp="🚣🏾" type="tts">Ɛni N wa Ɔkɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚣🏿">adúláwɔ̀ | Ɛni N wa Ɔkɔ | Ɛni N wa Ɔkɔ: adúláwɔ̀ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
+		<annotation cp="🚣🏿">adúláwɔ̀ | Ɛni N wa Ɔkɔ | kɔ́ ojú omi kékeré | ɔkɔ̀ ojú omi</annotation>
 		<annotation cp="🚣🏿" type="tts">Ɛni N wa Ɔkɔ: adúláwɔ̀</annotation>
-		<annotation cp="🚣🏻‍♂">amɔ́lára | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára</annotation>
+		<annotation cp="🚣🏻‍♂">amɔ́lára | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré</annotation>
 		<annotation cp="🚣🏻‍♂" type="tts">ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára</annotation>
-		<annotation cp="🚣🏼‍♂">amɔ́lára díɛ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🚣🏼‍♂">amɔ́lára díɛ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré</annotation>
 		<annotation cp="🚣🏼‍♂" type="tts">ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚣🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚣🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré</annotation>
 		<annotation cp="🚣🏽‍♂" type="tts">ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚣🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚣🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré</annotation>
 		<annotation cp="🚣🏾‍♂" type="tts">ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚣🏿‍♂">adúláwɔ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀</annotation>
+		<annotation cp="🚣🏿‍♂">adúláwɔ̀ | ɔkɔ̀ ojú omi | ɔkɔ̀ ojú omo kékeré | ɔkùnrin | ɔkùnrin tí ń wakɔ̀ ojú omo kékeré</annotation>
 		<annotation cp="🚣🏿‍♂" type="tts">ɔkùnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀</annotation>
-		<annotation cp="🚣🏻‍♀">amɔ́lára | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
+		<annotation cp="🚣🏻‍♀">amɔ́lára | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
 		<annotation cp="🚣🏻‍♀" type="tts">obìnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára</annotation>
-		<annotation cp="🚣🏼‍♀">amɔ́lára díɛ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára díɛ̀ | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
+		<annotation cp="🚣🏼‍♀">amɔ́lára díɛ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
 		<annotation cp="🚣🏼‍♀" type="tts">obìnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚣🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́láwɔ̀ díɛ̀ | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
+		<annotation cp="🚣🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
 		<annotation cp="🚣🏽‍♀" type="tts">obìnrin tí ń wakɔ̀ ojú omo kékeré: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚣🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀ díɛ̀ | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
+		<annotation cp="🚣🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
 		<annotation cp="🚣🏾‍♀" type="tts">obìnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚣🏿‍♀">adúláwɔ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀ | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
+		<annotation cp="🚣🏿‍♀">adúláwɔ̀ | obìnrin tí ń wakɔ̀ ojú omo kékeré | obìrin | ɔkɔ̀ ojú omi | ɔkɔ́ ojú omi kékeré</annotation>
 		<annotation cp="🚣🏿‍♀" type="tts">obìnrin tí ń wakɔ̀ ojú omo kékeré: adúláwɔ̀</annotation>
-		<annotation cp="🏊🏻">amɔ́lára | Ɛni tí ń wɛdò | Ɛni tí ń wɛdò: amɔ́lára | wɛdò</annotation>
+		<annotation cp="🏊🏻">amɔ́lára | Ɛni tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏻" type="tts">Ɛni tí ń wɛdò: amɔ́lára</annotation>
-		<annotation cp="🏊🏼">amɔ́lára díɛ̀ | Ɛni tí ń wɛdò | Ɛni tí ń wɛdò: amɔ́lára díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏼">amɔ́lára díɛ̀ | Ɛni tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏼" type="tts">Ɛni tí ń wɛdò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏊🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni tí ń wɛdò | Ɛni tí ń wɛdò: amɔ́láwɔ̀ díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏽" type="tts">Ɛni tí ń wɛdò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏊🏾">adúláwɔ̀ díɛ̀ | Ɛni tí ń wɛdò | Ɛni tí ń wɛdò: adúláwɔ̀ díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏾">adúláwɔ̀ díɛ̀ | Ɛni tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏾" type="tts">Ɛni tí ń wɛdò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏊🏿">adúláwɔ̀ | Ɛni tí ń wɛdò | Ɛni tí ń wɛdò: adúláwɔ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏿">adúláwɔ̀ | Ɛni tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏿" type="tts">Ɛni tí ń wɛdò: adúláwɔ̀</annotation>
-		<annotation cp="🏊🏻‍♂">amɔ́lára | ɔkùnrin | ɔkùnrin tí ń wɛdò | ɔkùnrin tí ń wɛdò: amɔ́lára | wɛdò</annotation>
+		<annotation cp="🏊🏻‍♂">amɔ́lára | ɔkùnrin | ɔkùnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏻‍♂" type="tts">ɔkùnrin tí ń wɛdò: amɔ́lára</annotation>
-		<annotation cp="🏊🏼‍♂">amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | ɔkùnrin tí ń wɛdò: amɔ́lára díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏼‍♂">amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏼‍♂" type="tts">ɔkùnrin tí ń wɛdò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏊🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | ɔkùnrin tí ń wɛdò: amɔ́láwɔ̀ díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏽‍♂" type="tts">ɔkùnrin tí ń wɛdò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏊🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | ɔkùnrin tí ń wɛdò: adúláwɔ̀ díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏾‍♂">adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏾‍♂" type="tts">ɔkùnrin tí ń wɛdò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏊🏿‍♂">adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | ɔkùnrin tí ń wɛdò: adúláwɔ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏿‍♂">adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏿‍♂" type="tts">ɔkùnrin tí ń wɛdò: adúláwɔ̀</annotation>
-		<annotation cp="🏊🏻‍♀">amɔ́lára | obìnrin | obìnrin tí ń wɛdò | obìnrin tí ń wɛdò: amɔ́lára | wɛdò</annotation>
+		<annotation cp="🏊🏻‍♀">amɔ́lára | obìnrin | obìnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏻‍♀" type="tts">obìnrin tí ń wɛdò: amɔ́lára</annotation>
-		<annotation cp="🏊🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin tí ń wɛdò | obìnrin tí ń wɛdò: amɔ́lára díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏼‍♀">amɔ́lára díɛ̀ | obìnrin | obìnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏼‍♀" type="tts">obìnrin tí ń wɛdò: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏊🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń wɛdò | obìnrin tí ń wɛdò: amɔ́láwɔ̀ díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏽‍♀">amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏽‍♀" type="tts">obìnrin tí ń wɛdò: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏊🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń wɛdò | obìnrin tí ń wɛdò: adúláwɔ̀ díɛ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏾‍♀">adúláwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏾‍♀" type="tts">obìnrin tí ń wɛdò: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏊🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin tí ń wɛdò | obìnrin tí ń wɛdò: adúláwɔ̀ | wɛdò</annotation>
+		<annotation cp="🏊🏿‍♀">adúláwɔ̀ | obìnrin | obìnrin tí ń wɛdò | wɛdò</annotation>
 		<annotation cp="🏊🏿‍♀" type="tts">obìnrin tí ń wɛdò: adúláwɔ̀</annotation>
-		<annotation cp="⛹🏻">amɔ́lára | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù: amɔ́lára</annotation>
+		<annotation cp="⛹🏻">amɔ́lára | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏻" type="tts">ɛni tà boun bɔ́ɔ̀lù: amɔ́lára</annotation>
-		<annotation cp="⛹🏼">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù: amɔ́lára díɛ̀</annotation>
+		<annotation cp="⛹🏼">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏼" type="tts">ɛni tà boun bɔ́ɔ̀lù: amɔ́lára díɛ̀</annotation>
-		<annotation cp="⛹🏽">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="⛹🏽">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏽" type="tts">ɛni tà boun bɔ́ɔ̀lù: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="⛹🏾">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="⛹🏾">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏾" type="tts">ɛni tà boun bɔ́ɔ̀lù: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="⛹🏿">adúláwɔ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù: adúláwɔ̀</annotation>
+		<annotation cp="⛹🏿">adúláwɔ̀ | bɔ́ɔ̀lù | ɛni tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏿" type="tts">ɛni tà boun bɔ́ɔ̀lù: adúláwɔ̀</annotation>
-		<annotation cp="⛹🏻‍♂">amɔ́lára | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: amɔ́lára</annotation>
+		<annotation cp="⛹🏻‍♂">amɔ́lára | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏻‍♂" type="tts">ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: amɔ́lára</annotation>
-		<annotation cp="⛹🏼‍♂">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: amɔ́lára díɛ̀</annotation>
+		<annotation cp="⛹🏼‍♂">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏼‍♂" type="tts">ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: amɔ́lára díɛ̀</annotation>
-		<annotation cp="⛹🏽‍♂">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="⛹🏽‍♂">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏽‍♂" type="tts">ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="⛹🏾‍♂">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="⛹🏾‍♂">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏾‍♂" type="tts">ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="⛹🏿‍♂">adúláwɔ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: adúláwɔ̀</annotation>
+		<annotation cp="⛹🏿‍♂">adúláwɔ̀ | bɔ́ɔ̀lù | ɔkùnrin | ɔkùnrin tí ń tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏿‍♂" type="tts">ɔkùnrin tí ń tà boun bɔ́ɔ̀lù: adúláwɔ̀</annotation>
-		<annotation cp="⛹🏻‍♀">amɔ́lára | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù | obìnrin tà boun bɔ́ɔ̀lù: amɔ́lára</annotation>
+		<annotation cp="⛹🏻‍♀">amɔ́lára | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏻‍♀" type="tts">obìnrin tà boun bɔ́ɔ̀lù: amɔ́lára</annotation>
-		<annotation cp="⛹🏼‍♀">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù | obìnrin tà boun bɔ́ɔ̀lù: amɔ́lára díɛ̀</annotation>
+		<annotation cp="⛹🏼‍♀">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏼‍♀" type="tts">obìnrin tà boun bɔ́ɔ̀lù: amɔ́lára díɛ̀</annotation>
-		<annotation cp="⛹🏽‍♀">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù | obìnrin tà boun bɔ́ɔ̀lù: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="⛹🏽‍♀">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏽‍♀" type="tts">obìnrin tà boun bɔ́ɔ̀lù: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="⛹🏾‍♀">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù | obìnrin tà boun bɔ́ɔ̀lù: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="⛹🏾‍♀">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏾‍♀" type="tts">obìnrin tà boun bɔ́ɔ̀lù: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="⛹🏿‍♀">adúláwɔ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù | obìnrin tà boun bɔ́ɔ̀lù: adúláwɔ̀</annotation>
+		<annotation cp="⛹🏿‍♀">adúláwɔ̀ | bɔ́ɔ̀lù | obìnrin | obìnrin tà boun bɔ́ɔ̀lù</annotation>
 		<annotation cp="⛹🏿‍♀" type="tts">obìnrin tà boun bɔ́ɔ̀lù: adúláwɔ̀</annotation>
-		<annotation cp="🏋🏻">a fà ńkan sókè | amɔ́lára | ɛni fa ìwɔ̀n sókè | ɛni fa ìwɔ̀n sókè: amɔ́lára | ìwɔ̀n</annotation>
+		<annotation cp="🏋🏻">a fà ńkan sókè | amɔ́lára | ɛni fa ìwɔ̀n sókè | ìwɔ̀n</annotation>
 		<annotation cp="🏋🏻" type="tts">ɛni fa ìwɔ̀n sókè: amɔ́lára</annotation>
-		<annotation cp="🏋🏼">a fà ńkan sókè | amɔ́lára díɛ̀ | ɛni fa ìwɔ̀n sókè | ɛni fa ìwɔ̀n sókè: amɔ́lára díɛ̀ | ìwɔ̀n</annotation>
+		<annotation cp="🏋🏼">a fà ńkan sókè | amɔ́lára díɛ̀ | ɛni fa ìwɔ̀n sókè | ìwɔ̀n</annotation>
 		<annotation cp="🏋🏼" type="tts">ɛni fa ìwɔ̀n sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏋🏽">a fà ńkan sókè | amɔ́láwɔ̀ díɛ̀ | ɛni fa ìwɔ̀n sókè | ɛni fa ìwɔ̀n sókè: amɔ́láwɔ̀ díɛ̀ | ìwɔ̀n</annotation>
+		<annotation cp="🏋🏽">a fà ńkan sókè | amɔ́láwɔ̀ díɛ̀ | ɛni fa ìwɔ̀n sókè | ìwɔ̀n</annotation>
 		<annotation cp="🏋🏽" type="tts">ɛni fa ìwɔ̀n sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏋🏾">a fà ńkan sókè | adúláwɔ̀ díɛ̀ | ɛni fa ìwɔ̀n sókè | ɛni fa ìwɔ̀n sókè: adúláwɔ̀ díɛ̀ | ìwɔ̀n</annotation>
+		<annotation cp="🏋🏾">a fà ńkan sókè | adúláwɔ̀ díɛ̀ | ɛni fa ìwɔ̀n sókè | ìwɔ̀n</annotation>
 		<annotation cp="🏋🏾" type="tts">ɛni fa ìwɔ̀n sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏋🏿">a fà ńkan sókè | adúláwɔ̀ | ɛni fa ìwɔ̀n sókè | ɛni fa ìwɔ̀n sókè: adúláwɔ̀ | ìwɔ̀n</annotation>
+		<annotation cp="🏋🏿">a fà ńkan sókè | adúláwɔ̀ | ɛni fa ìwɔ̀n sókè | ìwɔ̀n</annotation>
 		<annotation cp="🏋🏿" type="tts">ɛni fa ìwɔ̀n sókè: adúláwɔ̀</annotation>
-		<annotation cp="🏋🏻‍♂">a fà ìwɔ̀n sókè | amɔ́lára | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè | ɔkùnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára</annotation>
+		<annotation cp="🏋🏻‍♂">a fà ìwɔ̀n sókè | amɔ́lára | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏻‍♂" type="tts">ɔkùnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára</annotation>
-		<annotation cp="🏋🏼‍♂">a fà ìwɔ̀n sókè | amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè | ɔkùnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🏋🏼‍♂">a fà ìwɔ̀n sókè | amɔ́lára díɛ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏼‍♂" type="tts">ɔkùnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏋🏽‍♂">a fà ìwɔ̀n sókè | amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè | ɔkùnrin tí ń a fà ìwɔ̀n sókè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏋🏽‍♂">a fà ìwɔ̀n sókè | amɔ́láwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏽‍♂" type="tts">ɔkùnrin tí ń a fà ìwɔ̀n sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏋🏾‍♂">a fà ìwɔ̀n sókè | adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè | ɔkùnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏋🏾‍♂">a fà ìwɔ̀n sókè | adúláwɔ̀ díɛ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏾‍♂" type="tts">ɔkùnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏋🏿‍♂">a fà ìwɔ̀n sókè | adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè | ɔkùnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀</annotation>
+		<annotation cp="🏋🏿‍♂">a fà ìwɔ̀n sókè | adúláwɔ̀ | ɔkùnrin | ɔkùnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏿‍♂" type="tts">ɔkùnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀</annotation>
-		<annotation cp="🏋🏻‍♀">a fà ìwɔ̀n sókè | amɔ́lára | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè | obìnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára</annotation>
+		<annotation cp="🏋🏻‍♀">a fà ìwɔ̀n sókè | amɔ́lára | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏻‍♀" type="tts">obìnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára</annotation>
-		<annotation cp="🏋🏼‍♀">a fà ìwɔ̀n sókè | amɔ́lára díɛ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè | obìnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🏋🏼‍♀">a fà ìwɔ̀n sókè | amɔ́lára díɛ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏼‍♀" type="tts">obìnrin tí ń a fà ìwɔ̀n sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🏋🏽‍♀">a fà ìwɔ̀n sókè | amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè | obìnrin tí ń a fà ìwɔ̀n sókè: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏋🏽‍♀">a fà ìwɔ̀n sókè | amɔ́láwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏽‍♀" type="tts">obìnrin tí ń a fà ìwɔ̀n sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏋🏾‍♀">a fà ìwɔ̀n sókè | adúláwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè | obìnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🏋🏾‍♀">a fà ìwɔ̀n sókè | adúláwɔ̀ díɛ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏾‍♀" type="tts">obìnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🏋🏿‍♀">a fà ìwɔ̀n sókè | adúláwɔ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè | obìnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀</annotation>
+		<annotation cp="🏋🏿‍♀">a fà ìwɔ̀n sókè | adúláwɔ̀ | obìnrin | obìnrin tí ń a fà ìwɔ̀n sókè</annotation>
 		<annotation cp="🏋🏿‍♀" type="tts">obìnrin tí ń a fà ìwɔ̀n sókè: adúláwɔ̀</annotation>
-		<annotation cp="🚴🏻">amɔ́lára | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | Ɛni N Gun Kɛkɛ: amɔ́lára | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
+		<annotation cp="🚴🏻">amɔ́lára | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏻" type="tts">Ɛni N Gun Kɛkɛ: amɔ́lára</annotation>
-		<annotation cp="🚴🏼">amɔ́lára díɛ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | Ɛni N Gun Kɛkɛ: amɔ́lára díɛ̀ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
+		<annotation cp="🚴🏼">amɔ́lára díɛ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏼" type="tts">Ɛni N Gun Kɛkɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚴🏽">amɔ́láwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | Ɛni N Gun Kɛkɛ: amɔ́láwɔ̀ díɛ̀ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
+		<annotation cp="🚴🏽">amɔ́láwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏽" type="tts">Ɛni N Gun Kɛkɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚴🏾">adúláwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | Ɛni N Gun Kɛkɛ: adúláwɔ̀ díɛ̀ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
+		<annotation cp="🚴🏾">adúláwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏾" type="tts">Ɛni N Gun Kɛkɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚴🏿">adúláwɔ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | Ɛni N Gun Kɛkɛ: adúláwɔ̀ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
+		<annotation cp="🚴🏿">adúláwɔ̀ | awa kɛ̀kɛ́ | Ɛni N Gun Kɛkɛ | ìwákɛ̀kɛ́ | kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏿" type="tts">Ɛni N Gun Kɛkɛ: adúláwɔ̀</annotation>
-		<annotation cp="🚴🏻‍♂">amɔ́lára | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́ | ɔkùnrin tí ń wa kɛ̀kɛ́: amɔ́lára</annotation>
+		<annotation cp="🚴🏻‍♂">amɔ́lára | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏻‍♂" type="tts">ɔkùnrin tí ń wa kɛ̀kɛ́: amɔ́lára</annotation>
-		<annotation cp="🚴🏼‍♂">amɔ́lára díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́ | ɔkùnrin tí ń wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🚴🏼‍♂">amɔ́lára díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏼‍♂" type="tts">ɔkùnrin tí ń wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚴🏽‍♂">amɔ́láwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́ | ɔkùnrin tí ń wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚴🏽‍♂">amɔ́láwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏽‍♂" type="tts">ɔkùnrin tí ń wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚴🏾‍♂">adúláwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́ | ɔkùnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚴🏾‍♂">adúláwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏾‍♂" type="tts">ɔkùnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚴🏿‍♂">adúláwɔ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́ | ɔkùnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀</annotation>
+		<annotation cp="🚴🏿‍♂">adúláwɔ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | ɔkùnrin | ɔkùnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏿‍♂" type="tts">ɔkùnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🚴🏻‍♀">amɔ́lára | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́ | obìnrin tí ń wa kɛ̀kɛ́: amɔ́lára</annotation>
+		<annotation cp="🚴🏻‍♀">amɔ́lára | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏻‍♀" type="tts">obìnrin tí ń wa kɛ̀kɛ́: amɔ́lára</annotation>
-		<annotation cp="🚴🏼‍♀">amɔ́lára díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́ | obìnrin tí ń wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🚴🏼‍♀">amɔ́lára díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏼‍♀" type="tts">obìnrin tí ń wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚴🏽‍♀">amɔ́láwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́ | obìnrin tí ń wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚴🏽‍♀">amɔ́láwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏽‍♀" type="tts">obìnrin tí ń wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚴🏾‍♀">adúláwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́ | obìnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚴🏾‍♀">adúláwɔ̀ díɛ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏾‍♀" type="tts">obìnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚴🏿‍♀">adúláwɔ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́ | obìnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀</annotation>
+		<annotation cp="🚴🏿‍♀">adúláwɔ̀ | awa kɛ̀kɛ́ | ìwákɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tí ń wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚴🏿‍♀" type="tts">obìnrin tí ń wa kɛ̀kɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🚵🏻">amɔ́lára | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | Ɛni N Gun Kɛkɛ Gun Apata: amɔ́lára | kɛ̀kɛ́ | òkè</annotation>
+		<annotation cp="🚵🏻">amɔ́lára | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏻" type="tts">Ɛni N Gun Kɛkɛ Gun Apata: amɔ́lára</annotation>
-		<annotation cp="🚵🏼">amɔ́lára díɛ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | Ɛni N Gun Kɛkɛ Gun Apata: amɔ́lára díɛ̀ | kɛ̀kɛ́ | òkè</annotation>
+		<annotation cp="🚵🏼">amɔ́lára díɛ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏼" type="tts">Ɛni N Gun Kɛkɛ Gun Apata: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚵🏽">amɔ́láwɔ̀ díɛ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | Ɛni N Gun Kɛkɛ Gun Apata: amɔ́láwɔ̀ díɛ̀ | kɛ̀kɛ́ | òkè</annotation>
+		<annotation cp="🚵🏽">amɔ́láwɔ̀ díɛ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏽" type="tts">Ɛni N Gun Kɛkɛ Gun Apata: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚵🏾">adúláwɔ̀ díɛ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | Ɛni N Gun Kɛkɛ Gun Apata: adúláwɔ̀ díɛ̀ | kɛ̀kɛ́ | òkè</annotation>
+		<annotation cp="🚵🏾">adúláwɔ̀ díɛ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏾" type="tts">Ɛni N Gun Kɛkɛ Gun Apata: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚵🏿">adúláwɔ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | Ɛni N Gun Kɛkɛ Gun Apata: adúláwɔ̀ | kɛ̀kɛ́ | òkè</annotation>
+		<annotation cp="🚵🏿">adúláwɔ̀ | awakɛ̀kɛ́ | Ɛni N Gun Kɛkɛ Gun Apata | kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏿" type="tts">Ɛni N Gun Kɛkɛ Gun Apata: adúláwɔ̀</annotation>
-		<annotation cp="🚵🏻‍♂">amɔ́lára | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́ | ɔkùnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára</annotation>
+		<annotation cp="🚵🏻‍♂">amɔ́lára | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚵🏻‍♂" type="tts">ɔkùnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára</annotation>
-		<annotation cp="🚵🏼‍♂">amɔ́lára díɛ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́ | ɔkùnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🚵🏼‍♂">amɔ́lára díɛ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚵🏼‍♂" type="tts">ɔkùnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚵🏽‍♂">amɔ́láwɔ̀ díɛ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́ | ɔkùnrin tín gùn kè wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚵🏽‍♂">amɔ́láwɔ̀ díɛ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚵🏽‍♂" type="tts">ɔkùnrin tín gùn kè wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚵🏾‍♂">adúláwɔ̀ díɛ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́ | ɔkùnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🚵🏾‍♂">adúláwɔ̀ díɛ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚵🏾‍♂" type="tts">ɔkùnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚵🏿‍♂">adúláwɔ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́ | ɔkùnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀</annotation>
+		<annotation cp="🚵🏿‍♂">adúláwɔ̀ | awakɛ̀kɛ́ | kɛ̀kɛ́ | òkè | ɔkùnrin | ɔkùnrin tín gùn kè wa kɛ̀kɛ́</annotation>
 		<annotation cp="🚵🏿‍♂" type="tts">ɔkùnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🚵🏻‍♀">amɔ́lára | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | obìnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára | òkè</annotation>
+		<annotation cp="🚵🏻‍♀">amɔ́lára | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏻‍♀" type="tts">obìnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára</annotation>
-		<annotation cp="🚵🏼‍♀">amɔ́lára díɛ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | obìnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára díɛ̀ | òkè</annotation>
+		<annotation cp="🚵🏼‍♀">amɔ́lára díɛ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏼‍♀" type="tts">obìnrin tín gùn kè wa kɛ̀kɛ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🚵🏽‍♀">amɔ́láwɔ̀ díɛ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | obìnrin tín gùn kè wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀ | òkè</annotation>
+		<annotation cp="🚵🏽‍♀">amɔ́láwɔ̀ díɛ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏽‍♀" type="tts">obìnrin tín gùn kè wa kɛ̀kɛ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚵🏾‍♀">adúláwɔ̀ díɛ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | obìnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀ | òkè</annotation>
+		<annotation cp="🚵🏾‍♀">adúláwɔ̀ díɛ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏾‍♀" type="tts">obìnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🚵🏿‍♀">adúláwɔ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | obìnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀ | òkè</annotation>
+		<annotation cp="🚵🏿‍♀">adúláwɔ̀ | awakɛ̀kɛ́ | ìwa kɛ̀kɛ́ | kɛ̀kɛ́ | obìnrin | obìnrin tín gùn kè wa kɛ̀kɛ́ | òkè</annotation>
 		<annotation cp="🚵🏿‍♀" type="tts">obìnrin tín gùn kè wa kɛ̀kɛ́: adúláwɔ̀</annotation>
-		<annotation cp="🤸🏻">amɔ́lára | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | Ɛni Kawɔ Tilɛ Kɛsɛ Soke: amɔ́lára | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
+		<annotation cp="🤸🏻">amɔ́lára | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏻" type="tts">Ɛni Kawɔ Tilɛ Kɛsɛ Soke: amɔ́lára</annotation>
-		<annotation cp="🤸🏼">amɔ́lára díɛ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | Ɛni Kawɔ Tilɛ Kɛsɛ Soke: amɔ́lára díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
+		<annotation cp="🤸🏼">amɔ́lára díɛ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏼" type="tts">Ɛni Kawɔ Tilɛ Kɛsɛ Soke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤸🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | Ɛni Kawɔ Tilɛ Kɛsɛ Soke: amɔ́láwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
+		<annotation cp="🤸🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏽" type="tts">Ɛni Kawɔ Tilɛ Kɛsɛ Soke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤸🏾">adúláwɔ̀ díɛ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | Ɛni Kawɔ Tilɛ Kɛsɛ Soke: adúláwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
+		<annotation cp="🤸🏾">adúláwɔ̀ díɛ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏾" type="tts">Ɛni Kawɔ Tilɛ Kɛsɛ Soke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤸🏿">adúláwɔ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | Ɛni Kawɔ Tilɛ Kɛsɛ Soke: adúláwɔ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
+		<annotation cp="🤸🏿">adúláwɔ̀ | Ɛni Kawɔ Tilɛ Kɛsɛ Soke | ìdárayá | kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏿" type="tts">Ɛni Kawɔ Tilɛ Kɛsɛ Soke: adúláwɔ̀</annotation>
-		<annotation cp="🤸🏻‍♂">amɔ́lára | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára</annotation>
+		<annotation cp="🤸🏻‍♂">amɔ́lára | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏻‍♂" type="tts">ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára</annotation>
-		<annotation cp="🤸🏼‍♂">amɔ́lára díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤸🏼‍♂">amɔ́lára díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏼‍♂" type="tts">ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤸🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤸🏽‍♂">amɔ́láwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏽‍♂" type="tts">ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤸🏾‍♂">adúláwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤸🏾‍♂">adúláwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏾‍♂" type="tts">ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤸🏿‍♂">adúláwɔ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀</annotation>
+		<annotation cp="🤸🏿‍♂">adúláwɔ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | ɔkùnrin | ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏿‍♂" type="tts">ɔkùnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀</annotation>
-		<annotation cp="🤸🏻‍♀">amɔ́lára | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára</annotation>
+		<annotation cp="🤸🏻‍♀">amɔ́lára | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏻‍♀" type="tts">obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára</annotation>
-		<annotation cp="🤸🏼‍♀">amɔ́lára díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤸🏼‍♀">amɔ́lára díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏼‍♀" type="tts">obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤸🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤸🏽‍♀">amɔ́láwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏽‍♀" type="tts">obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤸🏾‍♀">adúláwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤸🏾‍♀">adúláwɔ̀ díɛ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏾‍♀" type="tts">obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤸🏿‍♀">adúláwɔ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀</annotation>
+		<annotation cp="🤸🏿‍♀">adúláwɔ̀ | ìdárayá | kɛ̀kɛ́ alágbɔ̀n | obìnrin | obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n</annotation>
 		<annotation cp="🤸🏿‍♀" type="tts">obìnrin tí ń yí kɛ̀kɛ́ alágbɔ̀n: adúláwɔ̀</annotation>
-		<annotation cp="🤽🏻">amɔ́lára | Ɛni N shere Olomi | Ɛni N shere Olomi: amɔ́lára | omi | pólò</annotation>
+		<annotation cp="🤽🏻">amɔ́lára | Ɛni N shere Olomi | omi | pólò</annotation>
 		<annotation cp="🤽🏻" type="tts">Ɛni N shere Olomi: amɔ́lára</annotation>
-		<annotation cp="🤽🏼">amɔ́lára díɛ̀ | Ɛni N shere Olomi | Ɛni N shere Olomi: amɔ́lára díɛ̀ | omi | pólò</annotation>
+		<annotation cp="🤽🏼">amɔ́lára díɛ̀ | Ɛni N shere Olomi | omi | pólò</annotation>
 		<annotation cp="🤽🏼" type="tts">Ɛni N shere Olomi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤽🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N shere Olomi | Ɛni N shere Olomi: amɔ́láwɔ̀ díɛ̀ | omi | pólò</annotation>
+		<annotation cp="🤽🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N shere Olomi | omi | pólò</annotation>
 		<annotation cp="🤽🏽" type="tts">Ɛni N shere Olomi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤽🏾">adúláwɔ̀ díɛ̀ | Ɛni N shere Olomi | Ɛni N shere Olomi: adúláwɔ̀ díɛ̀ | omi | pólò</annotation>
+		<annotation cp="🤽🏾">adúláwɔ̀ díɛ̀ | Ɛni N shere Olomi | omi | pólò</annotation>
 		<annotation cp="🤽🏾" type="tts">Ɛni N shere Olomi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤽🏿">adúláwɔ̀ | Ɛni N shere Olomi | Ɛni N shere Olomi: adúláwɔ̀ | omi | pólò</annotation>
+		<annotation cp="🤽🏿">adúláwɔ̀ | Ɛni N shere Olomi | omi | pólò</annotation>
 		<annotation cp="🤽🏿" type="tts">Ɛni N shere Olomi: adúláwɔ̀</annotation>
-		<annotation cp="🤽🏻‍♂">amɔ́lára | eré omi | okùnrin | ɔkùnrin n shere olomi | ɔkùnrin n shere olomi: amɔ́lára</annotation>
+		<annotation cp="🤽🏻‍♂">amɔ́lára | eré omi | okùnrin | ɔkùnrin n shere olomi</annotation>
 		<annotation cp="🤽🏻‍♂" type="tts">ɔkùnrin n shere olomi: amɔ́lára</annotation>
-		<annotation cp="🤽🏼‍♂">amɔ́lára díɛ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi | ɔkùnrin n shere olomi: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤽🏼‍♂">amɔ́lára díɛ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi</annotation>
 		<annotation cp="🤽🏼‍♂" type="tts">ɔkùnrin n shere olomi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤽🏽‍♂">amɔ́láwɔ̀ díɛ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi | ɔkùnrin n shere olomi: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤽🏽‍♂">amɔ́láwɔ̀ díɛ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi</annotation>
 		<annotation cp="🤽🏽‍♂" type="tts">ɔkùnrin n shere olomi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤽🏾‍♂">adúláwɔ̀ díɛ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi | ɔkùnrin n shere olomi: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤽🏾‍♂">adúláwɔ̀ díɛ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi</annotation>
 		<annotation cp="🤽🏾‍♂" type="tts">ɔkùnrin n shere olomi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤽🏿‍♂">adúláwɔ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi | ɔkùnrin n shere olomi: adúláwɔ̀</annotation>
+		<annotation cp="🤽🏿‍♂">adúláwɔ̀ | eré omi | okùnrin | ɔkùnrin n shere olomi</annotation>
 		<annotation cp="🤽🏿‍♂" type="tts">ɔkùnrin n shere olomi: adúláwɔ̀</annotation>
-		<annotation cp="🤽🏻‍♀">amɔ́lára | eré omi | obìnrin | obìnrin n shere olomi | obìnrin n shere olomi: amɔ́lára</annotation>
+		<annotation cp="🤽🏻‍♀">amɔ́lára | eré omi | obìnrin | obìnrin n shere olomi</annotation>
 		<annotation cp="🤽🏻‍♀" type="tts">obìnrin n shere olomi: amɔ́lára</annotation>
-		<annotation cp="🤽🏼‍♀">amɔ́lára díɛ̀ | eré omi | obìnrin | obìnrin n shere olomi | obìnrin n shere olomi: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤽🏼‍♀">amɔ́lára díɛ̀ | eré omi | obìnrin | obìnrin n shere olomi</annotation>
 		<annotation cp="🤽🏼‍♀" type="tts">obìnrin n shere olomi: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤽🏽‍♀">amɔ́láwɔ̀ díɛ̀ | eré omi | obìnrin | obìnrin n shere olomi | obìnrin n shere olomi: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤽🏽‍♀">amɔ́láwɔ̀ díɛ̀ | eré omi | obìnrin | obìnrin n shere olomi</annotation>
 		<annotation cp="🤽🏽‍♀" type="tts">obìnrin n shere olomi: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤽🏾‍♀">adúláwɔ̀ díɛ̀ | eré omi | obìnrin | obìnrin n shere olomi | obìnrin n shere olomi: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤽🏾‍♀">adúláwɔ̀ díɛ̀ | eré omi | obìnrin | obìnrin n shere olomi</annotation>
 		<annotation cp="🤽🏾‍♀" type="tts">obìnrin n shere olomi: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤽🏿‍♀">adúláwɔ̀ | eré omi | obìnrin | obìnrin n shere olomi | obìnrin n shere olomi: adúláwɔ̀</annotation>
+		<annotation cp="🤽🏿‍♀">adúláwɔ̀ | eré omi | obìnrin | obìnrin n shere olomi</annotation>
 		<annotation cp="🤽🏿‍♀" type="tts">obìnrin n shere olomi: adúláwɔ̀</annotation>
-		<annotation cp="🤾🏻">amɔ́lára | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ: amɔ́lára</annotation>
+		<annotation cp="🤾🏻">amɔ́lára | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ</annotation>
 		<annotation cp="🤾🏻" type="tts">Ɛni N Shere Bɔɔlu Ɔlɔwɔ: amɔ́lára</annotation>
-		<annotation cp="🤾🏼">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤾🏼">amɔ́lára díɛ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ</annotation>
 		<annotation cp="🤾🏼" type="tts">Ɛni N Shere Bɔɔlu Ɔlɔwɔ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤾🏽">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤾🏽">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ</annotation>
 		<annotation cp="🤾🏽" type="tts">Ɛni N Shere Bɔɔlu Ɔlɔwɔ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤾🏾">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤾🏾">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ</annotation>
 		<annotation cp="🤾🏾" type="tts">Ɛni N Shere Bɔɔlu Ɔlɔwɔ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤾🏿">adúláwɔ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ: adúláwɔ̀</annotation>
+		<annotation cp="🤾🏿">adúláwɔ̀ | bɔ́ɔ̀lù | bɔ́ɔ̀lù ɔlɔ́wɔ́ | Ɛni N Shere Bɔɔlu Ɔlɔwɔ</annotation>
 		<annotation cp="🤾🏿" type="tts">Ɛni N Shere Bɔɔlu Ɔlɔwɔ: adúláwɔ̀</annotation>
-		<annotation cp="🤾🏻‍♂">amɔ́lára | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára</annotation>
+		<annotation cp="🤾🏻‍♂">amɔ́lára | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏻‍♂" type="tts">ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára</annotation>
-		<annotation cp="🤾🏼‍♂">amɔ́lára díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤾🏼‍♂">amɔ́lára díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏼‍♂" type="tts">ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤾🏽‍♂">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤾🏽‍♂">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏽‍♂" type="tts">ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤾🏾‍♂">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤾🏾‍♂">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏾‍♂" type="tts">ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤾🏿‍♂">adúláwɔ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀</annotation>
+		<annotation cp="🤾🏿‍♂">adúláwɔ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | ɔkùnrin | ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏿‍♂" type="tts">ɔkùnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🤾🏻‍♀">amɔ́lára | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára</annotation>
+		<annotation cp="🤾🏻‍♀">amɔ́lára | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏻‍♀" type="tts">obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára</annotation>
-		<annotation cp="🤾🏼‍♀">amɔ́lára díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára díɛ̀</annotation>
+		<annotation cp="🤾🏼‍♀">amɔ́lára díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏼‍♀" type="tts">obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤾🏽‍♀">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤾🏽‍♀">amɔ́láwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏽‍♀" type="tts">obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤾🏾‍♀">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀ díɛ̀</annotation>
+		<annotation cp="🤾🏾‍♀">adúláwɔ̀ díɛ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏾‍♀" type="tts">obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤾🏿‍♀">adúláwɔ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀</annotation>
+		<annotation cp="🤾🏿‍♀">adúláwɔ̀ | bɔ́ɔ̀lù ɔlɔ́wɔ́ | obìnrin | obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́</annotation>
 		<annotation cp="🤾🏿‍♀" type="tts">obìnrin tí ń gbá bɔ́ɔ̀lù ɔlɔ́wɔ́: adúláwɔ̀</annotation>
-		<annotation cp="🤹🏻">amɔ́lára | Ɛni N ju Nnkan soke | Ɛni N ju Nnkan soke: amɔ́lára | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏻">amɔ́lára | Ɛni N ju Nnkan soke | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏻" type="tts">Ɛni N ju Nnkan soke: amɔ́lára</annotation>
-		<annotation cp="🤹🏼">amɔ́lára díɛ̀ | Ɛni N ju Nnkan soke | Ɛni N ju Nnkan soke: amɔ́lára díɛ̀ | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏼">amɔ́lára díɛ̀ | Ɛni N ju Nnkan soke | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏼" type="tts">Ɛni N ju Nnkan soke: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤹🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N ju Nnkan soke | Ɛni N ju Nnkan soke: amɔ́láwɔ̀ díɛ̀ | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏽">amɔ́láwɔ̀ díɛ̀ | Ɛni N ju Nnkan soke | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏽" type="tts">Ɛni N ju Nnkan soke: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤹🏾">adúláwɔ̀ díɛ̀ | Ɛni N ju Nnkan soke | Ɛni N ju Nnkan soke: adúláwɔ̀ díɛ̀ | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏾">adúláwɔ̀ díɛ̀ | Ɛni N ju Nnkan soke | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏾" type="tts">Ɛni N ju Nnkan soke: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤹🏿">adúláwɔ̀ | Ɛni N ju Nnkan soke | Ɛni N ju Nnkan soke: adúláwɔ̀ | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏿">adúláwɔ̀ | Ɛni N ju Nnkan soke | ìdɔ́gba | ìmɔ̀ɔ́she | jíju ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏿" type="tts">Ɛni N ju Nnkan soke: adúláwɔ̀</annotation>
-		<annotation cp="🤹🏻‍♂">amɔ́lára | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔkùnrin tí ń jù ǹkan sókè: amɔ́lára | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏻‍♂">amɔ́lára | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏻‍♂" type="tts">ɔkùnrin tí ń jù ǹkan sókè: amɔ́lára</annotation>
-		<annotation cp="🤹🏼‍♂">amɔ́lára díɛ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔkùnrin tí ń jù ǹkan sókè: amɔ́lára díɛ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏼‍♂">amɔ́lára díɛ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏼‍♂" type="tts">ɔkùnrin tí ń jù ǹkan sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤹🏽‍♂">amɔ́láwɔ̀ díɛ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔkùnrin tí ń jù ǹkan sókè: amɔ́láwɔ̀ díɛ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏽‍♂">amɔ́láwɔ̀ díɛ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏽‍♂" type="tts">ɔkùnrin tí ń jù ǹkan sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤹🏾‍♂">adúláwɔ̀ díɛ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔkùnrin tí ń jù ǹkan sókè: adúláwɔ̀ díɛ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏾‍♂">adúláwɔ̀ díɛ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏾‍♂" type="tts">ɔkùnrin tí ń jù ǹkan sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤹🏿‍♂">adúláwɔ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔkùnrin tí ń jù ǹkan sókè: adúláwɔ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏿‍♂">adúláwɔ̀ | jíjù ǹkan sókè | ɔkùnrin | ɔkùnrin tí ń jù ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏿‍♂" type="tts">ɔkùnrin tí ń jù ǹkan sókè: adúláwɔ̀</annotation>
-		<annotation cp="🤹🏻‍♀">amɔ́lára | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | obìnrin tí ń jú ǹkan sókè: amɔ́lára | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏻‍♀">amɔ́lára | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏻‍♀" type="tts">obìnrin tí ń jú ǹkan sókè: amɔ́lára</annotation>
-		<annotation cp="🤹🏼‍♀">amɔ́lára díɛ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | obìnrin tí ń jú ǹkan sókè: amɔ́lára díɛ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏼‍♀">amɔ́lára díɛ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏼‍♀" type="tts">obìnrin tí ń jú ǹkan sókè: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🤹🏽‍♀">amɔ́láwɔ̀ díɛ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | obìnrin tí ń jú ǹkan sókè: amɔ́láwɔ̀ díɛ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏽‍♀">amɔ́láwɔ̀ díɛ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏽‍♀" type="tts">obìnrin tí ń jú ǹkan sókè: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤹🏾‍♀">adúláwɔ̀ díɛ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | obìnrin tí ń jú ǹkan sókè: adúláwɔ̀ díɛ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏾‍♀">adúláwɔ̀ díɛ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏾‍♀" type="tts">obìnrin tí ń jú ǹkan sókè: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🤹🏿‍♀">adúláwɔ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | obìnrin tí ń jú ǹkan sókè: adúláwɔ̀ | ɔ̀pɔ̀ ishɛ́</annotation>
+		<annotation cp="🤹🏿‍♀">adúláwɔ̀ | jíjù ǹkan sókè | obìnrin | obìnrin tí ń jú ǹkan sókè | ɔ̀pɔ̀ ishɛ́</annotation>
 		<annotation cp="🤹🏿‍♀" type="tts">obìnrin tí ń jú ǹkan sókè: adúláwɔ̀</annotation>
-		<annotation cp="🧘🏻">amɔ́lára | Ènìyàn nípò ìgbàgbé | Ènìyàn nípò ìgbàgbé: amɔ́lára | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏻">amɔ́lára | Ènìyàn nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏻" type="tts">Ènìyàn nípò ìgbàgbé: amɔ́lára</annotation>
-		<annotation cp="🧘🏼">amɔ́lára díɛ̀ | Ènìyàn nípò ìgbàgbé | Ènìyàn nípò ìgbàgbé: amɔ́lára díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏼">amɔ́lára díɛ̀ | Ènìyàn nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏼" type="tts">Ènìyàn nípò ìgbàgbé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧘🏽">amɔ́láwɔ̀ díɛ̀ | Ènìyàn nípò ìgbàgbé | Ènìyàn nípò ìgbàgbé: amɔ́láwɔ̀ díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏽">amɔ́láwɔ̀ díɛ̀ | Ènìyàn nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏽" type="tts">Ènìyàn nípò ìgbàgbé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧘🏾">adúláwɔ̀ díɛ̀ | Ènìyàn nípò ìgbàgbé | Ènìyàn nípò ìgbàgbé: adúláwɔ̀ díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏾">adúláwɔ̀ díɛ̀ | Ènìyàn nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏾" type="tts">Ènìyàn nípò ìgbàgbé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧘🏿">adúláwɔ̀ | Ènìyàn nípò ìgbàgbé | Ènìyàn nípò ìgbàgbé: adúláwɔ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏿">adúláwɔ̀ | Ènìyàn nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏿" type="tts">Ènìyàn nípò ìgbàgbé: adúláwɔ̀</annotation>
-		<annotation cp="🧘🏻‍♂">amɔ́lára | Ɔkùnrin nípò ìgbàgbé | Ɔkùnrin nípò ìgbàgbé: amɔ́lára | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏻‍♂">amɔ́lára | Ɔkùnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏻‍♂" type="tts">Ɔkùnrin nípò ìgbàgbé: amɔ́lára</annotation>
-		<annotation cp="🧘🏼‍♂">amɔ́lára díɛ̀ | Ɔkùnrin nípò ìgbàgbé | Ɔkùnrin nípò ìgbàgbé: amɔ́lára díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏼‍♂">amɔ́lára díɛ̀ | Ɔkùnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏼‍♂" type="tts">Ɔkùnrin nípò ìgbàgbé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧘🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin nípò ìgbàgbé | Ɔkùnrin nípò ìgbàgbé: amɔ́láwɔ̀ díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏽‍♂">amɔ́láwɔ̀ díɛ̀ | Ɔkùnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏽‍♂" type="tts">Ɔkùnrin nípò ìgbàgbé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧘🏾‍♂">adúláwɔ̀ díɛ̀ | Ɔkùnrin nípò ìgbàgbé | Ɔkùnrin nípò ìgbàgbé: adúláwɔ̀ díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏾‍♂">adúláwɔ̀ díɛ̀ | Ɔkùnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏾‍♂" type="tts">Ɔkùnrin nípò ìgbàgbé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧘🏿‍♂">adúláwɔ̀ | Ɔkùnrin nípò ìgbàgbé | Ɔkùnrin nípò ìgbàgbé: adúláwɔ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏿‍♂">adúláwɔ̀ | Ɔkùnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏿‍♂" type="tts">Ɔkùnrin nípò ìgbàgbé: adúláwɔ̀</annotation>
-		<annotation cp="🧘🏻‍♀">amɔ́lára | Obìnrin nípò ìgbàgbé | Obìnrin nípò ìgbàgbé: amɔ́lára | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏻‍♀">amɔ́lára | Obìnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏻‍♀" type="tts">Obìnrin nípò ìgbàgbé: amɔ́lára</annotation>
-		<annotation cp="🧘🏼‍♀">amɔ́lára díɛ̀ | Obìnrin nípò ìgbàgbé | Obìnrin nípò ìgbàgbé: amɔ́lára díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏼‍♀">amɔ́lára díɛ̀ | Obìnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏼‍♀" type="tts">Obìnrin nípò ìgbàgbé: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧘🏽‍♀">amɔ́láwɔ̀ díɛ̀ | Obìnrin nípò ìgbàgbé | Obìnrin nípò ìgbàgbé: amɔ́láwɔ̀ díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏽‍♀">amɔ́láwɔ̀ díɛ̀ | Obìnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏽‍♀" type="tts">Obìnrin nípò ìgbàgbé: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧘🏾‍♀">adúláwɔ̀ díɛ̀ | Obìnrin nípò ìgbàgbé | Obìnrin nípò ìgbàgbé: adúláwɔ̀ díɛ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏾‍♀">adúláwɔ̀ díɛ̀ | Obìnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏾‍♀" type="tts">Obìnrin nípò ìgbàgbé: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧘🏿‍♀">adúláwɔ̀ | Obìnrin nípò ìgbàgbé | Obìnrin nípò ìgbàgbé: adúláwɔ̀ | shàshàrò | Yógà</annotation>
+		<annotation cp="🧘🏿‍♀">adúláwɔ̀ | Obìnrin nípò ìgbàgbé | shàshàrò | Yógà</annotation>
 		<annotation cp="🧘🏿‍♀" type="tts">Obìnrin nípò ìgbàgbé: adúláwɔ̀</annotation>
-		<annotation cp="🛀🏻">àgbá ìwé | amɔ́lára | Ɛni Nwɛ | Ɛni Nwɛ: amɔ́lára | ìwɛ̀</annotation>
+		<annotation cp="🛀🏻">àgbá ìwé | amɔ́lára | Ɛni Nwɛ | ìwɛ̀</annotation>
 		<annotation cp="🛀🏻" type="tts">Ɛni Nwɛ: amɔ́lára</annotation>
-		<annotation cp="🛀🏼">àgbá ìwé | amɔ́lára díɛ̀ | Ɛni Nwɛ | Ɛni Nwɛ: amɔ́lára díɛ̀ | ìwɛ̀</annotation>
+		<annotation cp="🛀🏼">àgbá ìwé | amɔ́lára díɛ̀ | Ɛni Nwɛ | ìwɛ̀</annotation>
 		<annotation cp="🛀🏼" type="tts">Ɛni Nwɛ: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🛀🏽">àgbá ìwé | amɔ́láwɔ̀ díɛ̀ | Ɛni Nwɛ | Ɛni Nwɛ: amɔ́láwɔ̀ díɛ̀ | ìwɛ̀</annotation>
+		<annotation cp="🛀🏽">àgbá ìwé | amɔ́láwɔ̀ díɛ̀ | Ɛni Nwɛ | ìwɛ̀</annotation>
 		<annotation cp="🛀🏽" type="tts">Ɛni Nwɛ: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🛀🏾">adúláwɔ̀ díɛ̀ | àgbá ìwé | Ɛni Nwɛ | Ɛni Nwɛ: adúláwɔ̀ díɛ̀ | ìwɛ̀</annotation>
+		<annotation cp="🛀🏾">adúláwɔ̀ díɛ̀ | àgbá ìwé | Ɛni Nwɛ | ìwɛ̀</annotation>
 		<annotation cp="🛀🏾" type="tts">Ɛni Nwɛ: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🛀🏿">adúláwɔ̀ | àgbá ìwé | Ɛni Nwɛ | Ɛni Nwɛ: adúláwɔ̀ | ìwɛ̀</annotation>
+		<annotation cp="🛀🏿">adúláwɔ̀ | àgbá ìwé | Ɛni Nwɛ | ìwɛ̀</annotation>
 		<annotation cp="🛀🏿" type="tts">Ɛni Nwɛ: adúláwɔ̀</annotation>
-		<annotation cp="🛌🏻">amɔ́lára | Ɛniyan Nibusun | Ɛniyan Nibusun: amɔ́lára | ilé ìtura | sùn</annotation>
+		<annotation cp="🛌🏻">amɔ́lára | Ɛniyan Nibusun | ilé ìtura | sùn</annotation>
 		<annotation cp="🛌🏻" type="tts">Ɛniyan Nibusun: amɔ́lára</annotation>
-		<annotation cp="🛌🏼">amɔ́lára díɛ̀ | Ɛniyan Nibusun | Ɛniyan Nibusun: amɔ́lára díɛ̀ | ilé ìtura | sùn</annotation>
+		<annotation cp="🛌🏼">amɔ́lára díɛ̀ | Ɛniyan Nibusun | ilé ìtura | sùn</annotation>
 		<annotation cp="🛌🏼" type="tts">Ɛniyan Nibusun: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🛌🏽">amɔ́láwɔ̀ díɛ̀ | Ɛniyan Nibusun | Ɛniyan Nibusun: amɔ́láwɔ̀ díɛ̀ | ilé ìtura | sùn</annotation>
+		<annotation cp="🛌🏽">amɔ́láwɔ̀ díɛ̀ | Ɛniyan Nibusun | ilé ìtura | sùn</annotation>
 		<annotation cp="🛌🏽" type="tts">Ɛniyan Nibusun: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🛌🏾">adúláwɔ̀ díɛ̀ | Ɛniyan Nibusun | Ɛniyan Nibusun: adúláwɔ̀ díɛ̀ | ilé ìtura | sùn</annotation>
+		<annotation cp="🛌🏾">adúláwɔ̀ díɛ̀ | Ɛniyan Nibusun | ilé ìtura | sùn</annotation>
 		<annotation cp="🛌🏾" type="tts">Ɛniyan Nibusun: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🛌🏿">adúláwɔ̀ | Ɛniyan Nibusun | Ɛniyan Nibusun: adúláwɔ̀ | ilé ìtura | sùn</annotation>
+		<annotation cp="🛌🏿">adúláwɔ̀ | Ɛniyan Nibusun | ilé ìtura | sùn</annotation>
 		<annotation cp="🛌🏿" type="tts">Ɛniyan Nibusun: adúláwɔ̀</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏻">amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏻">amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏻" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏼">amɔ́lára | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, amɔ́lára díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏼">amɔ́lára | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏼" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏽" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏾" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏻‍🤝‍🧑🏿">adúláwɔ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, adúláwɔ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏻‍🤝‍🧑🏿">adúláwɔ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏻‍🤝‍🧑🏿" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏻">amɔ́lára | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, amɔ́lára | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏻">amɔ́lára | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏻" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏼">amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏼">amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏼" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏽" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏾" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏼‍🤝‍🧑🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, adúláwɔ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏼‍🤝‍🧑🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏼‍🤝‍🧑🏿" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, amɔ́lára | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏻" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏼" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏽">amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏽">amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏽" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏾" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏽‍🤝‍🧑🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏽‍🤝‍🧑🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏽‍🤝‍🧑🏿" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, amɔ́lára | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏻" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏼" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏽" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏾">adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏾" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏾‍🤝‍🧑🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, adúláwɔ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏾‍🤝‍🧑🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏾‍🤝‍🧑🏿" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏻">adúláwɔ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, amɔ́lára | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏻">adúláwɔ̀ | amɔ́lára | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏻" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, amɔ́lára díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏼" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏽" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏾" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="🧑🏿‍🤝‍🧑🏿">adúláwɔ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀ | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="🧑🏿‍🤝‍🧑🏿">adúláwɔ̀ | àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú | àwɔn ènìyàn tó dira wɔn lɔ́wɔ́ mú | dìmú | ènìyàn | ń diraɛni lɔ́wɔ́ mú | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="🧑🏿‍🤝‍🧑🏿" type="tts">àwɔn ènìyàn tó di ara wɔn lɔ́wɔ́ mú: adúláwɔ̀</annotation>
-		<annotation cp="👭🏻">amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👭🏻">amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👭🏻" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏼">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏼">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏼" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏽" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏾" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍🤝‍👩🏿">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👩🏿">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👩🏿" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏻">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏻">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏻" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👭🏼">amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👭🏼">amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👭🏼" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏽" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏾" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👩🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👩🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👩🏿" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏻" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏼" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👭🏽">amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👭🏽">amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👭🏽" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏾" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍🤝‍👩🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👩🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👩🏿" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏻" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏼" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏽" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👭🏾">adúláwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👭🏾">adúláwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👭🏾" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🤝‍👩🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👩🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👩🏿" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏻">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏻">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏻" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏼" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏽" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🤝‍👩🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👩🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👩🏾" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👭🏿">adúláwɔ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👭🏿">adúláwɔ̀ | dìmú | obìnrin | Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👭🏿" type="tts">Obinrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀</annotation>
-		<annotation cp="👫🏻">amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👫🏻">amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👫🏻" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏼">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏼" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏽">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏽" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏾" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏻‍🤝‍👨🏿">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏻‍🤝‍👨🏿">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏻‍🤝‍👨🏿" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏻">amɔ́lára | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏻" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👫🏼">amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👫🏼">amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👫🏼" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏽">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏽" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏾" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏼‍🤝‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏼‍🤝‍👨🏿">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏼‍🤝‍👨🏿" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏻">amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏻" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏼">amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏼" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👫🏽">amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👫🏽">amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👫🏽" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏾" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏽‍🤝‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏽‍🤝‍👨🏿">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏽‍🤝‍👨🏿" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏻">adúláwɔ̀ díɛ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏻" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏼">adúláwɔ̀ díɛ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏼" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏽">adúláwɔ̀ díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏽" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👫🏾">adúláwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👫🏾">adúláwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👫🏾" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏾‍🤝‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏾‍🤝‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏾‍🤝‍👨🏿" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏻">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏻">adúláwɔ̀ | amɔ́lára | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏻" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏼">adúláwɔ̀ | amɔ́lára díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏼" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏽">adúláwɔ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏽" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👩🏿‍🤝‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👩🏿‍🤝‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👩🏿‍🤝‍👨🏾" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👫🏿">adúláwɔ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👫🏿">adúláwɔ̀ | dìmú | obìnrin | ɔkùnrin | Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👫🏿" type="tts">Ɔkunrin Ati Obirin Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀</annotation>
-		<annotation cp="👬🏻">àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👬🏻">àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👬🏻" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏼">àmi oshù ìbí | amɔ́lára | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏼">àmi oshù ìbí | amɔ́lára | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏼" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏽">àmi oshù ìbí | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏽">àmi oshù ìbí | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏽" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏾" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏻‍🤝‍👨🏿">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏻‍🤝‍👨🏿">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏻‍🤝‍👨🏿" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára, adúláwɔ̀</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏻">àmi oshù ìbí | amɔ́lára | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏻">àmi oshù ìbí | amɔ́lára | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏻" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👬🏼">àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👬🏼">àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👬🏼" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏽">àmi oshù ìbí | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏽">àmi oshù ìbí | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏽" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏾" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏼‍🤝‍👨🏿">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏼‍🤝‍👨🏿">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏼‍🤝‍👨🏿" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́lára díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏻">àmi oshù ìbí | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏻">àmi oshù ìbí | amɔ́lára | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏻" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏼">àmi oshù ìbí | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏼">àmi oshù ìbí | amɔ́lára díɛ̀ | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏼" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👬🏽">àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👬🏽">àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👬🏽" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏾" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏽‍🤝‍👨🏿">adúláwɔ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏽‍🤝‍👨🏿">adúláwɔ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏽‍🤝‍👨🏿" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: amɔ́láwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏻">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏻">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏻" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏼">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏼">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏼" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏽">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏽">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏽" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👬🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👬🏾">adúláwɔ̀ díɛ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👬🏾" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏾‍🤝‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏾‍🤝‍👨🏿">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏾‍🤝‍👨🏿" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ díɛ̀, adúláwɔ̀</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏻">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏻">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏻" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏼">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏼">adúláwɔ̀ | àmi oshù ìbí | amɔ́lára díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏼" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́lára díɛ̀</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏽">adúláwɔ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏽">adúláwɔ̀ | àmi oshù ìbí | amɔ́láwɔ̀ díɛ̀ | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏽" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="👨🏿‍🤝‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, adúláwɔ̀ díɛ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👨🏿‍🤝‍👨🏾">adúláwɔ̀ | adúláwɔ̀ díɛ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👨🏿‍🤝‍👨🏾" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀, adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="👬🏿">adúláwɔ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀ | ɔwɔ́ | tɔkɔtaya</annotation>
+		<annotation cp="👬🏿">adúláwɔ̀ | àmi oshù ìbí | dìmú | Gemini | ìbejì | ɔkùnrin | Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu | ɔwɔ́ | tɔkɔtaya</annotation>
 		<annotation cp="👬🏿" type="tts">Ɔkunrin Meji Ti O Dɔwɔ Ara Wɔn Mu: adúláwɔ̀</annotation>
-		<annotation cp="💏🏻">amɔ́lára | Ifɛnuko | Ifɛnuko: amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="💏🏻">amɔ́lára | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="💏🏻" type="tts">Ifɛnuko: amɔ́lára</annotation>
-		<annotation cp="💏🏼">amɔ́lára díɛ̀ | Ifɛnuko | Ifɛnuko: amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💏🏼">amɔ́lára díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="💏🏼" type="tts">Ifɛnuko: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💏🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💏🏽">amɔ́láwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="💏🏽" type="tts">Ifɛnuko: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💏🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | Ifɛnuko: adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💏🏾">adúláwɔ̀ díɛ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="💏🏾" type="tts">Ifɛnuko: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💏🏿">adúláwɔ̀ | Ifɛnuko | Ifɛnuko: adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💏🏿">adúláwɔ̀ | Ifɛnuko | tɔkɔtaya</annotation>
 		<annotation cp="💏🏿" type="tts">Ifɛnuko: adúláwɔ̀</annotation>
-		<annotation cp="👩‍❤‍💋‍👨">Ifɛnuko | Ifɛnuko: Obìnrin, Ɔkùnrin | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩‍❤‍💋‍👨">Ifɛnuko | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩‍❤‍💋‍👨" type="tts">Ifɛnuko: Obìnrin, Ɔkùnrin</annotation>
-		<annotation cp="👨‍❤‍💋‍👨">Ifɛnuko | Ifɛnuko: Ɔkùnrin, Ɔkùnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨‍❤‍💋‍👨">Ifɛnuko | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨‍❤‍💋‍👨" type="tts">Ifɛnuko: Ɔkùnrin, Ɔkùnrin</annotation>
-		<annotation cp="👩‍❤‍💋‍👩">Ifɛnuko | Ifɛnuko: Obìnrin, Obìnrin | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩‍❤‍💋‍👩">Ifɛnuko | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩‍❤‍💋‍👩" type="tts">Ifɛnuko: Obìnrin, Obìnrin</annotation>
-		<annotation cp="💑🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: amɔ́lára | tɔkɔtaya</annotation>
+		<annotation cp="💑🏻">amɔ́lára | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="💑🏻" type="tts">Lɔkɔlaya Pɛlu ɔkan: amɔ́lára</annotation>
-		<annotation cp="💑🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: amɔ́lára díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💑🏼">amɔ́lára díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="💑🏼" type="tts">Lɔkɔlaya Pɛlu ɔkan: amɔ́lára díɛ̀</annotation>
-		<annotation cp="💑🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: amɔ́láwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💑🏽">amɔ́láwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="💑🏽" type="tts">Lɔkɔlaya Pɛlu ɔkan: amɔ́láwɔ̀ díɛ̀</annotation>
-		<annotation cp="💑🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: adúláwɔ̀ díɛ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💑🏾">adúláwɔ̀ díɛ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="💑🏾" type="tts">Lɔkɔlaya Pɛlu ɔkan: adúláwɔ̀ díɛ̀</annotation>
-		<annotation cp="💑🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: adúláwɔ̀ | tɔkɔtaya</annotation>
+		<annotation cp="💑🏿">adúláwɔ̀ | ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | tɔkɔtaya</annotation>
 		<annotation cp="💑🏿" type="tts">Lɔkɔlaya Pɛlu ɔkan: adúláwɔ̀</annotation>
-		<annotation cp="👩‍❤‍👨">ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩‍❤‍👨">ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩‍❤‍👨" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Ɔkùnrin</annotation>
-		<annotation cp="👨‍❤‍👨">ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin | Ɔkùnrin | tɔkɔtaya</annotation>
+		<annotation cp="👨‍❤‍👨">ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Ɔkùnrin | tɔkɔtaya</annotation>
 		<annotation cp="👨‍❤‍👨" type="tts">Lɔkɔlaya Pɛlu ɔkan: Ɔkùnrin, Ɔkùnrin</annotation>
-		<annotation cp="👩‍❤‍👩">ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin | Obìnrin | tɔkɔtaya</annotation>
+		<annotation cp="👩‍❤‍👩">ìfɛ́ | Lɔkɔlaya Pɛlu ɔkan | Obìnrin | tɔkɔtaya</annotation>
 		<annotation cp="👩‍❤‍👩" type="tts">Lɔkɔlaya Pɛlu ɔkan: Obìnrin, Obìnrin</annotation>
-		<annotation cp="👨‍👩‍👦">Ɛbí | Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔkùnrin | Obìnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👩‍👦">Ɛbí | Obìnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👩‍👦" type="tts">Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👩‍👧">Ɛbí | Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔbìrin | Obìnrin | Ɔkùnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👨‍👩‍👧">Ɛbí | Obìnrin | Ɔkùnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👨‍👩‍👧" type="tts">Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔbìrin</annotation>
-		<annotation cp="👨‍👩‍👧‍👦">Ɛbí | Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔbìrin, ɔmɔkùnrin | Obìnrin | Ɔkùnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👩‍👧‍👦">Ɛbí | Obìnrin | Ɔkùnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👩‍👧‍👦" type="tts">Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔbìrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👩‍👦‍👦">Ɛbí | Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔkùnrin, ɔmɔkùnrin | Obìnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👩‍👦‍👦">Ɛbí | Obìnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👩‍👦‍👦" type="tts">Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👩‍👧‍👧">Ɛbí | Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔbìrin, ɔmɔbìrin | Obìnrin | Ɔkùnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👨‍👩‍👧‍👧">Ɛbí | Obìnrin | Ɔkùnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👨‍👩‍👧‍👧" type="tts">Ɛbí: Ɔkùnrin, Obìnrin, ɔmɔbìrin, ɔmɔbìrin</annotation>
-		<annotation cp="👨‍👨‍👦">Ɛbí | Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔkùnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👨‍👦">Ɛbí | Ɔkùnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👨‍👦" type="tts">Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👨‍👧">Ɛbí | Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔbìrin | Ɔkùnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👨‍👨‍👧">Ɛbí | Ɔkùnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👨‍👨‍👧" type="tts">Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔbìrin</annotation>
-		<annotation cp="👨‍👨‍👧‍👦">Ɛbí | Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔbìrin, ɔmɔkùnrin | Ɔkùnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👨‍👧‍👦">Ɛbí | Ɔkùnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👨‍👧‍👦" type="tts">Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔbìrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👨‍👦‍👦">Ɛbí | Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔkùnrin, ɔmɔkùnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👨‍👦‍👦">Ɛbí | Ɔkùnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👨‍👦‍👦" type="tts">Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👨‍👧‍👧">Ɛbí | Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔbìrin, ɔmɔbìrin | Ɔkùnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👨‍👨‍👧‍👧">Ɛbí | Ɔkùnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👨‍👨‍👧‍👧" type="tts">Ɛbí: Ɔkùnrin, Ɔkùnrin, ɔmɔbìrin, ɔmɔbìrin</annotation>
-		<annotation cp="👩‍👩‍👦">Ɛbí | Ɛbí: Obìnrin, Obìnrin, ɔmɔkùnrin | Obìnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👩‍👩‍👦">Ɛbí | Obìnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👩‍👩‍👦" type="tts">Ɛbí: Obìnrin, Obìnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👩‍👩‍👧">Ɛbí | Ɛbí: Obìnrin, Obìnrin, ɔmɔbìrin | Obìnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👩‍👩‍👧">Ɛbí | Obìnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👩‍👩‍👧" type="tts">Ɛbí: Obìnrin, Obìnrin, ɔmɔbìrin</annotation>
-		<annotation cp="👩‍👩‍👧‍👦">Ɛbí | Ɛbí: Obìnrin, Obìnrin, ɔmɔbìrin, ɔmɔkùnrin | Obìnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👩‍👩‍👧‍👦">Ɛbí | Obìnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👩‍👩‍👧‍👦" type="tts">Ɛbí: Obìnrin, Obìnrin, ɔmɔbìrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👩‍👩‍👦‍👦">Ɛbí | Ɛbí: Obìnrin, Obìnrin, ɔmɔkùnrin, ɔmɔkùnrin | Obìnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👩‍👩‍👦‍👦">Ɛbí | Obìnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👩‍👩‍👦‍👦" type="tts">Ɛbí: Obìnrin, Obìnrin, ɔmɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👩‍👩‍👧‍👧">Ɛbí | Ɛbí: Obìnrin, Obìnrin, ɔmɔbìrin, ɔmɔbìrin | Obìnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👩‍👩‍👧‍👧">Ɛbí | Obìnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👩‍👩‍👧‍👧" type="tts">Ɛbí: Obìnrin, Obìnrin, ɔmɔbìrin, ɔmɔbìrin</annotation>
-		<annotation cp="👨‍👦">Ɛbí | Ɛbí: Ɔkùnrin, ɔmɔkùnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👦">Ɛbí | Ɔkùnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👦" type="tts">Ɛbí: Ɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👦‍👦">Ɛbí | Ɛbí: Ɔkùnrin, ɔmɔkùnrin, ɔmɔkùnrin | Ɔkùnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👦‍👦">Ɛbí | Ɔkùnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👦‍👦" type="tts">Ɛbí: Ɔkùnrin, ɔmɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👧">Ɛbí | Ɛbí: Ɔkùnrin, ɔmɔbìrin | Ɔkùnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👨‍👧">Ɛbí | Ɔkùnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👨‍👧" type="tts">Ɛbí: Ɔkùnrin, ɔmɔbìrin</annotation>
-		<annotation cp="👨‍👧‍👦">Ɛbí | Ɛbí: Ɔkùnrin, ɔmɔbìrin, ɔmɔkùnrin | Ɔkùnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👨‍👧‍👦">Ɛbí | Ɔkùnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👨‍👧‍👦" type="tts">Ɛbí: Ɔkùnrin, ɔmɔbìrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👨‍👧‍👧">Ɛbí | Ɛbí: Ɔkùnrin, ɔmɔbìrin, ɔmɔbìrin | Ɔkùnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👨‍👧‍👧">Ɛbí | Ɔkùnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👨‍👧‍👧" type="tts">Ɛbí: Ɔkùnrin, ɔmɔbìrin, ɔmɔbìrin</annotation>
-		<annotation cp="👩‍👦">Ɛbí | Ɛbí: Obìnrin, ɔmɔkùnrin | Obìnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👩‍👦">Ɛbí | Obìnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👩‍👦" type="tts">Ɛbí: Obìnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👩‍👦‍👦">Ɛbí | Ɛbí: Obìnrin, ɔmɔkùnrin, ɔmɔkùnrin | Obìnrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👩‍👦‍👦">Ɛbí | Obìnrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👩‍👦‍👦" type="tts">Ɛbí: Obìnrin, ɔmɔkùnrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👩‍👧">Ɛbí | Ɛbí: Obìnrin, ɔmɔbìrin | Obìnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👩‍👧">Ɛbí | Obìnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👩‍👧" type="tts">Ɛbí: Obìnrin, ɔmɔbìrin</annotation>
-		<annotation cp="👩‍👧‍👦">Ɛbí | Ɛbí: Obìnrin, ɔmɔbìrin, ɔmɔkùnrin | Obìnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
+		<annotation cp="👩‍👧‍👦">Ɛbí | Obìnrin | ɔmɔbìrin | ɔmɔkùnrin</annotation>
 		<annotation cp="👩‍👧‍👦" type="tts">Ɛbí: Obìnrin, ɔmɔbìrin, ɔmɔkùnrin</annotation>
-		<annotation cp="👩‍👧‍👧">Ɛbí | Ɛbí: Obìnrin, ɔmɔbìrin, ɔmɔbìrin | Obìnrin | ɔmɔbìrin</annotation>
+		<annotation cp="👩‍👧‍👧">Ɛbí | Obìnrin | ɔmɔbìrin</annotation>
 		<annotation cp="👩‍👧‍👧" type="tts">Ɛbí: Obìnrin, ɔmɔbìrin, ɔmɔbìrin</annotation>
-		<annotation cp="🇦🇪">filaagi | filaagi: Ɛmirate ti Awɔn Arabu</annotation>
 		<annotation cp="🇦🇪" type="tts">filaagi: Ɛmirate ti Awɔn Arabu</annotation>
-		<annotation cp="🇦🇸">filaagi | filaagi: Sámóánì ti Orílɛ́ède Àméríkà</annotation>
 		<annotation cp="🇦🇸" type="tts">filaagi: Sámóánì ti Orílɛ́ède Àméríkà</annotation>
-		<annotation cp="🇦🇽">filaagi | filaagi: Àwɔn Erékùsù ti Åland</annotation>
 		<annotation cp="🇦🇽" type="tts">filaagi: Àwɔn Erékùsù ti Åland</annotation>
-		<annotation cp="🇦🇿">filaagi | filaagi: Asɛ́bájánì</annotation>
 		<annotation cp="🇦🇿" type="tts">filaagi: Asɛ́bájánì</annotation>
-		<annotation cp="🇧🇦">filaagi | filaagi: Bɔ̀síníà àti Ɛtisɛgófínà</annotation>
 		<annotation cp="🇧🇦" type="tts">filaagi: Bɔ̀síníà àti Ɛtisɛgófínà</annotation>
-		<annotation cp="🇧🇪">filaagi | filaagi: Bégíɔ́mù</annotation>
 		<annotation cp="🇧🇪" type="tts">filaagi: Bégíɔ́mù</annotation>
-		<annotation cp="🇧🇯">filaagi | filaagi: Bɛ̀nɛ̀</annotation>
 		<annotation cp="🇧🇯" type="tts">filaagi: Bɛ̀nɛ̀</annotation>
-		<annotation cp="🇧🇱">filaagi | filaagi: Ìlú Bátílɛ́mì</annotation>
 		<annotation cp="🇧🇱" type="tts">filaagi: Ìlú Bátílɛ́mì</annotation>
-		<annotation cp="🇧🇳">filaagi | filaagi: Búrúnɛ́lì</annotation>
 		<annotation cp="🇧🇳" type="tts">filaagi: Búrúnɛ́lì</annotation>
-		<annotation cp="🇧🇴">filaagi | filaagi: Bɔ̀lífíyà</annotation>
 		<annotation cp="🇧🇴" type="tts">filaagi: Bɔ̀lífíyà</annotation>
-		<annotation cp="🇧🇶">filaagi | filaagi: Kàríbíánì ti Nɛ́dálándì</annotation>
 		<annotation cp="🇧🇶" type="tts">filaagi: Kàríbíánì ti Nɛ́dálándì</annotation>
-		<annotation cp="🇧🇼">filaagi | filaagi: Bɔ̀tìsúwánà</annotation>
 		<annotation cp="🇧🇼" type="tts">filaagi: Bɔ̀tìsúwánà</annotation>
-		<annotation cp="🇧🇿">filaagi | filaagi: Bèlísɛ̀</annotation>
 		<annotation cp="🇧🇿" type="tts">filaagi: Bèlísɛ̀</annotation>
-		<annotation cp="🇨🇭">filaagi | filaagi: switishilandi</annotation>
 		<annotation cp="🇨🇭" type="tts">filaagi: switishilandi</annotation>
-		<annotation cp="🇨🇱">filaagi | filaagi: Shílè</annotation>
 		<annotation cp="🇨🇱" type="tts">filaagi: Shílè</annotation>
-		<annotation cp="🇨🇳">filaagi | filaagi: Sháínà</annotation>
 		<annotation cp="🇨🇳" type="tts">filaagi: Sháínà</annotation>
-		<annotation cp="🇨🇿">filaagi | filaagi: Shɛ́ɛ́kì</annotation>
 		<annotation cp="🇨🇿" type="tts">filaagi: Shɛ́ɛ́kì</annotation>
-		<annotation cp="🇩🇬">filaagi | filaagi: Diego Gashia</annotation>
 		<annotation cp="🇩🇬" type="tts">filaagi: Diego Gashia</annotation>
-		<annotation cp="🇩🇯">filaagi | filaagi: Díbɔ́ótì</annotation>
 		<annotation cp="🇩🇯" type="tts">filaagi: Díbɔ́ótì</annotation>
-		<annotation cp="🇩🇰">filaagi | filaagi: Dɛ́mákì</annotation>
 		<annotation cp="🇩🇰" type="tts">filaagi: Dɛ́mákì</annotation>
-		<annotation cp="🇪🇭">filaagi | filaagi: Ìwɔ̀òòrùn Sàhárà</annotation>
 		<annotation cp="🇪🇭" type="tts">filaagi: Ìwɔ̀òòrùn Sàhárà</annotation>
-		<annotation cp="🇪🇺">filaagi | filaagi: Àpapɔ̀ Yúróòpù</annotation>
 		<annotation cp="🇪🇺" type="tts">filaagi: Àpapɔ̀ Yúróòpù</annotation>
-		<annotation cp="🇫🇴">filaagi | filaagi: Àwɔn Erékùsù ti Faroe</annotation>
 		<annotation cp="🇫🇴" type="tts">filaagi: Àwɔn Erékùsù ti Faroe</annotation>
-		<annotation cp="🇬🇧">filaagi | filaagi: Gɛ̀ɛ́sì</annotation>
 		<annotation cp="🇬🇧" type="tts">filaagi: Gɛ̀ɛ́sì</annotation>
-		<annotation cp="🇬🇪">filaagi | filaagi: Gɔgia</annotation>
 		<annotation cp="🇬🇪" type="tts">filaagi: Gɔgia</annotation>
-		<annotation cp="🇬🇫">filaagi | filaagi: Firenshi Guana</annotation>
 		<annotation cp="🇬🇫" type="tts">filaagi: Firenshi Guana</annotation>
-		<annotation cp="🇬🇸">filaagi | filaagi: Gúúsù Georgia àti Gúúsù Àwɔn Erékùsù Sandwich</annotation>
 		<annotation cp="🇬🇸" type="tts">filaagi: Gúúsù Georgia àti Gúúsù Àwɔn Erékùsù Sandwich</annotation>
-		<annotation cp="🇭🇰">filaagi | filaagi: Agbègbè Ìshàkóso Ìshúná Hong Kong Tí Shánà Ń Darí</annotation>
 		<annotation cp="🇭🇰" type="tts">filaagi: Agbègbè Ìshàkóso Ìshúná Hong Kong Tí Shánà Ń Darí</annotation>
-		<annotation cp="🇮🇨">filaagi | filaagi: Ɛrékùsù Kánárì</annotation>
 		<annotation cp="🇮🇨" type="tts">filaagi: Ɛrékùsù Kánárì</annotation>
-		<annotation cp="🇮🇱">filaagi | filaagi: Iserɛli</annotation>
 		<annotation cp="🇮🇱" type="tts">filaagi: Iserɛli</annotation>
-		<annotation cp="🇮🇸">filaagi | filaagi: Ashilandi</annotation>
 		<annotation cp="🇮🇸" type="tts">filaagi: Ashilandi</annotation>
-		<annotation cp="🇯🇴">filaagi | filaagi: Jɔdani</annotation>
 		<annotation cp="🇯🇴" type="tts">filaagi: Jɔdani</annotation>
-		<annotation cp="🇰🇬">filaagi | filaagi: Kurishisitani</annotation>
 		<annotation cp="🇰🇬" type="tts">filaagi: Kurishisitani</annotation>
-		<annotation cp="🇰🇵">filaagi | filaagi: Guusu Kɔria</annotation>
 		<annotation cp="🇰🇵" type="tts">filaagi: Guusu Kɔria</annotation>
-		<annotation cp="🇰🇷">filaagi | filaagi: Ariwa Kɔria</annotation>
 		<annotation cp="🇰🇷" type="tts">filaagi: Ariwa Kɔria</annotation>
-		<annotation cp="🇰🇿">filaagi | filaagi: Kashashatani</annotation>
 		<annotation cp="🇰🇿" type="tts">filaagi: Kashashatani</annotation>
-		<annotation cp="🇱🇨">filaagi | filaagi: Lushia</annotation>
 		<annotation cp="🇱🇨" type="tts">filaagi: Lushia</annotation>
-		<annotation cp="🇱🇮">filaagi | filaagi: Lɛshitɛnisiteni</annotation>
 		<annotation cp="🇱🇮" type="tts">filaagi: Lɛshitɛnisiteni</annotation>
-		<annotation cp="🇲🇭">filaagi | filaagi: Etikun Máshali</annotation>
 		<annotation cp="🇲🇭" type="tts">filaagi: Etikun Máshali</annotation>
-		<annotation cp="🇲🇴">filaagi | filaagi: Agbègbè Ìshàkóso Pàtàkì Macao</annotation>
 		<annotation cp="🇲🇴" type="tts">filaagi: Agbègbè Ìshàkóso Pàtàkì Macao</annotation>
-		<annotation cp="🇲🇿">filaagi | filaagi: Moshamibiku</annotation>
 		<annotation cp="🇲🇿" type="tts">filaagi: Moshamibiku</annotation>
-		<annotation cp="🇳🇫">filaagi | filaagi: Etikun Nɔ́úfókì</annotation>
 		<annotation cp="🇳🇫" type="tts">filaagi: Etikun Nɔ́úfókì</annotation>
-		<annotation cp="🇳🇴">filaagi | filaagi: Nɔɔwii</annotation>
 		<annotation cp="🇳🇴" type="tts">filaagi: Nɔɔwii</annotation>
-		<annotation cp="🇳🇿">filaagi | filaagi: Shilandi Titun</annotation>
 		<annotation cp="🇳🇿" type="tts">filaagi: Shilandi Titun</annotation>
-		<annotation cp="🇴🇲">filaagi | filaagi: Ɔɔma</annotation>
 		<annotation cp="🇴🇲" type="tts">filaagi: Ɔɔma</annotation>
-		<annotation cp="🇵🇫">filaagi | filaagi: Firenshi Polinesia</annotation>
 		<annotation cp="🇵🇫" type="tts">filaagi: Firenshi Polinesia</annotation>
-		<annotation cp="🇵🇲">filaagi | filaagi: Pɛɛri ati mikuloni</annotation>
 		<annotation cp="🇵🇲" type="tts">filaagi: Pɛɛri ati mikuloni</annotation>
-		<annotation cp="🇵🇷">filaagi | filaagi: Pɔto Riko</annotation>
 		<annotation cp="🇵🇷" type="tts">filaagi: Pɔto Riko</annotation>
-		<annotation cp="🇵🇸">filaagi | filaagi: Agbègbè ara Palɛsítínì</annotation>
 		<annotation cp="🇵🇸" type="tts">filaagi: Agbègbè ara Palɛsítínì</annotation>
-		<annotation cp="🇵🇹">filaagi | filaagi: Pɔ́túgà</annotation>
 		<annotation cp="🇵🇹" type="tts">filaagi: Pɔ́túgà</annotation>
-		<annotation cp="🇷🇸">filaagi | filaagi: Sɛ́bíà</annotation>
 		<annotation cp="🇷🇸" type="tts">filaagi: Sɛ́bíà</annotation>
-		<annotation cp="🇷🇺">filaagi | filaagi: Rɔshia</annotation>
 		<annotation cp="🇷🇺" type="tts">filaagi: Rɔshia</annotation>
-		<annotation cp="🇸🇨">filaagi | filaagi: Sheshɛlɛsi</annotation>
 		<annotation cp="🇸🇨" type="tts">filaagi: Sheshɛlɛsi</annotation>
-		<annotation cp="🇸🇭">filaagi | filaagi: Hɛlena</annotation>
 		<annotation cp="🇸🇭" type="tts">filaagi: Hɛlena</annotation>
-		<annotation cp="🇸🇯">filaagi | filaagi: Sífábáàdì àti Jánì Máyɛ̀nì</annotation>
 		<annotation cp="🇸🇯" type="tts">filaagi: Sífábáàdì àti Jánì Máyɛ̀nì</annotation>
-		<annotation cp="🇸🇳">filaagi | filaagi: Sɛnɛga</annotation>
 		<annotation cp="🇸🇳" type="tts">filaagi: Sɛnɛga</annotation>
-		<annotation cp="🇸🇹">filaagi | filaagi: Sao tomi ati piriishipi</annotation>
 		<annotation cp="🇸🇹" type="tts">filaagi: Sao tomi ati piriishipi</annotation>
-		<annotation cp="🇸🇻">filaagi | filaagi: Ɛɛsáfádò</annotation>
 		<annotation cp="🇸🇻" type="tts">filaagi: Ɛɛsáfádò</annotation>
-		<annotation cp="🇸🇽">filaagi | filaagi: Síntì Mátɛ́ɛ̀nì</annotation>
 		<annotation cp="🇸🇽" type="tts">filaagi: Síntì Mátɛ́ɛ̀nì</annotation>
-		<annotation cp="🇸🇿">filaagi | filaagi: Sashiland</annotation>
 		<annotation cp="🇸🇿" type="tts">filaagi: Sashiland</annotation>
-		<annotation cp="🇹🇨">filaagi | filaagi: Tɔɔki ati Etikun Kakɔsi</annotation>
 		<annotation cp="🇹🇨" type="tts">filaagi: Tɔɔki ati Etikun Kakɔsi</annotation>
-		<annotation cp="🇹🇩">filaagi | filaagi: Shààdì</annotation>
 		<annotation cp="🇹🇩" type="tts">filaagi: Shààdì</annotation>
-		<annotation cp="🇹🇫">filaagi | filaagi: Agbègbè Gúúsù Faranshé</annotation>
 		<annotation cp="🇹🇫" type="tts">filaagi: Agbègbè Gúúsù Faranshé</annotation>
-		<annotation cp="🇹🇱">filaagi | filaagi: ÌlàOòrùn Tímɔ̀</annotation>
 		<annotation cp="🇹🇱" type="tts">filaagi: ÌlàOòrùn Tímɔ̀</annotation>
-		<annotation cp="🇹🇲">filaagi | filaagi: Tɔɔkimenisita</annotation>
 		<annotation cp="🇹🇲" type="tts">filaagi: Tɔɔkimenisita</annotation>
-		<annotation cp="🇹🇳">filaagi | filaagi: Tunishia</annotation>
 		<annotation cp="🇹🇳" type="tts">filaagi: Tunishia</annotation>
-		<annotation cp="🇹🇷">filaagi | filaagi: Tɔɔki</annotation>
 		<annotation cp="🇹🇷" type="tts">filaagi: Tɔɔki</annotation>
-		<annotation cp="🇺🇲">filaagi | filaagi: Àwɔn Erékùsù Kékèké Agbègbè US</annotation>
 		<annotation cp="🇺🇲" type="tts">filaagi: Àwɔn Erékùsù Kékèké Agbègbè US</annotation>
-		<annotation cp="🇺🇳">filaagi | filaagi: Ìshɔ̀kan àgbáyé</annotation>
 		<annotation cp="🇺🇳" type="tts">filaagi: Ìshɔ̀kan àgbáyé</annotation>
-		<annotation cp="🇺🇸">filaagi | filaagi: Amɛrikà</annotation>
 		<annotation cp="🇺🇸" type="tts">filaagi: Amɛrikà</annotation>
-		<annotation cp="🇺🇿">filaagi | filaagi: Nshibɛkisitani</annotation>
 		<annotation cp="🇺🇿" type="tts">filaagi: Nshibɛkisitani</annotation>
-		<annotation cp="🇻🇨">filaagi | filaagi: Fisɛnnti ati Genadina</annotation>
 		<annotation cp="🇻🇨" type="tts">filaagi: Fisɛnnti ati Genadina</annotation>
-		<annotation cp="🇻🇪">filaagi | filaagi: Fɛnɛshuɛla</annotation>
 		<annotation cp="🇻🇪" type="tts">filaagi: Fɛnɛshuɛla</annotation>
-		<annotation cp="🇻🇮">filaagi | filaagi: Etikun Fagini ti Amɛrika</annotation>
 		<annotation cp="🇻🇮" type="tts">filaagi: Etikun Fagini ti Amɛrika</annotation>
-		<annotation cp="🇻🇳">filaagi | filaagi: Fɛtinami</annotation>
 		<annotation cp="🇻🇳" type="tts">filaagi: Fɛtinami</annotation>
-		<annotation cp="🇼🇸">filaagi | filaagi: Samɔ</annotation>
 		<annotation cp="🇼🇸" type="tts">filaagi: Samɔ</annotation>
-		<annotation cp="🇿🇦">filaagi | filaagi: Gúúshù Áfíríkà</annotation>
 		<annotation cp="🇿🇦" type="tts">filaagi: Gúúshù Áfíríkà</annotation>
-		<annotation cp="🇿🇲">filaagi | filaagi: Shamibia</annotation>
 		<annotation cp="🇿🇲" type="tts">filaagi: Shamibia</annotation>
-		<annotation cp="🇿🇼">filaagi | filaagi: Shimibabe</annotation>
 		<annotation cp="🇿🇼" type="tts">filaagi: Shimibabe</annotation>
-		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿">filaagi | filaagi: Ilɛ̀gɛ̀ɛ́sì</annotation>
 		<annotation cp="🏴󠁧󠁢󠁥󠁮󠁧󠁿" type="tts">filaagi: Ilɛ̀gɛ̀ɛ́sì</annotation>
-		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿">filaagi | filaagi: Skɔ́tlándì</annotation>
 		<annotation cp="🏴󠁧󠁢󠁳󠁣󠁴󠁿" type="tts">filaagi: Skɔ́tlándì</annotation>
-		<annotation cp="¤">owóníná àìmɔ̀</annotation>
 		<annotation cp="¤" type="tts">owóníná àìmɔ̀</annotation>
-		<annotation cp="֏">Dírààmù Àmɛ́níà</annotation>
 		<annotation cp="֏" type="tts">Dírààmù Àmɛ́níà</annotation>
-		<annotation cp="৳">Tákà Báńgíládɛ̀ɛ̀shì</annotation>
 		<annotation cp="৳" type="tts">Tákà Báńgíládɛ̀ɛ̀shì</annotation>
-		<annotation cp="៛">Ráyò Kàm̀bɔ́díà</annotation>
 		<annotation cp="៛" type="tts">Ráyò Kàm̀bɔ́díà</annotation>
-		<annotation cp="₡">Kólɔ́ɔ̀nì Kosita Ríkà</annotation>
 		<annotation cp="₡" type="tts">Kólɔ́ɔ̀nì Kosita Ríkà</annotation>
-		<annotation cp="₪">Shékélì Tuntun Ísírɛ̀ɛ̀lì</annotation>
 		<annotation cp="₪" type="tts">Shékélì Tuntun Ísírɛ̀ɛ̀lì</annotation>
-		<annotation cp="₴">Ɔrifiníyà Yukiréníà</annotation>
 		<annotation cp="₴" type="tts">Ɔrifiníyà Yukiréníà</annotation>
-		<annotation cp="₸">Tɛngé Kasakísítàànì</annotation>
 		<annotation cp="₸" type="tts">Tɛngé Kasakísítàànì</annotation>
-		<annotation cp="₺">Lírà Tɔ́kì</annotation>
 		<annotation cp="₺" type="tts">Lírà Tɔ́kì</annotation>
-		<annotation cp="₾">Lárì Jɔ́jíà</annotation>
 		<annotation cp="₾" type="tts">Lárì Jɔ́jíà</annotation>
 	</annotations>
 </ldml>

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -18,917 +18,917 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<localeKeyTypePattern>↑↑↑</localeKeyTypePattern>
 		</localeDisplayPattern>
 		<languages>
-			<language type="ab">↑↑↑</language>
-			<language type="ace">↑↑↑</language>
-			<language type="ada">↑↑↑</language>
-			<language type="ady">↑↑↑</language>
-			<language type="af">↑↑↑</language>
-			<language type="agq">↑↑↑</language>
-			<language type="ain">↑↑↑</language>
-			<language type="ak">↑↑↑</language>
-			<language type="ale">↑↑↑</language>
-			<language type="alt">↑↑↑</language>
-			<language type="am">↑↑↑</language>
-			<language type="an">↑↑↑</language>
-			<language type="ann">↑↑↑</language>
-			<language type="anp">↑↑↑</language>
-			<language type="ar">↑↑↑</language>
-			<language type="ar_001">↑↑↑</language>
-			<language type="arn">↑↑↑</language>
-			<language type="arp">↑↑↑</language>
-			<language type="ars">↑↑↑</language>
-			<language type="as">↑↑↑</language>
-			<language type="asa">↑↑↑</language>
-			<language type="ast">↑↑↑</language>
-			<language type="atj">↑↑↑</language>
-			<language type="av">↑↑↑</language>
-			<language type="awa">↑↑↑</language>
-			<language type="ay">↑↑↑</language>
-			<language type="az">↑↑↑</language>
-			<language type="az" alt="short">↑↑↑</language>
-			<language type="ba">↑↑↑</language>
-			<language type="ban">↑↑↑</language>
-			<language type="bas">↑↑↑</language>
-			<language type="be">↑↑↑</language>
-			<language type="bem">↑↑↑</language>
-			<language type="bez">↑↑↑</language>
-			<language type="bg">↑↑↑</language>
-			<language type="bgc">↑↑↑</language>
-			<language type="bho">↑↑↑</language>
-			<language type="bi">↑↑↑</language>
-			<language type="bin">↑↑↑</language>
-			<language type="bla">↑↑↑</language>
-			<language type="bm">↑↑↑</language>
-			<language type="bn">↑↑↑</language>
-			<language type="bo">↑↑↑</language>
-			<language type="br">↑↑↑</language>
-			<language type="brx">↑↑↑</language>
-			<language type="bs">↑↑↑</language>
-			<language type="bug">↑↑↑</language>
-			<language type="byn">↑↑↑</language>
-			<language type="ca">↑↑↑</language>
-			<language type="cay">↑↑↑</language>
-			<language type="ccp">↑↑↑</language>
-			<language type="ce">↑↑↑</language>
-			<language type="ceb">↑↑↑</language>
-			<language type="cgg">↑↑↑</language>
-			<language type="ch">↑↑↑</language>
-			<language type="chk">↑↑↑</language>
-			<language type="chm">↑↑↑</language>
-			<language type="cho">↑↑↑</language>
-			<language type="chp">↑↑↑</language>
-			<language type="chr">↑↑↑</language>
-			<language type="chy">↑↑↑</language>
-			<language type="ckb">↑↑↑</language>
+			<language type="ab">Abkhazian</language>
+			<language type="ace">Achinese</language>
+			<language type="ada">Adangme</language>
+			<language type="ady">Adyghe</language>
+			<language type="af">Afirkanci</language>
+			<language type="agq">Aghem</language>
+			<language type="ain">Ainu</language>
+			<language type="ak">Akan</language>
+			<language type="ale">Aleut</language>
+			<language type="alt">Altai na Kudanci</language>
+			<language type="am">Amharik</language>
+			<language type="an">Aragonesanci</language>
+			<language type="ann">Obolo</language>
+			<language type="anp">Angika</language>
+			<language type="ar">Larabci</language>
+			<language type="ar_001">Larabci Asali Na Zamani</language>
+			<language type="arn">Mapuche</language>
+			<language type="arp">Arapaho</language>
+			<language type="ars">Larabcin Najdi</language>
+			<language type="as">Asamisanci</language>
+			<language type="asa">Asu</language>
+			<language type="ast">Asturia</language>
+			<language type="atj">Atikamekw</language>
+			<language type="av">Avaric</language>
+			<language type="awa">Awadhi</language>
+			<language type="ay">Aymaranci</language>
+			<language type="az">Azerbaijanci</language>
+			<language type="az" alt="short">Azeri</language>
+			<language type="ba">Bashkir</language>
+			<language type="ban">Balenesanci</language>
+			<language type="bas">Basaa</language>
+			<language type="be">Belarusanci</language>
+			<language type="bem">Bemba</language>
+			<language type="bez">Bena</language>
+			<language type="bg">Bulgariyanci</language>
+			<language type="bgc">Haryanvi</language>
+			<language type="bho">Bhojpuri</language>
+			<language type="bi">Bislama</language>
+			<language type="bin">Bini</language>
+			<language type="bla">Siksiká</language>
+			<language type="bm">Bambara</language>
+			<language type="bn">Bengali</language>
+			<language type="bo">Tibetan</language>
+			<language type="br">Buretananci</language>
+			<language type="brx">Bodo</language>
+			<language type="bs">Bosniyanci</language>
+			<language type="bug">Buginesanci</language>
+			<language type="byn">Blin</language>
+			<language type="ca">Kataloniyanci</language>
+			<language type="cay">Cayuga</language>
+			<language type="ccp">Chakma</language>
+			<language type="ce">Chechen</language>
+			<language type="ceb">Cebuano</language>
+			<language type="cgg">Chiga</language>
+			<language type="ch">Chamorro</language>
+			<language type="chk">Chuukese</language>
+			<language type="chm">Mari</language>
+			<language type="cho">Choctaw</language>
+			<language type="chp">Chipewyan</language>
+			<language type="chr">Cherokee</language>
+			<language type="chy">Cheyenne</language>
+			<language type="ckb">Kurdawa ta Tsakiya</language>
 			<language type="ckb" alt="menu">↑↑↑</language>
 			<language type="ckb" alt="variant">↑↑↑</language>
-			<language type="clc">↑↑↑</language>
-			<language type="co">↑↑↑</language>
-			<language type="crg">↑↑↑</language>
-			<language type="crj">↑↑↑</language>
-			<language type="crk">↑↑↑</language>
-			<language type="crl">↑↑↑</language>
-			<language type="crm">↑↑↑</language>
-			<language type="crr">↑↑↑</language>
-			<language type="cs">↑↑↑</language>
-			<language type="csw">↑↑↑</language>
-			<language type="cu">↑↑↑</language>
-			<language type="cv">↑↑↑</language>
-			<language type="cy">↑↑↑</language>
-			<language type="da">↑↑↑</language>
-			<language type="dak">↑↑↑</language>
-			<language type="dar">↑↑↑</language>
-			<language type="dav">↑↑↑</language>
-			<language type="de">↑↑↑</language>
-			<language type="de_AT">↑↑↑</language>
-			<language type="de_CH">↑↑↑</language>
-			<language type="dgr">↑↑↑</language>
-			<language type="dje">↑↑↑</language>
-			<language type="doi">↑↑↑</language>
-			<language type="dsb">↑↑↑</language>
-			<language type="dua">↑↑↑</language>
-			<language type="dv">↑↑↑</language>
-			<language type="dyo">↑↑↑</language>
-			<language type="dz">↑↑↑</language>
-			<language type="dzg">↑↑↑</language>
-			<language type="ebu">↑↑↑</language>
-			<language type="ee">↑↑↑</language>
-			<language type="efi">↑↑↑</language>
-			<language type="eka">↑↑↑</language>
-			<language type="el">↑↑↑</language>
-			<language type="en">↑↑↑</language>
-			<language type="en_AU">↑↑↑</language>
-			<language type="en_CA">↑↑↑</language>
-			<language type="en_GB">↑↑↑</language>
-			<language type="en_GB" alt="short">↑↑↑</language>
-			<language type="en_US">↑↑↑</language>
-			<language type="en_US" alt="short">↑↑↑</language>
-			<language type="eo">↑↑↑</language>
-			<language type="es">↑↑↑</language>
-			<language type="es_419">↑↑↑</language>
-			<language type="es_ES">↑↑↑</language>
-			<language type="es_MX">↑↑↑</language>
-			<language type="et">↑↑↑</language>
-			<language type="eu">↑↑↑</language>
-			<language type="ewo">↑↑↑</language>
-			<language type="fa">↑↑↑</language>
-			<language type="fa_AF">↑↑↑</language>
-			<language type="ff">↑↑↑</language>
-			<language type="fi">↑↑↑</language>
-			<language type="fil">↑↑↑</language>
-			<language type="fj">↑↑↑</language>
-			<language type="fo">↑↑↑</language>
-			<language type="fon">↑↑↑</language>
-			<language type="fr">↑↑↑</language>
-			<language type="fr_CA">↑↑↑</language>
-			<language type="fr_CH">↑↑↑</language>
-			<language type="frc">↑↑↑</language>
-			<language type="frr">↑↑↑</language>
-			<language type="fur">↑↑↑</language>
-			<language type="fy">↑↑↑</language>
-			<language type="ga">↑↑↑</language>
-			<language type="gaa">↑↑↑</language>
-			<language type="gd">↑↑↑</language>
-			<language type="gez">↑↑↑</language>
-			<language type="gil">↑↑↑</language>
-			<language type="gl">↑↑↑</language>
-			<language type="gn">↑↑↑</language>
-			<language type="gor">↑↑↑</language>
-			<language type="gsw">↑↑↑</language>
-			<language type="gu">↑↑↑</language>
-			<language type="guz">↑↑↑</language>
-			<language type="gv">↑↑↑</language>
-			<language type="gwi">↑↑↑</language>
-			<language type="ha">↑↑↑</language>
-			<language type="hai">↑↑↑</language>
-			<language type="haw">↑↑↑</language>
-			<language type="hax">↑↑↑</language>
-			<language type="he">↑↑↑</language>
-			<language type="hi">↑↑↑</language>
-			<language type="hi_Latn">↑↑↑</language>
-			<language type="hi_Latn" alt="variant">↑↑↑</language>
-			<language type="hil">↑↑↑</language>
-			<language type="hmn">↑↑↑</language>
-			<language type="hr">↑↑↑</language>
-			<language type="hsb">↑↑↑</language>
-			<language type="ht">↑↑↑</language>
-			<language type="hu">↑↑↑</language>
-			<language type="hup">↑↑↑</language>
-			<language type="hur">↑↑↑</language>
-			<language type="hy">↑↑↑</language>
-			<language type="hz">↑↑↑</language>
-			<language type="ia">↑↑↑</language>
-			<language type="iba">↑↑↑</language>
-			<language type="ibb">↑↑↑</language>
-			<language type="id">↑↑↑</language>
-			<language type="ie">↑↑↑</language>
-			<language type="ig">↑↑↑</language>
-			<language type="ii">↑↑↑</language>
-			<language type="ikt">↑↑↑</language>
-			<language type="ilo">↑↑↑</language>
-			<language type="inh">↑↑↑</language>
-			<language type="io">↑↑↑</language>
-			<language type="is">↑↑↑</language>
-			<language type="it">↑↑↑</language>
-			<language type="iu">↑↑↑</language>
-			<language type="ja">↑↑↑</language>
-			<language type="jbo">↑↑↑</language>
-			<language type="jgo">↑↑↑</language>
-			<language type="jmc">↑↑↑</language>
-			<language type="jv">↑↑↑</language>
-			<language type="ka">↑↑↑</language>
-			<language type="kab">↑↑↑</language>
-			<language type="kac">↑↑↑</language>
-			<language type="kaj">↑↑↑</language>
-			<language type="kam">↑↑↑</language>
-			<language type="kbd">↑↑↑</language>
-			<language type="kcg">↑↑↑</language>
-			<language type="kde">↑↑↑</language>
-			<language type="kea">↑↑↑</language>
-			<language type="kfo">↑↑↑</language>
-			<language type="kgp">↑↑↑</language>
-			<language type="kha">↑↑↑</language>
-			<language type="khq">↑↑↑</language>
-			<language type="ki">↑↑↑</language>
-			<language type="kj">↑↑↑</language>
-			<language type="kk">↑↑↑</language>
-			<language type="kkj">↑↑↑</language>
-			<language type="kl">↑↑↑</language>
-			<language type="kln">↑↑↑</language>
-			<language type="km">↑↑↑</language>
-			<language type="kmb">↑↑↑</language>
-			<language type="kn">↑↑↑</language>
-			<language type="ko">↑↑↑</language>
-			<language type="kok">↑↑↑</language>
-			<language type="kpe">↑↑↑</language>
-			<language type="kr">↑↑↑</language>
-			<language type="krc">↑↑↑</language>
-			<language type="krl">↑↑↑</language>
-			<language type="kru">↑↑↑</language>
-			<language type="ks">↑↑↑</language>
-			<language type="ksb">↑↑↑</language>
-			<language type="ksf">↑↑↑</language>
-			<language type="ksh">↑↑↑</language>
-			<language type="ku">↑↑↑</language>
-			<language type="kum">↑↑↑</language>
-			<language type="kv">↑↑↑</language>
-			<language type="kw">↑↑↑</language>
-			<language type="kwk">↑↑↑</language>
-			<language type="ky">↑↑↑</language>
-			<language type="la">↑↑↑</language>
-			<language type="lad">↑↑↑</language>
-			<language type="lag">↑↑↑</language>
-			<language type="lb">↑↑↑</language>
-			<language type="lez">↑↑↑</language>
-			<language type="lg">↑↑↑</language>
-			<language type="li">↑↑↑</language>
-			<language type="lil">↑↑↑</language>
-			<language type="lkt">↑↑↑</language>
-			<language type="ln">↑↑↑</language>
-			<language type="lo">↑↑↑</language>
-			<language type="lou">↑↑↑</language>
-			<language type="loz">↑↑↑</language>
-			<language type="lrc">↑↑↑</language>
-			<language type="lsm">↑↑↑</language>
-			<language type="lt">↑↑↑</language>
-			<language type="lu">↑↑↑</language>
-			<language type="lua">↑↑↑</language>
-			<language type="lun">↑↑↑</language>
-			<language type="luo">↑↑↑</language>
-			<language type="lus">↑↑↑</language>
-			<language type="luy">↑↑↑</language>
-			<language type="lv">↑↑↑</language>
-			<language type="mad">↑↑↑</language>
-			<language type="mag">↑↑↑</language>
-			<language type="mai">↑↑↑</language>
-			<language type="mak">↑↑↑</language>
-			<language type="mas">↑↑↑</language>
-			<language type="mdf">↑↑↑</language>
-			<language type="men">↑↑↑</language>
-			<language type="mer">↑↑↑</language>
-			<language type="mfe">↑↑↑</language>
-			<language type="mg">↑↑↑</language>
-			<language type="mgh">↑↑↑</language>
-			<language type="mgo">↑↑↑</language>
-			<language type="mh">↑↑↑</language>
-			<language type="mi">↑↑↑</language>
-			<language type="mic">↑↑↑</language>
-			<language type="min">↑↑↑</language>
-			<language type="mk">↑↑↑</language>
-			<language type="ml">↑↑↑</language>
-			<language type="mn">↑↑↑</language>
-			<language type="mni">↑↑↑</language>
-			<language type="moe">↑↑↑</language>
-			<language type="moh">↑↑↑</language>
-			<language type="mos">↑↑↑</language>
-			<language type="mr">↑↑↑</language>
-			<language type="ms">↑↑↑</language>
-			<language type="mt">↑↑↑</language>
-			<language type="mua">↑↑↑</language>
-			<language type="mul">↑↑↑</language>
-			<language type="mus">↑↑↑</language>
-			<language type="mwl">↑↑↑</language>
-			<language type="my">↑↑↑</language>
-			<language type="myv">↑↑↑</language>
-			<language type="mzn">↑↑↑</language>
-			<language type="na">↑↑↑</language>
-			<language type="nap">↑↑↑</language>
-			<language type="naq">↑↑↑</language>
-			<language type="nb">↑↑↑</language>
-			<language type="nd">↑↑↑</language>
-			<language type="nds">↑↑↑</language>
-			<language type="ne">↑↑↑</language>
-			<language type="new">↑↑↑</language>
-			<language type="ng">↑↑↑</language>
-			<language type="nia">↑↑↑</language>
-			<language type="niu">↑↑↑</language>
-			<language type="nl">↑↑↑</language>
+			<language type="clc">Chilcotin</language>
+			<language type="co">Corsican</language>
+			<language type="crg">Michif</language>
+			<language type="crj">Cree na Kusu-Maso-Gabas</language>
+			<language type="crk">Plains Cree</language>
+			<language type="crl">Cree na Arewacin-Gabas</language>
+			<language type="crm">Moose Cree</language>
+			<language type="crr">Carolina Algonquian</language>
+			<language type="cs">Cek</language>
+			<language type="csw">Swampy Cree</language>
+			<language type="cu">Church Slavic</language>
+			<language type="cv">Chuvash</language>
+			<language type="cy">Welsh</language>
+			<language type="da">Danish</language>
+			<language type="dak">Dakota</language>
+			<language type="dar">Dargwa</language>
+			<language type="dav">Taita</language>
+			<language type="de">Jamusanci</language>
+			<language type="de_AT">Jamusanci Ostiriya</language>
+			<language type="de_CH">Jamusanci Suwizalan</language>
+			<language type="dgr">Dogrib</language>
+			<language type="dje">Zarma</language>
+			<language type="doi">Harshen Dogri</language>
+			<language type="dsb">Sorbianci ta kasa</language>
+			<language type="dua">Duala</language>
+			<language type="dv">Divehi</language>
+			<language type="dyo">Jola-Fonyi</language>
+			<language type="dz">Dzongkha</language>
+			<language type="dzg">Dazaga</language>
+			<language type="ebu">Embu</language>
+			<language type="ee">Ewe</language>
+			<language type="efi">Efik</language>
+			<language type="eka">Ekajuk</language>
+			<language type="el">Girkanci</language>
+			<language type="en">Turanci</language>
+			<language type="en_AU">Turanci Ostareliya</language>
+			<language type="en_CA">Turanci Kanada</language>
+			<language type="en_GB">Turanci Biritaniya</language>
+			<language type="en_GB" alt="short">Turancin Ingila</language>
+			<language type="en_US">Turanci Amirka</language>
+			<language type="en_US" alt="short">Turancin Amurka</language>
+			<language type="eo">Esperanto</language>
+			<language type="es">Sifaniyanci</language>
+			<language type="es_419">Sifaniyancin Latin Amirka</language>
+			<language type="es_ES">Sifaniyanci Turai</language>
+			<language type="es_MX">Sifaniyanci Mesiko</language>
+			<language type="et">Istoniyanci</language>
+			<language type="eu">Basque</language>
+			<language type="ewo">Ewondo</language>
+			<language type="fa">Farisa</language>
+			<language type="fa_AF">Farisanci na Afaganistan</language>
+			<language type="ff">Fulah</language>
+			<language type="fi">Yaren mutanen Finland</language>
+			<language type="fil">Dan Filifin</language>
+			<language type="fj">Fijiyanci</language>
+			<language type="fo">Faroese</language>
+			<language type="fon">Fon</language>
+			<language type="fr">Faransanci</language>
+			<language type="fr_CA">Farasanci Kanada</language>
+			<language type="fr_CH">Farasanci Suwizalan</language>
+			<language type="frc">Faransancin Cajun</language>
+			<language type="frr">Firisiyanci na Arewaci</language>
+			<language type="fur">Friulian</language>
+			<language type="fy">Frisian ta Yamma</language>
+			<language type="ga">Dan Irish</language>
+			<language type="gaa">Ga</language>
+			<language type="gd">Kʼabilan Scots Gaelic</language>
+			<language type="gez">Geez</language>
+			<language type="gil">Gilbertese</language>
+			<language type="gl">Bagalike</language>
+			<language type="gn">Guwaraniyanci</language>
+			<language type="gor">Gorontalo</language>
+			<language type="gsw">Jamusanci Swiss</language>
+			<language type="gu">Gujarati</language>
+			<language type="guz">Gusii</language>
+			<language type="gv">Manx</language>
+			<language type="gwi">Gwichʼin</language>
+			<language type="ha">Hausa</language>
+			<language type="hai">Haida</language>
+			<language type="haw">Hawaiianci</language>
+			<language type="hax">Haida na Kudanci</language>
+			<language type="he">Ibrananci</language>
+			<language type="hi">Harshen Hindi</language>
+			<language type="hi_Latn">Hindi (Latinanci)</language>
+			<language type="hi_Latn" alt="variant">Hinglish</language>
+			<language type="hil">Hiligaynon</language>
+			<language type="hmn">Hmong</language>
+			<language type="hr">Kuroshiyan</language>
+			<language type="hsb">Sorbianci ta Sama</language>
+			<language type="ht">Haitian Creole</language>
+			<language type="hu">Harshen Hungari</language>
+			<language type="hup">Hupa</language>
+			<language type="hur">Halkomelem</language>
+			<language type="hy">Armeniyanci</language>
+			<language type="hz">Herero</language>
+			<language type="ia">Yare Tsakanin Kasashe</language>
+			<language type="iba">Iban</language>
+			<language type="ibb">Ibibio</language>
+			<language type="id">Harshen Indunusiya</language>
+			<language type="ie">Intagulanci</language>
+			<language type="ig">Igbo</language>
+			<language type="ii">Sichuan Yi</language>
+			<language type="ikt">Inuktitut na Yammacin Kanada</language>
+			<language type="ilo">Ikolo</language>
+			<language type="inh">Ingush</language>
+			<language type="io">Ido</language>
+			<language type="is">Yaren mutanen Iceland</language>
+			<language type="it">Italiyanci</language>
+			<language type="iu">Inuktitut</language>
+			<language type="ja">Japananci</language>
+			<language type="jbo">Lojban</language>
+			<language type="jgo">Ngomba</language>
+			<language type="jmc">Machame</language>
+			<language type="jv">Jafananci</language>
+			<language type="ka">Jojiyanci</language>
+			<language type="kab">Kabyle</language>
+			<language type="kac">Kachin</language>
+			<language type="kaj">Jju</language>
+			<language type="kam">Kamba</language>
+			<language type="kbd">Karbadiyanci</language>
+			<language type="kcg">Tyap</language>
+			<language type="kde">Makonde</language>
+			<language type="kea">Kabuverdianu</language>
+			<language type="kfo">Koro</language>
+			<language type="kgp">Kaingang</language>
+			<language type="kha">Khasi</language>
+			<language type="khq">Koyra Chiini</language>
+			<language type="ki">Kikuyu</language>
+			<language type="kj">Kuanyama</language>
+			<language type="kk">Kazakh</language>
+			<language type="kkj">Kako</language>
+			<language type="kl">Kalaallisut</language>
+			<language type="kln">Kalenjin</language>
+			<language type="km">Harshen Kimar</language>
+			<language type="kmb">Kimbundu</language>
+			<language type="kn">Kannada</language>
+			<language type="ko">Harshen Koreya</language>
+			<language type="kok">Konkananci</language>
+			<language type="kpe">Kpelle</language>
+			<language type="kr">Kanuri</language>
+			<language type="krc">Karachay-Balkar</language>
+			<language type="krl">Kareliyanci</language>
+			<language type="kru">Kurukh</language>
+			<language type="ks">Kashmiri</language>
+			<language type="ksb">Shambala</language>
+			<language type="ksf">Bafia</language>
+			<language type="ksh">Colognian</language>
+			<language type="ku">Kurdanci</language>
+			<language type="kum">Kumyk</language>
+			<language type="kv">Komi</language>
+			<language type="kw">Cornish</language>
+			<language type="kwk">Kwakʼwala</language>
+			<language type="ky">Kirgizanci</language>
+			<language type="la">Dan Kabilar Latin</language>
+			<language type="lad">Ladino</language>
+			<language type="lag">Langi</language>
+			<language type="lb">Luxembourgish</language>
+			<language type="lez">Lezghiniyanci</language>
+			<language type="lg">Ganda</language>
+			<language type="li">Limburgish</language>
+			<language type="lil">Lillooet</language>
+			<language type="lkt">Lakota</language>
+			<language type="ln">Lingala</language>
+			<language type="lo">Lao</language>
+			<language type="lou">Creole na Louisiana</language>
+			<language type="loz">Lozi</language>
+			<language type="lrc">Arewacin Luri</language>
+			<language type="lsm">Saamiyanci</language>
+			<language type="lt">Lituweniyanci</language>
+			<language type="lu">Luba-Katanga</language>
+			<language type="lua">Luba-Lulua</language>
+			<language type="lun">Lunda</language>
+			<language type="luo">Luo</language>
+			<language type="lus">Mizo</language>
+			<language type="luy">Luyia</language>
+			<language type="lv">Latbiyanci</language>
+			<language type="mad">Madurese</language>
+			<language type="mag">Magahi</language>
+			<language type="mai">Maithili</language>
+			<language type="mak">Makasar</language>
+			<language type="mas">Harshen Masai</language>
+			<language type="mdf">Moksha</language>
+			<language type="men">Mende</language>
+			<language type="mer">Meru</language>
+			<language type="mfe">Morisyen</language>
+			<language type="mg">Malagasi</language>
+			<language type="mgh">Makhuwa-Meetto</language>
+			<language type="mgo">Metaʼ</language>
+			<language type="mh">Marshallese</language>
+			<language type="mi">Maori</language>
+			<language type="mic">Mi'kmaq</language>
+			<language type="min">Minangkabau</language>
+			<language type="mk">Dan Masedoniya</language>
+			<language type="ml">Malayalamci</language>
+			<language type="mn">Mongoliyanci</language>
+			<language type="mni">Manipuri</language>
+			<language type="moe">Innu-aimun</language>
+			<language type="moh">Mohawk</language>
+			<language type="mos">Mossi</language>
+			<language type="mr">Maratinci</language>
+			<language type="ms">Harshen Malai</language>
+			<language type="mt">Harshen Maltis</language>
+			<language type="mua">Mundang</language>
+			<language type="mul">Harsuna masu yawa</language>
+			<language type="mus">Muscogee</language>
+			<language type="mwl">Mirandese</language>
+			<language type="my">Burmanci</language>
+			<language type="myv">Erzya</language>
+			<language type="mzn">Mazanderani</language>
+			<language type="na">Nauru</language>
+			<language type="nap">Neapolitan</language>
+			<language type="naq">Nama</language>
+			<language type="nb">Norwegian Bokmål</language>
+			<language type="nd">North Ndebele</language>
+			<language type="nds">Low German</language>
+			<language type="ne">Nepali</language>
+			<language type="new">Newari</language>
+			<language type="ng">Ndonga</language>
+			<language type="nia">Nias</language>
+			<language type="niu">Niuean</language>
+			<language type="nl">Holanci</language>
 			<language type="nl_BE">↑↑↑</language>
-			<language type="nmg">↑↑↑</language>
-			<language type="nn">↑↑↑</language>
-			<language type="nnh">↑↑↑</language>
-			<language type="no">↑↑↑</language>
-			<language type="nog">↑↑↑</language>
-			<language type="nqo">↑↑↑</language>
-			<language type="nr">↑↑↑</language>
-			<language type="nso">↑↑↑</language>
-			<language type="nus">↑↑↑</language>
-			<language type="nv">↑↑↑</language>
-			<language type="ny">↑↑↑</language>
-			<language type="nyn">↑↑↑</language>
-			<language type="oc">↑↑↑</language>
-			<language type="ojb">↑↑↑</language>
-			<language type="ojc">↑↑↑</language>
-			<language type="ojs">↑↑↑</language>
-			<language type="ojw">↑↑↑</language>
-			<language type="oka">↑↑↑</language>
-			<language type="om">↑↑↑</language>
-			<language type="or">↑↑↑</language>
-			<language type="os">↑↑↑</language>
-			<language type="pa">↑↑↑</language>
-			<language type="pag">↑↑↑</language>
-			<language type="pam">↑↑↑</language>
-			<language type="pap">↑↑↑</language>
-			<language type="pau">↑↑↑</language>
-			<language type="pcm">↑↑↑</language>
-			<language type="pis">↑↑↑</language>
-			<language type="pl">↑↑↑</language>
-			<language type="pqm">↑↑↑</language>
-			<language type="prg">↑↑↑</language>
-			<language type="ps">↑↑↑</language>
-			<language type="pt">↑↑↑</language>
-			<language type="pt_BR">↑↑↑</language>
-			<language type="pt_PT">↑↑↑</language>
-			<language type="qu">↑↑↑</language>
-			<language type="raj">↑↑↑</language>
-			<language type="rap">↑↑↑</language>
-			<language type="rar">↑↑↑</language>
-			<language type="rhg">↑↑↑</language>
-			<language type="rm">↑↑↑</language>
-			<language type="rn">↑↑↑</language>
-			<language type="ro">↑↑↑</language>
-			<language type="rof">↑↑↑</language>
-			<language type="ru">↑↑↑</language>
-			<language type="rup">↑↑↑</language>
-			<language type="rw">↑↑↑</language>
-			<language type="rwk">↑↑↑</language>
-			<language type="sa">↑↑↑</language>
-			<language type="sad">↑↑↑</language>
-			<language type="sah">↑↑↑</language>
-			<language type="saq">↑↑↑</language>
-			<language type="sat">↑↑↑</language>
-			<language type="sba">↑↑↑</language>
-			<language type="sbp">↑↑↑</language>
-			<language type="sc">↑↑↑</language>
-			<language type="scn">↑↑↑</language>
-			<language type="sco">↑↑↑</language>
-			<language type="sd">↑↑↑</language>
-			<language type="se">↑↑↑</language>
-			<language type="seh">↑↑↑</language>
-			<language type="ses">↑↑↑</language>
-			<language type="sg">↑↑↑</language>
-			<language type="sh">↑↑↑</language>
-			<language type="shi">↑↑↑</language>
-			<language type="shn">↑↑↑</language>
-			<language type="si">↑↑↑</language>
-			<language type="sk">↑↑↑</language>
-			<language type="sl">↑↑↑</language>
-			<language type="slh">↑↑↑</language>
-			<language type="sm">↑↑↑</language>
-			<language type="smn">↑↑↑</language>
-			<language type="sms">↑↑↑</language>
-			<language type="sn">↑↑↑</language>
-			<language type="snk">↑↑↑</language>
-			<language type="so">↑↑↑</language>
-			<language type="sq">↑↑↑</language>
-			<language type="sr">↑↑↑</language>
-			<language type="srn">↑↑↑</language>
-			<language type="ss">↑↑↑</language>
-			<language type="st">↑↑↑</language>
-			<language type="str">↑↑↑</language>
-			<language type="su">↑↑↑</language>
-			<language type="suk">↑↑↑</language>
-			<language type="sv">↑↑↑</language>
-			<language type="sw">↑↑↑</language>
-			<language type="swb">↑↑↑</language>
-			<language type="syr">↑↑↑</language>
-			<language type="ta">↑↑↑</language>
-			<language type="tce">↑↑↑</language>
-			<language type="te">↑↑↑</language>
-			<language type="tem">↑↑↑</language>
-			<language type="teo">↑↑↑</language>
-			<language type="tet">↑↑↑</language>
-			<language type="tg">↑↑↑</language>
-			<language type="tgx">↑↑↑</language>
-			<language type="th">↑↑↑</language>
-			<language type="tht">↑↑↑</language>
-			<language type="ti">↑↑↑</language>
-			<language type="tig">↑↑↑</language>
-			<language type="tk">↑↑↑</language>
-			<language type="tlh">↑↑↑</language>
-			<language type="tli">↑↑↑</language>
-			<language type="tn">↑↑↑</language>
-			<language type="to">↑↑↑</language>
-			<language type="tok">↑↑↑</language>
-			<language type="tpi">↑↑↑</language>
-			<language type="tr">↑↑↑</language>
-			<language type="trv">↑↑↑</language>
-			<language type="ts">↑↑↑</language>
-			<language type="tt">↑↑↑</language>
-			<language type="ttm">↑↑↑</language>
-			<language type="tum">↑↑↑</language>
-			<language type="tvl">↑↑↑</language>
-			<language type="tw">↑↑↑</language>
-			<language type="twq">↑↑↑</language>
-			<language type="ty">↑↑↑</language>
-			<language type="tyv">↑↑↑</language>
-			<language type="tzm">↑↑↑</language>
-			<language type="udm">↑↑↑</language>
-			<language type="ug">↑↑↑</language>
-			<language type="uk">↑↑↑</language>
-			<language type="umb">↑↑↑</language>
-			<language type="und">↑↑↑</language>
-			<language type="ur">↑↑↑</language>
-			<language type="uz">↑↑↑</language>
-			<language type="vai">↑↑↑</language>
-			<language type="ve">↑↑↑</language>
-			<language type="vi">↑↑↑</language>
-			<language type="vo">↑↑↑</language>
-			<language type="vun">↑↑↑</language>
-			<language type="wa">↑↑↑</language>
-			<language type="wae">↑↑↑</language>
-			<language type="wal">↑↑↑</language>
-			<language type="war">↑↑↑</language>
-			<language type="wo">↑↑↑</language>
-			<language type="wuu">↑↑↑</language>
-			<language type="xal">↑↑↑</language>
-			<language type="xh">↑↑↑</language>
-			<language type="xog">↑↑↑</language>
-			<language type="yav">↑↑↑</language>
-			<language type="ybb">↑↑↑</language>
-			<language type="yi">↑↑↑</language>
-			<language type="yo">↑↑↑</language>
-			<language type="yrl">↑↑↑</language>
-			<language type="yue">↑↑↑</language>
-			<language type="yue" alt="menu">↑↑↑</language>
-			<language type="zgh">↑↑↑</language>
-			<language type="zh">↑↑↑</language>
-			<language type="zh" alt="menu">↑↑↑</language>
-			<language type="zh_Hans">↑↑↑</language>
+			<language type="nmg">Kwasio</language>
+			<language type="nn">Norwegian Nynorsk</language>
+			<language type="nnh">Ngiemboon</language>
+			<language type="no">Harhsen Norway</language>
+			<language type="nog">Harshen Nogai</language>
+			<language type="nqo">N’Ko</language>
+			<language type="nr">Ndebele na Kudu</language>
+			<language type="nso">Sotho na Arewaci</language>
+			<language type="nus">Nuer</language>
+			<language type="nv">Navajo</language>
+			<language type="ny">Nyanja</language>
+			<language type="nyn">Nyankole</language>
+			<language type="oc">Ositanci</language>
+			<language type="ojb">Ojibwa na Arewa-Maso-Yamma</language>
+			<language type="ojc">Ojibwa na Tsakiya</language>
+			<language type="ojs">Oji-Cree</language>
+			<language type="ojw">Ojibwa na Yammaci</language>
+			<language type="oka">Okanagan</language>
+			<language type="om">Oromo</language>
+			<language type="or">Odiya</language>
+			<language type="os">Ossetic</language>
+			<language type="pa">Punjabi</language>
+			<language type="pag">Pangasinanci</language>
+			<language type="pam">Pampanga</language>
+			<language type="pap">Papiamento</language>
+			<language type="pau">Palauan</language>
+			<language type="pcm">Pidgin na Najeriya</language>
+			<language type="pis">Pijin</language>
+			<language type="pl">Harshen Polan</language>
+			<language type="pqm">Maliseet-Passamaquoddy</language>
+			<language type="prg">Ferusawa</language>
+			<language type="ps">Pashtanci</language>
+			<language type="pt">Harshen Potugis</language>
+			<language type="pt_BR">Harshen Potugis na Birazil</language>
+			<language type="pt_PT">Potugis Ƙasashen Turai</language>
+			<language type="qu">Quechua</language>
+			<language type="raj">Rajasthani</language>
+			<language type="rap">Rapanui</language>
+			<language type="rar">Rarotongan</language>
+			<language type="rhg">Harshen Rohingya</language>
+			<language type="rm">Romansh</language>
+			<language type="rn">Rundi</language>
+			<language type="ro">Romaniyanci</language>
+			<language type="rof">Rombo</language>
+			<language type="ru">Rashanci</language>
+			<language type="rup">Aromaniyanci</language>
+			<language type="rw">Kinyarwanda</language>
+			<language type="rwk">Rwa</language>
+			<language type="sa">Sanskrit</language>
+			<language type="sad">Sandawe</language>
+			<language type="sah">Sakha</language>
+			<language type="saq">Samburu</language>
+			<language type="sat">Santali</language>
+			<language type="sba">Ngambay</language>
+			<language type="sbp">Sangu</language>
+			<language type="sc">Sardiniyanci</language>
+			<language type="scn">Sisiliyanci</language>
+			<language type="sco">Scots</language>
+			<language type="sd">Sindiyanci</language>
+			<language type="se">Sami ta Arewa</language>
+			<language type="seh">Sena</language>
+			<language type="ses">Koyraboro Senni</language>
+			<language type="sg">Sango</language>
+			<language type="sh">Kuroweshiyancin-Sabiya</language>
+			<language type="shi">Tachelhit</language>
+			<language type="shn">Shan</language>
+			<language type="si">Sinhalanci</language>
+			<language type="sk">Basulke</language>
+			<language type="sl">Basulabe</language>
+			<language type="slh">Lushbootseed na Kudanci</language>
+			<language type="sm">Samoan</language>
+			<language type="smn">Inari Sami</language>
+			<language type="sms">Skolt Sami</language>
+			<language type="sn">Shona</language>
+			<language type="snk">Soninke</language>
+			<language type="so">Somalianci</language>
+			<language type="sq">Albaniyanci</language>
+			<language type="sr">Sabiyan</language>
+			<language type="srn">Sranan Tongo</language>
+			<language type="ss">Swati</language>
+			<language type="st">Sesotanci</language>
+			<language type="str">Straits Salish</language>
+			<language type="su">Harshen Sundanese</language>
+			<language type="suk">Sukuma</language>
+			<language type="sv">Harshen Suwedan</language>
+			<language type="sw">Harshen Suwahili</language>
+			<language type="swb">Komoriyanci</language>
+			<language type="syr">Syriac</language>
+			<language type="ta">Tamil</language>
+			<language type="tce">Tutchone na Kudanci</language>
+			<language type="te">Telugu</language>
+			<language type="tem">Timne</language>
+			<language type="teo">Teso</language>
+			<language type="tet">Tatum</language>
+			<language type="tg">Tajik</language>
+			<language type="tgx">Tagish</language>
+			<language type="th">Thai</language>
+			<language type="tht">Tahltan</language>
+			<language type="ti">Tigrinyanci</language>
+			<language type="tig">Tigre</language>
+			<language type="tk">Tukmenistanci</language>
+			<language type="tlh">Klingon</language>
+			<language type="tli">Tlingit</language>
+			<language type="tn">Tswana</language>
+			<language type="to">Tonganci</language>
+			<language type="tok">Toki Pona</language>
+			<language type="tpi">Tok Pisin</language>
+			<language type="tr">Harshen Turkiyya</language>
+			<language type="trv">Taroko</language>
+			<language type="ts">Tsonga</language>
+			<language type="tt">Tatar</language>
+			<language type="ttm">Tutchone na Arewaci</language>
+			<language type="tum">Tumbuka</language>
+			<language type="tvl">Tuvalu</language>
+			<language type="tw">Tiwiniyanci</language>
+			<language type="twq">Tasawak</language>
+			<language type="ty">Tahitiyanci</language>
+			<language type="tyv">Tuviniyanci</language>
+			<language type="tzm">Tamazight na Atlas Tsaka</language>
+			<language type="udm">Udmurt</language>
+			<language type="ug">Ugiranci</language>
+			<language type="uk">Harshen Yukuren</language>
+			<language type="umb">Umbundu</language>
+			<language type="und">Harshen da ba a sani ba</language>
+			<language type="ur">Urdanci</language>
+			<language type="uz">Uzbek</language>
+			<language type="vai">Vai</language>
+			<language type="ve">Venda</language>
+			<language type="vi">Harshen Biyetinam</language>
+			<language type="vo">Volapük</language>
+			<language type="vun">Vunjo</language>
+			<language type="wa">Walloon</language>
+			<language type="wae">Walser</language>
+			<language type="wal">Wolaytta</language>
+			<language type="war">Waray</language>
+			<language type="wo">Wolof</language>
+			<language type="wuu">Sinancin Wu</language>
+			<language type="xal">Kalmyk</language>
+			<language type="xh">Bazosa</language>
+			<language type="xog">Soga</language>
+			<language type="yav">Yangben</language>
+			<language type="ybb">Yemba</language>
+			<language type="yi">Yaren Yiddish</language>
+			<language type="yo">Yarbanci</language>
+			<language type="yrl">Nheengatu</language>
+			<language type="yue">Harshen Cantonese</language>
+			<language type="yue" alt="menu">Sinanci, Cantonese</language>
+			<language type="zgh">Daidaitaccen Moroccan Tamazight</language>
+			<language type="zh">Harshen Sinanci</language>
+			<language type="zh" alt="menu">Harshen, Sinanci</language>
+			<language type="zh_Hans">Sauƙaƙaƙƙen Sinanci</language>
 			<language type="zh_Hans" alt="long">↑↑↑</language>
-			<language type="zh_Hant">↑↑↑</language>
+			<language type="zh_Hant">Sinanci na gargajiya</language>
 			<language type="zh_Hant" alt="long">↑↑↑</language>
-			<language type="zu">↑↑↑</language>
-			<language type="zun">↑↑↑</language>
-			<language type="zxx">↑↑↑</language>
-			<language type="zza">↑↑↑</language>
+			<language type="zu">Harshen Zulu</language>
+			<language type="zun">Zuni</language>
+			<language type="zxx">Babu abun cikin yare</language>
+			<language type="zza">Zaza</language>
 		</languages>
 		<scripts>
-			<script type="Adlm">↑↑↑</script>
-			<script type="Arab">↑↑↑</script>
-			<script type="Aran">↑↑↑</script>
-			<script type="Armn">↑↑↑</script>
-			<script type="Beng">↑↑↑</script>
-			<script type="Bopo">↑↑↑</script>
-			<script type="Brai">↑↑↑</script>
-			<script type="Cakm">↑↑↑</script>
+			<script type="Adlm">Adlam</script>
+			<script type="Arab">Larabci</script>
+			<script type="Aran">Rubutun Nastaliq</script>
+			<script type="Armn">Armeniyawa</script>
+			<script type="Beng">Bangla</script>
+			<script type="Bopo">Bopomofo</script>
+			<script type="Brai">Rubutun Makafi</script>
+			<script type="Cakm">Chakma</script>
 			<script type="Cans">Haɗaɗɗun Gaɓoɓin Ƴan Asali na Kanada</script>
-			<script type="Cher">↑↑↑</script>
-			<script type="Cyrl">↑↑↑</script>
-			<script type="Deva">↑↑↑</script>
-			<script type="Ethi">↑↑↑</script>
-			<script type="Geor">↑↑↑</script>
-			<script type="Grek">↑↑↑</script>
-			<script type="Gujr">↑↑↑</script>
-			<script type="Guru">↑↑↑</script>
-			<script type="Hanb">↑↑↑</script>
-			<script type="Hang">↑↑↑</script>
-			<script type="Hani">↑↑↑</script>
-			<script type="Hans">↑↑↑</script>
-			<script type="Hans" alt="stand-alone">↑↑↑</script>
-			<script type="Hant">↑↑↑</script>
-			<script type="Hant" alt="stand-alone">↑↑↑</script>
-			<script type="Hebr">↑↑↑</script>
-			<script type="Hira">↑↑↑</script>
-			<script type="Hrkt">↑↑↑</script>
-			<script type="Jamo">↑↑↑</script>
-			<script type="Jpan">↑↑↑</script>
-			<script type="Kana">↑↑↑</script>
-			<script type="Khmr">↑↑↑</script>
-			<script type="Knda">↑↑↑</script>
-			<script type="Kore">↑↑↑</script>
-			<script type="Laoo">↑↑↑</script>
-			<script type="Latn">↑↑↑</script>
-			<script type="Mlym">↑↑↑</script>
-			<script type="Mong">↑↑↑</script>
-			<script type="Mtei">↑↑↑</script>
-			<script type="Mymr">↑↑↑</script>
-			<script type="Nkoo">↑↑↑</script>
-			<script type="Olck">↑↑↑</script>
-			<script type="Orya">↑↑↑</script>
-			<script type="Rohg">↑↑↑</script>
-			<script type="Sinh">↑↑↑</script>
-			<script type="Sund">↑↑↑</script>
-			<script type="Syrc">↑↑↑</script>
-			<script type="Taml">↑↑↑</script>
-			<script type="Telu">↑↑↑</script>
-			<script type="Tfng">↑↑↑</script>
-			<script type="Thaa">↑↑↑</script>
-			<script type="Thai">↑↑↑</script>
-			<script type="Tibt">↑↑↑</script>
-			<script type="Vaii">↑↑↑</script>
-			<script type="Yiii">↑↑↑</script>
-			<script type="Zmth">↑↑↑</script>
-			<script type="Zsye">↑↑↑</script>
-			<script type="Zsym">↑↑↑</script>
-			<script type="Zxxx">↑↑↑</script>
-			<script type="Zyyy">↑↑↑</script>
-			<script type="Zzzz">↑↑↑</script>
+			<script type="Cher">Cherokee</script>
+			<script type="Cyrl">Cyrillic</script>
+			<script type="Deva">Devanagari</script>
+			<script type="Ethi">Ethiopic</script>
+			<script type="Geor">Georgian</script>
+			<script type="Grek">Girka</script>
+			<script type="Gujr">Gujarati</script>
+			<script type="Guru">Gurmukhi</script>
+			<script type="Hanb">Han tare da Bopomofo</script>
+			<script type="Hang">Yaren Hangul</script>
+			<script type="Hani">Mutanen Han na ƙasar Sin</script>
+			<script type="Hans">Sauƙaƙaƙƙen</script>
+			<script type="Hans" alt="stand-alone">Sauƙaƙaƙƙen Hans</script>
+			<script type="Hant">Na gargajiya</script>
+			<script type="Hant" alt="stand-alone">Han na gargajiya</script>
+			<script type="Hebr">Ibrananci</script>
+			<script type="Hira">Tsarin Rubutun Hiragana</script>
+			<script type="Hrkt">kalaman Jafananci</script>
+			<script type="Jamo">Jamo</script>
+			<script type="Jpan">Jafanis</script>
+			<script type="Kana">Tsarin Rubutun Katakana</script>
+			<script type="Khmr">Yaren Khmer</script>
+			<script type="Knda">Yaren Kannada</script>
+			<script type="Kore">Rubutun Koriya</script>
+			<script type="Laoo">Yan lao</script>
+			<script type="Latn">Latin</script>
+			<script type="Mlym">Yaren Malayalam</script>
+			<script type="Mong">Na kasar Mongolia</script>
+			<script type="Mtei">Meitei Mayek</script>
+			<script type="Mymr">Ƙasar Myanmar</script>
+			<script type="Nkoo">N’Ko</script>
+			<script type="Olck">Ol Chiki</script>
+			<script type="Orya">Yaren Odia</script>
+			<script type="Rohg">Hanifi</script>
+			<script type="Sinh">Yaren Sinhala</script>
+			<script type="Sund">Sudananci</script>
+			<script type="Syrc">Siriyanci</script>
+			<script type="Taml">Yaren Tamil</script>
+			<script type="Telu">Yaren Telugu</script>
+			<script type="Tfng">Tifinagh</script>
+			<script type="Thaa">Yaren Thaana</script>
+			<script type="Thai">Thai</script>
+			<script type="Tibt">Yaren Tibet</script>
+			<script type="Vaii">Vai</script>
+			<script type="Yiii">Yi</script>
+			<script type="Zmth">Alamar Lissafi</script>
+			<script type="Zsye">Alama ta hoto</script>
+			<script type="Zsym">Alamomi</script>
+			<script type="Zxxx">Ba rubutacce ba</script>
+			<script type="Zyyy">Gama-gari</script>
+			<script type="Zzzz">Rubutun da ba sani ba</script>
 		</scripts>
 		<territories>
-			<territory type="001">↑↑↑</territory>
-			<territory type="002">↑↑↑</territory>
-			<territory type="003">↑↑↑</territory>
-			<territory type="005">↑↑↑</territory>
-			<territory type="009">↑↑↑</territory>
-			<territory type="011">↑↑↑</territory>
-			<territory type="013">↑↑↑</territory>
-			<territory type="014">↑↑↑</territory>
-			<territory type="015">↑↑↑</territory>
-			<territory type="017">↑↑↑</territory>
-			<territory type="018">↑↑↑</territory>
-			<territory type="019">↑↑↑</territory>
-			<territory type="021">↑↑↑</territory>
-			<territory type="029">↑↑↑</territory>
-			<territory type="030">↑↑↑</territory>
-			<territory type="034">↑↑↑</territory>
-			<territory type="035">↑↑↑</territory>
-			<territory type="039">↑↑↑</territory>
-			<territory type="053">↑↑↑</territory>
-			<territory type="054">↑↑↑</territory>
-			<territory type="057">↑↑↑</territory>
-			<territory type="061">↑↑↑</territory>
-			<territory type="142">↑↑↑</territory>
-			<territory type="143">↑↑↑</territory>
-			<territory type="145">↑↑↑</territory>
-			<territory type="150">↑↑↑</territory>
-			<territory type="151">↑↑↑</territory>
-			<territory type="154">↑↑↑</territory>
-			<territory type="155">↑↑↑</territory>
-			<territory type="202">↑↑↑</territory>
-			<territory type="419">↑↑↑</territory>
-			<territory type="AC">↑↑↑</territory>
-			<territory type="AD">↑↑↑</territory>
-			<territory type="AE">↑↑↑</territory>
-			<territory type="AF">↑↑↑</territory>
-			<territory type="AG">↑↑↑</territory>
-			<territory type="AI">↑↑↑</territory>
-			<territory type="AL">↑↑↑</territory>
-			<territory type="AM">↑↑↑</territory>
-			<territory type="AO">↑↑↑</territory>
-			<territory type="AQ">↑↑↑</territory>
-			<territory type="AR">↑↑↑</territory>
-			<territory type="AS">↑↑↑</territory>
-			<territory type="AT">↑↑↑</territory>
-			<territory type="AU">↑↑↑</territory>
-			<territory type="AW">↑↑↑</territory>
-			<territory type="AX">↑↑↑</territory>
-			<territory type="AZ">↑↑↑</territory>
-			<territory type="BA">↑↑↑</territory>
-			<territory type="BB">↑↑↑</territory>
-			<territory type="BD">↑↑↑</territory>
-			<territory type="BE">↑↑↑</territory>
-			<territory type="BF">↑↑↑</territory>
-			<territory type="BG">↑↑↑</territory>
-			<territory type="BH">↑↑↑</territory>
-			<territory type="BI">↑↑↑</territory>
-			<territory type="BJ">↑↑↑</territory>
-			<territory type="BL">↑↑↑</territory>
-			<territory type="BM">↑↑↑</territory>
-			<territory type="BN">↑↑↑</territory>
-			<territory type="BO">↑↑↑</territory>
-			<territory type="BQ">↑↑↑</territory>
-			<territory type="BR">↑↑↑</territory>
-			<territory type="BS">↑↑↑</territory>
-			<territory type="BT">↑↑↑</territory>
-			<territory type="BV">↑↑↑</territory>
-			<territory type="BW">↑↑↑</territory>
-			<territory type="BY">↑↑↑</territory>
-			<territory type="BZ">↑↑↑</territory>
-			<territory type="CA">↑↑↑</territory>
-			<territory type="CC">↑↑↑</territory>
-			<territory type="CD">↑↑↑</territory>
-			<territory type="CD" alt="variant">↑↑↑</territory>
-			<territory type="CF">↑↑↑</territory>
-			<territory type="CG">↑↑↑</territory>
-			<territory type="CG" alt="variant">↑↑↑</territory>
-			<territory type="CH">↑↑↑</territory>
-			<territory type="CI">↑↑↑</territory>
+			<territory type="001">Duniya</territory>
+			<territory type="002">Afirka</territory>
+			<territory type="003">Amurka ta Arewa</territory>
+			<territory type="005">Amurka ta Kudu</territory>
+			<territory type="009">Osheniya</territory>
+			<territory type="011">Afirka ta Yamma</territory>
+			<territory type="013">Amurka ta Tsakiya</territory>
+			<territory type="014">Afirka ta Gabas</territory>
+			<territory type="015">Arewacin Afirka</territory>
+			<territory type="017">Afirka ta Tsakiya</territory>
+			<territory type="018">Kudancin Afirka</territory>
+			<territory type="019">Nahiyoyin Amurka</territory>
+			<territory type="021">Arewacin Amurka</territory>
+			<territory type="029">Karebiyan</territory>
+			<territory type="030">Gabashin Asiya</territory>
+			<territory type="034">Kudancin Asiya</territory>
+			<territory type="035">Kudu Maso Gabashin Asiya</territory>
+			<territory type="039">Kudancin Turai</territory>
+			<territory type="053">Asturesiya</territory>
+			<territory type="054">Melanesia</territory>
+			<territory type="057">Yankin Micronesiya</territory>
+			<territory type="061">Kasar Polynesia</territory>
+			<territory type="142">Asiya</territory>
+			<territory type="143">Asiya ta Tsakiya</territory>
+			<territory type="145">Yammacin Asiya</territory>
+			<territory type="150">Turai</territory>
+			<territory type="151">Gabashin Turai</territory>
+			<territory type="154">Arewacin Turai</territory>
+			<territory type="155">Yammacin Turai</territory>
+			<territory type="202">Afirka ta Kudancin Sahara</territory>
+			<territory type="419">Latin Amurka</territory>
+			<territory type="AC">Tsibirin Ascension</territory>
+			<territory type="AD">Andora</territory>
+			<territory type="AE">Haɗaɗɗiyar Daular Larabawa</territory>
+			<territory type="AF">Afaganistan</territory>
+			<territory type="AG">Antigua da Barbuda</territory>
+			<territory type="AI">Angila</territory>
+			<territory type="AL">Albaniya</territory>
+			<territory type="AM">Armeniya</territory>
+			<territory type="AO">Angola</territory>
+			<territory type="AQ">Antatika</territory>
+			<territory type="AR">Arjantiniya</territory>
+			<territory type="AS">Samowa Ta Amurka</territory>
+			<territory type="AT">Ostiriya</territory>
+			<territory type="AU">Ostareliya</territory>
+			<territory type="AW">Aruba</territory>
+			<territory type="AX">Tsibirai na Åland</territory>
+			<territory type="AZ">Azarbaijan</territory>
+			<territory type="BA">Bosniya da Harzagobina</territory>
+			<territory type="BB">Barbadas</territory>
+			<territory type="BD">Bangiladas</territory>
+			<territory type="BE">Belgiyom</territory>
+			<territory type="BF">Burkina Faso</territory>
+			<territory type="BG">Bulgariya</territory>
+			<territory type="BH">Baharan</territory>
+			<territory type="BI">Burundi</territory>
+			<territory type="BJ">Binin</territory>
+			<territory type="BL">San Barthélemy</territory>
+			<territory type="BM">Barmuda</territory>
+			<territory type="BN">Burune</territory>
+			<territory type="BO">Bolibiya</territory>
+			<territory type="BQ">Caribbean Netherlands</territory>
+			<territory type="BR">Birazil</territory>
+			<territory type="BS">Bahamas</territory>
+			<territory type="BT">Butan</territory>
+			<territory type="BV">Tsibirin Bouvet</territory>
+			<territory type="BW">Baswana</territory>
+			<territory type="BY">Belarus</territory>
+			<territory type="BZ">Beliz</territory>
+			<territory type="CA">Kanada</territory>
+			<territory type="CC">Tsibirai Cocos (Keeling)</territory>
+			<territory type="CD">Jamhuriyar Dimokuraɗiyyar Kongo</territory>
+			<territory type="CD" alt="variant">Kongo (DRC)</territory>
+			<territory type="CF">Jamhuriyar Afirka Ta Tsakiya</territory>
+			<territory type="CG">Kongo</territory>
+			<territory type="CG" alt="variant">Jamhuriyar Kongo</territory>
+			<territory type="CH">Suwizalan</territory>
+			<territory type="CI">Aibari Kwas</territory>
 			<territory type="CI" alt="variant">↑↑↑</territory>
-			<territory type="CK">↑↑↑</territory>
-			<territory type="CL">↑↑↑</territory>
-			<territory type="CM">↑↑↑</territory>
-			<territory type="CN">↑↑↑</territory>
-			<territory type="CO">↑↑↑</territory>
-			<territory type="CP">↑↑↑</territory>
-			<territory type="CR">↑↑↑</territory>
-			<territory type="CU">↑↑↑</territory>
-			<territory type="CV">↑↑↑</territory>
-			<territory type="CW">↑↑↑</territory>
-			<territory type="CX">↑↑↑</territory>
-			<territory type="CY">↑↑↑</territory>
-			<territory type="CZ">↑↑↑</territory>
+			<territory type="CK">Tsibiran Kuku</territory>
+			<territory type="CL">Cayile</territory>
+			<territory type="CM">Kamaru</territory>
+			<territory type="CN">Sin</territory>
+			<territory type="CO">Kolambiya</territory>
+			<territory type="CP">Tsibirin Clipperton</territory>
+			<territory type="CR">Kwasta Rika</territory>
+			<territory type="CU">Kyuba</territory>
+			<territory type="CV">Tsibiran Kap Barde</territory>
+			<territory type="CW">Ƙasar Curaçao</territory>
+			<territory type="CX">Tsibirin Kirsmati</territory>
+			<territory type="CY">Sifurus</territory>
+			<territory type="CZ">Jamhuriyar Cak</territory>
 			<territory type="CZ" alt="variant">↑↑↑</territory>
-			<territory type="DE">↑↑↑</territory>
-			<territory type="DG">↑↑↑</territory>
-			<territory type="DJ">↑↑↑</territory>
-			<territory type="DK">↑↑↑</territory>
-			<territory type="DM">↑↑↑</territory>
-			<territory type="DO">↑↑↑</territory>
-			<territory type="DZ">↑↑↑</territory>
-			<territory type="EA">↑↑↑</territory>
-			<territory type="EC">↑↑↑</territory>
-			<territory type="EE">↑↑↑</territory>
-			<territory type="EG">↑↑↑</territory>
-			<territory type="EH">↑↑↑</territory>
-			<territory type="ER">↑↑↑</territory>
-			<territory type="ES">↑↑↑</territory>
-			<territory type="ET">↑↑↑</territory>
-			<territory type="EU">↑↑↑</territory>
-			<territory type="EZ">↑↑↑</territory>
-			<territory type="FI">↑↑↑</territory>
-			<territory type="FJ">↑↑↑</territory>
-			<territory type="FK">↑↑↑</territory>
+			<territory type="DE">Jamus</territory>
+			<territory type="DG">Tsibirn Diego Garcia</territory>
+			<territory type="DJ">Jibuti</territory>
+			<territory type="DK">Danmark</territory>
+			<territory type="DM">Dominika</territory>
+			<territory type="DO">Jamhuriyar Dominika</territory>
+			<territory type="DZ">Aljeriya</territory>
+			<territory type="EA">Ceuta da Melilla</territory>
+			<territory type="EC">Ekwador</territory>
+			<territory type="EE">Estoniya</territory>
+			<territory type="EG">Misira</territory>
+			<territory type="EH">Yammacin Sahara</territory>
+			<territory type="ER">Eritireya</territory>
+			<territory type="ES">Sipen</territory>
+			<territory type="ET">Habasha</territory>
+			<territory type="EU">Tarayyar Turai</territory>
+			<territory type="EZ">Sashin Turai</territory>
+			<territory type="FI">Finlan</territory>
+			<territory type="FJ">Fiji</territory>
+			<territory type="FK">Tsibiran Falkilan</territory>
 			<territory type="FK" alt="variant">↑↑↑</territory>
-			<territory type="FM">↑↑↑</territory>
-			<territory type="FO">↑↑↑</territory>
-			<territory type="FR">↑↑↑</territory>
-			<territory type="GA">↑↑↑</territory>
-			<territory type="GB">↑↑↑</territory>
+			<territory type="FM">Mikuronesiya</territory>
+			<territory type="FO">Tsibirai na Faroe</territory>
+			<territory type="FR">Faransa</territory>
+			<territory type="GA">Gabon</territory>
+			<territory type="GB">Biritaniya</territory>
 			<territory type="GB" alt="short">↑↑↑</territory>
-			<territory type="GD">↑↑↑</territory>
-			<territory type="GE">↑↑↑</territory>
-			<territory type="GF">↑↑↑</territory>
-			<territory type="GG">↑↑↑</territory>
-			<territory type="GH">↑↑↑</territory>
-			<territory type="GI">↑↑↑</territory>
-			<territory type="GL">↑↑↑</territory>
-			<territory type="GM">↑↑↑</territory>
-			<territory type="GN">↑↑↑</territory>
-			<territory type="GP">↑↑↑</territory>
-			<territory type="GQ">↑↑↑</territory>
-			<territory type="GR">↑↑↑</territory>
-			<territory type="GS">↑↑↑</territory>
-			<territory type="GT">↑↑↑</territory>
-			<territory type="GU">↑↑↑</territory>
-			<territory type="GW">↑↑↑</territory>
-			<territory type="GY">↑↑↑</territory>
-			<territory type="HK">↑↑↑</territory>
+			<territory type="GD">Girnada</territory>
+			<territory type="GE">Jiwarjiya</territory>
+			<territory type="GF">Gini Ta Faransa</territory>
+			<territory type="GG">Yankin Guernsey</territory>
+			<territory type="GH">Gana</territory>
+			<territory type="GI">Jibaraltar</territory>
+			<territory type="GL">Grinlan</territory>
+			<territory type="GM">Gambiya</territory>
+			<territory type="GN">Gini</territory>
+			<territory type="GP">Gwadaluf</territory>
+			<territory type="GQ">Gini Ta Ikwaita</territory>
+			<territory type="GR">Girka</territory>
+			<territory type="GS">Kudancin Geogia da Kudancin Tsibirin Sandiwic</territory>
+			<territory type="GT">Gwatamala</territory>
+			<territory type="GU">Gwam</territory>
+			<territory type="GW">Gini Bisau</territory>
+			<territory type="GY">Guyana</territory>
+			<territory type="HK">Babban Yankin Mulkin Hong Kong na Ƙasar Sin</territory>
 			<territory type="HK" alt="short">↑↑↑</territory>
-			<territory type="HM">↑↑↑</territory>
-			<territory type="HN">↑↑↑</territory>
-			<territory type="HR">↑↑↑</territory>
-			<territory type="HT">↑↑↑</territory>
-			<territory type="HU">↑↑↑</territory>
-			<territory type="IC">↑↑↑</territory>
-			<territory type="ID">↑↑↑</territory>
-			<territory type="IE">↑↑↑</territory>
-			<territory type="IL">↑↑↑</territory>
-			<territory type="IM">↑↑↑</territory>
-			<territory type="IN">↑↑↑</territory>
-			<territory type="IO">↑↑↑</territory>
+			<territory type="HM">Tsibirin Heard da McDonald</territory>
+			<territory type="HN">Yankin Honduras</territory>
+			<territory type="HR">Kurowaishiya</territory>
+			<territory type="HT">Haiti</territory>
+			<territory type="HU">Hungari</territory>
+			<territory type="IC">Tsibiran Canary</territory>
+			<territory type="ID">Indunusiya</territory>
+			<territory type="IE">Ayalan</territory>
+			<territory type="IL">Israʼila</territory>
+			<territory type="IM">Isle na Mutum</territory>
+			<territory type="IN">Indiya</territory>
+			<territory type="IO">Yankin Birtaniya Na Tekun Indiya</territory>
 			<territory type="IO" alt="biot">↑↑↑</territory>
 			<territory type="IO" alt="chagos">↑↑↑</territory>
-			<territory type="IQ">↑↑↑</territory>
-			<territory type="IR">↑↑↑</territory>
-			<territory type="IS">↑↑↑</territory>
-			<territory type="IT">↑↑↑</territory>
-			<territory type="JE">↑↑↑</territory>
-			<territory type="JM">↑↑↑</territory>
-			<territory type="JO">↑↑↑</territory>
-			<territory type="JP">↑↑↑</territory>
-			<territory type="KE">↑↑↑</territory>
-			<territory type="KG">↑↑↑</territory>
-			<territory type="KH">↑↑↑</territory>
-			<territory type="KI">↑↑↑</territory>
-			<territory type="KM">↑↑↑</territory>
-			<territory type="KN">↑↑↑</territory>
-			<territory type="KP">↑↑↑</territory>
-			<territory type="KR">↑↑↑</territory>
-			<territory type="KW">↑↑↑</territory>
-			<territory type="KY">↑↑↑</territory>
-			<territory type="KZ">↑↑↑</territory>
-			<territory type="LA">↑↑↑</territory>
-			<territory type="LB">↑↑↑</territory>
-			<territory type="LC">↑↑↑</territory>
-			<territory type="LI">↑↑↑</territory>
-			<territory type="LK">↑↑↑</territory>
-			<territory type="LR">↑↑↑</territory>
-			<territory type="LS">↑↑↑</territory>
-			<territory type="LT">↑↑↑</territory>
-			<territory type="LU">↑↑↑</territory>
-			<territory type="LV">↑↑↑</territory>
-			<territory type="LY">↑↑↑</territory>
-			<territory type="MA">↑↑↑</territory>
-			<territory type="MC">↑↑↑</territory>
-			<territory type="MD">↑↑↑</territory>
-			<territory type="ME">↑↑↑</territory>
-			<territory type="MF">↑↑↑</territory>
-			<territory type="MG">↑↑↑</territory>
-			<territory type="MH">↑↑↑</territory>
-			<territory type="MK">↑↑↑</territory>
-			<territory type="ML">↑↑↑</territory>
-			<territory type="MM">↑↑↑</territory>
-			<territory type="MN">↑↑↑</territory>
-			<territory type="MO">↑↑↑</territory>
+			<territory type="IQ">Iraƙi</territory>
+			<territory type="IR">Iran</territory>
+			<territory type="IS">Aisalan</territory>
+			<territory type="IT">Italiya</territory>
+			<territory type="JE">Kasar Jersey</territory>
+			<territory type="JM">Jamaika</territory>
+			<territory type="JO">Jordan</territory>
+			<territory type="JP">Japan</territory>
+			<territory type="KE">Kenya</territory>
+			<territory type="KG">Kirgizistan</territory>
+			<territory type="KH">Kambodiya</territory>
+			<territory type="KI">Kiribati</territory>
+			<territory type="KM">Kwamoras</territory>
+			<territory type="KN">San Kiti Da Nebis</territory>
+			<territory type="KP">Koriya Ta Arewa</territory>
+			<territory type="KR">Koriya Ta Kudu</territory>
+			<territory type="KW">Kwiyat</territory>
+			<territory type="KY">Tsibiran Kaiman</territory>
+			<territory type="KZ">Kazakistan</territory>
+			<territory type="LA">Lawas</territory>
+			<territory type="LB">Labanan</territory>
+			<territory type="LC">San Lusiya</territory>
+			<territory type="LI">Licansitan</territory>
+			<territory type="LK">Siri Lanka</territory>
+			<territory type="LR">Laberiya</territory>
+			<territory type="LS">Lesoto</territory>
+			<territory type="LT">Lituweniya</territory>
+			<territory type="LU">Lukusambur</territory>
+			<territory type="LV">Litibiya</territory>
+			<territory type="LY">Libiya</territory>
+			<territory type="MA">Maroko</territory>
+			<territory type="MC">Monako</territory>
+			<territory type="MD">Maldoba</territory>
+			<territory type="ME">Mantanegara</territory>
+			<territory type="MF">San Martin</territory>
+			<territory type="MG">Madagaskar</territory>
+			<territory type="MH">Tsibiran Marshal</territory>
+			<territory type="MK">Macedonia ta Arewa</territory>
+			<territory type="ML">Mali</territory>
+			<territory type="MM">Burma, Miyamar</territory>
+			<territory type="MN">Mangoliya</territory>
+			<territory type="MO">Babban Yankin Mulkin Macao na Ƙasar Sin</territory>
 			<territory type="MO" alt="short">↑↑↑</territory>
-			<territory type="MP">↑↑↑</territory>
-			<territory type="MQ">↑↑↑</territory>
-			<territory type="MR">↑↑↑</territory>
-			<territory type="MS">↑↑↑</territory>
-			<territory type="MT">↑↑↑</territory>
-			<territory type="MU">↑↑↑</territory>
-			<territory type="MV">↑↑↑</territory>
-			<territory type="MW">↑↑↑</territory>
-			<territory type="MX">↑↑↑</territory>
-			<territory type="MY">↑↑↑</territory>
-			<territory type="MZ">↑↑↑</territory>
-			<territory type="NA">↑↑↑</territory>
-			<territory type="NC">↑↑↑</territory>
-			<territory type="NE">↑↑↑</territory>
-			<territory type="NF">↑↑↑</territory>
-			<territory type="NG">↑↑↑</territory>
-			<territory type="NI">↑↑↑</territory>
-			<territory type="NL">↑↑↑</territory>
-			<territory type="NO">↑↑↑</territory>
-			<territory type="NP">↑↑↑</territory>
-			<territory type="NR">↑↑↑</territory>
-			<territory type="NU">↑↑↑</territory>
-			<territory type="NZ">↑↑↑</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
-			<territory type="OM">↑↑↑</territory>
-			<territory type="PA">↑↑↑</territory>
-			<territory type="PE">↑↑↑</territory>
-			<territory type="PF">↑↑↑</territory>
-			<territory type="PG">↑↑↑</territory>
-			<territory type="PH">↑↑↑</territory>
-			<territory type="PK">↑↑↑</territory>
-			<territory type="PL">↑↑↑</territory>
-			<territory type="PM">↑↑↑</territory>
-			<territory type="PN">↑↑↑</territory>
-			<territory type="PR">↑↑↑</territory>
-			<territory type="PS">↑↑↑</territory>
-			<territory type="PS" alt="short">↑↑↑</territory>
-			<territory type="PT">↑↑↑</territory>
-			<territory type="PW">↑↑↑</territory>
-			<territory type="PY">↑↑↑</territory>
-			<territory type="QA">↑↑↑</territory>
-			<territory type="QO">↑↑↑</territory>
-			<territory type="RE">↑↑↑</territory>
-			<territory type="RO">↑↑↑</territory>
-			<territory type="RS">↑↑↑</territory>
-			<territory type="RU">↑↑↑</territory>
-			<territory type="RW">↑↑↑</territory>
-			<territory type="SA">↑↑↑</territory>
-			<territory type="SB">↑↑↑</territory>
-			<territory type="SC">↑↑↑</territory>
-			<territory type="SD">↑↑↑</territory>
-			<territory type="SE">↑↑↑</territory>
-			<territory type="SG">↑↑↑</territory>
-			<territory type="SH">↑↑↑</territory>
-			<territory type="SI">↑↑↑</territory>
-			<territory type="SJ">↑↑↑</territory>
-			<territory type="SK">↑↑↑</territory>
-			<territory type="SL">↑↑↑</territory>
-			<territory type="SM">↑↑↑</territory>
-			<territory type="SN">↑↑↑</territory>
-			<territory type="SO">↑↑↑</territory>
-			<territory type="SR">↑↑↑</territory>
-			<territory type="SS">↑↑↑</territory>
-			<territory type="ST">↑↑↑</territory>
-			<territory type="SV">↑↑↑</territory>
-			<territory type="SX">↑↑↑</territory>
-			<territory type="SY">↑↑↑</territory>
-			<territory type="SZ">↑↑↑</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
-			<territory type="TA">↑↑↑</territory>
-			<territory type="TC">↑↑↑</territory>
-			<territory type="TD">↑↑↑</territory>
-			<territory type="TF">↑↑↑</territory>
-			<territory type="TG">↑↑↑</territory>
-			<territory type="TH">↑↑↑</territory>
-			<territory type="TJ">↑↑↑</territory>
-			<territory type="TK">↑↑↑</territory>
-			<territory type="TL">↑↑↑</territory>
+			<territory type="MP">Tsibiran Mariyana Na Arewa</territory>
+			<territory type="MQ">Martinik</territory>
+			<territory type="MR">Moritaniya</territory>
+			<territory type="MS">Manserati</territory>
+			<territory type="MT">Malta</territory>
+			<territory type="MU">Moritus</territory>
+			<territory type="MV">Maldibi</territory>
+			<territory type="MW">Malawi</territory>
+			<territory type="MX">Mesiko</territory>
+			<territory type="MY">Malaisiya</territory>
+			<territory type="MZ">Mozambik</territory>
+			<territory type="NA">Namibiya</territory>
+			<territory type="NC">Kaledoniya Sabuwa</territory>
+			<territory type="NE">Nijar</territory>
+			<territory type="NF">Tsibirin Narfalk</territory>
+			<territory type="NG">Nijeriya</territory>
+			<territory type="NI">Nikaraguwa</territory>
+			<territory type="NL">Holan</territory>
+			<territory type="NO">Norwe</territory>
+			<territory type="NP">Nefal</territory>
+			<territory type="NR">Nauru</territory>
+			<territory type="NU">Niyu</territory>
+			<territory type="NZ">Nuzilan</territory>
+			<territory type="NZ" alt="variant">Aotearoa Nuzilan</territory>
+			<territory type="OM">Oman</territory>
+			<territory type="PA">Panama</territory>
+			<territory type="PE">Feru</territory>
+			<territory type="PF">Folinesiya Ta Faransa</territory>
+			<territory type="PG">Papuwa Nugini</territory>
+			<territory type="PH">Filipin</territory>
+			<territory type="PK">Pakistan</territory>
+			<territory type="PL">Polan</territory>
+			<territory type="PM">San Piyar da Mikelan</territory>
+			<territory type="PN">Pitakarin</territory>
+			<territory type="PR">Porto Riko</territory>
+			<territory type="PS">Yankunan Palasɗinu</territory>
+			<territory type="PS" alt="short">Palasɗinu</territory>
+			<territory type="PT">Portugal</territory>
+			<territory type="PW">Palau</territory>
+			<territory type="PY">Faragwai</territory>
+			<territory type="QA">Katar</territory>
+			<territory type="QO">Bakin Teku</territory>
+			<territory type="RE">Rawuniyan</territory>
+			<territory type="RO">Romaniya</territory>
+			<territory type="RS">Sabiya</territory>
+			<territory type="RU">Rasha</territory>
+			<territory type="RW">Ruwanda</territory>
+			<territory type="SA">Saudiyya</territory>
+			<territory type="SB">Tsibiran Salaman</territory>
+			<territory type="SC">Seychelles</territory>
+			<territory type="SD">Sudan</territory>
+			<territory type="SE">Suwedan</territory>
+			<territory type="SG">Singapur</territory>
+			<territory type="SH">San Helena</territory>
+			<territory type="SI">Sulobeniya</territory>
+			<territory type="SJ">Svalbard da Jan Mayen</territory>
+			<territory type="SK">Sulobakiya</territory>
+			<territory type="SL">Salewo</territory>
+			<territory type="SM">San Marino</territory>
+			<territory type="SN">Sanigal</territory>
+			<territory type="SO">Somaliya</territory>
+			<territory type="SR">Suriname</territory>
+			<territory type="SS">Sudan ta Kudu</territory>
+			<territory type="ST">Sawo Tome Da Paransip</territory>
+			<territory type="SV">El Salbador</territory>
+			<territory type="SX">San Maarten</territory>
+			<territory type="SY">Sham, Siriya</territory>
+			<territory type="SZ">Eswatini</territory>
+			<territory type="SZ" alt="variant">Suwazilan</territory>
+			<territory type="TA">Tritan da Kunha</territory>
+			<territory type="TC">Turkis Da Tsibiran Kaikwas</territory>
+			<territory type="TD">Cadi</territory>
+			<territory type="TF">Yankin Faransi ta Kudu</territory>
+			<territory type="TG">Togo</territory>
+			<territory type="TH">Tailan</territory>
+			<territory type="TJ">Tajikistan</territory>
+			<territory type="TK">Takelau</territory>
+			<territory type="TL">Timor Ta Gabas</territory>
 			<territory type="TL" alt="variant">↑↑↑</territory>
-			<territory type="TM">↑↑↑</territory>
-			<territory type="TN">↑↑↑</territory>
-			<territory type="TO">↑↑↑</territory>
-			<territory type="TR">↑↑↑</territory>
+			<territory type="TM">Turkumenistan</territory>
+			<territory type="TN">Tunisiya</territory>
+			<territory type="TO">Tonga</territory>
+			<territory type="TR">Turkiyya</territory>
 			<territory type="TR" alt="variant">↑↑↑</territory>
-			<territory type="TT">↑↑↑</territory>
-			<territory type="TV">↑↑↑</territory>
-			<territory type="TW">↑↑↑</territory>
-			<territory type="TZ">↑↑↑</territory>
-			<territory type="UA">↑↑↑</territory>
-			<territory type="UG">↑↑↑</territory>
-			<territory type="UM">↑↑↑</territory>
-			<territory type="UN">↑↑↑</territory>
-			<territory type="US">↑↑↑</territory>
+			<territory type="TT">Tirinidad Da Tobago</territory>
+			<territory type="TV">Tubalu</territory>
+			<territory type="TW">Taiwan</territory>
+			<territory type="TZ">Tanzaniya</territory>
+			<territory type="UA">Yukaran</territory>
+			<territory type="UG">Yuganda</territory>
+			<territory type="UM">Rukunin Tsibirin U.S</territory>
+			<territory type="UN">Majalisar Ɗinkin Duniya</territory>
+			<territory type="US">Amurka</territory>
 			<territory type="US" alt="short">↑↑↑</territory>
-			<territory type="UY">↑↑↑</territory>
-			<territory type="UZ">↑↑↑</territory>
-			<territory type="VA">↑↑↑</territory>
-			<territory type="VC">↑↑↑</territory>
-			<territory type="VE">↑↑↑</territory>
-			<territory type="VG">↑↑↑</territory>
-			<territory type="VI">↑↑↑</territory>
-			<territory type="VN">↑↑↑</territory>
-			<territory type="VU">↑↑↑</territory>
-			<territory type="WF">↑↑↑</territory>
-			<territory type="WS">↑↑↑</territory>
-			<territory type="XA">↑↑↑</territory>
-			<territory type="XB">↑↑↑</territory>
-			<territory type="XK">↑↑↑</territory>
-			<territory type="YE">↑↑↑</territory>
-			<territory type="YT">↑↑↑</territory>
-			<territory type="ZA">↑↑↑</territory>
-			<territory type="ZM">↑↑↑</territory>
-			<territory type="ZW">↑↑↑</territory>
-			<territory type="ZZ">↑↑↑</territory>
+			<territory type="UY">Yurigwai</territory>
+			<territory type="UZ">Uzubekistan</territory>
+			<territory type="VA">Batikan</territory>
+			<territory type="VC">San Binsan Da Girnadin</territory>
+			<territory type="VE">Benezuwela</territory>
+			<territory type="VG">Tsibirin Birjin Na Birtaniya</territory>
+			<territory type="VI">Tsibiran Birjin Ta Amurka</territory>
+			<territory type="VN">Biyetinam</territory>
+			<territory type="VU">Banuwatu</territory>
+			<territory type="WF">Walis Da Futuna</territory>
+			<territory type="WS">Samoa</territory>
+			<territory type="XA">Gogewar Kwalwa</territory>
+			<territory type="XB">Gano wani abu ta hanyar amfani da fasaha</territory>
+			<territory type="XK">Kasar Kosovo</territory>
+			<territory type="YE">Yamal</territory>
+			<territory type="YT">Mayoti</territory>
+			<territory type="ZA">Afirka Ta Kudu</territory>
+			<territory type="ZM">Zambiya</territory>
+			<territory type="ZW">Zimbabuwe</territory>
+			<territory type="ZZ">Yanki da ba a sani ba</territory>
 		</territories>
 		<keys>
-			<key type="calendar">↑↑↑</key>
-			<key type="cf">↑↑↑</key>
-			<key type="collation">↑↑↑</key>
-			<key type="currency">↑↑↑</key>
-			<key type="hc">↑↑↑</key>
-			<key type="lb">↑↑↑</key>
-			<key type="ms">↑↑↑</key>
-			<key type="numbers">↑↑↑</key>
+			<key type="calendar">Kalanda</key>
+			<key type="cf">Yanayin Kudi</key>
+			<key type="collation">Tsarin Rabewa</key>
+			<key type="currency">Kudin Kasa</key>
+			<key type="hc">Zagayen Awowi</key>
+			<key type="lb">Salo na Raba Layi</key>
+			<key type="ms">Tsarin Awo</key>
+			<key type="numbers">Lambobi</key>
 		</keys>
 		<types>
-			<type key="calendar" type="buddhist">↑↑↑</type>
-			<type key="calendar" type="chinese">↑↑↑</type>
-			<type key="calendar" type="coptic">↑↑↑</type>
-			<type key="calendar" type="dangi">↑↑↑</type>
-			<type key="calendar" type="ethiopic">↑↑↑</type>
-			<type key="calendar" type="ethiopic-amete-alem">↑↑↑</type>
-			<type key="calendar" type="gregorian">↑↑↑</type>
-			<type key="calendar" type="hebrew">↑↑↑</type>
-			<type key="calendar" type="islamic">↑↑↑</type>
-			<type key="calendar" type="islamic-civil">↑↑↑</type>
-			<type key="calendar" type="islamic-tbla">↑↑↑</type>
-			<type key="calendar" type="islamic-umalqura">↑↑↑</type>
-			<type key="calendar" type="iso8601">↑↑↑</type>
-			<type key="calendar" type="japanese">↑↑↑</type>
-			<type key="calendar" type="persian">↑↑↑</type>
-			<type key="calendar" type="roc">↑↑↑</type>
-			<type key="cf" type="account">↑↑↑</type>
-			<type key="cf" type="standard">↑↑↑</type>
-			<type key="collation" type="ducet">↑↑↑</type>
-			<type key="collation" type="search">↑↑↑</type>
-			<type key="collation" type="standard">↑↑↑</type>
-			<type key="hc" type="h11">↑↑↑</type>
-			<type key="hc" type="h12">↑↑↑</type>
-			<type key="hc" type="h23">↑↑↑</type>
-			<type key="hc" type="h24">↑↑↑</type>
-			<type key="lb" type="loose">↑↑↑</type>
-			<type key="lb" type="normal">↑↑↑</type>
-			<type key="lb" type="strict">↑↑↑</type>
-			<type key="ms" type="metric">↑↑↑</type>
-			<type key="ms" type="uksystem">↑↑↑</type>
-			<type key="ms" type="ussystem">↑↑↑</type>
-			<type key="numbers" type="arab">↑↑↑</type>
-			<type key="numbers" type="arabext">↑↑↑</type>
-			<type key="numbers" type="armn">↑↑↑</type>
-			<type key="numbers" type="armnlow">↑↑↑</type>
-			<type key="numbers" type="beng">↑↑↑</type>
-			<type key="numbers" type="cakm">↑↑↑</type>
-			<type key="numbers" type="deva">↑↑↑</type>
-			<type key="numbers" type="ethi">↑↑↑</type>
-			<type key="numbers" type="fullwide">↑↑↑</type>
-			<type key="numbers" type="geor">↑↑↑</type>
-			<type key="numbers" type="grek">↑↑↑</type>
-			<type key="numbers" type="greklow">↑↑↑</type>
-			<type key="numbers" type="gujr">↑↑↑</type>
-			<type key="numbers" type="guru">↑↑↑</type>
-			<type key="numbers" type="hanidec">↑↑↑</type>
-			<type key="numbers" type="hans">↑↑↑</type>
-			<type key="numbers" type="hansfin">↑↑↑</type>
-			<type key="numbers" type="hant">↑↑↑</type>
-			<type key="numbers" type="hantfin">↑↑↑</type>
-			<type key="numbers" type="hebr">↑↑↑</type>
-			<type key="numbers" type="java">↑↑↑</type>
-			<type key="numbers" type="jpan">↑↑↑</type>
-			<type key="numbers" type="jpanfin">↑↑↑</type>
-			<type key="numbers" type="khmr">↑↑↑</type>
-			<type key="numbers" type="knda">↑↑↑</type>
-			<type key="numbers" type="laoo">↑↑↑</type>
-			<type key="numbers" type="latn">↑↑↑</type>
-			<type key="numbers" type="mlym">↑↑↑</type>
-			<type key="numbers" type="mtei">↑↑↑</type>
-			<type key="numbers" type="mymr">↑↑↑</type>
-			<type key="numbers" type="olck">↑↑↑</type>
-			<type key="numbers" type="orya">↑↑↑</type>
-			<type key="numbers" type="roman">↑↑↑</type>
-			<type key="numbers" type="romanlow">↑↑↑</type>
-			<type key="numbers" type="taml">↑↑↑</type>
-			<type key="numbers" type="tamldec">↑↑↑</type>
-			<type key="numbers" type="telu">↑↑↑</type>
-			<type key="numbers" type="thai">↑↑↑</type>
-			<type key="numbers" type="tibt">↑↑↑</type>
-			<type key="numbers" type="vaii">↑↑↑</type>
+			<type key="calendar" type="buddhist">Kalandar Buddist</type>
+			<type key="calendar" type="chinese">Kalandar Sin</type>
+			<type key="calendar" type="coptic">Kalandar Coptic</type>
+			<type key="calendar" type="dangi">Kalandar Dangi</type>
+			<type key="calendar" type="ethiopic">Kalandar Etiofic</type>
+			<type key="calendar" type="ethiopic-amete-alem">Kalandar Ethiopic Amete Alem</type>
+			<type key="calendar" type="gregorian">Kalandar Gregoria</type>
+			<type key="calendar" type="hebrew">Kalandar Ibrananci</type>
+			<type key="calendar" type="islamic">Kalandar Musulunci</type>
+			<type key="calendar" type="islamic-civil">Kalandar Musulunci (tabular, civil epoch)</type>
+			<type key="calendar" type="islamic-tbla">Kalandar Musulunci (tabular, astronomical epoch)</type>
+			<type key="calendar" type="islamic-umalqura">Kalandar Musulunci (Umm al-Qura)</type>
+			<type key="calendar" type="iso8601">Kalandar ISO-8601</type>
+			<type key="calendar" type="japanese">Kalandar Jafan</type>
+			<type key="calendar" type="persian">Kalandar Farisa</type>
+			<type key="calendar" type="roc">Kalandar kasar Sin</type>
+			<type key="cf" type="account">Tsarin Kudi na Kididdiga</type>
+			<type key="cf" type="standard">Tsarin Kudi Nagartacce</type>
+			<type key="collation" type="ducet">Tsarin Rabewa na Dan-maƙalu na Asali</type>
+			<type key="collation" type="search">Bincike na Dalilai-Gamagari</type>
+			<type key="collation" type="standard">Daidaitaccen Kasawa</type>
+			<type key="hc" type="h11">Tsarin Awowi 12(0–11)</type>
+			<type key="hc" type="h12">Tsarin Awowi 12(1–12)</type>
+			<type key="hc" type="h23">Tsarin Awowi 24(0–23)</type>
+			<type key="hc" type="h24">Tsarin Awowi 24(1–24)</type>
+			<type key="lb" type="loose">Salo na Raba Layi Sakakke</type>
+			<type key="lb" type="normal">Salo na Raba Layi na Kodayaushe</type>
+			<type key="lb" type="strict">Salo na Raba Layi mai Tsauri</type>
+			<type key="ms" type="metric">Tsarin Awo na Metric</type>
+			<type key="ms" type="uksystem">Tsarin Awo na Imperial</type>
+			<type key="ms" type="ussystem">Tsarin Awo na Amurka</type>
+			<type key="numbers" type="arab">Lambobi na Larabawan a Gabas</type>
+			<type key="numbers" type="arabext">Fitattun lambobin lissafi na Larabci</type>
+			<type key="numbers" type="armn">Lambobin ƙirga na Armenia</type>
+			<type key="numbers" type="armnlow">Kananan Haruffan Armenia</type>
+			<type key="numbers" type="beng">Lambobin Yaren Bangla</type>
+			<type key="numbers" type="cakm">Lambobin Chakma</type>
+			<type key="numbers" type="deva">Lambobin Tsarin Rubutu na Devangari</type>
+			<type key="numbers" type="ethi">Lambobin ƙirga na Ethiopia</type>
+			<type key="numbers" type="fullwide">Lambobi masu Cikakken-Faɗi</type>
+			<type key="numbers" type="geor">Lambobin ƙirga na Georgia</type>
+			<type key="numbers" type="grek">Lambobin ƙirga na Girka</type>
+			<type key="numbers" type="greklow">Kananan Haruffa na Girka</type>
+			<type key="numbers" type="gujr">Lambobin Yaren Gujarati</type>
+			<type key="numbers" type="guru">Lambobi na Tsarin Rubutun Gurmukhi</type>
+			<type key="numbers" type="hanidec">Lambobin Gomiya na Yaren ƙasar Sin</type>
+			<type key="numbers" type="hans">Lambobin ƙirga na Yaren ƙasar Sin wanda aka Sauƙaƙa</type>
+			<type key="numbers" type="hansfin">Lambobin Ƙirgan Kudi na Yaren ƙasar Sin wanda aka Sauƙaƙa</type>
+			<type key="numbers" type="hant">Lambobin Ƙirga na Yaren ƙasar Sin na Alʼada</type>
+			<type key="numbers" type="hantfin">Lambobin Ƙirgan Kudi na Yaren ƙasar Sin na Alʼada</type>
+			<type key="numbers" type="hebr">Lambobin ƙirga na Hebrew</type>
+			<type key="numbers" type="java">Lambobin Javanese</type>
+			<type key="numbers" type="jpan">Lambobin ƙirga na Jafananci</type>
+			<type key="numbers" type="jpanfin">Lambobin ƙirgan Kudi na Jafananci</type>
+			<type key="numbers" type="khmr">Lambobin Yaren Khmer</type>
+			<type key="numbers" type="knda">Lambobin Yaren Kannada</type>
+			<type key="numbers" type="laoo">Lambobin Yaren Lao</type>
+			<type key="numbers" type="latn">Lambobi na Yammaci</type>
+			<type key="numbers" type="mlym">Lambobin Yaren Malayalam</type>
+			<type key="numbers" type="mtei">Lambobin Meetei Mayek</type>
+			<type key="numbers" type="mymr">Lambobin Myanmar</type>
+			<type key="numbers" type="olck">Lambobin Ol Chiki</type>
+			<type key="numbers" type="orya">Lambobin Yaren Odia</type>
+			<type key="numbers" type="roman">Lambobin Rumawa</type>
+			<type key="numbers" type="romanlow">Lambobin Kirga Kanana na Rumawa</type>
+			<type key="numbers" type="taml">Lambobin ƙirga na Tamil na Alʼada</type>
+			<type key="numbers" type="tamldec">Lambobin Tamil</type>
+			<type key="numbers" type="telu">Lambobin yaren Telugu</type>
+			<type key="numbers" type="thai">Lambobin yaren Thai</type>
+			<type key="numbers" type="tibt">Lambobin yaren Tibet</type>
+			<type key="numbers" type="vaii">Lambobin Vai</type>
 		</types>
 		<measurementSystemNames>
-			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
-			<measurementSystemName type="UK">↑↑↑</measurementSystemName>
-			<measurementSystemName type="US">↑↑↑</measurementSystemName>
+			<measurementSystemName type="metric">Tsarin awo</measurementSystemName>
+			<measurementSystemName type="UK">Tsarin awo kasar Ingila</measurementSystemName>
+			<measurementSystemName type="US">Amurka</measurementSystemName>
 		</measurementSystemNames>
 		<codePatterns>
-			<codePattern type="language">↑↑↑</codePattern>
-			<codePattern type="script">↑↑↑</codePattern>
-			<codePattern type="territory">↑↑↑</codePattern>
+			<codePattern type="language">Harshe: {0}</codePattern>
+			<codePattern type="script">Rubutu: {0}</codePattern>
+			<codePattern type="territory">Yanki: {0}</codePattern>
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
@@ -981,49 +981,49 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE, d MMMM, y G</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM, y G</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM, y G</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d/M/yy GGGGG</pattern>
+							<datetimeSkeleton>GGGGGyyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
 				<dateTimeFormats>
 					<dateTimeFormatLength type="full">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{0} 'da' {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{0} 'da' {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
 							<pattern>↑↑↑</pattern>
@@ -1031,7 +1031,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{0}, {1}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
 							<pattern>↑↑↑</pattern>
@@ -1062,22 +1062,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="hms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Hms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
 						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
@@ -1205,18 +1205,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Jan</month>
+							<month type="2">Fab</month>
+							<month type="3">Mar</month>
+							<month type="4">Afi</month>
+							<month type="5">May</month>
+							<month type="6">Yun</month>
+							<month type="7">Yul</month>
+							<month type="8">Agu</month>
+							<month type="9">Sat</month>
+							<month type="10">Okt</month>
+							<month type="11">Nuw</month>
+							<month type="12">Dis</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">↑↑↑</month>
@@ -1233,18 +1233,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">Janairu</month>
+							<month type="2">Faburairu</month>
+							<month type="3">Maris</month>
+							<month type="4">Afirilu</month>
+							<month type="5">Mayu</month>
+							<month type="6">Yuni</month>
+							<month type="7">Yuli</month>
+							<month type="8">Agusta</month>
+							<month type="9">Satumba</month>
+							<month type="10">Oktoba</month>
+							<month type="11">Nuwamba</month>
+							<month type="12">Disamba</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
@@ -1263,18 +1263,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">↑↑↑</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
-							<month type="3">↑↑↑</month>
-							<month type="4">↑↑↑</month>
-							<month type="5">↑↑↑</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
-							<month type="10">↑↑↑</month>
-							<month type="11">↑↑↑</month>
-							<month type="12">↑↑↑</month>
+							<month type="1">J</month>
+							<month type="2">F</month>
+							<month type="3">M</month>
+							<month type="4">A</month>
+							<month type="5">M</month>
+							<month type="6">Y</month>
+							<month type="7">Y</month>
+							<month type="8">A</month>
+							<month type="9">S</month>
+							<month type="10">O</month>
+							<month type="11">N</month>
+							<month type="12">D</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">↑↑↑</month>
@@ -1295,13 +1295,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Lah</day>
+							<day type="mon">Lit</day>
+							<day type="tue">Tal</day>
+							<day type="wed">Lar</day>
+							<day type="thu">Alh</day>
+							<day type="fri">Jum</day>
+							<day type="sat">Asa</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">↑↑↑</day>
@@ -1313,22 +1313,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Lh</day>
+							<day type="mon">Li</day>
+							<day type="tue">Ta</day>
+							<day type="wed">Lr</day>
+							<day type="thu">Al</day>
+							<day type="fri">Ju</day>
+							<day type="sat">As</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sun">Lahadi</day>
+							<day type="mon">Litinin</day>
+							<day type="tue">Talata</day>
+							<day type="wed">Laraba</day>
+							<day type="thu">Alhamis</day>
+							<day type="fri">Jummaʼa</day>
+							<day type="sat">Asabar</day>
 						</dayWidth>
 					</dayContext>
 					<dayContext type="stand-alone">
@@ -1342,13 +1342,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
+							<day type="sun">L</day>
+							<day type="mon">L</day>
 							<day type="tue">↑↑↑</day>
-							<day type="wed">↑↑↑</day>
-							<day type="thu">↑↑↑</day>
-							<day type="fri">↑↑↑</day>
-							<day type="sat">↑↑↑</day>
+							<day type="wed">L</day>
+							<day type="thu">A</day>
+							<day type="fri">J</day>
+							<day type="sat">A</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">↑↑↑</day>
@@ -1373,10 +1373,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<quarters>
 					<quarterContext type="format">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">K1</quarter>
+							<quarter type="2">K2</quarter>
+							<quarter type="3">K3</quarter>
+							<quarter type="4">K4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">↑↑↑</quarter>
@@ -1385,10 +1385,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
-							<quarter type="3">↑↑↑</quarter>
-							<quarter type="4">↑↑↑</quarter>
+							<quarter type="1">Kwata na ɗaya</quarter>
+							<quarter type="2">Kwata na biyu</quarter>
+							<quarter type="3">Kwata na uku</quarter>
+							<quarter type="4">Kwata na huɗu</quarter>
 						</quarterWidth>
 					</quarterContext>
 					<quarterContext type="stand-alone">
@@ -1415,16 +1415,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dayPeriods>
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="abbreviated">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">SF</dayPeriod>
+							<dayPeriod type="pm">YM</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
-							<dayPeriod type="am">↑↑↑</dayPeriod>
-							<dayPeriod type="pm">↑↑↑</dayPeriod>
+							<dayPeriod type="am">Safiya</dayPeriod>
+							<dayPeriod type="pm">Yamma</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
@@ -1444,41 +1444,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">Kafin haihuwar annab</era>
 						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1">Bayan haihuwar annab</era>
+						<era type="1" alt="variant">Sanannen Zamani</era>
 					</eraNames>
 					<eraAbbr>
-						<era type="0">↑↑↑</era>
-						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="0">K.H</era>
+						<era type="0" alt="variant">K.H.Y</era>
+						<era type="1">BHAI</era>
+						<era type="1" alt="variant">B.H.Y</era>
 					</eraAbbr>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>EEEE d MMMM, y</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMMM, y</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>d MMM, y</pattern>
 							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d/M/yy</pattern>
+							<datetimeSkeleton>yyMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -1514,20 +1514,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'da' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'da' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
 							<pattern>↑↑↑</pattern>
@@ -1535,7 +1535,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
 						<dateTimeFormat>
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
 							<pattern>↑↑↑</pattern>
@@ -1549,7 +1549,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="E">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EBhm">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EBhms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Ed">E, d</dateFormatItem>
 						<dateFormatItem id="Ehm">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EHm">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Ehms">↑↑↑</dateFormatItem>
@@ -1561,37 +1561,37 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="h">↑↑↑</dateFormatItem>
 						<dateFormatItem id="H">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hm">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hm">h:mm a</dateFormatItem>
 						<dateFormatItem id="Hm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hms">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hms">h:mm:ss a</dateFormatItem>
 						<dateFormatItem id="Hms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="hmsv">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Hmsv">↑↑↑</dateFormatItem>
 						<dateFormatItem id="hmv">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Hmv">↑↑↑</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="one">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMW" count="other">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMW" count="other">'satin' W 'cikin' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
 						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMd">d MMM, y</dateFormatItem>
 						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
 						<dateFormatItem id="yw" count="one">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yw" count="other">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yw" count="other">'sati' w 'cikin' Y</dateFormatItem>
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Timezone">↑↑↑</appendItem>
@@ -1649,14 +1649,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
 							<greatestDifference id="h">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
 							<greatestDifference id="H">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
 							<greatestDifference id="h">↑↑↑</greatestDifference>
 							<greatestDifference id="m">↑↑↑</greatestDifference>
 						</intervalFormatItem>
@@ -1688,7 +1688,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd/M – E, dd/M</greatestDifference>
 							<greatestDifference id="M">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
@@ -1706,36 +1706,36 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM/y – MM/y</greatestDifference>
+							<greatestDifference id="y">MM/y – MM/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">dd/MM/y – dd/MM/y</greatestDifference>
+							<greatestDifference id="M">dd/MM/y – dd/MM/y</greatestDifference>
 							<greatestDifference id="y">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
 							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">↑↑↑</greatestDifference>
 							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
 							<greatestDifference id="d">↑↑↑</greatestDifference>
 							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y MMMM – y MMMM</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1779,7 +1779,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="5">↑↑↑</month>
 							<month type="6">↑↑↑</month>
 							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
+							<month type="8">Shaʼaban</month>
 							<month type="9">↑↑↑</month>
 							<month type="10">↑↑↑</month>
 							<month type="11">↑↑↑</month>
@@ -1862,45 +1862,45 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<availableFormats>
 						<dateFormatItem id="d">↑↑↑</dateFormatItem>
 						<dateFormatItem id="E">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Ed">d E</dateFormatItem>
+						<dateFormatItem id="Gy">y G</dateFormatItem>
+						<dateFormatItem id="GyMd">GGGGG dd-MM-y</dateFormatItem>
+						<dateFormatItem id="GyMMM">G MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMd">G d MMM y</dateFormatItem>
+						<dateFormatItem id="GyMMMEd">G d MMM y, E</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
 						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, d MMM</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E d MMM</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yM">yM</dateFormatItem>
+						<dateFormatItem id="yMEd">E, d M y</dateFormatItem>
+						<dateFormatItem id="yMMM">y MMM</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, d MMM, y</dateFormatItem>
 						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yyyyQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yQQQ">y QQQ</dateFormatItem>
+						<dateFormatItem id="yQQQQ">y QQQQ</dateFormatItem>
+						<dateFormatItem id="yyyy">y G</dateFormatItem>
+						<dateFormatItem id="yyyyM">y/M GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMd">d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMEd">E, d/M/y GGGGG</dateFormatItem>
+						<dateFormatItem id="yyyyMMM">y G MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMd">y G d MMM</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEd">y G d MMM, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMM">y G MMMM</dateFormatItem>
+						<dateFormatItem id="yyyyQQQ">y G QQQ</dateFormatItem>
+						<dateFormatItem id="yyyyQQQQ">y G QQQQ</dateFormatItem>
 					</availableFormats>
 				</dateTimeFormats>
 			</calendar>
 		</calendars>
 		<fields>
 			<field type="era">
-				<displayName>↑↑↑</displayName>
+				<displayName>zamani</displayName>
 			</field>
 			<field type="era-short">
 				<displayName>↑↑↑</displayName>
@@ -1909,17 +1909,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="year">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>shekara</displayName>
+				<relative type="-1">bara</relative>
+				<relative type="0">bana</relative>
+				<relative type="1">badi</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a shekarar {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a shekaru {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">shekara da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-short">
@@ -1951,17 +1951,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="quarter">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>kwata</displayName>
+				<relative type="-1">kwatan karshe</relative>
+				<relative type="0">wannan kwatan</relative>
+				<relative type="1">kwata na gaba</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a cikin kwata {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin kwatas {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">kwata da suka gabata {0}</relativeTimePattern>
+					<relativeTimePattern count="other">kwatas da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
@@ -1987,17 +1987,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>wata</displayName>
+				<relative type="-1">watan da ya gabata</relative>
+				<relative type="0">wannan watan</relative>
+				<relative type="1">wata na gaba</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a cikin watan {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin watanni {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">watan da ya gabata</relativeTimePattern>
+					<relativeTimePattern count="other">watanni da suka gabata {0}}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-short">
@@ -2007,11 +2007,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin watan {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">watan da ya gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month-narrow">
@@ -2024,24 +2024,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">watan da ya gabata {0}</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="week">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>mako</displayName>
+				<relative type="-1">satin da ya gabata</relative>
+				<relative type="0">wannan satin</relative>
+				<relative type="1">sati na gaba</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a cikin mako {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin makonni {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">mako da ya gabata {0}</relativeTimePattern>
+					<relativeTimePattern count="other">makonni da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>↑↑↑</relativePeriod>
+				<relativePeriod>sati na {0}</relativePeriod>
 			</field>
 			<field type="week-short">
 				<displayName>↑↑↑</displayName>
@@ -2050,11 +2050,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin mako {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">mako da ya gabata {0}</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>↑↑↑</relativePeriod>
 			</field>
@@ -2068,32 +2068,32 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">mako da suka gabata {0}</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativePeriod>↑↑↑</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
-				<displayName>↑↑↑</displayName>
+				<displayName>Makon Wata</displayName>
 			</field>
 			<field type="weekOfMonth-short">
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mk. wt.</displayName>
 			</field>
 			<field type="day">
-				<displayName>↑↑↑</displayName>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<displayName>kwana</displayName>
+				<relative type="-1">jiya</relative>
+				<relative type="0">yau</relative>
+				<relative type="1">gobe</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">a cikin rana {0}</relativeTimePattern>
+					<relativeTimePattern count="other">a cikin kwanaki {0}</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">rana da ya gabata {0}</relativeTimePattern>
+					<relativeTimePattern count="other">kwanaki da suka gabata {0}</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="day-short">
@@ -2125,7 +2125,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayOfYear">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kwanan Shekara</displayName>
 			</field>
 			<field type="dayOfYear-short">
 				<displayName>↑↑↑</displayName>
@@ -2134,7 +2134,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="weekday">
-				<displayName>↑↑↑</displayName>
+				<displayName>ranar mako</displayName>
 			</field>
 			<field type="weekday-short">
 				<displayName>↑↑↑</displayName>
@@ -2143,7 +2143,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="weekdayOfMonth">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ranar Aikin Wata</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
 				<displayName>↑↑↑</displayName>
@@ -2152,16 +2152,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="sun">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Lahadin da ya gabata</relative>
+				<relative type="0">wanan Lahadi</relative>
+				<relative type="1">Lahadi mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Lahadi</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Lahadin da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sun-short">
@@ -2191,16 +2191,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="mon">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Litinin din da ta gabata</relative>
+				<relative type="0">wannan Litinin din</relative>
+				<relative type="1">Litinin din da ya gabata</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Litinin</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Litinin din da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="mon-short">
@@ -2225,21 +2225,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="one">{0} Litinin din da ta</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Litinin din da ta</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Talata da ta gabata</relative>
+				<relative type="0">wannan Talata</relative>
+				<relative type="1">Talata mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Talata</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Talatar da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="tue-short">
@@ -2269,16 +2269,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Laraba da ta gabata</relative>
+				<relative type="0">wannan Larabar</relative>
+				<relative type="1">Laraba mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Laraba</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Laraba da ta gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="wed-short">
@@ -2308,16 +2308,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="thu">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Alhamis din da ya Gabata</relative>
+				<relative type="0">wannan Alhamis din</relative>
+				<relative type="1">Alhamis din mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Alhamis</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Alhamis din da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="thu-short">
@@ -2347,16 +2347,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Jumaʼa da ta gabata</relative>
+				<relative type="0">wannan Jumaʼar</relative>
+				<relative type="1">Jumaʼa mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Jumaʼa</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Jumaʼa da ta wuce</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-short">
@@ -2386,16 +2386,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="sat">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Asabar din da ya gabata</relative>
+				<relative type="0">wannan Asabar din</relative>
+				<relative type="1">Asabar mai zuwa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} Asabar</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Asabar din da ya wuce</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-short">
@@ -2428,21 +2428,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="dayperiod">
-				<displayName>↑↑↑</displayName>
+				<displayName>SF/YM</displayName>
 			</field>
 			<field type="dayperiod-narrow">
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="hour">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>awa</displayName>
+				<relative type="0">wannan awa</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} awa</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} awa da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="hour-short">
@@ -2468,15 +2468,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="minute">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>minti</displayName>
+				<relative type="0">wannan mintin</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} minti</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} minti da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="minute-short">
@@ -2502,15 +2502,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="second">
-				<displayName>↑↑↑</displayName>
-				<relative type="0">↑↑↑</relative>
+				<displayName>daƙiƙa</displayName>
+				<relative type="0">yanzu</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">cikin {0} dakika</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} dakika da ya gabata</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="second-short">
@@ -2536,7 +2536,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="zone">
-				<displayName>↑↑↑</displayName>
+				<displayName>Lokacin yanki</displayName>
 			</field>
 			<field type="zone-short">
 				<displayName>↑↑↑</displayName>
@@ -2549,17 +2549,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<hourFormat>↑↑↑</hourFormat>
 			<gmtFormat>↑↑↑</gmtFormat>
 			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
-			<regionFormat>↑↑↑</regionFormat>
-			<regionFormat type="daylight">↑↑↑</regionFormat>
-			<regionFormat type="standard">↑↑↑</regionFormat>
+			<regionFormat>{0} Lokaci</regionFormat>
+			<regionFormat type="daylight">{0} Lokacin Rana</regionFormat>
+			<regionFormat type="standard">{0} Daidaitaccen Lokaci</regionFormat>
 			<fallbackFormat>↑↑↑</fallbackFormat>
 			<zone type="Etc/UTC">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Hadewa Lokaci na Duniya</standard>
 				</long>
 			</zone>
 			<zone type="Etc/Unknown">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>Birni da ba a sani ba</exemplarCity>
 			</zone>
 			<zone type="Europe/Andorra">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3043,7 +3043,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<zone type="Europe/London">
 				<long>
-					<daylight>↑↑↑</daylight>
+					<daylight>Lokacin Bazara na Birtaniya</daylight>
 				</long>
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
@@ -3136,7 +3136,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<zone type="Europe/Dublin">
 				<long>
-					<daylight>↑↑↑</daylight>
+					<daylight>Tsayayyen Lokacin Irish</daylight>
 				</long>
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
@@ -3747,13 +3747,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/Beulah">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>Beulah, Arewacin Dakota</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/New_Salem">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>New Salem, Arewacin Dakota</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/Center">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>Center, Arewacin Dakota</exemplarCity>
 			</zone>
 			<zone type="America/Chicago">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3850,888 +3850,888 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<metazone type="Afghanistan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Afghanistan</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Central">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Afirka ta Tsakiya</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Gabashin Afirka</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Southern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>South Africa Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Afirka ta Yamma</generic>
+					<standard>Tsayayyen Lokacin Afirka ta Yamma</standard>
+					<daylight>Lokacin Bazara na Afirka ta Yamma</daylight>
 				</long>
 			</metazone>
 			<metazone type="Alaska">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Alaska</generic>
+					<standard>Tsayayyen Lokacin Alaska</standard>
+					<daylight>Lokacin Rana na Alaska</daylight>
 				</long>
 			</metazone>
 			<metazone type="Amazon">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Amazon</generic>
+					<standard>Tsayayyen Lokacin Amazon</standard>
+					<daylight>Lokacin Bazara na Amazon</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokaci dake Amurika arewa ta tsakiyar</generic>
+					<standard>Tsayayyen Lokaci dake Arewacin Amurika ta Tsakiya</standard>
+					<daylight>Lokacin Rana dake Arewacin Amurika ta Tsakiya</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Gabas dake Arewacin Amurikaa</generic>
+					<standard>Tsayayyen Lokacin Gabas dake Arewacin Amurika</standard>
+					<daylight>Lokacin Rana ta Gabas dake Arewacin Amurika</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Mountain">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Tsauni na Arewacin Amurka</generic>
+					<standard>Lokaci tsayayye na tsauni a Arewacin Amurica</standard>
+					<daylight>Lokacin Rana na Tsaunin Arewacin Amurka</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Pacific">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Arewacin Amurika</generic>
+					<standard>Lokaci Tsayayye na Arewacin Amurika</standard>
+					<daylight>Lokacin Rana na Arewacin Amurka</daylight>
 				</long>
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Apia</generic>
+					<standard>Tsayayyen Lokacin Apia</standard>
+					<daylight>Lokacin Rana na Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Arebiya</generic>
+					<standard>Arabian Standard Time</standard>
+					<daylight>Lokacin Rana na Arebiya</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Argentina</generic>
+					<standard>Tsayayyen Lokacin Argentina</standard>
+					<daylight>Lokacin Bazara na Argentina</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Yammacin Argentina</generic>
+					<standard>Tsayayyen Lokacin Yammacin Argentina</standard>
+					<daylight>Lokacin Bazara na Yammacin Argentina</daylight>
 				</long>
 			</metazone>
 			<metazone type="Armenia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Armenia</generic>
+					<standard>Tsayayyen Lokacin Armenia</standard>
+					<daylight>Lokacin Bazara na Armenia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Atlantic">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Kanada, Puerto Rico da Virgin Islands</generic>
+					<standard>Tsayayyen Lokacin Kanada, Puerto Rico da Virgin Islands</standard>
+					<daylight>Lokacin Rana na Kanada, Puerto Rico da Virgin Islands</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Central Australia Time</generic>
+					<standard>Tsayayyen Lokacin Tsakiyar Austiraliya</standard>
+					<daylight>Lokacin Rana na Tsakiyar Austiraliya</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_CentralWestern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Yammacin Tsakiyar Austiraliya</generic>
+					<standard>Tsayayyen Lokacin Yammacin Tsakiyar Austiraliya</standard>
+					<daylight>Lokacin Rana na Yammacin Tsakiyar Austiraliya</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Gabashin Austiraliya</generic>
+					<standard>Australian Eastern Standard Time</standard>
+					<daylight>Lokacin Rana na Gabashin Austiraliya</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Yammacin Austiralia</generic>
+					<standard>Tsayayyen Lokacin Yammacin Austiralia</standard>
+					<daylight>Lokacin Rana na Yammacin Austiralia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Azerbaijan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Azerbaijan</generic>
+					<standard>Tsayayyen Lokacin Azerbaijan</standard>
+					<daylight>Lokacin Bazara na Azerbaijan</daylight>
 				</long>
 			</metazone>
 			<metazone type="Azores">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Azores</generic>
+					<standard>Lokacin Azores Daidaitacce</standard>
+					<daylight>Lokacin Azure na Bazara</daylight>
 				</long>
 			</metazone>
 			<metazone type="Bangladesh">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Bangladesh</generic>
+					<standard>Tsayayyen Lokacin Bangladesh</standard>
+					<daylight>Lokacin Bazara na Bangladesh</daylight>
 				</long>
 			</metazone>
 			<metazone type="Bhutan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Bhutan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Bolivia">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Bolivia</standard>
 				</long>
 			</metazone>
 			<metazone type="Brasilia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Brasillia</generic>
+					<standard>Tsayayyen Lokacin Brasillia</standard>
+					<daylight>Lokacin Bazara na Brasillia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Brunei">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Brunei Darussalam</standard>
 				</long>
 			</metazone>
 			<metazone type="Cape_Verde">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Cape Verde</generic>
+					<standard>Cape Verde Standard Time</standard>
+					<daylight>Lokacin Bazara na Cape Verde</daylight>
 				</long>
 			</metazone>
 			<metazone type="Chamorro">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tsayayyen Lokacin Chamorro</standard>
 				</long>
 			</metazone>
 			<metazone type="Chatham">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Chatham</generic>
+					<standard>Tsayayyen Lokacin Chatham</standard>
+					<daylight>Lokacin Rana na Chatham</daylight>
 				</long>
 			</metazone>
 			<metazone type="Chile">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Chile</generic>
+					<standard>Tsayayyen Lokacin Chile</standard>
+					<daylight>Lokacin Bazara na Chile</daylight>
 				</long>
 			</metazone>
 			<metazone type="China">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Sin</generic>
+					<standard>Tsayayyen Lokacin Sin</standard>
+					<daylight>Lokacin Rana na Sin</daylight>
 				</long>
 			</metazone>
 			<metazone type="Choibalsan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Choibalsan</generic>
+					<standard>Tsayayyen Lokacin Choibalsan</standard>
+					<daylight>Lokacin Bazara na Choibalsan</daylight>
 				</long>
 			</metazone>
 			<metazone type="Christmas">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Christmas Island</standard>
 				</long>
 			</metazone>
 			<metazone type="Cocos">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Cocos Islands</standard>
 				</long>
 			</metazone>
 			<metazone type="Colombia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Colombia</generic>
+					<standard>Tsayayyen Lokacin Colombia</standard>
+					<daylight>Lokacin Bazara na Colombia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cook">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Cook Islands</generic>
+					<standard>Tsayayyen Lokacin Cook Islands</standard>
+					<daylight>Rabin Lokacin Bazara na Cook Islands</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cuba">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokaci na Kuba</generic>
+					<standard>Tsayayyen Lokacin Kuba</standard>
+					<daylight>Lokacin Rana na Kuba</daylight>
 				</long>
 			</metazone>
 			<metazone type="Davis">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Davis</standard>
 				</long>
 			</metazone>
 			<metazone type="DumontDUrville">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Dumont-d’Urville</standard>
 				</long>
 			</metazone>
 			<metazone type="East_Timor">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin East Timor</standard>
 				</long>
 			</metazone>
 			<metazone type="Easter">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Easter Island</generic>
+					<standard>Tsayayyen Lokacin Easter Island</standard>
+					<daylight>Lokacin Bazara na Easter Island</daylight>
 				</long>
 			</metazone>
 			<metazone type="Ecuador">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Ecuador</standard>
 				</long>
 			</metazone>
 			<metazone type="Europe_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Tsakiyar a lokaci turai</generic>
+					<standard>Ida Tsakiyar a Lokaci Turai</standard>
+					<daylight>Tsakiyar bazara a lokaci turai</daylight>
 				</long>
 			</metazone>
 			<metazone type="Europe_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokaci a turai gabas</generic>
+					<standard>Ida lokaci a turai gabas</standard>
+					<daylight>Gabas a lokaci turai da bazara</daylight>
 				</long>
 			</metazone>
 			<metazone type="Europe_Further_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Gabashin Turai mai Nisa</standard>
 				</long>
 			</metazone>
 			<metazone type="Europe_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokaci ta yammacin turai</generic>
+					<standard>Ida lokaci ta yammacin turai</standard>
+					<daylight>Ida lokaci ta yammacin turai da bazara</daylight>
 				</long>
 			</metazone>
 			<metazone type="Falkland">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Falkland Islands</generic>
+					<standard>Tsayayyen Lokacin Falkland Islands</standard>
+					<daylight>Lokacin Bazara na Falkland Islands</daylight>
 				</long>
 			</metazone>
 			<metazone type="Fiji">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Fiji</generic>
+					<standard>Tsayayyen Lokacin Fiji</standard>
+					<daylight>Lokacin Bazara na Fiji</daylight>
 				</long>
 			</metazone>
 			<metazone type="French_Guiana">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin French Guiana</standard>
 				</long>
 			</metazone>
 			<metazone type="French_Southern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Kudancin Faransa da Antarctic</standard>
 				</long>
 			</metazone>
 			<metazone type="Galapagos">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Galapagos</standard>
 				</long>
 			</metazone>
 			<metazone type="Gambier">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Gambier</standard>
 				</long>
 			</metazone>
 			<metazone type="Georgia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Georgia</generic>
+					<standard>Tsayayyen Lokacin Georgia</standard>
+					<daylight>Georgia Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Gilbert_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Gilbert Islands</standard>
 				</long>
 			</metazone>
 			<metazone type="GMT">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Greenwhich a London</standard>
 				</long>
 			</metazone>
 			<metazone type="Greenland_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Gabas na Greenland</generic>
+					<standard>Tsayayyen Lokacin Gabashin Greenland</standard>
+					<daylight>Lokacin Rana na Gabashin Greenland</daylight>
 				</long>
 			</metazone>
 			<metazone type="Greenland_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Yammacin Greenland</generic>
+					<standard>Tsayayyen Lokacin Yammacin Greenland</standard>
+					<daylight>Lokacin Rana na Yammacin Greenland</daylight>
 				</long>
 			</metazone>
 			<metazone type="Gulf">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Golf</standard>
 				</long>
 			</metazone>
 			<metazone type="Guyana">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Guyana</standard>
 				</long>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokaci na Hawaii-Aleutian</generic>
+					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
+					<daylight>Lokacin Rana na Hawaii-Aleutian</daylight>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Hong Kong</generic>
+					<standard>Tsayayyen Lokacin Hong Kong</standard>
+					<daylight>Lokacin Bazara na Hong Kong</daylight>
 				</long>
 			</metazone>
 			<metazone type="Hovd">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Hovd</generic>
+					<standard>Tsayayyen Lokacin Hovd</standard>
+					<daylight>Lokacin Bazara na Hovd</daylight>
 				</long>
 			</metazone>
 			<metazone type="India">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>India Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Indian_Ocean">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Tekun Indiya</standard>
 				</long>
 			</metazone>
 			<metazone type="Indochina">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Indochina</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Central">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Indonesia ta Tsakiya</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Eastern Indonesia Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Western">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Yammacin Indonesia</standard>
 				</long>
 			</metazone>
 			<metazone type="Iran">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Iran</generic>
+					<standard>Tsayayyen Lokacin Iran</standard>
+					<daylight>Lokacin Rana na Iran</daylight>
 				</long>
 			</metazone>
 			<metazone type="Irkutsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Irkutsk</generic>
+					<standard>Tsayayyen Lokacin Irkutsk</standard>
+					<daylight>Lokacin Bazara na Irkutsk</daylight>
 				</long>
 			</metazone>
 			<metazone type="Israel">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Israʼila</generic>
+					<standard>Israel Standard Time</standard>
+					<daylight>Israel Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Japan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Japan</generic>
+					<standard>Japan Standard Time</standard>
+					<daylight>Japan Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kazakhstan_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Gabashin Kazakhstan</standard>
 				</long>
 			</metazone>
 			<metazone type="Kazakhstan_Western">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Yammacin Kazakhstan</standard>
 				</long>
 			</metazone>
 			<metazone type="Korea">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Koriya</generic>
+					<standard>Tsayayyen Lokacin Koriya</standard>
+					<daylight>Lokacin Rana na Koriya</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kosrae">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Kosrae</standard>
 				</long>
 			</metazone>
 			<metazone type="Krasnoyarsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Krasnoyarsk</generic>
+					<standard>Tsayayyen Lokacin Krasnoyarsk</standard>
+					<daylight>Lokacin Bazara na Krasnoyarsk</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kyrgystan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Kazakhstan</standard>
 				</long>
 			</metazone>
 			<metazone type="Line_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Line Islands</standard>
 				</long>
 			</metazone>
 			<metazone type="Lord_Howe">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Lord Howe</generic>
+					<standard>Tsayayyen Lokacin Lord Howe</standard>
+					<daylight>Lokacin Rana na Vote Lord Howe</daylight>
 				</long>
 			</metazone>
 			<metazone type="Macquarie">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Macquarie Island</standard>
 				</long>
 			</metazone>
 			<metazone type="Magadan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Magadan</generic>
+					<standard>Tsayayyen Lokacin Magadan</standard>
+					<daylight>Lokacin Bazara na Magadan</daylight>
 				</long>
 			</metazone>
 			<metazone type="Malaysia">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Malaysia</standard>
 				</long>
 			</metazone>
 			<metazone type="Maldives">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Maldives</standard>
 				</long>
 			</metazone>
 			<metazone type="Marquesas">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Marquesas</standard>
 				</long>
 			</metazone>
 			<metazone type="Marshall_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Marshall Islands</standard>
 				</long>
 			</metazone>
 			<metazone type="Mauritius">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Mauritius</generic>
+					<standard>Tsayayyen Lokacin Mauritius</standard>
+					<daylight>Lokacin Bazara na Mauritius</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mawson">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Mawson</standard>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Northwest">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Arewa Maso Yammacin Mekziko</generic>
+					<standard>Tsayayyen Lokacin Arewa Maso Yammacin Mekziko</standard>
+					<daylight>Lokacin Rana na Arewa Maso Yammacin Mekziko</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Pacific">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Mekziko Pacific</generic>
+					<standard>Tsayayyen Lokacin Mekziko Pacific</standard>
+					<daylight>Lokacin Rana na Mekziko Pacific</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mongolia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Ulaanbaatar</generic>
+					<standard>Tsayayyen Lokacin Ulaanbaatar</standard>
+					<daylight>Lokacin Bazara na Ulaanbaatar</daylight>
 				</long>
 			</metazone>
 			<metazone type="Moscow">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Moscow</generic>
+					<standard>Tsayayyen Lokacin Moscow</standard>
+					<daylight>Lokacin Bazara na Moscow</daylight>
 				</long>
 			</metazone>
 			<metazone type="Myanmar">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Myanmar</standard>
 				</long>
 			</metazone>
 			<metazone type="Nauru">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Nauru</standard>
 				</long>
 			</metazone>
 			<metazone type="Nepal">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Nepal</standard>
 				</long>
 			</metazone>
 			<metazone type="New_Caledonia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin New Caledonia</generic>
+					<standard>Tsayayyen Lokacin New Caledonia</standard>
+					<daylight>Lokacin Bazara na New Caledonia</daylight>
 				</long>
 			</metazone>
 			<metazone type="New_Zealand">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin New Zealand</generic>
+					<standard>Tsayayyen Lokacin New Zealand</standard>
+					<daylight>Lokacin Rana na New Zealand</daylight>
 				</long>
 			</metazone>
 			<metazone type="Newfoundland">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Newfoundland</generic>
+					<standard>Lokaci Tsayayye ta Newfoundland</standard>
+					<daylight>Lokaci rana ta Newfoundland</daylight>
 				</long>
 			</metazone>
 			<metazone type="Niue">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Niue</standard>
 				</long>
 			</metazone>
 			<metazone type="Norfolk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Norfolk Island</generic>
+					<standard>Tsayayyen Lokacin Norfolk Island</standard>
+					<daylight>Lokacin Rana na Norfolk Island</daylight>
 				</long>
 			</metazone>
 			<metazone type="Noronha">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Fernando de Noronha</generic>
+					<standard>Tsayayyen Lokacin Fernando de Noronha</standard>
+					<daylight>Lokacin Bazara na Fernando de Noronha</daylight>
 				</long>
 			</metazone>
 			<metazone type="Novosibirsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Novosibirsk</generic>
+					<standard>Novosibirsk Standard Time</standard>
+					<daylight>Lokacin Bazara na Novosibirsk</daylight>
 				</long>
 			</metazone>
 			<metazone type="Omsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Omsk</generic>
+					<standard>Tsayayyen Lokacin Omsk</standard>
+					<daylight>Lokacin Bazara na Omsk</daylight>
 				</long>
 			</metazone>
 			<metazone type="Pakistan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Pakistan</generic>
+					<standard>Tsayayyen Lokacin Pakistan</standard>
+					<daylight>Lokacin Bazara na Pakistan</daylight>
 				</long>
 			</metazone>
 			<metazone type="Palau">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Palau</standard>
 				</long>
 			</metazone>
 			<metazone type="Papua_New_Guinea">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Papua New Guinea</standard>
 				</long>
 			</metazone>
 			<metazone type="Paraguay">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Paraguay</generic>
+					<standard>Tsayayyen Lokacin Paraguay</standard>
+					<daylight>Lokacin Bazara na Paraguay</daylight>
 				</long>
 			</metazone>
 			<metazone type="Peru">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Peru</generic>
+					<standard>Tsayayyen Lokacin Peru</standard>
+					<daylight>Lokacin Bazara na Peru</daylight>
 				</long>
 			</metazone>
 			<metazone type="Philippines">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Philippine</generic>
+					<standard>Tsayayyen Lokacin Philippine</standard>
+					<daylight>Lokacin Bazara na Philippine</daylight>
 				</long>
 			</metazone>
 			<metazone type="Phoenix_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Phoenix Islands</standard>
 				</long>
 			</metazone>
 			<metazone type="Pierre_Miquelon">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin St. Pierre da Miquelon</generic>
+					<standard>Tsayayyen Lokacin St. Pierre da Miquelon</standard>
+					<daylight>Lokacin Rana na St. Pierre da Miquelon</daylight>
 				</long>
 			</metazone>
 			<metazone type="Pitcairn">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Pitcairn</standard>
 				</long>
 			</metazone>
 			<metazone type="Ponape">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Ponape</standard>
 				</long>
 			</metazone>
 			<metazone type="Pyongyang">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Pyongyang</standard>
 				</long>
 			</metazone>
 			<metazone type="Reunion">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Réunion</standard>
 				</long>
 			</metazone>
 			<metazone type="Rothera">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Rothera</standard>
 				</long>
 			</metazone>
 			<metazone type="Sakhalin">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Sakhalin</generic>
+					<standard>Tsayayyen Lokacin Sakhalin</standard>
+					<daylight>Lokacin Bazara na Sakhalin</daylight>
 				</long>
 			</metazone>
 			<metazone type="Samoa">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Samoa</generic>
+					<standard>Tsayayyen Lokacin Samoa</standard>
+					<daylight>Lokacin Rana na Vote Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Seychelles">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Seychelles</standard>
 				</long>
 			</metazone>
 			<metazone type="Singapore">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tsayayyen Lokacin Singapore</standard>
 				</long>
 			</metazone>
 			<metazone type="Solomon">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Rana na Solomon</standard>
 				</long>
 			</metazone>
 			<metazone type="South_Georgia">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Kudancin Georgia</standard>
 				</long>
 			</metazone>
 			<metazone type="Suriname">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Suriname</standard>
 				</long>
 			</metazone>
 			<metazone type="Syowa">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Syowa</standard>
 				</long>
 			</metazone>
 			<metazone type="Tahiti">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Tahiti</standard>
 				</long>
 			</metazone>
 			<metazone type="Taipei">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Taipei</generic>
+					<standard>Tsayayyen Lokacin Taipei</standard>
+					<daylight>Lokacin Rana na Taipei</daylight>
 				</long>
 			</metazone>
 			<metazone type="Tajikistan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Tajikistan</standard>
 				</long>
 			</metazone>
 			<metazone type="Tokelau">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tokelau Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Tonga">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Tonga</generic>
+					<standard>Tsayayyen Lokacin Tonga</standard>
+					<daylight>Lokacin Bazara na Tonga</daylight>
 				</long>
 			</metazone>
 			<metazone type="Truk">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Chuuk</standard>
 				</long>
 			</metazone>
 			<metazone type="Turkmenistan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Turkmenistan</generic>
+					<standard>Tsayayyen Lokacin Turkmenistan</standard>
+					<daylight>Turkmenistan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Tuvalu">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Tuvalu</standard>
 				</long>
 			</metazone>
 			<metazone type="Uruguay">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Uruguay</generic>
+					<standard>Tsayayyen Lokacin Uruguay</standard>
+					<daylight>Lokacin Bazara na Uruguay</daylight>
 				</long>
 			</metazone>
 			<metazone type="Uzbekistan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Uzbekistan</generic>
+					<standard>Tsayayyen Lokacin Uzbekistan</standard>
+					<daylight>Lokacin Bazara na Uzbekistan</daylight>
 				</long>
 			</metazone>
 			<metazone type="Vanuatu">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Vanuatu</generic>
+					<standard>Tsayayyen Lokacin Vanuatu</standard>
+					<daylight>Lokacin Bazara na Vanuatu</daylight>
 				</long>
 			</metazone>
 			<metazone type="Venezuela">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Venezuela</standard>
 				</long>
 			</metazone>
 			<metazone type="Vladivostok">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Vladivostok</generic>
+					<standard>Tsayayyen Lokacin Vladivostok</standard>
+					<daylight>Lokacin Bazara na Vladivostok</daylight>
 				</long>
 			</metazone>
 			<metazone type="Volgograd">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Volgograd</generic>
+					<standard>Tsayayyen Lokacin Volgograd</standard>
+					<daylight>Lokacin Bazara na Volgograd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Vostok">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Vostok</standard>
 				</long>
 			</metazone>
 			<metazone type="Wake">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Wake Island</standard>
 				</long>
 			</metazone>
 			<metazone type="Wallis">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Wallis da Futuna</standard>
 				</long>
 			</metazone>
 			<metazone type="Yakutsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Yakutsk</generic>
+					<standard>Tsayayyen Lokacin Yakutsk</standard>
+					<daylight>Lokacin Bazara na Yakutsk</daylight>
 				</long>
 			</metazone>
 			<metazone type="Yekaterinburg">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lokacin Yekaterinburg</generic>
+					<standard>Tsayayyen Lokacin Yekaterinburg</standard>
+					<daylight>Lokacin Bazara na Yekaterinburg</daylight>
 				</long>
 			</metazone>
 			<metazone type="Yukon">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Lokacin Yukon</standard>
 				</long>
 			</metazone>
 		</timeZoneNames>
@@ -4763,40 +4763,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="one">Dubu 0</pattern>
+					<pattern type="1000" count="other">Dubu 0</pattern>
+					<pattern type="10000" count="one">Dubu 00</pattern>
+					<pattern type="10000" count="other">Dubu 00</pattern>
+					<pattern type="100000" count="one">Dubu 000</pattern>
+					<pattern type="100000" count="other">Dubu 000</pattern>
+					<pattern type="1000000" count="one">Miliyan 0</pattern>
+					<pattern type="1000000" count="other">Miliyan 0</pattern>
+					<pattern type="10000000" count="one">Miliyan 00</pattern>
+					<pattern type="10000000" count="other">Miliyan 00</pattern>
+					<pattern type="100000000" count="one">Miliyan 000</pattern>
+					<pattern type="100000000" count="other">Miliyan 000</pattern>
+					<pattern type="1000000000" count="one">Biliyan 0</pattern>
+					<pattern type="1000000000" count="other">Biliyan 0</pattern>
+					<pattern type="10000000000" count="one">Biliyan 00</pattern>
+					<pattern type="10000000000" count="other">Biliyan 00</pattern>
+					<pattern type="100000000000" count="one">Biliyan 000</pattern>
+					<pattern type="100000000000" count="other">Biliyan 000</pattern>
+					<pattern type="1000000000000" count="one">Triliyan 0</pattern>
+					<pattern type="1000000000000" count="other">Triliyan 0</pattern>
+					<pattern type="10000000000000" count="one">Triliyan 00</pattern>
+					<pattern type="10000000000000" count="other">Triliyan 00</pattern>
+					<pattern type="100000000000000" count="one">Triliyan 000</pattern>
+					<pattern type="100000000000000" count="other">Triliyan 000</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
 				<decimalFormat>
 					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="other">0D</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
+					<pattern type="10000" count="other">00D</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
+					<pattern type="100000" count="other">000D</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
@@ -4804,11 +4804,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000000000" count="other">0B</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
+					<pattern type="10000000000" count="other">00B</pattern>
 					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
+					<pattern type="100000000000" count="other">000B</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000000" count="other">↑↑↑</pattern>
 					<pattern type="10000000000000" count="one">↑↑↑</pattern>
@@ -4845,11 +4845,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="other">¤ 0D</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
+					<pattern type="10000" count="other">¤ 00D</pattern>
+					<pattern type="100000" count="one">¤ 000K</pattern>
+					<pattern type="100000" count="other">¤ 000D</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
@@ -4858,955 +4858,961 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="other">↑↑↑</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="other">¤0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
+					<pattern type="10000000000" count="other">¤00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
+					<pattern type="100000000000" count="other">¤000B</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
+					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Haɗaɗɗiyar Daular Larabawa</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AFN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Afghani na ƙasar Afghanistan</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ALL">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Albania</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AMD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Armenia</displayName>
+				<displayName count="one">kuɗin Armenia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ANG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Antillean Guilder na ƙasar Netherlands</displayName>
+				<displayName count="one">Antillean guilder na ƙasar Netherlands</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AOA">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Angola</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ARS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Peso na ƙasar Argentina</displayName>
+				<displayName count="one">peso na ƙasar Argentina</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="AUD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Ostareliya</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalolin Ostareliya</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="AWG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Florin na yankin Aruba</displayName>
+				<displayName count="one">florin na yankin Aruba</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="AZN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Azerbaijani</displayName>
+				<displayName count="one">kuɗin Azerbaijani</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BAM">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗaɗen Bosnia da Herzegovina</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BBD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar ƙasar Barbados</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BDT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Taka na ƙasar Bangladesh</displayName>
+				<displayName count="one">taka na ƙasar Bangladesh</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BGN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Bulgeria</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BHD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Baharan</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BIF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Burundi</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BMD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar ƙasar Bermuda</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BND">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Brunei</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalolin Brunei</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BOB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Boloviano na ƙasar Bolivia</displayName>
+				<displayName count="one">boliviano na ƙasar Bolivia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BRL">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ril Kudin Birazil</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Ril Kuɗin Birazil</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BSD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar ƙasar Bahamas</displayName>
+				<displayName count="one">dalar ƙasar Bahamas</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BTN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Ngultrum na ƙasar Bhutan</displayName>
+				<displayName count="one">ngultrum na ƙasar Bhutan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="BWP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Baswana</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BYN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Belarus</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="BZD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar ƙasar Belize</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CAD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Kanada</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CDF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Kongo</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CHF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Suwizalan</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CLP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Peso na ƙasar Chile</displayName>
+				<displayName count="one">peso na ƙasar Chile</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CNH">
-				<displayName>↑↑↑</displayName>
+				<displayName>Yuwan na ƙasar Sin (na wajen ƙasa)</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">yuwan na ƙasar Sin (na wajen ƙasa)</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CNY">
-				<displayName>↑↑↑</displayName>
+				<displayName>Yuwan na ƙasar Sin</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="COP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Peso na ƙasar Columbia</displayName>
+				<displayName count="one">peso na ƙasar Columbia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CRC">
-				<displayName>↑↑↑</displayName>
+				<displayName>Colón na ƙasar Costa Rica</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">colón na ƙasar Costa Rica</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CUC">
-				<displayName>↑↑↑</displayName>
+				<displayName>Peso mai fuska biyu na ƙasar Kuba</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CUP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Peso na ƙasar Kuba</displayName>
+				<displayName count="one">peso na ƙasar Cuba</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="CVE">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Tsibiran Kap Barde</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="CZK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Czech</displayName>
+				<displayName count="one">kuɗin Czech</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="DJF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Jibuti</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="DKK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Krone na ƙasar Denmark</displayName>
+				<displayName count="one">krone na ƙasar Denmark</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="DOP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Peso na jamhuriyar Dominica</displayName>
+				<displayName count="one">peso na jamhuriyar Dominica</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="DZD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Aljeriya</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dinarin Aljeriya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="EGP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fam kin Masar</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Fam na Masar</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ERN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Eritireya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ETB">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Habasha</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="EUR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Yuro</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="FJD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Fiji</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalolin Fiji</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="FKP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fam na ƙasar Tsibirai na Falkland</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GBP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fam na Ingila</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GEL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Georgia</displayName>
+				<displayName count="one">kuɗin Georgia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GHC">
-				<displayName>↑↑↑</displayName>
+				<displayName>Cedi</displayName>
 			</currency>
 			<currency type="GHS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sidi na Ghana</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GIP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Gibraltal</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GMD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Gambiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="GNF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Guinea</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GNS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Gini</displayName>
 			</currency>
 			<currency type="GTQ">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Quetzal na ƙasar Guatemala</displayName>
+				<displayName count="one">quetzal na ƙasar Guatemala</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="GYD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar Guyana</displayName>
+				<displayName count="one">dalar Guyana</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HKD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar Hong Kong</displayName>
+				<displayName count="one">dalar Hong Kong</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HNL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Lempira na ƙasar Honduras</displayName>
+				<displayName count="one">lempira na ƙasar Honduras</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HRK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Croatia</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="HTG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Gourde na ƙasar Haiti</displayName>
+				<displayName count="one">gourde na ƙasar Haiti</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="HUF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Hungary</displayName>
+				<displayName count="one">kuɗin Hungary</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="IDR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Rupiah na ƙasar Indonesia</displayName>
+				<displayName count="one">rupiah na ƙasar Indonesia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ILS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sabbin Kuɗin Israʼila</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="INR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Indiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="IQD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dinarin Iraqi</displayName>
+				<displayName count="one">dinarin Iraqi</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="IRR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Riyal na ƙasar Iran</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Riyal-riyal na ƙasar Iran</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ISK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Króna na ƙasar Iceland</displayName>
+				<displayName count="one">króna na ƙasar Iceland</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="JMD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar Jamaica</displayName>
+				<displayName count="one">dalar Jamaica</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="JOD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dinarin Jordan</displayName>
+				<displayName count="one">dinarin Jordan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="JPY">
-				<displayName>↑↑↑</displayName>
+				<displayName>Yen na ƙasar Japan</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>¥</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KES">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sulen Kenya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KGS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Som na ƙasar Kyrgystani</displayName>
+				<displayName count="one">som na ƙasar Kyrgystani</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KHR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Riel na ƙasar Cambodia</displayName>
+				<displayName count="one">riel na ƙasar Cambodia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KMF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Kwamoras</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KPW">
-				<displayName>↑↑↑</displayName>
+				<displayName>Won na ƙasar Koriya ta Arewa</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">won na ƙasar Koriya ta Arewa</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KRW">
-				<displayName>↑↑↑</displayName>
+				<displayName>Won na Koriya ta Kudu</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">won na Koriya ta Kudu</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KWD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dinarin Kuwaiti</displayName>
+				<displayName count="one">dinarin Kuwaiti</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="KYD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar ƙasar Tsibirai na Cayman</displayName>
+				<displayName count="one">dalar ƙasar Tsibirai na Cayman</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="KZT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Tenge na ƙasar Kazkhstan</displayName>
+				<displayName count="one">tenge na ƙasar Kazakhstan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LAK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Laos</displayName>
+				<displayName count="one">kuɗin Laos</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LBP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Lebanon</displayName>
+				<displayName count="one">kuɗin Lebanon</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LKR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Rupee na ƙasar Sri Lanka</displayName>
+				<displayName count="one">rupee na ƙasar Sri Lanka</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LRD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Laberiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="LSL">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Lesoto</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kuɗaɗen Lesoto</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LYD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Libiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dinarin Libiya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MAD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Kuɗin Maroko</displayName>
+				<displayName count="one">Dirhamin Maroko</displayName>
+				<displayName count="other">Dirhamomin Maroko</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MDL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Kuɗaɗen Moldova</displayName>
+				<displayName count="one">Kuɗaɗen Moldova</displayName>
+				<displayName count="other">kuɗaɗen Moldova</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MGA">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Madagaskar</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MKD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dinarin Macedonia</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MMK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Myanmar</displayName>
+				<displayName count="one">kuɗin Myanmar</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MNT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Tugrik na Mongolia</displayName>
+				<displayName count="one">tugrik na Mongoliya</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MOP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Pataca na ƙasar Macao</displayName>
+				<displayName count="one">pataca na ƙasar Macao</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MRO">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Moritaniya (1973–2017)</displayName>
 			</currency>
 			<currency type="MRU">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Moritaniya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MUR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Moritus</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MVR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rufiyaa na ɓasar Maldives</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MWK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Malawi</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="MXN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Peso na ƙasar Mekziko</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">peso na ƙasar Mekziko</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MYR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Malaysia</displayName>
+				<displayName count="one">kuɗin Malaysia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="MZM">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Mozambik</displayName>
 			</currency>
 			<currency type="MZN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Metical na ƙasar Mozambique</displayName>
+				<displayName count="one">metical na ƙasar Mozambique</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="NAD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Namibiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NGN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<displayName>Nairar Najeriya</displayName>
+				<displayName count="one">Nairar Nijeriya</displayName>
+				<displayName count="other">Nairorin Najeriya</displayName>
+				<symbol>₦</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NIO">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Córdoba na ƙasar Nicaragua</displayName>
+				<displayName count="one">córdoba na ƙasar Nicaragua</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NOK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Krone na ƙasar Norway</displayName>
+				<displayName count="one">krone na ƙasar Norway</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NPR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Rupee na Nepal</displayName>
+				<displayName count="one">rupee na Nepal</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="NZD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar New Zealand</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalolin New Zealand</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="OMR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Riyal ɗin Oman</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PAB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Balboa na ƙasar Panama</displayName>
+				<displayName count="one">balboa na ƙasar Panama</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PEN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Sol na ƙasar Peru</displayName>
+				<displayName count="one">sol na ƙasar Peru</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PGK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kina na ƙasar Papua Sabon Guinea</displayName>
+				<displayName count="one">kina na ƙasar Papua Sabon Guinea</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="PHP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Philippine</displayName>
+				<displayName count="one">kuɗin Philippine</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="PKR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Rupee na ƙasar Pakistan</displayName>
+				<displayName count="one">rupee na ƙasar Pakistan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="PLN">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Kuɗin Polan</displayName>
+				<displayName count="one">kuɗin Polan</displayName>
+				<displayName count="other">kuɗaɗen Polan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="PYG">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Guarani na ƙasar Paraguay</displayName>
+				<displayName count="one">guarani na ƙasar Paraguay</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="QAR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Riyal ɗin Qatar</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="RON">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Romania</displayName>
+				<displayName count="one">kuɗin Romania</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="RSD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dinarin Serbia</displayName>
+				<displayName count="one">dinarin Serbia</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="RUB">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ruble na ƙasar Rasha</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="RWF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Ruwanda</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SAR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Riyal</displayName>
+				<displayName count="one">Riyal ɗin Saudiyya</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SBD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Tsibirai na Solomon</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalolin Tsibirai na Solomon</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SCR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Saishal</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SDG">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fam na Sudan</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SEK">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Krona na ƙasar Sweden</displayName>
+				<displayName count="one">krona na ƙasar Sweden</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SGD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Singapore</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dalolin Singapore</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SHP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Fam kin San Helena</displayName>
+				<displayName count="one">Fam na San Helena</displayName>
+				<displayName count="other">fam na San Helena</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
-			<currency type="SLL">
-				<displayName>↑↑↑</displayName>
+			<currency type="SLE">
+				<displayName>Kuɗin Salewo</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Kuɗin Saliyo</displayName>
+				<symbol>↑↑↑</symbol>
+			</currency>
+			<currency type="SLL">
+				<displayName>Kuɗin Salewo (1964—2022)</displayName>
+				<displayName count="one">↑↑↑</displayName>
+				<displayName count="other">Kuɗin Saliyo (1964—2022)</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SOS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sulen Somaliya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="SRD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar ƙasar Suriname</displayName>
+				<displayName count="one">dalar ƙasar Suriname</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SSP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Fam na Kudancin Sudan</displayName>
+				<displayName count="one">fam na Kudancin Sudan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="STD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Sawo Tome da Paransip (1977–2017)</displayName>
 			</currency>
 			<currency type="STN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Sawo Tome da Paransip</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SYP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Siriya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="SZL">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Lilangeni</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="THB">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Baht na ƙasar Thailand</displayName>
+				<displayName count="one">baht na ƙasar Thailand</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TJS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Somoni na ƙasar Tajikistan</displayName>
+				<displayName count="one">somoni na ƙasar Tajikistan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TMT">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Manat na ƙasar Turkmenistan</displayName>
+				<displayName count="one">manat na ƙasar Turkmenistan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TND">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Tunisiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Dinarin Tunusiya</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="TOP">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Paʻanga na ƙasar Tonga</displayName>
+				<displayName count="one">paʻanga na ƙasar Tonga</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TRY">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Turkiyya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
@@ -5814,183 +5820,183 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="variant">↑↑↑</symbol>
 			</currency>
 			<currency type="TTD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar ƙasar Trinidad da Tobago</displayName>
+				<displayName count="one">dalar ƙasar Trinidad da Tobago</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TWD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Sabuwar Dalar Taiwan</displayName>
+				<displayName count="one">Sabuwar dalar Taiwan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="TZS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sulen Tanzaniya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="UAH">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Kudin Ukrainian</displayName>
+				<displayName count="one">kuɗin Ukrain</displayName>
+				<displayName count="other">Kuɗin Ukrain</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="UGX">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sule Yuganda</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">Sulallan Yuganda</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="USD">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Dalar Amurka</displayName>
+				<displayName count="one">Dalar Amirka</displayName>
 				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>$</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="UYU">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Peso na ƙasar Uruguay</displayName>
+				<displayName count="one">peso na ƙasar Uruguay</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="UZS">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Som na ƙasar Uzbekistan</displayName>
+				<displayName count="one">som na ƙasar Uzbekistan</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="VES">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Bolívar na ƙasar Venezuela</displayName>
+				<displayName count="one">bolívar na ƙasar Venezuela</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="VND">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin Vietnam</displayName>
+				<displayName count="one">kuɗin Vietnam</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="VUV">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Vatu da ƙasar Vanuatu</displayName>
+				<displayName count="one">vatu na ƙasar Vanuatu</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="WST">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Tala na ƙasar Samoa</displayName>
+				<displayName count="one">tala na ƙasar Samoa</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XAF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Sefa na Afirka Ta Tsakiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XCD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar Gabashin Karebiyan</displayName>
 				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName count="other">dalar Gabashin Karebiyan</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="XOF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Sefa na Afirka Ta Yamma</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XPF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Kuɗin CFP franc</displayName>
+				<displayName count="one">kuɗin CFP franc</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="XXX">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Kudin da ba a sani ba</displayName>
+				<displayName count="one">(kuɗin sashe da ba a sani ba)</displayName>
+				<displayName count="other">(Kudin da ba a sani ba)</displayName>
 			</currency>
 			<currency type="YER">
-				<displayName>↑↑↑</displayName>
-				<displayName count="one">↑↑↑</displayName>
+				<displayName>Riyal ɗin Yemen</displayName>
+				<displayName count="one">riyal ɗin Yemen</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 			</currency>
 			<currency type="ZAR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Afirka Ta Kudu</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ZMK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Zambiya (1968–2012)</displayName>
 			</currency>
 			<currency type="ZMW">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kuɗin Zambiya</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol>↑↑↑</symbol>
 				<symbol alt="narrow">↑↑↑</symbol>
 			</currency>
 			<currency type="ZWD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalar zimbabuwe</displayName>
 			</currency>
 		</currencies>
 		<miscPatterns numberSystem="latn">
 			<pattern type="approximately">↑↑↑</pattern>
-			<pattern type="atLeast">↑↑↑</pattern>
+			<pattern type="atLeast">{0}+</pattern>
 			<pattern type="atMost">↑↑↑</pattern>
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="one">↑↑↑</pluralMinimalPairs>
-			<pluralMinimalPairs count="other">↑↑↑</pluralMinimalPairs>
+			<pluralMinimalPairs count="one">rana {0}</pluralMinimalPairs>
+			<pluralMinimalPairs count="other">kwanaki {0}</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>
 		<unitLength type="long">
 			<compoundUnit type="10p-1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>deci{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>senti{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>milli{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>mikro{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>nano{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>pico{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>femto{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>atto{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-21">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>zepto{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-24">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>yocto{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-27">
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
@@ -5999,28 +6005,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>deka{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>hekta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>kilo{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>mega{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p9">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>giga{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p12">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>tera{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p15">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>peta{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p18">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>exa{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p21">
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
@@ -6059,650 +6065,650 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
+				<compoundUnitPattern>{0} a {1}</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">sikwaya {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">sikwaya {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="one">↑↑↑</compoundUnitPattern1>
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="one">kubic {0}</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">kubic {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">g-force {0}</unitPattern>
+				<unitPattern count="other">g-force {0}</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>meters per second squared</displayName>
+				<unitPattern count="one">meter per second squared {0}</unitPattern>
+				<unitPattern count="other">meters per second squared {0}</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>revolution</displayName>
+				<unitPattern count="one">revolution {0}</unitPattern>
+				<unitPattern count="other">revolutions {0}</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>radians</displayName>
+				<unitPattern count="one">radian {0}</unitPattern>
+				<unitPattern count="other">radians {0}</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">degree {0}</unitPattern>
+				<unitPattern count="other">degrees {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcminutes</displayName>
+				<unitPattern count="one">arcminute {0}</unitPattern>
+				<unitPattern count="other">arcminutes {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcseconds</displayName>
+				<unitPattern count="one">arcsecond {0}</unitPattern>
+				<unitPattern count="other">arcseconds {0}</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sikwaya kilomitoci</displayName>
+				<unitPattern count="one">sikwaya kilomita {0}</unitPattern>
+				<unitPattern count="other">sikwaya kilomitoci {0}</unitPattern>
+				<perUnitPattern>{0} a sikwaya kilomita</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">hekta {0}</unitPattern>
+				<unitPattern count="other">hektoci {0}</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sikwaya mitoci</displayName>
+				<unitPattern count="one">sikwaya mita {0}</unitPattern>
+				<unitPattern count="other">sikwaya mitoci {0}</unitPattern>
+				<perUnitPattern>{0} a sikwaya mita</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sikwaya sentimitoci</displayName>
+				<unitPattern count="one">sikwaya sentimita {0}</unitPattern>
+				<unitPattern count="other">sikwaya sentimitoci {0}</unitPattern>
+				<perUnitPattern>{0} a sikwaya sentimita</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sikwaya mil-mil</displayName>
+				<unitPattern count="one">sikwaya mil {0}</unitPattern>
+				<unitPattern count="other">sikwaya mil-mil {0}</unitPattern>
+				<perUnitPattern>{0} a sikwaya mil</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eka</displayName>
+				<unitPattern count="one">eka {0}</unitPattern>
+				<unitPattern count="other">ekoki {0}</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sikwaya yadina</displayName>
+				<unitPattern count="one">sikwaya yadi {0}</unitPattern>
+				<unitPattern count="other">sikwaya yaduna {0}</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sikwaya ƙafafu</displayName>
+				<unitPattern count="one">sikwaya ƙafa {0}</unitPattern>
+				<unitPattern count="other">sikwaya ƙafafu {0}</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sikwaya incis</displayName>
+				<unitPattern count="one">sikwaya inci {0}</unitPattern>
+				<unitPattern count="other">sikwaya incina {0}</unitPattern>
+				<perUnitPattern>{0} a sikwaya inci</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dunams {0}</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">karat {0}</unitPattern>
+				<unitPattern count="other">karats {0}</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milligrams per deciliter</displayName>
+				<unitPattern count="one">milligram per deciliter {0}</unitPattern>
+				<unitPattern count="other">milligrams per deciliter {0}</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimoles per liter</displayName>
+				<unitPattern count="one">millimole per liter {0}</unitPattern>
+				<unitPattern count="other">millimoles per liter {0}</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
+				<displayName>abubuwa</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">abubuwa {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>parts per million</displayName>
+				<unitPattern count="one">part per million {0}</unitPattern>
+				<unitPattern count="other">parts per million {0}</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kaso {0}</unitPattern>
+				<unitPattern count="other">Kaso {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">permille {0}</unitPattern>
+				<unitPattern count="other">permille {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">permyriad {0}</unitPattern>
+				<unitPattern count="other">permyriad {0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>moles</displayName>
+				<unitPattern count="one">mole {0}</unitPattern>
+				<unitPattern count="other">moles {0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litoci a kilomita</displayName>
+				<unitPattern count="one">lita a kilomita {0}</unitPattern>
+				<unitPattern count="other">litoci a kilomita {0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>litoci a kilomitoci 100</displayName>
+				<unitPattern count="one">lita a kilomitoci 100 {0}</unitPattern>
+				<unitPattern count="other">litoci a kilomitoci 100 {0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil-mil a galan</displayName>
+				<unitPattern count="one">mil a galan {0}</unitPattern>
+				<unitPattern count="other">mil-mil a galan {0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil-mil a Imp. gallon</displayName>
+				<unitPattern count="one">mil a Imp. gallon {0}</unitPattern>
+				<unitPattern count="other">mil-mil a Imp. gallon {0}</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>petabytes</displayName>
+				<unitPattern count="one">petabyte {0}</unitPattern>
+				<unitPattern count="other">petabytes {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>terabytes</displayName>
+				<unitPattern count="one">terabyte {0}</unitPattern>
+				<unitPattern count="other">terabytes {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>terabits</displayName>
+				<unitPattern count="one">terabit {0}</unitPattern>
+				<unitPattern count="other">terabits {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigabytes</displayName>
+				<unitPattern count="one">gigabyte {0}</unitPattern>
+				<unitPattern count="other">gigabytes {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigabits</displayName>
+				<unitPattern count="one">gigabit {0}</unitPattern>
+				<unitPattern count="other">gigabits {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megabytes</displayName>
+				<unitPattern count="one">megabyte {0}</unitPattern>
+				<unitPattern count="other">megabytes {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megabits</displayName>
+				<unitPattern count="one">megabit {0}</unitPattern>
+				<unitPattern count="other">megabits {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilobytes</displayName>
+				<unitPattern count="one">kilobyte {0}</unitPattern>
+				<unitPattern count="other">kilobytes {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilobits</displayName>
+				<unitPattern count="one">kilobit {0}</unitPattern>
+				<unitPattern count="other">kilobits {0}</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
+				<displayName>bytes</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">bytes {0}</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
+				<displayName>bits</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">bits {0}</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ƙarnoni</displayName>
+				<unitPattern count="one">ƙarni {0}</unitPattern>
+				<unitPattern count="other">ƙarnoni {0}</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>shekaru goma-goma</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">shk gm-gm {0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">shekara {0}</unitPattern>
+				<unitPattern count="other">shekaru {0}</unitPattern>
+				<perUnitPattern>{0} a shekara</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kwatoci</displayName>
+				<unitPattern count="one">kwata {0}</unitPattern>
+				<unitPattern count="other">kwatoci {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>wat</displayName>
+				<unitPattern count="one">wata {0}</unitPattern>
+				<unitPattern count="other">watanni {0}</unitPattern>
+				<perUnitPattern>{0} a wata</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">mako {0}</unitPattern>
+				<unitPattern count="other">makonni {0}</unitPattern>
+				<perUnitPattern>{0} a mako</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">ranaku {0}</unitPattern>
+				<perUnitPattern>{0} a rana</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">sa′a {0}</unitPattern>
+				<unitPattern count="other">sa′o′i {0}</unitPattern>
+				<perUnitPattern>{0} a saʼa</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mintoci</displayName>
+				<unitPattern count="one">minti {0}</unitPattern>
+				<unitPattern count="other">mintoci {0}</unitPattern>
+				<perUnitPattern>{0} a minti</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>daƙiƙoƙi</displayName>
+				<unitPattern count="one">daƙiƙa {0}</unitPattern>
+				<unitPattern count="other">daƙiƙoƙi {0}</unitPattern>
+				<perUnitPattern>{0} a daƙiƙa</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millisakan</displayName>
+				<unitPattern count="one">millisakan {0}</unitPattern>
+				<unitPattern count="other">millisakans {0}</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>makirosekan</displayName>
+				<unitPattern count="one">makirosekan {0}</unitPattern>
+				<unitPattern count="other">makirosekans {0}</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanosekan</displayName>
+				<unitPattern count="one">nanosekan {0}</unitPattern>
+				<unitPattern count="other">nanosekans {0}</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>amperes</displayName>
+				<unitPattern count="one">ampere {0}</unitPattern>
+				<unitPattern count="other">amperes {0}</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milliamperes</displayName>
+				<unitPattern count="one">milliamperes {0}</unitPattern>
+				<unitPattern count="other">milliamperes {0}</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohms</displayName>
+				<unitPattern count="one">ohm {0}</unitPattern>
+				<unitPattern count="other">ohms {0}</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">volt {0}</unitPattern>
+				<unitPattern count="other">volts {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilokaloris</displayName>
+				<unitPattern count="one">kilokalori {0}</unitPattern>
+				<unitPattern count="other">kilokaloris {0}</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kaloris</displayName>
+				<unitPattern count="one">kalori {0}</unitPattern>
+				<unitPattern count="other">kaloris {0}</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kaloris</displayName>
+				<unitPattern count="one">Kalori {0}</unitPattern>
+				<unitPattern count="other">Kaloris {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilojoules</displayName>
+				<unitPattern count="one">kilojoule {0}</unitPattern>
+				<unitPattern count="other">kilojoules {0}</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">joule {0}</unitPattern>
+				<unitPattern count="other">joules {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilowatt-hours</displayName>
+				<unitPattern count="one">kilowatt hour {0}</unitPattern>
+				<unitPattern count="other">kilowatt-hours {0}</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>electronvolts</displayName>
+				<unitPattern count="one">electronvolt {0}</unitPattern>
+				<unitPattern count="other">electronvolts {0}</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>British thermal units</displayName>
+				<unitPattern count="one">British thermal unit {0}</unitPattern>
+				<unitPattern count="other">British thermal units {0}</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">US therms {0}</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pounds of force</displayName>
+				<unitPattern count="one">pound of force {0}</unitPattern>
+				<unitPattern count="other">pounds of force {0}</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>newtons</displayName>
+				<unitPattern count="one">newton {0}</unitPattern>
+				<unitPattern count="other">newtons {0}</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilowatt-hour per 100 kilometers</displayName>
+				<unitPattern count="one">kilowatt-hour per 100 kilometers {0}</unitPattern>
+				<unitPattern count="other">kilowatt-hours per 100 kilometers {0}</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigahertz</displayName>
+				<unitPattern count="one">gigahertz {0}</unitPattern>
+				<unitPattern count="other">gigahertz {0}</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megahertz</displayName>
+				<unitPattern count="one">megahertz {0}</unitPattern>
+				<unitPattern count="other">megahertz {0}</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilohertz</displayName>
+				<unitPattern count="one">kilohertz {0}</unitPattern>
+				<unitPattern count="other">kilohertz {0}</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hertz</displayName>
+				<unitPattern count="one">hertz {0}</unitPattern>
+				<unitPattern count="other">hertz {0}</unitPattern>
 			</unit>
 			<unit type="graphics-em">
-				<displayName>↑↑↑</displayName>
+				<displayName>typographic em</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} ems</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fikzel</displayName>
+				<unitPattern count="one">fikzel {0}</unitPattern>
+				<unitPattern count="other">fikzels {0}</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">megafikzel {0}</unitPattern>
+				<unitPattern count="other">megafikzels {0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fikzels a sentimita</displayName>
+				<unitPattern count="one">{0} fikzel a sentimita</unitPattern>
+				<unitPattern count="other">{0} fikzels a sentimita</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fikzel a inci</displayName>
+				<unitPattern count="one">{0} fikzel a inci</unitPattern>
+				<unitPattern count="other">{0} fikzels a inci</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ayoyi a sentimita</displayName>
+				<unitPattern count="one">{0} aya a sentimita</unitPattern>
+				<unitPattern count="other">{0} ayoyi a sentimita</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ayoyi a inci</displayName>
+				<unitPattern count="one">{0} aya a inci</unitPattern>
+				<unitPattern count="other">{0} ayoyi a inci</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">aya {0}</unitPattern>
+				<unitPattern count="other">aya {0}</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>earth radius</displayName>
+				<unitPattern count="one">earth radius {0}</unitPattern>
+				<unitPattern count="other">earth radius {0}</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kilomitoci</displayName>
+				<unitPattern count="one">kilomita {0}</unitPattern>
+				<unitPattern count="other">kilomitoci {0}</unitPattern>
+				<perUnitPattern>{0} a kilomita</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>mitoci</displayName>
+				<unitPattern count="one">mita {0}</unitPattern>
+				<unitPattern count="other">mitoci {0}</unitPattern>
+				<perUnitPattern>{0} a mita</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>disimitoci</displayName>
+				<unitPattern count="one">disimita {0}</unitPattern>
+				<unitPattern count="other">disimitoci {0}</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>sentimitoci</displayName>
+				<unitPattern count="one">sentimita {0}</unitPattern>
+				<unitPattern count="other">sentimitoci {0}</unitPattern>
+				<perUnitPattern>{0} a sentimita</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milimitoci</displayName>
+				<unitPattern count="one">milimita {0}</unitPattern>
+				<unitPattern count="other">milimitoci {0}</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>makiromitoci</displayName>
+				<unitPattern count="one">makiromita {0}</unitPattern>
+				<unitPattern count="other">makiromitoci {0}</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nanomitoci</displayName>
+				<unitPattern count="one">nanomita {0}</unitPattern>
+				<unitPattern count="other">nanomitoci {0}</unitPattern>
 			</unit>
 			<unit type="length-picometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fikomitoci</displayName>
+				<unitPattern count="one">fikomita {0}</unitPattern>
+				<unitPattern count="other">fikomitoci {0}</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mil {0}</unitPattern>
+				<unitPattern count="other">mil-mil {0}</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">yadi {0}</unitPattern>
+				<unitPattern count="other">yaduka {0}</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">ƙafa {0}</unitPattern>
+				<unitPattern count="other">ƙafafu {0}</unitPattern>
+				<perUnitPattern>{0} a ƙafa</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">inci {0}</unitPattern>
+				<unitPattern count="other">incina {0}</unitPattern>
+				<perUnitPattern>{0} a inci</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">fasek {0}</unitPattern>
+				<unitPattern count="other">fasekoki {0}</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>shekarun haske</displayName>
+				<unitPattern count="one">shekarar haske {0}</unitPattern>
+				<unitPattern count="other">shekarun haske {0}</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>astronomical units</displayName>
+				<unitPattern count="one">astronomical unit {0}</unitPattern>
+				<unitPattern count="other">astronomical units {0}</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">furlong {0}</unitPattern>
+				<unitPattern count="other">furlongs {0}</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fathoms</displayName>
+				<unitPattern count="one">fathom {0}</unitPattern>
+				<unitPattern count="other">fathoms {0}</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>nautical miles</displayName>
+				<unitPattern count="one">nautical mile {0}</unitPattern>
+				<unitPattern count="other">nautical miles {0}</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mile-scandinavian</displayName>
+				<unitPattern count="one">mile-scandinavian {0}</unitPattern>
+				<unitPattern count="other">miles-scandinavian {0}</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">maki {0}</unitPattern>
+				<unitPattern count="other">makuna {0}</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">solar radius {0}</unitPattern>
+				<unitPattern count="other">solar radii {0}</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">lux {0}</unitPattern>
+				<unitPattern count="other">lux {0}</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>candela</displayName>
+				<unitPattern count="one">candela {0}</unitPattern>
+				<unitPattern count="other">candela {0}</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lumen</displayName>
+				<unitPattern count="one">lumen {0}</unitPattern>
+				<unitPattern count="other">lumen {0}</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">solar luminosity {0}</unitPattern>
+				<unitPattern count="other">solar luminosities {0}</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metric tons</displayName>
+				<unitPattern count="one">metric ton {0}</unitPattern>
+				<unitPattern count="other">metric tons {0}</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kilogiramgiram</displayName>
+				<unitPattern count="one">kilogiram {0}</unitPattern>
+				<unitPattern count="other">kilogiramgiram {0}</unitPattern>
+				<perUnitPattern>{0} a kilogiram</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>giram-giram</displayName>
+				<unitPattern count="one">giram {0}</unitPattern>
+				<unitPattern count="other">giram-giram {0}</unitPattern>
+				<perUnitPattern>{0} a giram</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milligiramgiram</displayName>
+				<unitPattern count="one">milligiram {0}</unitPattern>
+				<unitPattern count="other">milligiramgiram {0}</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>makirogiramgiram</displayName>
+				<unitPattern count="one">Makirogiram {0}</unitPattern>
+				<unitPattern count="other">makirogiramgiram {0}</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">tan {0}</unitPattern>
+				<unitPattern count="other">tan-tan {0}</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">stone {0}</unitPattern>
+				<unitPattern count="other">stones {0}</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Laba {0}</unitPattern>
+				<unitPattern count="other">laba-laba {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>oza-oza</displayName>
+				<unitPattern count="one">oza {0}</unitPattern>
+				<unitPattern count="other">oza-oza {0}</unitPattern>
+				<perUnitPattern>{0} a oza</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oza-ozar troy</displayName>
+				<unitPattern count="one">oza troy {0}</unitPattern>
+				<unitPattern count="other">oza-ozar troy {0}</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">carat {0}</unitPattern>
+				<unitPattern count="other">carats {0}</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">dalton {0}</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Earth mas {0}</unitPattern>
+				<unitPattern count="other">Earth masses {0}</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">solar mas {0}</unitPattern>
+				<unitPattern count="other">solar masses {0}</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
@@ -6710,104 +6716,104 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gigawatwat</displayName>
+				<unitPattern count="one">gigawat {0}</unitPattern>
+				<unitPattern count="other">gigawatwat {0}</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megawatwat</displayName>
+				<unitPattern count="one">megawat {0}</unitPattern>
+				<unitPattern count="other">megawatwat {0}</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilowatwat</displayName>
+				<unitPattern count="one">kilowat {0}</unitPattern>
+				<unitPattern count="other">kilowatwat {0}</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">wat {0}</unitPattern>
+				<unitPattern count="other">wat-wat {0}</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>milliwatwat</displayName>
+				<unitPattern count="one">milliwat {0}</unitPattern>
+				<unitPattern count="other">milliwatwat {0}</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ƙarfin inji</displayName>
+				<unitPattern count="one">ƙarfin inji {0}</unitPattern>
+				<unitPattern count="other">ƙarfin inji {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimitocin zaiba</displayName>
+				<unitPattern count="one">millimitar zaiba {0}</unitPattern>
+				<unitPattern count="other">millimitocin zaiba {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>laba-laba a sikwaya inci</displayName>
+				<unitPattern count="one">laba a sikwaya inci {0}</unitPattern>
+				<unitPattern count="other">laba-laba a sikwaya inci {0}</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>incinan zaiba</displayName>
+				<unitPattern count="one">incin zaiba {0}</unitPattern>
+				<unitPattern count="other">incinan zaiba {0}</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>sanduna</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">anduna {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millibars</displayName>
+				<unitPattern count="one">millibar {0}</unitPattern>
+				<unitPattern count="other">millibars {0}</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yanaye-yanaye</displayName>
+				<unitPattern count="one">Yanayi {0}</unitPattern>
+				<unitPattern count="other">yanaye-yanaye {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pascals</displayName>
+				<unitPattern count="one">pascal {0}</unitPattern>
+				<unitPattern count="other">pascals {0}</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hectopascals</displayName>
+				<unitPattern count="one">hectopascal {0}</unitPattern>
+				<unitPattern count="other">hectopascals {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilopascals</displayName>
+				<unitPattern count="one">kilopascal {0}</unitPattern>
+				<unitPattern count="other">kilopascals {0}</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megapascals</displayName>
+				<unitPattern count="one">megapascal {0}</unitPattern>
+				<unitPattern count="other">megapascals {0}</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kilomitoci a saʼa</displayName>
+				<unitPattern count="one">kilomita {0} a sa′a</unitPattern>
+				<unitPattern count="other">kilomitoci {0} a sa′a</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mitoci a daƙiƙa</displayName>
+				<unitPattern count="one">mita a daƙiƙa {0}</unitPattern>
+				<unitPattern count="other">mitoci a daƙiƙa {0}</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mil-mil a saʼa</displayName>
+				<unitPattern count="one">mil {0} a sa′a</unitPattern>
+				<unitPattern count="other">mil-mil {0} a sa′a</unitPattern>
 			</unit>
 			<unit type="speed-knot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>knots</displayName>
+				<unitPattern count="one">knot {0}</unitPattern>
+				<unitPattern count="other">knots {0}</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>↑↑↑</displayName>
@@ -6816,183 +6822,183 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Digirin yanayi {0}</unitPattern>
+				<unitPattern count="other">digiri-digiri {0}</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>digiri-digiri Selsiyas</displayName>
+				<unitPattern count="one">Digiri Selsiyas {0}</unitPattern>
+				<unitPattern count="other">digiri-digiri Selsiyas {0}</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>digiri-digiri faranhit</displayName>
+				<unitPattern count="one">Digiri Faranhit {0}</unitPattern>
+				<unitPattern count="other">digiri-digiri faranhit {0}</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kelvins</displayName>
+				<unitPattern count="one">kelvin {0}</unitPattern>
+				<unitPattern count="other">kelvins {0}</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pound-feet</displayName>
+				<unitPattern count="one">Pound-force-foot {0}</unitPattern>
+				<unitPattern count="other">pound-feet {0}</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>newton-meters</displayName>
+				<unitPattern count="one">newton-meter {0}</unitPattern>
+				<unitPattern count="other">newton-meters {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kubik kilomitoci</displayName>
+				<unitPattern count="one">kubik kilomita {0}</unitPattern>
+				<unitPattern count="other">kubik kilomitoci {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kubic mitoci</displayName>
+				<unitPattern count="one">kubic mita {0}</unitPattern>
+				<unitPattern count="other">kubic mitoci {0}</unitPattern>
+				<perUnitPattern>{0} a kubic mita</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kubik sentimitoci</displayName>
+				<unitPattern count="one">kubik sentimita {0}</unitPattern>
+				<unitPattern count="other">kubik sentimitoci {0}</unitPattern>
+				<perUnitPattern>{0} a kubik sentimita</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kubik mil-mil</displayName>
+				<unitPattern count="one">kubik mil {0}</unitPattern>
+				<unitPattern count="other">kubik mil-mil {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kubik yaduka</displayName>
+				<unitPattern count="one">kubik yadi {0}</unitPattern>
+				<unitPattern count="other">kubik yaduka {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kubik ƙafafu</displayName>
+				<unitPattern count="one">kubik ƙafa {0}</unitPattern>
+				<unitPattern count="other">kubik ƙafafu {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kubic incina</displayName>
+				<unitPattern count="one">kubik inci {0}</unitPattern>
+				<unitPattern count="other">kubik incina {0}</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>megalitoci</displayName>
+				<unitPattern count="one">megalita {0}</unitPattern>
+				<unitPattern count="other">megalitoci {0}</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hektolitoci</displayName>
+				<unitPattern count="one">hektolita {0}</unitPattern>
+				<unitPattern count="other">hektolitoci {0}</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">lita {0}</unitPattern>
+				<unitPattern count="other">litoci {0}</unitPattern>
+				<perUnitPattern>{0} a lita</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>desilitoci</displayName>
+				<unitPattern count="one">desilita {0}</unitPattern>
+				<unitPattern count="other">desilitoci {0}</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sentilitoci</displayName>
+				<unitPattern count="one">sentilita {0}</unitPattern>
+				<unitPattern count="other">sentilitoci {0}</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>millimitoci</displayName>
+				<unitPattern count="one">millimita {0}</unitPattern>
+				<unitPattern count="other">millimitoci {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metric pints</displayName>
+				<unitPattern count="one">metric pint {0}</unitPattern>
+				<unitPattern count="other">metric pints {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>metric cups</displayName>
+				<unitPattern count="one">metric cup {0}</unitPattern>
+				<unitPattern count="other">metric cups {0}</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eka-ƙafafu</displayName>
+				<unitPattern count="one">eka-ƙafa {0}</unitPattern>
+				<unitPattern count="other">eka-ƙafafu {0}</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">bushel {0}</unitPattern>
+				<unitPattern count="other">bushels {0}</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>galan-galan</displayName>
+				<unitPattern count="one">galan {0}</unitPattern>
+				<unitPattern count="other">galan-galan {0}</unitPattern>
+				<perUnitPattern>{0} a galan</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp. gallons</displayName>
+				<unitPattern count="one">Imp. gallon {0}</unitPattern>
+				<unitPattern count="other">Imp. gallons {0}</unitPattern>
+				<perUnitPattern>{0} a Imp. gallons</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>quarts</displayName>
+				<unitPattern count="one">quart {0}</unitPattern>
+				<unitPattern count="other">quarts {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">pint {0}</unitPattern>
+				<unitPattern count="other">pints {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kofi {0}</unitPattern>
+				<unitPattern count="other">kofuna {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fluid ounces</displayName>
+				<unitPattern count="one">fluid ounce {0}</unitPattern>
+				<unitPattern count="other">fluid ounces {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. fluid ounces</displayName>
+				<unitPattern count="one">Imp. fluid ounce {0}</unitPattern>
+				<unitPattern count="other">Imp. fluid ounces {0}</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>manyan cokula</displayName>
+				<unitPattern count="one">babban cokali {0}</unitPattern>
+				<unitPattern count="other">manyan cokula {0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ƙananan cokula</displayName>
+				<unitPattern count="one">ƙaramin cokali {0}</unitPattern>
+				<unitPattern count="other">ƙananan cokula {0}</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ganguna</displayName>
+				<unitPattern count="one">ganga {0}</unitPattern>
+				<unitPattern count="other">ganguna {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dessert spoon</displayName>
+				<unitPattern count="one">dessert spoon {0}</unitPattern>
+				<unitPattern count="other">dessert spoon {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. dessert spoon</displayName>
+				<unitPattern count="one">Imp. dessert spoon {0}</unitPattern>
+				<unitPattern count="other">Imp. dessert spoon {0}</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
@@ -7000,9 +7006,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dram</displayName>
+				<unitPattern count="one">dram {0}</unitPattern>
+				<unitPattern count="other">{0} dram</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
@@ -7015,16 +7021,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp. quart</displayName>
+				<unitPattern count="one">Imp. quart {0}</unitPattern>
+				<unitPattern count="other">Imp. quart {0}</unitPattern>
 			</unit>
 			<coordinateUnit>
-				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<displayName>wurin fuskanta</displayName>
+				<coordinateUnitPattern type="east">Gabas {0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">Arewa {0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">Kudu {0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">Yamma {0}</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="short">
@@ -7143,400 +7149,400 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">G {0}</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>meters/sec²</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">m/s² {0}</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">rev {0}</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
+				<displayName>radian</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">rad {0}</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
+				<displayName>degrees</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">deg {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcmins</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">arcmin {0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>arcsecs</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">arcsec {0}</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">km² {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
+				<displayName>hektoci</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ha {0}</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>mitoci²</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">m² {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">cm² {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>sk mil-mil</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sq mi {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
+				<displayName>ekoki</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ek {0}</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yaduna²</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">yd² {0}</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>sk ƙafa</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sk ƙf {0}</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>incina²</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">in² {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
+				<displayName>dunams</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dunam {0}</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
+				<displayName>karats</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kt {0}</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mg/dL {0}</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>millimol/liter</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mmol/L {0}</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>abu</displayName>
+				<unitPattern count="one">abu {0}</unitPattern>
+				<unitPattern count="other">Abw. {0}</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
+				<displayName>parts/million</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ppm {0}</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
-				<displayName>↑↑↑</displayName>
+				<displayName>kaso</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>permille</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">‰{0}</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>permyriad</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">‱{0}</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
+				<displayName>mole</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mol {0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>litoci/km</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">L/km {0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">L/100km {0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil/gal</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mag {0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil/gal Imp.</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mag Imp. {0}</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>PByte</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">PB {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>TByte</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">TB {0}</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tbit</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Tb {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>GByte</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">GB {0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gbit</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Gb {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>MByte</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">MB {0}</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mbit</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Mb {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
+				<displayName>KByte</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kB {0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
+				<displayName>kbit</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kb {0}</unitPattern>
 			</unit>
 			<unit type="digital-byte">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">byte {0}</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">bit {0}</unitPattern>
 			</unit>
 			<unit type="duration-century">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙ</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ƙ {0}</unitPattern>
 			</unit>
 			<unit type="duration-decade">
-				<displayName>↑↑↑</displayName>
+				<displayName>shkr gm</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sk gm {0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>shekaru</displayName>
+				<unitPattern count="one">shkr {0}</unitPattern>
+				<unitPattern count="other">shkru {0}</unitPattern>
+				<perUnitPattern>{0}/s</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>kwt</displayName>
+				<unitPattern count="one">kwt {0}</unitPattern>
+				<unitPattern count="other">kwtc {0}</unitPattern>
+				<perUnitPattern>k/{0}</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>watanni</displayName>
+				<unitPattern count="one">wat {0}</unitPattern>
+				<unitPattern count="other">wtnn {0}</unitPattern>
+				<perUnitPattern>{0}/w</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>makonni</displayName>
+				<unitPattern count="one">mk {0}</unitPattern>
+				<unitPattern count="other">mkn {0}</unitPattern>
+				<perUnitPattern>{0}/m</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ranaku</displayName>
+				<unitPattern count="one">rana {0}</unitPattern>
+				<unitPattern count="other">Rnk. {0}</unitPattern>
+				<perUnitPattern>{0}/r</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>saʼoʼi</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">s {0}</unitPattern>
+				<perUnitPattern>{0}/saʼa</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
+				<displayName>mintc</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">mnt {0}</unitPattern>
+				<perUnitPattern>{0}/mnt</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>daƙ</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">d {0}</unitPattern>
+				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>milseks</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ms {0}</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>μsecs</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">μs {0}</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>nanoseks</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ns {0}</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">A {0}</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
+				<displayName>milliamps</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mA {0}</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Ω {0}</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
+				<displayName>volts</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">V {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kcal {0}</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
-				<displayName>↑↑↑</displayName>
+				<displayName>kal</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kal {0}</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Kal</displayName>
+				<unitPattern count="one">Kal {0}</unitPattern>
+				<unitPattern count="other">Kal {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
+				<displayName>kilojoule</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kj {0}</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
+				<displayName>joules</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">J {0}</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>kW-hour</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kWh {0}</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
+				<displayName>electronvolt</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">eV {0}</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
+				<displayName>BTU</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Btu {0}</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">US therm {0}</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
+				<displayName>pounds-force</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">lbf {0}</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
+				<displayName>newton</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">N {0}</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kWh/100km {0}</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">GHz {0}</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">MHz {0}</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kHz {0}</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Hz {0}</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">em {0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>fikzels</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">px {0}</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
-				<displayName>↑↑↑</displayName>
+				<displayName>megafikzels</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">MP {0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
@@ -7546,147 +7552,147 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ppi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dpcm {0}</unitPattern>
+				<unitPattern count="other">dpcm {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dpi {0}</unitPattern>
+				<unitPattern count="other">dpi {0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
-				<displayName>↑↑↑</displayName>
+				<displayName>aya</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">R⊕ {0}</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">km {0}</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
-				<displayName>↑↑↑</displayName>
+				<displayName>m</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">m {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dm {0}</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">cm {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mm {0}</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
-				<displayName>↑↑↑</displayName>
+				<displayName>μmeters</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">μm {0}</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">nm {0}</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">pm {0}</unitPattern>
 			</unit>
 			<unit type="length-mile">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mi {0}</unitPattern>
 			</unit>
 			<unit type="length-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yaduka</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">yd {0}</unitPattern>
 			</unit>
 			<unit type="length-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ƙafafu</displayName>
+				<unitPattern count="one">ƙf {0}</unitPattern>
+				<unitPattern count="other">ƙff {0}</unitPattern>
+				<perUnitPattern>{0}/ƙf</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>incina</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">in {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
+				<displayName>fasekoki</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">pc {0}</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>shkr haske</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sh {0}</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">au {0}</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
+				<displayName>furlongs</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">fur {0}</unitPattern>
 			</unit>
 			<unit type="length-fathom">
-				<displayName>↑↑↑</displayName>
+				<displayName>fathom</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">fth {0}</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">nmi {0}</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">smi {0}</unitPattern>
 			</unit>
 			<unit type="length-point">
-				<displayName>↑↑↑</displayName>
+				<displayName>makuna</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mk {0}</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
+				<displayName>solar radii</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">R☉ {0}</unitPattern>
 			</unit>
 			<unit type="light-lux">
-				<displayName>↑↑↑</displayName>
+				<displayName>lux</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">lx {0}</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">cd {0}</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
@@ -7694,188 +7700,188 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
+				<displayName>solar luminosities</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">L☉ {0}</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">t {0}</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kg {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
-				<displayName>↑↑↑</displayName>
+				<displayName>giram</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">g {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mg {0}</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">μg {0}</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
+				<displayName>tan-tan</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">tn {0}</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>stones</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">st {0}</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
+				<displayName>laba-laba</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">lb {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">oz {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
+				<displayName>ozar troy</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">oz t {0}</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
+				<displayName>carats</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">CD {0}</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>daltons</displayName>
+				<unitPattern count="one">Da {0}</unitPattern>
+				<unitPattern count="other">daltons {0}</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>Earth masses</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">M⊕ {0}</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
+				<displayName>solar masses</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">M☉ {0}</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙwaya</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ƙwaya {0}</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">GW {0}</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">MW {0}</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kW {0}</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
+				<displayName>wat-wat</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">W {0}</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mW {0}</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙi</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ƙi {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mmHg {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">psi {0}</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">inHg {0}</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
-				<displayName>↑↑↑</displayName>
+				<displayName>sanda</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sanda {0}</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mbar {0}</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
-				<displayName>↑↑↑</displayName>
+				<displayName>yny</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">yny {0}</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">Pa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">hPa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kPa {0}</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">MPa {0}</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>km/saʼa</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">km/s {0}</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
+				<displayName>mitoci/daƙ</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">m/s {0}</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>mil-mil/saʼa</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mas {0}</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">kn {0}</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>↑↑↑</displayName>
@@ -7885,214 +7891,214 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">°{0}</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
+				<displayName>dig. S</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">°S{0}</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
+				<displayName>dig. F</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">F°{0}</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">K {0}</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">lbf⋅ft {0}</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">N⋅m {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">km³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">m³ {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">cm³ {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mi³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
-				<displayName>↑↑↑</displayName>
+				<displayName>yaduka³</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">yd³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>ƙafafu³</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ƙf³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
-				<displayName>↑↑↑</displayName>
+				<displayName>incina³</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">in³ {0}</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ML {0}</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">hL {0}</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
+				<displayName>litoci</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="other">L {0}</unitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dL {0}</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sL {0}</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mL {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mpt {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">mc {0}</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
+				<displayName>eka ƙf</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ek ƙf {0}</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bushels</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">bu {0}</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
+				<displayName>gal</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">gal {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">gal Imp. {0}</unitPattern>
+				<unitPattern count="other">gal Imp.{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
+				<displayName>qts</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">qt {0}</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
+				<displayName>pints</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">pt {0}</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
+				<displayName>kofuna</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">k {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
+				<displayName>fl oz</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">fl oz {0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">fl oz Imp. {0}</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>↑↑↑</displayName>
+				<displayName>bckl</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">bckl {0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>ƙmc</displayName>
+				<unitPattern count="one">ƙmc {0}</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">gang {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dstspn {0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dstspn Imp {0}</unitPattern>
 			</unit>
 			<unit type="volume-drop">
-				<displayName>↑↑↑</displayName>
+				<displayName>ɗigo</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">ɗigo {0}</unitPattern>
 			</unit>
 			<unit type="volume-dram">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">dram fl {0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">jigger {0}</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">pinch {0}</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">qt Imp. {0}</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east">G {0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">A {0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">K {0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">Y {0}</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<unitLength type="narrow">
@@ -8210,264 +8216,264 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">G{0}</unitPattern>
+				<unitPattern count="other">Gs{0}</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/s²</displayName>
+				<unitPattern count="one">m/s²{0}</unitPattern>
+				<unitPattern count="other">m/s²{0}</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">rev{0}</unitPattern>
+				<unitPattern count="other">rev{0}</unitPattern>
 			</unit>
 			<unit type="angle-radian">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rad</displayName>
+				<unitPattern count="one">rad{0}</unitPattern>
+				<unitPattern count="other">rad{0}</unitPattern>
 			</unit>
 			<unit type="angle-degree">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>deg</displayName>
+				<unitPattern count="one">deg{0}</unitPattern>
+				<unitPattern count="other">deg{0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcmin</displayName>
+				<unitPattern count="one">arcmin{0}</unitPattern>
+				<unitPattern count="other">arcmin{0}</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>arcsec</displayName>
+				<unitPattern count="one">arcsecs{0}</unitPattern>
+				<unitPattern count="other">arcsecs{0}</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">km²{0}</unitPattern>
+				<unitPattern count="other">km²{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>hekta</displayName>
+				<unitPattern count="one">ha{0}</unitPattern>
+				<unitPattern count="other">hk{0}</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">m²{0}</unitPattern>
+				<unitPattern count="other">m²{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">cm²{0}</unitPattern>
+				<unitPattern count="other">cm²{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">sq mi{0}</unitPattern>
+				<unitPattern count="other">sq mi{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eka</displayName>
+				<unitPattern count="one">ek{0}</unitPattern>
+				<unitPattern count="other">ek{0}</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>yd²</displayName>
+				<unitPattern count="one">yd²{0}</unitPattern>
+				<unitPattern count="other">yd²{0}</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">sk ƙf{0}</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">in²{0}</unitPattern>
+				<unitPattern count="other">in²{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dunam</displayName>
+				<unitPattern count="one">dunam{0}</unitPattern>
+				<unitPattern count="other">dunam{0}</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>karat</displayName>
+				<unitPattern count="one">kt{0}</unitPattern>
+				<unitPattern count="other">kt{0}</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mg/dL{0}</unitPattern>
+				<unitPattern count="other">mg/dL{0}</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmol/L</displayName>
+				<unitPattern count="one">mmol/L{0}</unitPattern>
+				<unitPattern count="other">mmol/L{0}</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">abu{0}</unitPattern>
+				<unitPattern count="other">Abw{0}</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ppm</displayName>
+				<unitPattern count="one">ppm{0}</unitPattern>
+				<unitPattern count="other">ppm{0}</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">%{0}</unitPattern>
+				<unitPattern count="other">%{0}</unitPattern>
 			</unit>
 			<unit type="concentr-permille">
-				<displayName>↑↑↑</displayName>
+				<displayName>‰</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
-				<displayName>↑↑↑</displayName>
+				<displayName>‱</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-mole">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mol</displayName>
+				<unitPattern count="one">mol{0}</unitPattern>
+				<unitPattern count="other">mol{0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L/km</displayName>
+				<unitPattern count="one">L/km{0}</unitPattern>
+				<unitPattern count="other">L/km{0}</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">L/100km{0}</unitPattern>
+				<unitPattern count="other">L/100km{0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mag{0}</unitPattern>
+				<unitPattern count="other">mag{0}</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mag UK</displayName>
+				<unitPattern count="one">m/gUK{0}</unitPattern>
+				<unitPattern count="other">m/gUK{0}</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="one">PB{0}</unitPattern>
+				<unitPattern count="other">PB{0}</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="one">TB{0}</unitPattern>
+				<unitPattern count="other">TB{0}</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tb</displayName>
+				<unitPattern count="one">Tb{0}</unitPattern>
+				<unitPattern count="other">Tb{0}</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="one">GB{0}</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="one">Gb{0}</unitPattern>
+				<unitPattern count="other">Gb{0}</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="one">MB{0}</unitPattern>
+				<unitPattern count="other">MB{0}</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="one">Mb{0}</unitPattern>
+				<unitPattern count="other">Mb{0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="one">kB{0}</unitPattern>
+				<unitPattern count="other">kB{0}</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="one">kb{0}</unitPattern>
+				<unitPattern count="other">kb{0}</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="one">B{0}</unitPattern>
+				<unitPattern count="other">B{0}</unitPattern>
 			</unit>
 			<unit type="digital-bit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">bit{0}</unitPattern>
+				<unitPattern count="other">bit{0}</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ƙ{0}</unitPattern>
+				<unitPattern count="other">ƙ{0}</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">sk gm{0}</unitPattern>
+				<unitPattern count="other">sk gm{0}</unitPattern>
 			</unit>
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
+				<displayName>shkr</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">s{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kwt{0}</unitPattern>
+				<unitPattern count="other">kwt{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wata</displayName>
+				<unitPattern count="one">w{0}</unitPattern>
+				<unitPattern count="other">w{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mk</displayName>
+				<unitPattern count="one">m{0}</unitPattern>
+				<unitPattern count="other">m{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>rana</displayName>
+				<unitPattern count="one">r{0}</unitPattern>
+				<unitPattern count="other">r{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>saʼa</displayName>
+				<unitPattern count="one">s{0}</unitPattern>
+				<unitPattern count="other">s{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mnt</displayName>
+				<unitPattern count="one">minti{0}</unitPattern>
+				<unitPattern count="other">minti {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-second">
@@ -8477,473 +8483,473 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-millisecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>msek</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">μs{0}</unitPattern>
+				<unitPattern count="other">μs{0}</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ns{0}</unitPattern>
+				<unitPattern count="other">ns{0}</unitPattern>
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">A{0}</unitPattern>
+				<unitPattern count="other">A{0}</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mA</displayName>
+				<unitPattern count="one">mA{0}</unitPattern>
+				<unitPattern count="other">mA{0}</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Ω{0}</unitPattern>
+				<unitPattern count="other">Ω{0}</unitPattern>
 			</unit>
 			<unit type="electric-volt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>volt</displayName>
+				<unitPattern count="one">V{0}</unitPattern>
+				<unitPattern count="other">V{0}</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kcal{0}</unitPattern>
+				<unitPattern count="other">kcal{0}</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kal{0}</unitPattern>
+				<unitPattern count="other">kal{0}</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Kal{0}</unitPattern>
+				<unitPattern count="other">Kal{0}</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kj</displayName>
+				<unitPattern count="one">kj{0}</unitPattern>
+				<unitPattern count="other">kj{0}</unitPattern>
 			</unit>
 			<unit type="energy-joule">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>joule</displayName>
+				<unitPattern count="one">J{0}</unitPattern>
+				<unitPattern count="other">J{0}</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kWh</displayName>
+				<unitPattern count="one">kWh{0}</unitPattern>
+				<unitPattern count="other">kWh{0}</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>eV</displayName>
+				<unitPattern count="one">eV{0}</unitPattern>
+				<unitPattern count="other">eV{0}</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Btu{0}</unitPattern>
+				<unitPattern count="other">Btu{0}</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">US therm{0}</unitPattern>
+				<unitPattern count="other">US therm{0}</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lbf</displayName>
+				<unitPattern count="one">lbf{0}</unitPattern>
+				<unitPattern count="other">lbf{0}</unitPattern>
 			</unit>
 			<unit type="force-newton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>N</displayName>
+				<unitPattern count="one">N{0}</unitPattern>
+				<unitPattern count="other">N{0}</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kWh/100km{0}</unitPattern>
+				<unitPattern count="other">kWh/100km{0}</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">GHz{0}</unitPattern>
+				<unitPattern count="other">GHz{0}</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">MHz{0}</unitPattern>
+				<unitPattern count="other">MHz{0}</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kHz{0}</unitPattern>
+				<unitPattern count="other">kHz{0}</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Hz{0}</unitPattern>
+				<unitPattern count="other">Hz{0}</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">em{0}</unitPattern>
+				<unitPattern count="other">em{0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">px{0}</unitPattern>
+				<unitPattern count="other">px{0}</unitPattern>
 			</unit>
 			<unit type="graphics-megapixel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">MP{0}</unitPattern>
+				<unitPattern count="other">MP{0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ppcm{0}</unitPattern>
+				<unitPattern count="other">ppcm{0}</unitPattern>
 			</unit>
 			<unit type="graphics-pixel-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ppi{0}</unitPattern>
+				<unitPattern count="other">ppi{0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dpcm{0}</unitPattern>
+				<unitPattern count="other">dpcm{0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dpi{0}</unitPattern>
+				<unitPattern count="other">dpi{0}</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">aya{0}</unitPattern>
+				<unitPattern count="other">ayoyi{0}</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">R⊕{0}</unitPattern>
+				<unitPattern count="other">R⊕{0}</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">km{0}</unitPattern>
+				<unitPattern count="other">km{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">m{0}</unitPattern>
+				<unitPattern count="other">m{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-decimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dm{0}</unitPattern>
+				<unitPattern count="other">dm{0}</unitPattern>
 			</unit>
 			<unit type="length-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">cm{0}</unitPattern>
+				<unitPattern count="other">cm{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mm{0}</unitPattern>
+				<unitPattern count="other">mm{0}</unitPattern>
 			</unit>
 			<unit type="length-micrometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">μm{0}</unitPattern>
+				<unitPattern count="other">μm{0}</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">nm{0}</unitPattern>
+				<unitPattern count="other">nm{0}</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">pm{0}</unitPattern>
+				<unitPattern count="other">pm{0}</unitPattern>
 			</unit>
 			<unit type="length-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mi{0}</unitPattern>
+				<unitPattern count="other">mil-mil{0}</unitPattern>
 			</unit>
 			<unit type="length-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">yd{0}</unitPattern>
+				<unitPattern count="other">ydk{0}</unitPattern>
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ƙf{0}</unitPattern>
+				<unitPattern count="other">ƙff{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">{0}″</unitPattern>
+				<unitPattern count="other">{0}″</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fasek</displayName>
+				<unitPattern count="one">fasek{0}</unitPattern>
+				<unitPattern count="other">fasekoki{0}</unitPattern>
 			</unit>
 			<unit type="length-light-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sh</displayName>
+				<unitPattern count="one">sh{0}</unitPattern>
+				<unitPattern count="other">sh{0}</unitPattern>
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">au{0}</unitPattern>
+				<unitPattern count="other">au{0}</unitPattern>
 			</unit>
 			<unit type="length-furlong">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>furlong</displayName>
+				<unitPattern count="one">fur{0}</unitPattern>
+				<unitPattern count="other">fur{0}</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">fth{0}</unitPattern>
+				<unitPattern count="other">fth{0}</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">nmi{0}</unitPattern>
+				<unitPattern count="other">nmi{0}</unitPattern>
 			</unit>
 			<unit type="length-mile-scandinavian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">smi{0}</unitPattern>
+				<unitPattern count="other">smi{0}</unitPattern>
 			</unit>
 			<unit type="length-point">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mk{0}</unitPattern>
+				<unitPattern count="other">mk{0}</unitPattern>
 			</unit>
 			<unit type="length-solar-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R☉</displayName>
+				<unitPattern count="one">R☉{0}</unitPattern>
+				<unitPattern count="other">R☉{0}</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">lx{0}</unitPattern>
+				<unitPattern count="other">lx{0}</unitPattern>
 			</unit>
 			<unit type="light-candela">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">cd{0}</unitPattern>
+				<unitPattern count="other">cd{0}</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">lm{0}</unitPattern>
+				<unitPattern count="other">lm{0}</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>L☉</displayName>
+				<unitPattern count="one">L☉{0}</unitPattern>
+				<unitPattern count="other">L☉{0}</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">t{0}</unitPattern>
+				<unitPattern count="other">t{0}</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kg{0}</unitPattern>
+				<unitPattern count="other">kg{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-gram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">g{0}</unitPattern>
+				<unitPattern count="other">g{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mg{0}</unitPattern>
+				<unitPattern count="other">mg{0}</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">μg{0}</unitPattern>
+				<unitPattern count="other">μg{0}</unitPattern>
 			</unit>
 			<unit type="mass-ton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>tan</displayName>
+				<unitPattern count="one">tn{0}</unitPattern>
+				<unitPattern count="other">tn{0}</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>stone</displayName>
+				<unitPattern count="one">st{0}</unitPattern>
+				<unitPattern count="other">st{0}</unitPattern>
 			</unit>
 			<unit type="mass-pound">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>laba</displayName>
+				<unitPattern count="one">{0}#</unitPattern>
+				<unitPattern count="other">{0}#</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">oz{0}</unitPattern>
+				<unitPattern count="other">oz{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>oz t</displayName>
+				<unitPattern count="one">oz t{0}</unitPattern>
+				<unitPattern count="other">oz t{0}</unitPattern>
 			</unit>
 			<unit type="mass-carat">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>carat</displayName>
+				<unitPattern count="one">CD{0}</unitPattern>
+				<unitPattern count="other">CD{0}</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Da</displayName>
+				<unitPattern count="one">Da{0}</unitPattern>
+				<unitPattern count="other">Da{0}</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M⊕</displayName>
+				<unitPattern count="one">M⊕{0}</unitPattern>
+				<unitPattern count="other">M⊕{0}</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>M☉</displayName>
+				<unitPattern count="one">M☉{0}</unitPattern>
+				<unitPattern count="other">M☉{0}</unitPattern>
 			</unit>
 			<unit type="mass-grain">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ƙwaya{0}</unitPattern>
+				<unitPattern count="other">ƙwaya{0}</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">GW{0}</unitPattern>
+				<unitPattern count="other">GW{0}</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">MW{0}</unitPattern>
+				<unitPattern count="other">MW{0}</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kW{0}</unitPattern>
+				<unitPattern count="other">kW{0}</unitPattern>
 			</unit>
 			<unit type="power-watt">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>wat</displayName>
+				<unitPattern count="one">W{0}</unitPattern>
+				<unitPattern count="other">W{0}</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mW{0}</unitPattern>
+				<unitPattern count="other">mW{0}</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ƙi{0}</unitPattern>
+				<unitPattern count="other">ƙi{0}</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="one">mmHg{0}</unitPattern>
+				<unitPattern count="other">mmHg{0}</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">psi{0}</unitPattern>
+				<unitPattern count="other">psi{0}</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>″ Hg</displayName>
+				<unitPattern count="one">″ Hg{0}</unitPattern>
+				<unitPattern count="other">″ Hg{0}</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">sanda{0}</unitPattern>
+				<unitPattern count="other">sanda{0}</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mbar{0}</unitPattern>
+				<unitPattern count="other">mbar{0}</unitPattern>
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">yny{0}</unitPattern>
+				<unitPattern count="other">yny{0}</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">Pa{0}</unitPattern>
+				<unitPattern count="other">Pa{0}</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">hPa{0}</unitPattern>
+				<unitPattern count="other">hPa{0}</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kPa{0}</unitPattern>
+				<unitPattern count="other">kPa{0}</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">MPa{0}</unitPattern>
+				<unitPattern count="other">MPa{0}</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">km/s{0}</unitPattern>
+				<unitPattern count="other">km/s{0}</unitPattern>
 			</unit>
 			<unit type="speed-meter-per-second">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>m/d</displayName>
+				<unitPattern count="one">m/d{0}</unitPattern>
+				<unitPattern count="other">m/d{0}</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mas{0}</unitPattern>
+				<unitPattern count="other">mas{0}</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">kn{0}</unitPattern>
+				<unitPattern count="other">kn{0}</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>↑↑↑</displayName>
@@ -8956,211 +8962,211 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-celsius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°S</displayName>
+				<unitPattern count="one">S°{0}</unitPattern>
+				<unitPattern count="other">S°{0}</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>°F</displayName>
+				<unitPattern count="one">°{0}</unitPattern>
+				<unitPattern count="other">°{0}</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">K{0}</unitPattern>
+				<unitPattern count="other">K{0}</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">lbf⋅ft{0}</unitPattern>
+				<unitPattern count="other">lbf⋅ft{0}</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">N⋅m{0}</unitPattern>
+				<unitPattern count="other">N⋅m{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">km³{0}</unitPattern>
+				<unitPattern count="other">km³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">m³{0}</unitPattern>
+				<unitPattern count="other">m³{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">cm³{0}</unitPattern>
+				<unitPattern count="other">cm³{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mi³{0}</unitPattern>
+				<unitPattern count="other">mi³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">yd³{0}</unitPattern>
+				<unitPattern count="other">yd³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ƙf³{0}</unitPattern>
+				<unitPattern count="other">ƙf³{0}</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">in³{0}</unitPattern>
+				<unitPattern count="other">in³{0}</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ML{0}</unitPattern>
+				<unitPattern count="other">ML{0}</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">hL{0}</unitPattern>
+				<unitPattern count="other">hL{0}</unitPattern>
 			</unit>
 			<unit type="volume-liter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>lita</displayName>
+				<unitPattern count="one">L{0}</unitPattern>
+				<unitPattern count="other">L{0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">dL{0}</unitPattern>
+				<unitPattern count="other">dL{0}</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="one">sL{0}</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mL{0}</unitPattern>
+				<unitPattern count="other">mL{0}</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mpt{0}</unitPattern>
+				<unitPattern count="other">mpt{0}</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mc{0}</unitPattern>
+				<unitPattern count="other">mc{0}</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ek ƙf{0}</unitPattern>
+				<unitPattern count="other">ek ƙf{0}</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
-				<displayName>↑↑↑</displayName>
+				<displayName>bu</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<unitPattern count="one">gal{0}</unitPattern>
+				<unitPattern count="other">gal{0}</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp gal</displayName>
+				<unitPattern count="one">galIm{0}</unitPattern>
+				<unitPattern count="other">galIm{0}</unitPattern>
+				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>qt</displayName>
+				<unitPattern count="one">qt{0}</unitPattern>
+				<unitPattern count="other">qt{0}</unitPattern>
 			</unit>
 			<unit type="volume-pint">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pt</displayName>
+				<unitPattern count="one">pt{0}</unitPattern>
+				<unitPattern count="other">pt{0}</unitPattern>
 			</unit>
 			<unit type="volume-cup">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kofi</displayName>
+				<unitPattern count="one">k{0}</unitPattern>
+				<unitPattern count="other">kfn{0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">fl oz{0}</unitPattern>
+				<unitPattern count="other">fl oz{0}</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp fl oz</displayName>
+				<unitPattern count="one">fl oz Im{0}</unitPattern>
+				<unitPattern count="other">fl oz Im{0}</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">bckl{0}</unitPattern>
+				<unitPattern count="other">bckl{0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ƙmc{0}</unitPattern>
+				<unitPattern count="other">ƙmc{0}</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">gang{0}</unitPattern>
+				<unitPattern count="other">gang{0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dsp</displayName>
+				<unitPattern count="one">dsp{0}</unitPattern>
+				<unitPattern count="other">dsp{0}</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dsp lmp</displayName>
+				<unitPattern count="one">dsp-lmp{0}</unitPattern>
+				<unitPattern count="other">dsp-lmp{0}</unitPattern>
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">ɗigo{0}</unitPattern>
+				<unitPattern count="other">ɗigo{0}</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl.dr.</displayName>
+				<unitPattern count="one">fl.dr.{0}</unitPattern>
+				<unitPattern count="other">fl.dr.{0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">jigger{0}</unitPattern>
+				<unitPattern count="other">jigger{0}</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pn</displayName>
+				<unitPattern count="one">pn{0}</unitPattern>
+				<unitPattern count="other">pn{0}</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">qt-Imp.{0}</unitPattern>
+				<unitPattern count="other">qt-Imp.{0}</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>↑↑↑</displayName>
-				<coordinateUnitPattern type="east">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="north">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="south">↑↑↑</coordinateUnitPattern>
-				<coordinateUnitPattern type="west">↑↑↑</coordinateUnitPattern>
+				<coordinateUnitPattern type="east">G{0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="north">A{0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="south">K{0}</coordinateUnitPattern>
+				<coordinateUnitPattern type="west">Y{0}</coordinateUnitPattern>
 			</coordinateUnit>
 		</unitLength>
 		<durationUnit type="hm">
@@ -9177,14 +9183,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<listPattern>
 			<listPatternPart type="start">↑↑↑</listPatternPart>
 			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}, da {1}</listPatternPart>
+			<listPatternPart type="2">{0} da {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or">
 			<listPatternPart type="start">↑↑↑</listPatternPart>
 			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0} ko {1}</listPatternPart>
+			<listPatternPart type="2">{0} ko {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
 			<listPatternPart type="start">↑↑↑</listPatternPart>
@@ -9225,192 +9231,192 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<listPattern type="unit-short">
 			<listPatternPart type="start">↑↑↑</listPatternPart>
 			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}, {1}</listPatternPart>
+			<listPatternPart type="2">{0}, {1}</listPatternPart>
 		</listPattern>
 	</listPatterns>
 	<posix>
 		<messages>
-			<yesstr>↑↑↑</yesstr>
-			<nostr>↑↑↑</nostr>
+			<yesstr>i</yesstr>
+			<nostr>aʼa:a</nostr>
 		</messages>
 	</posix>
 	<characterLabels>
-		<characterLabelPattern type="all">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="all">{0} — duk</characterLabelPattern>
 		<characterLabelPattern type="category-list">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="compatibility">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="enclosed">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="extended">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="facing-left">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="compatibility">{0} — jituwa</characterLabelPattern>
+		<characterLabelPattern type="enclosed">{0} — a kewaye</characterLabelPattern>
+		<characterLabelPattern type="extended">{0} — faɗaɗaɗɗe</characterLabelPattern>
+		<characterLabelPattern type="facing-left">{0} kallon gefe</characterLabelPattern>
 		<characterLabelPattern type="facing-right">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="historic">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="miscellaneous">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="other">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="scripts">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="historic">{0} — na tarihi</characterLabelPattern>
+		<characterLabelPattern type="miscellaneous">{0} — daban-daban</characterLabelPattern>
+		<characterLabelPattern type="other">{0} — wani dabam</characterLabelPattern>
+		<characterLabelPattern type="scripts">rubututtuka — {0}</characterLabelPattern>
 		<characterLabelPattern type="strokes" count="one">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="other">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="subscript">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="superscript">↑↑↑</characterLabelPattern>
-		<characterLabel type="activities">↑↑↑</characterLabel>
-		<characterLabel type="african_scripts">↑↑↑</characterLabel>
-		<characterLabel type="american_scripts">↑↑↑</characterLabel>
-		<characterLabel type="animal">↑↑↑</characterLabel>
-		<characterLabel type="animals_nature">↑↑↑</characterLabel>
-		<characterLabel type="arrows">↑↑↑</characterLabel>
-		<characterLabel type="body">↑↑↑</characterLabel>
-		<characterLabel type="box_drawing">↑↑↑</characterLabel>
-		<characterLabel type="braille">↑↑↑</characterLabel>
-		<characterLabel type="building">↑↑↑</characterLabel>
-		<characterLabel type="bullets_stars">↑↑↑</characterLabel>
-		<characterLabel type="consonantal_jamo">↑↑↑</characterLabel>
-		<characterLabel type="currency_symbols">↑↑↑</characterLabel>
-		<characterLabel type="dash_connector">↑↑↑</characterLabel>
-		<characterLabel type="digits">↑↑↑</characterLabel>
+		<characterLabelPattern type="strokes" count="other">bugu-bugu {0}</characterLabelPattern>
+		<characterLabelPattern type="subscript">rubutu ƙasa {0}</characterLabelPattern>
+		<characterLabelPattern type="superscript">rubutu sama {0}</characterLabelPattern>
+		<characterLabel type="activities">aiki</characterLabel>
+		<characterLabel type="african_scripts">rubutun Afirka</characterLabel>
+		<characterLabel type="american_scripts">rubutun Amurka</characterLabel>
+		<characterLabel type="animal">dabba</characterLabel>
+		<characterLabel type="animals_nature">dabba ko ɗabiʼa</characterLabel>
+		<characterLabel type="arrows">kibiya</characterLabel>
+		<characterLabel type="body">jiki</characterLabel>
+		<characterLabel type="box_drawing">zana akwati</characterLabel>
+		<characterLabel type="braille">rubutun makafi</characterLabel>
+		<characterLabel type="building">gini</characterLabel>
+		<characterLabel type="bullets_stars">harsashi ko tauraro</characterLabel>
+		<characterLabel type="consonantal_jamo">baƙin jamo</characterLabel>
+		<characterLabel type="currency_symbols">alamar kuɗi</characterLabel>
+		<characterLabel type="dash_connector">ɗigo ko mahaɗi</characterLabel>
+		<characterLabel type="digits">lamba</characterLabel>
 		<characterLabel type="dingbats">↑↑↑</characterLabel>
-		<characterLabel type="divination_symbols">↑↑↑</characterLabel>
-		<characterLabel type="downwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="downwards_upwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="east_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="emoji">↑↑↑</characterLabel>
-		<characterLabel type="european_scripts">↑↑↑</characterLabel>
-		<characterLabel type="female">↑↑↑</characterLabel>
-		<characterLabel type="flag">↑↑↑</characterLabel>
-		<characterLabel type="flags">↑↑↑</characterLabel>
-		<characterLabel type="food_drink">↑↑↑</characterLabel>
-		<characterLabel type="format">↑↑↑</characterLabel>
-		<characterLabel type="format_whitespace">↑↑↑</characterLabel>
-		<characterLabel type="full_width_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="geometric_shapes">↑↑↑</characterLabel>
-		<characterLabel type="half_width_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="han_characters">↑↑↑</characterLabel>
-		<characterLabel type="han_radicals">↑↑↑</characterLabel>
+		<characterLabel type="divination_symbols">alamar duba</characterLabel>
+		<characterLabel type="downwards_arrows">kibiya zuwa ƙasa</characterLabel>
+		<characterLabel type="downwards_upwards_arrows">kibiya zuwa ƙasa sama</characterLabel>
+		<characterLabel type="east_asian_scripts">Rubutun gabashin Asiya</characterLabel>
+		<characterLabel type="emoji">imoji</characterLabel>
+		<characterLabel type="european_scripts">rubutun Turai</characterLabel>
+		<characterLabel type="female">mace</characterLabel>
+		<characterLabel type="flag">tuta</characterLabel>
+		<characterLabel type="flags">tutoci</characterLabel>
+		<characterLabel type="food_drink">abinci da abin sha</characterLabel>
+		<characterLabel type="format">tsara</characterLabel>
+		<characterLabel type="format_whitespace">tsara da fararin-sarari</characterLabel>
+		<characterLabel type="full_width_form_variant">nauʼi mai cikakken faɗi</characterLabel>
+		<characterLabel type="geometric_shapes">siffar lissafi</characterLabel>
+		<characterLabel type="half_width_form_variant">nauʼi mai rabin faɗi</characterLabel>
+		<characterLabel type="han_characters">harafin Han</characterLabel>
+		<characterLabel type="han_radicals">Han mai tsattsaura</characterLabel>
 		<characterLabel type="hanja">↑↑↑</characterLabel>
-		<characterLabel type="hanzi_simplified">↑↑↑</characterLabel>
-		<characterLabel type="hanzi_traditional">↑↑↑</characterLabel>
-		<characterLabel type="heart">↑↑↑</characterLabel>
-		<characterLabel type="historic_scripts">↑↑↑</characterLabel>
-		<characterLabel type="ideographic_desc_characters">↑↑↑</characterLabel>
-		<characterLabel type="japanese_kana">↑↑↑</characterLabel>
+		<characterLabel type="hanzi_simplified">Hanzi (sauƙaƙaƙƙe)</characterLabel>
+		<characterLabel type="hanzi_traditional">Hanzi (na gargajiya)</characterLabel>
+		<characterLabel type="heart">zuciya</characterLabel>
+		<characterLabel type="historic_scripts">rubutu mai tarihi</characterLabel>
+		<characterLabel type="ideographic_desc_characters">baƙin ideographic desc.</characterLabel>
+		<characterLabel type="japanese_kana">kana na Japan</characterLabel>
 		<characterLabel type="kanbun">↑↑↑</characterLabel>
 		<characterLabel type="kanji">↑↑↑</characterLabel>
-		<characterLabel type="keycap">↑↑↑</characterLabel>
-		<characterLabel type="leftwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="leftwards_rightwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="letterlike_symbols">↑↑↑</characterLabel>
-		<characterLabel type="limited_use">↑↑↑</characterLabel>
-		<characterLabel type="male">↑↑↑</characterLabel>
-		<characterLabel type="math_symbols">↑↑↑</characterLabel>
-		<characterLabel type="middle_eastern_scripts">↑↑↑</characterLabel>
-		<characterLabel type="miscellaneous">↑↑↑</characterLabel>
-		<characterLabel type="modern_scripts">↑↑↑</characterLabel>
-		<characterLabel type="modifier">↑↑↑</characterLabel>
-		<characterLabel type="musical_symbols">↑↑↑</characterLabel>
-		<characterLabel type="nature">↑↑↑</characterLabel>
-		<characterLabel type="nonspacing">↑↑↑</characterLabel>
-		<characterLabel type="numbers">↑↑↑</characterLabel>
-		<characterLabel type="objects">↑↑↑</characterLabel>
-		<characterLabel type="other">↑↑↑</characterLabel>
-		<characterLabel type="paired">↑↑↑</characterLabel>
-		<characterLabel type="person">↑↑↑</characterLabel>
-		<characterLabel type="phonetic_alphabet">↑↑↑</characterLabel>
-		<characterLabel type="pictographs">↑↑↑</characterLabel>
-		<characterLabel type="place">↑↑↑</characterLabel>
-		<characterLabel type="plant">↑↑↑</characterLabel>
-		<characterLabel type="punctuation">↑↑↑</characterLabel>
-		<characterLabel type="rightwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="sign_standard_symbols">↑↑↑</characterLabel>
-		<characterLabel type="small_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="smiley">↑↑↑</characterLabel>
-		<characterLabel type="smileys_people">↑↑↑</characterLabel>
-		<characterLabel type="south_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="southeast_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="spacing">↑↑↑</characterLabel>
-		<characterLabel type="sport">↑↑↑</characterLabel>
-		<characterLabel type="symbols">↑↑↑</characterLabel>
-		<characterLabel type="technical_symbols">↑↑↑</characterLabel>
-		<characterLabel type="tone_marks">↑↑↑</characterLabel>
-		<characterLabel type="travel">↑↑↑</characterLabel>
-		<characterLabel type="travel_places">↑↑↑</characterLabel>
-		<characterLabel type="upwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="variant_forms">↑↑↑</characterLabel>
-		<characterLabel type="vocalic_jamo">↑↑↑</characterLabel>
-		<characterLabel type="weather">↑↑↑</characterLabel>
-		<characterLabel type="western_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="whitespace">↑↑↑</characterLabel>
+		<characterLabel type="keycap">maɓalli na musamman</characterLabel>
+		<characterLabel type="leftwards_arrows">kibiyar hagu</characterLabel>
+		<characterLabel type="leftwards_rightwards_arrows">kibiyar hagu dama</characterLabel>
+		<characterLabel type="letterlike_symbols">alamar haruffa</characterLabel>
+		<characterLabel type="limited_use">taƙaitaccen-amfani</characterLabel>
+		<characterLabel type="male">namiji</characterLabel>
+		<characterLabel type="math_symbols">alamar lissafi</characterLabel>
+		<characterLabel type="middle_eastern_scripts">rubutun Gabas ta Tsakiya</characterLabel>
+		<characterLabel type="miscellaneous">daban-daban</characterLabel>
+		<characterLabel type="modern_scripts">rubutun zamani</characterLabel>
+		<characterLabel type="modifier">mai gyagyarawa</characterLabel>
+		<characterLabel type="musical_symbols">alamar kiɗa</characterLabel>
+		<characterLabel type="nature">ɗabiʼa</characterLabel>
+		<characterLabel type="nonspacing">marar-sarari</characterLabel>
+		<characterLabel type="numbers">lambobi</characterLabel>
+		<characterLabel type="objects">abu</characterLabel>
+		<characterLabel type="other">wani daban</characterLabel>
+		<characterLabel type="paired">an haɗa</characterLabel>
+		<characterLabel type="person">mutum</characterLabel>
+		<characterLabel type="phonetic_alphabet">harafin sauti</characterLabel>
+		<characterLabel type="pictographs">rubutun hoto</characterLabel>
+		<characterLabel type="place">wuri</characterLabel>
+		<characterLabel type="plant">shuka</characterLabel>
+		<characterLabel type="punctuation">alamar rubutu</characterLabel>
+		<characterLabel type="rightwards_arrows">kibiyar dama</characterLabel>
+		<characterLabel type="sign_standard_symbols">alama ko alama</characterLabel>
+		<characterLabel type="small_form_variant">ƙaramin nauʼi</characterLabel>
+		<characterLabel type="smiley">murmushi</characterLabel>
+		<characterLabel type="smileys_people">murmushi ko mutum</characterLabel>
+		<characterLabel type="south_asian_scripts">rubutun Kudu-maso-gabashin Asiya</characterLabel>
+		<characterLabel type="southeast_asian_scripts">rubutun Kudu-maso-gabashin Asiya</characterLabel>
+		<characterLabel type="spacing">tazara</characterLabel>
+		<characterLabel type="sport">wasa</characterLabel>
+		<characterLabel type="symbols">alama</characterLabel>
+		<characterLabel type="technical_symbols">alamar fasaha</characterLabel>
+		<characterLabel type="tone_marks">alamar karin sauti</characterLabel>
+		<characterLabel type="travel">bulaguro</characterLabel>
+		<characterLabel type="travel_places">bulaguro ko wuri</characterLabel>
+		<characterLabel type="upwards_arrows">kibiyoyi sama</characterLabel>
+		<characterLabel type="variant_forms">nauʼi</characterLabel>
+		<characterLabel type="vocalic_jamo">muryar jamo</characterLabel>
+		<characterLabel type="weather">yanayi</characterLabel>
+		<characterLabel type="western_asian_scripts">rubutun Yammacin Asiya</characterLabel>
+		<characterLabel type="whitespace">farin-sarari</characterLabel>
 	</characterLabels>
 	<typographicNames>
-		<axisName type="ital">↑↑↑</axisName>
-		<axisName type="opsz">↑↑↑</axisName>
-		<axisName type="slnt">↑↑↑</axisName>
-		<axisName type="wdth">↑↑↑</axisName>
-		<axisName type="wght">↑↑↑</axisName>
-		<styleName type="ital" subtype="1">↑↑↑</styleName>
-		<styleName type="opsz" subtype="8">↑↑↑</styleName>
-		<styleName type="opsz" subtype="12">↑↑↑</styleName>
-		<styleName type="opsz" subtype="18">↑↑↑</styleName>
-		<styleName type="opsz" subtype="72">↑↑↑</styleName>
-		<styleName type="opsz" subtype="144">↑↑↑</styleName>
-		<styleName type="slnt" subtype="-12">↑↑↑</styleName>
-		<styleName type="slnt" subtype="0">↑↑↑</styleName>
-		<styleName type="slnt" subtype="12">↑↑↑</styleName>
-		<styleName type="slnt" subtype="24">↑↑↑</styleName>
-		<styleName type="wdth" subtype="50">↑↑↑</styleName>
-		<styleName type="wdth" subtype="50" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="50" alt="narrow">↑↑↑</styleName>
-		<styleName type="wdth" subtype="62.5">↑↑↑</styleName>
-		<styleName type="wdth" subtype="62.5" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="62.5" alt="narrow">↑↑↑</styleName>
-		<styleName type="wdth" subtype="75">↑↑↑</styleName>
-		<styleName type="wdth" subtype="75" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="75" alt="narrow">↑↑↑</styleName>
-		<styleName type="wdth" subtype="87.5">↑↑↑</styleName>
-		<styleName type="wdth" subtype="87.5" alt="compressed">↑↑↑</styleName>
-		<styleName type="wdth" subtype="87.5" alt="narrow">↑↑↑</styleName>
-		<styleName type="wdth" subtype="100">↑↑↑</styleName>
-		<styleName type="wdth" subtype="112.5">↑↑↑</styleName>
-		<styleName type="wdth" subtype="112.5" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="112.5" alt="wide">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125" alt="wide">↑↑↑</styleName>
-		<styleName type="wdth" subtype="150">↑↑↑</styleName>
-		<styleName type="wdth" subtype="150" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="150" alt="wide">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200" alt="wide">↑↑↑</styleName>
-		<styleName type="wght" subtype="100">↑↑↑</styleName>
-		<styleName type="wght" subtype="200">↑↑↑</styleName>
-		<styleName type="wght" subtype="200" alt="ultra">↑↑↑</styleName>
-		<styleName type="wght" subtype="300">↑↑↑</styleName>
-		<styleName type="wght" subtype="350">↑↑↑</styleName>
-		<styleName type="wght" subtype="380">↑↑↑</styleName>
-		<styleName type="wght" subtype="400">↑↑↑</styleName>
-		<styleName type="wght" subtype="500">↑↑↑</styleName>
-		<styleName type="wght" subtype="600">↑↑↑</styleName>
-		<styleName type="wght" subtype="600" alt="demi">↑↑↑</styleName>
-		<styleName type="wght" subtype="700">↑↑↑</styleName>
-		<styleName type="wght" subtype="800">↑↑↑</styleName>
-		<styleName type="wght" subtype="900">↑↑↑</styleName>
-		<styleName type="wght" subtype="900" alt="heavy">↑↑↑</styleName>
-		<styleName type="wght" subtype="950">↑↑↑</styleName>
-		<styleName type="wght" subtype="950" alt="ultrablack">↑↑↑</styleName>
-		<styleName type="wght" subtype="950" alt="ultraheavy">↑↑↑</styleName>
-		<featureName type="afrc">↑↑↑</featureName>
-		<featureName type="cpsp">↑↑↑</featureName>
-		<featureName type="dlig">↑↑↑</featureName>
-		<featureName type="frac">↑↑↑</featureName>
-		<featureName type="lnum">↑↑↑</featureName>
-		<featureName type="onum">↑↑↑</featureName>
-		<featureName type="ordn">↑↑↑</featureName>
-		<featureName type="pnum">↑↑↑</featureName>
-		<featureName type="smcp">↑↑↑</featureName>
-		<featureName type="tnum">↑↑↑</featureName>
-		<featureName type="zero">↑↑↑</featureName>
+		<axisName type="ital">tafiyar-tsuta</axisName>
+		<axisName type="opsz">girman gani</axisName>
+		<axisName type="slnt">kusurwa</axisName>
+		<axisName type="wdth">faɗi</axisName>
+		<axisName type="wght">nauyi</axisName>
+		<styleName type="ital" subtype="1">a haɗe</styleName>
+		<styleName type="opsz" subtype="8">rubutu</styleName>
+		<styleName type="opsz" subtype="12">matani</styleName>
+		<styleName type="opsz" subtype="18">sa suna</styleName>
+		<styleName type="opsz" subtype="72">nuna</styleName>
+		<styleName type="opsz" subtype="144">fasta</styleName>
+		<styleName type="slnt" subtype="-12">kwanta baya</styleName>
+		<styleName type="slnt" subtype="0">tsaye</styleName>
+		<styleName type="slnt" subtype="12">kwanta gaba</styleName>
+		<styleName type="slnt" subtype="24">kwanta gaba sosai</styleName>
+		<styleName type="wdth" subtype="50">kwanta gaba ƙwarai</styleName>
+		<styleName type="wdth" subtype="50" alt="compressed">matsatte ƙwarai</styleName>
+		<styleName type="wdth" subtype="50" alt="narrow">tsukakke ƙwarai</styleName>
+		<styleName type="wdth" subtype="62.5">tararre sosai</styleName>
+		<styleName type="wdth" subtype="62.5" alt="compressed">matsattse sosai</styleName>
+		<styleName type="wdth" subtype="62.5" alt="narrow">tsukakke sosai</styleName>
+		<styleName type="wdth" subtype="75">tararre</styleName>
+		<styleName type="wdth" subtype="75" alt="compressed">matsattse</styleName>
+		<styleName type="wdth" subtype="75" alt="narrow">matsattse</styleName>
+		<styleName type="wdth" subtype="87.5">ɗan tararre</styleName>
+		<styleName type="wdth" subtype="87.5" alt="compressed">ɗan matsattse</styleName>
+		<styleName type="wdth" subtype="87.5" alt="narrow">ɗan tsukakke</styleName>
+		<styleName type="wdth" subtype="100">na alʼada</styleName>
+		<styleName type="wdth" subtype="112.5">ɗan faɗaɗaɗɗe</styleName>
+		<styleName type="wdth" subtype="112.5" alt="extended">ɗan ƙararre</styleName>
+		<styleName type="wdth" subtype="112.5" alt="wide">mai ɗan faɗi</styleName>
+		<styleName type="wdth" subtype="125">faɗaɗaɗɗe</styleName>
+		<styleName type="wdth" subtype="125" alt="extended">ƙararre</styleName>
+		<styleName type="wdth" subtype="125" alt="wide">faɗi</styleName>
+		<styleName type="wdth" subtype="150">faɗaɗaɗɗe ƙwarai</styleName>
+		<styleName type="wdth" subtype="150" alt="extended">ƙararre ƙwarai</styleName>
+		<styleName type="wdth" subtype="150" alt="wide">mai faɗi ƙwarai</styleName>
+		<styleName type="wdth" subtype="200">faɗaɗaɗɗe sosai</styleName>
+		<styleName type="wdth" subtype="200" alt="extended">ƙararre sosai</styleName>
+		<styleName type="wdth" subtype="200" alt="wide">mai faɗi sosai</styleName>
+		<styleName type="wght" subtype="100">siriri</styleName>
+		<styleName type="wght" subtype="200">marar nauyi sosai</styleName>
+		<styleName type="wght" subtype="200" alt="ultra">marar nauyi ainun</styleName>
+		<styleName type="wght" subtype="300">marar nauyi</styleName>
+		<styleName type="wght" subtype="350">rabin nauyi</styleName>
+		<styleName type="wght" subtype="380">littafi</styleName>
+		<styleName type="wght" subtype="400">na ƙaʼida</styleName>
+		<styleName type="wght" subtype="500">matsakaici</styleName>
+		<styleName type="wght" subtype="600">ɗan mai kauri</styleName>
+		<styleName type="wght" subtype="600" alt="demi">rabin kauri</styleName>
+		<styleName type="wght" subtype="700">kauri</styleName>
+		<styleName type="wght" subtype="800">kauri sosai</styleName>
+		<styleName type="wght" subtype="900">baƙi</styleName>
+		<styleName type="wght" subtype="900" alt="heavy">nauyi</styleName>
+		<styleName type="wght" subtype="950">baƙiƙƙirin</styleName>
+		<styleName type="wght" subtype="950" alt="ultrablack">matsanancin baki</styleName>
+		<styleName type="wght" subtype="950" alt="ultraheavy">matsanancin nauyi</styleName>
+		<featureName type="afrc">ginshiƙan tsaye</featureName>
+		<featureName type="cpsp">tazarar babban harafi</featureName>
+		<featureName type="dlig">haɗi na zaɓi</featureName>
+		<featureName type="frac">ginshiƙan karkace</featureName>
+		<featureName type="lnum">lambobin rufi</featureName>
+		<featureName type="onum">lambobi tsohon yayi</featureName>
+		<featureName type="ordn">odinaloli</featureName>
+		<featureName type="pnum">lambobin daidai</featureName>
+		<featureName type="smcp">ƙananan haruffa</featureName>
+		<featureName type="tnum">lambobin tabula</featureName>
+		<featureName type="zero">sifili mai layi</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrderLocales order="givenFirst">↑↑↑</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
+		<nameOrderLocales order="givenFirst">und ha</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ko vi yue zh</nameOrderLocales>
 		<parameterDefault parameter="formality">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length">↑↑↑</parameterDefault>
 		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
@@ -9421,13 +9427,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -9439,13 +9445,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -9454,82 +9460,82 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal} {surname-initial}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2-initial} {generation}, {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
 			<namePattern>↑↑↑</namePattern>
@@ -9544,50 +9550,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<sampleName item="nativeG">
-			<nameField type="given">↑↑↑</nameField>
+			<nameField type="given">Sule</nameField>
 		</sampleName>
 		<sampleName item="nativeGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Shehu</nameField>
+			<nameField type="surname">Muhammed</nameField>
 		</sampleName>
 		<sampleName item="nativeGGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Fatima</nameField>
+			<nameField type="given2">Amina</nameField>
+			<nameField type="surname">Umar</nameField>
 		</sampleName>
 		<sampleName item="nativeFull">
-			<nameField type="title">↑↑↑</nameField>
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given-informal">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname-prefix">↑↑↑</nameField>
-			<nameField type="surname-core">↑↑↑</nameField>
-			<nameField type="surname2">↑↑↑</nameField>
-			<nameField type="generation">↑↑↑</nameField>
-			<nameField type="credentials">↑↑↑</nameField>
+			<nameField type="title">Malam</nameField>
+			<nameField type="given">Shehu</nameField>
+			<nameField type="given-informal">∅∅∅</nameField>
+			<nameField type="given2">Bello</nameField>
+			<nameField type="surname-prefix">∅∅∅</nameField>
+			<nameField type="surname-core">Modibbo</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="generation">∅∅∅</nameField>
+			<nameField type="credentials">MP</nameField>
 		</sampleName>
 		<sampleName item="foreignG">
-			<nameField type="given">↑↑↑</nameField>
+			<nameField type="given">Sinbad</nameField>
 		</sampleName>
 		<sampleName item="foreignGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Käthe</nameField>
+			<nameField type="surname">Müller</nameField>
 		</sampleName>
 		<sampleName item="foreignGGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Zäzilia</nameField>
+			<nameField type="given2">Hamish</nameField>
+			<nameField type="surname">Stöber</nameField>
 		</sampleName>
 		<sampleName item="foreignFull">
-			<nameField type="title">↑↑↑</nameField>
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given-informal">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname-prefix">↑↑↑</nameField>
-			<nameField type="surname-core">↑↑↑</nameField>
-			<nameField type="surname2">↑↑↑</nameField>
-			<nameField type="generation">↑↑↑</nameField>
-			<nameField type="credentials">↑↑↑</nameField>
+			<nameField type="title">Farf. Dr.</nameField>
+			<nameField type="given">Ada Cornelia</nameField>
+			<nameField type="given-informal">Neele</nameField>
+			<nameField type="given2">Eva Sophia</nameField>
+			<nameField type="surname-prefix">van den</nameField>
+			<nameField type="surname-core">Wolf</nameField>
+			<nameField type="surname2">Becker Schmidt</nameField>
+			<nameField type="generation">Jr</nameField>
+			<nameField type="credentials">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -3031,7 +3031,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>
-					<relativeTimePattern count="few">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="few">za {0} ponedeljka</relativeTimePattern>
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
@@ -5871,9 +5871,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="one">↑↑↑</unitPattern>
-			<unitPattern count="few">↑↑↑</unitPattern>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="few">{0} {1}</unitPattern>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="ADP">

--- a/common/main/sr_Latn_BA.xml
+++ b/common/main/sr_Latn_BA.xml
@@ -6131,6 +6131,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
+			<currency type="SLE">
+				<displayName>↑↑↑</displayName>
+				<displayName count="one">↑↑↑</displayName>
+				<displayName count="few">↑↑↑</displayName>
+				<displayName count="other">↑↑↑</displayName>
+				<symbol draft="contributed">↑↑↑</symbol>
+			</currency>
 			<currency type="SLL">
 				<displayName>↑↑↑</displayName>
 				<displayName count="one">↑↑↑</displayName>
@@ -8412,7 +8419,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="speed-beaufort">
 				<displayName>Bft</displayName>
 				<unitPattern count="one">B {0}</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="few">B {0}</unitPattern>
 				<unitPattern count="other">B {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
@@ -9813,8 +9820,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
+				<unitPattern count="one">B {0}</unitPattern>
+				<unitPattern count="few">B {0}</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
@@ -11065,9 +11072,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>Bft</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">B {0}</unitPattern>
+				<unitPattern count="few">B {0}</unitPattern>
+				<unitPattern count="other">B {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -18,104 +18,104 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<localeKeyTypePattern>↑↑↑</localeKeyTypePattern>
 		</localeDisplayPattern>
 		<languages>
-			<language type="ab">↑↑↑</language>
-			<language type="ace">↑↑↑</language>
-			<language type="ada">↑↑↑</language>
-			<language type="ady">↑↑↑</language>
-			<language type="af">↑↑↑</language>
+			<language type="ab">Èdè Abasia</language>
+			<language type="ace">Èdè Akinisi</language>
+			<language type="ada">Èdè Adame</language>
+			<language type="ady">Èdè Adiji</language>
+			<language type="af">Èdè Afrikani</language>
 			<language type="agq">Èdè Ágɛ̀ɛ̀mù</language>
-			<language type="ain">↑↑↑</language>
-			<language type="ak">↑↑↑</language>
-			<language type="ale">↑↑↑</language>
-			<language type="alt">↑↑↑</language>
-			<language type="am">↑↑↑</language>
-			<language type="an">↑↑↑</language>
-			<language type="ann">↑↑↑</language>
-			<language type="anp">↑↑↑</language>
-			<language type="ar">↑↑↑</language>
+			<language type="ain">Èdè Ainu</language>
+			<language type="ak">Èdè Akani</language>
+			<language type="ale">Èdè Aleti</language>
+			<language type="alt">Èdè Gusu Ata</language>
+			<language type="am">Èdè Amariki</language>
+			<language type="an">Èdè Aragoni</language>
+			<language type="ann">Èdè Obolo</language>
+			<language type="anp">Èdè Angika</language>
+			<language type="ar">Èdè Árábìkì</language>
 			<language type="ar_001">↑↑↑</language>
-			<language type="arn">↑↑↑</language>
-			<language type="arp">↑↑↑</language>
-			<language type="ars">↑↑↑</language>
-			<language type="as">↑↑↑</language>
-			<language type="asa">↑↑↑</language>
-			<language type="ast">↑↑↑</language>
-			<language type="atj">↑↑↑</language>
-			<language type="av">↑↑↑</language>
-			<language type="awa">↑↑↑</language>
-			<language type="ay">↑↑↑</language>
-			<language type="az">↑↑↑</language>
+			<language type="arn">Èdè Mapushe</language>
+			<language type="arp">Èdè Arapaho</language>
+			<language type="ars">Èdè Arabiki ti Najidi</language>
+			<language type="as">Èdè Ti Assam</language>
+			<language type="asa">Èdè Asu</language>
+			<language type="ast">Èdè Asturian</language>
+			<language type="atj">Èdè Atikameki</language>
+			<language type="av">Èdè Afariki</language>
+			<language type="awa">Èdè Awadi</language>
+			<language type="ay">Èdè Amara</language>
+			<language type="az">Èdè Azerbaijani</language>
 			<language type="az" alt="short">↑↑↑</language>
-			<language type="ba">↑↑↑</language>
-			<language type="ban">↑↑↑</language>
-			<language type="bas">↑↑↑</language>
-			<language type="be">↑↑↑</language>
-			<language type="bem">↑↑↑</language>
+			<language type="ba">Èdè Bashiri</language>
+			<language type="ban">Èdè Balini</language>
+			<language type="bas">Èdè Basaa</language>
+			<language type="be">Èdè Belarusi</language>
+			<language type="bem">Èdè Béḿbà</language>
 			<language type="bez">Èdè Bɛ́nà</language>
-			<language type="bg">↑↑↑</language>
-			<language type="bgc">↑↑↑</language>
-			<language type="bho">↑↑↑</language>
-			<language type="bi">↑↑↑</language>
-			<language type="bin">↑↑↑</language>
-			<language type="bla">↑↑↑</language>
-			<language type="bm">↑↑↑</language>
-			<language type="bn">↑↑↑</language>
-			<language type="bo">↑↑↑</language>
-			<language type="br">↑↑↑</language>
-			<language type="brx">↑↑↑</language>
-			<language type="bs">↑↑↑</language>
-			<language type="bug">↑↑↑</language>
-			<language type="byn">↑↑↑</language>
-			<language type="ca">↑↑↑</language>
-			<language type="cay">↑↑↑</language>
-			<language type="ccp">↑↑↑</language>
-			<language type="ce">↑↑↑</language>
-			<language type="ceb">↑↑↑</language>
-			<language type="cgg">↑↑↑</language>
-			<language type="ch">↑↑↑</language>
-			<language type="chk">↑↑↑</language>
-			<language type="chm">↑↑↑</language>
-			<language type="cho">↑↑↑</language>
-			<language type="chp">↑↑↑</language>
+			<language type="bg">Èdè Bugaria</language>
+			<language type="bgc">Èdè Haryanvi</language>
+			<language type="bho">Èdè Bojuri</language>
+			<language type="bi">Èdè Bisilama</language>
+			<language type="bin">Èdè Bini</language>
+			<language type="bla">Èdè Sikiska</language>
+			<language type="bm">Èdè Báḿbàrà</language>
+			<language type="bn">Èdè Bengali</language>
+			<language type="bo">Tibetán</language>
+			<language type="br">Èdè Bretoni</language>
+			<language type="brx">Èdè Bódò</language>
+			<language type="bs">Èdè Bosnia</language>
+			<language type="bug">Èdè Bugini</language>
+			<language type="byn">Èdè Bilini</language>
+			<language type="ca">Èdè Catala</language>
+			<language type="cay">Èdè Kayuga</language>
+			<language type="ccp">Èdè Chakma</language>
+			<language type="ce">Èdè Chechen</language>
+			<language type="ceb">Èdè Cebuano</language>
+			<language type="cgg">Èdè Chiga</language>
+			<language type="ch">Èdè S̩amoro</language>
+			<language type="chk">Èdè Shuki</language>
+			<language type="chm">Èdè Mari</language>
+			<language type="cho">Èdè Shokita</language>
+			<language type="chp">Èdè Shipewa</language>
 			<language type="chr">Èdè Shɛ́rókiì</language>
-			<language type="chy">↑↑↑</language>
-			<language type="ckb">↑↑↑</language>
+			<language type="chy">Èdè Sheyeni</language>
+			<language type="ckb">Ààrin Gbùngbùn Kurdish</language>
 			<language type="ckb" alt="menu">↑↑↑</language>
 			<language type="ckb" alt="variant">↑↑↑</language>
-			<language type="clc">↑↑↑</language>
-			<language type="co">↑↑↑</language>
-			<language type="crg">↑↑↑</language>
-			<language type="crj">↑↑↑</language>
-			<language type="crk">↑↑↑</language>
-			<language type="crl">↑↑↑</language>
-			<language type="crm">↑↑↑</language>
-			<language type="crr">↑↑↑</language>
-			<language type="cs">↑↑↑</language>
-			<language type="csw">↑↑↑</language>
+			<language type="clc">Èdè Shikoti</language>
+			<language type="co">Èdè Corsican</language>
+			<language type="crg">Èdè Misifu</language>
+			<language type="crj">Èdè Gusu Ila-oorun Kri</language>
+			<language type="crk">Èdè Papa Kri</language>
+			<language type="crl">Èdè ti Ila oorun Ariwa Kri</language>
+			<language type="crm">Èdè Moose Kri</language>
+			<language type="crr">Èdè Alonkuia ti Karolina</language>
+			<language type="cs">Èdè Seeki</language>
+			<language type="csw">Èdè Swampi Kri</language>
 			<language type="cu">Èdè Síláfííkì Ilé Ìjɔ́sìn</language>
-			<language type="cv">↑↑↑</language>
-			<language type="cy">↑↑↑</language>
+			<language type="cv">Èdè Shufasi</language>
+			<language type="cy">Èdè Welshi</language>
 			<language type="da">Èdè Ilɛ̀ Denmark</language>
-			<language type="dak">↑↑↑</language>
-			<language type="dar">↑↑↑</language>
-			<language type="dav">↑↑↑</language>
-			<language type="de">↑↑↑</language>
+			<language type="dak">Èdè Dakota</language>
+			<language type="dar">Èdè Dagiwa</language>
+			<language type="dav">Táítà</language>
+			<language type="de">Èdè Jámánì</language>
 			<language type="de_AT">Èdè Jámánì (Ɔ́síríà )</language>
 			<language type="de_CH">Èdè Ilɛ̀ Jámánì (Orílɛ́ède swítsàlandì)</language>
-			<language type="dgr">↑↑↑</language>
+			<language type="dgr">Èdè Dogribu</language>
 			<language type="dje">Shárúmà</language>
-			<language type="doi">↑↑↑</language>
+			<language type="doi">Èdè Dogiri</language>
 			<language type="dsb">Shóbíánù Apá Ìshàlɛ̀</language>
-			<language type="dua">↑↑↑</language>
-			<language type="dv">↑↑↑</language>
-			<language type="dyo">↑↑↑</language>
-			<language type="dz">↑↑↑</language>
-			<language type="dzg">↑↑↑</language>
+			<language type="dua">Èdè Duala</language>
+			<language type="dv">Èdè Difehi</language>
+			<language type="dyo">Jola-Fonyi</language>
+			<language type="dz">Èdè Dzongkha</language>
+			<language type="dzg">Èdè Dasaga</language>
 			<language type="ebu">Èdè Ɛmbù</language>
-			<language type="ee">↑↑↑</language>
-			<language type="efi">↑↑↑</language>
-			<language type="eka">↑↑↑</language>
-			<language type="el">↑↑↑</language>
+			<language type="ee">Èdè Ewè</language>
+			<language type="efi">Èdè Efiki</language>
+			<language type="eka">Èdè Ekaju</language>
+			<language type="el">Èdè Giriki</language>
 			<language type="en">Èdè Gɛ̀ɛ́sì</language>
 			<language type="en_AU">Èdè Gɛ̀ɛ́sì (órílɛ̀-èdè Ɔsirélíà)</language>
 			<language type="en_CA">Èdè Gɛ̀ɛ́sì (Orílɛ̀-èdè Kánádà)</language>
@@ -123,331 +123,331 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="en_GB" alt="short">Èdè Gɛ̀ɛ́sì (GB)</language>
 			<language type="en_US">↑↑↑</language>
 			<language type="en_US" alt="short">Èdè Gɛ̀ɛ́sì (US)</language>
-			<language type="eo">↑↑↑</language>
+			<language type="eo">Èdè Esperanto</language>
 			<language type="es">Èdè Sípáníìshì</language>
 			<language type="es_419">Èdè Sípáníìshì (orílɛ̀-èdè Látìn-Amɛ́ríkà)</language>
 			<language type="es_ES">Èdè Sípáníìshì (orílɛ̀-èdè Yúróòpù)</language>
 			<language type="es_MX">Èdè Sípáníìshì (orílɛ̀-èdè Mɛ́síkò)</language>
-			<language type="et">↑↑↑</language>
-			<language type="eu">↑↑↑</language>
-			<language type="ewo">↑↑↑</language>
-			<language type="fa">↑↑↑</language>
+			<language type="et">Èdè Estonia</language>
+			<language type="eu">Èdè Baski</language>
+			<language type="ewo">Èdè Èwóǹdò</language>
+			<language type="fa">Èdè Pasia</language>
 			<language type="fa_AF">↑↑↑</language>
-			<language type="ff">↑↑↑</language>
-			<language type="fi">↑↑↑</language>
-			<language type="fil">↑↑↑</language>
-			<language type="fj">↑↑↑</language>
-			<language type="fo">↑↑↑</language>
-			<language type="fon">↑↑↑</language>
-			<language type="fr">↑↑↑</language>
+			<language type="ff">Èdè Fúlàní</language>
+			<language type="fi">Èdè Finisi</language>
+			<language type="fil">Èdè Filipino</language>
+			<language type="fj">Èdè Fiji</language>
+			<language type="fo">Èdè Faroesi</language>
+			<language type="fon">Èdè Fon</language>
+			<language type="fr">Èdè Faransé</language>
 			<language type="fr_CA">Èdè Faransé (orílɛ̀-èdè Kánádà)</language>
 			<language type="fr_CH">Èdè Faranshé (Súwísàlaǹdì)</language>
-			<language type="frc">↑↑↑</language>
-			<language type="frr">↑↑↑</language>
-			<language type="fur">↑↑↑</language>
-			<language type="fy">↑↑↑</language>
-			<language type="ga">↑↑↑</language>
-			<language type="gaa">↑↑↑</language>
-			<language type="gd">↑↑↑</language>
+			<language type="frc">Èdè Faranse ti Kajun</language>
+			<language type="frr">Èdè Ariwa Frisa</language>
+			<language type="fur">Firiúlíànì</language>
+			<language type="fy">Èdè Frisia</language>
+			<language type="ga">Èdè Ireland</language>
+			<language type="gaa">Èdè Gaa</language>
+			<language type="gd">Èdè Gaelik ti Ilu Scotland</language>
 			<language type="gez">Ede Gɛ́sì</language>
-			<language type="gil">↑↑↑</language>
-			<language type="gl">↑↑↑</language>
-			<language type="gn">↑↑↑</language>
-			<language type="gor">↑↑↑</language>
-			<language type="gsw">↑↑↑</language>
-			<language type="gu">↑↑↑</language>
-			<language type="guz">↑↑↑</language>
-			<language type="gv">↑↑↑</language>
-			<language type="gwi">↑↑↑</language>
-			<language type="ha">↑↑↑</language>
-			<language type="hai">↑↑↑</language>
-			<language type="haw">↑↑↑</language>
-			<language type="hax">↑↑↑</language>
-			<language type="he">↑↑↑</language>
-			<language type="hi">↑↑↑</language>
-			<language type="hi_Latn">↑↑↑</language>
+			<language type="gil">Èdè Gibaati</language>
+			<language type="gl">Èdè Galicia</language>
+			<language type="gn">Èdè Guarani</language>
+			<language type="gor">Èdè Gorontalo</language>
+			<language type="gsw">Súwísì ti Jámánì</language>
+			<language type="gu">Èdè Gujarati</language>
+			<language type="guz">Gusii</language>
+			<language type="gv">Máǹkì</language>
+			<language type="gwi">Èdè giwisi</language>
+			<language type="ha">Èdè Hausa</language>
+			<language type="hai">Èdè Haida</language>
+			<language type="haw">Hawaiian</language>
+			<language type="hax">Èdè Gusu Haida</language>
+			<language type="he">Èdè Heberu</language>
+			<language type="hi">Èdè Híńdì</language>
+			<language type="hi_Latn">Èdè Híndì (Látìnì)</language>
 			<language type="hi_Latn" alt="variant">Èdè Híńgílíshì</language>
-			<language type="hil">↑↑↑</language>
-			<language type="hmn">↑↑↑</language>
-			<language type="hr">↑↑↑</language>
-			<language type="hsb">↑↑↑</language>
-			<language type="ht">↑↑↑</language>
-			<language type="hu">↑↑↑</language>
-			<language type="hup">↑↑↑</language>
-			<language type="hur">↑↑↑</language>
-			<language type="hy">↑↑↑</language>
-			<language type="hz">↑↑↑</language>
-			<language type="ia">↑↑↑</language>
-			<language type="iba">↑↑↑</language>
-			<language type="ibb">↑↑↑</language>
+			<language type="hil">Èdè Hilgayo</language>
+			<language type="hmn">Hmong</language>
+			<language type="hr">Èdè Kroatia</language>
+			<language type="hsb">Sorbian Apá Òkè</language>
+			<language type="ht">Haitian Creole</language>
+			<language type="hu">Èdè Hungaria</language>
+			<language type="hup">Èdè Hupa</language>
+			<language type="hur">Èdè Hakomelemi</language>
+			<language type="hy">Èdè Ile Armenia</language>
+			<language type="hz">Èdè Herero</language>
+			<language type="ia">Èdè pipo</language>
+			<language type="iba">Èdè Iba</language>
+			<language type="ibb">Èdè Ibibio</language>
 			<language type="id">Èdè Indonéshíà</language>
-			<language type="ie">↑↑↑</language>
-			<language type="ig">↑↑↑</language>
+			<language type="ie">Iru Èdè</language>
+			<language type="ig">Èdè Yíbò</language>
 			<language type="ii">Shíkuán Yì</language>
-			<language type="ikt">↑↑↑</language>
-			<language type="ilo">↑↑↑</language>
-			<language type="inh">↑↑↑</language>
-			<language type="io">↑↑↑</language>
-			<language type="is">↑↑↑</language>
-			<language type="it">↑↑↑</language>
-			<language type="iu">↑↑↑</language>
-			<language type="ja">↑↑↑</language>
-			<language type="jbo">↑↑↑</language>
-			<language type="jgo">↑↑↑</language>
+			<language type="ikt">Èdè Iwoorun Inutitu ti Kanada</language>
+			<language type="ilo">Èdè Iloko</language>
+			<language type="inh">Èdè Ingusi</language>
+			<language type="io">Èdè Ido</language>
+			<language type="is">Èdè Icelandic</language>
+			<language type="it">Èdè Ítálì</language>
+			<language type="iu">Èdè Inukitu</language>
+			<language type="ja">Èdè Jàpáànù</language>
+			<language type="jbo">Èdè Lobani</language>
+			<language type="jgo">Ńgòmbà</language>
 			<language type="jmc">Máshámè</language>
-			<language type="jv">↑↑↑</language>
-			<language type="ka">↑↑↑</language>
-			<language type="kab">↑↑↑</language>
-			<language type="kac">↑↑↑</language>
-			<language type="kaj">↑↑↑</language>
-			<language type="kam">↑↑↑</language>
-			<language type="kbd">↑↑↑</language>
-			<language type="kcg">↑↑↑</language>
-			<language type="kde">↑↑↑</language>
-			<language type="kea">↑↑↑</language>
-			<language type="kfo">↑↑↑</language>
-			<language type="kgp">↑↑↑</language>
-			<language type="kha">↑↑↑</language>
+			<language type="jv">Èdè Javanasi</language>
+			<language type="ka">Èdè Georgia</language>
+			<language type="kab">Kabilè</language>
+			<language type="kac">Èdè Kashini</language>
+			<language type="kaj">Èdè Ju</language>
+			<language type="kam">Káńbà</language>
+			<language type="kbd">Èdè Kabadia</language>
+			<language type="kcg">Èdè Tiyapu</language>
+			<language type="kde">Mákondé</language>
+			<language type="kea">Kabufadíánù</language>
+			<language type="kfo">Èdè Koro</language>
+			<language type="kgp">Èdè Kaigani</language>
+			<language type="kha">Èdè Kasi</language>
 			<language type="khq">Koira Shíínì</language>
-			<language type="ki">↑↑↑</language>
-			<language type="kj">↑↑↑</language>
+			<language type="ki">Kíkúyù</language>
+			<language type="kj">Èdè Kuayama</language>
 			<language type="kk">Kashakì</language>
-			<language type="kkj">↑↑↑</language>
-			<language type="kl">↑↑↑</language>
+			<language type="kkj">Kàkó</language>
+			<language type="kl">Kalaalísùtì</language>
 			<language type="kln">Kálɛnjín</language>
-			<language type="km">↑↑↑</language>
-			<language type="kmb">↑↑↑</language>
-			<language type="kn">↑↑↑</language>
-			<language type="ko">↑↑↑</language>
-			<language type="kok">↑↑↑</language>
-			<language type="kpe">↑↑↑</language>
-			<language type="kr">↑↑↑</language>
-			<language type="krc">↑↑↑</language>
-			<language type="krl">↑↑↑</language>
-			<language type="kru">↑↑↑</language>
+			<language type="km">Èdè kameri</language>
+			<language type="kmb">Èdè Kimbundu</language>
+			<language type="kn">Èdè Kannada</language>
+			<language type="ko">Èdè Kòríà</language>
+			<language type="kok">Kónkánì</language>
+			<language type="kpe">Èdè Pele</language>
+			<language type="kr">Èdè Kanuri</language>
+			<language type="krc">Èdè Karasha-Baka</language>
+			<language type="krl">Èdè Karelia</language>
+			<language type="kru">Èdè Kuruki</language>
 			<language type="ks">Kashímirì</language>
 			<language type="ksb">Sháńbálà</language>
-			<language type="ksf">↑↑↑</language>
-			<language type="ksh">↑↑↑</language>
+			<language type="ksf">Èdè Báfíà</language>
+			<language type="ksh">Èdè Colognian</language>
 			<language type="ku">Kɔdishì</language>
-			<language type="kum">↑↑↑</language>
-			<language type="kv">↑↑↑</language>
+			<language type="kum">Èdè Kumiki</language>
+			<language type="kv">Èdè Komi</language>
 			<language type="kw">Èdè Kɔ́nììshì</language>
-			<language type="kwk">↑↑↑</language>
-			<language type="ky">↑↑↑</language>
-			<language type="la">↑↑↑</language>
-			<language type="lad">↑↑↑</language>
-			<language type="lag">↑↑↑</language>
+			<language type="kwk">Èdè Kwawala</language>
+			<language type="ky">Kírígíìsì</language>
+			<language type="la">Èdè Latini</language>
+			<language type="lad">Èdè Ladino</language>
+			<language type="lag">Láńgì</language>
 			<language type="lb">Lùshɛ́mbɔ́ɔ̀gì</language>
-			<language type="lez">↑↑↑</language>
-			<language type="lg">↑↑↑</language>
-			<language type="li">↑↑↑</language>
-			<language type="lil">↑↑↑</language>
-			<language type="lkt">↑↑↑</language>
-			<language type="ln">↑↑↑</language>
-			<language type="lo">↑↑↑</language>
-			<language type="lou">↑↑↑</language>
-			<language type="loz">↑↑↑</language>
-			<language type="lrc">↑↑↑</language>
-			<language type="lsm">↑↑↑</language>
-			<language type="lt">↑↑↑</language>
-			<language type="lu">↑↑↑</language>
-			<language type="lua">↑↑↑</language>
-			<language type="lun">↑↑↑</language>
+			<language type="lez">Èdè Lesgina</language>
+			<language type="lg">Ganda</language>
+			<language type="li">Èdè Limbogishi</language>
+			<language type="lil">Èdè Liloeti</language>
+			<language type="lkt">Lákota</language>
+			<language type="ln">Lìǹgálà</language>
+			<language type="lo">Láò</language>
+			<language type="lou">Èdè Kreoli ti Louisiana</language>
+			<language type="loz">Èdè Lozi</language>
+			<language type="lrc">Apáàríwá Lúrì</language>
+			<language type="lsm">Èdè Samia</language>
+			<language type="lt">Èdè Lithuania</language>
+			<language type="lu">Lúbà-Katanga</language>
+			<language type="lua">Èdè Luba Lulua</language>
+			<language type="lun">Èdè Lunda</language>
 			<language type="luo">↑↑↑</language>
-			<language type="lus">↑↑↑</language>
-			<language type="luy">↑↑↑</language>
-			<language type="lv">↑↑↑</language>
-			<language type="mad">↑↑↑</language>
-			<language type="mag">↑↑↑</language>
-			<language type="mai">↑↑↑</language>
-			<language type="mak">↑↑↑</language>
-			<language type="mas">↑↑↑</language>
-			<language type="mdf">↑↑↑</language>
-			<language type="men">↑↑↑</language>
-			<language type="mer">↑↑↑</language>
-			<language type="mfe">↑↑↑</language>
-			<language type="mg">↑↑↑</language>
-			<language type="mgh">↑↑↑</language>
-			<language type="mgo">↑↑↑</language>
-			<language type="mh">↑↑↑</language>
-			<language type="mi">↑↑↑</language>
-			<language type="mic">↑↑↑</language>
-			<language type="min">↑↑↑</language>
-			<language type="mk">↑↑↑</language>
-			<language type="ml">↑↑↑</language>
-			<language type="mn">↑↑↑</language>
-			<language type="mni">↑↑↑</language>
-			<language type="moe">↑↑↑</language>
-			<language type="moh">↑↑↑</language>
-			<language type="mos">↑↑↑</language>
-			<language type="mr">↑↑↑</language>
-			<language type="ms">↑↑↑</language>
-			<language type="mt">↑↑↑</language>
-			<language type="mua">↑↑↑</language>
+			<language type="lus">Èdè Miso</language>
+			<language type="luy">Luyíà</language>
+			<language type="lv">Èdè Latvianu</language>
+			<language type="mad">Èdè Maduri</language>
+			<language type="mag">Èdè Magahi</language>
+			<language type="mai">Èdè Matihi</language>
+			<language type="mak">Èdè Makasa</language>
+			<language type="mas">Másáì</language>
+			<language type="mdf">Èdè Mokisa</language>
+			<language type="men">Èdè Mende</language>
+			<language type="mer">Mérù</language>
+			<language type="mfe">Morisiyen</language>
+			<language type="mg">Malagasì</language>
+			<language type="mgh">Makhuwa-Meeto</language>
+			<language type="mgo">Métà</language>
+			<language type="mh">Èdè Mashali</language>
+			<language type="mi">Màórì</language>
+			<language type="mic">Èdè Mikmaki</language>
+			<language type="min">Èdè Minakabau</language>
+			<language type="mk">Èdè Macedonia</language>
+			<language type="ml">Málàyálámù</language>
+			<language type="mn">Mòngólíà</language>
+			<language type="mni">Èdè Manipuri</language>
+			<language type="moe">Èdè Inuamu</language>
+			<language type="moh">Èdè Mohaki</language>
+			<language type="mos">Èdè Mosi</language>
+			<language type="mr">Èdè marathi</language>
+			<language type="ms">Èdè Malaya</language>
+			<language type="mt">Èdè Malta</language>
+			<language type="mua">Múndàngì</language>
 			<language type="mul">Ɔlɔ́pɔ̀ èdè</language>
-			<language type="mus">↑↑↑</language>
-			<language type="mwl">↑↑↑</language>
-			<language type="my">↑↑↑</language>
-			<language type="myv">↑↑↑</language>
-			<language type="mzn">↑↑↑</language>
-			<language type="na">↑↑↑</language>
-			<language type="nap">↑↑↑</language>
-			<language type="naq">↑↑↑</language>
+			<language type="mus">Èdè Muskogi</language>
+			<language type="mwl">Èdè Mirandisi</language>
+			<language type="my">Èdè Bumiisi</language>
+			<language type="myv">Èdè Esiya</language>
+			<language type="mzn">Masanderani</language>
+			<language type="na">Èdè Nauru</language>
+			<language type="nap">Èdè Neapolita</language>
+			<language type="naq">Námà</language>
 			<language type="nb">Nɔ́ɔ́wè Bokímàl</language>
-			<language type="nd">↑↑↑</language>
+			<language type="nd">Àríwá Ndebele</language>
 			<language type="nds">Jámánì ìpìlɛ̀</language>
-			<language type="ne">↑↑↑</language>
-			<language type="new">↑↑↑</language>
-			<language type="ng">↑↑↑</language>
-			<language type="nia">↑↑↑</language>
-			<language type="niu">↑↑↑</language>
+			<language type="ne">Èdè Nepali</language>
+			<language type="new">Èdè Newari</language>
+			<language type="ng">Èdè Ndonga</language>
+			<language type="nia">Èdè Nia</language>
+			<language type="niu">Èdè Niu</language>
 			<language type="nl">Èdè Dɔ́ɔ̀shì</language>
 			<language type="nl_BE">↑↑↑</language>
 			<language type="nmg">Kíwáshíò</language>
 			<language type="nn">Nɔ́ɔ́wè Nínɔ̀sìkì</language>
-			<language type="nnh">↑↑↑</language>
-			<language type="no">↑↑↑</language>
-			<language type="nog">↑↑↑</language>
-			<language type="nqo">↑↑↑</language>
-			<language type="nr">↑↑↑</language>
-			<language type="nso">↑↑↑</language>
+			<language type="nnh">Ngiembùnù</language>
+			<language type="no">Èdè Norway</language>
+			<language type="nog">Èdè Nogai</language>
+			<language type="nqo">Èdè Nko</language>
+			<language type="nr">Èdè Gusu Ndebele</language>
+			<language type="nso">Èdè Ariwa Soto</language>
 			<language type="nus">Núɛ̀</language>
-			<language type="nv">↑↑↑</language>
-			<language type="ny">↑↑↑</language>
+			<language type="nv">Èdè Nafajo</language>
+			<language type="ny">Ńyájà</language>
 			<language type="nyn">Ńyákɔ́lè</language>
-			<language type="oc">↑↑↑</language>
-			<language type="ojb">↑↑↑</language>
-			<language type="ojc">↑↑↑</language>
-			<language type="ojs">↑↑↑</language>
-			<language type="ojw">↑↑↑</language>
-			<language type="oka">↑↑↑</language>
+			<language type="oc">Èdè Occitani</language>
+			<language type="ojb">Èdè Ariwa-iwoorun Ojibwa</language>
+			<language type="ojc">Èdè Ojibwa Aarin</language>
+			<language type="ojs">Èdè Oji Kri</language>
+			<language type="ojw">Èdè Iwoorun Ojibwa</language>
+			<language type="oka">Èdè Okanaga</language>
 			<language type="om">Òròmɔ́</language>
-			<language type="or">↑↑↑</language>
+			<language type="or">Òdíà</language>
 			<language type="os">Ɔshɛ́tíìkì</language>
-			<language type="pa">↑↑↑</language>
-			<language type="pag">↑↑↑</language>
-			<language type="pam">↑↑↑</language>
-			<language type="pap">↑↑↑</language>
-			<language type="pau">↑↑↑</language>
-			<language type="pcm">↑↑↑</language>
-			<language type="pis">↑↑↑</language>
-			<language type="pl">↑↑↑</language>
-			<language type="pqm">↑↑↑</language>
+			<language type="pa">Èdè Punjabi</language>
+			<language type="pag">Èdè Pangasina</language>
+			<language type="pam">Èdè Pampanga</language>
+			<language type="pap">Èdè Papiamento</language>
+			<language type="pau">Èdè Pala</language>
+			<language type="pcm">Èdè Pijini ti Naijiriya</language>
+			<language type="pis">Èdè Piji</language>
+			<language type="pl">Èdè Póláǹdì</language>
+			<language type="pqm">Èdè Maliseti-Pasamkodi</language>
 			<language type="prg">Púrúshíànù</language>
-			<language type="ps">↑↑↑</language>
+			<language type="ps">Páshítò</language>
 			<language type="pt">Èdè Pɔtogí</language>
 			<language type="pt_BR">Èdè Pɔtogí (Orilɛ̀-èdè Bràsíl)</language>
 			<language type="pt_PT">Èdè Pɔtogí (orílɛ̀-èdè Yúróòpù)</language>
 			<language type="qu">Kúɛ́ńjùà</language>
-			<language type="rap">↑↑↑</language>
-			<language type="rar">↑↑↑</language>
-			<language type="rhg">↑↑↑</language>
+			<language type="rap">Èdè Rapanu</language>
+			<language type="rar">Èdè Rarotonga</language>
+			<language type="rhg">Èdè Rohinga</language>
 			<language type="rm">Rómáǹshì</language>
-			<language type="rn">↑↑↑</language>
-			<language type="ro">↑↑↑</language>
-			<language type="rof">↑↑↑</language>
+			<language type="rn">Rúńdì</language>
+			<language type="ro">Èdè Romania</language>
+			<language type="rof">Róńbò</language>
 			<language type="ru">Èdè Rɔ́shíà</language>
-			<language type="rup">↑↑↑</language>
-			<language type="rw">↑↑↑</language>
-			<language type="rwk">↑↑↑</language>
-			<language type="sa">↑↑↑</language>
-			<language type="sad">↑↑↑</language>
-			<language type="sah">↑↑↑</language>
-			<language type="saq">↑↑↑</language>
-			<language type="sat">↑↑↑</language>
-			<language type="sba">↑↑↑</language>
-			<language type="sbp">↑↑↑</language>
-			<language type="sc">↑↑↑</language>
-			<language type="scn">↑↑↑</language>
-			<language type="sco">↑↑↑</language>
-			<language type="sd">↑↑↑</language>
-			<language type="se">↑↑↑</language>
+			<language type="rup">Èdè Aromani</language>
+			<language type="rw">Èdè Ruwanda</language>
+			<language type="rwk">Riwa</language>
+			<language type="sa">Èdè awon ara Indo</language>
+			<language type="sad">Èdè Sandawe</language>
+			<language type="sah">Sàkíhà</language>
+			<language type="saq">Samburu</language>
+			<language type="sat">Èdè Santali</language>
+			<language type="sba">Èdè Ngambayi</language>
+			<language type="sbp">Sangu</language>
+			<language type="sc">Èdè Sadini</language>
+			<language type="scn">Èdè Sikila</language>
+			<language type="sco">Èdè Sikoti</language>
+			<language type="sd">Èdè Sindhi</language>
+			<language type="se">Apáàríwá Sami</language>
 			<language type="seh">Shɛnà</language>
-			<language type="ses">↑↑↑</language>
-			<language type="sg">↑↑↑</language>
-			<language type="sh">↑↑↑</language>
+			<language type="ses">Koiraboro Seni</language>
+			<language type="sg">Sango</language>
+			<language type="sh">Èdè Serbo-Croatiani</language>
 			<language type="shi">Tashelíìtì</language>
-			<language type="shn">↑↑↑</language>
-			<language type="si">↑↑↑</language>
-			<language type="sk">↑↑↑</language>
-			<language type="sl">↑↑↑</language>
-			<language type="slh">↑↑↑</language>
-			<language type="sm">↑↑↑</language>
-			<language type="smn">↑↑↑</language>
-			<language type="sms">↑↑↑</language>
+			<language type="shn">Èdè Shani</language>
+			<language type="si">Èdè Sinhalese</language>
+			<language type="sk">Èdè Slovaki</language>
+			<language type="sl">Èdè Slovenia</language>
+			<language type="slh">Èdè Gusu Lushootseed</language>
+			<language type="sm">Sámóánù</language>
+			<language type="smn">Inari Sami</language>
+			<language type="sms">Èdè Sikoti Smi</language>
 			<language type="sn">Shɔnà</language>
-			<language type="snk">↑↑↑</language>
-			<language type="so">↑↑↑</language>
-			<language type="sq">↑↑↑</language>
-			<language type="sr">↑↑↑</language>
-			<language type="srn">↑↑↑</language>
-			<language type="ss">↑↑↑</language>
-			<language type="st">↑↑↑</language>
-			<language type="str">↑↑↑</language>
-			<language type="su">↑↑↑</language>
-			<language type="suk">↑↑↑</language>
-			<language type="sv">↑↑↑</language>
-			<language type="sw">↑↑↑</language>
-			<language type="swb">↑↑↑</language>
-			<language type="syr">↑↑↑</language>
-			<language type="ta">↑↑↑</language>
-			<language type="tce">↑↑↑</language>
-			<language type="te">↑↑↑</language>
-			<language type="tem">↑↑↑</language>
+			<language type="snk">Èdè Sonike</language>
+			<language type="so">Èdè ara Somalia</language>
+			<language type="sq">Èdè Albania</language>
+			<language type="sr">Èdè Serbia</language>
+			<language type="srn">Èdè Sirana Tongo</language>
+			<language type="ss">Èdè Suwati</language>
+			<language type="st">Èdè Sesoto</language>
+			<language type="str">Èdè Sitirati Salisi</language>
+			<language type="su">Èdè Sudanísì</language>
+			<language type="suk">Èdè Sukuma</language>
+			<language type="sv">Èdè Suwidiisi</language>
+			<language type="sw">Èdè Swahili</language>
+			<language type="swb">Èdè Komora</language>
+			<language type="syr">Èdè Siriaki</language>
+			<language type="ta">Èdè Tamili</language>
+			<language type="tce">Èdè Gusu Tushoni</language>
+			<language type="te">Èdè Telugu</language>
+			<language type="tem">Èdè Timne</language>
 			<language type="teo">Tɛ́sò</language>
-			<language type="tet">↑↑↑</language>
-			<language type="tg">↑↑↑</language>
-			<language type="tgx">↑↑↑</language>
-			<language type="th">↑↑↑</language>
-			<language type="tht">↑↑↑</language>
-			<language type="ti">↑↑↑</language>
-			<language type="tig">↑↑↑</language>
-			<language type="tk">↑↑↑</language>
-			<language type="tlh">↑↑↑</language>
-			<language type="tli">↑↑↑</language>
-			<language type="tn">↑↑↑</language>
-			<language type="to">↑↑↑</language>
-			<language type="tok">↑↑↑</language>
-			<language type="tpi">↑↑↑</language>
+			<language type="tet">Èdè Tetum</language>
+			<language type="tg">Tàjíìkì</language>
+			<language type="tgx">Èdè Tagisi</language>
+			<language type="th">Èdè Tai</language>
+			<language type="tht">Èdè Tajiti</language>
+			<language type="ti">Èdè Tigrinya</language>
+			<language type="tig">Èdè Tigre</language>
+			<language type="tk">Èdè Turkmen</language>
+			<language type="tlh">Èdè Klingoni</language>
+			<language type="tli">Èdè Tlingiti</language>
+			<language type="tn">Èdè Suwana</language>
+			<language type="to">Tóńgàn</language>
+			<language type="tok">Èdè Toki Pona</language>
+			<language type="tpi">Èdè Tok Pisini</language>
 			<language type="tr">Èdè Tɔɔkisi</language>
-			<language type="trv">↑↑↑</language>
-			<language type="ts">↑↑↑</language>
-			<language type="tt">↑↑↑</language>
-			<language type="ttm">↑↑↑</language>
-			<language type="tum">↑↑↑</language>
-			<language type="tvl">↑↑↑</language>
-			<language type="twq">↑↑↑</language>
-			<language type="ty">↑↑↑</language>
-			<language type="tyv">↑↑↑</language>
-			<language type="tzm">↑↑↑</language>
-			<language type="udm">↑↑↑</language>
+			<language type="trv">Èdè Taroko</language>
+			<language type="ts">Èdè Songa</language>
+			<language type="tt">Tatarí</language>
+			<language type="ttm">Èdè Ariwa Tusoni</language>
+			<language type="tum">Èdè Tumbuka</language>
+			<language type="tvl">Èdè Tifalu</language>
+			<language type="twq">Tasawak</language>
+			<language type="ty">Èdè Tahiti</language>
+			<language type="tyv">Èdè Tuvini</language>
+			<language type="tzm">Ààrin Gbùngbùn Atlas Tamazight</language>
+			<language type="udm">Èdè Udmuti</language>
 			<language type="ug">Yúgɔ̀</language>
-			<language type="uk">↑↑↑</language>
-			<language type="umb">↑↑↑</language>
+			<language type="uk">Èdè Ukania</language>
+			<language type="umb">Èdè Umbundu</language>
 			<language type="und">Èdè àìmɔ̀</language>
-			<language type="ur">↑↑↑</language>
-			<language type="uz">↑↑↑</language>
+			<language type="ur">Èdè Udu</language>
+			<language type="uz">Èdè Uzbek</language>
 			<language type="vai">↑↑↑</language>
-			<language type="ve">↑↑↑</language>
-			<language type="vi">↑↑↑</language>
+			<language type="ve">Èdè Fenda</language>
+			<language type="vi">Èdè Jetinamu</language>
 			<language type="vo">Fɔ́lápùùkù</language>
-			<language type="vun">↑↑↑</language>
-			<language type="wa">↑↑↑</language>
+			<language type="vun">Funjo</language>
+			<language type="wa">Èdè Waluni</language>
 			<language type="wae">Wɔsà</language>
-			<language type="wal">↑↑↑</language>
-			<language type="war">↑↑↑</language>
+			<language type="wal">Èdè Wolata</language>
+			<language type="war">Èdè Wara</language>
 			<language type="wo">Wɔ́lɔ́ɔ̀fù</language>
-			<language type="wuu">↑↑↑</language>
-			<language type="xal">↑↑↑</language>
-			<language type="xh">↑↑↑</language>
+			<language type="wuu">Èdè Wu ti Saina</language>
+			<language type="xal">Èdè Kalimi</language>
+			<language type="xh">Èdè Xhosa</language>
 			<language type="xog">Shógà</language>
 			<language type="yav">Yangbɛn</language>
-			<language type="ybb">↑↑↑</language>
-			<language type="yi">↑↑↑</language>
-			<language type="yo">↑↑↑</language>
-			<language type="yrl">↑↑↑</language>
-			<language type="yue">↑↑↑</language>
+			<language type="ybb">Èdè Yemba</language>
+			<language type="yi">Èdè Yiddishi</language>
+			<language type="yo">Èdè Yorùbá</language>
+			<language type="yrl">Èdè Ningatu</language>
+			<language type="yue">Èdè Cantonese</language>
 			<language type="yue" alt="menu">↑↑↑</language>
 			<language type="zgh">Àfɛnùkò Támásáìtì ti Mòrókò</language>
 			<language type="zh">Edè Sháínà</language>
@@ -457,87 +457,87 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="zh_Hant">Èdè Sháínà Ìbílɛ̀</language>
 			<language type="zh_Hant" alt="long">Èdè Mandárínì Sháínà Ìbílɛ̀</language>
 			<language type="zu">Èdè Shulu</language>
-			<language type="zun">↑↑↑</language>
-			<language type="zxx">↑↑↑</language>
-			<language type="zza">↑↑↑</language>
+			<language type="zun">Èdè Suni</language>
+			<language type="zxx">Kò sí àkóònú elédè</language>
+			<language type="zza">Èdè Sasa</language>
 		</languages>
 		<scripts>
-			<script type="Adlm">↑↑↑</script>
-			<script type="Arab">↑↑↑</script>
-			<script type="Aran">↑↑↑</script>
+			<script type="Adlm">Èdè Adam</script>
+			<script type="Arab">èdè Lárúbáwá</script>
+			<script type="Aran">Èdè Aran</script>
 			<script type="Armn">Àmɛ́níà</script>
-			<script type="Beng">↑↑↑</script>
-			<script type="Bopo">↑↑↑</script>
-			<script type="Brai">↑↑↑</script>
-			<script type="Cakm">↑↑↑</script>
-			<script type="Cans">↑↑↑</script>
-			<script type="Cher">↑↑↑</script>
+			<script type="Beng">Báńgílà</script>
+			<script type="Bopo">Bopomófò</script>
+			<script type="Brai">Bíráìlè</script>
+			<script type="Cakm">Kami</script>
+			<script type="Cans">Èdè Apapo Onile Onisilebu ti Kanada</script>
+			<script type="Cher">Èdè Sheroki</script>
 			<script type="Cyrl">èdè ilɛ̀ Rɔ́shíà</script>
 			<script type="Deva">Dɛfanagárì</script>
 			<script type="Ethi">Ɛtiópíìkì</script>
 			<script type="Geor">Jɔ́jíànù</script>
 			<script type="Grek">Jɔ́jíà</script>
-			<script type="Gujr">↑↑↑</script>
-			<script type="Guru">↑↑↑</script>
+			<script type="Gujr">Gujaráti</script>
+			<script type="Guru">Gurumúkhì</script>
 			<script type="Hanb">Han pɛ̀lú Bopomófò</script>
-			<script type="Hang">↑↑↑</script>
-			<script type="Hani">↑↑↑</script>
+			<script type="Hang">Háńgùlù</script>
+			<script type="Hani">Háànù</script>
 			<script type="Hans">tí wɔ́n mú rɔrùn.</script>
 			<script type="Hans" alt="stand-alone">Hans tí wɔ́n mú rɔrùn.</script>
 			<script type="Hant">Hans àtɔwɔ́dɔ́wɔ́</script>
 			<script type="Hant" alt="stand-alone">↑↑↑</script>
-			<script type="Hebr">↑↑↑</script>
-			<script type="Hira">↑↑↑</script>
+			<script type="Hebr">Hébérù</script>
+			<script type="Hira">Hiragánà</script>
 			<script type="Hrkt">ìlànà àfɔwɔ́kɔ ará Jàpánù</script>
 			<script type="Jamo">↑↑↑</script>
-			<script type="Jpan">↑↑↑</script>
-			<script type="Kana">↑↑↑</script>
+			<script type="Jpan">èdè jàpáànù</script>
+			<script type="Kana">Katakánà</script>
 			<script type="Khmr">Kɛmɛ̀</script>
-			<script type="Knda">↑↑↑</script>
-			<script type="Kore">↑↑↑</script>
-			<script type="Laoo">↑↑↑</script>
-			<script type="Latn">↑↑↑</script>
-			<script type="Mlym">↑↑↑</script>
-			<script type="Mong">↑↑↑</script>
-			<script type="Mtei">↑↑↑</script>
-			<script type="Mymr">↑↑↑</script>
-			<script type="Nkoo">↑↑↑</script>
-			<script type="Olck">↑↑↑</script>
-			<script type="Orya">↑↑↑</script>
-			<script type="Rohg">↑↑↑</script>
-			<script type="Sinh">↑↑↑</script>
-			<script type="Sund">↑↑↑</script>
-			<script type="Syrc">↑↑↑</script>
-			<script type="Taml">↑↑↑</script>
-			<script type="Telu">↑↑↑</script>
-			<script type="Tfng">↑↑↑</script>
-			<script type="Thaa">↑↑↑</script>
+			<script type="Knda">Kanada</script>
+			<script type="Kore">Kóríà</script>
+			<script type="Laoo">Láò</script>
+			<script type="Latn">Èdè Látìn</script>
+			<script type="Mlym">Málàyálámù</script>
+			<script type="Mong">Mòngólíà</script>
+			<script type="Mtei">Èdè Meitei Mayeki</script>
+			<script type="Mymr">Myánmarà</script>
+			<script type="Nkoo">Èdè Nkoo</script>
+			<script type="Olck">Èdè Ol Siki</script>
+			<script type="Orya">Òdíà</script>
+			<script type="Rohg">Èdè Hanifi</script>
+			<script type="Sinh">Sìnhálà</script>
+			<script type="Sund">Èdè Sundani</script>
+			<script type="Syrc">Èdè Siriaki</script>
+			<script type="Taml">Támílì</script>
+			<script type="Telu">Télúgù</script>
+			<script type="Tfng">Èdè Tifina</script>
+			<script type="Thaa">Taana</script>
 			<script type="Thai">↑↑↑</script>
-			<script type="Tibt">↑↑↑</script>
-			<script type="Vaii">↑↑↑</script>
-			<script type="Yiii">↑↑↑</script>
+			<script type="Tibt">Tíbétán</script>
+			<script type="Vaii">Èdè Fai</script>
+			<script type="Yiii">Èdè Yi</script>
 			<script type="Zmth">Àmì Ìshèsìrò</script>
-			<script type="Zsye">↑↑↑</script>
+			<script type="Zsye">Émójì</script>
 			<script type="Zsym">Àwɔn àmì</script>
 			<script type="Zxxx">Aikɔsilɛ</script>
 			<script type="Zyyy">Wɔ́pɔ̀</script>
 			<script type="Zzzz">Ìshɔwɔ́kɔ̀wé àìmɔ̀</script>
 		</scripts>
 		<territories>
-			<territory type="001">↑↑↑</territory>
-			<territory type="002">↑↑↑</territory>
+			<territory type="001">Agbáyé</territory>
+			<territory type="002">Áfíríkà</territory>
 			<territory type="003">Àríwá Amɛ́ríkà</territory>
 			<territory type="005">Gúúshù Amɛ́ríkà</territory>
 			<territory type="009">Òsɔ́ɔ́níà</territory>
 			<territory type="011">Ìwɔ̀ oorùn Afíríkà</territory>
 			<territory type="013">Ààrin Gbùgbùn Àmɛ́ríkà</territory>
-			<territory type="014">↑↑↑</territory>
-			<territory type="015">↑↑↑</territory>
-			<territory type="017">↑↑↑</territory>
-			<territory type="018">↑↑↑</territory>
+			<territory type="014">Ìlà Oorùn Áfíríkà</territory>
+			<territory type="015">Àríwá Afíríkà</territory>
+			<territory type="017">Ààrín gbùngbùn Afíríkà</territory>
+			<territory type="018">Apágúúsù Áfíríkà</territory>
 			<territory type="019">Amɛ́ríkà</territory>
 			<territory type="021">Apáàríwá Amɛ́ríkà</territory>
-			<territory type="029">↑↑↑</territory>
+			<territory type="029">Káríbíànù</territory>
 			<territory type="030">Ìlà Òòrùn Eshíà</territory>
 			<territory type="034">Gúúshù Eshíà</territory>
 			<territory type="035">Gúúshù ìlà òòrùn Éshíà</territory>
@@ -549,287 +549,287 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="142">Áshíà</territory>
 			<territory type="143">Ààrin Gbùngbùn Éshíà</territory>
 			<territory type="145">Ìwɔ̀ Òòrùn Eshíà</territory>
-			<territory type="150">↑↑↑</territory>
-			<territory type="151">↑↑↑</territory>
-			<territory type="154">↑↑↑</territory>
+			<territory type="150">Yúróòpù</territory>
+			<territory type="151">Ìlà Òrùn Yúrópù</territory>
+			<territory type="154">Àríwá Yúróòpù</territory>
 			<territory type="155">Ìwɔ̀ Òòrùn Yúrópù</territory>
-			<territory type="202">↑↑↑</territory>
+			<territory type="202">Apá Sàhárà Áfíríkà</territory>
 			<territory type="419">Látín Amɛ́ríkà</territory>
-			<territory type="AC">↑↑↑</territory>
-			<territory type="AD">↑↑↑</territory>
+			<territory type="AC">Erékùsù Ascension</territory>
+			<territory type="AD">Ààndórà</territory>
 			<territory type="AE">Ɛmirate ti Awɔn Arabu</territory>
-			<territory type="AF">↑↑↑</territory>
-			<territory type="AG">↑↑↑</territory>
-			<territory type="AI">↑↑↑</territory>
-			<territory type="AL">↑↑↑</territory>
-			<territory type="AM">↑↑↑</territory>
-			<territory type="AO">↑↑↑</territory>
-			<territory type="AQ">↑↑↑</territory>
-			<territory type="AR">↑↑↑</territory>
+			<territory type="AF">Àfùgànístánì</territory>
+			<territory type="AG">Ààntígúà àti Báríbúdà</territory>
+			<territory type="AI">Ààngúlílà</territory>
+			<territory type="AL">Àlùbàníánì</territory>
+			<territory type="AM">Améníà</territory>
+			<territory type="AO">Ààngólà</territory>
+			<territory type="AQ">Antakítíkà</territory>
+			<territory type="AR">Agentínà</territory>
 			<territory type="AS">Sámóánì ti Orílɛ́ède Àméríkà</territory>
-			<territory type="AT">↑↑↑</territory>
-			<territory type="AU">↑↑↑</territory>
-			<territory type="AW">↑↑↑</territory>
+			<territory type="AT">Asítíríà</territory>
+			<territory type="AU">Ástràlìá</territory>
+			<territory type="AW">Árúbà</territory>
 			<territory type="AX">Àwɔn Erékùsù ti Åland</territory>
 			<territory type="AZ">Asɛ́bájánì</territory>
 			<territory type="BA">Bɔ̀síníà àti Ɛtisɛgófínà</territory>
-			<territory type="BB">↑↑↑</territory>
-			<territory type="BD">↑↑↑</territory>
+			<territory type="BB">Bábádósì</territory>
+			<territory type="BD">Bángáládésì</territory>
 			<territory type="BE">Bégíɔ́mù</territory>
-			<territory type="BF">↑↑↑</territory>
-			<territory type="BG">↑↑↑</territory>
-			<territory type="BH">↑↑↑</territory>
-			<territory type="BI">↑↑↑</territory>
+			<territory type="BF">Bùùkíná Fasò</territory>
+			<territory type="BG">Bùùgáríà</territory>
+			<territory type="BH">Báránì</territory>
+			<territory type="BI">Bùùrúndì</territory>
 			<territory type="BJ">Bɛ̀nɛ̀</territory>
 			<territory type="BL">Ìlú Bátílɛ́mì</territory>
-			<territory type="BM">↑↑↑</territory>
+			<territory type="BM">Bémúdà</territory>
 			<territory type="BN">Búrúnɛ́lì</territory>
 			<territory type="BO">Bɔ̀lífíyà</territory>
 			<territory type="BQ">Kàríbíánì ti Nɛ́dálándì</territory>
-			<territory type="BR">↑↑↑</territory>
-			<territory type="BS">↑↑↑</territory>
-			<territory type="BT">↑↑↑</territory>
-			<territory type="BV">↑↑↑</territory>
+			<territory type="BR">Bàràsílì</territory>
+			<territory type="BS">Bàhámásì</territory>
+			<territory type="BT">Bútánì</territory>
+			<territory type="BV">Erékùsù Bouvet</territory>
 			<territory type="BW">Bɔ̀tìsúwánà</territory>
-			<territory type="BY">↑↑↑</territory>
+			<territory type="BY">Bélárúsì</territory>
 			<territory type="BZ">Bèlísɛ̀</territory>
-			<territory type="CA">↑↑↑</territory>
-			<territory type="CC">↑↑↑</territory>
-			<territory type="CD">↑↑↑</territory>
-			<territory type="CD" alt="variant">↑↑↑</territory>
-			<territory type="CF">↑↑↑</territory>
-			<territory type="CG">↑↑↑</territory>
-			<territory type="CG" alt="variant">↑↑↑</territory>
+			<territory type="CA">Kánádà</territory>
+			<territory type="CC">Erékùsù Cocos (Keeling)</territory>
+			<territory type="CD">Kóńgò – Kinshasa</territory>
+			<territory type="CD" alt="variant">Kóńgò (Tiwantiwa)</territory>
+			<territory type="CF">Àrin gùngun Áfíríkà</territory>
+			<territory type="CG">Kóńgò – Brazaville</territory>
+			<territory type="CG" alt="variant">Kóńgò (Olómìnira)</territory>
 			<territory type="CH">switishilandi</territory>
-			<territory type="CI">↑↑↑</territory>
+			<territory type="CI">Kóútè forà</territory>
 			<territory type="CI" alt="variant">↑↑↑</territory>
-			<territory type="CK">↑↑↑</territory>
+			<territory type="CK">Etíokun Kùúkù</territory>
 			<territory type="CL">Shílè</territory>
-			<territory type="CM">↑↑↑</territory>
+			<territory type="CM">Kamerúúnì</territory>
 			<territory type="CN">Sháínà</territory>
-			<territory type="CO">↑↑↑</territory>
-			<territory type="CP">↑↑↑</territory>
-			<territory type="CR">↑↑↑</territory>
-			<territory type="CU">↑↑↑</territory>
-			<territory type="CV">↑↑↑</territory>
-			<territory type="CW">↑↑↑</territory>
-			<territory type="CX">↑↑↑</territory>
-			<territory type="CY">↑↑↑</territory>
+			<territory type="CO">Kòlómíbìa</territory>
+			<territory type="CP">Erékùsù Clipperston</territory>
+			<territory type="CR">Kuusita Ríkà</territory>
+			<territory type="CU">Kúbà</territory>
+			<territory type="CV">Etíokun Kápé féndè</territory>
+			<territory type="CW">Curaçao</territory>
+			<territory type="CX">Erékùsù Christmas</territory>
+			<territory type="CY">Kúrúsì</territory>
 			<territory type="CZ">Shɛ́ɛ́kì</territory>
 			<territory type="CZ" alt="variant">↑↑↑</territory>
-			<territory type="DE">↑↑↑</territory>
+			<territory type="DE">Jámánì</territory>
 			<territory type="DG">Diego Gashia</territory>
 			<territory type="DJ">Díbɔ́ótì</territory>
 			<territory type="DK">Dɛ́mákì</territory>
-			<territory type="DM">↑↑↑</territory>
-			<territory type="DO">↑↑↑</territory>
-			<territory type="DZ">↑↑↑</territory>
-			<territory type="EA">↑↑↑</territory>
-			<territory type="EC">↑↑↑</territory>
-			<territory type="EE">↑↑↑</territory>
-			<territory type="EG">↑↑↑</territory>
+			<territory type="DM">Dòmíníkà</territory>
+			<territory type="DO">Dòmíníkánì</territory>
+			<territory type="DZ">Àlùgèríánì</territory>
+			<territory type="EA">Seuta àti Melilla</territory>
+			<territory type="EC">Ekuádò</territory>
+			<territory type="EE">Esitonia</territory>
+			<territory type="EG">Égípítì</territory>
 			<territory type="EH">Ìwɔ̀òòrùn Sàhárà</territory>
-			<territory type="ER">↑↑↑</territory>
-			<territory type="ES">↑↑↑</territory>
-			<territory type="ET">↑↑↑</territory>
+			<territory type="ER">Eritira</territory>
+			<territory type="ES">Sipani</territory>
+			<territory type="ET">Etopia</territory>
 			<territory type="EU">Àpapɔ̀ Yúróòpù</territory>
-			<territory type="EZ">↑↑↑</territory>
-			<territory type="FI">↑↑↑</territory>
-			<territory type="FJ">↑↑↑</territory>
-			<territory type="FK">↑↑↑</territory>
+			<territory type="EZ">Agbègbè Yúrò</territory>
+			<territory type="FI">Filandi</territory>
+			<territory type="FJ">Fiji</territory>
+			<territory type="FK">Etikun Fakalandi</territory>
 			<territory type="FK" alt="variant">↑↑↑</territory>
-			<territory type="FM">↑↑↑</territory>
+			<territory type="FM">Makoronesia</territory>
 			<territory type="FO">Àwɔn Erékùsù ti Faroe</territory>
-			<territory type="FR">↑↑↑</territory>
-			<territory type="GA">↑↑↑</territory>
+			<territory type="FR">Faranse</territory>
+			<territory type="GA">Gabon</territory>
 			<territory type="GB">Gɛ̀ɛ́sì</territory>
 			<territory type="GB" alt="short">↑↑↑</territory>
-			<territory type="GD">↑↑↑</territory>
+			<territory type="GD">Genada</territory>
 			<territory type="GE">Gɔgia</territory>
 			<territory type="GF">Firenshi Guana</territory>
-			<territory type="GG">↑↑↑</territory>
-			<territory type="GH">↑↑↑</territory>
-			<territory type="GI">↑↑↑</territory>
-			<territory type="GL">↑↑↑</territory>
-			<territory type="GM">↑↑↑</territory>
-			<territory type="GN">↑↑↑</territory>
-			<territory type="GP">↑↑↑</territory>
-			<territory type="GQ">↑↑↑</territory>
-			<territory type="GR">↑↑↑</territory>
+			<territory type="GG">Guernsey</territory>
+			<territory type="GH">Gana</territory>
+			<territory type="GI">Gibaratara</territory>
+			<territory type="GL">Gerelandi</territory>
+			<territory type="GM">Gambia</territory>
+			<territory type="GN">Gene</territory>
+			<territory type="GP">Gadelope</territory>
+			<territory type="GQ">Ekutoria Gini</territory>
+			<territory type="GR">Geriisi</territory>
 			<territory type="GS">Gúúsù Georgia àti Gúúsù Àwɔn Erékùsù Sandwich</territory>
-			<territory type="GT">↑↑↑</territory>
-			<territory type="GU">↑↑↑</territory>
-			<territory type="GW">↑↑↑</territory>
-			<territory type="GY">↑↑↑</territory>
+			<territory type="GT">Guatemala</territory>
+			<territory type="GU">Guamu</territory>
+			<territory type="GW">Gene-Busau</territory>
+			<territory type="GY">Guyana</territory>
 			<territory type="HK">Agbègbè Ìshàkóso Ìshúná Hong Kong Tí Shánà Ń Darí</territory>
-			<territory type="HK" alt="short">↑↑↑</territory>
-			<territory type="HM">↑↑↑</territory>
-			<territory type="HN">↑↑↑</territory>
-			<territory type="HR">↑↑↑</territory>
-			<territory type="HT">↑↑↑</territory>
-			<territory type="HU">↑↑↑</territory>
+			<territory type="HK" alt="short">Hong Kong</territory>
+			<territory type="HM">Erékùsù Heard àti Erékùsù McDonald</territory>
+			<territory type="HN">Hondurasi</territory>
+			<territory type="HR">Kòróátíà</territory>
+			<territory type="HT">Haati</territory>
+			<territory type="HU">Hungari</territory>
 			<territory type="IC">Ɛrékùsù Kánárì</territory>
-			<territory type="ID">↑↑↑</territory>
-			<territory type="IE">↑↑↑</territory>
+			<territory type="ID">Indonesia</territory>
+			<territory type="IE">Ailandi</territory>
 			<territory type="IL">Iserɛli</territory>
-			<territory type="IM">↑↑↑</territory>
-			<territory type="IN">↑↑↑</territory>
-			<territory type="IO">↑↑↑</territory>
+			<territory type="IM">Isle of Man</territory>
+			<territory type="IN">India</territory>
+			<territory type="IO">Etíkun Índíánì ti Ìlú Bírítísì</territory>
 			<territory type="IO" alt="biot">Àlà-ilɛ̀ Bírítéènì ní Etíkun Índíà</territory>
 			<territory type="IO" alt="chagos">Àkójɔpɔ̀ Àwɔn Erékùshù Shágòsì</territory>
-			<territory type="IQ">↑↑↑</territory>
-			<territory type="IR">↑↑↑</territory>
+			<territory type="IQ">Iraki</territory>
+			<territory type="IR">Irani</territory>
 			<territory type="IS">Ashilandi</territory>
-			<territory type="IT">↑↑↑</territory>
-			<territory type="JE">↑↑↑</territory>
-			<territory type="JM">↑↑↑</territory>
+			<territory type="IT">Itáli</territory>
+			<territory type="JE">Jersey</territory>
+			<territory type="JM">Jamaika</territory>
 			<territory type="JO">Jɔdani</territory>
-			<territory type="JP">↑↑↑</territory>
-			<territory type="KE">↑↑↑</territory>
+			<territory type="JP">Japani</territory>
+			<territory type="KE">Kenya</territory>
 			<territory type="KG">Kurishisitani</territory>
-			<territory type="KH">↑↑↑</territory>
-			<territory type="KI">↑↑↑</territory>
-			<territory type="KM">↑↑↑</territory>
-			<territory type="KN">↑↑↑</territory>
+			<territory type="KH">Kàmùbódíà</territory>
+			<territory type="KI">Kiribati</territory>
+			<territory type="KM">Kòmòrósì</territory>
+			<territory type="KN">Kiiti ati Neefi</territory>
 			<territory type="KP">Guusu Kɔria</territory>
 			<territory type="KR">Ariwa Kɔria</territory>
-			<territory type="KW">↑↑↑</territory>
-			<territory type="KY">↑↑↑</territory>
+			<territory type="KW">Kuweti</territory>
+			<territory type="KY">Etíokun Kámánì</territory>
 			<territory type="KZ">Kashashatani</territory>
-			<territory type="LA">↑↑↑</territory>
-			<territory type="LB">↑↑↑</territory>
+			<territory type="LA">Laosi</territory>
+			<territory type="LB">Lebanoni</territory>
 			<territory type="LC">Lushia</territory>
 			<territory type="LI">Lɛshitɛnisiteni</territory>
-			<territory type="LK">↑↑↑</territory>
-			<territory type="LR">↑↑↑</territory>
-			<territory type="LS">↑↑↑</territory>
-			<territory type="LT">↑↑↑</territory>
-			<territory type="LU">↑↑↑</territory>
-			<territory type="LV">↑↑↑</territory>
-			<territory type="LY">↑↑↑</territory>
-			<territory type="MA">↑↑↑</territory>
-			<territory type="MC">↑↑↑</territory>
-			<territory type="MD">↑↑↑</territory>
-			<territory type="ME">↑↑↑</territory>
-			<territory type="MF">↑↑↑</territory>
-			<territory type="MG">↑↑↑</territory>
+			<territory type="LK">Siri Lanka</territory>
+			<territory type="LR">Laberia</territory>
+			<territory type="LS">Lesoto</territory>
+			<territory type="LT">Lituania</territory>
+			<territory type="LU">Lusemogi</territory>
+			<territory type="LV">Latifia</territory>
+			<territory type="LY">Libiya</territory>
+			<territory type="MA">Moroko</territory>
+			<territory type="MC">Monako</territory>
+			<territory type="MD">Modofia</territory>
+			<territory type="ME">Montenegro</territory>
+			<territory type="MF">Ìlú Màtìnì</territory>
+			<territory type="MG">Madasika</territory>
 			<territory type="MH">Etikun Máshali</territory>
-			<territory type="MK">↑↑↑</territory>
-			<territory type="ML">↑↑↑</territory>
-			<territory type="MM">↑↑↑</territory>
-			<territory type="MN">↑↑↑</territory>
+			<territory type="MK">Àríwá Macedonia</territory>
+			<territory type="ML">Mali</territory>
+			<territory type="MM">Manamari</territory>
+			<territory type="MN">Mogolia</territory>
 			<territory type="MO">Agbègbè Ìshàkóso Pàtàkì Macao</territory>
-			<territory type="MO" alt="short">↑↑↑</territory>
-			<territory type="MP">↑↑↑</territory>
-			<territory type="MQ">↑↑↑</territory>
-			<territory type="MR">↑↑↑</territory>
-			<territory type="MS">↑↑↑</territory>
-			<territory type="MT">↑↑↑</territory>
-			<territory type="MU">↑↑↑</territory>
-			<territory type="MV">↑↑↑</territory>
-			<territory type="MW">↑↑↑</territory>
-			<territory type="MX">↑↑↑</territory>
-			<territory type="MY">↑↑↑</territory>
+			<territory type="MO" alt="short">Màkáò</territory>
+			<territory type="MP">Etikun Guusu Mariana</territory>
+			<territory type="MQ">Matinikuwi</territory>
+			<territory type="MR">Maritania</territory>
+			<territory type="MS">Motserati</territory>
+			<territory type="MT">Malata</territory>
+			<territory type="MU">Maritiusi</territory>
+			<territory type="MV">Maladifi</territory>
+			<territory type="MW">Malawi</territory>
+			<territory type="MX">Mesiko</territory>
+			<territory type="MY">Malasia</territory>
 			<territory type="MZ">Moshamibiku</territory>
-			<territory type="NA">↑↑↑</territory>
-			<territory type="NC">↑↑↑</territory>
-			<territory type="NE">↑↑↑</territory>
+			<territory type="NA">Namibia</territory>
+			<territory type="NC">Kaledonia Titun</territory>
+			<territory type="NE">Nàìjá</territory>
 			<territory type="NF">Etikun Nɔ́úfókì</territory>
-			<territory type="NG">↑↑↑</territory>
-			<territory type="NI">↑↑↑</territory>
-			<territory type="NL">↑↑↑</territory>
+			<territory type="NG">Nàìjíríà</territory>
+			<territory type="NI">Nikaragua</territory>
+			<territory type="NL">Nedalandi</territory>
 			<territory type="NO">Nɔɔwii</territory>
-			<territory type="NP">↑↑↑</territory>
-			<territory type="NR">↑↑↑</territory>
-			<territory type="NU">↑↑↑</territory>
+			<territory type="NP">Nepa</territory>
+			<territory type="NR">Nauru</territory>
+			<territory type="NU">Niue</territory>
 			<territory type="NZ">Shilandi Titun</territory>
-			<territory type="NZ" alt="variant">↑↑↑</territory>
+			<territory type="NZ" alt="variant">Sílándì Titun ti Atìríà</territory>
 			<territory type="OM">Ɔɔma</territory>
-			<territory type="PA">↑↑↑</territory>
-			<territory type="PE">↑↑↑</territory>
+			<territory type="PA">Panama</territory>
+			<territory type="PE">Peru</territory>
 			<territory type="PF">Firenshi Polinesia</territory>
-			<territory type="PG">↑↑↑</territory>
-			<territory type="PH">↑↑↑</territory>
-			<territory type="PK">↑↑↑</territory>
-			<territory type="PL">↑↑↑</territory>
+			<territory type="PG">Paapu ti Giini</territory>
+			<territory type="PH">Filipini</territory>
+			<territory type="PK">Pakisitan</territory>
+			<territory type="PL">Polandi</territory>
 			<territory type="PM">Pɛɛri ati mikuloni</territory>
-			<territory type="PN">↑↑↑</territory>
+			<territory type="PN">Pikarini</territory>
 			<territory type="PR">Pɔto Riko</territory>
 			<territory type="PS">Agbègbè ara Palɛsítínì</territory>
 			<territory type="PS" alt="short">Palɛsítínì</territory>
 			<territory type="PT">Pɔ́túgà</territory>
-			<territory type="PW">↑↑↑</territory>
-			<territory type="PY">↑↑↑</territory>
-			<territory type="QA">↑↑↑</territory>
+			<territory type="PW">Paalu</territory>
+			<territory type="PY">Paraguye</territory>
+			<territory type="QA">Kota</territory>
 			<territory type="QO">Agbègbè Òshɔ́ɔ́níà</territory>
-			<territory type="RE">↑↑↑</territory>
-			<territory type="RO">↑↑↑</territory>
+			<territory type="RE">Riuniyan</territory>
+			<territory type="RO">Romaniya</territory>
 			<territory type="RS">Sɛ́bíà</territory>
 			<territory type="RU">Rɔshia</territory>
-			<territory type="RW">↑↑↑</territory>
-			<territory type="SA">↑↑↑</territory>
-			<territory type="SB">↑↑↑</territory>
+			<territory type="RW">Ruwanda</territory>
+			<territory type="SA">Saudi Arabia</territory>
+			<territory type="SB">Etikun Solomoni</territory>
 			<territory type="SC">Sheshɛlɛsi</territory>
-			<territory type="SD">↑↑↑</territory>
-			<territory type="SE">↑↑↑</territory>
-			<territory type="SG">↑↑↑</territory>
+			<territory type="SD">Sudani</territory>
+			<territory type="SE">Swidini</territory>
+			<territory type="SG">Singapo</territory>
 			<territory type="SH">Hɛlena</territory>
-			<territory type="SI">↑↑↑</territory>
+			<territory type="SI">Silofania</territory>
 			<territory type="SJ">Sífábáàdì àti Jánì Máyɛ̀nì</territory>
-			<territory type="SK">↑↑↑</territory>
-			<territory type="SL">↑↑↑</territory>
-			<territory type="SM">↑↑↑</territory>
+			<territory type="SK">Silofakia</territory>
+			<territory type="SL">Siria looni</territory>
+			<territory type="SM">Sani Marino</territory>
 			<territory type="SN">Sɛnɛga</territory>
-			<territory type="SO">↑↑↑</territory>
-			<territory type="SR">↑↑↑</territory>
-			<territory type="SS">↑↑↑</territory>
+			<territory type="SO">Somalia</territory>
+			<territory type="SR">Surinami</territory>
+			<territory type="SS">Gúúsù Sudan</territory>
 			<territory type="ST">Sao tomi ati piriishipi</territory>
 			<territory type="SV">Ɛɛsáfádò</territory>
 			<territory type="SX">Síntì Mátɛ́ɛ̀nì</territory>
-			<territory type="SY">↑↑↑</territory>
+			<territory type="SY">Siria</territory>
 			<territory type="SZ">Sashiland</territory>
-			<territory type="SZ" alt="variant">↑↑↑</territory>
-			<territory type="TA">↑↑↑</territory>
+			<territory type="SZ" alt="variant">Síwásìlandì</territory>
+			<territory type="TA">Tristan da Kunha</territory>
 			<territory type="TC">Tɔɔki ati Etikun Kakɔsi</territory>
 			<territory type="TD">Shààdì</territory>
 			<territory type="TF">Agbègbè Gúúsù Faranshé</territory>
-			<territory type="TG">↑↑↑</territory>
-			<territory type="TH">↑↑↑</territory>
-			<territory type="TJ">↑↑↑</territory>
-			<territory type="TK">↑↑↑</territory>
+			<territory type="TG">Togo</territory>
+			<territory type="TH">Tailandi</territory>
+			<territory type="TJ">Takisitani</territory>
+			<territory type="TK">Tokelau</territory>
 			<territory type="TL">ÌlàOòrùn Tímɔ̀</territory>
 			<territory type="TL" alt="variant">Ìlà Òòrùn Tímɔ̀</territory>
 			<territory type="TM">Tɔɔkimenisita</territory>
 			<territory type="TN">Tunishia</territory>
-			<territory type="TO">↑↑↑</territory>
+			<territory type="TO">Tonga</territory>
 			<territory type="TR">Tɔɔki</territory>
 			<territory type="TR" alt="variant">↑↑↑</territory>
-			<territory type="TT">↑↑↑</territory>
-			<territory type="TV">↑↑↑</territory>
-			<territory type="TW">↑↑↑</territory>
-			<territory type="TZ">↑↑↑</territory>
-			<territory type="UA">↑↑↑</territory>
-			<territory type="UG">↑↑↑</territory>
+			<territory type="TT">Tirinida ati Tobaga</territory>
+			<territory type="TV">Tufalu</territory>
+			<territory type="TW">Taiwani</territory>
+			<territory type="TZ">Tàǹsáníà</territory>
+			<territory type="UA">Ukarini</territory>
+			<territory type="UG">Uganda</territory>
 			<territory type="UM">Àwɔn Erékùsù Kékèké Agbègbè US</territory>
 			<territory type="UN">Ìshɔ̀kan àgbáyé</territory>
 			<territory type="US">Amɛrikà</territory>
 			<territory type="US" alt="short">↑↑↑</territory>
-			<territory type="UY">↑↑↑</territory>
+			<territory type="UY">Nruguayi</territory>
 			<territory type="UZ">Nshibɛkisitani</territory>
-			<territory type="VA">↑↑↑</territory>
+			<territory type="VA">Ìlú Vatican</territory>
 			<territory type="VC">Fisɛnnti ati Genadina</territory>
 			<territory type="VE">Fɛnɛshuɛla</territory>
-			<territory type="VG">↑↑↑</territory>
+			<territory type="VG">Etíkun Fágínì ti ìlú Bírítísì</territory>
 			<territory type="VI">Etikun Fagini ti Amɛrika</territory>
 			<territory type="VN">Fɛtinami</territory>
-			<territory type="VU">↑↑↑</territory>
-			<territory type="WF">↑↑↑</territory>
+			<territory type="VU">Faniatu</territory>
+			<territory type="WF">Wali ati futuna</territory>
 			<territory type="WS">Samɔ</territory>
 			<territory type="XA">ìsɔ̀rɔ̀sí irɔ́</territory>
 			<territory type="XB">ibi irɔ́</territory>
-			<territory type="XK">↑↑↑</territory>
-			<territory type="YE">↑↑↑</territory>
-			<territory type="YT">↑↑↑</territory>
+			<territory type="XK">Kòsófò</territory>
+			<territory type="YE">Yemeni</territory>
+			<territory type="YT">Mayote</territory>
 			<territory type="ZA">Gúúshù Áfíríkà</territory>
 			<territory type="ZM">Shamibia</territory>
 			<territory type="ZW">Shimibabe</territory>
@@ -838,25 +838,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<subdivisions>
 			<subdivision type="gbeng">Ilɛ̀gɛ̀ɛ́sì</subdivision>
 			<subdivision type="gbsct">Skɔ́tlándì</subdivision>
-			<subdivision type="gbwls">↑↑↑</subdivision>
+			<subdivision type="gbwls">Wélsì</subdivision>
 		</subdivisions>
 		<keys>
 			<key type="calendar">Kàlɛ́ńdà</key>
 			<key type="cf">Ìgúnrégé Kɔ́rɛ́ńsì</key>
 			<key type="collation">Ètò Ɛlɛ́sɛɛsɛ</key>
 			<key type="currency">Kɔ́rɛ́ńsì</key>
-			<key type="hc">↑↑↑</key>
-			<key type="lb">↑↑↑</key>
+			<key type="hc">Òbíríkiti Wákàtí (12 vs 24)</key>
+			<key type="lb">Àra Ìda Ìlà</key>
 			<key type="ms">Èto Ìdiwɔ̀n</key>
 			<key type="numbers">Àwɔn nɔ́ńbà</key>
 		</keys>
 		<types>
 			<type key="calendar" type="buddhist">Kàlɛ́ńdà Buddhist</type>
 			<type key="calendar" type="chinese">Kàlɛ́ńdà ti Sháìnà</type>
-			<type key="calendar" type="coptic">↑↑↑</type>
+			<type key="calendar" type="coptic">Èdè Kopti</type>
 			<type key="calendar" type="dangi">Kàlɛ́ńdà dangi</type>
 			<type key="calendar" type="ethiopic">Kàlɛ́ńdà Ɛtíópíìkì</type>
-			<type key="calendar" type="ethiopic-amete-alem">↑↑↑</type>
+			<type key="calendar" type="ethiopic-amete-alem">Èdè Kalenda Alem Amete tio Etiopia</type>
 			<type key="calendar" type="gregorian">Kàlɛ́ńdà Gregory</type>
 			<type key="calendar" type="hebrew">Kàlɛ́ńdà Hébérù</type>
 			<type key="calendar" type="islamic">Kàlɛ́ńdà Lárúbáwá</type>
@@ -870,14 +870,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="cf" type="standard">Ìgúnrégé Gbèdéke Kɔ́rɛ́ńsì</type>
 			<type key="collation" type="ducet">Ètò Ɛlɛ́sɛɛsɛ Àkùàyàn Unicode</type>
 			<type key="collation" type="search">Ìshàwárí Ète-Gbogbogbò</type>
-			<type key="collation" type="standard">↑↑↑</type>
-			<type key="hc" type="h11">↑↑↑</type>
-			<type key="hc" type="h12">↑↑↑</type>
-			<type key="hc" type="h23">↑↑↑</type>
-			<type key="hc" type="h24">↑↑↑</type>
-			<type key="lb" type="loose">↑↑↑</type>
-			<type key="lb" type="normal">↑↑↑</type>
-			<type key="lb" type="strict">↑↑↑</type>
+			<type key="collation" type="standard">Ìlànà Onírúurú Ètò</type>
+			<type key="hc" type="h11">Èto Wákàtí 12 (0–11)</type>
+			<type key="hc" type="h12">Èto Wákàtí 12 (1–12)</type>
+			<type key="hc" type="h23">Èto Wákàtí 24 (0–23)</type>
+			<type key="hc" type="h24">Èto Wákàtí 24 (1–24)</type>
+			<type key="lb" type="loose">Àra Ìda Ìlà Títú</type>
+			<type key="lb" type="normal">Àra Ìda Ìlà Déédéé</type>
+			<type key="lb" type="strict">Àra Ìda Ìlà Mímúná</type>
 			<type key="ms" type="metric">Èto Mɛ́tíríìkì</type>
 			<type key="ms" type="uksystem">Èto Ìdiwɔ̀n Ɔba</type>
 			<type key="ms" type="ussystem">Èto Ìdiwɔ̀n US</type>
@@ -928,9 +928,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<measurementSystemName type="US">↑↑↑</measurementSystemName>
 		</measurementSystemNames>
 		<codePatterns>
-			<codePattern type="language">↑↑↑</codePattern>
+			<codePattern type="language">Èdè: {0}</codePattern>
 			<codePattern type="script">Ìshɔwɔ́kɔ̀wé: {0}</codePattern>
-			<codePattern type="territory">↑↑↑</codePattern>
+			<codePattern type="territory">Àgbègbè: {0}</codePattern>
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
@@ -983,26 +983,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, d MM y G</pattern>
+							<datetimeSkeleton>GyMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MM y G</pattern>
+							<datetimeSkeleton>GyMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MM y G</pattern>
+							<datetimeSkeleton>GyMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>dd/MM/y G</pattern>
+							<datetimeSkeleton>GyMMdd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -1012,7 +1012,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'ní' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1020,7 +1020,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'ní' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1028,7 +1028,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1036,7 +1036,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1053,33 +1053,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="Ehms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EHms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="h">↑↑↑</dateFormatItem>
 						<dateFormatItem id="H">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hm">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hm">h:mm a</dateFormatItem>
 						<dateFormatItem id="Hm">↑↑↑</dateFormatItem>
 						<dateFormatItem id="hms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Hms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Md">M/d</dateFormatItem>
+						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMMEd">E, MMMM d</dateFormatItem>
 						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="y">y</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
@@ -1208,16 +1208,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
 							<month type="1">Shɛ́r</month>
-							<month type="2">↑↑↑</month>
+							<month type="2">Èrèl</month>
 							<month type="3">Ɛrɛ̀n</month>
-							<month type="4">↑↑↑</month>
+							<month type="4">Ìgb</month>
 							<month type="5">Ɛ̀bi</month>
-							<month type="6">↑↑↑</month>
+							<month type="6">Òkú</month>
 							<month type="7">Agɛ</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="8">Ògú</month>
+							<month type="9">Owe</month>
 							<month type="10">Ɔ̀wà</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">Bél</month>
 							<month type="12">Ɔ̀pɛ</month>
 						</monthWidth>
 						<monthWidth type="narrow">
@@ -1252,44 +1252,44 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
 							<month type="1">Shɛ́</month>
-							<month type="2">↑↑↑</month>
+							<month type="2">Èr</month>
 							<month type="3">Ɛr</month>
-							<month type="4">↑↑↑</month>
+							<month type="4">Ìg</month>
 							<month type="5">Ɛ̀b</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="6">Òk</month>
+							<month type="7">Ag</month>
+							<month type="8">Òg</month>
+							<month type="9">Ow</month>
 							<month type="10">Ɔ̀w</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">Bé</month>
 							<month type="12">Ɔ̀p</month>
 						</monthWidth>
 						<monthWidth type="narrow">
-							<month type="1">↑↑↑</month>
-							<month type="2">↑↑↑</month>
+							<month type="1">S</month>
+							<month type="2">È</month>
 							<month type="3">Ɛ</month>
-							<month type="4">↑↑↑</month>
+							<month type="4">Ì</month>
 							<month type="5">Ɛ̀</month>
-							<month type="6">↑↑↑</month>
-							<month type="7">↑↑↑</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="6">Ò</month>
+							<month type="7">A</month>
+							<month type="8">Ò</month>
+							<month type="9">O</month>
 							<month type="10">Ɔ̀</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">B</month>
 							<month type="12">Ɔ̀</month>
 						</monthWidth>
 						<monthWidth type="wide">
 							<month type="1">Shɛ́rɛ́</month>
-							<month type="2">↑↑↑</month>
+							<month type="2">Èrèlè</month>
 							<month type="3">Ɛrɛ̀nà</month>
-							<month type="4">↑↑↑</month>
+							<month type="4">Ìgbé</month>
 							<month type="5">Ɛ̀bibi</month>
-							<month type="6">↑↑↑</month>
+							<month type="6">Òkúdu</month>
 							<month type="7">Agɛmɔ</month>
-							<month type="8">↑↑↑</month>
-							<month type="9">↑↑↑</month>
+							<month type="8">Ògún</month>
+							<month type="9">Owewe</month>
 							<month type="10">Ɔ̀wàrà</month>
-							<month type="11">↑↑↑</month>
+							<month type="11">Bélú</month>
 							<month type="12">Ɔ̀pɛ̀</month>
 						</monthWidth>
 					</monthContext>
@@ -1297,13 +1297,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
+							<day type="sun">Àìk</day>
+							<day type="mon">Aj</day>
 							<day type="tue">Ìsɛ́g</day>
 							<day type="wed">Ɔjɔ́r</day>
 							<day type="thu">Ɔjɔ́b</day>
 							<day type="fri">Ɛt</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">Àbám</day>
 						</dayWidth>
 						<dayWidth type="narrow">
 							<day type="sun">↑↑↑</day>
@@ -1344,13 +1344,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
-							<day type="tue">↑↑↑</day>
+							<day type="sun">À</day>
+							<day type="mon">A</day>
+							<day type="tue">Ì</day>
 							<day type="wed">Ɔ</day>
 							<day type="thu">Ɔ</day>
 							<day type="fri">Ɛ</day>
-							<day type="sat">↑↑↑</day>
+							<day type="sat">À</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">↑↑↑</day>
@@ -1362,8 +1362,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">↑↑↑</day>
-							<day type="mon">↑↑↑</day>
+							<day type="sun">Àìkú</day>
+							<day type="mon">Ajé</day>
 							<day type="tue">Ìsɛ́gun</day>
 							<day type="wed">↑↑↑</day>
 							<day type="thu">↑↑↑</day>
@@ -1381,8 +1381,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
+							<quarter type="1">kíní</quarter>
+							<quarter type="2">Kejì</quarter>
 							<quarter type="3">Kɛta</quarter>
 							<quarter type="4">Kɛin</quarter>
 						</quarterWidth>
@@ -1401,8 +1401,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
-							<quarter type="1">↑↑↑</quarter>
-							<quarter type="2">↑↑↑</quarter>
+							<quarter type="1">kí</quarter>
+							<quarter type="2">Ke</quarter>
 							<quarter type="3">Kɛt</quarter>
 							<quarter type="4">Kɛr</quarter>
 						</quarterWidth>
@@ -1446,41 +1446,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</dayPeriods>
 				<eras>
 					<eraNames>
-						<era type="0">↑↑↑</era>
+						<era type="0">Saju Kristi</era>
 						<era type="0" alt="variant">Sáájú ìgbà mímɔ̀</era>
-						<era type="1">↑↑↑</era>
+						<era type="1">Lehin Kristi</era>
 						<era type="1" alt="variant">↑↑↑</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">↑↑↑</era>
 						<era type="0" alt="variant">↑↑↑</era>
-						<era type="1">↑↑↑</era>
-						<era type="1" alt="variant">↑↑↑</era>
+						<era type="1">AD</era>
+						<era type="1" alt="variant">CE</era>
 					</eraAbbr>
 				</eras>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>EEEE, d MMM y</pattern>
+							<datetimeSkeleton>yMMMEEEEd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="long">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MMM y</pattern>
+							<datetimeSkeleton>yMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d MM y</pattern>
+							<datetimeSkeleton>yMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="short">
 						<dateFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>d/M/y</pattern>
+							<datetimeSkeleton>yMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 				</dateFormats>
@@ -1493,20 +1493,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					</timeFormatLength>
 					<timeFormatLength type="long">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>H:mm:ss z</pattern>
+							<datetimeSkeleton>Hmmssz</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="medium">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>H:m:s</pattern>
+							<datetimeSkeleton>Hms</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="short">
 						<timeFormat>
-							<pattern>↑↑↑</pattern>
-							<datetimeSkeleton>↑↑↑</datetimeSkeleton>
+							<pattern>H:m</pattern>
+							<datetimeSkeleton>Hm</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 				</timeFormats>
@@ -1516,7 +1516,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'ní' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1524,7 +1524,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1} 'níti' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1532,7 +1532,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">
@@ -1540,7 +1540,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>↑↑↑</pattern>
+							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<availableFormats>
@@ -1551,46 +1551,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="E">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EBhm">↑↑↑</dateFormatItem>
 						<dateFormatItem id="EBhms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ehm">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Ed">E, d</dateFormatItem>
+						<dateFormatItem id="Ehm">E h:mm a</dateFormatItem>
 						<dateFormatItem id="EHm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Ehms">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Ehms">E h:mm:ss a</dateFormatItem>
 						<dateFormatItem id="EHms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Gy">↑↑↑</dateFormatItem>
-						<dateFormatItem id="GyMd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="GyMd">d/M/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="GyMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="h">↑↑↑</dateFormatItem>
+						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hm">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hm">h:mm a</dateFormatItem>
 						<dateFormatItem id="Hm">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hms">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hms">h:mm:ss a</dateFormatItem>
 						<dateFormatItem id="Hms">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hmsv">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hmsv">h:mm:ss a v</dateFormatItem>
 						<dateFormatItem id="Hmsv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hmv">↑↑↑</dateFormatItem>
+						<dateFormatItem id="hmv">h:mm a v</dateFormatItem>
 						<dateFormatItem id="Hmv">↑↑↑</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Md">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Md">d/M</dateFormatItem>
+						<dateFormatItem id="MEd">E, d/M</dateFormatItem>
 						<dateFormatItem id="MMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="MMMMEd">↑↑↑</dateFormatItem>
+						<dateFormatItem id="MMMd">d MMM</dateFormatItem>
+						<dateFormatItem id="MMMEd">d MMM, E</dateFormatItem>
+						<dateFormatItem id="MMMMd">d MMMM</dateFormatItem>
+						<dateFormatItem id="MMMMEd">d, MMMM E</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">↑↑↑</dateFormatItem>
 						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMEd">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMMMM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQ">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yQQQQ">↑↑↑</dateFormatItem>
+						<dateFormatItem id="yM">M/y</dateFormatItem>
+						<dateFormatItem id="yMd">d/M/y</dateFormatItem>
+						<dateFormatItem id="yMEd">d/M/y, E</dateFormatItem>
+						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMd">d MMM y</dateFormatItem>
+						<dateFormatItem id="yMMMEd">E, d MMM , y</dateFormatItem>
+						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
+						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
+						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>
 						<dateFormatItem id="yw" count="other">↑↑↑</dateFormatItem>
 					</availableFormats>
 					<appendItems>
@@ -1611,71 +1611,71 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="d">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Gy">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
+							<greatestDifference id="G">y G – y G</greatestDifference>
 							<greatestDifference id="y">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">M/y G – M/y G</greatestDifference>
+							<greatestDifference id="M">M/y – M/y G</greatestDifference>
+							<greatestDifference id="y">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">M/d/y – M/d/y G</greatestDifference>
+							<greatestDifference id="G">M/d/y G – M/d/y G</greatestDifference>
+							<greatestDifference id="M">M/d/y – M/d/y G</greatestDifference>
+							<greatestDifference id="y">M/d/y – M/d/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, M/d/y – E, M/d/y G</greatestDifference>
+							<greatestDifference id="G">E, M/d/y G – E, M/d/y G</greatestDifference>
+							<greatestDifference id="M">E, M/d/y – E, M/d/y G</greatestDifference>
+							<greatestDifference id="y">E, M/d/y – E, M/d/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d – d, y G</greatestDifference>
+							<greatestDifference id="G">MMM d, y G – MMM d, y G</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d, y G</greatestDifference>
+							<greatestDifference id="y">MMM d, y – MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="G">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="G">E, MMM d, y G – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="M">E, MMM d – E, MMM d, y G</greatestDifference>
+							<greatestDifference id="y">E, MMM d, y – E, MMM d, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a</greatestDifference>
+							<greatestDifference id="h">h–h a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="H">
 							<greatestDifference id="H">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hm">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hm">
 							<greatestDifference id="H">↑↑↑</greatestDifference>
 							<greatestDifference id="m">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
-							<greatestDifference id="m">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h:mm a – h:mm a v</greatestDifference>
+							<greatestDifference id="h">h:mm–h:mm a v</greatestDifference>
+							<greatestDifference id="m">h:mm–h:mm a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hmv">
 							<greatestDifference id="H">↑↑↑</greatestDifference>
 							<greatestDifference id="m">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
-							<greatestDifference id="a">↑↑↑</greatestDifference>
-							<greatestDifference id="h">↑↑↑</greatestDifference>
+							<greatestDifference id="a">h a – h a v</greatestDifference>
+							<greatestDifference id="h">h–h a v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H">↑↑↑</greatestDifference>
@@ -1684,58 +1684,58 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="M">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Md">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd – MM-dd</greatestDifference>
+							<greatestDifference id="M">MM-dd – MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MM-dd, E – MM-dd, E</greatestDifference>
+							<greatestDifference id="M">MM-dd, E – MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">↑↑↑</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MM-y – MM-y</greatestDifference>
+							<greatestDifference id="y">y-MM – y-MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="M">y-MM-dd – y-MM-dd</greatestDifference>
+							<greatestDifference id="y">y-MM-dd – y-MM-dd</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">E, dd-MM-y – E dd-MM-y, E</greatestDifference>
+							<greatestDifference id="M">y-MM-dd, E – y-MM-dd, E</greatestDifference>
+							<greatestDifference id="y">y-MM-dd, E – y-MM-dd, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="y">y MMM – y MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d–d y</greatestDifference>
+							<greatestDifference id="M">MMM d – MMM d y</greatestDifference>
+							<greatestDifference id="y">y MMM d – y MMM d</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">↑↑↑</greatestDifference>
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="d">MMM d, E – MMM d, E y</greatestDifference>
+							<greatestDifference id="M">MMM d, E – MMM d, E y</greatestDifference>
+							<greatestDifference id="y">y MMM d y, E – MMM d, E y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">↑↑↑</greatestDifference>
-							<greatestDifference id="y">↑↑↑</greatestDifference>
+							<greatestDifference id="M">MMMM–MMMM y</greatestDifference>
+							<greatestDifference id="y">MMMM – y MMMM y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>
@@ -1743,13 +1743,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 		<fields>
 			<field type="era">
-				<displayName>↑↑↑</displayName>
+				<displayName>sáà</displayName>
 			</field>
 			<field type="era-short">
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sáà</displayName>
 			</field>
 			<field type="year">
 				<displayName>Ɔdún</displayName>
@@ -1818,7 +1818,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="month">
-				<displayName>↑↑↑</displayName>
+				<displayName>Osù</displayName>
 				<relative type="-1">óshù tó kɔjá</relative>
 				<relative type="0">oshù yìí</relative>
 				<relative type="1">óshù tó ń bɔ̀,</relative>
@@ -1904,10 +1904,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="day">
 				<displayName>Ɔjɔ́</displayName>
 				<relative type="-2">íjɛta</relative>
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">Àná</relative>
+				<relative type="0">Òní</relative>
 				<relative type="1">Ɔ̀la</relative>
-				<relative type="2">↑↑↑</relative>
+				<relative type="2">òtúùnla</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
 				</relativeTime>
@@ -2059,7 +2059,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<relative type="0">Ìshɛ́gun yì</relative>
 				<relative type="1">Ìshɛ́gun tɔ́ńbɔ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">+{0} Ìs</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} Ìs tɛ́lɛ̀</relativeTimePattern>
@@ -2088,11 +2088,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="wed-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">O àná</relative>
+				<relative type="0">O yì</relative>
 				<relative type="1">O tóńbɔ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">ní {0} O</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} W tɛ́lɛ̀</relativeTimePattern>
@@ -2132,55 +2132,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="fri">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">E̩tì tóko̩já</relative>
+				<relative type="0">E̩tì èyí</relative>
+				<relative type="1">E̩tì tómbò̩</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Àwo̩n Eti</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Àwo̩n E̩tì té̩lè̩</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">Etì àná</relative>
+				<relative type="0">Etì yì</relative>
 				<relative type="1">Et tónbɔ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Et</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} Et sɛ́yìn</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="fri-narrow">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">F tóko̩já</relative>
+				<relative type="0">F èyí</relative>
+				<relative type="1">F tómbò̩</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} F</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} F tɛ́lɛ̀</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="-1">Abameta tóko̩já</relative>
+				<relative type="0">Abameta eyi</relative>
+				<relative type="1">Abameta tombo</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Awon Abameta</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Abameta tokoja</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="sat-short">
-				<relative type="-1">↑↑↑</relative>
-				<relative type="0">↑↑↑</relative>
+				<relative type="-1">Aba tókojá</relative>
+				<relative type="0">Aba èyí</relative>
 				<relative type="1">Aba tónbɔ̀</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Aba</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} Aba. sɛ́yìn</relativeTimePattern>
@@ -2188,10 +2188,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="sat-narrow">
 				<relative type="-1">Ab sɛ́yìn</relative>
-				<relative type="0">↑↑↑</relative>
-				<relative type="1">↑↑↑</relative>
+				<relative type="0">Ab èyí</relative>
+				<relative type="1">Ab tónbò</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
+					<relativeTimePattern count="other">{0} Ab</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="other">{0} Ab ɛ̀yí</relativeTimePattern>
@@ -2207,7 +2207,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 			</field>
 			<field type="hour">
-				<displayName>↑↑↑</displayName>
+				<displayName>Wákàtí</displayName>
 				<relative type="0">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other">↑↑↑</relativeTimePattern>
@@ -2291,7 +2291,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="zone">
-				<displayName>↑↑↑</displayName>
+				<displayName>Agbègbè àkókò</displayName>
 			</field>
 			<field type="zone-short">
 				<displayName>↑↑↑</displayName>
@@ -2302,11 +2302,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</fields>
 		<timeZoneNames>
 			<hourFormat>↑↑↑</hourFormat>
-			<gmtFormat>↑↑↑</gmtFormat>
-			<gmtZeroFormat>↑↑↑</gmtZeroFormat>
-			<regionFormat>↑↑↑</regionFormat>
+			<gmtFormat>WAT{0}</gmtFormat>
+			<gmtZeroFormat>WAT</gmtZeroFormat>
+			<regionFormat>Ìgbà {0}</regionFormat>
 			<regionFormat type="daylight">{0} Àkókò ojúmɔmɔ</regionFormat>
-			<regionFormat type="standard">↑↑↑</regionFormat>
+			<regionFormat type="standard">{0} Ìlànà Àkókò</regionFormat>
 			<fallbackFormat>↑↑↑</fallbackFormat>
 			<zone type="Etc/UTC">
 				<long>
@@ -2326,10 +2326,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Antigua">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Antígùà</exemplarCity>
 			</zone>
 			<zone type="America/Anguilla">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Angúílà</exemplarCity>
 			</zone>
 			<zone type="Europe/Tirane">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2452,7 +2452,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Aruba">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Arúbá</exemplarCity>
 			</zone>
 			<zone type="Europe/Mariehamn">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2488,7 +2488,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/St_Barthelemy">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Batilemì</exemplarCity>
 			</zone>
 			<zone type="Atlantic/Bermuda">
 				<exemplarCity>ìlú Bɛ̀múdà</exemplarCity>
@@ -2551,7 +2551,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Nassau">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Nasaò</exemplarCity>
 			</zone>
 			<zone type="Asia/Thimphu">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2566,82 +2566,82 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>ìlú Bɛ̀líìsì</exemplarCity>
 			</zone>
 			<zone type="America/Dawson">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Dawson</exemplarCity>
 			</zone>
 			<zone type="America/Whitehorse">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Whitehosì</exemplarCity>
 			</zone>
 			<zone type="America/Inuvik">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Inuvik</exemplarCity>
 			</zone>
 			<zone type="America/Vancouver">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Vankuva</exemplarCity>
 			</zone>
 			<zone type="America/Fort_Nelson">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Fort Nelson</exemplarCity>
 			</zone>
 			<zone type="America/Dawson_Creek">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Dawson Creek</exemplarCity>
 			</zone>
 			<zone type="America/Creston">
 				<exemplarCity>ìlú Kírɛstɔ́ɔ̀nù</exemplarCity>
 			</zone>
 			<zone type="America/Yellowknife">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Yelonáfù</exemplarCity>
 			</zone>
 			<zone type="America/Edmonton">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Edmonton</exemplarCity>
 			</zone>
 			<zone type="America/Swift_Current">
 				<exemplarCity>ìlú Súfítù Kɔ̀rentì</exemplarCity>
 			</zone>
 			<zone type="America/Cambridge_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú òkun kambíríìjì</exemplarCity>
 			</zone>
 			<zone type="America/Regina">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Regina</exemplarCity>
 			</zone>
 			<zone type="America/Winnipeg">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Winipegì</exemplarCity>
 			</zone>
 			<zone type="America/Resolute">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Resolútì</exemplarCity>
 			</zone>
 			<zone type="America/Rainy_River">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Raini Rifà</exemplarCity>
 			</zone>
 			<zone type="America/Rankin_Inlet">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Rankin Inlet</exemplarCity>
 			</zone>
 			<zone type="America/Coral_Harbour">
 				<exemplarCity>ìlú àtikɔkàn</exemplarCity>
 			</zone>
 			<zone type="America/Thunder_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Omi Thunder</exemplarCity>
 			</zone>
 			<zone type="America/Nipigon">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Nipigoni</exemplarCity>
 			</zone>
 			<zone type="America/Toronto">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Toronto</exemplarCity>
 			</zone>
 			<zone type="America/Iqaluit">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Iqaluit</exemplarCity>
 			</zone>
 			<zone type="America/Pangnirtung">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Panituni</exemplarCity>
 			</zone>
 			<zone type="America/Moncton">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Montoni</exemplarCity>
 			</zone>
 			<zone type="America/Halifax">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Halifásì</exemplarCity>
 			</zone>
 			<zone type="America/Goose_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú omi Goosù</exemplarCity>
 			</zone>
 			<zone type="America/Glace_Bay">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú omi Glace</exemplarCity>
 			</zone>
 			<zone type="America/Blanc-Sablon">
 				<exemplarCity>ìlú Blank Sabulɔ́ɔ̀nì</exemplarCity>
@@ -2695,10 +2695,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Costa_Rica">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Kosta Ríkà</exemplarCity>
 			</zone>
 			<zone type="America/Havana">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Havana</exemplarCity>
 			</zone>
 			<zone type="Atlantic/Cape_Verde">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2731,10 +2731,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Dominica">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Dominika</exemplarCity>
 			</zone>
 			<zone type="America/Santo_Domingo">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Santo Domigo</exemplarCity>
 			</zone>
 			<zone type="Africa/Algiers">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2798,12 +2798,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<zone type="Europe/London">
 				<long>
-					<daylight>↑↑↑</daylight>
+					<daylight>British Summer Time</daylight>
 				</long>
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Grenada">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Grenada</exemplarCity>
 			</zone>
 			<zone type="Asia/Tbilisi">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2821,16 +2821,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Thule">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Tulè</exemplarCity>
 			</zone>
 			<zone type="America/Godthab">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Nuuk</exemplarCity>
 			</zone>
 			<zone type="America/Scoresbysund">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Itokotomiti</exemplarCity>
 			</zone>
 			<zone type="America/Danmarkshavn">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Banmarkshan</exemplarCity>
 			</zone>
 			<zone type="Africa/Banjul">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2839,7 +2839,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Guadeloupe">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Guadeloupe</exemplarCity>
 			</zone>
 			<zone type="Africa/Malabo">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2851,7 +2851,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Guatemala">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Guatemala</exemplarCity>
 			</zone>
 			<zone type="Pacific/Guam">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2866,13 +2866,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Tegucigalpa">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Tegusigapà</exemplarCity>
 			</zone>
 			<zone type="Europe/Zagreb">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Port-au-Prince">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Port-au-Prince</exemplarCity>
 			</zone>
 			<zone type="Europe/Budapest">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2891,7 +2891,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<zone type="Europe/Dublin">
 				<long>
-					<daylight>↑↑↑</daylight>
+					<daylight>Irish Standard Time</daylight>
 				</long>
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
@@ -2923,7 +2923,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Jamaica">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Jamaikà</exemplarCity>
 			</zone>
 			<zone type="Asia/Amman">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2956,7 +2956,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/St_Kitts">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú St kitisì</exemplarCity>
 			</zone>
 			<zone type="Asia/Pyongyang">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2968,7 +2968,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Cayman">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ilú Kayman</exemplarCity>
 			</zone>
 			<zone type="Asia/Aqtau">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2998,7 +2998,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/St_Lucia">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú St Lusia</exemplarCity>
 			</zone>
 			<zone type="Europe/Vaduz">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3073,13 +3073,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Martinique">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Mátíníkì</exemplarCity>
 			</zone>
 			<zone type="Africa/Nouakchott">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Montserrat">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Monseratì</exemplarCity>
 			</zone>
 			<zone type="Europe/Malta">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3094,16 +3094,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Tijuana">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Tíjúana</exemplarCity>
 			</zone>
 			<zone type="America/Hermosillo">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Hermosilo</exemplarCity>
 			</zone>
 			<zone type="America/Ciudad_Juarez">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Mazatlan">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Masatiani</exemplarCity>
 			</zone>
 			<zone type="America/Chihuahua">
 				<exemplarCity>ìlú Shihuahua</exemplarCity>
@@ -3112,22 +3112,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>ìlú Báhì Bándɛ́rásì</exemplarCity>
 			</zone>
 			<zone type="America/Ojinaga">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Ojinaga</exemplarCity>
 			</zone>
 			<zone type="America/Monterrey">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Monteri</exemplarCity>
 			</zone>
 			<zone type="America/Mexico_City">
 				<exemplarCity>ìlú Mɛ́síkò</exemplarCity>
 			</zone>
 			<zone type="America/Matamoros">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Matamorosì</exemplarCity>
 			</zone>
 			<zone type="America/Merida">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Merida</exemplarCity>
 			</zone>
 			<zone type="America/Cancun">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Kancun</exemplarCity>
 			</zone>
 			<zone type="Asia/Kuala_Lumpur">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3154,7 +3154,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Managua">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Managua</exemplarCity>
 			</zone>
 			<zone type="Europe/Amsterdam">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3181,7 +3181,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Panama">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Panama</exemplarCity>
 			</zone>
 			<zone type="America/Lima">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3217,7 +3217,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Puerto_Rico">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Puerto Riko</exemplarCity>
 			</zone>
 			<zone type="Asia/Gaza">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3385,10 +3385,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/El_Salvador">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú El Savador</exemplarCity>
 			</zone>
 			<zone type="America/Lower_Princes">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Lower Prince’s Quarter</exemplarCity>
 			</zone>
 			<zone type="Asia/Damascus">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3397,7 +3397,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Grand_Turk">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Grand Turk</exemplarCity>
 			</zone>
 			<zone type="Africa/Ndjamena">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3433,7 +3433,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Port_of_Spain">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú etí omi Sípéènì</exemplarCity>
 			</zone>
 			<zone type="Pacific/Funafuti">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3466,10 +3466,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Adak">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Adákì</exemplarCity>
 			</zone>
 			<zone type="America/Nome">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Nomi</exemplarCity>
 			</zone>
 			<zone type="Pacific/Johnston">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3478,79 +3478,79 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>ìlú Ankɔ́réèjì</exemplarCity>
 			</zone>
 			<zone type="America/Yakutat">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Yakuta</exemplarCity>
 			</zone>
 			<zone type="America/Sitka">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Sika</exemplarCity>
 			</zone>
 			<zone type="America/Juneau">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Junu</exemplarCity>
 			</zone>
 			<zone type="America/Metlakatla">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Metilakatila</exemplarCity>
 			</zone>
 			<zone type="America/Los_Angeles">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Los Angeles</exemplarCity>
 			</zone>
 			<zone type="America/Boise">
 				<exemplarCity>ìlú Bɔ́isè</exemplarCity>
 			</zone>
 			<zone type="America/Phoenix">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Fínísì</exemplarCity>
 			</zone>
 			<zone type="America/Denver">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Denver</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/Beulah">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Beulà ní North Dakota</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/New_Salem">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú New Salem ni North Dakota</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/Center">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Senta North Dakota</exemplarCity>
 			</zone>
 			<zone type="America/Chicago">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Chicago</exemplarCity>
 			</zone>
 			<zone type="America/Menominee">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Menominì</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Vincennes">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Vincennes ní Indiana</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Petersburg">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Petersburg</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Tell_City">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Tell City</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Knox">
 				<exemplarCity>ìlú nɔ́sì</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Winamac">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Winamak ní Indiana</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Marengo">
 				<exemplarCity>ìlú Marɛ́ngo</exemplarCity>
 			</zone>
 			<zone type="America/Indianapolis">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Indianapolis</exemplarCity>
 			</zone>
 			<zone type="America/Louisville">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Lúífíìlì</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Vevay">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Vevay</exemplarCity>
 			</zone>
 			<zone type="America/Kentucky/Monticello">
 				<exemplarCity>ìlú Montisɛ́lò</exemplarCity>
 			</zone>
 			<zone type="America/Detroit">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Detroit</exemplarCity>
 			</zone>
 			<zone type="America/New_York">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú New York</exemplarCity>
 			</zone>
 			<zone type="America/Montevideo">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3565,13 +3565,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/St_Vincent">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Finsentì</exemplarCity>
 			</zone>
 			<zone type="America/Caracas">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Tortola">
-				<exemplarCity>↑↑↑</exemplarCity>
+				<exemplarCity>ìlú Totola</exemplarCity>
 			</zone>
 			<zone type="America/St_Thomas">
 				<exemplarCity>ìlú St Tɔ́màsì</exemplarCity>
@@ -3605,22 +3605,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</zone>
 			<metazone type="Afghanistan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Afghanistan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Central">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Àárín Afírikà</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Ìlà-Oòrùn Afírikà</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Southern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>South Africa Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Western">
@@ -3632,7 +3632,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Alaska">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Alásíkà</generic>
 					<standard>Àkókò Àfɛnukò Alásíkà</standard>
 					<daylight>Àkókò Ìyálɛ̀ta Alásíkà</daylight>
 				</long>
@@ -3646,51 +3646,51 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="America_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>àkókò àárín gbùngbùn</generic>
+					<standard>àkókò asiko àárín gbùngbùn</standard>
 					<daylight>Akókò àárín gbùngbùn ojúmɔmɔ</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>Àkókò ìhà ìlà oòrùn</generic>
+					<standard>Akókò Àsikò Ìha Ìla Oòrùn</standard>
 					<daylight>Àkókò ojúmɔmɔ Ìhà Ìlà Oòrun</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Mountain">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>Àkókò òkè</generic>
+					<standard>Àkókò asiko òkè</standard>
 					<daylight>Àkókò ojúmɔmɔ Ori-òkè</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Pacific">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>Àkókò Pàsífíìkì</generic>
+					<standard>Àkókò àsikò Pàsífíìkì</standard>
 					<daylight>Àkókò Ìyálɛta Pàsífíìkì</daylight>
 				</long>
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Apia Time</generic>
+					<standard>Apia Standard Time</standard>
+					<daylight>Apia Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Arabian Time</generic>
+					<standard>Arabian Standard Time</standard>
+					<daylight>Arabian Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina">
 				<long>
 					<generic>Aago Ajɛntìnà</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<standard>Aago àsìkò Argentina</standard>
+					<daylight>Aago Soma Argentina</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina_Western">
@@ -3702,51 +3702,51 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Armenia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Armenia Time</generic>
+					<standard>Armenia Standard Time</standard>
+					<daylight>Armenia Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Atlantic">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>Àkókò Àtìláńtíìkì</generic>
+					<standard>Àkókò àsikò Àtìláńtíìkì</standard>
 					<daylight>Àkókò Ìyálɛta Àtìláńtíìkì</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Central Australia Time</generic>
+					<standard>Australian Central Standard Time</standard>
+					<daylight>Australian Central Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_CentralWestern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Australian Central Western Time</generic>
+					<standard>Australian Central Western Standard Time</standard>
+					<daylight>Australian Central Western Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Eastern Australia Time</generic>
+					<standard>Australian Eastern Standard Time</standard>
+					<daylight>Australian Eastern Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Western">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Western Australia Time</generic>
+					<standard>Australian Western Standard Time</standard>
+					<daylight>Australian Western Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Azerbaijan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Azerbaijan Time</generic>
+					<standard>Azerbaijan Standard Time</standard>
+					<daylight>Azerbaijan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Azores">
@@ -3758,50 +3758,50 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Bangladesh">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Bangladesh Time</generic>
+					<standard>Bangladesh Standard Time</standard>
+					<daylight>Bangladesh Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Bhutan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Bhutan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Bolivia">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Aago Bolivia</standard>
 				</long>
 			</metazone>
 			<metazone type="Brasilia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Aago Bùràsílíà</generic>
+					<standard>Aago àsìkò Bùràsílíà</standard>
+					<daylight>Aago Soma Brasilia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Brunei">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Brunei Darussalam Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Cape_Verde">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Képú Fáàdì</generic>
 					<standard>Àkókò Àfɛnukò Képú Fáàdì</standard>
 					<daylight>Àkókò Sɔ́mà Képú Fáàdì</daylight>
 				</long>
 			</metazone>
 			<metazone type="Chamorro">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Chamorro Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Chatham">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Chatham Time</generic>
+					<standard>Chatham Standard Time</standard>
+					<daylight>Chatham Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Chile">
@@ -3820,86 +3820,86 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Choibalsan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Choibalsan Time</generic>
+					<standard>Choibalsan Standard Time</standard>
+					<daylight>Choibalsan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Christmas">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Christmas Island Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Cocos">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Cocos Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Colombia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Aago Kolombia</generic>
+					<standard>Aago àsìkò Kolombia</standard>
+					<daylight>Aago Soma Colombia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cook">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Cook Islands Time</generic>
+					<standard>Cook Islands Standard Time</standard>
+					<daylight>Cook Islands Half Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cuba">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Kúbà</generic>
 					<standard>Àkókò Àfɛnukò Kúbà</standard>
 					<daylight>Àkókò Ojúmɔmɔ Kúbà</daylight>
 				</long>
 			</metazone>
 			<metazone type="Davis">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Davis Time</standard>
 				</long>
 			</metazone>
 			<metazone type="DumontDUrville">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Dumont-d’Urville Time</standard>
 				</long>
 			</metazone>
 			<metazone type="East_Timor">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Ìlà oorùn Timor</standard>
 				</long>
 			</metazone>
 			<metazone type="Easter">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Aago Ajnde Ibùgbé Omi</generic>
+					<standard>Aago àsìkò Easter Island</standard>
+					<daylight>Aago Soma Easter Island</daylight>
 				</long>
 			</metazone>
 			<metazone type="Ecuador">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Aago Ecuador</standard>
 				</long>
 			</metazone>
 			<metazone type="Europe_Central">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>Àkókò Àárin Europe</generic>
+					<standard>Àkókò Àárin àsikò Europe</standard>
 					<daylight>Àkókò Àárin Sɔmà Europe</daylight>
 				</long>
 			</metazone>
 			<metazone type="Europe_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>Àkókò Ìhà Ìlà Oòrùn Europe</generic>
+					<standard>Àkókò àsikò Ìhà Ìlà Oòrùn Europe</standard>
 					<daylight>Àkókò Sɔmà Ìha Ìlà Oòrùn Europe</daylight>
 				</long>
 			</metazone>
 			<metazone type="Europe_Further_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Iwájú Ìlà Oòrùn Yúróòpù</standard>
 				</long>
 			</metazone>
 			<metazone type="Europe_Western">
@@ -3911,60 +3911,60 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Falkland">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Fókílándì</generic>
 					<standard>Àkókò Àfɛnukò Etíkun Fókílándì</standard>
-					<daylight>↑↑↑</daylight>
+					<daylight>Àkókò Ooru Etíkun Fókílándì</daylight>
 				</long>
 			</metazone>
 			<metazone type="Fiji">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Fiji Time</generic>
+					<standard>Fiji Standard Time</standard>
+					<daylight>Fiji Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="French_Guiana">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Gúyánà Fáránsè</standard>
 				</long>
 			</metazone>
 			<metazone type="French_Southern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Gúsù Fáransé àti Àntátíìkì</standard>
 				</long>
 			</metazone>
 			<metazone type="Galapagos">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Aago Galapago</standard>
 				</long>
 			</metazone>
 			<metazone type="Gambier">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Gambier Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Georgia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Georgia Time</generic>
+					<standard>Georgia Standard Time</standard>
+					<daylight>Georgia Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Gilbert_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Gilbert Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="GMT">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Greenwich Mean Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Greenland_Eastern">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Ìlà oorùn Greenland</generic>
 					<standard>Àkókò Ìwɔ̀ Ìfɛnukò oorùn Greenland</standard>
-					<daylight>↑↑↑</daylight>
+					<daylight>Àkókò ìgbà Ooru Greenland</daylight>
 				</long>
 			</metazone>
 			<metazone type="Greenland_Western">
@@ -3976,58 +3976,58 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Gulf">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Gulf Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Guyana">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Gúyànà</standard>
 				</long>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Hawaii-Aleutian</generic>
 					<standard>Àkókò Àfɛnukò Hawaii-Aleutian</standard>
 					<daylight>Àkókò Ojúmɔmɔ Hawaii-Aleutian</daylight>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Hong Kong Time</generic>
+					<standard>Hong Kong Standard Time</standard>
+					<daylight>Hong Kong Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Hovd">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Hovd Time</generic>
+					<standard>Hovd Standard Time</standard>
+					<daylight>Hovd Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="India">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>India Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Indian_Ocean">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Etíkun Índíà</standard>
 				</long>
 			</metazone>
 			<metazone type="Indochina">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Indochina</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Central">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Ààrin Gbùngbùn Indonesia</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Eastern Indonesia Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Western">
@@ -4037,108 +4037,108 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Iran">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Iran Time</generic>
+					<standard>Iran Standard Time</standard>
+					<daylight>Iran Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Irkutsk">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Íkósíkì</generic>
 					<standard>Àkókò Àfɛnukò Íkósíkì</standard>
 					<daylight>Àkókò Sɔmà Íkúsíkì</daylight>
 				</long>
 			</metazone>
 			<metazone type="Israel">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Israel Time</generic>
+					<standard>Israel Standard Time</standard>
+					<daylight>Israel Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Japan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Japan Time</generic>
+					<standard>Japan Standard Time</standard>
+					<daylight>Japan Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kazakhstan_Eastern">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>East Kazakhstan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Kazakhstan_Western">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>West Kazakhstan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Korea">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Korean Time</generic>
+					<standard>Korean Standard Time</standard>
+					<daylight>Korean Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kosrae">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Kosrae Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Krasnoyarsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Krasnoyarsk Time</generic>
+					<standard>Krasnoyarsk Standard Time</standard>
+					<daylight>Krasnoyarsk Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kyrgystan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Kyrgyzstan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Line_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Line Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Lord_Howe">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Lord Howe Time</generic>
+					<standard>Lord Howe Standard Time</standard>
+					<daylight>Lord Howe Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Macquarie">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Macquarie Island Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Magadan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Magadan Time</generic>
+					<standard>Magadan Standard Time</standard>
+					<daylight>Magadan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Malaysia">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Malaysia Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Maldives">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Maldives Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Marquesas">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Marquesas Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Marshall_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Marshall Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Mauritius">
@@ -4150,7 +4150,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Mawson">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Mawson Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Northwest">
@@ -4169,150 +4169,150 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Mongolia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Ulaanbaatar Time</generic>
+					<standard>Ulaanbaatar Standard Time</standard>
+					<daylight>Ulaanbaatar Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Moscow">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Moscow Time</generic>
+					<standard>Moscow Standard Time</standard>
+					<daylight>Moscow Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Myanmar">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Myanmar Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Nauru">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Nauru Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Nepal">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Nepal Time</standard>
 				</long>
 			</metazone>
 			<metazone type="New_Caledonia">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>New Caledonia Time</generic>
+					<standard>New Caledonia Standard Time</standard>
+					<daylight>New Caledonia Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="New_Zealand">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>New Zealand Time</generic>
+					<standard>New Zealand Standard Time</standard>
+					<daylight>New Zealand Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Newfoundland">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Newfoundland</generic>
 					<standard>Àkókò Àfɛnukò Newfoundland</standard>
 					<daylight>Àkókò Ojúmɔmɔ Newfoundland</daylight>
 				</long>
 			</metazone>
 			<metazone type="Niue">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Niue Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Norfolk">
 				<long>
-					<generic draft="contributed">↑↑↑</generic>
-					<standard draft="contributed">↑↑↑</standard>
-					<daylight draft="contributed">↑↑↑</daylight>
+					<generic draft="contributed">Norfolk Island Time</generic>
+					<standard draft="contributed">Norfolk Island Standard Time</standard>
+					<daylight draft="contributed">Norfolk Island Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Noronha">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Aago Fenando de Norona</generic>
+					<standard>Aago àsìkò Fenando de Norona</standard>
+					<daylight>Aago Soma Fernando de Noronha</daylight>
 				</long>
 			</metazone>
 			<metazone type="Novosibirsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Novosibirsk Time</generic>
+					<standard>Novosibirsk Standard Time</standard>
+					<daylight>Novosibirsk Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Omsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Omsk Time</generic>
+					<standard>Omsk Standard Time</standard>
+					<daylight>Omsk Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Pakistan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Pakistan Time</generic>
+					<standard>Pakistan Standard Time</standard>
+					<daylight>Pakistan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Palau">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Palau Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Papua_New_Guinea">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Papua New Guinea Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Paraguay">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Párágúwè</generic>
 					<standard>Àkókò Àfɛnukò Párágúwè</standard>
-					<daylight>↑↑↑</daylight>
+					<daylight>Àkókò Ooru Párágúwè</daylight>
 				</long>
 			</metazone>
 			<metazone type="Peru">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Pérù</generic>
 					<standard>Àkókò Àfɛnukò Pérù</standard>
-					<daylight>↑↑↑</daylight>
+					<daylight>Àkókò Ooru Pérù</daylight>
 				</long>
 			</metazone>
 			<metazone type="Philippines">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Philippine Time</generic>
+					<standard>Philippine Standard Time</standard>
+					<daylight>Philippine Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Phoenix_Islands">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Phoenix Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Pierre_Miquelon">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Àkókò Pierre &amp; Miquelon</generic>
 					<standard>Àkókò Àfɛnukò Pierre &amp; Miquelon</standard>
 					<daylight>Àkókò Ojúmɔmɔ Pierre &amp; Miquelon</daylight>
 				</long>
 			</metazone>
 			<metazone type="Pitcairn">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Pitcairn Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Ponape">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Ponape Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Pyongyang">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Pyongyang Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Reunion">
@@ -4322,21 +4322,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Rothera">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Rothera Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Sakhalin">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Sakhalin Time</generic>
+					<standard>Sakhalin Standard Time</standard>
+					<daylight>Sakhalin Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Samoa">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Samoa Time</generic>
+					<standard>Samoa Standard Time</standard>
+					<daylight>Samoa Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Seychelles">
@@ -4346,12 +4346,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Singapore">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Singapore Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Solomon">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Solomon Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="South_Georgia">
@@ -4361,127 +4361,127 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Suriname">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Àkókò Súrínámù</standard>
 				</long>
 			</metazone>
 			<metazone type="Syowa">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Syowa Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Tahiti">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tahiti Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Taipei">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Taipei Time</generic>
+					<standard>Taipei Standard Time</standard>
+					<daylight>Taipei Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Tajikistan">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tajikistan Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Tokelau">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tokelau Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Tonga">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Tonga Time</generic>
+					<standard>Tonga Standard Time</standard>
+					<daylight>Tonga Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Truk">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Chuuk Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Turkmenistan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Turkmenistan Time</generic>
+					<standard>Turkmenistan Standard Time</standard>
+					<daylight>Turkmenistan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Tuvalu">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Tuvalu Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Uruguay">
 				<long>
-					<generic>↑↑↑</generic>
+					<generic>Aago Uruguay</generic>
 					<standard>Àkókò Àfɛnukò Úrúgúwè</standard>
-					<daylight>↑↑↑</daylight>
+					<daylight>Aago Soma Uruguay</daylight>
 				</long>
 			</metazone>
 			<metazone type="Uzbekistan">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Uzbekistan Time</generic>
+					<standard>Uzbekistan Standard Time</standard>
+					<daylight>Uzbekistan Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Vanuatu">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Vanuatu Time</generic>
+					<standard>Vanuatu Standard Time</standard>
+					<daylight>Vanuatu Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Venezuela">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Aago Venezuela</standard>
 				</long>
 			</metazone>
 			<metazone type="Vladivostok">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Vladivostok Time</generic>
+					<standard>Vladivostok Standard Time</standard>
+					<daylight>Vladivostok Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Volgograd">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Volgograd Time</generic>
+					<standard>Volgograd Standard Time</standard>
+					<daylight>Volgograd Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Vostok">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Vostok Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Wake">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Wake Island Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Wallis">
 				<long>
-					<standard>↑↑↑</standard>
+					<standard>Wallis &amp; Futuna Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Yakutsk">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Yakutsk Time</generic>
+					<standard>Yakutsk Standard Time</standard>
+					<daylight>Yakutsk Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Yekaterinburg">
 				<long>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
+					<generic>Yekaterinburg Time</generic>
+					<standard>Yekaterinburg Standard Time</standard>
+					<daylight>Yekaterinburg Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Yukon">
@@ -4566,46 +4566,46 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber" draft="provisional">↑↑↑</pattern>
+					<pattern>¤#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber" draft="provisional">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="other">¤0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="10000" count="other">¤00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="100000" count="other">¤000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="1000000" count="other">¤0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="10000000" count="other">¤00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="100000000" count="other">¤000M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
+					<pattern type="1000000000" count="other">¤0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
+					<pattern type="10000000000" count="other">¤00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
+					<pattern type="100000000000" count="other">¤000B</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
+					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
-			<unitPattern count="other">↑↑↑</unitPattern>
+			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
+			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="AED">
@@ -4614,7 +4614,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AFN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Afugánì Afuganísítàànì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4631,12 +4631,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ANG">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gílídà Netherlands Antillean</displayName>
 				<displayName count="other">àwɔn gílídà Netherlands Antillean</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AOA">
-				<displayName>↑↑↑</displayName>
+				<displayName>kíwánsà Angola</displayName>
 				<displayName count="other">àwɔn kíwánsà Angola</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4654,18 +4654,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AWG">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fuloríìnì Àrúbà</displayName>
 				<displayName count="other">àwɔn fuloríìnì Àrúbà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AZN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Mánààtì Àsàbáíjáì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BAM">
-				<displayName>↑↑↑</displayName>
+				<displayName>Àmi Yíyípadà Bosnia-Herzegovina</displayName>
 				<displayName count="other">àwɔn àmi Yíyípadà Bosnia-Herzegovina</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4693,7 +4693,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BIF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Faransi Bùùrúndì</displayName>
 				<displayName count="other">àwɔn faransi Bùùrúndì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4757,13 +4757,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="CDF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Firanki Kongo</displayName>
 				<displayName count="other">àwɔn firanki Kongo</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="CHF">
-				<displayName>↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Faransí Síwíìsì</displayName>
+				<displayName count="other">Faransi Siwisi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="CLP">
@@ -4773,7 +4773,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="CNH">
-				<displayName>↑↑↑</displayName>
+				<displayName>Yúànì Sháínà</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4808,7 +4808,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="CVE">
-				<displayName>↑↑↑</displayName>
+				<displayName>Èsìkúdò Kapú Faadì</displayName>
 				<displayName count="other">àwɔn èsìkúdò Kapú Faadì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4819,7 +4819,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="DJF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Faransi Dibouti</displayName>
 				<displayName count="other">àwɔn faransi Dibouti</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4847,18 +4847,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ERN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Nakifasì Eritira</displayName>
 				<displayName count="other">àwɔn nakifasì Eritira</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ETB">
-				<displayName>↑↑↑</displayName>
+				<displayName>Báà Etópíà</displayName>
 				<displayName count="other">àwɔn báà Etópíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="EUR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>owó Yúrò</displayName>
+				<displayName count="other">Awon owó Yúrò</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4890,7 +4890,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>shidi ti Orílɛ́ède Gana</displayName>
 			</currency>
 			<currency type="GHS">
-				<displayName>↑↑↑</displayName>
+				<displayName>sídì Gana</displayName>
 				<displayName count="other">àwɔn sídì Gana</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4902,12 +4902,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GMD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dalasi Gamibia</displayName>
 				<displayName count="other">àwɔn dalasi Gamibia</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="GNF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fírànkì Gínì</displayName>
 				<displayName count="other">àwɔn fírànkì Gínì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4957,7 +4957,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="IDR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rúpìyá Indonésíà</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -4975,17 +4975,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="IQD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dínárì Ìráákì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="IRR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rial Iranian</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ISK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kòrónà Icelandic</displayName>
 				<displayName count="other">kórónɔ̀ Áílándíìkì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5013,7 +5013,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KGS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sómú Kirijísítàànì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5024,7 +5024,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KMF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Faransi Komori</displayName>
 				<displayName count="other">àwɔn faransi Komori</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5042,7 +5042,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KWD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dínárì Kuwaiti</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5059,7 +5059,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LAK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kíììpù Làótì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5071,7 +5071,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LKR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rúpìì Siri Láńkà</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5088,22 +5088,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LYD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dínà Líbíyà</displayName>
 				<displayName count="other">àwɔn dínà Líbíyà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MAD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dírámì Morokò</displayName>
 				<displayName count="other">àwɔn dírámì Morokò</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MDL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Owó Léhù Moldovan</displayName>
+				<displayName count="other">Léhì Moldovan</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MGA">
-				<displayName>↑↑↑</displayName>
+				<displayName>Faransi Malagasi</displayName>
 				<displayName count="other">àwɔn faransi Malagasi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5114,19 +5114,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MMK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kíyàtì Myanmar</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MNT">
-				<displayName>↑↑↑</displayName>
+				<displayName>Túgúrììkì Mòǹgólíà</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MOP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pàtákà Màkáò</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5139,7 +5139,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MUR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rupi Maritusi</displayName>
 				<displayName count="other">àwɔn rupi Maritusi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5150,7 +5150,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MWK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kásà Màláwì</displayName>
 				<displayName count="other">àwɔn kásà Màláwì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5181,9 +5181,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="NGN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Náírà Nàìjíríà</displayName>
 				<displayName count="other">↑↑↑</displayName>
-				<symbol>↑↑↑</symbol>
+				<symbol>₦</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="NIO">
@@ -5211,33 +5211,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="OMR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ráyò Omani</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PAB">
-				<displayName>↑↑↑</displayName>
+				<displayName>Bálíbóà Pànámà</displayName>
 				<displayName count="other">àwɔn bálíbóà Pànámà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PEN">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sólì Pèrúù</displayName>
 				<displayName count="other">àwɔn sólì Pèrúù</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PGK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kínà Papua Guinea Tuntun</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PHP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Písò Fílípìnì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PKR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rúpìì Pakisitánì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5249,35 +5249,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PYG">
-				<displayName>↑↑↑</displayName>
+				<displayName>Gúáránì Párágúwè</displayName>
 				<displayName count="other">àwɔn gúáránì Párágúwè</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="QAR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Ráyò Kàtárì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="RON">
-				<displayName>↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Léhù Ròméníà</displayName>
+				<displayName count="other">Léhì Ròméníà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="RSD">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dínárì Sàbíà</displayName>
 				<displayName count="other">àwɔn dínárì Sàbíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="RUB">
 				<displayName>Owó ruble ti ilɛ̀ Rɔ́shíà</displayName>
 				<displayName count="other">↑↑↑</displayName>
-				<symbol draft="contributed">↑↑↑</symbol>
+				<symbol draft="contributed">₽</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="RWF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Faransi Ruwanda</displayName>
 				<displayName count="other">àwɔn faransi Ruwanda</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5294,7 +5294,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SCR">
-				<displayName>↑↑↑</displayName>
+				<displayName>Rúpì Sayiselesi</displayName>
 				<displayName count="other">àwɔ́n rúpì Sayiselesi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5307,7 +5307,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Pɔɔun ti Orílɛ́ède Sudani</displayName>
 			</currency>
 			<currency type="SEK">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kòrónà Súwídìn</displayName>
 				<displayName count="other">Kòrónɔ̀ Súwídìn</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5325,12 +5325,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SLE">
-				<displayName>↑↑↑</displayName>
+				<displayName>Líónì Sira Líonì</displayName>
 				<displayName count="other">àwɔn líónì Sira Líonì</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SLL">
-				<displayName>↑↑↑</displayName>
+				<displayName>Líónì Sira Líonì (1964—2022)</displayName>
 				<displayName count="other">àwɔn líónì Sira Líonì (1964—2022)</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5367,18 +5367,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="SZL">
-				<displayName>↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Lilangeni Suwasi</displayName>
+				<displayName count="other">emalangeni Suwasi</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="THB">
-				<displayName>↑↑↑</displayName>
+				<displayName>Báàtì Tháì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TJS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sómónì Tajikístàànì</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5393,7 +5393,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TOP">
-				<displayName>↑↑↑</displayName>
+				<displayName>Pàángà Tóńgà</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5418,7 +5418,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TZS">
-				<displayName>↑↑↑</displayName>
+				<displayName>Sile Tansania</displayName>
 				<displayName count="other">àwɔn shile Tansania</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5436,7 +5436,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currency type="USD">
 				<displayName>Dɔ́là</displayName>
 				<displayName count="other">↑↑↑</displayName>
-				<symbol draft="contributed">↑↑↑</symbol>
+				<symbol draft="contributed">$</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="UYU">
@@ -5456,23 +5456,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="VND">
-				<displayName>↑↑↑</displayName>
+				<displayName>Dáhùn Vietnamese</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="VUV">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fátù Vanuatu</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="WST">
-				<displayName>↑↑↑</displayName>
+				<displayName>Tálà Sàmóà</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="XAF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Firanki àárín Afíríkà</displayName>
 				<displayName count="other">àwɔn firanki àárín Afíríkà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5488,7 +5488,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="XPF">
-				<displayName>↑↑↑</displayName>
+				<displayName>Fírànkì CFP</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5502,8 +5502,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ZAR">
-				<displayName>↑↑↑</displayName>
-				<displayName count="other">↑↑↑</displayName>
+				<displayName>Rándì Gúúsù Afíríkà</displayName>
+				<displayName count="other">rándì Gúúsù Afíríkà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5511,7 +5511,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>Kawasha ti Orílɛ́ède Saabia (1968–2012)</displayName>
 			</currency>
 			<currency type="ZMW">
-				<displayName>↑↑↑</displayName>
+				<displayName>Kàwasà Sámbíà</displayName>
 				<displayName count="other">àwɔn kàwasà Sámbíà</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
@@ -5606,13 +5606,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>kibi{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
 				<unitPrefixPattern>mɛ́bì {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>gíbí {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
 				<unitPrefixPattern>tɛbi {0}</unitPrefixPattern>
@@ -5627,16 +5627,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>sɛ́bì {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>yóòbù {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">{0} sikuwe</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="power3">
-				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
+				<compoundUnitPattern1 count="other">kubiki {0}</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
@@ -5728,7 +5728,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-item">
 				<displayName>àwɔ́n ohun</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} àwon ohun</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>↑↑↑</displayName>
@@ -5824,9 +5824,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0} ɔd</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>idamerin</displayName>
+				<unitPattern count="other">{0} idamerin</unitPattern>
+				<perUnitPattern>{0}/ida</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>↑↑↑</displayName>
@@ -5863,7 +5863,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-microsecond">
-				<displayName>↑↑↑</displayName>
+				<displayName>iseju aya kekere</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-nanosecond">
@@ -6119,7 +6119,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-stone">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} àwon okùta</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>↑↑↑</displayName>
@@ -6152,7 +6152,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
+				<displayName>giréènì</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
@@ -6236,8 +6236,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Beaufort</displayName>
+				<unitPattern count="other">Beaufort {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
@@ -6401,8 +6401,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ìdásímérin</displayName>
+				<unitPattern count="other">{0} ìdásímérin</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>↑↑↑</displayName>
@@ -6486,28 +6486,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Kí {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Mi {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p3">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Gi {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p4">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Ti {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Pi {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Ei {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p7">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Sí {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
@@ -6609,8 +6609,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-item">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>ohun</displayName>
+				<unitPattern count="other">{0} ohun</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>ara/milíɔ̀nù</displayName>
@@ -6622,7 +6622,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>ìdákan nínú ɛgbɛ̀rún</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} pasenti</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
@@ -6649,24 +6649,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Píbáìtì</displayName>
+				<unitPattern count="other">{0} Píbáìtì</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Tíbáìtì</displayName>
+				<unitPattern count="other">{0} Tíbáìtì</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jíbáìtì</displayName>
+				<unitPattern count="other">{0} jíbáìtì</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jíbíìtì</displayName>
+				<unitPattern count="other">{0}jíbíìtì</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
 				<displayName>ɛ́mbáìtì</displayName>
@@ -6677,20 +6677,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} ɛ́mbiì</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kébáìtì</displayName>
+				<unitPattern count="other">{0} kébáìtì</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kébiì</displayName>
+				<unitPattern count="other">{0} kébiì</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>báìtì</displayName>
+				<unitPattern count="other">{0} báìtì</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bíìtì</displayName>
+				<unitPattern count="other">{0} bíìtì</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>↑↑↑</displayName>
@@ -6706,9 +6706,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/ɔd</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>idame</displayName>
+				<unitPattern count="other">{0} idame</unitPattern>
+				<perUnitPattern>{0}/id</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
 				<displayName>oshù</displayName>
@@ -6726,9 +6726,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>{0}/ɔj</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>wkt</displayName>
+				<unitPattern count="other">{0} wkt</unitPattern>
+				<perUnitPattern>{0}/wkt</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
 				<displayName>ìsh</displayName>
@@ -6962,8 +6962,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>sídiì</displayName>
+				<unitPattern count="other">{0} sídiì</unitPattern>
 			</unit>
 			<unit type="light-lumen">
 				<displayName>àmì lumɛ́ɛ̀nì</displayName>
@@ -7000,7 +7000,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
+				<displayName>àwon okùta</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-pound">
@@ -7034,8 +7034,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gíréènì</displayName>
+				<unitPattern count="other">{0} gíréènì</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
@@ -7271,20 +7271,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">{0} dírɔ́pù</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>omi dírámù</displayName>
+				<unitPattern count="other">{0} àmì omi dírámù</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jígà</displayName>
+				<unitPattern count="other">{0} jígà</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>píńshì</displayName>
 				<unitPattern count="other">{0} píńshì</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>àmì ìdásímérin</displayName>
+				<unitPattern count="other">{0} àmì ìdásímérin</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>↑↑↑</displayName>
@@ -7368,7 +7368,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p1">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Ki {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p2">
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
@@ -7380,7 +7380,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p5">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Pí {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p6">
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
@@ -7389,7 +7389,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="1024p8">
-				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
+				<unitPrefixPattern>àmì Yí {0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
 				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
@@ -7407,19 +7407,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Gs</unitPattern>
 			</unit>
 			<unit type="acceleration-meter-per-square-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}m/s²</unitPattern>
 			</unit>
 			<unit type="angle-revolution">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}rev</unitPattern>
 			</unit>
 			<unit type="angle-radian">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}rad</unitPattern>
 			</unit>
 			<unit type="angle-degree">
 				<displayName>↑↑↑</displayName>
@@ -7435,12 +7435,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}km²</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-hectare">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ha</unitPattern>
 			</unit>
 			<unit type="area-square-meter">
 				<displayName>↑↑↑</displayName>
@@ -7449,54 +7449,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="area-square-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}cm²</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mi²</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-acre">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ac</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}yd²</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ft²</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}in²</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="area-dunam">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}dunam</unitPattern>
 			</unit>
 			<unit type="concentr-karat">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kt</unitPattern>
 			</unit>
 			<unit type="concentr-milligram-ofglucose-per-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mg/dL</unitPattern>
 			</unit>
 			<unit type="concentr-millimole-per-liter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mmol/L</unitPattern>
 			</unit>
 			<unit type="concentr-item">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ohun</unitPattern>
 			</unit>
 			<unit type="concentr-permillion">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ppm</unitPattern>
 			</unit>
 			<unit type="concentr-percent">
 				<displayName>↑↑↑</displayName>
@@ -7504,7 +7504,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-permille">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}‰</unitPattern>
 			</unit>
 			<unit type="concentr-permyriad">
 				<displayName>↑↑↑</displayName>
@@ -7512,67 +7512,67 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="concentr-mole">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mol</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}L/km</unitPattern>
 			</unit>
 			<unit type="consumption-liter-per-100-kilometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg</displayName>
+				<unitPattern count="other">{0}mpg</unitPattern>
 			</unit>
 			<unit type="consumption-mile-per-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mpg UK</displayName>
+				<unitPattern count="other">{0}m/gUK</unitPattern>
 			</unit>
 			<unit type="digital-petabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>PB</displayName>
+				<unitPattern count="other">{0}PB</unitPattern>
 			</unit>
 			<unit type="digital-terabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>TB</displayName>
+				<unitPattern count="other">{0}TB</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Tb</unitPattern>
 			</unit>
 			<unit type="digital-gigabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>GB</displayName>
+				<unitPattern count="other">{0}GB</unitPattern>
 			</unit>
 			<unit type="digital-gigabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Gb</displayName>
+				<unitPattern count="other">{0}Gb</unitPattern>
 			</unit>
 			<unit type="digital-megabyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>MB</displayName>
+				<unitPattern count="other">{0}MB</unitPattern>
 			</unit>
 			<unit type="digital-megabit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Mb</displayName>
+				<unitPattern count="other">{0}Mb</unitPattern>
 			</unit>
 			<unit type="digital-kilobyte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kB</displayName>
+				<unitPattern count="other">{0}kB</unitPattern>
 			</unit>
 			<unit type="digital-kilobit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>kb</displayName>
+				<unitPattern count="other">{0}kb</unitPattern>
 			</unit>
 			<unit type="digital-byte">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>B</displayName>
+				<unitPattern count="other">{0}B</unitPattern>
 			</unit>
 			<unit type="digital-bit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>bit</displayName>
+				<unitPattern count="other">{0}bíìtì</unitPattern>
 			</unit>
 			<unit type="duration-century">
 				<displayName>↑↑↑</displayName>
@@ -7589,7 +7589,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0} i</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-month">
@@ -7636,83 +7636,83 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="electric-ampere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}A</unitPattern>
 			</unit>
 			<unit type="electric-milliampere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mA</unitPattern>
 			</unit>
 			<unit type="electric-ohm">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Ω</unitPattern>
 			</unit>
 			<unit type="electric-volt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}V</unitPattern>
 			</unit>
 			<unit type="energy-kilocalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kcal</unitPattern>
 			</unit>
 			<unit type="energy-calorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}cal</unitPattern>
 			</unit>
 			<unit type="energy-foodcalorie">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Cal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kJ</unitPattern>
 			</unit>
 			<unit type="energy-joule">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}J</unitPattern>
 			</unit>
 			<unit type="energy-kilowatt-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kWh</unitPattern>
 			</unit>
 			<unit type="energy-electronvolt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}eV</unitPattern>
 			</unit>
 			<unit type="energy-british-thermal-unit">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>BTU</displayName>
+				<unitPattern count="other">{0}Btu</unitPattern>
 			</unit>
 			<unit type="energy-therm-us">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}US therms</unitPattern>
 			</unit>
 			<unit type="force-pound-force">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}lbf</unitPattern>
 			</unit>
 			<unit type="force-newton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}N</unitPattern>
 			</unit>
 			<unit type="force-kilowatt-hour-per-100-kilometer">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>KWh ní 100km</displayName>
+				<unitPattern count="other">{0} kWh ní 100km</unitPattern>
 			</unit>
 			<unit type="frequency-gigahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}GHz</unitPattern>
 			</unit>
 			<unit type="frequency-megahertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}MHz</unitPattern>
 			</unit>
 			<unit type="frequency-kilohertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kHz</unitPattern>
 			</unit>
 			<unit type="frequency-hertz">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Hz</unitPattern>
 			</unit>
 			<unit type="graphics-em">
 				<displayName>↑↑↑</displayName>
@@ -7735,20 +7735,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpcm</displayName>
+				<unitPattern count="other">{0}dpcm</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>dpi</displayName>
+				<unitPattern count="other">{0}dpi</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>R⊕</displayName>
+				<unitPattern count="other">{0}R⊕</unitPattern>
 			</unit>
 			<unit type="length-kilometer">
 				<displayName>↑↑↑</displayName>
@@ -7817,11 +7817,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}fur</unitPattern>
 			</unit>
 			<unit type="length-fathom">
 				<displayName>fatɔ́</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}fth</unitPattern>
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>↑↑↑</displayName>
@@ -7841,23 +7841,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="light-lux">
 				<displayName>lɔ́s</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}lx</unitPattern>
 			</unit>
 			<unit type="light-candela">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>cd</displayName>
+				<unitPattern count="other">{0}cd</unitPattern>
 			</unit>
 			<unit type="light-lumen">
-				<displayName>↑↑↑</displayName>
+				<displayName>lm</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="light-solar-luminosity">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}L☉</unitPattern>
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}t</unitPattern>
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>↑↑↑</displayName>
@@ -7871,19 +7871,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-milligram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mg</unitPattern>
 			</unit>
 			<unit type="mass-microgram">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}μg</unitPattern>
 			</unit>
 			<unit type="mass-ton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}tn</unitPattern>
 			</unit>
 			<unit type="mass-stone">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>okùta</displayName>
+				<unitPattern count="other">{0}st</unitPattern>
 			</unit>
 			<unit type="mass-pound">
 				<displayName>↑↑↑</displayName>
@@ -7892,72 +7892,72 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}oz</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}oz t</unitPattern>
 			</unit>
 			<unit type="mass-carat">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}CD</unitPattern>
 			</unit>
 			<unit type="mass-dalton">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Da</unitPattern>
 			</unit>
 			<unit type="mass-earth-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}M⊕</unitPattern>
 			</unit>
 			<unit type="mass-solar-mass">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}M☉</unitPattern>
 			</unit>
 			<unit type="mass-grain">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>gr</displayName>
+				<unitPattern count="other">{0}gr</unitPattern>
 			</unit>
 			<unit type="power-gigawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}GW</unitPattern>
 			</unit>
 			<unit type="power-megawatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}MW</unitPattern>
 			</unit>
 			<unit type="power-kilowatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kW</unitPattern>
 			</unit>
 			<unit type="power-watt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}W</unitPattern>
 			</unit>
 			<unit type="power-milliwatt">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mW</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}hp</unitPattern>
 			</unit>
 			<unit type="pressure-millimeter-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>mmHg</displayName>
+				<unitPattern count="other">{0}mmHg</unitPattern>
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>″ Hg</displayName>
+				<unitPattern count="other">{0}″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}bar</unitPattern>
 			</unit>
 			<unit type="pressure-millibar">
 				<displayName>↑↑↑</displayName>
@@ -7965,23 +7965,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="pressure-atmosphere">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}atm</unitPattern>
 			</unit>
 			<unit type="pressure-pascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}Pa</unitPattern>
 			</unit>
 			<unit type="pressure-hectopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}hPa</unitPattern>
 			</unit>
 			<unit type="pressure-kilopascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kPa</unitPattern>
 			</unit>
 			<unit type="pressure-megapascal">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}MPa</unitPattern>
 			</unit>
 			<unit type="speed-kilometer-per-hour">
 				<displayName>↑↑↑</displayName>
@@ -7989,15 +7989,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="speed-meter-per-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}m/s</unitPattern>
 			</unit>
 			<unit type="speed-mile-per-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mph</unitPattern>
 			</unit>
 			<unit type="speed-knot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>↑↑↑</displayName>
@@ -8013,136 +8013,136 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}°</unitPattern>
 			</unit>
 			<unit type="temperature-kelvin">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}K</unitPattern>
 			</unit>
 			<unit type="torque-pound-force-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}lbf⋅ft</unitPattern>
 			</unit>
 			<unit type="torque-newton-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}N⋅m</unitPattern>
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}km³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-meter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}m³</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-centimeter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}cm³</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mi³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-yard">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}yd³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ft³</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}in³</unitPattern>
 			</unit>
 			<unit type="volume-megaliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}ML</unitPattern>
 			</unit>
 			<unit type="volume-hectoliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}hL</unitPattern>
 			</unit>
 			<unit type="volume-liter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<perUnitPattern>{0}/L</perUnitPattern>
 			</unit>
 			<unit type="volume-deciliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}dL</unitPattern>
 			</unit>
 			<unit type="volume-centiliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}cL</unitPattern>
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mL</unitPattern>
 			</unit>
 			<unit type="volume-pint-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mpt</unitPattern>
 			</unit>
 			<unit type="volume-cup-metric">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}mc</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>acre ft</displayName>
+				<unitPattern count="other">{0}ac ft</unitPattern>
 			</unit>
 			<unit type="volume-bushel">
 				<displayName>búsɛ́li</displayName>
 				<unitPattern count="other">{0}búsɛ́ɛ̀li</unitPattern>
 			</unit>
 			<unit type="volume-gallon">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>gal</displayName>
+				<unitPattern count="other">{0}gal</unitPattern>
+				<perUnitPattern>{0}/gal</perUnitPattern>
 			</unit>
 			<unit type="volume-gallon-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>Imp gal</displayName>
+				<unitPattern count="other">{0}galIm</unitPattern>
+				<perUnitPattern>{0}/galIm</perUnitPattern>
 			</unit>
 			<unit type="volume-quart">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}qt</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}pt</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}c</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl oz</displayName>
+				<unitPattern count="other">{0}fl oz</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>Imp fl oz</displayName>
+				<unitPattern count="other">{0}fl oz Im</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}tbsp</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}tsp</unitPattern>
 			</unit>
 			<unit type="volume-barrel">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}bbl</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}dsp</unitPattern>
 			</unit>
 			<unit type="volume-dessert-spoon-imperial">
 				<displayName>↑↑↑</displayName>
@@ -8150,23 +8150,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-drop">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}dr</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>fl.dr.</displayName>
+				<unitPattern count="other">{0}fl.dr.</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>jìgá</displayName>
+				<unitPattern count="other">{0}jìgá</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<displayName>pn</displayName>
+				<unitPattern count="other">{0}pn</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="other">{0}àmì ìdásímérin</unitPattern>
 			</unit>
 			<coordinateUnit>
 				<displayName>↑↑↑</displayName>
@@ -8196,8 +8196,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<listPattern type="or">
 			<listPatternPart type="start">{0} pɛ̀lú {1}</listPatternPart>
 			<listPatternPart type="middle">↑↑↑</listPatternPart>
-			<listPatternPart type="end">↑↑↑</listPatternPart>
-			<listPatternPart type="2">↑↑↑</listPatternPart>
+			<listPatternPart type="end">{0}, tabi {1}</listPatternPart>
+			<listPatternPart type="2">{0} tàbí {1}</listPatternPart>
 		</listPattern>
 		<listPattern type="or-narrow">
 			<listPatternPart type="start">↑↑↑</listPatternPart>
@@ -8249,122 +8249,122 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</messages>
 	</posix>
 	<characterLabels>
-		<characterLabelPattern type="all">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="all">{0} - gbogbo</characterLabelPattern>
 		<characterLabelPattern type="category-list">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="compatibility">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="enclosed">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="extended">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="compatibility">{0}-ibaramu</characterLabelPattern>
+		<characterLabelPattern type="enclosed">{0} ipade</characterLabelPattern>
+		<characterLabelPattern type="extended">{0}-ifasiwaju</characterLabelPattern>
 		<characterLabelPattern type="facing-left">{0} ìdojúkɔ òsì</characterLabelPattern>
 		<characterLabelPattern type="facing-right">{0} ìdojúkɔ ɔ̀tún</characterLabelPattern>
-		<characterLabelPattern type="historic">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="miscellaneous">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="other">↑↑↑</characterLabelPattern>
+		<characterLabelPattern type="historic">{0}-àtijó̩</characterLabelPattern>
+		<characterLabelPattern type="miscellaneous">{0} - míràn</characterLabelPattern>
+		<characterLabelPattern type="other">{0} miran</characterLabelPattern>
 		<characterLabelPattern type="scripts">àwɔ́n ìwé - {0}</characterLabelPattern>
-		<characterLabelPattern type="strokes" count="other">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="subscript">↑↑↑</characterLabelPattern>
-		<characterLabelPattern type="superscript">↑↑↑</characterLabelPattern>
-		<characterLabel type="activities">↑↑↑</characterLabel>
-		<characterLabel type="african_scripts">↑↑↑</characterLabel>
-		<characterLabel type="american_scripts">↑↑↑</characterLabel>
-		<characterLabel type="animal">↑↑↑</characterLabel>
-		<characterLabel type="animals_nature">↑↑↑</characterLabel>
-		<characterLabel type="arrows">↑↑↑</characterLabel>
-		<characterLabel type="body">↑↑↑</characterLabel>
-		<characterLabel type="box_drawing">↑↑↑</characterLabel>
-		<characterLabel type="braille">↑↑↑</characterLabel>
-		<characterLabel type="building">↑↑↑</characterLabel>
-		<characterLabel type="bullets_stars">↑↑↑</characterLabel>
-		<characterLabel type="consonantal_jamo">↑↑↑</characterLabel>
-		<characterLabel type="currency_symbols">↑↑↑</characterLabel>
-		<characterLabel type="dash_connector">↑↑↑</characterLabel>
-		<characterLabel type="digits">↑↑↑</characterLabel>
-		<characterLabel type="dingbats">↑↑↑</characterLabel>
-		<characterLabel type="divination_symbols">↑↑↑</characterLabel>
-		<characterLabel type="downwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="downwards_upwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="east_asian_scripts">↑↑↑</characterLabel>
+		<characterLabelPattern type="strokes" count="other">{0} ìlà</characterLabelPattern>
+		<characterLabelPattern type="subscript">ìwé kékeré {0}</characterLabelPattern>
+		<characterLabelPattern type="superscript">ìwé nl {0}</characterLabelPattern>
+		<characterLabel type="activities">Ise</characterLabel>
+		<characterLabel type="african_scripts">Iwe Adulawo</characterLabel>
+		<characterLabel type="american_scripts">Iwe Amerika</characterLabel>
+		<characterLabel type="animal">eranko</characterLabel>
+		<characterLabel type="animals_nature">eranko tabi eda</characterLabel>
+		<characterLabel type="arrows">ofa</characterLabel>
+		<characterLabel type="body">ara</characterLabel>
+		<characterLabel type="box_drawing">pali yíyà</characterLabel>
+		<characterLabel type="braille">burali</characterLabel>
+		<characterLabel type="building">ile</characterLabel>
+		<characterLabel type="bullets_stars">búlé̩tì tàbí ìràwò̩</characterLabel>
+		<characterLabel type="consonantal_jamo">jamo konsonanti</characterLabel>
+		<characterLabel type="currency_symbols">ami owo</characterLabel>
+		<characterLabel type="dash_connector">dasi tabi asopo</characterLabel>
+		<characterLabel type="digits">digibaati</characterLabel>
+		<characterLabel type="dingbats">digibaati</characterLabel>
+		<characterLabel type="divination_symbols">ami idifa</characterLabel>
+		<characterLabel type="downwards_arrows">ofa isale</characterLabel>
+		<characterLabel type="downwards_upwards_arrows">ofa isale ati oke</characterLabel>
+		<characterLabel type="east_asian_scripts">Iwe Ila oorun Asia</characterLabel>
 		<characterLabel type="emoji">↑↑↑</characterLabel>
 		<characterLabel type="european_scripts">↑↑↑</characterLabel>
 		<characterLabel type="female">↑↑↑</characterLabel>
-		<characterLabel type="flag">↑↑↑</characterLabel>
-		<characterLabel type="flags">↑↑↑</characterLabel>
-		<characterLabel type="food_drink">↑↑↑</characterLabel>
-		<characterLabel type="format">↑↑↑</characterLabel>
-		<characterLabel type="format_whitespace">↑↑↑</characterLabel>
-		<characterLabel type="full_width_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="geometric_shapes">↑↑↑</characterLabel>
-		<characterLabel type="half_width_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="han_characters">↑↑↑</characterLabel>
-		<characterLabel type="han_radicals">↑↑↑</characterLabel>
+		<characterLabel type="flag">filaagi</characterLabel>
+		<characterLabel type="flags">awon filaagi</characterLabel>
+		<characterLabel type="food_drink">ounje ati omi</characterLabel>
+		<characterLabel type="format">ilana</characterLabel>
+		<characterLabel type="format_whitespace">ìlànà àti àyè funfun</characterLabel>
+		<characterLabel type="full_width_form_variant">kun-egbe eda</characterLabel>
+		<characterLabel type="geometric_shapes">seepu jiometiriki</characterLabel>
+		<characterLabel type="half_width_form_variant">aarin-egbe eda</characterLabel>
+		<characterLabel type="han_characters">ami ikowe Han</characterLabel>
+		<characterLabel type="han_radicals">ikowe Han</characterLabel>
 		<characterLabel type="hanja">↑↑↑</characterLabel>
-		<characterLabel type="hanzi_simplified">↑↑↑</characterLabel>
-		<characterLabel type="hanzi_traditional">↑↑↑</characterLabel>
-		<characterLabel type="heart">↑↑↑</characterLabel>
-		<characterLabel type="historic_scripts">↑↑↑</characterLabel>
-		<characterLabel type="ideographic_desc_characters">↑↑↑</characterLabel>
-		<characterLabel type="japanese_kana">↑↑↑</characterLabel>
-		<characterLabel type="kanbun">↑↑↑</characterLabel>
-		<characterLabel type="kanji">↑↑↑</characterLabel>
-		<characterLabel type="keycap">↑↑↑</characterLabel>
-		<characterLabel type="leftwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="leftwards_rightwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="letterlike_symbols">↑↑↑</characterLabel>
-		<characterLabel type="limited_use">↑↑↑</characterLabel>
-		<characterLabel type="male">↑↑↑</characterLabel>
-		<characterLabel type="math_symbols">↑↑↑</characterLabel>
-		<characterLabel type="middle_eastern_scripts">↑↑↑</characterLabel>
-		<characterLabel type="miscellaneous">↑↑↑</characterLabel>
-		<characterLabel type="modern_scripts">↑↑↑</characterLabel>
-		<characterLabel type="modifier">↑↑↑</characterLabel>
-		<characterLabel type="musical_symbols">↑↑↑</characterLabel>
-		<characterLabel type="nature">↑↑↑</characterLabel>
-		<characterLabel type="nonspacing">↑↑↑</characterLabel>
-		<characterLabel type="numbers">↑↑↑</characterLabel>
-		<characterLabel type="objects">↑↑↑</characterLabel>
-		<characterLabel type="other">↑↑↑</characterLabel>
-		<characterLabel type="paired">↑↑↑</characterLabel>
-		<characterLabel type="person">↑↑↑</characterLabel>
-		<characterLabel type="phonetic_alphabet">↑↑↑</characterLabel>
-		<characterLabel type="pictographs">↑↑↑</characterLabel>
-		<characterLabel type="place">↑↑↑</characterLabel>
-		<characterLabel type="plant">↑↑↑</characterLabel>
+		<characterLabel type="hanzi_simplified">Hansi</characterLabel>
+		<characterLabel type="hanzi_traditional">Hansi</characterLabel>
+		<characterLabel type="heart">okan</characterLabel>
+		<characterLabel type="historic_scripts">iwe atijo</characterLabel>
+		<characterLabel type="ideographic_desc_characters">ikowe isapejuwe</characterLabel>
+		<characterLabel type="japanese_kana">kana ti Japaani</characterLabel>
+		<characterLabel type="kanbun">Kabuni</characterLabel>
+		<characterLabel type="kanji">Kanji</characterLabel>
+		<characterLabel type="keycap">Keyacap</characterLabel>
+		<characterLabel type="leftwards_arrows">ofa osi</characterLabel>
+		<characterLabel type="leftwards_rightwards_arrows">ofa osi ati otun</characterLabel>
+		<characterLabel type="letterlike_symbols">ami ti leta</characterLabel>
+		<characterLabel type="limited_use">ilo die</characterLabel>
+		<characterLabel type="male">okunrin</characterLabel>
+		<characterLabel type="math_symbols">ami isiro</characterLabel>
+		<characterLabel type="middle_eastern_scripts">iwe aarin ila-oorun</characterLabel>
+		<characterLabel type="miscellaneous">eyikeyi</characterLabel>
+		<characterLabel type="modern_scripts">iwe ode-oni</characterLabel>
+		<characterLabel type="modifier">ayán nnkan</characterLabel>
+		<characterLabel type="musical_symbols">ami orin</characterLabel>
+		<characterLabel type="nature">eda</characterLabel>
+		<characterLabel type="nonspacing">ailaye</characterLabel>
+		<characterLabel type="numbers">awon nonba</characterLabel>
+		<characterLabel type="objects">nnkan</characterLabel>
+		<characterLabel type="other">miran</characterLabel>
+		<characterLabel type="paired">pinsimeji</characterLabel>
+		<characterLabel type="person">eniyan</characterLabel>
+		<characterLabel type="phonetic_alphabet">afabeeti iro</characterLabel>
+		<characterLabel type="pictographs">aworan</characterLabel>
+		<characterLabel type="place">ibi</characterLabel>
+		<characterLabel type="plant">eso</characterLabel>
 		<characterLabel type="punctuation">↑↑↑</characterLabel>
-		<characterLabel type="rightwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="sign_standard_symbols">↑↑↑</characterLabel>
-		<characterLabel type="small_form_variant">↑↑↑</characterLabel>
-		<characterLabel type="smiley">↑↑↑</characterLabel>
-		<characterLabel type="smileys_people">↑↑↑</characterLabel>
-		<characterLabel type="south_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="southeast_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="spacing">↑↑↑</characterLabel>
-		<characterLabel type="sport">↑↑↑</characterLabel>
-		<characterLabel type="symbols">↑↑↑</characterLabel>
-		<characterLabel type="technical_symbols">↑↑↑</characterLabel>
-		<characterLabel type="tone_marks">↑↑↑</characterLabel>
-		<characterLabel type="travel">↑↑↑</characterLabel>
-		<characterLabel type="travel_places">↑↑↑</characterLabel>
+		<characterLabel type="rightwards_arrows">ofa otun</characterLabel>
+		<characterLabel type="sign_standard_symbols">ami</characterLabel>
+		<characterLabel type="small_form_variant">awon è̩dà kékèkè</characterLabel>
+		<characterLabel type="smiley">oju irerin</characterLabel>
+		<characterLabel type="smileys_people">oju rerin tabi eniyan</characterLabel>
+		<characterLabel type="south_asian_scripts">iwe Gusu Asia</characterLabel>
+		<characterLabel type="southeast_asian_scripts">Iwe Gusu-ila oorun Asia</characterLabel>
+		<characterLabel type="spacing">aye</characterLabel>
+		<characterLabel type="sport">ere idaraya</characterLabel>
+		<characterLabel type="symbols">ami</characterLabel>
+		<characterLabel type="technical_symbols">ami ise</characterLabel>
+		<characterLabel type="tone_marks">ami ohun</characterLabel>
+		<characterLabel type="travel">irinajo</characterLabel>
+		<characterLabel type="travel_places">irinajo tabi ibi</characterLabel>
 		<characterLabel type="upwards_arrows">↑↑↑</characterLabel>
-		<characterLabel type="variant_forms">↑↑↑</characterLabel>
-		<characterLabel type="vocalic_jamo">↑↑↑</characterLabel>
+		<characterLabel type="variant_forms">eda</characterLabel>
+		<characterLabel type="vocalic_jamo">awon iwe</characterLabel>
 		<characterLabel type="weather">ojú=ɔjɔ́</characterLabel>
-		<characterLabel type="western_asian_scripts">↑↑↑</characterLabel>
-		<characterLabel type="whitespace">↑↑↑</characterLabel>
+		<characterLabel type="western_asian_scripts">Iwe Iwoorun to Asia</characterLabel>
+		<characterLabel type="whitespace">àyè funfun</characterLabel>
 	</characterLabels>
 	<typographicNames>
-		<axisName type="ital">↑↑↑</axisName>
-		<axisName type="opsz">↑↑↑</axisName>
-		<axisName type="slnt">↑↑↑</axisName>
+		<axisName type="ital">ítálísì</axisName>
+		<axisName type="opsz">iwon oput;ikà</axisName>
+		<axisName type="slnt">sílántì</axisName>
 		<axisName type="wdth">fífɛ̀ sí</axisName>
-		<axisName type="wght">↑↑↑</axisName>
+		<axisName type="wght">títobi sí</axisName>
 		<styleName type="ital" subtype="1">kíkɔ́</styleName>
 		<styleName type="opsz" subtype="8">ɔ̀rɔ̀ àtúmɔ̀</styleName>
 		<styleName type="opsz" subtype="12">àtɛ̀jíshɛ́</styleName>
-		<styleName type="opsz" subtype="18">↑↑↑</styleName>
-		<styleName type="opsz" subtype="72">↑↑↑</styleName>
-		<styleName type="opsz" subtype="144">↑↑↑</styleName>
+		<styleName type="opsz" subtype="18">títì</styleName>
+		<styleName type="opsz" subtype="72">ìfihàn</styleName>
+		<styleName type="opsz" subtype="144">posítà</styleName>
 		<styleName type="slnt" subtype="-12">sílántì ɛ̀yìn</styleName>
-		<styleName type="slnt" subtype="0">↑↑↑</styleName>
-		<styleName type="slnt" subtype="12">↑↑↑</styleName>
+		<styleName type="slnt" subtype="0">dídúró</styleName>
+		<styleName type="slnt" subtype="12">tó sílántì</styleName>
 		<styleName type="slnt" subtype="24">sílántì-púpɔ̀</styleName>
 		<styleName type="wdth" subtype="50">kànpɔ̀ gidigidi</styleName>
 		<styleName type="wdth" subtype="50" alt="compressed">tɛ̀pɔ̀ gidigidi</styleName>
@@ -8378,51 +8378,51 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<styleName type="wdth" subtype="87.5">tɛ̀pɔ̀ díɛ̀</styleName>
 		<styleName type="wdth" subtype="87.5" alt="compressed">kànpɔ̀ díɛ̀</styleName>
 		<styleName type="wdth" subtype="87.5" alt="narrow">papɔ̀ díɛ̀</styleName>
-		<styleName type="wdth" subtype="100">↑↑↑</styleName>
+		<styleName type="wdth" subtype="100">dára</styleName>
 		<styleName type="wdth" subtype="112.5">tóbi díɛ̀</styleName>
-		<styleName type="wdth" subtype="112.5" alt="extended">↑↑↑</styleName>
+		<styleName type="wdth" subtype="112.5" alt="extended">fasiwaju díe</styleName>
 		<styleName type="wdth" subtype="112.5" alt="wide">sánra díɛ̀</styleName>
-		<styleName type="wdth" subtype="125">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="125" alt="wide">↑↑↑</styleName>
+		<styleName type="wdth" subtype="125">tóbi</styleName>
+		<styleName type="wdth" subtype="125" alt="extended">fasiwaju</styleName>
+		<styleName type="wdth" subtype="125" alt="wide">sanra</styleName>
 		<styleName type="wdth" subtype="150">tobi-púpɔ̀</styleName>
-		<styleName type="wdth" subtype="150" alt="extended">↑↑↑</styleName>
+		<styleName type="wdth" subtype="150" alt="extended">fasiwaju pupo</styleName>
 		<styleName type="wdth" subtype="150" alt="wide">sanra-pupɔ̀</styleName>
-		<styleName type="wdth" subtype="200">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200" alt="extended">↑↑↑</styleName>
-		<styleName type="wdth" subtype="200" alt="wide">↑↑↑</styleName>
-		<styleName type="wght" subtype="100">↑↑↑</styleName>
+		<styleName type="wdth" subtype="200">tóbi gidigidi</styleName>
+		<styleName type="wdth" subtype="200" alt="extended">fasiwaju gidigidi</styleName>
+		<styleName type="wdth" subtype="200" alt="wide">sanra gidigidi</styleName>
+		<styleName type="wght" subtype="100">tínínrín</styleName>
 		<styleName type="wght" subtype="200">fuyɛ́ púpɔ̀</styleName>
 		<styleName type="wght" subtype="200" alt="ultra">fúyɛ́ gidigidi</styleName>
 		<styleName type="wght" subtype="300">fúyɛ́</styleName>
 		<styleName type="wght" subtype="350">fúyɛ́ díɛ̀</styleName>
-		<styleName type="wght" subtype="380">↑↑↑</styleName>
+		<styleName type="wght" subtype="380">Ìwé</styleName>
 		<styleName type="wght" subtype="400">níwɔ́n</styleName>
-		<styleName type="wght" subtype="500">↑↑↑</styleName>
+		<styleName type="wght" subtype="500">aarin</styleName>
 		<styleName type="wght" subtype="600">gbojú díɛ̀</styleName>
-		<styleName type="wght" subtype="600" alt="demi">↑↑↑</styleName>
-		<styleName type="wght" subtype="700">↑↑↑</styleName>
-		<styleName type="wght" subtype="800">↑↑↑</styleName>
-		<styleName type="wght" subtype="900">↑↑↑</styleName>
-		<styleName type="wght" subtype="900" alt="heavy">↑↑↑</styleName>
+		<styleName type="wght" subtype="600" alt="demi">boodi die</styleName>
+		<styleName type="wght" subtype="700">gbójú</styleName>
+		<styleName type="wght" subtype="800">boodi nla</styleName>
+		<styleName type="wght" subtype="900">dúdú</styleName>
+		<styleName type="wght" subtype="900" alt="heavy">wúwo</styleName>
 		<styleName type="wght" subtype="950">dúdú-púpɔ̀</styleName>
-		<styleName type="wght" subtype="950" alt="ultrablack">↑↑↑</styleName>
-		<styleName type="wght" subtype="950" alt="ultraheavy">↑↑↑</styleName>
-		<featureName type="afrc">↑↑↑</featureName>
-		<featureName type="cpsp">↑↑↑</featureName>
+		<styleName type="wght" subtype="950" alt="ultrablack">dúdú gidigidi</styleName>
+		<styleName type="wght" subtype="950" alt="ultraheavy">wúwo gidigidi</styleName>
+		<featureName type="afrc">ìsirò ila</featureName>
+		<featureName type="cpsp">alafo nla</featureName>
 		<featureName type="dlig">ligasɔ̀ ti o fɛ́</featureName>
-		<featureName type="frac">↑↑↑</featureName>
-		<featureName type="lnum">↑↑↑</featureName>
-		<featureName type="onum">↑↑↑</featureName>
-		<featureName type="ordn">↑↑↑</featureName>
-		<featureName type="pnum">↑↑↑</featureName>
-		<featureName type="smcp">↑↑↑</featureName>
-		<featureName type="tnum">↑↑↑</featureName>
-		<featureName type="zero">↑↑↑</featureName>
+		<featureName type="frac">isiro apa kan</featureName>
+		<featureName type="lnum">nonba tito</featureName>
+		<featureName type="onum">nonba tele</featureName>
+		<featureName type="ordn">kika</featureName>
+		<featureName type="pnum">nonba</featureName>
+		<featureName type="smcp">leta kekere</featureName>
+		<featureName type="tnum">nonba ni tebu</featureName>
+		<featureName type="zero">odo silasi</featureName>
 	</typographicNames>
 	<personNames>
-		<nameOrderLocales order="givenFirst">↑↑↑</nameOrderLocales>
-		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
+		<nameOrderLocales order="givenFirst">und yo</nameOrderLocales>
+		<nameOrderLocales order="surnameFirst">ko vi yue zh</nameOrderLocales>
 		<parameterDefault parameter="formality">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length">↑↑↑</parameterDefault>
 		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
@@ -8430,176 +8430,176 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="givenFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given} {given2-initial} {surname} {credentials}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-initial} {given2-initial} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal} {surname-initial}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="givenFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="formal">
 			<namePattern>↑↑↑</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="long" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given} {given2-initial} {credentials}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="medium" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-initial} {given2-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname} {given-initial}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{title} {surname}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="addressing" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="surnameFirst" length="short" usage="monogram" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{given-informal-monogram-allCaps}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="long" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given} {given2-initial} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="medium" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="formal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname-core}, {given-initial} {given2-initial} {surname-prefix}</namePattern>
 		</personName>
 		<personName order="sorting" length="short" usage="referring" formality="informal">
-			<namePattern>↑↑↑</namePattern>
+			<namePattern>{surname}, {given-informal}</namePattern>
 		</personName>
 		<sampleName item="nativeG">
-			<nameField type="given">↑↑↑</nameField>
+			<nameField type="given">Boluwatife</nameField>
 		</sampleName>
 		<sampleName item="nativeGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Olabisi</nameField>
+			<nameField type="surname">Adeboye</nameField>
 		</sampleName>
 		<sampleName item="nativeGGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Adeolu</nameField>
+			<nameField type="given2">Adegboyega</nameField>
+			<nameField type="surname">Akintola</nameField>
 		</sampleName>
 		<sampleName item="nativeFull">
 			<nameField type="title">Ɔ̀gbɛ́ni</nameField>
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given-informal">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname-prefix">↑↑↑</nameField>
-			<nameField type="surname-core">↑↑↑</nameField>
-			<nameField type="surname2">↑↑↑</nameField>
-			<nameField type="generation">↑↑↑</nameField>
-			<nameField type="credentials">↑↑↑</nameField>
+			<nameField type="given">Adebola Opeyemi</nameField>
+			<nameField type="given-informal">Bolanle</nameField>
+			<nameField type="given2">Olumide Ajao</nameField>
+			<nameField type="surname-prefix">∅∅∅</nameField>
+			<nameField type="surname-core">Adekunle</nameField>
+			<nameField type="surname2">∅∅∅</nameField>
+			<nameField type="generation">Jr</nameField>
+			<nameField type="credentials">Asofin</nameField>
 		</sampleName>
 		<sampleName item="foreignG">
-			<nameField type="given">↑↑↑</nameField>
+			<nameField type="given">Sinbad</nameField>
 		</sampleName>
 		<sampleName item="foreignGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Käthe</nameField>
+			<nameField type="surname">Müller</nameField>
 		</sampleName>
 		<sampleName item="foreignGGS">
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname">↑↑↑</nameField>
+			<nameField type="given">Zäzilia</nameField>
+			<nameField type="given2">Hamish</nameField>
+			<nameField type="surname">Stöber</nameField>
 		</sampleName>
 		<sampleName item="foreignFull">
 			<nameField type="title">Ɔ̀jɔ̀gbɔ́n Ɔ̀mɔ̀wé</nameField>
-			<nameField type="given">↑↑↑</nameField>
-			<nameField type="given-informal">↑↑↑</nameField>
-			<nameField type="given2">↑↑↑</nameField>
-			<nameField type="surname-prefix">↑↑↑</nameField>
-			<nameField type="surname-core">↑↑↑</nameField>
-			<nameField type="surname2">↑↑↑</nameField>
-			<nameField type="generation">↑↑↑</nameField>
-			<nameField type="credentials">↑↑↑</nameField>
+			<nameField type="given">Ada Cornelia</nameField>
+			<nameField type="given-informal">Neele</nameField>
+			<nameField type="given2">César Martín</nameField>
+			<nameField type="surname-prefix">von</nameField>
+			<nameField type="surname-core">Brühl</nameField>
+			<nameField type="surname2">González Domingo</nameField>
+			<nameField type="generation">Jr</nameField>
+			<nameField type="credentials">M.D. Ph.D.</nameField>
 		</sampleName>
 	</personNames>
 </ldml>


### PR DESCRIPTION
CLDR-17073

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17073)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

This is a replacement for [PR #3248](https://github.com/unicode-org/cldr/pull/3248) since I could not figure out how to undo the CLDRModify -fp (lowercase) in that one. But note: Unlike that one, this one was begun **after** [PR #3259](https://github.com/unicode-org/cldr/pull/3259) was merged (which ran the 3 standard CLDRModify passes), so there are some differences. And the CLDRModify step for this one (using -fP, uppercase P) produced no changes.
For this one:

1. CLDRileTransformer, no arguments, produced commit 1
2. CLDRModify -fP for the files modified in step 1, produced no changes
3. GenerateDerivedAnnotations, no arguments, produced commit 2
