### PR TITLE
CLDR-16329 Add convertUnit exponent attribute for beaufort; update UnitConverter and some related code

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -454,6 +454,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST convertUnit factor CDATA #IMPLIED >
     <!--@MATCH:regex/[-+*/\._ 0-9a-zA-Z]+-->
     <!--@VALUE-->
+<!ATTLIST convertUnit exponent CDATA #IMPLIED >
+    <!--@MATCH:regex/[-+*/\._ 0-9a-zA-Z]+-->
+    <!--@VALUE-->
 <!ATTLIST convertUnit offset CDATA #IMPLIED >
     <!--@MATCH:regex/[-+*/\._ 0-9a-zA-Z]+-->
     <!--@VALUE-->

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -342,6 +342,7 @@ For terms of use, see http://www.unicode.org/copyright.html
        
         <!-- speed -->
         <convertUnit source='knot' baseUnit='meter-per-second' factor='1852/3600' systems="ussystem uksystem si_acceptable"/>
+        <convertUnit source='beaufort' baseUnit='meter-per-second' factor='0.836' exponent='3/2' systems="metric_adjacent"/>
         
         <!-- magnetic-induction -->
         <convertUnit source='tesla' baseUnit='kilogram-per-square-second-ampere' systems='si metric prefixable'/>

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -860,6 +860,8 @@ An implementation need not use rationals directly for conversion; it could use d
 
 <!ATTLIST convertUnit factor CDATA #IMPLIED >
 
+<!ATTLIST convertUnit exponent CDATA #IMPLIED >
+
 <!ATTLIST convertUnit offset CDATA #IMPLIED >
 
 <!ATTLIST convertUnit description CDATA #IMPLIED >
@@ -869,7 +871,7 @@ An implementation need not use rationals directly for conversion; it could use d
 
 The conversion data provides the data for converting all of the cldr unit identifiers to base units, and back. That allows conversion between any two convertible units, such as two units of length. For any two convertible units (such as acre and dunum) the first can be converted to the base unit (square-meter), then that base unit can be converted to the second unit.
 
-The data is expressed as conversions to the base unit. The information can also be used for the conversion back.
+The data is expressed as conversions to the base unit from the source unit. The information can also be used for the conversion back.
 
 Examples:
 
@@ -885,17 +887,20 @@ Examples:
 
 For example, to convert from 3 carats to kilograms, the factor 0.0002 is used, resulting in 0.0006. To convert between carats and ounces, first the carets are converted to kilograms, then the kilograms to ounces (by reversing the mapping).
 
-The factor and offset use the same structure as in the value in unitConstant; in particular, * binds more tightly than /.
-
-The conversion may also require an offset, such as the following:
+The conversion may also require an offset or exponent, such as the following:
 
 ```xml
 <convertUnit source='fahrenheit' baseUnit='kelvin' factor='5/9' offset='2298.35/9' systems="ussystem uksystem"/>
+
+<convertUnit source='beaufort' baseUnit='meter-per-second' factor='0.836' exponent='3/2' systems="metric_adjacent"/>
 ```
 
-The factor and offset can be simple expressions, just like the values in the unitConstants.
+The complete expression for conversion from sourceUnit to baseUnit is `baseUnit = factor * sourceUnit^exponent + offset`.
+The inverse conversion is thus `sourceUnit = ((baseUnit - offset)/factor)^(1/exponent)`.
 
