### PR TITLE
CLDR-17326 cache Factory.getSourceDirectoriesForLocale()

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleFactory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleFactory.java
@@ -779,7 +779,7 @@ public class SimpleFactory extends Factory {
         return sourceDirectories;
     }
 
-    LoadingCache<String, List<File>> sourceDirCache =
+    private LoadingCache<String, List<File>> sourceDirCache =
             CacheBuilder.newBuilder()
                     .build(
                             new CacheLoader<>() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -24,6 +25,7 @@ import org.unicode.cldr.test.CheckMetazones;
 import org.unicode.cldr.tool.PathInfo;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.LocaleInheritanceInfo.Reason;
+import org.unicode.cldr.util.SimpleFactory.NoSourceDirectoryException;
 
 /**
  * This contains additional tests in JUnit.
@@ -370,6 +372,21 @@ public class TestCLDRFile {
                 assertTrue(s != s0);
                 assertTrue(s == s0.intern(), () -> "in resolved en was not interned: " + s);
             }
+        }
+    }
+
+    @Test
+    @Disabled
+    /** enable manually - for testing performance */
+    public void TestSimpleFactoryPerf() {
+        for (int i = 0; i < 10000; i++) {
+            Factory baselineFactory =
+                    CLDRConfig.getInstance().getCommonAndSeedAndMainAndAnnotationsFactory();
+            baselineFactory.make("en_BE".toString(), true);
+            assertThrows(
+                    NoSourceDirectoryException.class,
+                    () -> baselineFactory.make("de_RU".toString(), true));
+            baselineFactory.make("es_MX".toString(), true);
         }
     }
 }


### PR DESCRIPTION
CLDR-17326 

- [X] This PR completes the ticket.

- includes a disabled test - could be run manually.

- Note: I wasn't able to measure a very large improvement, but this code did show up as a hotspot in profiling.

ALLOW_MANY_COMMITS=true
