### PR TITLE
CLDR-17129 Fix inconsistency in fr dayPeriods for night1; always use [du] matin, not [de la] nuit

### DIFF
--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -3026,7 +3026,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning1">matin</dayPeriod>
 							<dayPeriod type="afternoon1">après-midi</dayPeriod>
 							<dayPeriod type="evening1">soir</dayPeriod>
-							<dayPeriod type="night1">nuit</dayPeriod>
+							<dayPeriod type="night1">matin</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">↑↑↑</dayPeriod>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
@@ -431,6 +431,20 @@ public class DayPeriodInfo {
             return false;
         }
 
+        // Hack for French night1, CLDR-17132 for better fix
+        if ((dayPeriod1 == DayPeriod.night1
+                        && (dayPeriod2 == DayPeriod.morning1 || dayPeriod2 == DayPeriod.am))
+                || (dayPeriod2 == DayPeriod.night1
+                        && (dayPeriod1 == DayPeriod.morning1 || dayPeriod1 == DayPeriod.am))) {
+            if (dayPeriodsToSpans.get(DayPeriod.night1).size() == 1) {
+                for (Span s : dayPeriodsToSpans.get(DayPeriod.night1)) {
+                    if (s.start == MIDNIGHT) {
+                        return false;
+                    }
+                }
+            }
+        }
+
         // we use the more lenient if they are mixed types
         if (type2 == Type.format) {
             type1 = Type.format;


### PR DESCRIPTION
CLDR-17129

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Notice this when investigating a problem in production data with `fr_CA` abbreviated day periods longer than wide.

`fr` was inconsistent in naming of day periods. In most cases (including for different widths) is used forms of "matin" (morning) for both morning1 and night1 (as did `fr_CA`); however for format abbreviated it used "nuit" (night) for night1. I first thought the use of "matin" for night1 was an error until I read the Survey Tool forum comments; the vetters for fr (and fr_CA) all agreed that the period 00:00-04:00 (night1 for fr) should be referred to using morning ("matin"), along with the the period 04:00-12:00 (morning1). So the only necessary consistency change was to fix the one place that instead used "nuit" for night1, and change it to "matin".

Also (as a quick hack fix) allow display collisions between the names for night1 and either morning1 or am, if night1 starts at midnight. Filed https://unicode-org.atlassian.net/browse/CLDR-17132 for a better fix for this French night1 issue.

ALLOW_MANY_COMMITS=true
