### PR TITLE
CLDR-16965 Move Automatic Snapshot time later so still finished by 8:30 am

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -43,9 +43,9 @@ import org.unicode.cldr.web.VettingViewerQueue.LoadingPolicy;
 public class Summary {
 
     /** When to start a daily automatic snapshot */
-    private static final int AUTO_SNAP_HOUR_OF_DAY = 1;
+    private static final int AUTO_SNAP_HOUR_OF_DAY = 8;
 
-    private static final int AUTO_SNAP_MINUTE_OF_HOUR = 11; // 1:11 am
+    private static final int AUTO_SNAP_MINUTE_OF_HOUR = 0; // 8:00 am
     private static final int AUTO_SNAP_MINIMUM_START_MINUTES = 3;
     private static final String AUTO_SNAP_TIME_ZONE = "America/Los_Angeles";
     private static ScheduledFuture<?> autoSnapshotFuture = null;


### PR DESCRIPTION
-Start at 8:00 am PT (America/Los_Angeles); typical duration is eight minutes

-Purpose of the change is for snapshot to be more up to date for morning meeting

CLDR-16965

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
