### PR TITLE
CLDR-17233 Have DAIP coalesce multiple spaces to strictest; fix in fr.xml, reorder zones in root

### DIFF
--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -11702,7 +11702,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-foodcalorie">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} kcal</unitPattern>
-				<unitPattern count="other">{0}  kcal</unitPattern>
+				<unitPattern count="other">{0} kcal</unitPattern>
 			</unit>
 			<unit type="energy-kilojoule">
 				<displayName>↑↑↑</displayName>

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -2211,14 +2211,14 @@ annotations.
 						<intervalFormatItem id="GyMMMd">
 							<greatestDifference id="d">G y MMM d–d</greatestDifference>
 							<greatestDifference id="G">G y MMM d – G y MMM d</greatestDifference>
-							<greatestDifference id="M">G y MMM d  – MMM d</greatestDifference>
-							<greatestDifference id="y">G y MMM d –  y d MMM</greatestDifference>
+							<greatestDifference id="M">G y MMM d – MMM d</greatestDifference>
+							<greatestDifference id="y">G y MMM d – y d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
 							<greatestDifference id="d">G y MMM d, E – MMM d, E</greatestDifference>
-							<greatestDifference id="G">G y MMM d, E –  G y MMM d, E</greatestDifference>
-							<greatestDifference id="M">G y MMM d, E –  MMM d, E</greatestDifference>
-							<greatestDifference id="y">G y MMM d, E –  y MMM d, E</greatestDifference>
+							<greatestDifference id="G">G y MMM d, E – G y MMM d, E</greatestDifference>
+							<greatestDifference id="M">G y MMM d, E – MMM d, E</greatestDifference>
+							<greatestDifference id="y">G y MMM d, E – y MMM d, E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="h">
 							<greatestDifference id="a">↑↑↑</greatestDifference>

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -1186,9 +1186,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">G d'ê' MMM'a' y'an' – d'ê' MMM'a' y'an'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">G d'ê' MMM'a' y'an' E  – d'ê' MMM'a' y'an' E</greatestDifference>
-							<greatestDifference id="M">G d'ê' MMM'a' y'an' E  – d'ê' MMM'a' y'an' E</greatestDifference>
-							<greatestDifference id="y">G d'ê' MMM'a' y'an' E  – d'ê' MMM'a' y'an' E</greatestDifference>
+							<greatestDifference id="d">G d'ê' MMM'a' y'an' E – d'ê' MMM'a' y'an' E</greatestDifference>
+							<greatestDifference id="M">G d'ê' MMM'a' y'an' E – d'ê' MMM'a' y'an' E</greatestDifference>
+							<greatestDifference id="y">G d'ê' MMM'a' y'an' E – d'ê' MMM'a' y'an' E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">G MMMM – MMMM y</greatestDifference>
@@ -1722,9 +1722,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<greatestDifference id="y">d'ê' MMM'a' y'an' – d'ê' MMM'a' y'an'</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">d'ê' MMM'a' y'an' E  – d'ê' MMM'a' y'an' E</greatestDifference>
-							<greatestDifference id="M">d'ê' MMM'a' y'an' E  – d'ê' MMM'a' y'an' E</greatestDifference>
-							<greatestDifference id="y">d'ê' MMM'a' y'an' E  – d'ê' MMM'a' y'an' E</greatestDifference>
+							<greatestDifference id="d">d'ê' MMM'a' y'an' E – d'ê' MMM'a' y'an' E</greatestDifference>
+							<greatestDifference id="M">d'ê' MMM'a' y'an' E – d'ê' MMM'a' y'an' E</greatestDifference>
+							<greatestDifference id="y">d'ê' MMM'a' y'an' E – d'ê' MMM'a' y'an' E</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
 							<greatestDifference id="M">MMMM – MMMM y</greatestDifference>

--- a/common/main/pap.xml
+++ b/common/main/pap.xml
@@ -388,7 +388,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMMEd">
 							<greatestDifference id="d" draft="unconfirmed">E, d MMM – d MMM y G</greatestDifference>
-							<greatestDifference id="G" draft="unconfirmed">E, d MMM y G  – E, d MMM y G</greatestDifference>
+							<greatestDifference id="G" draft="unconfirmed">E, d MMM y G – E, d MMM y G</greatestDifference>
 							<greatestDifference id="M" draft="unconfirmed">E, d MMM – E, d MMM y G</greatestDifference>
 							<greatestDifference id="y" draft="unconfirmed">E, d MMM y – E, d MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -905,7 +905,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d" draft="unconfirmed">d–d MMM</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">d MMM  – d MMM</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d" draft="unconfirmed">E, d MMM – E, d MMM</greatestDifference>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -2907,6 +2907,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<zone type="America/St_Johns">
 				<exemplarCity>St. John’s</exemplarCity>
 			</zone>
