### PR TITLE
CLDR-17289 fix for VettingViewer

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -173,7 +173,7 @@ public class VettingViewer<T> {
             options = new HashMap<>();
             result = new ArrayList<>();
             checkCldr = CheckCLDR.getCheckAll(factory, ".*");
-            checkCldr.handleSetCldrFileToCheck(cldrFile, new Options(options), result);
+            checkCldr.setCldrFileToCheck(cldrFile, new Options(options), result);
             return Status.ok;
         }
 


### PR DESCRIPTION
- May roll this into CLDR-7646
- needed to unbreak ST

I'm splitting this out because it fixes a critical issue. CLDR-7646 is the eventual improvement.

CLDR-17289

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
