### PR TITLE
CLDR-17195 v44: update en with locales now at basic

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -93,6 +93,7 @@ annotations.
 			<language type="bjn">Banjar</language>
 			<language type="bkm">Kom</language>
 			<language type="bla">Siksiká</language>
+			<language type="blo">Anii</language>
 			<language type="blt">Tai Dam</language>
 			<language type="bm">Bambara</language>
 			<language type="bn">Bangla</language>
@@ -353,6 +354,7 @@ annotations.
 			<language type="kv">Komi</language>
 			<language type="kw">Cornish</language>
 			<language type="kwk">Kwakʼwala</language>
+			<language type="kxv">Kuvi</language>
 			<language type="ky">Kyrgyz</language>
 			<language type="ky" alt="variant">Kirghiz</language>
 			<language type="la">Latin</language>
@@ -677,6 +679,7 @@ annotations.
 			<language type="xal">Kalmyk</language>
 			<language type="xh">Xhosa</language>
 			<language type="xmf">Mingrelian</language>
+			<language type="xnr">Kangri</language>
 			<language type="xog">Soga</language>
 			<language type="yao">Yao</language>
 			<language type="yap">Yapese</language>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -331,7 +331,7 @@ public class LikelySubtagsTest extends TestFmwk {
     }
 
     public void TestMissingInfoForLanguage() {
-        CLDRFile english = CLDR_CONFIG.getEnglish();
+        CLDRFile english = CLDR_CONFIG.getEnglish().getUnresolved();
 
         CalculatedCoverageLevels ccl = CalculatedCoverageLevels.getInstance();
 
@@ -357,7 +357,7 @@ public class LikelySubtagsTest extends TestFmwk {
                         continue; // skip error
                     }
                 }
-                errln("Missing English translation for: " + language);
+                errln("Missing English translation for: " + language + " which is at " + covLevel);
             }
         }
     }


### PR DESCRIPTION
CLDR-17195

- [X] This PR completes the ticket.
- also fixes a test case which ought to have failed on this case.  Confirmed that there are no other cases besides these (`blo`,`xnr`, `kxv`)

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
