### PR TITLE
CLDR-17356 BRS45 CLDRModify before alpha0: lv/mus exemplar spacing, mus glottal fix char

### DIFF
--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2023 Unicode, Inc.
+<!-- Copyright © 1991-2024 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1171,9 +1171,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[aā b c č d eē f g ģ h iī j k ķ l ļ m n ņ o p r s š t uū v z ž]</exemplarCharacters>
+		<exemplarCharacters>[a ā b c č d e ē f g ģ h i ī j k ķ l ļ m n ņ o p r s š t u ū v z ž]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[y ō q ŗ w x]</exemplarCharacters>
-		<exemplarCharacters type="index">[AĀ B C Č D EĒ F G Ģ H IĪY J K Ķ L Ļ M N Ņ O P Q R S Š T UŪ V W X Z Ž]</exemplarCharacters>
+		<exemplarCharacters type="index">[A Ā B C Č D E Ē F G Ģ H I Y Ī J K Ķ L Ļ M N Ņ O P Q R S Š T U Ū V W X Z Ž]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[  \- ‑ , % ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐‑ – — , ; \: ! ? . … '‘’‚ &quot;“”„ ( ) \[ \] § @ * / \&amp; # † ‡ ′ ″]</exemplarCharacters>
 		<ellipsis type="final">↑↑↑</ellipsis>

--- a/common/main/mus.xml
+++ b/common/main/mus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2023 Unicode, Inc.
+<!-- Copyright © 1991-2024 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-DFS-2016
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -22,7 +22,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</measurementSystemNames>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[a c e ē f h i k l m n o p r s t u v w y ʼ]</exemplarCharacters>
+		<exemplarCharacters>[a c eē f h i k l m n o p r s t u v w y ʼ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[b d g j q z]</exemplarCharacters>
 		<exemplarCharacters type="index">[A C E F H I K L M N O P R S T U V W Y]</exemplarCharacters>
 		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
@@ -89,13 +89,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="wide">
-							<day type="sun">Nettv'cako</day>
+							<day type="sun">Nettvʼcako</day>
 							<day type="mon">Enhvteceskv</day>
 							<day type="tue">Enhvteceskv Enhvyvtke</day>
 							<day type="wed">Ennvrkvpv</day>
 							<day type="thu">Ennvrkvpv Enhvyvtke</day>
 							<day type="fri">Nak Okkoskv Nettv</day>
-							<day type="sat">Nettv Cak'cuse</day>
+							<day type="sat">Nettv Cakʼcuse</day>
 						</dayWidth>
 					</dayContext>
 				</days>


### PR DESCRIPTION
CLDR-17356

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17356)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

CLDRModify passes before v45 alpha0 (only -fP = DAIP made any changes):
- Adjust exemplar set spacing for `lv`, `mus`
- Update the glottal stop character used to spell weekdays in `mus` (Creek)

ALLOW_MANY_COMMITS=true
