### PR TITLE
CLDR-17356 In testLanguageTagParserIsValid, mark co-reformed as valid (though deprecated)

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -953,6 +953,8 @@ public class TestLocale extends TestFmwkPlus {
                         LstrType.extension,
                         new AllowedMatch("co", "direct"),
                         LstrType.extension,
+                        new AllowedMatch("co", "reformed"),
+                        LstrType.extension,
                         new AllowedMatch("rg", "unknown"),
                         LstrType.extension,
                         new AllowedMatch(
@@ -990,11 +992,7 @@ public class TestLocale extends TestFmwkPlus {
                 try {
                     ltp.set(composite); // clears other fields
                     LocaleValidator.isValid(ltp, bcp47, errors);
-                    if (logKnownIssue(
-                                    "CLDR-17345",
-                                    "testLanguageTagParserIsValid() fail on en-u-co-reformed after CLDR-17143")
-                            && composite.endsWith("-co-reformed")) {
-                    } else if (!assertEquals(composite, expected, Joiner.on("; ").join(errors))) {
+                    if (!assertEquals(composite, expected, Joiner.on("; ").join(errors))) {
                         LocaleValidator.isValid(ltp, bcp47, errors);
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
CLDR-17356

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Fix the earlier test failure in testLanguageTagParserIsValid() the right way, by marking co-reformed as valid (even though it is deprecated), as is done with co-direct. Then remove the logKnownIssue added earlier.

ALLOW_MANY_COMMITS=true
