### PR TITLE
CLDR-17171 v44 JSON: don't emit {} for space replacement

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -2264,9 +2264,16 @@ public class Ldml2JsonConverter {
             // out.name(objName);
             if (value.isEmpty()) {
                 if (valueIsSpacesepArray) {
+                    // empty value, output as empty space-sep array: []
                     out.getAsJsonObject().add(objName, new JsonArray());
                 } else {
-                    out.getAsJsonObject().add(objName, new JsonObject());
+                    // empty value.
+                    if (objName.endsWith("SpaceReplacement")) { // foreignSpaceReplacement or
+                        // nativeSpaceReplacement
+                        out.getAsJsonObject().addProperty(objName, "");
+                    } else {
+                        out.getAsJsonObject().add(objName, new JsonObject());
+                    }
                 }
             } else if (type == RunType.annotations || type == RunType.annotationsDerived) {
                 JsonArray a = new JsonArray();


### PR DESCRIPTION
CLDR-17171

- Punt a better fix to CLDR-17186
- ONLY fixes `*SpaceReplacement` elements

example:

```patch
diff --git a/cldr-json/cldr-person-names-modern/main/zh/personNames.json b/cldr-json/cldr-person-names-modern/main/zh/personNames.json
index 5f3ab58077..4263171e2c 100644
--- a/cldr-json/cldr-person-names-modern/main/zh/personNames.json
+++ b/cldr-json/cldr-person-names-modern/main/zh/personNames.json
@@ -21,7 +21,7 @@
         ],
         "formality": "informal",
         "length": "medium",
-        "nativeSpaceReplacement": {},
+        "nativeSpaceReplacement": "",
         "foreignSpaceReplacement": "·",
         "initial": "{0}",
         "initialSequence": "{0} {1}",
```

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
