### PR TITLE
CLDR-16595 Add DisplayAndInputProcessor rule for normalizing Kashmiri, normalize Kashmiri

### DIFF
--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -42,7 +42,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="arn">ایرو کونِیَن</language>
 			<language type="arp">اَراپاہو</language>
 			<language type="arw">اَراوَک</language>
-			<language type="as">اسٲمۍ</language>
+			<language type="as">اسٲمؠ</language>
 			<language type="ast">ایسٹوٗریَن</language>
 			<language type="av">اَوارِک</language>
 			<language type="awa">اَوَدی</language>
@@ -62,7 +62,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="bin">بِنی</language>
 			<language type="bla">سِکسِکا</language>
 			<language type="bm">بَمبارا</language>
-			<language type="bn">بَنگٲلۍ</language>
+			<language type="bn">بَنگٲلؠ</language>
 			<language type="bo">تِبتی</language>
 			<language type="br">بریٹَن</language>
 			<language type="bra">برج</language>
@@ -118,14 +118,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="eka">ایکاجُک</language>
 			<language type="el">یوٗنٲنی</language>
 			<language type="elx">ایلامایِٹ</language>
-			<language type="en">اَنگیٖزۍ</language>
-			<language type="en_AU">آسٹریلیَن اَنگریٖزۍ</language>
-			<language type="en_CA">کینَڈِیٲیی اَنگریٖزۍ</language>
-			<language type="en_GB">بَرطانوی اَنگریٖزۍ</language>
-			<language type="en_GB" alt="short">UK اَنٛگریٖزۍ</language>
-			<language type="en_US">امریٖکی اَنٛگریٖزۍ</language>
-			<language type="en_US" alt="short">US اَنٛگریٖزۍ</language>
-			<language type="enm">وَسطی اَنگریٖزۍ</language>
+			<language type="en">اَنگیٖزؠ</language>
+			<language type="en_AU">آسٹریلیَن اَنگریٖزؠ</language>
+			<language type="en_CA">کینَڈِیٲیی اَنگریٖزؠ</language>
+			<language type="en_GB">بَرطانوی اَنگریٖزؠ</language>
+			<language type="en_GB" alt="short">UK اَنٛگریٖزؠ</language>
+			<language type="en_US">امریٖکی اَنٛگریٖزؠ</language>
+			<language type="en_US" alt="short">US اَنٛگریٖزؠ</language>
+			<language type="enm">وَسطی اَنگریٖزؠ</language>
 			<language type="eo">ایسپَرینٹو</language>
 			<language type="es">ہسپانوی</language>
 			<language type="es_419">لاطیٖنی امریٖکی ہسپانوی</language>
@@ -175,7 +175,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ha">ہاوسا</language>
 			<language type="hai">ہَیدا</language>
 			<language type="haw">ہوایِیَن</language>
-			<language type="he">عبرٲنۍ</language>
+			<language type="he">عبرٲنؠ</language>
 			<language type="hi">ہِندی</language>
 			<language type="hil">ہِلیٖگینَن</language>
 			<language type="hit">ہِتایِت</language>
@@ -201,7 +201,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="is">آیِسلینڈِک</language>
 			<language type="it">اِطالوی</language>
 			<language type="iu">اِنُکتِتوٗ</language>
-			<language type="ja">جاپٲنۍ</language>
+			<language type="ja">جاپٲنؠ</language>
 			<language type="jbo">لوجبان</language>
 			<language type="jpr">جوڈیو فارسی</language>
 			<language type="jrb">جوڈیو عربی</language>
@@ -283,7 +283,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="mni">مَنیپوٗری</language>
 			<language type="moh">موہاک</language>
 			<language type="mos">موسی</language>
-			<language type="mr">مَرٲٹھۍ</language>
+			<language type="mr">مَرٲٹھؠ</language>
 			<language type="ms">مَلَے</language>
 			<language type="mt">مَلتیٖس</language>
 			<language type="mul">واریاہ زبان</language>
@@ -297,7 +297,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="nb">ناروییَن بوکمال</language>
 			<language type="nd">شُمال ڈَبیل</language>
 			<language type="nds">بۆنِم جٔرمَن</language>