+			<zone type="America/Curacao">
+				<exemplarCity>Curaçao</exemplarCity>
+			</zone>
 			<zone type="Africa/Asmera">
 				<exemplarCity>Asmara</exemplarCity>
 			</zone>
@@ -2955,8 +2958,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<zone type="Asia/Katmandu">
 				<exemplarCity>Kathmandu</exemplarCity>
 			</zone>
+			<zone type="America/Asuncion">
+				<exemplarCity>Asunción</exemplarCity>
+			</zone>
+			<zone type="Indian/Reunion">
+				<exemplarCity>Réunion</exemplarCity>
+			</zone>
 			<zone type="Atlantic/St_Helena">
 				<exemplarCity>St. Helena</exemplarCity>
+			</zone>
+			<zone type="Africa/Sao_Tome">
+				<exemplarCity>São Tomé</exemplarCity>
 			</zone>
 			<zone type="America/Lower_Princes">
 				<exemplarCity>Lower Prince’s Quarter</exemplarCity>
@@ -3005,18 +3017,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</zone>
 			<zone type="Asia/Saigon">
 				<exemplarCity>Ho Chi Minh</exemplarCity>
-			</zone>
-			<zone type="America/Curacao">
-				<exemplarCity>Curaçao</exemplarCity>
-			</zone>
-			<zone type="America/Asuncion">
-				<exemplarCity>Asunción</exemplarCity>
-			</zone>
-			<zone type="Indian/Reunion">
-				<exemplarCity>Réunion</exemplarCity>
-			</zone>
-			<zone type="Africa/Sao_Tome">
-				<exemplarCity>São Tomé</exemplarCity>
 			</zone>
 		</timeZoneNames>
 	</dates>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -1200,7 +1200,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<appendItem request="Timezone">↑↑↑</appendItem>
 					</appendItems>
 					<intervalFormats>
-						<intervalFormatFallback>{0}  –  {1}</intervalFormatFallback>
+						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">↑↑↑</greatestDifference>
 							<greatestDifference id="h">↑↑↑</greatestDifference>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -2523,15 +2523,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">d/M/y – d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="G">d/M/y GGGGG  –  d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">d/M/y GGGGG – d/M/y GGGGG</greatestDifference>
 							<greatestDifference id="M">d/M/y – d/M/y GGGGG</greatestDifference>
 							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">E, d/M/y  –  E, d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="G">E, d/M/y GGGGG  –  E, d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="M">E, d/M/y  –  E, d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="y">E, d/M/y  –  E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="d">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="G">E, d/M/y GGGGG – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
 							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
@@ -2590,19 +2590,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d/M  –  E, d/M</greatestDifference>
-							<greatestDifference id="M">E, d/M  –  E, d/M</greatestDifference>
+							<greatestDifference id="d">E, d/M – E, d/M</greatestDifference>
+							<greatestDifference id="M">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
-							<greatestDifference id="M">MMM  –  MMM</greatestDifference>
+							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">d – d MMM</greatestDifference>
-							<greatestDifference id="M">d MMM  –  d MMM</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
-							<greatestDifference id="d">E, d MMM  –  E, d MMM</greatestDifference>
-							<greatestDifference id="M">E, d MMM  –  E, d MMM</greatestDifference>
+							<greatestDifference id="d">E, d MMM – E, d MMM</greatestDifference>
+							<greatestDifference id="M">E, d MMM – E, d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="y">
 							<greatestDifference id="y">y–y G</greatestDifference>
@@ -2617,26 +2617,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d/M/y – d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d/M/y  –  E, d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="M">E, d/M/y  –  E, d/M/y GGGGG</greatestDifference>
-							<greatestDifference id="y">E, d/M/y  –  E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="d">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="M">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
+							<greatestDifference id="y">E, d/M/y – E, d/M/y GGGGG</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">MMM  –  MMM y G</greatestDifference>
-							<greatestDifference id="y">MMM y  –  MMM y G</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">d – d MMM, y G</greatestDifference>
-							<greatestDifference id="M">d MMM  –  d MMM, y G</greatestDifference>
-							<greatestDifference id="y">d MMM, y  –  d MMM, y G</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM, y G</greatestDifference>
+							<greatestDifference id="y">d MMM, y – d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d MMM  –  E, d MMM, y G</greatestDifference>
-							<greatestDifference id="M">E, d MMM  –  E, d MMM, y G</greatestDifference>
-							<greatestDifference id="y">E, d MMM, y  –  E, d MMM, y G</greatestDifference>
+							<greatestDifference id="d">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="M">E, d MMM – E, d MMM, y G</greatestDifference>
+							<greatestDifference id="y">E, d MMM, y – E, d MMM, y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">MMMM  –  MMMM y G</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM y G</greatestDifference>
 							<greatestDifference id="y">MMMM y – MMMM y G</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
