### PR TITLE
CLDR-16946 Fix triple up arrow producing error in VXML

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBoxXMLSource.java
@@ -54,9 +54,6 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
          *
          * Do not skip vote resolution if VoteLoadingContext.SINGLE_VOTE, even for empty xpd. Otherwise an Abstain can
          * result in "no votes", "skip vote resolution", failure to get the right winning value, possibly inherited.
-         *
-         * Do not skip vote resolution if VoteLoadingContext.VXML_GENERATION, even for empty xpd. We may need to call
-         * getWinningValue for vote resolution for a larger set of paths to get baseline, etc.
          */
 
         /**
@@ -98,7 +95,6 @@ public class BallotBoxXMLSource<T> extends DelegateXMLSource {
         /*
          * Catch Status.missing, or it will trigger an exception in draftStatusFromWinningStatus
          * since there is no "missing" in DraftStatus.
-         * This may happen especially for VoteLoadingContext.VXML_GENERATION.
          *
          * Status.missing can also occur for VoteLoadingContext.SINGLE_VOTE, when a user abstains
          * after submitting a new value. Then, delegate.removeValueAtDPath and/or delegate.putValueAtPath

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
@@ -337,7 +337,7 @@ public class OutputFileManager {
         long st = System.currentTimeMillis();
         CLDRFile cldrFile;
         if (kind == Kind.vxml) {
-            cldrFile = sm.getSTFactory().makeVettedFile(loc);
+            cldrFile = sm.getSTFactory().make(loc.getBaseName(), false);
         } else if (kind == Kind.pxml) {
             cldrFile = sm.getSTFactory().makeProposedFile(loc);
         } else {


### PR DESCRIPTION
-Replace makeVettedFile with return make(loc.getBaseName(), false)

-Remove dead code including VoteLoadingContext.VXML_GENERATION, makeVettedSource, makeVettedFile

-Baseline has long been used instead of last-release; obsolete comments indicated VXML required VoteResolver for last-release

-Comments

CLDR-16946

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
