### PR TITLE
CLDR-17290 chore(build): fix gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,11 +8,10 @@ on:
     tags:
       - "release-*"
     # Only run if docs change.
-    ## TODO CLDR-15464 reenable this!!
-    # paths:
-    #   - "tools/scripts/tr-archive/**"
-    #   - "docs/**"
-    #   - '.github/workflows/gh-pages.yml'
+    paths:
+      - "tools/scripts/tr-archive/**"
+      - "docs/**"
+      - '.github/workflows/gh-pages.yml'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: tr35-spec
-          path: tools/scripts/tr-archiver/tr35.zip
+          path: tools/scripts/tr-archive/tr35.zip
       - name: 'Run TR link extractor (experimental)'
         # Note: see CLDR-16526 for making this an error
         run: 'cd tools/scripts/tr-archive/ && npm run extract-link-targets || (echo Warning, please fix these ; true)'
@@ -49,7 +48,7 @@ jobs:
         run: git status ; git diff
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true
       - name: Build Jekyll part of the site
         run: |
@@ -88,4 +87,7 @@ jobs:
           echo "::endgroup::"
           echo "Now go to https://cldr-smoke.unicode.org/spec/"$(basename ${GITHUB_REF_NAME})
 
-# zero change
+# only run one of these at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
- bump to ruby 3.2

CLDR-17290

- [X] This PR completes the ticket.
- also fixes CLDR-17286, a simple typo

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
