### PR TITLE
CLDR-16638 remove mention of "reformed" in spec

### DIFF
--- a/common/collation/sv.xml
+++ b/common/collation/sv.xml
@@ -37,5 +37,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 				&[before 1]ǀ<å<<<Å<ä<<<Ä<<æ<<<Æ<<ę<<<Ę<ö<<<Ö<<ø<<<Ø<<ő<<<Ő<<œ<<<Œ<<ô<<<Ô
 			]]></cr>
 		</collation>
+		<collation type="reformed">
+			<cr><![CDATA[
+				[import sv-u-co-standard]
+			]]></cr>
+		</collation>
 	</collations>
 </ldml>

--- a/common/collation/sv.xml
+++ b/common/collation/sv.xml
@@ -37,10 +37,5 @@ For terms of use, see http://www.unicode.org/copyright.html
 				&[before 1]ǀ<å<<<Å<ä<<<Ä<<æ<<<Æ<<ę<<<Ę<ö<<<Ö<<ø<<<Ø<<ő<<<Ő<<œ<<<Œ<<ô<<<Ô
 			]]></cr>
 		</collation>
-		<collation type="reformed">
-			<cr><![CDATA[
-				[import sv-u-co-standard]
-			]]></cr>
-		</collation>
 	</collations>
 </ldml>

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -753,8 +753,8 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
 
 <tr><td colspan="4"><b>A <a name="UnicodeCollationIdentifier" id="UnicodeCollationIdentifier" href="#UnicodeCollationIdentifier">Unicode Collation Identifier</a> defines a type of collation (sort order). The valid values are those <i>name</i> attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/collation.xml" target="_blank">collation.xml</a></b>.</td></tr>
 <tr><td colspan="4"><i>For information on each collation setting parameter, from <b>ka</b> to <b>vt</b>, see <a href="tr35-collation.md#Setting_Options">Setting Options</a></i></td></tr>
-<tr><td rowspan="9">"co"<br>(collation)</td>
-    <td rowspan="9">Collation type</td>
+<tr><td rowspan="8">"co"<br>(collation)</td>
+    <td rowspan="8">Collation type</td>
             <td>"standard"</td>
             <td>The default ordering for each language. For root it is based on the [<a href="#DUCET">DUCET</a>] (Default Unicode Collation Element Table): see <i><a href="tr35-collation.md#Root_Collation">Root Collation</a></i>. Each other locale is based on that, except for appropriate modifications to certain characters for that language.</td></tr>
         <tr><td>"search"</td>
@@ -765,7 +765,6 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
             <td>Requests a phonetic variant if available, where text is sorted based on pronunciation. It may interleave different scripts, if multiple scripts are in common use.</td></tr>
         <tr><td>"pinyin"</td>
             <td>Pinyin ordering for Latin and for CJK characters; that is, an ordering for CJK characters based on a character-by-character transliteration into a pinyin. (used in Chinese)</td></tr>
-        <tr><td>"reformed"</td><td>Reformed collation (such as in Swedish)</td></tr>
         <tr><td>"searchjl"</td>
             <td>Special collation type for a modified string search in which a pattern consisting of a sequence of Hangul initial consonants (jamo lead consonants) will match a sequence of Hangul syllable characters whose initial consonants match the pattern. The jamo lead consonants can be represented using conjoining or compatibility jamo. This search collator is best used at SECONDARY strength with an "asymmetric" search as described in the [<a href="https://www.unicode.org/reports/tr41/#UTS10">UCA</a>] section Asymmetric Search and obtained, for example, using ICU4C's usearch facility with attribute USEARCH_ELEMENT_COMPARISON set to value USEARCH_PATTERN_BASE_WEIGHT_IS_WILDCARD; this ensures that a full Hangul syllable in the search pattern will only match the same syllable in the searched text (instead of matching any syllable with the same initial consonant), while a Hangul initial consonant in the search pattern will match any Hangul syllable in the searched text with the same initial consonant.</td></tr>
         <tr><td colspan="2">…</td></tr>


### PR DESCRIPTION
CLDR-16638

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

However we should consider formally deprecating "reformed" as a collation type, I filed https://unicode-org.atlassian.net/browse/CLDR-17143 for that (and then we can get the Unicode FAQ updated, etc.). With this PR I have removed mention of it in the LDML spec. Note (as Markus pointed out) that clients who explicitly request the now-absent  "reformed" collation type in Swedish will fall back to getting the "standard" behavior, which is the desired result ("standard" has the data that used to be "reformed").

ALLOW_MANY_COMMITS=true
