### PR TITLE
CLDR-17282 Add currency attributes tz, to-tz and docs; use for currency changes from 2022-01-01

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -75,12 +75,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!-- use from and to instead. -->
     <!--@VALUE-->
     <!--@DEPRECATED-->
+<!ATTLIST currency iso4217 NMTOKEN #REQUIRED >
+    <!--@MATCH:validity/currency-->
 <!ATTLIST currency from NMTOKEN #IMPLIED >
     <!--@MATCH:time/yyyy-MM-dd-->
 <!ATTLIST currency to NMTOKEN #IMPLIED >
     <!--@MATCH:time/yyyy-MM-dd-->
-<!ATTLIST currency iso4217 NMTOKEN #REQUIRED >
-    <!--@MATCH:validity/currency-->
+<!ATTLIST currency tz CDATA #IMPLIED >
+    <!--@MATCH:bcp47/tz-->
+    <!--@VALUE-->
+<!ATTLIST currency to-tz CDATA #IMPLIED >
+    <!--@MATCH:bcp47/tz-->
+    <!--@VALUE-->
 <!ATTLIST currency digits NMTOKEN #IMPLIED >
     <!--@VALUE-->
 <!ATTLIST currency rounding NMTOKEN #IMPLIED >

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -545,8 +545,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="HNL" from="1926-04-03"/>
         </region>
         <region iso3166="HR">
-            <currency iso4217="EUR" from="2023-01-01" />
-            <currency iso4217="HRK" from="1994-05-30" to="2023-01-14"/>
+            <currency iso4217="EUR" from="2023-01-01" tz="Europe/Zagreb"/>
+            <currency iso4217="HRK" from="1994-05-30" to="2023-01-14" to-tz="Europe/Zagreb"/>
             <currency iso4217="HRD" from="1991-12-23" to="1995-01-01"/>
             <currency iso4217="YUN" from="1990-01-01" to="1991-12-23"/>
             <currency iso4217="YUD" from="1966-01-01" to="1990-01-01"/>
@@ -957,8 +957,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="CSK" from="1953-06-01" to="1992-12-31"/>
         </region>
         <region iso3166="SL">
