### PR TITLE
CLDR-16727 Remove short variant for Gulf Standard Time for en_GB

### DIFF
--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -5504,9 +5504,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<long>
 					<standard>↑↑↑</standard>
 				</long>
-				<short>
-					<standard>GTS</standard>
-				</short>
 			</metazone>
 			<metazone type="Guyana">
 				<long>


### PR DESCRIPTION
CLDR-16727

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Removing the GTS value for short variant of Gulf Standard Time for en_GB. This is a quick fix, while the real fix should be disabling this in Survey Tool

ALLOW_MANY_COMMITS=true