@@ -3081,7 +3081,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<intervalFormats>
 						<intervalFormatFallback>↑↑↑</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
-							<greatestDifference id="B">h 'giờ' B  –  h 'giờ' B</greatestDifference>
+							<greatestDifference id="B">h 'giờ' B – h 'giờ' B</greatestDifference>
 							<greatestDifference id="h">h – h 'giờ' B</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Bhm">
@@ -3097,24 +3097,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">y – y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyM">
-							<greatestDifference id="G">M/y G  –  M/y G</greatestDifference>
+							<greatestDifference id="G">M/y G – M/y G</greatestDifference>
 							<greatestDifference id="M">M/y– M/y G</greatestDifference>
 							<greatestDifference id="y">M/y – M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMd">
 							<greatestDifference id="d">d/M/y – d/M/y G</greatestDifference>
-							<greatestDifference id="G">d/M/y G  –  d/M/y G</greatestDifference>
+							<greatestDifference id="G">d/M/y G – d/M/y G</greatestDifference>
 							<greatestDifference id="M">d/M/y – d/M/y G</greatestDifference>
 							<greatestDifference id="y">d/M/y – d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMEd">
-							<greatestDifference id="d">E, d/M/y  –  E, d/M/y G</greatestDifference>
-							<greatestDifference id="G">E, d/M/y G  –  E, d/M/y G</greatestDifference>
-							<greatestDifference id="M">E, d/M/y  –  E, d/M/y G</greatestDifference>
-							<greatestDifference id="y">E, d/M/y  –  E, d/M/y G</greatestDifference>
+							<greatestDifference id="d">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="G">E, d/M/y G – E, d/M/y G</greatestDifference>
+							<greatestDifference id="M">E, d/M/y – E, d/M/y G</greatestDifference>
+							<greatestDifference id="y">E, d/M/y – E, d/M/y G</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="GyMMM">
-							<greatestDifference id="G">MMM y G  –  MMM y G</greatestDifference>
+							<greatestDifference id="G">MMM y G – MMM y G</greatestDifference>
 							<greatestDifference id="M">MMM – MMM y G</greatestDifference>
 							<greatestDifference id="y">MMM y – MMM y G</greatestDifference>
 						</intervalFormatItem>
@@ -3170,15 +3170,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="M">d/M – d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
-							<greatestDifference id="d">E, d/M  –  E, d/M</greatestDifference>
-							<greatestDifference id="M">E, d/M  –  E, d/M</greatestDifference>
+							<greatestDifference id="d">E, d/M – E, d/M</greatestDifference>
+							<greatestDifference id="M">E, d/M – E, d/M</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M">MMM – MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMd">
 							<greatestDifference id="d">d – d MMM</greatestDifference>
-							<greatestDifference id="M">d MMM  –  d MMM</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMMEd">
 							<greatestDifference id="d">E, d MMM – E, d MMM</greatestDifference>
@@ -3197,27 +3197,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="y">d/M/y – d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
-							<greatestDifference id="d">E, d/M/y  –  E, d/M/y</greatestDifference>
-							<greatestDifference id="M">E, d/M/y  –  E, d/M/y</greatestDifference>
-							<greatestDifference id="y">E, d/M/y  –  E, d/M/y</greatestDifference>
+							<greatestDifference id="d">E, d/M/y – E, d/M/y</greatestDifference>
+							<greatestDifference id="M">E, d/M/y – E, d/M/y</greatestDifference>
+							<greatestDifference id="y">E, d/M/y – E, d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
-							<greatestDifference id="M">MMM  –  MMM y</greatestDifference>
-							<greatestDifference id="y">MMM y  –  MMM y</greatestDifference>
+							<greatestDifference id="M">MMM – MMM y</greatestDifference>
+							<greatestDifference id="y">MMM y – MMM y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMd">
 							<greatestDifference id="d">d – d MMM, y</greatestDifference>
