### PR TITLE
CLDR-17089 kbd: avoid mixed children in collection

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -78,7 +78,8 @@ The LDML specification is divided into the following parts:
   * [Element: keys](#Element_keys)
   * [Element: key](#Element_key)
     * [Implied Keys](#implied-keys)
-    * [Elements: flicks, flick](#Element_flicks)
+    * [Elements: flicks](#Element_flicks)
+    * [Elements: flick, flickSegment](#Element_flick)
   * [Element: import](#Element_import)
   * [Element: displays](#Element_displays)
   * [Element: display](#Element_display)
@@ -274,7 +275,7 @@ Currently, the following attribute values allow _UnicodeSet_ notation:
 The `\u{...}` notation, a subset of hex notation, is described in [UTS #18 section 1.1](https://www.unicode.org/reports/tr18/#Hex_notation). It can refer to one or multiple individual codepoints. Currently, the following attribute values allow the `\u{...}` notation:
 
 * `to`, `longPress`, `multiTap`, and `longPressDefault` on the `<key>` element
-* `to` on the `<flick>` element
+* `to` on the `<flickSegment>` element
 * `from` or `to` on the `<transform>` element
 * `value` on the `<variable>` element
 * `to` and `display` on the `<display>` element
@@ -332,7 +333,7 @@ This is the top level element. All other elements defined below are under this e
 >
 > Parents: _none_
 >
-> Children: [displays](#Element_displays), [import](#Element_import), [info](#Element_info), [keys](#Element_keys), [layers](#Element_layers), [locales](#Element_locales), [settings](#Element_settings), [_special_](tr35.md#special), [transforms](#Element_transforms), [variables](#Element_variables), [version](#Element_version)
+> Children: [displays](#Element_displays), [import](#Element_import), [info](#Element_info), [keys](#Element_keys), [flicks](#Element_flicks), [layers](#Element_layers), [locales](#Element_locales), [settings](#Element_settings), [_special_](tr35.md#special), [transforms](#Element_transforms), [variables](#Element_variables), [version](#Element_version)
 >
 > Occurrence: required, single
 >
@@ -592,18 +593,13 @@ There is only a single `<keys>` element in each layout.
     <key … />
     <key … />
     <key … />
-    <flicks … />
-    <key … />
-    <flicks … />
 </keys>
 ```
-
-`key` and `flicks` elements may be interleaved in any order.
 
 > <small>
 >
 > Parents: [keyboard3](#Element_keyboard)
-> Children: [key](#Element_key), [flicks](#Element_flicks)
+> Children: [key](#Element_key)
 > Occurrence: optional, single
 >
 > </small>
@@ -824,24 +820,47 @@ Thus, the implied keys behave as if the following import were present.
 
 * * *
 
-#### <a name="Element_flicks" href="#Element_flicks">Elements: flicks, flick</a>
+#### <a name="Element_flicks" href="#Element_flicks">Elements: flicks</a>
 
-The `flicks` element is used to generate results from a "flick" of the finger on a mobile device.
+The `flicks` element is a collection of `flick` elements.
+
+> <small>
+>
+> Parents: [keyboard3](#Element_keyboard3)
+>
+> Children: [flick](#Element_flick), [import](#Element_import), [_special_](tr35.md#special)
+>
+> Occurrence: optional, single
+> </small>
+
+* * *
+
+#### <a name="Element_flick" href="#Element_flick">Elements: flick, flickSegment</a>
+
+The `flick` element is used to generate results from a "flick" of the finger on a mobile device.
 
 **Syntax**
 
 ```xml
-<key id="a" flicks="a-flicks" to="a" />
-<flicks id="a-flicks">
-    {a set of flick elements}
-</flicks>
+<keyboard3>
+    <keys>
+        <key id="a" flicks="a-flicks" to="a" />
+    </keys>
+    <flicks>
+        <flick id="a-flicks">
+            <flickSegment … />
+            <flickSegment … />
+            <flickSegment … />
+        </flick>
+    </flicks>
+</keyboard3>
 ```
 
 > <small>
 >
-> Parents: [keys](#Element_keys)
+> Parents: [flicks](#Element_flicks)
 >
-> Children: [flick](#Element_flick), [_special_](tr35.md#special)
+> Children: [flickSegment](#Element_flickSegment), [_special_](tr35.md#special)
 >
 > Occurrence: optional, multiple
 >
@@ -851,8 +870,8 @@ _Attribute:_ `id` (required)
 
 > The `id` attribute identifies the flicks. It can be any NMTOKEN.
 >
-> The `flicks` do not share a namespace with the `key`s, so it would also be allowed
-> to have `<key id="a" flicks="a"/><flicks id="a"/>`
+> The `flick` elements do not share a namespace with the `key`s, so it would also be allowed
+> to have `<key id="a" flick="a"/>`
 >
 > In the future, this attribute’s definition is expected to be updated to align with [UAX#31](https://www.unicode.org/reports/tr31/). Please see [CLDR-17043](https://unicode-org.atlassian.net/browse/CLDR-17043) for more details.
 
@@ -860,12 +879,12 @@ _Attribute:_ `id` (required)
 **Syntax**
 
 ```xml
-<flick directions="{list of directions}" to="{the output}" />
+<flickSegment directions="{list of directions}" to="{the output}" />
 ```
 
 > <small>
 >
-> Parents: [flicks](#Element_flicks)
+> Parents: [flick](#Element_flick)
 >
 > Children: _none_
 >
@@ -885,9 +904,9 @@ _Attribute:_ `to` (required)
 where a flick to the Northeast then South produces two code points.
 
 ```xml
-<flicks id="a">
-    <flick directions="ne s" to="\u{ABCD}\u{DCBA}" />
-</flicks>
+<flick id="a">
+    <flickSegment directions="ne s" to="\u{ABCD}\u{DCBA}" />
+</flick>
 ```
 
 * * *
@@ -910,7 +929,7 @@ If two identical elements are defined, the later element will take precedence, t
 ```
 > <small>
 >
-> Parents: [displays](#Element_displays), [keyboard3](#Element_keyboard), [keys](#Element_keys), [layers](#Element_layers), [names](#Element_names), [reorders](#Element_reorders), [transformGroup](#Element_transformGroup), [transforms](#Element_transforms), [variables](#Element_variables)
+> Parents: [displays](#Element_displays), [keyboard3](#Element_keyboard), [keys](#Element_keys), [flicks](#Element_flicks), [layers](#Element_layers), [names](#Element_names), [reorders](#Element_reorders), [transformGroup](#Element_transformGroup), [transforms](#Element_transforms), [variables](#Element_variables)
 > Children: _none_
 >
 > Occurrence: optional, multiple
@@ -2701,7 +2720,7 @@ This attribute specifies a key by means of the key’s `id` attribute.
 
 _Attribute:_ `flick`
 
-This attribute specifies a flick gesture to be performed on the specified key instead of a keypress, such as `e` or `nw se`. This value corresponds to the `directions` attribute of the [`<flick>`](#Element_flicks) element.
+This attribute specifies a flick gesture to be performed on the specified key instead of a keypress, such as `e` or `nw se`. This value corresponds to the `directions` attribute of the [`<flickSegment>`](#Element_flickSegment) element.
 
 _Attribute:_ `longPress`
 

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -67,24 +67,23 @@
 
 		<!-- test key -->
 		<key id="a" flicks="a" to="a" longPress="à â á ä ã å ā" />
-		<flicks id="a">
-			<flick directions="nw" to="\u{1234}" />
-			<flick directions="nw se" to="\u{FFFF}" />
-			<flick directions="e" to="\u{FFF0}" />
-		</flicks>
-
 		<!-- test key -->
 		<key id="A" flicks="b" to="A" longPress="À Á Ä Ã Å Ā" />
-
-		<!-- test flick -->
-		<flicks id="b">
-			<flick directions="nw" to="\u{4567}" />
-			<flick directions="nw se" to="\u{FFFF}" />
-			<flick directions="e" to="\u{FFF0}" />
-		</flicks>
-
 		<!-- TODO: all additional maps, hardware and touch -->
 	</keys>
+
+	<flicks>
+		<flick id="a">
+			<flickSegment directions="nw" to="\u{1234}" />
+			<flickSegment directions="nw se" to="\u{FFFF}" />
+			<flickSegment directions="e" to="\u{FFF0}" />
+		</flick>
+		<flick id="b">
+			<flickSegment directions="nw" to="\u{4567}" />
+			<flickSegment directions="nw se" to="\u{FFFF}" />
+			<flickSegment directions="e" to="\u{FFF0}" />
+		</flick>
+	</flicks>
 
 	<layers form="iso">
 		<!-- in DTD: required if conformsTo ≥ 41 -->

--- a/keyboards/dtd/ldmlKeyboard3.dtd
+++ b/keyboards/dtd/ldmlKeyboard3.dtd
@@ -10,7 +10,7 @@ The CLDR Keyboard Subcommittee is currently developing major changes to the CLDR
 Please view the subcommittee page for the most recent information.
 <https://cldr.unicode.org/index/keyboard-workgroup> -->
 
-<!ELEMENT keyboard3 ( import*, locales?, version?, info, settings?, displays?, keys?, forms?, layers*, variables?, transforms*, special* ) >
+<!ELEMENT keyboard3 ( import*, locales?, version?, info, settings?, displays?, keys?, flicks?, forms?, layers*, variables?, transforms*, special* ) >
     <!--@TECHPREVIEW-->
 <!ATTLIST keyboard3 locale CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-wellformed-->
@@ -89,7 +89,7 @@ Please view the subcommittee page for the most recent information.
 <!ELEMENT special ANY >
     <!--@TECHPREVIEW-->
 
-<!ELEMENT keys ( import*, ( key | flicks )*, special* ) >
+<!ELEMENT keys ( import*, key*, special* ) >
     <!--@TECHPREVIEW-->
 
 <!ELEMENT key EMPTY >
@@ -126,16 +126,18 @@ Please view the subcommittee page for the most recent information.
     <!--@MATCH:range/0.01~100.0-->
     <!--@VALUE-->
 
-<!ELEMENT flicks ( flick+, special* ) >
+<!ELEMENT flicks ( import*, flick*, special* ) >
+
+<!ELEMENT flick ( flickSegment+, special* ) >
     <!--@TECHPREVIEW-->
-<!ATTLIST flicks id NMTOKEN #REQUIRED >
+<!ATTLIST flick id NMTOKEN #REQUIRED >
     <!--@MATCH:any-->
 
-<!ELEMENT flick EMPTY >
+<!ELEMENT flickSegment EMPTY >
     <!--@TECHPREVIEW-->
-<!ATTLIST flick directions NMTOKENS #REQUIRED >
+<!ATTLIST flickSegment directions NMTOKENS #REQUIRED >
     <!--@MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))*-->
-<!ATTLIST flick to CDATA #REQUIRED >
+<!ATTLIST flickSegment to CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
     <!--@ALLOWS_UESC-->

--- a/keyboards/dtd/ldmlKeyboard3.xsd
+++ b/keyboards/dtd/ldmlKeyboard3.xsd
@@ -26,6 +26,7 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
         <xs:element minOccurs="0" ref="settings"/>
         <xs:element minOccurs="0" ref="displays"/>
         <xs:element minOccurs="0" ref="keys"/>
+        <xs:element minOccurs="0" ref="flicks"/>
         <xs:element minOccurs="0" ref="forms"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" ref="layers"/>
         <xs:element minOccurs="0" ref="variables"/>
@@ -165,10 +166,7 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
     <xs:complexType>
       <xs:sequence>
         <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
-        <xs:choice maxOccurs="unbounded" minOccurs="0">
-          <xs:element ref="key"/>
-          <xs:element ref="flicks"/>
-        </xs:choice>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="key"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
       </xs:sequence>
     </xs:complexType>
@@ -231,7 +229,16 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
   <xs:element name="flicks">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="flick"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="import"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="flick"/>
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="flick">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="flickSegment"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" ref="special"/>
       </xs:sequence>
       <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
@@ -239,7 +246,7 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
   </xs:element>
   
   
-  <xs:element name="flick">
+  <xs:element name="flickSegment">
     <xs:complexType>
       <xs:attribute name="directions" type="xs:NMTOKENS" use="required"/>
       <xs:attribute name="to" use="required"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -787,13 +787,12 @@ public class TestDtdData extends TestFmwk {
                         || elementName.equals("backspace") && attribute.equals("from")
                         || elementName.equals("backspace") && attribute.equals("after")
                         || elementName.equals("vkeys") && attribute.equals("type")
-                        || elementName.equals("flick") && attribute.equals("directions")
+                        || elementName.equals("flickSegment") && attribute.equals("directions")
                         // || elementName.equals("row") && attribute.equals("keys")
                         || elementName.equals("vkey") && attribute.equals("iso")
                         || elementName.equals("display") && attribute.equals("to")
                         || elementName.equals("display") && attribute.equals("id")
-                        || elementName.equals("flicks") && attribute.equals("id")
-                        || elementName.equals("flick") && attribute.equals("directions");
+                        || elementName.equals("flick") && attribute.equals("id");
             case keyboardTest3:
                 return elementName.equals("tests") && attribute.equals("name")
                         || elementName.equals("test") && attribute.equals("name")


### PR DESCRIPTION
- rename flick to flickSegment, rename flicks to flick
- move flick to child of new flicks element, not under keys
- update dtd, docs, samples

CLDR-17089

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
DISABLE_JIRA_ISSUE_MATCH=true

