### PR TITLE
CLDR-17216 generate cldr keyboard charts via maven, copy via GenerateAllCharts

### DIFF
--- a/docs/charts/keyboard/.gitignore
+++ b/docs/charts/keyboard/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 /static/data
+/node_modules
+/node
+/target

--- a/docs/charts/keyboard/README.md
+++ b/docs/charts/keyboard/README.md
@@ -1,0 +1,22 @@
+# Keyboard Charts
+
+## What are these
+
+The Keyboard Charts are now built as client-side JavaScript tables.
+
+## To Build from the command line
+
+- install <https://nodejs.org> current LTS version, then in this directory:
+- `npm i`
+- `npm run build`
+
+## To build from Maven
+
+Run this from the command line in the top level directory:
+
+- `mvn --file=tools/pom.xml -pl :cldr-keyboard-charts com.github.eirslett:frontend-maven-plugin:npm`
+
+## Trying them out
+
+- `npm run serve` will serve the charts locally on <http://localhost:3000>
+

--- a/docs/charts/keyboard/package-lock.json
+++ b/docs/charts/keyboard/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@unicode-org/keyboard-charts",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "Unicode-DFS-2016",
       "dependencies": {
         "fast-xml-parser": "^4.2.5"

--- a/docs/charts/keyboard/package.json
+++ b/docs/charts/keyboard/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "serve": "npx serve static",
-    "build": "node build.mjs"
+    "build": "node build.mjs",
+    "lint": "echo no linter yet",
+    "postinstall": "node build.mjs"
   },
   "keywords": [],
   "author": "Steven R. Loomis <srl295@gmail.com>",

--- a/docs/charts/keyboard/pom.xml
+++ b/docs/charts/keyboard/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>cldr-keyboard-charts</artifactId>
+	<packaging>pom</packaging>
+	<name>CLDR Keyboard Charts</name>
+
+	<url>https://unicode.org/cldr</url>
+
+	<scm>
+		<connection>scm:git:https://github.com/unicode-org/cldr.git</connection>
+	</scm>
+
+
+	<parent>
+		<groupId>org.unicode.cldr</groupId>
+		<artifactId>cldr-all</artifactId>
+		<version>45.0-SNAPSHOT</version>
+        <relativePath>../../../tools/pom.xml</relativePath>
+	</parent>
+
+    <build>
+		<plugins>
+			<plugin>
+            <!-- to get the node version-->
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>initialize</phase>
+						<configuration>
+							<target>
+								<concat append="no" destfile="${project.basedir}/target/node-version.properties">node.version=</concat>
+								<concat append="yes" destfile="${project.basedir}/target/node-version.properties">
+									<fileset dir="${project.basedir}/../../..">
+										<include name=".node-version" />
+									</fileset>
+								</concat>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>properties-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>initialize</phase>
+						<goals>
+							<goal>read-project-properties</goal>
+						</goals>
+						<configuration>
+							<files>
+								<file>${project.basedir}/target/node-version.properties</file>
+							</files>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.github.eirslett</groupId>
+				<artifactId>frontend-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>install node and npm</id>
+						<goals>
+							<goal>install-node-and-npm</goal>
+						</goals>
+                        <phase>integration-test</phase>
+					</execution>
+					<execution>
+						<id>npm install</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+                        <phase>integration-test</phase>
+					</execution>
+					<execution>
+						<id>npm run build</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+						<configuration>
+							<arguments>run build</arguments>
+						</configuration>
+                        <phase>integration-test</phase>
+					</execution>
+				</executions>
+				<configuration>
+					<nodeVersion>${node.version}</nodeVersion>
+					<!-- run in project sourcedir -->
+					<workingDirectory>${project.basedir}</workingDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+
+    <profiles>
+        <profile>
+        <id>build-keyboard-charts</id>
+        </profile>
+    </profiles>
+
+</project>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateAllCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateAllCharts.java
@@ -26,6 +26,7 @@ public class GenerateAllCharts {
             throw new IOException("Main dir doesn't exist: " + mainDir);
         }
         FileCopier.copy(GenerateAllCharts.class, "index.css", CLDRPaths.CHART_DIRECTORY);
+
         FileCopier.copy(
                 GenerateAllCharts.class,
                 "main-index.html",
@@ -54,5 +55,7 @@ public class GenerateAllCharts {
         VerifyZones.main(args);
         DateTimeFormats.main(args);
         new ChartPersonNames().writeChart(null);
+
+        GenerateKeyboardCharts.main(args);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKeyboardCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKeyboardCharts.java
@@ -1,0 +1,66 @@
+package org.unicode.cldr.tool;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.unicode.cldr.util.CLDRPaths;
+
+public class GenerateKeyboardCharts {
+
+    public static void main(String args[]) throws IOException {
+        final File mainDir = new File(CLDRPaths.CHART_DIRECTORY);
+        if (mainDir.mkdirs()) {
+            System.err.println("Created: " + mainDir);
+        }
+        if (!mainDir.isDirectory()) {
+            throw new IOException("Main dir doesn't exist: " + mainDir);
+        }
+        final File kbdDir = new File(CLDRPaths.BASE_DIRECTORY, "docs/charts/keyboard");
+        if (!kbdDir.exists()) {
+            throw new IOException("Keyboards root dir doesn't exist: " + kbdDir);
+        }
+        final File kbdStatic = new File(kbdDir, "static");
+        final File kbdStaticData = new File(kbdDir, "static/data");
+        if (!kbdStaticData.exists()) {
+            System.err.println(
+                    "ERROR: " + kbdStaticData + " does not exist. Keyboard charts weren't run.");
+            System.err.println("See " + new File(kbdDir, "README.md") + " for help.");
+            return;
+        }
+        final File staticTarg = new File(mainDir, "keyboard/static");
+        if (staticTarg.mkdirs()) {
+            System.err.println("Created: " + staticTarg);
+        }
+        System.out.println("Copying: " + kbdStatic + " to " + staticTarg);
+
+        Files.copy(
+                new File(kbdDir, "index.html").toPath(),
+                new File(mainDir, "keyboard/index.html").toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+        final String kbdStaticPrefix = kbdStatic.getAbsolutePath();
+        Files.walk(kbdStatic.toPath())
+                .forEach(
+                        path -> {
+                            if (!path.toFile().isFile()) return;
+                            path.getParent().toFile().mkdirs();
+
+                            System.out.println(path.toFile().getAbsolutePath());
+                            /** path from static prefix */
+                            final String rel =
+                                    path.toFile()
+                                            .getAbsolutePath()
+                                            .substring(kbdStaticPrefix.length());
+                            try {
+                                final Path out = new File(staticTarg, rel).toPath();
+                                System.out.println(" -> " + out);
+                                Files.copy(path, out, StandardCopyOption.REPLACE_EXISTING);
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                                System.err.println("Error copying " + path);
+                                System.exit(1);
+                            }
+                        });
+    }
+}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -41,6 +41,7 @@
 		<module>cldr-code</module>
 		<module>cldr-apps</module>
 		<module>cldr-rdf</module>
+		<module>../docs/charts/keyboard</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
- needs a node.js step to build, but can be invoked via maven

CLDR-17216

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