-Where a factor is not present, the value is 1; where an offset is not present, the value is 0.
+The factor, exponent and offset can be simple expressions, just like the values in the unitConstants. These use the same structure as in the value in unitConstant; in particular, * binds more tightly than /.
+
+Where a factor or exponent is not present, the value is 1; where an offset is not present, the value is 0. No current conversions specify both an exponent and and offset.
 
 The `systems` attribute indicates the measurement system(s) or other characteristics of a set of unts. Multiple values may be given; for example, a unit could be marked as systems="`si_acceptable` `metric_adjacent` `prefixable`".
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|45 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2024-01-14|
+|Date|2024-01-26|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-72/tr35.html">https://www.unicode.org/reports/tr35/tr35-72/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-71/tr35.html">https://www.unicode.org/reports/tr35/tr35-71/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|
@@ -4020,6 +4020,9 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 * [Numbers](tr35-numbers.md#Contents)
   * In [Supplemental Currency Data](tr35-numbers.md#Supplemental_Currency_Data), for the `currency` element, added attributes `tz` and `to-tz` to clarify the `from` and `to` dates.
+
+* [Supplemental](tr35-info.md#Contents)
+  * In [Conversion Data](tr35-info.md#conversion-data), added the `exponent` attribute for `convertUnit`, and provided the complete expressions for conversion between sourceUnit and baseUnit.
 
 **Differences from LDML Version 43 to 44.1**
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartUnitConversions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartUnitConversions.java
@@ -139,6 +139,7 @@ public class ChartUnitConversions extends Chart {
             all.add(sortKey);
 
             // get some formatted strings
+            // TODO: handle exponent here - how?
 
             final String repeatingFactor =
                     targetInfo.unitInfo.factor.toString(FormatStyle.repeating);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartUnitConversions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartUnitConversions.java
@@ -139,7 +139,7 @@ public class ChartUnitConversions extends Chart {
             all.add(sortKey);
 
             // get some formatted strings
-            // TODO: handle exponent here - how?
+            // TODO: handle exponent here - how? CLDR-16329 additional PR or follow-on ticket
 
             final String repeatingFactor =
                     targetInfo.unitInfo.factor.toString(FormatStyle.repeating);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/UnitValidityCanonicalizer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/UnitValidityCanonicalizer.java
@@ -94,6 +94,11 @@ public class UnitValidityCanonicalizer {
                         return comp;
                     }
 
+                    comp = ci1.exponent.compareTo(ci2.exponent);
+                    if (comp != 0) {
+                        return comp;
+                    }
+
                     comp = ci2.offset.compareTo(ci2.offset);
                     if (comp != 0) {
                         return comp;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
@@ -277,7 +277,7 @@ public final class Rational implements Comparable<Rational> {
         if (exponent.equals(Rational.ONE)) {
             return this;
         }
-        // Temporary quick implementation
+        // TODO Temporary implementation, improve per CLDR-16329 additional PR or follow-on ticket
         double resultDouble = Math.pow(this.doubleValue(), exponent.doubleValue());
         return Rational.of(new BigDecimal(resultDouble));
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
@@ -273,6 +273,15 @@ public final class Rational implements Comparable<Rational> {
         return new Rational(numerator.pow(i), denominator.pow(i));
     }
 
+    public Rational pow(Rational exponent) {
+        if (exponent.equals(Rational.ONE)) {
+            return this;
+        }
+        // Temporary quick implementation
+        double resultDouble = Math.pow(this.doubleValue(), exponent.doubleValue());
+        return Rational.of(new BigDecimal(resultDouble));
+    }
+
     public static Rational pow10(int i) {
         return i > 0 ? TEN.pow(i) : TENTH.pow(-i);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -1644,9 +1644,10 @@ public class SupplementalDataInfo {
             // itself " + parts);
             //            }
             String factor = parts.getAttributeValue(-1, "factor");
+            String exponent = parts.getAttributeValue(-1, "exponent");
             String offset = parts.getAttributeValue(-1, "offset");
             String systems = parts.getAttributeValue(-1, "systems");
-            unitConverter.addRaw(source, target, factor, offset, systems);
+            unitConverter.addRaw(source, target, factor, exponent, offset, systems);
             return true;
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -286,12 +286,21 @@ public class UnitConverter implements Freezable<UnitConverter> {
         }
 
         public String toString(String unit) {
+            String exponentStart = "";
+            String exponentEnd = "";
+            if (exponent.denominator.compareTo(BigInteger.ONE) != 0) {
+                exponentStart = " ( ";
+                exponentEnd = " ) ";
+            }
             return factor.toString(FormatStyle.formatted)
                     + " * "
                     + unit
                     + (exponent.equals(Rational.ONE)
                             ? ""
-                            : " ^ " + exponent.toString(FormatStyle.formatted))
+                            : " ^ "
+                                    + exponentStart
+                                    + exponent.toString(FormatStyle.formatted)
+                                    + exponentEnd)
                     + (offset.equals(Rational.ZERO)
                             ? ""
                             : (offset.compareTo(Rational.ZERO) < 0 ? " - " : " + ")
@@ -303,12 +312,21 @@ public class UnitConverter implements Freezable<UnitConverter> {
         }
 
         public String toDecimal(String unit) {
+            String exponentStart = "";
+            String exponentEnd = "";
+            if (exponent.denominator.compareTo(BigInteger.ONE) != 0) {
+                exponentStart = " ( ";
+                exponentEnd = " ) ";
+            }
             return factor.toBigDecimal(MathContext.DECIMAL64)
                     + " * "
                     + unit
                     + (exponent.equals(Rational.ONE)
                             ? ""
-                            : " ^ " + exponent.toBigDecimal(MathContext.DECIMAL64))
+                            : " ^ "
+                                    + exponentStart
+                                    + exponent.toBigDecimal(MathContext.DECIMAL64)
+                                    + exponentEnd)
                     + (offset.equals(Rational.ZERO)
                             ? ""
                             : (offset.compareTo(Rational.ZERO) < 0 ? " - " : " + ")
@@ -827,12 +845,13 @@ public class UnitConverter implements Freezable<UnitConverter> {
         return new ConversionInfo(
                 numerator.divide(denominator),
                 Rational.ONE,
-                offset); // TODO: handle exponent here - how?
+                offset); // TODO: handle exponent here - how? CLDR-16329 additional PR or follow-on
+        // ticket
     }
 
     /** Only for use for simple base unit comparison */
     private class UnitComparator implements Comparator<String> {
-        // TODO: handle exponent here - how?
+        // TODO: handle exponent here - how? CLDR-16329 additional PR or follow-on ticket
         // TODO, use order in units.xml
 
         @Override
@@ -2037,7 +2056,10 @@ public class UnitConverter implements Freezable<UnitConverter> {
         Output<String> sourceBase = new Output<>();
         ConversionInfo sourceConversionInfo = parseUnitId(inputUnit, sourceBase, false);
         String baseUnit = sourceBase.value;
-        Rational baseUnitToInput = sourceConversionInfo.factor; // TODO: handle exponent here - how?
+        Rational baseUnitToInput =
+                sourceConversionInfo
+                        .factor; // TODO: handle exponent here - how? CLDR-16329 additional PR or
+        // follow-on ticket
 
         putIfInRange(result, baseUnit, baseUnitToInput);
 
@@ -2073,6 +2095,8 @@ public class UnitConverter implements Freezable<UnitConverter> {
                         baseUnitToInput.multiply(
                                 sourceConversionInfo.factor
                                         .reciprocal()); // TODO: handle exponent here - how?
+                // CLDR-16329 additional PR or follow-on
+                // ticket
 
                 if (otherValue.compareTo(Rational.ONE) < 0) {
                     if (otherValue.compareTo(closestLessValue) > 0) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -539,6 +539,7 @@
 //supplementalData/unitQuantities/unitQuantity[@baseUnit="%A"]/_status	; Supplemental ; Units ; Quantity ; $1-status ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_baseUnit	; Supplemental ; Units ; Convert ; $1-baseUnit ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_factor	; Supplemental ; Units ; Convert ; $1-factor ; HIDE
+//supplementalData/convertUnits/convertUnit[@source="%A"]/_exponent	; Supplemental ; Units ; Convert ; $1-exponent ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_offset	; Supplemental ; Units ; Convert ; $1-offset ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_reciprocal	; Supplemental ; Units ; Convert ; $1-reciprocal ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_systems	; Supplemental ; Units ; Convert ; $1-systems ; HIDE

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/ExternalUnitConversionData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/ExternalUnitConversionData.java
@@ -25,6 +25,7 @@ final class ExternalUnitConversionData implements Comparable<ExternalUnitConvers
             String symbol,
             String target,
             Rational factor,
+            Rational exponent,
             Rational offset,
             Set<UnitSystem> systems,
             String from,
@@ -34,7 +35,11 @@ final class ExternalUnitConversionData implements Comparable<ExternalUnitConvers
         this.source = source;
         this.symbol = symbol;
         this.target = target;
-        this.info = new ConversionInfo(factor, offset == null ? Rational.ZERO : offset);
+        this.info =
+                new ConversionInfo(
+                        factor,
+                        exponent == null ? Rational.ONE : exponent,
+                        offset == null ? Rational.ZERO : offset);
         this.systems = systems == null ? ImmutableSet.of() : ImmutableSet.copyOf(systems);
         this.from = from;
         this.line = line;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/GenerateNewUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/GenerateNewUnits.java
@@ -239,6 +239,7 @@ public class GenerateNewUnits {
                 bestSymbol,
                 bestTarget,
                 bestFactor,
+                Rational.ONE,
                 Rational.ZERO,
                 null,
                 null,

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NistUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NistUnits.java
@@ -143,6 +143,7 @@ final class NistUnits {
                             "kilogram",
                             Rational.of("1.660538782E-27"),
                             null,
+                            null,
                             Set.of(UnitSystem.si_acceptable),
                             "HACK",
                             "hack"));
@@ -153,6 +154,7 @@ final class NistUnits {
                             "g",
                             "kilogram",
                             Rational.of("1E-3"),
+                            null,
                             null,
                             Set.of(UnitSystem.si),
                             "HACK",
@@ -185,6 +187,7 @@ final class NistUnits {
                                                 null,
                                                 parts.get(1),
                                                 factor,
+                                                null,
                                                 null,
                                                 _siAcceptable,
                                                 NIST_CONVERSIONS,
@@ -222,6 +225,7 @@ final class NistUnits {
                                                 symbol,
                                                 name, //
                                                 Rational.ONE, //
+                                                null, //
                                                 null, //
                                                 _siAcceptable, //
                                                 NIST_BASE_UNITS,
@@ -273,7 +277,8 @@ final class NistUnits {
                                 name,
                                 new TargetInfo(
                                         targetUnit,
-                                        new ConversionInfo(Rational.ONE, Rational.ZERO),
+                                        new ConversionInfo(
+                                                Rational.ONE, Rational.ONE, Rational.ZERO),
                                         Collections.emptyMap()));
 
                         ExternalUnitConversionData data =
@@ -283,6 +288,7 @@ final class NistUnits {
                                         symbol,
                                         targetUnit, //
                                         Rational.ONE, //
+                                        null, //
                                         null, //
                                         _siAcceptable, //
                                         NIST_DERIVED_UNITS,
@@ -374,6 +380,7 @@ final class NistUnits {
             String symbolRaw,
             String targetRaw,
             Rational factor,
+            Rational exponent,
             Rational offset,
             Set<String> acceptable,
             String from,
@@ -404,7 +411,7 @@ final class NistUnits {
                 break;
         }
         return new ExternalUnitConversionData(
-                quantity, source, symbol, target, factor, offset, systems, from, line);
+                quantity, source, symbol, target, factor, exponent, offset, systems, from, line);
     }
 
     private static String extractUnit(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -297,7 +297,7 @@ public class TestUnits extends TestFmwk {
                 if (simpleUnit.equals(baseUnit)) {
                     continue;
                 }
-                System.out.println(
+                System.out.println( // TODO: handle exponent
                         ++count
                                 + ")\t"
                                 + simpleUnit
@@ -752,7 +752,7 @@ public class TestUnits extends TestFmwk {
         assertEquals("", Rational.of(1237, 10), Rational.of(BigDecimal.valueOf(1237.0 / 10)));
         assertEquals("", Rational.of(1237, 10000), Rational.of(BigDecimal.valueOf(1237.0 / 10000)));
 
-        ConversionInfo uinfo = new ConversionInfo(Rational.of(2), Rational.of(3));
+        ConversionInfo uinfo = new ConversionInfo(Rational.of(2), Rational.of(1), Rational.of(3));
         assertEquals("", Rational.of(3), uinfo.convert(Rational.ZERO));
         assertEquals("", Rational.of(7), uinfo.convert(Rational.of(2)));
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -297,7 +297,8 @@ public class TestUnits extends TestFmwk {
                 if (simpleUnit.equals(baseUnit)) {
                     continue;
                 }
-                System.out.println( // TODO: handle exponent
+                System.out.println( // TODO: handle exponent, CLDR-16329 additional PR or follow-on
+                        // ticket
                         ++count
                                 + ")\t"
                                 + simpleUnit


### PR DESCRIPTION
CLDR-16329

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16329)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

- Add the `exponent` attribute for the `convertUnit` element to support the non-linear unit conversions needed for Beaufort.
- Document how `exponent` is intended to be used in combination with the existing `factor` and `offset` attributes for conversions between sourceUnit and baseUnit.
- Add the `convertUnit` data for Beaufort to units.xml, using the new `exponent` attribute
- Update UnitConverter to handle `exponent`. May not be complete (can finish in separate PR).
    - As part of this, needed to add to Rational a version of `pow` that handles non-integer exponents. This initial version may not be as accurate or efficient as desired.
- Updated some of the test code to at least compile and pass tests with the updated version of UnitCoverter. More s probably needed in this area, can be a separate PR.

ALLOW_MANY_COMMITS=true
