### PR TITLE
CLDR-16329 Add convertUnit special attribute for beaufort; update UnitConverter and some related code

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -458,7 +458,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:regex/[-+*/\._ 0-9a-zA-Z]+-->
     <!--@VALUE-->
 <!ATTLIST convertUnit special NMTOKEN #IMPLIED >
-    <!--@MATCH:regex/(100-)?[A-Za-z][-A-Za-z0-9]*-->
+    <!--@MATCH:regex/[A-Za-z][-A-Za-z0-9]*-->
     <!--@VALUE-->
 <!ATTLIST convertUnit systems NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/si, si_acceptable, metric, metric_adjacent, ussystem, uksystem, jpsystem, astronomical, person_age, other, prefixable-->

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -457,6 +457,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST convertUnit offset CDATA #IMPLIED >
     <!--@MATCH:regex/[-+*/\._ 0-9a-zA-Z]+-->
     <!--@VALUE-->
+<!ATTLIST convertUnit special NMTOKEN #IMPLIED >
+    <!--@MATCH:regex/(100-)?[A-Za-z][-A-Za-z0-9]*-->
+    <!--@VALUE-->
 <!ATTLIST convertUnit systems NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/si, si_acceptable, metric, metric_adjacent, ussystem, uksystem, jpsystem, astronomical, person_age, other, prefixable-->
     <!--@VALUE-->

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -342,6 +342,8 @@ For terms of use, see http://www.unicode.org/copyright.html
        
         <!-- speed -->
         <convertUnit source='knot' baseUnit='meter-per-second' factor='1852/3600' systems="ussystem uksystem si_acceptable"/>
+        <convertUnit source='beaufort' baseUnit='meter-per-second' special='beaufort' systems="metric_adjacent"/>
+
         
         <!-- magnetic-induction -->
         <convertUnit source='tesla' baseUnit='kilogram-per-square-second-ampere' systems='si metric prefixable'/>

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -862,14 +862,16 @@ An implementation need not use rationals directly for conversion; it could use d
 
 <!ATTLIST convertUnit offset CDATA #IMPLIED >
 
-<!ATTLIST convertUnit description CDATA #IMPLIED >
+<!ATTLIST convertUnit special NMTOKEN #IMPLIED >
 
 <!ATTLIST convertUnit systems NMTOKENS #IMPLIED >
