### PR TITLE
CLDR-16372 Code to replace lateral inheritance markers in trunk

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -79,6 +79,7 @@ import org.unicode.cldr.util.SupplementalDataInfo;
 // import org.unicode.cldr.util.Log;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
+import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.util.XPathParts.Comments;
@@ -2876,11 +2877,11 @@ public class CLDRModify {
 
                     @Override
                     public void handleStart() {
-                        // skip if the locale id's parent isn't root. That is, it must be at level-1
-                        // locale.
+                        // skip if the locale is root.
                         skip = getLocaleID().equals(XMLSource.ROOT_ID);
                         if (!skip) {
                             parentId = LocaleIDParser.getParent(getLocaleID());
+                            // This locale is "L1" (level one) if its parent is root.
                             isL1 = parentId.equals(XMLSource.ROOT_ID);
                             parentFile = null; // lazy evaluate
                         }
@@ -2931,14 +2932,19 @@ public class CLDRModify {
                                     parentFile = factory.make(parentId, true);
                                 }
                                 String parentValue = parentFile.getStringValueWithBailey(xpath);
-                                if (!parentValue.equals(baileyValue)) {
-                                    harden = true;
+                                if (!baileyValue.equals(parentValue)) {
+                                    harden = true; // true if parentValue == null, see comment below
                                 }
                                 message2 = "; L2+";
 
                                 // Problem case: the parent value is null (not inheritance marker)
                                 // but the child value is ^^^.
                                 // See if we need to fix that.
+                                // Currently harden is true if parentValue is null, which, as of
+                                // 2023-09-20, happens here for only two paths, both in locale
+                                // en_AU:
+                                // //ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMEd"]
+                                // //ldml/dates/calendars/calendar[@type="islamic"]/dateTimeFormats/availableFormats/dateFormatItem[@id="yMd"]
                             }
                             if (harden) {
                                 String fullPath = cldrFileToFilter.getFullXPath(xpath);
@@ -3050,6 +3056,26 @@ public class CLDRModify {
                         final String value = cldrFileToFilter.getStringValue(xpath);
                         final String newPath = TARGET_STATUS.updateXPath(fullPath);
                         replace(fullPath, newPath, value, "Upgrade to " + TARGET_STATUS.name());
+                    }
+                });
+
+        fixList.add(
+                'Z',
+                "Zero lateral: convert inheritance marker to specific value if inheritance would be lateral/problematic",
+                new CLDRFilter() {
+                    @Override
+                    public void handlePath(String xpath) {
+                        String value = cldrFileToFilter.getStringValue(xpath);
+                        if (!CldrUtility.INHERITANCE_MARKER.equals(value)) {
+                            return;
+                        }
+                        String newValue =
+                                VoteResolver.reviseInheritanceAsNeeded(xpath, value, getResolved());
+                        if (value.equals(newValue)) {
+                            return;
+                        }
+                        String fullXPath = cldrFileToFilter.getFullXPath(xpath);
+                        replace(fullXPath, fullXPath, newValue);
                     }
                 });
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -2264,7 +2264,7 @@ public class VoteResolver<T> {
             // TODO: decide whether to continue treating GlossonymConstructor.PSEUDO_PATH
             // (constructed values) as lateral inheritance. This method originally did not
             // take constructed values into account, so it implicitly treated constructed
-            // values as inherited, given that pathWhereFound doesn't equal path.
+            // values as laterally inherited, given that pathWhereFound doesn't equal path.
             // This original behavior corresponds to CONSTRUCTED_PSEUDO_PATH_NOT_LATERAL = false.
             // Reference: https://unicode-org.atlassian.net/browse/CLDR-16372
             final boolean CONSTRUCTED_PSEUDO_PATH_NOT_LATERAL = false;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -2261,8 +2261,18 @@ public class VoteResolver<T> {
         String baileyValue = cldrFile.getBaileyValue(path, pathWhereFound, localeWhereFound);
         if (baileyValue != null
                 && (CldrUtility.INHERITANCE_MARKER.equals(value) || baileyValue.equals(value))) {
+            // TODO: decide whether to continue treating GlossonymConstructor.PSEUDO_PATH
+            // (constructed values) as lateral inheritance. This method originally did not
+            // take constructed values into account, so it implicitly treated constructed
+            // values as inherited, given that pathWhereFound doesn't equal path.
+            // This original behavior corresponds to CONSTRUCTED_PSEUDO_PATH_NOT_LATERAL = false.
+            // Reference: https://unicode-org.atlassian.net/browse/CLDR-16372
+            final boolean CONSTRUCTED_PSEUDO_PATH_NOT_LATERAL = false;
             value =
-                    pathWhereFound.value.equals(path)
+                    (pathWhereFound.value.equals(path)
+                                    || (CONSTRUCTED_PSEUDO_PATH_NOT_LATERAL
+                                            && GlossonymConstructor.PSEUDO_PATH.equals(
+                                                    pathWhereFound.value)))
                             ? CldrUtility.INHERITANCE_MARKER
                             : baileyValue;
         }


### PR DESCRIPTION
-New CLDRModify -fZ, Zero lateral, replace INHERITANCE_MARKER with bailey for all lateral inheritance

-For -fZ new boolean CONSTRUCTED_PSEUDO_PATH_NOT_LATERAL in VoteResolver#reviseInheritanceAsNeeded, no change in behavior as it stands

-Revise CLDRModify -fV, values that would inherit laterally, do not crash if parentValue is null

-Comments

CLDR-16372

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
