### PR TITLE
CLDR-13970 ST Examples used in patterns; fix front end refresh bug

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAnnounce.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAnnounce.mjs
@@ -5,6 +5,15 @@
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 
+/**
+ * This should be false for production. It can be made true during debugging, which
+ * may be useful for performance testing. Also, there is a bug where "announce" requests
+ * (as well as "completion" requests) are not only made too often (every 15 seconds synced
+ * with status requests), but are made in pairs where one "announce" request immediately follows
+ * another, see https://unicode-org.atlassian.net/browse/CLDR-16900
+ */
+const DISABLE_ANNOUNCEMENTS = false;
+
 let thePosts = null;
 
 let callbackSetData = null;
@@ -16,6 +25,9 @@ async function getUnreadCount(setUnreadCount) {
 }
 
 async function refresh(viewCallbackSetData) {
+  if (DISABLE_ANNOUNCEMENTS) {
+    return;
+  }
   if (!cldrStatus.getSurveyUser()) {
     if (viewCallbackSetData) {
       viewCallbackSetData(null);

--- a/tools/cldr-apps/js/src/esm/cldrLoad.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.mjs
@@ -611,6 +611,11 @@ function specialLoad(itemLoadInfo, curSpecial, theDiv) {
     cldrInfo.closePanel();
     // Most special.load() functions do not use a parameter; an exception is
     // cldrGenericVue.load() which expects the special name as a parameter
+    if (CLDR_LOAD_DEBUG) {
+      console.log(
+        "cldrLoad.specialLoad: running special.load(" + curSpecial + ")"
+      );
+    }
     special.load(curSpecial);
   } else if (curSpecial !== "general") {
     // Avoid recursion.
@@ -628,10 +633,16 @@ function unspecialLoad(itemLoadInfo, theDiv) {
     const curPage = cldrStatus.getCurrentPage();
     const curId = cldrStatus.getCurrentId();
     if (!curPage && !curId) {
+      if (CLDR_LOAD_DEBUG) {
+        console.log("cldrLoad.unspecialLoad: running specialLoad(general)");
+      }
       cldrStatus.setCurrentSpecial("general");
       specialLoad(itemLoadInfo, "general", theDiv);
     } else if (curId === "!") {
       // TODO: clarify when and why this would happen
+      if (CLDR_LOAD_DEBUG) {
+        console.log("cldrLoad.unspecialLoad: running loadExclamationPoint");
+      }
       loadExclamationPoint();
     } else {
       if (!cldrSurvey.isInputBusy()) {
@@ -639,10 +650,20 @@ function unspecialLoad(itemLoadInfo, theDiv) {
          * Make “all rows” requests only when !isInputBusy, to avoid wasted requests
          * if the user leaves the input box open for an extended time.
          */
+        if (CLDR_LOAD_DEBUG) {
+          console.log("cldrLoad.unspecialLoad: running loadAllRows");
+        }
         loadAllRows(itemLoadInfo, theDiv);
+      } else if (CLDR_LOAD_DEBUG) {
+        console.log(
+          "cldrLoad.unspecialLoad: skipping loadAllRows because input is busy"
+        );
       }
     }
   } else if (curSpecial) {
+    if (CLDR_LOAD_DEBUG) {
+      console.log("cldrLoad.unspecialLoad: calling handleMissingSpecial");
+    }
     handleMissingSpecial(curSpecial);
   }
 }
@@ -774,6 +795,10 @@ function loadAllRows(itemLoadInfo, theDiv) {
   );
   const url = cldrTable.getPageUrl(curLocale, curPage, curId);
   $("#nav-page").show(); // make top "Prev/Next" buttons visible while loading, cf. '#nav-page-footer' below
+
+  if (CLDR_LOAD_DEBUG) {
+    console.log("cldrLoad.loadAllRows sending request");
+  }
   cldrAjax
     .doFetch(url)
     .then((response) => response.json())
@@ -786,6 +811,9 @@ function loadAllRows(itemLoadInfo, theDiv) {
 }
 
 function loadAllRowsFromJson(json, theDiv) {
+  if (CLDR_LOAD_DEBUG) {
+    console.log("cldrLoad.loadAllRowsFromJson got response");
+  }
   isLoading = false;
   cldrSurvey.showLoader(cldrText.get("loading2"));
   if (json.err) {
@@ -826,6 +854,9 @@ function loadAllRowsFromJson(json, theDiv) {
     } else {
       cldrStatus.setCurrentPage("");
     }
+    if (CLDR_LOAD_DEBUG) {
+      console.log("cldrLoad.loadAllRowsFromJson got json.page.nocontent");
+    }
     cldrSurvey.showLoader(null);
     updateHashAndMenus(); // find out why there's no content. (locmap)
   } else if (!json.page.rows) {
@@ -846,6 +877,9 @@ function loadAllRowsFromJson(json, theDiv) {
     updateHashAndMenus(); // now that we have a pageid
     if (!cldrSurvey.isInputBusy()) {
       cldrSurvey.showLoader(cldrText.get("loading3"));
+      if (CLDR_LOAD_DEBUG) {
+        console.log("cldrLoad.loadAllRowsFromJson calling insertRows");
+      }
       cldrTable.insertRows(
         theDiv,
         json.pageId,
@@ -860,6 +894,10 @@ function loadAllRowsFromJson(json, theDiv) {
       if (!cldrStatus.getCurrentId()) {
         cldrInfo.showMessage(getGuidanceMessage(json.canModify));
       }
+    } else if (CLDR_LOAD_DEBUG) {
+      console.log(
+        "cldrLoad.loadAllRowsFromJson skipping insertRows because isInputBusy"
+      );
     }
   }
 }

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -230,7 +230,7 @@ function handleVoteErr(tr, message, button) {
  * @returns the sanitized string
  */
 function makeSafe(s) {
-  return s.replace(/[<>&]/g, '');
+  return s.replace(/[<>&]/g, "");
 }
 
 function logVote(rowHash, vHash, value) {


### PR DESCRIPTION
-Initialize surveyNextLocaleStamp to NaN instead of 0, to avoid complication of wrap-around (however rare/unlikely)

-Bug fix: when surveyNextLocaleStamp is NaN, handle any newly received stamp as a change

-Bug fix: when newly received stamp is less than surveyNextLocaleStamp, that is also a change (however rare/unlikely)

-Add DEBUG_SHOWER, DEBUG_LOCALE_STAMP, and DISABLE_ANNOUNCEMENTS for debugging

-Additional debug logging dependent on existing CLDR_LOAD_DEBUG

-Delete obsolete code and comment about dijitInp; we no longer use Dijit/Dojo

-Comments

CLDR-13970

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