-			<language type="ne">نیپٲلۍ</language>
+			<language type="ne">نیپٲلؠ</language>
 			<language type="new">نیواری</language>
 			<language type="ng">ڈونگا</language>
 			<language type="nia">نِیاس</language>
@@ -325,7 +325,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="os">اۆسیٹِک</language>
 			<language type="osa">اۆسیج</language>
 			<language type="ota">اوٹومَن تُرکِش</language>
-			<language type="pa">پَنجٲبۍ</language>
+			<language type="pa">پَنجٲبؠ</language>
 			<language type="pag">پَنگاسِنَن</language>
 			<language type="pal">پَہلَوی</language>
 			<language type="pam">پَمپَنگا</language>
@@ -342,7 +342,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="pt_BR">برازیٖلی پُرتَگیٖز</language>
 			<language type="pt_PT">یوٗرپی پُرتَگیٖز</language>
 			<language type="qu">کُویشُوا</language>
-			<language type="raj">راجِستھٲنۍ</language>
+			<language type="raj">راجِستھٲنؠ</language>
 			<language type="rap">رَپانوی</language>
 			<language type="rar">رَروٹونگَن</language>
 			<language type="rm">رومانش</language>
@@ -428,7 +428,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="uga">اُگارتِک</language>
 			<language type="uk">یوٗکرینیٲیی</language>
 			<language type="umb">یُمبُندوٗ</language>
-			<language type="und">اَنزٲنۍ یا نَہ لَگہٕہار زبان</language>
+			<language type="und">اَنزٲنؠ یا نَہ لَگہٕہار زبان</language>
 			<language type="ur">اُردوٗ</language>
 			<language type="uz">اُزبیک</language>
 			<language type="vai">واے</language>
@@ -468,7 +468,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Avst">اَویستَن</script>
 			<script type="Bali">بالَنیٖز</script>
 			<script type="Batk">باتَک</script>
-			<script type="Beng">بینگٲلۍ</script>
+			<script type="Beng">بینگٲلؠ</script>
 			<script type="Blis">بِلِس سِمبلز</script>
 			<script type="Bopo">بوپوموفو</script>
 			<script type="Brah">براہمی</script>
@@ -496,13 +496,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Goth">گوتھِک</script>
 			<script type="Grek">گرَنتھا</script>
 			<script type="Gujr">گریٖک</script>
-			<script type="Guru">گُجرٲتۍ</script>
+			<script type="Guru">گُجرٲتؠ</script>
 			<script type="Hang">ہانگُل</script>
 			<script type="Hani">ہان</script>
 			<script type="Hano">ہانُنوٗ</script>
-			<script type="Hans">سَہل ﴿ترجمع اِشارٕ: یِم ورژن رَسم الخط ہُک ناؤ چھُ چیٖنی باپتھ زَبانٕ ناؤ کِس مجموعَس سٕتۍ اِستعمال یِوان کرنٕہ۔﴾</script>
+			<script type="Hans">سَہل ﴿ترجمع اِشارٕ: یِم ورژن رَسم الخط ہُک ناؤ چھُ چیٖنی باپتھ زَبانٕ ناؤ کِس مجموعَس سٕتؠ اِستعمال یِوان کرنٕہ۔﴾</script>
 			<script type="Hans" alt="stand-alone">سَہل ہان ﴿ترجمع اِشارٕ: یِم ورژن رَسم الخط ہُک ناؤ چھُ چیٖنی باپتھ زَبانٕ ناؤ کِس مجموعَس بغٲرٕ الگ اِستعمال یِوان کرنٕہ۔﴾</script>
