### PR TITLE
CLDR-17304 capture internalError check stack traces into the system log

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -344,6 +344,8 @@ public class ConsoleCheckCLDR {
      * @throws Throwable
      */
     public static void main(String[] args) throws Throwable {
+        // turn off logging to not mess up html and other output.
+        CheckCLDR.setLoggerLevel(java.util.logging.Level.OFF);
         MyOptions.parse(args, true);
         ElapsedTimer totalTimer = new ElapsedTimer();
         UOption.parseArgs(args, options);


### PR DESCRIPTION
CLDR-17304

- before shipping off to front end, call system logger on any Subtype.internalError messages
- confirmed that they show up in the liberty logfile. so, should be picked up by datadog

- [x] This PR completes the ticket.


ALLOW_MANY_COMMITS=true
