### PR TITLE
CLDR-17126 Update CLDR segment tailorings to reflect ICU 74 word break changes

### DIFF
--- a/common/segments/en_US_POSIX.xml
+++ b/common/segments/en_US_POSIX.xml
@@ -16,7 +16,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<segmentation type="WordBreak">
 			<variables>
 				<variable id="$MidNumLet">[[$MidNumLet]-[.]]</variable>
-				<variable id="$MidLetter">[[$MidLetter]-[\:]]</variable>
 				<variable id="$MidNum">[[$MidNum] [.]]</variable>
 			</variables>
 		</segmentation>

--- a/common/segments/root.xml
+++ b/common/segments/root.xml
@@ -375,7 +375,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<variable id="$Format">[\p{Word_Break=Format}]</variable>
 				<variable id="$Katakana">\p{Word_Break=Katakana}</variable>
 				<variable id="$ALetter">\p{Word_Break=ALetter}</variable>
-				<variable id="$MidLetter">\p{Word_Break=MidLetter}</variable>
+				<variable id="$MidLetter">[\p{Word_Break = MidLetter} - [\: \uFE55 \uFF1A]]</variable>
 				<variable id="$MidNum">\p{Word_Break=MidNum}</variable>
 				<variable id="$MidNumLet">\p{Word_Break=MidNumLet}</variable>
 				<variable id="$Numeric">\p{Word_Break=Numeric}</variable>


### PR DESCRIPTION
CLDR-17126

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17126)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Update CLDR segmentation tailorings to reflect word break tailorings updates in ICU 74 (CLDR 44 did not make any tailoring updates that need to be synced to ICU).

ALLOW_MANY_COMMITS=true
