### PR TITLE
CLDR-16369 Move VoteStatus enum from VettingViewer to VoteResolver

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Race.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Race.java
@@ -4,8 +4,8 @@ package org.unicode.cldr.web;
 
 import java.util.Map;
 import org.unicode.cldr.util.Organization;
-import org.unicode.cldr.util.VettingViewer.VoteStatus;
 import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.util.VoteResolver.VoteStatus;
 import org.unicode.cldr.web.UserRegistry.User;
 
 /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STUsersChoice.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STUsersChoice.java
@@ -2,7 +2,7 @@ package org.unicode.cldr.web;
 
 import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.VettingViewer.UsersChoice;
-import org.unicode.cldr.util.VettingViewer.VoteStatus;
+import org.unicode.cldr.util.VoteResolver.VoteStatus;
 import org.unicode.cldr.web.UserRegistry.User;
 
 public class STUsersChoice implements UsersChoice<Organization> {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -88,40 +88,6 @@ public class VettingViewer<T> {
     private static PathHeader.Factory pathTransform;
     private static final OutdatedPaths outdatedPaths = new OutdatedPaths();
 
-    /** See VoteResolver getStatusForOrganization to see how this is computed. */
-    public enum VoteStatus {
-        /**
-         * The value for the path is either contributed or approved, and the user's organization
-         * didn't vote. (see class def for null user)
-         */
-        ok_novotes,
-
-        /**
-         * The value for the path is either contributed or approved, and the user's organization
-         * chose the winning value. (see class def for null user)
-         */
-        ok,
-
-        /**
-         * The user's organization chose the winning value for the path, but that value is neither
-         * contributed nor approved. (see class def for null user)
-         */
-        provisionalOrWorse,
-
-        /**
-         * The user's organization's choice is not winning. There may be insufficient votes to
-         * overcome a previously approved value, or other organizations may be voting against it.
-         * (see class def for null user)
-         */
-        losing,
-
-        /**
-         * There is a dispute, meaning more than one item with votes, or the item with votes didn't
-         * win.
-         */
-        disputed
-    }
-
     /**
      * @author markdavis
      * @param <T>
@@ -139,7 +105,8 @@ public class VettingViewer<T> {
          * Return the vote status NOTE: if organization = null, then it must disregard the
          * organization and never return losing. See VoteStatus.
          */
-        VoteStatus getStatusForUsersOrganization(CLDRFile cldrFile, String path, T organization);
+        VoteResolver.VoteStatus getStatusForUsersOrganization(
+                CLDRFile cldrFile, String path, T organization);
 
         /**
          * Has the given user voted for the given path and locale?
@@ -530,9 +497,9 @@ public class VettingViewer<T> {
                 problems.add(NotificationCategory.inheritedChanged);
                 vc.problemCounter.increment(NotificationCategory.inheritedChanged);
             }
-            VoteStatus voteStatus =
+            VoteResolver.VoteStatus voteStatus =
                     userVoteStatus.getStatusForUsersOrganization(sourceFile, path, organization);
-            boolean itemsOkIfVoted = (voteStatus == VoteStatus.ok);
+            boolean itemsOkIfVoted = (voteStatus == VoteResolver.VoteStatus.ok);
             MissingStatus missingStatus =
                     onlyRecordErrors
                             ? null
@@ -695,7 +662,7 @@ public class VettingViewer<T> {
         }
 
         private void recordLosingDisputedEtc(
-                String path, VoteStatus voteStatus, MissingStatus missingStatus) {
+                String path, VoteResolver.VoteStatus voteStatus, MissingStatus missingStatus) {
             switch (voteStatus) {
                 case losing:
                     if (choices.contains(NotificationCategory.weLost)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -15,7 +15,6 @@ import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.Phase;
 import org.unicode.cldr.test.CheckWidths;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
-import org.unicode.cldr.util.VettingViewer.VoteStatus;
 
 /**
  * This class implements the vote resolution process agreed to by the CLDR committee. Here is an
@@ -433,6 +432,40 @@ public class VoteResolver<T> {
         public boolean canDeleteUsers() {
             return isAdmin();
         }
+    }
+
+    /** See VoteResolver getStatusForOrganization to see how this is computed. */
+    public enum VoteStatus {
+        /**
+         * The value for the path is either contributed or approved, and the user's organization
+         * didn't vote. (see class def for null user)
+         */
+        ok_novotes,
+
+        /**
+         * The value for the path is either contributed or approved, and the user's organization
+         * chose the winning value. (see class def for null user)
+         */
+        ok,
+
+        /**
+         * The user's organization chose the winning value for the path, but that value is neither
+         * contributed nor approved. (see class def for null user)
+         */
+        provisionalOrWorse,
+
+        /**
+         * The user's organization's choice is not winning. There may be insufficient votes to
+         * overcome a previously approved value, or other organizations may be voting against it.
+         * (see class def for null user)
+         */
+        losing,
+
+        /**
+         * There is a dispute, meaning more than one item with votes, or the item with votes didn't
+         * win.
+         */
+        disputed
     }
 
     /** Internal class for voter information. It is public for testing only */

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VotelessUsersChoice.java
@@ -13,7 +13,7 @@ public class VotelessUsersChoice implements VettingViewer.UsersChoice<Organizati
     }
 
     @Override
-    public VettingViewer.VoteStatus getStatusForUsersOrganization(
+    public VoteResolver.VoteStatus getStatusForUsersOrganization(
             CLDRFile cldrFile, String path, Organization org) {
         final CLDRLocale loc = CLDRLocale.getInstance(cldrFile.getLocaleID());
         return getVoteResolver(cldrFile, loc, path).getStatusForOrganization(org);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUtilities.java
@@ -41,9 +41,9 @@ import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.VettingViewer.MissingStatus;
-import org.unicode.cldr.util.VettingViewer.VoteStatus;
 import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.util.VoteResolver.Status;
+import org.unicode.cldr.util.VoteResolver.VoteStatus;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
 import org.unicode.cldr.util.props.ICUPropertyFactory;
 
@@ -400,9 +400,9 @@ public class TestUtilities extends TestFmwkPlus {
         resolver.add("fii", toVoterId("appleV"));
         VoteStatus voteStatus;
         voteStatus = resolver.getStatusForOrganization(Organization.google);
-        assertEquals("", VoteStatus.ok, voteStatus);
+        assertEquals("", VoteResolver.VoteStatus.ok, voteStatus);
         voteStatus = resolver.getStatusForOrganization(Organization.apple);
-        assertEquals("", VoteStatus.ok, voteStatus);
+        assertEquals("", VoteResolver.VoteStatus.ok, voteStatus);
 
         // make non-equal foo
         String s1 = "foo";
@@ -415,7 +415,7 @@ public class TestUtilities extends TestFmwkPlus {
         resolver.setBaseline(s1, Status.approved);
         resolver.add(s2, toVoterId("appleV"));
         voteStatus = resolver.getStatusForOrganization(Organization.apple);
-        assertEquals("", VoteStatus.ok, voteStatus);
+        assertEquals("", VoteResolver.VoteStatus.ok, voteStatus);
     }
 
     public void TestLosingStatus() {
@@ -432,7 +432,7 @@ public class TestUtilities extends TestFmwkPlus {
         resolver.setBaseline("BQ", Status.missing);
         resolver.setBaileyValue("bailey");
         VoteStatus status = resolver.getStatusForOrganization(Organization.openoffice_org);
-        assertEquals("", VoteStatus.provisionalOrWorse, status);
+        assertEquals("", VoteResolver.VoteStatus.provisionalOrWorse, status);
 
         // {lastRelease: {{0}: {1}, missing}, trunk: {null, null}, {orgToVotes:
         // pakistan={{0}: {1}=8}, totals: {{0}:
@@ -444,7 +444,7 @@ public class TestUtilities extends TestFmwkPlus {
         // resolver.setLastRelease("{0}: {1}", Status.missing);
         resolver.add("{0}: {1}", toVoterId("adobeE"));
         status = resolver.getStatusForOrganization(Organization.openoffice_org);
-        assertEquals("", VoteStatus.ok, status);
+        assertEquals("", VoteResolver.VoteStatus.ok, status);
 
         // {lastRelease: {Arabisch, approved}, trunk: {Arabisch, approved},
         // {orgToVotes: , totals: {}, conflicted: []},
@@ -455,7 +455,7 @@ public class TestUtilities extends TestFmwkPlus {
         // resolver.setLastRelease("Arabisch", Status.approved);
         resolver.setBaseline("Arabisch", Status.approved);
         status = resolver.getStatusForOrganization(Organization.openoffice_org);
-        assertEquals("", VoteStatus.ok_novotes, status);
+        assertEquals("", VoteResolver.VoteStatus.ok_novotes, status);
     }
 
     public void TestTotalVotesStatus() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVettingViewer.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.unicode.cldr.test.OutdatedPaths;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
-import org.unicode.cldr.util.VettingViewer.VoteStatus;
+import org.unicode.cldr.util.VoteResolver.VoteStatus;
 
 /** Also see {@link org.unicode.cldr.unittest.TestUtilities} */
 class TestVettingViewer {
@@ -38,7 +38,7 @@ class TestVettingViewer {
                             @Override
                             public VoteStatus getStatusForUsersOrganization(
                                     CLDRFile cldrFile, String path, Organization user) {
-                                return VoteStatus.losing;
+                                return VoteResolver.VoteStatus.losing;
                             }
 
                             @Override

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestVoteResolver.java
@@ -8,7 +8,6 @@ import com.ibm.icu.util.Output;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.unittest.TestUtilities;
-import org.unicode.cldr.util.VettingViewer.VoteStatus;
 import org.unicode.cldr.util.VoteResolver.Status;
 
 /**
@@ -43,7 +42,8 @@ public class TestVoteResolver {
                 () -> assertEquals("Illa Bouvet", vr.getWinningValue()),
                 () ->
                         assertEquals(
-                                VoteStatus.ok, vr.getStatusForOrganization(Organization.google)));
+                                VoteResolver.VoteStatus.ok,
+                                vr.getStatusForOrganization(Organization.google)));
     }
 
     @Test


### PR DESCRIPTION
-VettingViewer should depend on VoteResolver, not vice-versa

CLDR-16369

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
