### PR TITLE
CLDR-17128 GenerateProductionData should not add defaultNumberingSystem items to ar_001

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -575,7 +575,7 @@ public class GenerateProductionData {
     }
 
     private static boolean localeIsSpecial(String localeId) {
-        return localeId.equals("ar") || localeId.startsWith("ar_");
+        return localeId.equals("ar") || (localeId.startsWith("ar_") && !"ar_001".equals(localeId));
     }
 
     private static final String[] SPECIAL_PATHS =


### PR DESCRIPTION
-The method localeIsSpecial should return false for the default content locale ar_001

CLDR-17128

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
