### PR TITLE
CLDR-7646 TestCache concurrency issues

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestCache.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestCache.java
@@ -2,7 +2,6 @@ package org.unicode.cldr.test;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -62,11 +61,19 @@ public class TestCache implements XMLSource.Listener {
              */
             result.clear();
             Pair<String, String> key = new Pair<>(path, value);
-            List<CheckStatus> cachedResult = pathCache.computeIfAbsent(key, (Pair<String, String> k) -> {
-                List<CheckStatus> l = new ArrayList<CheckStatus>();
-                cc.check(k.getFirst(), file.getFullXPath(k.getFirst()), k.getSecond(), options, l);
-                return l;
-            });
+            List<CheckStatus> cachedResult =
+                    pathCache.computeIfAbsent(
+                            key,
+                            (Pair<String, String> k) -> {
+                                List<CheckStatus> l = new ArrayList<CheckStatus>();
+                                cc.check(
+                                        k.getFirst(),
+                                        file.getFullXPath(k.getFirst()),
+                                        k.getSecond(),
+                                        options,
+                                        l);
+                                return l;
+                            });
             if (cachedResult != null) {
                 result.addAll(cachedResult);
             }
@@ -91,6 +98,7 @@ public class TestCache implements XMLSource.Listener {
     private Cache<CheckCLDR.Options, TestResultBundle> testResultCache =
             CacheBuilder.newBuilder()
                     .maximumSize(CLDRConfig.getInstance().getProperty("CLDR_TESTCACHE_SIZE", 12))
+                    .concurrencyLevel(1)
                     .softValues()
                     .build();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestCache.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestCache.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.Options;
@@ -60,12 +62,13 @@ public class TestCache implements XMLSource.Listener {
              */
             result.clear();
             Pair<String, String> key = new Pair<>(path, value);
-            List<CheckStatus> cachedResult = pathCache.get(key);
+            List<CheckStatus> cachedResult = pathCache.computeIfAbsent(key, (Pair<String, String> k) -> {
+                List<CheckStatus> l = new ArrayList<CheckStatus>();
+                cc.check(k.getFirst(), file.getFullXPath(k.getFirst()), k.getSecond(), options, l);
+                return l;
+            });
             if (cachedResult != null) {
                 result.addAll(cachedResult);
-            } else {
-                cc.check(path, file.getFullXPath(path), value, options, result);
-                pathCache.put(key, ImmutableList.copyOf(result));
             }
         }
 
@@ -96,16 +99,13 @@ public class TestCache implements XMLSource.Listener {
     private String nameMatcher = ".*";
 
     /** Get the bundle for this test */
-    public TestResultBundle getBundle(CheckCLDR.Options options) {
-        TestResultBundle b = testResultCache.getIfPresent(options);
-        if (b != null) {
-            logger.finest(() -> this + " Bundle refvalid: " + options);
-        }
-        if (b == null) {
-            // ElapsedTimer et = new ElapsedTimer("New test bundle " + locale + " opt " + options);
-            b = new TestResultBundle(options);
-            // System.err.println(et.toString());
-            testResultCache.put(options, b);
+    public TestResultBundle getBundle(final CheckCLDR.Options options) {
+        TestResultBundle b;
+        try {
+            b = testResultCache.get(options, () -> new TestResultBundle(options));
+        } catch (ExecutionException e) {
+            logger.log(Level.SEVERE, e, () -> "Failed to load " + options);
+            throw new RuntimeException(e);
         }
         return b;
     }


### PR DESCRIPTION
- fix the TestCacheBundle and TestCacheResult caches to be concurrent safe
- was using concurrent safe maps, but not computing the results safely.

CLDR-7646

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
