### PR TITLE
CLDR-17289 make setCldrFileToCheck a lazy load

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAlt.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAlt.java
@@ -48,7 +48,7 @@ public class CheckAlt extends CheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
         // Skip if the phase is not final testing
@@ -59,7 +59,7 @@ public class CheckAlt extends CheckCLDR {
             return this;
         }
 
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         seenSoFar.clear();
         return this;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAlt.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAlt.java
@@ -26,6 +26,8 @@ public class CheckAlt extends CheckCLDR {
             return this;
         }
 
+        if (!accept(result)) return this;
+
         String strippedPath = CLDRFile.getNondraftNonaltXPath(path);
         if (strippedPath.equals(path)) {
             return this; // paths equal, skip

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAltOnly.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAltOnly.java
@@ -40,6 +40,7 @@ public class CheckAltOnly extends FactoryCheckCLDR {
         if (file.getConstructedValue(nonAltPath) != null) {
             return this;
         }
+        if (!accept(result)) return this;
         /*
          * If the source locale is not code-fallback, it's not an error.
          * getSourceLocaleIdExtended with skipInheritanceMarker = false means that if the

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
@@ -18,6 +18,7 @@ public class CheckAnnotations extends CheckCLDR {
                 || !getCldrFileToCheck().isNotRoot(path)) {
             return this;
         }
+        if (!accept(result)) return this;
         final String ecode = hasAnnotationECode(value);
 
         if (ecode != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAttributeValues.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAttributeValues.java
@@ -93,6 +93,7 @@ public class CheckAttributeValues extends FactoryCheckCLDR {
         if (!getCldrFileToCheck().getLocaleID().equals(locale)) {
             return this;
         }
+        if (!accept(result)) return this;
         XPathParts parts = XPathParts.getFrozenInstance(fullPath);
         for (int i = 0; i < parts.size(); ++i) {
             if (parts.getAttributeCount(i) == 0) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAttributeValues.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAttributeValues.java
@@ -280,7 +280,7 @@ public class CheckAttributeValues extends FactoryCheckCLDR {
     LocaleIDParser localeIDParser = new LocaleIDParser();
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
         if (Phase.FINAL_TESTING == getPhase() || Phase.BUILD == getPhase()) {
@@ -292,7 +292,7 @@ public class CheckAttributeValues extends FactoryCheckCLDR {
 
         pluralInfo =
                 supplementalData.getPlurals(PluralType.cardinal, cldrFileToCheck.getLocaleID());
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         isEnglish = "en".equals(localeIDParser.set(cldrFileToCheck.getLocaleID()).getLanguage());
         synchronized (elementOrder) {
             if (!initialized) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -1421,7 +1421,7 @@ public abstract class CheckCLDR implements CheckAccessor {
                                     "Test setup time for " + item.getClass().toString() + ": {0}");
                 try {
                     item.setPhase(getPhase());
-                    item.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+                    item.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
                     if (SHOW_TIMES) {
                         if (item.isSkipTest()) {
                             System.out.println("Disabled : " + testTime);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -650,25 +650,6 @@ public abstract class CheckCLDR implements CheckAccessor {
     }
 
     /**
-     * Don't override this, use the other setCldrFileToCheck which takes an Options instead of a
-     * Map<>
-     *
-     * @param cldrFileToCheck
-     * @param options
-     * @param possibleErrors
-     * @return
-     * @see #setCldrFileToCheck(CLDRFile, Options, List)
-     * @deprecated
-     */
-    @Deprecated
-    public final CheckCLDR setCldrFileToCheck(
-            CLDRFile cldrFileToCheck,
-            Map<String, String> options,
-            List<CheckStatus> possibleErrors) {
-        return setCldrFileToCheck(cldrFileToCheck, new Options(options), possibleErrors);
-    }
-
-    /**
      * Set the CLDRFile. Must be done before calling check. If null is called, just skip Often
      * subclassed for initializing. If so, make the first 2 lines: if (cldrFileToCheck == null)
      * return this; super.setCldrFileToCheck(cldrFileToCheck); do stuff

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -679,7 +679,7 @@ public abstract class CheckCLDR implements CheckAccessor {
     public CheckCLDR setCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         this.cldrFileToCheck = cldrFileToCheck;
-        initted = false;
+        reset();
         // clear the *cached* possible Errors. Not counting any set immediately by subclasses.
         cachedPossibleErrors.clear();
         cachedOptions = new Options(options);
@@ -705,9 +705,15 @@ public abstract class CheckCLDR implements CheckAccessor {
         return this;
     }
 
+    /** override this if you want to return errors immediately when setCldrFileToCheck is called */
     protected void handleCheckPossibleErrors(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         // nothing by default.
+    }
+
+    /** override this if you want to reset state immediately when setCldrFileToCheck is called */
+    protected void reset() {
+        initted = false;
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -1126,33 +1126,6 @@ public abstract class CheckCLDR implements CheckAccessor {
     }
 
     /**
-     * Wraps the options in an Options and delegates.
-     *
-     * @param path Must be a distinguished path, such as what comes out of CLDRFile.iterator()
-     * @param fullPath Must be the full path
-     * @param value the value associated with the path
-     * @param options A set of test-specific options. Set these with code of the form:<br>
-     *     options.put("CoverageLevel.localeType", "G0")<br>
-     *     That is, the key is of the form <testname>.<optiontype>, and the value is of the form
-     *     <optionvalue>.<br>
-     *     There is one general option; the following will select only the tests that should be run
-     *     during this phase.<br>
-     *     options.put("phase", Phase.<something>); It can be used for new data entry.
-     * @param result
-     * @return
-     * @deprecated use CheckCLDR#check(String, String, String, Options, List)
-     */
-    @Deprecated
-    public final CheckCLDR check(
-            String path,
-            String fullPath,
-            String value,
-            Map<String, String> options,
-            List<CheckStatus> result) {
-        return check(path, fullPath, value, new Options(options), result);
-    }
-
-    /**
      * Checks the path/value in the cldrFileToCheck for correctness, according to some criterion. If
      * the path is relevant to the check, there is an alert or warning, then a CheckStatus is added
      * to List.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -652,13 +652,13 @@ public abstract class CheckCLDR implements CheckAccessor {
     /**
      * Set the CLDRFile. Must be done before calling check. If null is called, just skip Often
      * subclassed for initializing. If so, make the first 2 lines: if (cldrFileToCheck == null)
-     * return this; super.setCldrFileToCheck(cldrFileToCheck); do stuff
+     * return this; super.handleSetCldrFileToCheck(cldrFileToCheck); do stuff
      *
      * @param cldrFileToCheck
      * @param options (not currently used)
      * @param possibleErrors TODO
      */
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         this.cldrFileToCheck = cldrFileToCheck;
 
@@ -676,6 +676,11 @@ public abstract class CheckCLDR implements CheckAccessor {
             xpaths.add(filter.get2());
         }
         return this;
+    }
+
+    public CheckCLDR setCldrFileToCheck(
+            CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
+        return handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
     }
 
     /** Status value returned from check */
@@ -1361,7 +1366,7 @@ public abstract class CheckCLDR implements CheckAccessor {
         }
 
         @Override
-        public CheckCLDR setCldrFileToCheck(
+        public CheckCLDR handleSetCldrFileToCheck(
                 CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
             ElapsedTimer testTime = null, testOverallTime = null;
             if (cldrFileToCheck == null) return this;
@@ -1369,7 +1374,7 @@ public abstract class CheckCLDR implements CheckAccessor {
             setPhase(Phase.forString(options.get(Options.Option.phase)));
             if (SHOW_TIMES)
                 testOverallTime = new ElapsedTimer("Test setup time for setCldrFileToCheck: {0}");
-            super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+            super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
             possibleErrors.clear();
 
             for (Iterator<CheckCLDR> it = filteredCheckList.iterator(); it.hasNext(); ) {
@@ -1380,7 +1385,7 @@ public abstract class CheckCLDR implements CheckAccessor {
                                     "Test setup time for " + item.getClass().toString() + ": {0}");
                 try {
                     item.setPhase(getPhase());
-                    item.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+                    item.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
                     if (SHOW_TIMES) {
                         if (item.isSkipTest()) {
                             System.out.println("Disabled : " + testTime);
@@ -1408,7 +1413,7 @@ public abstract class CheckCLDR implements CheckAccessor {
                 CheckCLDR item = it.next();
                 if (filter == null || filter.reset(item.getClass().getName()).matches()) {
                     filteredCheckList.add(item);
-                    item.setCldrFileToCheck(getCldrFileToCheck(), (Options) null, null);
+                    item.handleSetCldrFileToCheck(getCldrFileToCheck(), (Options) null, null);
                 }
             }
             return this;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCasing.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCasing.java
@@ -46,6 +46,7 @@ public class CheckCasing extends CheckCLDR {
         if (fullPath == null) return this; // skip paths that we don't have
         if (fullPath.indexOf("casing") < 0) return this;
 
+        if (!accept(result)) return this;
         // pick up the casing attributes from the full path
         XPathParts parts = XPathParts.getFrozenInstance(fullPath);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCasing.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCasing.java
@@ -29,10 +29,10 @@ public class CheckCasing extends CheckCLDR {
     BreakIterator breaker = null;
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         uLocale = new ULocale(cldrFileToCheck.getLocaleID());
         breaker = BreakIterator.getWordInstance(uLocale);
         return this;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
@@ -11,7 +11,7 @@ import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 
-public class CheckChildren extends FactoryCheckCLDR {
+public class CheckChildren<resolvedCldrFileToCheck> extends FactoryCheckCLDR {
     CLDRFile[] immediateChildren;
     Map<String, String> tempSet = new HashMap<>();
 
@@ -59,6 +59,13 @@ public class CheckChildren extends FactoryCheckCLDR {
         result.add(item);
         tempSet.clear(); // free for gc
         return this;
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        immediateChildren = null; // reset this beforehand
+        tempSet.clear();
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
@@ -23,14 +23,13 @@ public class CheckChildren extends FactoryCheckCLDR {
     public CheckCLDR handleCheck(
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
         if (immediateChildren == null) return this; // skip - test isn't even relevant
-        if (isSkipTest()) return this; // disabled
         if (fullPath == null) return this; // skip paths that we don't have
         if (value == null) return this; // skip null values
         String winningValue = this.getCldrFileToCheck().getWinningValue(fullPath);
         if (!value.equals(winningValue)) {
             return this; // only run this test against winning values.
         }
-
+        if (!accept(result)) return this;
         // String current = getResolvedCldrFileToCheck().getStringValue(path);
         tempSet.clear();
         for (int i = 0; i < immediateChildren.length; ++i) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
@@ -63,7 +63,7 @@ public class CheckChildren extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
         if (cldrFileToCheck.getLocaleID().equals("root"))
@@ -78,7 +78,7 @@ public class CheckChildren extends FactoryCheckCLDR {
         }
 
         List<CLDRFile> iChildren = new ArrayList<>();
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         CLDRLocale myLocale = CLDRLocale.getInstance(cldrFileToCheck.getLocaleID());
         if (myLocale.getCountry() != null && myLocale.getCountry().length() == 2) {
             immediateChildren = null;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
@@ -22,14 +22,14 @@ public class CheckChildren extends FactoryCheckCLDR {
     @Override
     public CheckCLDR handleCheck(
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
-        if (immediateChildren == null) return this; // skip - test isn't even relevant
         if (fullPath == null) return this; // skip paths that we don't have
         if (value == null) return this; // skip null values
+        if (!accept(result)) return this;
+        if (immediateChildren == null) return this; // skip - test isn't even relevant
         String winningValue = this.getCldrFileToCheck().getWinningValue(fullPath);
         if (!value.equals(winningValue)) {
             return this; // only run this test against winning values.
         }
-        if (!accept(result)) return this;
         // String current = getResolvedCldrFileToCheck().getStringValue(path);
         tempSet.clear();
         for (int i = 0; i < immediateChildren.length; ++i) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
@@ -47,10 +47,10 @@ public class CheckConsistentCasing extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         locale = cldrFileToCheck.getLocaleID();
         // get info about casing; note that this is done in two steps since
         // ScriptMetadata.getInfo() returns null, in some instances.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
@@ -89,6 +89,7 @@ public class CheckConsistentCasing extends FactoryCheckCLDR {
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
         // it helps performance to have a quick reject of most paths
         if (fullPath == null) return this; // skip paths that we don't have
+        if (!accept(result)) return this; // causes hasCasingInfo to be calculated
         if (!hasCasingInfo) return this;
 
         String locale2 = getCldrFileToCheck().getSourceLocaleID(path, null);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
@@ -53,9 +53,7 @@ public class CheckCoverage extends FactoryCheckCLDR {
     public CheckCLDR handleCheck(
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
 
-        if (isSkipTest()) {
-            return this;
-        }
+        if (!accept(result)) return this;
 
         CLDRFile resolvedCldrFileToCheck = getResolvedCldrFileToCheck();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
@@ -124,7 +124,7 @@ public class CheckCoverage extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
         setSkipTest(true);
@@ -148,7 +148,7 @@ public class CheckCoverage extends FactoryCheckCLDR {
         }
 
         if (options != null && options.get(Options.Option.CheckCoverage_skip) != null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         if (localeID.equals(LocaleNames.ROOT)) return this;
 
         requiredLevel = options.getRequiredLevel(localeID);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCurrencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCurrencies.java
@@ -16,7 +16,7 @@ public class CheckCurrencies extends CheckCLDR {
         // it helps performance to have a quick reject of most paths
         if (fullPath == null) return this; // skip paths that we don't have
         if (path.indexOf("/currency") < 0 || path.indexOf("/symbol") < 0) return this;
-
+        if (!accept(result)) return this;
         // parts.set(path); // normally you have to parse out a path to get the exact one, but in
         // this case the quick
         // reject suffices

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -168,10 +168,10 @@ public class CheckDates extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
 
         icuServiceBuilder.setCldrFile(getResolvedCldrFileToCheck());
         // the following is a hack to work around a bug in ICU4J (the snapshot, not the released

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -339,6 +339,8 @@ public class CheckDates extends FactoryCheckCLDR {
             return this;
         }
 
+        if (!accept(result)) return this;
+
         String sourceLocale = getCldrFileToCheck().getSourceLocaleID(path, status);
 
         if (!path.equals(status.pathWhereFound)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -804,10 +804,10 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
     //    private Map<String,String> nameToSubdivisionId = Collections.emptyMap();
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         // pick up the 3 subdivisions
         //        nameToSubdivisionId =
         // EmojiSubdivisionNames.getNameToSubdivisionPath(cldrFileToCheck.getLocaleID());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -334,6 +334,7 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
                 || value.equals(CldrUtility.INHERITANCE_MARKER)) {
             return this;
         }
+        if (!accept(result)) return this;
 
         // find my type; bail if I don't have one.
         Type myType = Type.getType(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
@@ -173,6 +173,7 @@ public class CheckExemplars extends FactoryCheckCLDR {
             }
             return this;
         }
+        if (!accept(result)) return this;
         XPathParts oparts = XPathParts.getFrozenInstance(path);
         final String exemplarString = oparts.findAttributeValue("exemplarCharacters", "type");
         ExemplarType type =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
@@ -132,10 +132,10 @@ public class CheckExemplars extends FactoryCheckCLDR {
     // Allowed[:script=common:][:script=inherited:][:alphabetic=false:]
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         String locale = cldrFileToCheck.getLocaleID();
         isRoot = cldrFileToCheck.getLocaleID().equals("root");
         col = ComparatorUtilities.getIcuCollator(new ULocale(locale), Collator.IDENTICAL);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -87,6 +87,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
         if (fullPath == null || path == null || value == null) {
             return this; // skip root, and paths that we don't have
         }
+        if (!accept(result)) return this;
         Failure failure =
                 sameAsCodeOrEnglish(value, path, unresolvedFile, getCldrFileToCheck(), false);
         addFailure(result, failure);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -290,7 +290,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
 
         if (cldrFileToCheck == null) {
@@ -316,7 +316,7 @@ public class CheckForCopy extends FactoryCheckCLDR {
             return this;
         }
 
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         return this;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -185,11 +185,11 @@ public class CheckForExemplars extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFile, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFile == null) return this;
         skip = true;
-        super.setCldrFileToCheck(cldrFile, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFile, options, possibleErrors);
         if (cldrFile.getLocaleID().equals("root")) {
             return this;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -295,6 +295,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
         if (fullPath == null) return this; // skip paths that we don't have
         if (value == null) return this; // skip values that we don't have ?
+        if (!accept(result)) return this;
         if (skip) return this;
         if (path == null) {
             throw new InternalCldrException("Empty path!");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForInheritanceMarkers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForInheritanceMarkers.java
@@ -12,6 +12,7 @@ public class CheckForInheritanceMarkers extends CheckCLDR {
         if (value == null) {
             return this;
         }
+        if (!accept(result)) return this;
 
         if (value.contains(CldrUtility.INHERITANCE_MARKER)) {
             result.add(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
@@ -33,9 +33,9 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
 
         // skip the test unless we are at the top level, eg
         //    test root, fr, sr_Latn, ...

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckLogicalGroupings.java
@@ -61,6 +61,7 @@ public class CheckLogicalGroupings extends FactoryCheckCLDR {
         if (LogicalGrouping.isOptional(getCldrFileToCheck(), path)) {
             return this;
         }
+        if (!accept(result)) return this;
         new LogicalGroupChecker(this, path, value, result).run();
         return this;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckMetazones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckMetazones.java
@@ -18,6 +18,7 @@ public class CheckMetazones extends CheckCLDR {
         if (fullPath == null) return this; // skip paths that we don't have
         if (value == null) return this; // skip empty values
         if (path.indexOf("/metazone") < 0) return this;
+        if (!accept(result)) return this;
 
         // we're simply going to test to make sure that metazone values don't contain any digits
         if (value.matches(".*\\p{Nd}.*")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNames.java
@@ -20,6 +20,7 @@ public class CheckNames extends CheckCLDR {
         if (!YEARS_NOT_ALLOWED.matcher(path).matches() || !getCldrFileToCheck().isNotRoot(path)) {
             return this;
         }
+        if (!accept(result)) return this;
         Matcher matcher = RegexUtilities.PATTERN_3_OR_4_DIGITS.matcher(value);
         if (matcher.find()) {
             // If same as the code-fallback value (territories) then no error

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNew.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNew.java
@@ -36,6 +36,7 @@ public class CheckNew extends FactoryCheckCLDR {
         CLDRFile cldrFileToCheck = getCldrFileToCheck();
         // don't check inherited values
         // first see if the value is inherited or not
+        if (!accept(result)) return this;
         if (!isRoot
                 && value != null
                 && AnnotationUtil.pathIsAnnotation(path)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNew.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNew.java
@@ -18,12 +18,12 @@ public class CheckNew extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) {
             return this;
         }
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         isRoot = "root".equals(cldrFileToCheck.getLocaleID());
 
         return this;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
@@ -130,6 +130,9 @@ public class CheckNumbers extends FactoryCheckCLDR {
 
         if (fullPath == null || value == null) return this; // skip paths that we don't have
 
+        // TODO: could exclude more paths
+        if (!accept(result)) return this;
+
         // Do a quick check on the currencyMatch, to make sure that it is a proper UnicodeSet
         if (path.indexOf("/currencyMatch") >= 0) {
             try {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
@@ -84,10 +84,10 @@ public class CheckNumbers extends FactoryCheckCLDR {
      * calling the super.
      */
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFileToCheck == null) return this;
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         icuServiceBuilder.setCldrFile(getResolvedCldrFileToCheck());
         isPOSIX = cldrFileToCheck.getLocaleID().indexOf("POSIX") >= 0;
         SupplementalDataInfo supplementalData =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -98,6 +98,7 @@ public class CheckPersonNames extends CheckCLDR {
         if (isRoot || !path.startsWith("//ldml/personNames/")) {
             return this;
         }
+        if (!accept(result)) return this;
 
         XPathParts parts = XPathParts.getFrozenInstance(path);
         switch (parts.getElement(2)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPersonNames.java
@@ -52,7 +52,7 @@ public class CheckPersonNames extends CheckCLDR {
             new UnicodeSet("[\\p{sc=Kana}\\p{sc=Hira}]").addAll(HANI).freeze();
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         String localeId = cldrFileToCheck.getLocaleID();
         isRoot = localeId.equals("root");
@@ -72,7 +72,7 @@ public class CheckPersonNames extends CheckCLDR {
                 cldrFileToCheck
                         .getStringValue("//ldml/personNames/nativeSpaceReplacement")
                         .isEmpty();
-        return super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        return super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
     }
 
     public UnicodeSet getUnicodeSetForScript(String script) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -85,6 +85,8 @@ public class CheckPlaceHolders extends CheckCLDR {
         if (value == null || path.endsWith("/alias") || SKIP_PATH_LIST.matcher(path).matches()) {
             return this;
         }
+        // TODO: more skips here
+        if (!accept(result)) return this;
 
         if (path.contains("/personNames")) {
             XPathParts parts = XPathParts.getFrozenInstance(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -72,9 +72,9 @@ public class CheckPlaceHolders extends CheckCLDR {
     private Set<Modifier> allowedModifiers = null;
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         allowedModifiers = Modifier.getAllowedModifiers(cldrFileToCheck.getLocaleID());
         return this;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckQuotes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckQuotes.java
@@ -31,6 +31,7 @@ public class CheckQuotes extends CheckCLDR {
         }
 
         if (UNITS.matcher(path).matches()) {
+            if (!accept(result)) return this;
             Matcher matcher = ASCII_QUOTES.matcher(value);
             CheckStatus.Type type = CheckStatus.warningType;
             if (this.getCldrFileToCheck().getLocaleID().equals("en")) {
@@ -47,6 +48,7 @@ public class CheckQuotes extends CheckCLDR {
             }
         }
         if (DELIMITERS.matcher(path).matches()) {
+            if (!accept(result)) return this;
             if (!VALID_DELIMITERS.contains(value)) {
                 result.add(
                         new CheckStatus()

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckUnits.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckUnits.java
@@ -24,9 +24,9 @@ public class CheckUnits extends CheckCLDR {
     private Collection<String> genders = null;
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
 
         GrammarInfo grammarInfo =
                 CLDRConfig.getInstance()

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckUnits.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckUnits.java
@@ -50,6 +50,7 @@ public class CheckUnits extends CheckCLDR {
         if (value == null || !path.startsWith("//ldml/units")) {
             return this;
         }
+        if (!accept(result)) return this;
         final XPathParts parts = XPathParts.getFrozenInstance(path);
         String finalElement = parts.getElement(-1);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
@@ -533,14 +533,14 @@ public class CheckWidths extends CheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
         final String localeID = cldrFileToCheck.getLocaleID();
         supplementalData =
                 SupplementalDataInfo.getInstance(cldrFileToCheck.getSupplementalDirectory());
         coverageLevel = CoverageLevel2.getInstance(supplementalData, localeID);
 
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         return this;
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
@@ -497,6 +497,7 @@ public class CheckWidths extends CheckCLDR {
         if (value == null) {
             return this; // skip
         }
+        if (!accept(result)) return this;
         //        String testPrefix = "//ldml/units/unitLength[@type=\"narrow\"]";
         //        if (path.startsWith(testPrefix)) {
         //            int i = 0;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckZones.java
@@ -60,10 +60,9 @@ public class CheckZones extends FactoryCheckCLDR {
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
         if (fullPath == null) return this; // skip paths that we don't have
         if (path.indexOf("timeZoneNames") < 0 || path.indexOf("usesMetazone") < 0) return this;
+        if (!accept(result)) return this;
         if (timezoneFormatter == null) {
-            if (true) return this;
-            throw new InternalCldrException(
-                    "This should not occur: setCldrFileToCheck must create a TimezoneFormatter.");
+            return this; // error thrown above
         }
         XPathParts parts = XPathParts.getFrozenInstance(path);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckZones.java
@@ -27,7 +27,7 @@ public class CheckZones extends FactoryCheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFile, Options options, List<CheckStatus> possibleErrors) {
         if (cldrFile == null) return this;
         //        if (Phase.FINAL_TESTING == getPhase()) {
@@ -37,7 +37,7 @@ public class CheckZones extends FactoryCheckCLDR {
         //            return this;
         //        }
 
-        super.setCldrFileToCheck(cldrFile, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFile, options, possibleErrors);
         try {
             timezoneFormatter = new TimezoneFormatter(getResolvedCldrFileToCheck());
         } catch (RuntimeException e) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FactoryCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FactoryCheckCLDR.java
@@ -52,9 +52,9 @@ abstract class FactoryCheckCLDR extends CheckCLDR {
     }
 
     @Override
-    public CheckCLDR setCldrFileToCheck(
+    public CheckCLDR handleSetCldrFileToCheck(
             CLDRFile cldrFileToCheck, Options options, List<CheckStatus> possibleErrors) {
-        super.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
+        super.handleSetCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         resolvedCldrFileToCheck = null;
         return this;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertXTB.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertXTB.java
@@ -469,7 +469,7 @@ public class ConvertXTB {
         }
         Map<String, String> options = new HashMap<>();
         List<CheckStatus> possibleErrors = new ArrayList<>();
-        checkCldr.setCldrFileToCheck(cldrFile, options, possibleErrors);
+        checkCldr.setCldrFileToCheck(cldrFile, new CheckCLDR.Options(options), possibleErrors);
         for (CheckStatus status : possibleErrors) {
             System.out.println(locale + "\tLOCALE ERROR\t" + status.getMessage());
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertXTB.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertXTB.java
@@ -17,6 +17,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
+import org.unicode.cldr.test.CheckCLDR.CheckStatus.Type;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.util.CLDRFile;
@@ -478,7 +479,7 @@ public class ConvertXTB {
             String xpath = CLDRFile.getDistinguishingXPath(info.xpath, null);
             String fullPath = cldrFile.getFullXPath(xpath);
             String value = info.value;
-            checkCldr.check(xpath, fullPath, value, options, possibleErrors);
+            checkCldr.check(xpath, fullPath, value, new CheckCLDR.Options(options), possibleErrors);
             numErrors += displayErrors(locale, info.messageId, xpath, value, possibleErrors);
         }
         if (numErrors == 0) System.out.println("No errors found for " + locale);
@@ -519,7 +520,7 @@ public class ConvertXTB {
                             + status.getType()
                             + "\t"
                             + status.getMessage().replace('\t', ' '));
-            if (status.getType().equals("Error")) {
+            if (status.getType().equals(Type.Error)) {
                 numErrors++;
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchCLDR.java
@@ -331,7 +331,12 @@ public class SearchCLDR {
                     }
                     result.clear();
 
-                    checkCldr.check(path, file.getFullXPath(path), value, options, result);
+                    checkCldr.check(
+                            path,
+                            file.getFullXPath(path),
+                            value,
+                            new CheckCLDR.Options(options),
+                            result);
                     if (result.isEmpty()) {
                         continue;
                     }
@@ -346,7 +351,12 @@ public class SearchCLDR {
                     }
                     // for debugging
                     int debug = 0;
-                    checkCldr.check(path, file.getFullXPath(path), value, options, result);
+                    checkCldr.check(
+                            path,
+                            file.getFullXPath(path),
+                            value,
+                            new CheckCLDR.Options(options),
+                            result);
                 }
 
                 // made it through the sieve

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchCLDR.java
@@ -252,7 +252,7 @@ public class SearchCLDR {
                     int debug = 0;
                 }
                 result.clear();
-                checkCldr.setCldrFileToCheck(resolvedFile, options, result);
+                checkCldr.setCldrFileToCheck(resolvedFile, new CheckCLDR.Options(options), result);
             }
 
             if (cldrDiffFactory != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -173,7 +173,7 @@ public class VettingViewer<T> {
             options = new HashMap<>();
             result = new ArrayList<>();
             checkCldr = CheckCLDR.getCheckAll(factory, ".*");
-            checkCldr.setCldrFileToCheck(cldrFile, new Options(options), result);
+            checkCldr.handleSetCldrFileToCheck(cldrFile, new Options(options), result);
             return Status.ok;
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -121,13 +121,13 @@ public class TestCheckCLDR extends TestFmwk {
         Map<String, String> options = new LinkedHashMap<>();
         List<CheckStatus> possibleErrors = new ArrayList<>();
         final CLDRFile english = testInfo.getEnglish();
-        c.setCldrFileToCheck(english, options, possibleErrors);
+        c.setCldrFileToCheck(english, new CheckCLDR.Options(options), possibleErrors);
         for (String path : english) {
             c.check(
                     path,
                     english.getFullXPath(path),
                     english.getStringValue(path),
-                    options,
+                    new CheckCLDR.Options(options),
                     possibleErrors);
         }
     }
@@ -595,7 +595,7 @@ public class TestCheckCLDR extends TestFmwk {
 
     public void TestCheckNames() {
         CheckCLDR c = new CheckNames();
-        Map<String, String> options = new LinkedHashMap<>();
+        Options options = new CheckCLDR.Options(new LinkedHashMap<>());
         List<CheckStatus> possibleErrors = new ArrayList<>();
         final CLDRFile english = testInfo.getEnglish();
         c.setCldrFileToCheck(english, options, possibleErrors);
@@ -652,7 +652,7 @@ public class TestCheckCLDR extends TestFmwk {
 
         CheckCLDR c = new CheckNew(testInfo.getCommonAndSeedAndMainAndAnnotationsFactory());
         List<CheckStatus> result = new ArrayList<>();
-        Map<String, String> options = new HashMap<>();
+        final CheckCLDR.Options options = new CheckCLDR.Options(new HashMap<>());
         c.setCldrFileToCheck(testInfo.getCLDRFile(locale, true), options, result);
         c.check(path, path, "foobar", options, result);
         String actualMessage = "";
@@ -698,8 +698,8 @@ public class TestCheckCLDR extends TestFmwk {
                 TestFactory currFactory = makeTestFactory(root, localeSource);
                 CLDRFile cldrFile = currFactory.make(localeSource.getLocaleID(), true);
 
-                c.setCldrFileToCheck(cldrFile, options, result);
-                c.check(path, path, value, options, result);
+                c.setCldrFileToCheck(cldrFile, new CheckCLDR.Options(options), result);
+                c.check(path, path, value, new CheckCLDR.Options(options), result);
                 boolean gotOne = false;
                 for (CheckStatus status : result) {
                     if (status.getSubtype() == Subtype.valueMustBeOverridden) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
@@ -239,13 +239,14 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
         cdc.setEnglishFile(CLDRConfig.getInstance().getEnglish());
 
         List<CheckStatus> possibleErrors = new ArrayList<>();
-        cdc.setCldrFileToCheck(factory.make(locale, true), ImmutableMap.of(), possibleErrors);
+        cdc.setCldrFileToCheck(
+                factory.make(locale, true), new Options(ImmutableMap.of()), possibleErrors);
         for (Entry<String, String> entry : pathValuePairs.entrySet()) {
             cdc.check(
                     entry.getKey(),
                     entry.getKey(),
                     entry.getValue(),
-                    ImmutableMap.of(),
+                    new Options(ImmutableMap.of()),
                     possibleErrors);
             assertEquals(entry.toString(), Collections.emptyList(), possibleErrors);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckNumbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckNumbers.java
@@ -3,7 +3,7 @@ package org.unicode.cldr.unittest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Type;
@@ -51,7 +51,7 @@ public class TestCheckNumbers extends TestFmwkPlus {
         xmlSource.setLocaleID(locale);
         CLDRFile cldrFileToCheck = new CLDRFile(xmlSource);
 
-        Map<String, String> options = Collections.emptyMap();
+        final CheckCLDR.Options options = new CheckCLDR.Options(Collections.emptyMap());
         List<CheckStatus> possibleErrors = new ArrayList<>();
         checkNumbers.setCldrFileToCheck(cldrFileToCheck, options, possibleErrors);
         assertEquals("setCldrFileToCheck", Collections.EMPTY_LIST, possibleErrors);


### PR DESCRIPTION
CLDR-17289

Update for performance, especially when calling CLDR Checks on a single XPath.

- rename implementation functions `setCldrFileToCheck()` to `handleSetCldrFileToCheck()`  which is a deferred call.
- New internal subclass API, `accept(…)` which checks must call once they determined they accept the xpath
- New internal subclass override `reset()` which checks can use to reset their state.
- New internal subclass override `handleCheckPossibleErrors()` for checks that want to provide immediate possibleErrors.

- [X] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