-							<greatestDifference id="M">d MMM  –  d MMM, y</greatestDifference>
-							<greatestDifference id="y">d MMM, y  –  d MMM, y</greatestDifference>
+							<greatestDifference id="M">d MMM – d MMM, y</greatestDifference>
+							<greatestDifference id="y">d MMM, y – d MMM, y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMEd">
-							<greatestDifference id="d">E, d MMM  –  E, d MMM, y</greatestDifference>
-							<greatestDifference id="M">E, d MMM  –  E, d MMM, y</greatestDifference>
-							<greatestDifference id="y">E, d MMM, y  –  E, d MMM, y</greatestDifference>
+							<greatestDifference id="d">E, d MMM – E, d MMM, y</greatestDifference>
+							<greatestDifference id="M">E, d MMM – E, d MMM, y</greatestDifference>
+							<greatestDifference id="y">E, d MMM, y – E, d MMM, y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMMM">
-							<greatestDifference id="M">MMMM  –  MMMM 'năm' y</greatestDifference>
-							<greatestDifference id="y">MMMM 'năm' y  –  MMMM 'năm' y</greatestDifference>
+							<greatestDifference id="M">MMMM – MMMM 'năm' y</greatestDifference>
+							<greatestDifference id="y">MMMM 'năm' y – MMMM 'năm' y</greatestDifference>
 						</intervalFormatItem>
 					</intervalFormats>
 				</dateTimeFormats>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -155,6 +155,16 @@ public class DisplayAndInputProcessor {
     // private static final Pattern SPACE_PLUS_NBSP_TO_NORMALIZE =
     // PatternCache.get("\\u0020+[\\u00A0\\u202F]+");
 
+    // NNBSP 202F among other horizontal spaces (includes 0020, 00A0, 2009, 202F, etc.)
+    private static final Pattern NNBSP_AMONG_OTHER_SPACES =
+            PatternCache.get("[\\h&&[^\\u202F]]+\\u202F\\h*|\\u202F\\h+");
+    // NBSP 00A0 among other horizontal spaces
+    private static final Pattern NBSP_AMONG_OTHER_SPACES =
+            PatternCache.get("[\\h&&[^\\u00A0]]+\\u00A0\\h*|\\u00A0\\h+");
+    // THIN SPACE 2009 among other horizontal spaces
+    private static final Pattern THIN_SPACE_AMONG_OTHER_SPACES =
+            PatternCache.get("[\\h&&[^\\u2009]]+\\u2009\\h*|\\u2009\\h+");
+
     private static final Pattern INITIAL_NBSP = PatternCache.get("^[\\u00A0\\u202F]+");
     private static final Pattern FINAL_NBSP = PatternCache.get("[\\u00A0\\u202F]+$");
 
@@ -1288,6 +1298,14 @@ public class DisplayAndInputProcessor {
             value = PLACEHOLDER_SPACE_AFTER.matcher(value).replaceAll("}\u00A0"); // Regular NBSP
             value = PLACEHOLDER_SPACE_BEFORE.matcher(value).replaceAll("\u00A0{");
         }
+
+        // Finally, replace remaining space combinations with most restrictive type CLDR-17233
+        // If we have NNBSP U+202F in combination with other spaces, keep just it
+        value = NNBSP_AMONG_OTHER_SPACES.matcher(value).replaceAll("\u202F");
+        // Else if we have NBSP U+00A0 in combination with other spaces, keep just it
+        value = NBSP_AMONG_OTHER_SPACES.matcher(value).replaceAll("\u00A0");
+        // Else if we have THIN SPACE U+2009 in combination with other spaces, keep just it
+        value = THIN_SPACE_AMONG_OTHER_SPACES.matcher(value).replaceAll("\u2009");
 
         return value;
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -687,6 +687,17 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
                     "//ldml/units/unitLength[@type=\"short\"]unit[@type=\"mass-gram\"]/unitPattern[@count=\"other\"]",
                     "g {0}",
                     "g\u00A0{0}"),
+            // tests for CLDR-17233
+            new PathSpaceAdjustData(
+                    "es",
+                    "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dayPeriods/dayPeriodContext[@type=\"format\"]/dayPeriodWidth[@type=\"abbreviated\"]/dayPeriod[@type=\"am\"]",
+                    "a. \u202Fm.",
+                    "a.\u202Fm."),
+            new PathSpaceAdjustData(
+                    "vi",
+                    "//ldml/dates/calendars/calendar[@type=\"generic\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"MMM\"]/greatestDifference[@id=\"M\"]",
+                    "MMM\u2009 – \u2009MMM",
+                    "MMM\u2009–\u2009MMM"),
         };
 
         for (PathSpaceAdjustData testItem : testItems) {


### PR DESCRIPTION
CLDR-17233

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17233)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Fixed DAIP to coalesce multiple spaces of different types to the strictest type (NNBSP if present, else NBSP if present).
Fixed the specific problem in fr.xml short units that prompted the ticket.
Ran CLDRModify passes to test; this also rearranged some time zone names in root.xml.

This is on the maint/maint-44 branch; will need to be merged into the main branch (possibly along with other CLDR 44.1 fixes) under a separate ticket.

ALLOW_MANY_COMMITS=true
