### PR TITLE
CLDR-17063 CLDRModify -fQ debugging, real/fake keyword paths

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -2122,6 +2122,7 @@ public class CLDRModify {
                         }
                         XPathParts keywordParts = parts.cloneAsThawed().removeAttribute(2, "type");
                         String keywordPath = keywordParts.toString();
+                        keywordPath = cldrFileToFilter.getFullXPath(keywordPath);
                         fakeKeywordPaths.add(keywordPath);
                         String distinguishingKeywordPath =
                                 CLDRFile.getDistinguishingXPath(keywordPath, null);
@@ -2145,7 +2146,8 @@ public class CLDRModify {
 
                         String name = resolved.getStringValue(xpath);
                         String keywordValue = resolved.getStringValue(keywordPath);
-                        String sourceLocaleId = resolved.getSourceLocaleID(distinguishingKeywordPath, null);
+                        String sourceLocaleId =
+                                resolved.getSourceLocaleID(distinguishingKeywordPath, null);
                         sorted.clear();
                         sorted.add(name);
 
@@ -2166,18 +2168,28 @@ public class CLDRModify {
                     @Override
                     public void handleEnd() {
                         if (fakeKeywordPaths.isEmpty() || realKeywordPaths.isEmpty()) {
-                            throw new RuntimeException("fake/real EMPTY loc: " + cldrFileToFilter.getLocaleID());
+                            throw new RuntimeException(
+                                    "fake/real EMPTY loc: " + cldrFileToFilter.getLocaleID());
                         }
                         if (!fakeKeywordPaths.equals(realKeywordPaths)) {
                             fakeKeywordPaths.removeAll(realKeywordPaths);
                             realKeywordPaths.removeAll(fakeKeywordPaths);
                             for (String p : fakeKeywordPaths) {
-                                System.out.println("ONLY fake: " + p + " loc: " + cldrFileToFilter.getLocaleID());
+                                System.out.println(
+                                        "ONLY fake: "
+                                                + p
+                                                + " loc: "
+                                                + cldrFileToFilter.getLocaleID());
                             }
                             for (String p : realKeywordPaths) {
-                                System.out.println("ONLY real: " + p + " loc: " + cldrFileToFilter.getLocaleID());
+                                System.out.println(
+                                        "ONLY real: "
+                                                + p
+                                                + " loc: "
+                                                + cldrFileToFilter.getLocaleID());
                             }
-                            // throw new RuntimeException("fake/real diff  loc: " + cldrFileToFilter.getLocaleID());
+                            // throw new RuntimeException("fake/real diff loc: " +
+                            // cldrFileToFilter.getLocaleID());
                         }
                     }
                 });

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -4,6 +4,7 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.lang.CharSequences;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
@@ -815,6 +816,51 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
             if (set.contains("PandA beAR")) {
                 errln("PandA beAR should be filtered out");
             }
+        }
+    }
+
+    private class KeywordCaseTestData {
+        String[] array, expectedArray;
+
+        KeywordCaseTestData(String[] array, String[] expectedArray) {
+            this.array = array;
+            this.expectedArray = expectedArray;
+        }
+
+        boolean filtersAsExpected() {
+            TreeSet<String> set = new TreeSet<>(Arrays.asList(array));
+            TreeSet<String> expectedSet = new TreeSet<>(Arrays.asList(expectedArray));
+            DisplayAndInputProcessor.filterKeywordsDifferingOnlyInCase(set);
+            if (set.equals(expectedSet)) {
+                return true;
+            } else {
+                errln("Resulting set " + set + " differs from expected set " + expectedSet);
+                return false;
+            }
+        }
+    }
+
+    public void TestFilterKeywordsDifferingOnlyInCase() {
+        String[] array = new String[] {"BEAR", "Bear", "PANDA", "Panda", "panda"};
+        String[] expectedArray = new String[] {"BEAR", "PANDA"};
+        KeywordCaseTestData dat = new KeywordCaseTestData(array, expectedArray);
+        if (!dat.filtersAsExpected()) {
+            errln("Resulting set differs from expected set 1");
+        }
+        array =
+                new String[] {
+                    "gebou", "Japannees", "japanse poskantoor", "Japanse poskantoor", "pos"
+                };
+        expectedArray = new String[] {"gebou", "Japannees", "Japanse poskantoor", "pos"};
+        dat = new KeywordCaseTestData(array, expectedArray);
+        if (!dat.filtersAsExpected()) {
+            errln("Resulting set differs from expected set 2");
+        }
+        array = new String[] {"Aa", "Bb", "Cc", "Dd", "行"}; // should not change
+        expectedArray = array;
+        dat = new KeywordCaseTestData(array, expectedArray);
+        if (!dat.filtersAsExpected()) {
+            errln("Resulting set differs from expected set 3");
         }
     }
 }


### PR DESCRIPTION
-This illustrates cause of draft=unconfirmed bug

-The old, fake keyword path is derived from tts path by removeAttribute

-The new, real keyword path gotten from the CLDRFile

-In general, they are not the same, common difference is draft unconfirmed

CLDR-17063

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