+
+<!ATTLIST convertUnit description CDATA #IMPLIED >
 ```
 
 The conversion data provides the data for converting all of the cldr unit identifiers to base units, and back. That allows conversion between any two convertible units, such as two units of length. For any two convertible units (such as acre and dunum) the first can be converted to the base unit (square-meter), then that base unit can be converted to the second unit.
 
-The data is expressed as conversions to the base unit. The information can also be used for the conversion back.
+The data is expressed as conversions to the base unit from the source unit. The information can also be used for the conversion back.
 
 Examples:
 
@@ -896,6 +898,14 @@ The conversion may also require an offset, such as the following:
 The factor and offset can be simple expressions, just like the values in the unitConstants.
 
 Where a factor is not present, the value is 1; where an offset is not present, the value is 0.
+
+Instead of using `factor` and possibly `offset`, the `convertUnit` element can specify a `special` conversion that cannot be described by factor and offset (and this attribute cannot be used in conunction with factor and offset). For example:
+
+```xml
+<convertUnit source='beaufort' baseUnit='meter-per-second' special='beaufort' systems="metric_adjacent"/>
+```
+
+The only `special` conversion currently supported is for beaufort.
 
 The `systems` attribute indicates the measurement system(s) or other characteristics of a set of unts. Multiple values may be given; for example, a unit could be marked as systems="`si_acceptable` `metric_adjacent` `prefixable`".
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|45 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2024-01-14|
+|Date|2024-01-31|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-72/tr35.html">https://www.unicode.org/reports/tr35/tr35-72/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-71/tr35.html">https://www.unicode.org/reports/tr35/tr35-71/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|
@@ -4020,6 +4020,9 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 * [Numbers](tr35-numbers.md#Contents)
   * In [Supplemental Currency Data](tr35-numbers.md#Supplemental_Currency_Data), for the `currency` element, added attributes `tz` and `to-tz` to clarify the `from` and `to` dates.
+
+* [Supplemental](tr35-info.md#Contents)
+  * In [Conversion Data](tr35-info.md#conversion-data), added the `special` attribute for `convertUnit`, used for handling beaufort.
 
 **Differences from LDML Version 43 to 44.1**
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/LogicalGroupChecker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/LogicalGroupChecker.java
@@ -161,6 +161,10 @@ public class LogicalGroupChecker {
             if (optionalPaths.contains(apath)) {
                 continue;
             }
+            if (apath.contains("beaufort")) {
+                // TODO CLDR-17352 Missing grammatical inflections for unit Beaufort in many locales
+                continue;
+            }
             if (presentPaths.contains(apath)) {
                 groupHasOneOrMorePresentRequiredPaths = true;
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartUnitConversions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartUnitConversions.java
@@ -139,6 +139,7 @@ public class ChartUnitConversions extends Chart {
             all.add(sortKey);
 
             // get some formatted strings
+            // TODO: handle specials here, CLDR-16329 additional PR or follow-on ticket
 
             final String repeatingFactor =
                     targetInfo.unitInfo.factor.toString(FormatStyle.repeating);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/UnitValidityCanonicalizer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/UnitValidityCanonicalizer.java
@@ -89,12 +89,7 @@ public class UnitValidityCanonicalizer {
                     Output<String> metricUnit2 = new Output<>();
                     ConversionInfo ci2 = uc.parseUnitId(tc2.core, metricUnit2, false);
 
-                    comp = ci1.factor.compareTo(ci2.factor);
-                    if (comp != 0) {
-                        return comp;
-                    }
-
-                    comp = ci2.offset.compareTo(ci2.offset);
+                    comp = ci1.compareTo(ci2);
                     if (comp != 0) {
                         return comp;
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -1645,8 +1645,9 @@ public class SupplementalDataInfo {
             //            }
             String factor = parts.getAttributeValue(-1, "factor");
             String offset = parts.getAttributeValue(-1, "offset");
+            String special = parts.getAttributeValue(-1, "special");
             String systems = parts.getAttributeValue(-1, "systems");
-            unitConverter.addRaw(source, target, factor, offset, systems);
+            unitConverter.addRaw(source, target, factor, offset, special, systems);
             return true;
         }
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -540,6 +540,7 @@
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_baseUnit	; Supplemental ; Units ; Convert ; $1-baseUnit ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_factor	; Supplemental ; Units ; Convert ; $1-factor ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_offset	; Supplemental ; Units ; Convert ; $1-offset ; HIDE
+//supplementalData/convertUnits/convertUnit[@source="%A"]/_special	; Supplemental ; Units ; Convert ; $1-special ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_reciprocal	; Supplemental ; Units ; Convert ; $1-reciprocal ; HIDE
 //supplementalData/convertUnits/convertUnit[@source="%A"]/_systems	; Supplemental ; Units ; Convert ; $1-systems ; HIDE
 


### PR DESCRIPTION
CLDR-16329

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16329)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

This is an incomplete first pass at adding conversion support for Beaufort so it can be used in unitPreferences. It compiles and passes tests (but tests have not been updated to test or handle Beaufort). It replaces the first attempt in [#3467 ](https://github.com/unicode-org/cldr/pull/3467) whose approach was deemed wrong.
- Add the `special` attribute for the `convertUnit` element to support the special table-based conversions for Beaufort. When converting from meters/sec to Beaufort, these always map to an integral value that corresponds to a range of speeds that includes the input value. When converting from Beaufort to meters/sec, the Beaufort value is rounded to the nearest integer, then converted to a value in the corresponding range of speeds (generally the value from m/s = 0.836*Bft^(3/2), except for Bft 0).
- Document the new attribute.
- Add the `convertUnit` data for Beaufort to units.xml, using the new special attribute
- Update UnitConverter and SupplementalDataInfo to handle special (UnitConverter may not be quite complete, can finish in separate PR). Updated at least some of the tools code.
- Have not yet updated any of the test code.

ALLOW_MANY_COMMITS=true
