### PR TITLE
CLDR-15595 Reserve strings "undefined", "undefine", and "auto" in LDML

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -242,6 +242,14 @@ External specifications may also reference particular components of Unicode loca
 
 > _Field X can contain any Unicode region subtag values as given in Unicode Technical Standard #35: Unicode Locale Data Markup Language (LDML), excluding grouping codes._
 
+### <a name="String_Identifiers" href="#String_Identifiers">String Identifiers</a>
+
+Unicode LDML specifies many enumerations of string identifiers, such as days of the week ("`mon"`, `"tue"`, …), units of measurement (`"meter"`, `"inch"`, …), and person name fields (`"title"`, `"given"`, …). For any such string enumeration, the following identifiers are reserved for use by implementations and will not be added as explicit entries into the enumeration by LDML:
+
+1. `"undefined"` (could indicate the lack of a value)
+2. `"undefine"` (BCP-47 version of "undefined")
+3. `"auto"` (could indicate that the implementation should choose an appropriate value from context)
+
 
 
 ## <a name="Locale" href="#Locale">What is a Locale?</a>


### PR DESCRIPTION
CLDR-15595

- [x] This PR completes the ticket.

This change describes all of LDML, so I wasn't sure exactly where to put it, so I made a spot for it in the top-level tr35.md.