-			<script type="Hant">رِوٲجی ﴿ترجمع اِشارٕ: یِم ورژن رَسم الخط ہُک ناؤ چھُ چیٖنی باپتھ زَبانٕ ناؤ کِس مجموعَس سٕتۍ اِستعمال یِوان کرنٕہ۔﴾</script>
+			<script type="Hant">رِوٲجی ﴿ترجمع اِشارٕ: یِم ورژن رَسم الخط ہُک ناؤ چھُ چیٖنی باپتھ زَبانٕ ناؤ کِس مجموعَس سٕتؠ اِستعمال یِوان کرنٕہ۔﴾</script>
 			<script type="Hant" alt="stand-alone">رِوٲجی ہان ﴿ترجمع اِشارٕ: یِم ورژن رَسم الخط ہُک ناؤ چھُ چیٖنی باپتھ زَبانٕ ناؤ کِس مجموعَس بغٲرٕ الگ اِستعمال یِوان کرنٕہ۔﴾</script>
 			<script type="Hebr">ہِبرِو</script>
 			<script type="Hira">ہیٖراگانا</script>
@@ -737,7 +737,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="IL">اسرا ییل</territory>
 			<territory type="IM">آیِل آف مین</territory>
 			<territory type="IN">ہِندوستان</territory>
-			<territory type="IO" draft="provisional">برطانوی بحرِ ہِندۍ علاقہٕ</territory>
+			<territory type="IO" draft="provisional">برطانوی بحرِ ہِندؠ علاقہٕ</territory>
 			<territory type="IQ">ایٖراق</territory>
 			<territory type="IR">ایٖران</territory>
 			<territory type="IS">اَیِسلینڑ</territory>
@@ -813,7 +813,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="PK">پاکِستان</territory>
 			<territory type="PL">پولینڈ</territory>
 			<territory type="PM">سینٹ پیٖری تہٕ موکیلِیَن</territory>
-			<territory type="PN">پِٹکیرٕنۍ جٔزیٖرٕ</territory>
+			<territory type="PN">پِٹکیرٕنؠ جٔزیٖرٕ</territory>
 			<territory type="PR">پٔرٹو رِکو</territory>
 			<territory type="PS">فلسطینی علاقٕہ</territory>
 			<territory type="PS" alt="short">فلسطین</territory>
@@ -902,22 +902,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<variant type="1606NICT">بعد وَقت وَسطی فرانس پؠٹھ ۱۶٠۶ تام</variant>
 			<variant type="AREVELA">مَشرِقی اَمریٖکا</variant>
 			<variant type="BAKU1926">جٔمع کٔرِتھ تُرکی لاطیٖنی اَچھر</variant>
-			<variant type="BISKE">سین جارجِیو/بِلا بوٗلۍ</variant>
+			<variant type="BISKE">سین جارجِیو/بِلا بوٗلؠ</variant>
 			<variant type="FONIPA">آوازیات</variant>
 			<variant type="FONUPA">یوٗ پی اے آوازِیات</variant>
-			<variant type="LIPAW">روٗسی زَبانہِ ہِنز لِپوواز بوٗلۍ</variant>
+			<variant type="LIPAW">روٗسی زَبانہِ ہِنز لِپوواز بوٗلؠ</variant>
 			<variant type="MONOTON">اَکٔے لہجہٕ واجؠن زَبان</variant>
-			<variant type="NEDIS">نؠٹِسون بوٗلۍ</variant>
-			<variant type="NJIVA">نیجِوا بوٗلۍ</variant>
-			<variant type="OSOJS">اُشیکو/اوسوجین بوٗلۍ</variant>
+			<variant type="NEDIS">نؠٹِسون بوٗلؠ</variant>
+			<variant type="NJIVA">نیجِوا بوٗلؠ</variant>
+			<variant type="OSOJS">اُشیکو/اوسوجین بوٗلؠ</variant>
 			<variant type="POLYTON">واریاہ لہجہٕ واجؠن زَبان</variant>
 			<variant type="POSIX">کَمپیوٗٹَر</variant>
 			<variant type="REVISED">دُبارٕ دۄہراونہٕ آمُت عِلمہِ ہِجا</variant>
 			<variant type="ROZAJ">روٗسی</variant>
 			<variant type="SAAHO">سوہو</variant>
-			<variant type="SCOTLAND">سُکاٹِش مَیعٲری اَنگریٖزۍ</variant>
+			<variant type="SCOTLAND">سُکاٹِش مَیعٲری اَنگریٖزؠ</variant>
 			<variant type="SCOUSE">سِکوس</variant>
