### PR TITLE
CLDR-17270 st: don't use late cache busting for bundle.js

### DIFF
--- a/tools/cldr-apps/js/webpack.config.js
+++ b/tools/cldr-apps/js/webpack.config.js
@@ -1,6 +1,26 @@
 const path = require("path");
+const fs = require('fs');
 const { VueLoaderPlugin } = require("vue-loader");
-const { DefinePlugin } = require("webpack");
+const { DefinePlugin, Compiler } = require("webpack");
+
+class SurveyToolPlugin {
+  constructor() {
+
+  }
+  /**
+   *
+   * @param {Compiler} compiler
+   */
+  apply(compiler) {
+    compiler.hooks.afterEmit.tap('SurveyToolPlugin', (compilation) => {
+      const { assets } = compilation;
+      const jsfiles = Object.keys(assets).filter(s => /\.js$/.test(s));
+      const manifestFile = path.resolve(compiler.outputPath, 'manifest.json');
+      fs.writeFileSync(manifestFile, JSON.stringify({ jsfiles }), 'utf-8');
+      console.log('# SurveyToolPlugin Wrote: ', manifestFile);
+    });
+  }
+};
 
 module.exports = (env, argv) => {
   const {mode} = argv;
@@ -12,7 +32,7 @@ module.exports = (env, argv) => {
       cacheDirectory: path.resolve(__dirname, '../target/webpack_cache'),
     },
     output: {
-      filename: "bundle.js",
+      filename: "[name].[contenthash].js",
       path: path.resolve(__dirname, "..", "src", "main", "webapp", "dist"),
       library: "cldrBundle",
       libraryTarget: "var",
@@ -43,7 +63,9 @@ module.exports = (env, argv) => {
         // esm bundler flags,
         // see <https://github.com/vuejs/vue-next/tree/master/packages/vue#bundler-build-feature-flags>
         __VUE_PROD_DEVTOOLS__: JSON.stringify(DEV), // TODO: support dev mode
-        __VUE_OPTIONS_API__:   JSON.stringify(true),
-      })],
-    };
+        __VUE_OPTIONS_API__: JSON.stringify(true),
+      }),
+      new SurveyToolPlugin(),
+    ]
+  };
 };

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.web;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -7,7 +9,6 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletConfig;
@@ -18,9 +19,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.json.JSONException;
 import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrUtility;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 public class SurveyTool extends HttpServlet {
     static final Logger logger = SurveyLog.forClass(SurveyTool.class);
@@ -250,7 +248,7 @@ public class SurveyTool extends HttpServlet {
         }
     }
 
-    static private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final class STManifest {
         public String jsfiles[];
@@ -271,18 +269,22 @@ public class SurveyTool extends HttpServlet {
         // use WebPack-built manifest.json to include all chunks.
         // ideally this would all come from a static .html file built by WebPack.
         // TODO https://unicode-org.atlassian.net/browse/CLDR-17353
-        try (final InputStream is = request.getServletContext().getResourceAsStream("dist/manifest.json");
-            final Reader r = new InputStreamReader(is, StandardCharsets.UTF_8);) {
-                for(final String f : gson.fromJson(r, STManifest.class).jsfiles) {
-                    out.write("<script src=\"" + request.getContextPath() + "/dist/" + f.toString() + "\"></script>\n");
-                }
+        try (final InputStream is =
+                        request.getServletContext().getResourceAsStream("dist/manifest.json");
+                final Reader r = new InputStreamReader(is, StandardCharsets.UTF_8); ) {
+            for (final String f : gson.fromJson(r, STManifest.class).jsfiles) {
+                out.write(
+                        "<script src=\""
+                                + request.getContextPath()
+                                + "/dist/"
+                                + f.toString()
+                                + "\"></script>\n");
+            }
         }
 
         includeJqueryJavaScript(request, out);
         includeCldrJavaScript(request, out);
     }
-
-
 
     private static void includeJqueryJavaScript(HttpServletRequest request, Writer out)
             throws IOException {


### PR DESCRIPTION
changes us from using `index._GITHASH_.js` applied by cache busting function, to a statically generated webpack file `/cldr-apps/dist/main.71e4a712c8f0e9d8.js` (for example)

- instead, let webpack create a bundle name based on the content's hash, which will truly change when and only when the content changes.
- webpack hook to write the file
- read a manifest.json on the server side to serve that

CLDR-17270

- [ ] This PR completes the ticket.

Why?

1. it gets us closer to having a static index.html - webpack can create such files. - CLDR-17353
2. the hash only changes if the contents actually change.  The hash is based on the contents, so it's appropriate to cache them if they don't change
3. it lets the datadog source maps work properly, because we know ahead of time what the filename is going to be.

ALLOW_MANY_COMMITS=true
