### PR TITLE
CLDR-17342 speedup CoverageLevel2 construction

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CoverageLevel2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CoverageLevel2.java
@@ -22,7 +22,6 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility.VariableReplacer;
-import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
@@ -153,13 +152,13 @@ public class CoverageLevel2 {
     }
 
     private CoverageLevel2(SupplementalDataInfo sdi, String locale) {
-        myInfo.targetLanguage = new LanguageTagParser().set(locale).getLanguage();
+        myInfo.targetLanguage = CLDRLocale.getInstance(locale).getLanguage();
         myInfo.cvi = sdi.getCoverageVariableInfo(myInfo.targetLanguage);
         lookup = sdi.getCoverageLookup();
     }
 
     private CoverageLevel2(SupplementalDataInfo sdi, String locale, String ruleFile) {
-        myInfo.targetLanguage = new LanguageTagParser().set(locale).getLanguage();
+        myInfo.targetLanguage = CLDRLocale.getInstance(locale).getLanguage();
         myInfo.cvi = sdi.getCoverageVariableInfo(myInfo.targetLanguage);
         RawCoverageFile rcf = new RawCoverageFile();
         lookup = rcf.load(ruleFile);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
@@ -1,0 +1,31 @@
+package org.unicode.cldr.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.test.CoverageLevel2;
+
+public class TestCoverageLevel2 {
+
+    final int ITERATIONS = 100000; // keep this low for normal testing
+
+    private static SupplementalDataInfo sdi;
+
+    @BeforeAll
+    private static void setup() {
+        sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+        CoverageLevel2 c = CoverageLevel2.getInstance(sdi, "fr_CA");
+    }
+
+    @Test
+    public void TestCoveragePerf() {
+        for (int i = 0; i < ITERATIONS; i++) {
+            CoverageLevel2 c = CoverageLevel2.getInstance(sdi, "fr_CA");
+            assertEquals(
+                    Level.MODERATE,
+                    c.getLevel(
+                            "//ldml/characters/parseLenients[@scope=\"number\"][@level=\"lenient\"]/parseLenient[@sample=\",\"]"));
+        }
+    }
+}


### PR DESCRIPTION
- use CLDRLocale instead of LanguageTagParser
- about a 3x speedup for construct + 1 lookup

CLDR-17342

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