-			<variant type="SOLBA">ثٹولوِزا/سولبِکا بوٗلۍ</variant>
+			<variant type="SOLBA">ثٹولوِزا/سولبِکا بوٗلؠ</variant>
 			<variant type="TARASK">تاراسکیٖوِکا علمہ ہِجاِ</variant>
 		</variants>
 		<keys>
@@ -933,7 +933,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="calendar" type="islamic" draft="provisional">اِسلٲمی کیلنڑَر</type>
 			<type key="calendar" type="islamic-civil" draft="provisional">اِسلٲمی اِجتمٲیی کیلنڑَر</type>
 			<type key="calendar" type="iso8601">ISO-8601 کیلنڈر</type>
-			<type key="calendar" type="japanese">جاپٲنۍ کیلنڑَر</type>
+			<type key="calendar" type="japanese">جاپٲنؠ کیلنڑَر</type>
 			<type key="calendar" type="roc">جموٗریٲتی چیٖنی کیلَنڑَر</type>
 			<type key="collation" type="big5han">رؠوٲتی چیٖنی تِرتیٖب</type>
 			<type key="collation" type="phonebook">فون بُک تَرتیٖب</type>
@@ -1027,7 +1027,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{0} پٮ۪ٹھۍ {1}</pattern>
+							<pattern>{0} پٮ۪ٹھؠ {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1035,7 +1035,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{0} پٮ۪ٹھۍ {1}</pattern>
+							<pattern>{0} پٮ۪ٹھؠ {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1510,7 +1510,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{0} پٮ۪ٹھۍ {1}</pattern>
+							<pattern>{0} پٮ۪ٹھؠ {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1518,7 +1518,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{0} پٮ۪ٹھۍ {1}</pattern>
+							<pattern>{0} پٮ۪ٹھؠ {1}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1858,9 +1858,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="month">
 				<displayName>رؠتھ</displayName>
-				<relative type="-1">پٔتِم ریتھۍ</relative>
-				<relative type="0">یٕہ ریتھۍ</relative>
-				<relative type="1">نو ریتھۍ</relative>
+				<relative type="-1">پٔتِم ریتھؠ</relative>
+				<relative type="0">یٕہ ریتھؠ</relative>
+				<relative type="1">نو ریتھؠ</relative>
 			</field>
 			<field type="month-short">
 				<displayName>↑↑↑</displayName>
@@ -3683,7 +3683,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Indian_Ocean">
 				<long>
-					<standard>ہِندوستٲنۍ اوشَن ٹائم</standard>
+					<standard>ہِندوستٲنؠ اوشَن ٹائم</standard>
 				</long>
 			</metazone>
 			<metazone type="Indochina">
@@ -3708,8 +3708,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Iran">
 				<long>
-					<generic>اِیٖرٲنۍ ٹایِم</generic>
-					<standard>اِیٖرٲنۍ سٹینڑاڑ ٹایِم</standard>
+					<generic>اِیٖرٲنؠ ٹایِم</generic>
+					<standard>اِیٖرٲنؠ سٹینڑاڑ ٹایِم</standard>
 					<daylight>اِیٖرٲنی سَمَر ٹایِم</daylight>
 				</long>
 			</metazone>
@@ -3729,9 +3729,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Japan">
 				<long>
-					<generic>جاپٲنۍ ٹایِم</generic>
-					<standard>جاپٲنۍ سٹینڈرڈ ٹایِم</standard>
-					<daylight>جاپٲنۍ ڑےلایِٔٹ ٹایِم</daylight>
+					<generic>جاپٲنؠ ٹایِم</generic>
+					<standard>جاپٲنؠ سٹینڈرڈ ٹایِم</standard>
+					<daylight>جاپٲنؠ ڑےلایِٔٹ ٹایِم</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kamchatka">
@@ -3878,7 +3878,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Nepal">
 				<long>
-					<standard>نؠپٲلۍ ٹایِم</standard>
+					<standard>نؠپٲلؠ ٹایِم</standard>
 				</long>
 			</metazone>
 			<metazone type="New_Caledonia">
@@ -4307,7 +4307,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000000000" count="other" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="one">↑↑↑</unitPattern>
 			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>
@@ -4622,10 +4622,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>اِزرٲیِلی پاونڑ</displayName>
 			</currency>
 			<currency type="ILS">
-				<displayName>اِزرٲیِلی نٔوۍ شؠقٕل</displayName>
+				<displayName>اِزرٲیِلی نٔوؠ شؠقٕل</displayName>
 			</currency>
 			<currency type="INR">
-				<displayName>ہِندُستٲنۍ رۄپَے</displayName>
+				<displayName>ہِندُستٲنؠ رۄپَے</displayName>
 				<displayName count="one">↑↑↑</displayName>
 				<displayName count="other">↑↑↑</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
@@ -4839,7 +4839,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>پھِلِپایِٔن پؠسو</displayName>
 			</currency>
 			<currency type="PKR">
-				<displayName>پاکِستٲنۍ رۄپَے</displayName>
+				<displayName>پاکِستٲنؠ رۄپَے</displayName>
 			</currency>
 			<currency type="PLN">
 				<displayName>پولِش زلوٹی</displayName>

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -963,7 +963,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</orientation>
 	</layout>
 	<characters>
-		<exemplarCharacters>[ء آ أ ٲ ؤ ا ب پ ت ث ٹ ج چ ح خ د ذ ڈ ر ز ڑ ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن ں ھ ہ و ۄ ۆ ی ۍ ؠ ے]</exemplarCharacters>
+		<exemplarCharacters>[ء آ أ ٲ ؤ ا ب پ ت ث ٹ ج چ ح خ د ذ ڈ ر ز ڑ ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن ں ھ ہ و ۄ ۆ ی ؠ ے]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[\u200E\u200F َ ُ ِ ٔ ٕ ٟ ٖ ٗ ئ]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\u200E \- ‑ , ٫ ٬ . % ‰ + 0۰ 1۱ 2۲ 3۳ 4۴ 5۵ 6۶ 7۷ 8۸ 9۹]</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="contributed">[\- ‐‑ – — , ; \: ! ? . … '‘’ &quot;“” ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -180,6 +180,7 @@ public class DisplayAndInputProcessor {
     private static final CLDRLocale GERMAN_SWITZERLAND = CLDRLocale.getInstance("de_CH");
     private static final CLDRLocale SWISS_GERMAN = CLDRLocale.getInstance("gsw");
     private static final CLDRLocale FF_ADLAM = CLDRLocale.getInstance("ff_Adlm");
+    private static final CLDRLocale KASHMIRI = CLDRLocale.getInstance("ks");
     public static final Set<String> LANGUAGES_USING_MODIFIER_APOSTROPHE =
             new HashSet<>(
                     Arrays.asList(
@@ -222,6 +223,10 @@ public class DisplayAndInputProcessor {
     private static final char[][] KYRGYZ_CONVERSIONS = {{'ӊ', 'ң'}, {'Ӊ', 'Ң'}}; //  right modifier
 
     private static final char[][] URDU_PLUS_CONVERSIONS = {{'\u0643', '\u06A9'}}; //  wrong char
+
+    private static final char[][] KASHMIRI_CONVERSIONS = {
+        {'ۍ', 'ؠ'}
+    }; //  wrong char (see CLDR-16595)
 
     private static final ZawgyiDetector detector = new ZawgyiDetector();
     private static final Transliterator zawgyiUnicodeTransliterator =
@@ -598,6 +603,8 @@ public class DisplayAndInputProcessor {
             value = replaceChars(path, value, URDU_PLUS_CONVERSIONS, true);
         } else if (locale.childOf(FF_ADLAM) && !isUnicodeSet) {
             value = fixAdlamNasalization(value);
+        } else if (locale.childOf(KASHMIRI)) {
+            value = replaceChars(path, value, KASHMIRI_CONVERSIONS, false);
         }
         return value;
     }


### PR DESCRIPTION

This normalizes YEH WITH TAIL (an incorrect Pashto letter) to KASHMIRI YEH. See L2/23-241.

CLDR-16595

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true