### PR TITLE
CLDR-17229 keyboard: v45 cherry-pick from maint-44

### DIFF
--- a/keyboards/dtd/ldmlKeyboard3.dtd
+++ b/keyboards/dtd/ldmlKeyboard3.dtd
@@ -31,7 +31,6 @@ Please view the subcommittee page for the most recent information.
     <!--@TECHPREVIEW-->
 <!ATTLIST locale id CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-wellformed-->
-    <!--@VALUE-->
 
 <!ELEMENT version EMPTY >
     <!--@TECHPREVIEW-->

--- a/keyboards/dtd/ldmlKeyboard3.xsd
+++ b/keyboards/dtd/ldmlKeyboard3.xsd
@@ -76,7 +76,6 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
   </xs:element>
   
   
-  
   <xs:element name="version">
     <xs:complexType>
       <xs:attribute name="number"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -766,6 +766,7 @@ public class TestDtdData extends TestFmwk {
                         || elementName.equals("keyList") && attribute.equals("id")
                         || elementName.equals("flick") && attribute.equals("id")
                         || elementName.equals("import") && attribute.equals("path")
+                        || elementName.equals("locale") && attribute.equals("id")
                         || elementName.equals("import") && attribute.equals("base")
                         || elementName.equals("layer") && attribute.equals("id")
                         || elementName.equals("string") && attribute.equals("id")


### PR DESCRIPTION
- cherry-pick from maint-44: CLDR-17204 kbd: dtd fix for locales (#3369)

- the `<locale id>` attribute was set as `@VALUE` which caused it to be wrongly flagged as a duplicate.

(cherry picked from commit b07c9d8c52f1b03bffa85a93672b1101dd19c19d)

CLDR-17229 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
