### PR TITLE
CLDR-17357 alpha0 integration fix 1: Need valid end dates for currency ANG

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -364,7 +364,7 @@ The printed version of ISO-4217:2001
         </region>
         <region iso3166="CW">
             <currency iso4217="XCG" from="2024-03-31"/>
-            <currency iso4217="ANG" from="2010-10-10" to="2024-06-31"/>
+            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30"/>
         </region>
         <region iso3166="CX">
             <currency iso4217="AUD" from="1966-02-14"/>
@@ -997,7 +997,7 @@ The printed version of ISO-4217:2001
         </region>
         <region iso3166="SX">
             <currency iso4217="XCG" from="2024-03-31"/>
-            <currency iso4217="ANG" from="2010-10-10" to="2024-06-31"/>
+            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30"/>
         </region>
         <region iso3166="SY">
             <currency iso4217="SYP" from="1948-01-01"/>


### PR DESCRIPTION
CLDR-17357

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

The first of possibly several alpha0 integration fixes:
- The end date for currency ANG needs to be valid (June 30, not June 31), follow-on for CLDR-17274

ALLOW_MANY_COMMITS=true
