### PR TITLE
CLDR-17035 fil use gabi for eve/night (with ng for format), add standalone wide

### DIFF
--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -2328,7 +2328,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning2">madaling-araw</dayPeriod>
 							<dayPeriod type="afternoon1">tanghali</dayPeriod>
 							<dayPeriod type="evening1">ng gabi</dayPeriod>
-							<dayPeriod type="night1">gabi</dayPeriod>
+							<dayPeriod type="night1">ng gabi</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">↑↑↑</dayPeriod>
@@ -2350,7 +2350,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning2">↑↑↑</dayPeriod>
 							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
 							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">ng gabi</dayPeriod>
+							<dayPeriod type="night1">↑↑↑</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
@@ -2363,7 +2363,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="morning2">↑↑↑</dayPeriod>
 							<dayPeriod type="afternoon1">hapon</dayPeriod>
 							<dayPeriod type="evening1">gabi</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
+							<dayPeriod type="night1">gabi</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="midnight">↑↑↑</dayPeriod>
@@ -2381,11 +2381,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<dayPeriod type="am">↑↑↑</dayPeriod>
 							<dayPeriod type="noon">↑↑↑</dayPeriod>
 							<dayPeriod type="pm">↑↑↑</dayPeriod>
-							<dayPeriod type="morning1">↑↑↑</dayPeriod>
+							<dayPeriod type="morning1">umaga</dayPeriod>
 							<dayPeriod type="morning2">↑↑↑</dayPeriod>
-							<dayPeriod type="afternoon1">↑↑↑</dayPeriod>
-							<dayPeriod type="evening1">↑↑↑</dayPeriod>
-							<dayPeriod type="night1">↑↑↑</dayPeriod>
+							<dayPeriod type="afternoon1">hapon</dayPeriod>
+							<dayPeriod type="evening1">gabi</dayPeriod>
+							<dayPeriod type="night1">gabi</dayPeriod>
 						</dayPeriodWidth>
 					</dayPeriodContext>
 				</dayPeriods>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
@@ -432,6 +432,7 @@ public class DayPeriodInfo {
         }
 
         // Hack for French night1, CLDR-17132 for better fix
+        // Let night1 have the same name as morning1/am if night1 starts at 00:00
         if ((dayPeriod1 == DayPeriod.night1
                         && (dayPeriod2 == DayPeriod.morning1 || dayPeriod2 == DayPeriod.am))
                 || (dayPeriod2 == DayPeriod.night1
@@ -439,6 +440,19 @@ public class DayPeriodInfo {
             if (dayPeriodsToSpans.get(DayPeriod.night1).size() == 1) {
                 for (Span s : dayPeriodsToSpans.get(DayPeriod.night1)) {
                     if (s.start == MIDNIGHT) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // Hack for fil evening1/night1, CLDR-17139 for better fix
+        // Let night1 have the same name as evening1 if night1 ends at 24:00
+        if ((dayPeriod1 == DayPeriod.night1 && dayPeriod2 == DayPeriod.evening1)
+                || (dayPeriod2 == DayPeriod.night1 && dayPeriod1 == DayPeriod.evening1)) {
+            if (dayPeriodsToSpans.get(DayPeriod.night1).size() == 1) {
+                for (Span s : dayPeriodsToSpans.get(DayPeriod.night1)) {
+                    if (s.end == DAY_LIMIT) {
                         return false;
                     }
                 }


### PR DESCRIPTION
CLDR-17035

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Quick fix for dayPeriods in `fil`. There were a couple of issues:
- Standalone wide just used ↑↑↑; not sure what it was inheriting from. Copied the standalone abbreviated (which are actually wide) to standalone wide to ensure correct values (without ng).
- Vetters wanted to use the same name ([ng] gabi) for both evening1 and night1, but tests were preventing that, leading to strange values (like format abbreviated using "ng gabi" for one and "gabi" for another, when they should both be "ng gabi" for format style(. Fixed the tests to allow the same values for evening1 and night1 if night1 ends at 24:00.

ALLOW_MANY_COMMITS=true