-            <currency iso4217="SLE" from="2022-07-01"/>
-            <currency iso4217="SLL" from="1964-08-04" to="2023-12-31"/>
+            <currency iso4217="SLE" from="2022-07-01" tz="Africa/Freetown"/>
+            <currency iso4217="SLL" from="1964-08-04" to="2023-12-31" to-tz="Africa/Freetown"/>
             <currency iso4217="GBP" from="1808-11-30" to="1966-02-04"/>
         </region>
         <region iso3166="SM">

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -905,9 +905,11 @@ For background information on currency names, see [[CurrencyInfo](tr35.md#Curren
 <!ATTLIST region iso3166 NMTOKEN #REQUIRED >
 
 <!ELEMENT currency ( alternate* ) >
+<!ATTLIST currency iso4217 NMTOKEN #REQUIRED >
 <!ATTLIST currency from NMTOKEN #IMPLIED >
 <!ATTLIST currency to NMTOKEN #IMPLIED >
-<!ATTLIST currency iso4217 NMTOKEN #REQUIRED >
+<!ATTLIST currency tz CDATA #IMPLIED >
+<!ATTLIST currency to-tz CDATA #IMPLIED >
 <!ATTLIST currency tender ( true | false ) #IMPLIED >
 ```
 
@@ -963,17 +965,23 @@ Each `region` element contains one attribute:
 And can have any number of `currency` elements, with the `ordered` subelements.
 
 ```xml
-<region iso3166="IT"> <!-- Italy -->
-    <currency iso4217="EUR" from="2002-01-01"/>
-    <currency iso4217="ITL" to="2001-12-31"/>
+<region iso3166="HR"> <!-- Croatia -->
+    <currency iso4217="EUR" from="2023-01-01" tz="Europe/Zagreb"/>
+    <currency iso4217="HRK" from="1994-05-30" to="2023-01-14" to-tz="Europe/Zagreb"/>
+    <currency iso4217="HRD" from="1991-12-23" to="1995-01-01"/>
+    <currency iso4217="YUN" from="1990-01-01" to="1991-12-23"/>
+    <currency iso4217="YUD" from="1966-01-01" to="1990-01-01"/>
 </region>
 ```
 
 * **iso4217:** the ISO 4217 code for the currency in question. Note that some additional codes that were in widespread usage are included, others such as GHP are not included because they were never used.
-* **from:** the currency was valid from to the datetime indicated by the value. See the main document _[Dates and Date Ranges](tr35.md#Date_Ranges)_.
-* **to:** the currency was valid up to the datetime indicated by the value of _before_. See the main document _[Dates and Date Ranges](tr35.md#Date_Ranges)_.
+* **from:** the currency was valid from the datetime indicated by the value. See the main document _[Dates and Date Ranges](tr35.md#Date_Ranges)_.
+* **to:** the currency was valid up to the datetime indicated by the value. See the main document _[Dates and Date Ranges](tr35.md#Date_Ranges)_.
+* **tz:** the IANA timezone associated with the `from` transition datetime. If no `to-tz` attribute is specified, it also applies to the `to` transition datetime.
+* **to-tz:** the IANA timezone associated with the `to` transition datetime. This timezone applies to the `to` value, and need only be specified if it is different from any timezone specified by a `tz` attribute.
 * **tender:** indicates whether or not the ISO currency code represents a currency that was or is legal tender in some country. The default is "true". Certain ISO codes represent things like financial instruments or precious metals, and do not represent normally interchanged currencies.
 
+> **Note on converting transition datetimes for implementation use:** The fact that CLDR stores the timezone separately from the transition datetime is for ease of CLDR maintenance. Implementations that use CLDR data may want to convert the combination into something like a single UTC timestamp for internal use.
 
 That is, each `currency` element will list an interval in which it was valid. The _ordering_ of the elements in the list tells us which was the primary currency during any period in time. Here is an example of such an overlap:
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|45 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2024-01-08|
+|Date|2024-01-14|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-72/tr35.html">https://www.unicode.org/reports/tr35/tr35-72/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-71/tr35.html">https://www.unicode.org/reports/tr35/tr35-71/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|
@@ -4016,11 +4016,12 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
-**Differences from LDML Version 44**
+**Differences from LDML Version 44.1**
 
-(TBD)
+* [Numbers](tr35-numbers.md#Contents)
+  * In [Supplemental Currency Data](tr35-numbers.md#Supplemental_Currency_Data), for the `currency` element, added attributes `tz` and `to-tz` to clarify the `from` and `to` dates.
 
-**Differences from LDML Version 43 to 44**
+**Differences from LDML Version 43 to 44.1**
 
 * [Core](#Contents)
   * In [Time Zone Identifiers](#Time_Zone_Identifiers), added information on the new `iana` attribute for stability; also see information on `iana` in the section [U Extension Data Files](#Unicode_Locale_Extension_Data_Files).

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -471,9 +471,15 @@
 //supplementalData/currencyData/fractions/info[@iso4217="%A"]/_%E			; Supplemental ; Currency ; $1 ; Fractions-$2 ; HIDE
 //supplementalData/codeMappings/currencyCodes[@type="%A"]/_numeric			; Supplemental ; Currency ; $1 ; NumericCode ; HIDE
 
-//supplementalData/currencyData/region[@iso3166="%A"]/currency[@from="%A"][@to="%A"][@iso4217="%A"]/_tender			; Supplemental ; Currency ; $1 ; $4–$2–$3 ; HIDE
-//supplementalData/currencyData/region[@iso3166="%A"]/currency[@to="%A"][@iso4217="%A"]/_tender			; Supplemental ; Currency ; $1 ; $3–-∞..$2 ; HIDE
-//supplementalData/currencyData/region[@iso3166="%A"]/currency[@from="%A"][@iso4217="%A"]/_tender			; Supplemental ; Currency ; $1 ; $3–$2..∞ ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@from="%A"][@to="%A"]/_tender			; Supplemental ; Currency ; $1 ; $2–$3–$4 ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@from="%A"][@to="%A"]/_tz				; Supplemental ; Currency ; $1 ; $2–$3–$4 ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@from="%A"][@to="%A"]/_to-tz			; Supplemental ; Currency ; $1 ; $2–$3–$4 ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@to="%A"]/_tender			; Supplemental ; Currency ; $1 ; $2–-∞..$3 ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@to="%A"]/_tz				; Supplemental ; Currency ; $1 ; $2–-∞..$3 ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@to="%A"]/_to-tz			; Supplemental ; Currency ; $1 ; $2–-∞..$3 ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@from="%A"]/_tender			; Supplemental ; Currency ; $1 ; $2–$3..∞ ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@from="%A"]/_tz				; Supplemental ; Currency ; $1 ; $2–$3..∞ ; HIDE
+//supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"][@from="%A"]/_to-tz			; Supplemental ; Currency ; $1 ; $2–$3..∞ ; HIDE
 //supplementalData/currencyData/region[@iso3166="%A"]/currency[@iso4217="%A"]/_tender			; Supplemental ; Currency ; $1 ; $2–-∞..∞; HIDE
 
 //supplementalData/calendarData/calendar[@type="%A"]/eras/era[@type="%A"]/_%E			; Supplemental ; Calendar ; $1 ; $2-$3 ; HIDE


### PR DESCRIPTION
CLDR-17282

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17282)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

1. For the `currency` element, add attributes `tz` and `to-tz`. Document these in the spec, along with note that implementations may want to convert the combination of date time and timezone to a UTC timestamp or equivalent for use as runtime data.
    * I made these `@VALUE` since they are not distinguishing attributes (but rather annotations for the `to` and `from` attributes); however they are not really like element values either. I also updated PathHeader accordingly.

2. Update the supplemental currency data to use these new attributes for all currency transitions from 2022-01-01 onward. There were only two, for Croatia using tz Europe/Zagreb, and for Sierra Leone, using tz Africa/Freetown. Both of those zones are currently aliases in the backward file, but are still valid in CLDR I believe.

3. I have filed [ICU-22631](ttps://unicode-org.atlassian.net/browse/ICU-22631) for the associated work in the cldr-icu converter.

ALLOW_MANY_COMMITS=true


[ICU-22631]: https://unicode-org.atlassian.net/browse/ICU-22631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