### PR TITLE
CLDR-17336 Fix parentLocales

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -941,13 +941,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT parentLocales ( parentLocale* ) >
 <!ATTLIST parentLocales component NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/segmentations, collations-->
+    <!--@MATCH:set/literal/segmentations, collations, plurals, grammaticalFeatures-->
 
 <!ELEMENT parentLocale EMPTY >
 <!ATTLIST parentLocale parent NMTOKEN #REQUIRED >
     <!--@MATCH:validity/locale-->
 <!ATTLIST parentLocale locales NMTOKENS #REQUIRED >
-    <!--@MATCH:set/validity/locale-->
+    <!--@MATCH:or/set/validity/locale||literal/nonlikelyScript-->
     <!--@VALUE-->
 
 <!ELEMENT personNamesDefaults ( alias | ( nameOrderLocalesDefault* ) ) >

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -940,7 +940,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!-- # Parent locales -->
 
 <!ELEMENT parentLocales ( parentLocale* ) >
-<!ATTLIST parentLocales component NMTOKEN #IMPLIED >
+<!ATTLIST parentLocales component NMTOKENS #IMPLIED >
     <!--@MATCH:literal/segmentations, collations-->
 
 <!ELEMENT parentLocale EMPTY >

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -5425,7 +5425,7 @@ XXX Code for transations where no currency is involved
     </codeMappings>
 
 	<parentLocales>
-		<parentLocale parent="root" locales="az_Arab az_Cyrl bal_Latn blt_Latn bm_Nkoo bs_Cyrl byn_Latn cu_Glag dje_Arab dyo_Arab en_Dsrt en_Shaw ff_Adlm ff_Arab ha_Arab iu_Latn kk_Arab ks_Deva ku_Arab kxv_Deva kxv_Orya kxv_Telu ky_Arab ky_Latn ml_Arab mn_Mong mni_Mtei ms_Arab pa_Arab sat_Deva sd_Deva sd_Khoj sd_Sind shi_Latn so_Arab sr_Latn sw_Arab tg_Arab ug_Cyrl uz_Arab uz_Cyrl vai_Latn wo_Arab yo_Arab yue_Hans zh_Hant"/>
+		<parentLocale parent="root" locales="nonlikelyScript"/>
 		<parentLocale parent="en_001" locales="en_150 en_AG en_AI en_AU en_BB en_BM en_BS en_BW en_BZ en_CC en_CK en_CM en_CX en_CY en_DG en_DM en_ER en_FJ en_FK en_FM en_GB en_GD en_GG en_GH en_GI en_GM en_GY en_HK en_ID en_IE en_IL en_IM en_IN en_IO en_JE en_JM en_KE en_KI en_KN en_KY en_LC en_LR en_LS en_MG en_MO en_MS en_MT en_MU en_MV en_MW en_MY en_NA en_NF en_NG en_NR en_NU en_NZ en_PG en_PK en_PN en_PW en_RW en_SB en_SC en_SD en_SG en_SH en_SL en_SS en_SX en_SZ en_TC en_TK en_TO en_TT en_TV en_TZ en_UG en_VC en_VG en_VU en_WS en_ZA en_ZM en_ZW"/>
 		<parentLocale parent="en_150" locales="en_AT en_BE en_CH en_DE en_DK en_FI en_NL en_SE en_SI"/>
 		<parentLocale parent="en_IN" locales="hi_Latn"/>
@@ -5436,15 +5436,11 @@ XXX Code for transations where no currency is involved
 		<parentLocale parent="zh_Hant_HK" locales="zh_Hant_MO"/>
 	</parentLocales>
 
-	<parentLocales component="segmentations">
-		<parentLocale parent="zh" locales="zh_Hant"/>
+	<parentLocales component="segmentations grammaticalFeatures plurals">
 	</parentLocales>
 
 	<parentLocales component="collations">
-		<parentLocale parent="bs" locales="bs_Cyrl"/>
-		<parentLocale parent="sr" locales="sr_Latn"/>
 		<parentLocale parent="sr_ME" locales="sr_Cyrl_ME"/>
-		<parentLocale parent="zh" locales="zh_Hant"/>
 		<parentLocale parent="zh_Hant" locales="yue yue_Hant"/>
 		<parentLocale parent="zh_Hans" locales="yue_CN yue_Hans yue_Hans_CN"/>
 	</parentLocales>

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3351,7 +3351,7 @@ The following are constraints on the attribute values. Note: in future versions,
 | validity/\{field}         | currency, language, locale, region, script, subdivision, short-unit, unit, variant<br/>The field can be qualified by particular enums, such as:<br/>`validity/unit/regular deprecated`: matches only _deprecated_ and _regular_<br/>`validity/unit/!deprecated`: matches all but _deprecated_ |
 | version                   | 1 to 4 digit field version, such as 35.3.9 |
 | set/\{match}              | set of elements that match \{match} |
-| or/\{match1}XX\{match2}…  | matches at least one of \{match1}, etc |
+| or/\{match1}\|\|\{match2}…  | matches at least one of \{match1}, etc |
 
 
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1768,18 +1768,42 @@ _Examples:_
 <!ATTLIST parentLocale locales NMTOKENS #REQUIRED >
 ```
 
-In some cases, the normal truncation inheritance does not function well. This happens when:
+When the component does not occur, that is referred to as the ‘main’ component.
+Otherwise the component value typically corresponds to an element and its children, such as ‘collations’ or ‘plurals’.
 
-1.  The child locale is of a different script. In this case, mixing elements from the parent into the child data results in a mishmash.
-2.  A large number of child locales behave similarly, and differently from the truncation parent.
+The basic inheritance model for locales of the form <lang>_<script>_<region>_<variant1>_…<variantN> is to truncate from the end. That is, 
+remove the _u and _t extensions, then remove the last _ and following tag, then restore the extensions.
+
+For example
+```
+sr_Cyrl_ME
+→
+sr_Cyrl
+→
+sr
+
+```
+In some cases, the normal truncation inheritance does not function well.
+For example, if the truncation algorithm changes script,
+then a mixture of child and parent textual data is a mishmash of different scripts.
+
+Thus there are two cases where the truncation inheritance needs to be overridden:
+
+1.  When the parent locale would have a different script, and text would be mixed.
+2.  In certain exceptional circumstances where the parent.
 
 The `parentLocale` element is used to override the normal inheritance when accessing CLDR data.
 
-For case 1, the children are script locales, and the parent is "root". For example:
+For case 1, there is a special value for the locales, `nonlikelyScript`,
+which includes all locales of the form <lang>_<script>, where the <script> is not the likely script for <lang>.
 
 ```xml
-<parentLocale parent="root" locales="az_Cyrl ha_Arab … zh_Hant"/>
+<parentLocale parent="root" locales="nonlikelyScript"/>
 ```
+
+This is used for the main component.
+It is not used to components where text is not mixed, 
+such as the collations component or the plurals component.
 
 For case 2, the children and parent share the same primary language, but the region is changed. For example:
 
@@ -1795,65 +1819,11 @@ There are certain components that require addenda to the common parent fallback 
 </parentLocales>
 ```
 
-Logically, component-specific parent locales should be merged with the common parent locales as if merging maps with children as the keys and parents as the values, and retaining the component-specific parents whenever there are duplicate keys. For example, consider the following XML:
+Note: When components were first introduced, the component-specific parent locales were be merged with the main parent locales.
+This was determined to be an error, and the component-specific parent locales are now not merged, but are treated as stand-alone. 
 
-```xml
-<parentLocales>
-  <parentLocale parent="root" locales="az_Arab az_Cyrl yue_Hans zh_Hant"/>
-  <parentLocale parent="en_001" locales="en_150 en_AG en_SI"/>
-</parentLocales>
-<parentLocales component="collations">
-  <parentLocale parent="zh" locales="zh_Hant"/>
-  <parentLocale parent="zh_Hant" locales="yue yue_Hant"/>
-  <parentLocale parent="zh_Hans" locales="yue_CN yue_Hans yue_Hans_CN"/>
-</parentLocales>
-```
-
-These data correspond to the following key-value maps:
-
-```javascript
-// Common parents
-{
-  "az_Arab": "root",
-  "az_Cyrl": "root",
-  "en_150": "en_001",
-  "en_AG": "en_001",
-  "en_SI": "en_001",
-  "yue_Hans": "root",
-  "zh_Hant": "root",
-}
-
-// Collation overrides
-{
-  "yue_CN": "zh_Hans",
-  "yue_Hans_CN": "zh_Hans",
-  "yue_Hans": "zh_Hans",
-  "yue_Hant": "zh_Hant",
-  "yue": "zh_Hant",
-  "zh_Hant": "zh",
-}
-```
-
-The resulting set of parents used for collations should then be:
-
-```javascript
-// Resolved collation parents
-{
-  "az_Arab": "root",
-  "az_Cyrl": "root",
-  "en_150": "en_001",
-  "en_AG": "en_001",
-  "en_SI": "en_001",
-  "yue_CN": "zh_Hans",
-  "yue_Hans_CN": "zh_Hans",
-  "yue_Hans": "zh_Hans",
-  "yue_Hant": "zh_Hant",
-  "yue": "zh_Hant",
-  "zh_Hant": "zh",
-}
-```
-
-Since parentLocale information is not localizable on a per locale basis, the parentLocale information is contained in CLDR’s [supplemental data.](tr35-info.md)
+Since parentLocale information is not localizable on a per locale basis, 
+the parentLocale information is contained in CLDR’s [supplemental data.](tr35-info.md)
 
 When a `parentLocale` element is used to override normal inheritance, the following guidelines apply in most cases:
 
@@ -1866,7 +1836,7 @@ There may be specific exceptions to these for certain closely-related languages 
 
 There are certain invariants that must always be true:
 
-3. The parent must either be the root locale or have the same script as the child. This rule does not apply to component-specific parents.
+3. The parent must either be the root locale or have the same script as the child. This rule applies to component=main.
 4. There must never be cycles, such as: X parent of Y ... parent of X.
 5. Following the inheritance path, using parentLocale where available and otherwise truncating the locale, must always lead eventually to the root locale.
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -287,6 +287,7 @@ class LdmlConvertRules {
                 "measurementSystem-category-temperature", "territories", "type"),
         new SplittableAttributeSpec("paperSize", "territories", "type"),
         new SplittableAttributeSpec("parentLocale", "locales", "parent"),
+        new SplittableAttributeSpec("parentLocale", "component", null),
         new SplittableAttributeSpec(
                 "collations", "locales", "parent"), // parentLocale component=collations
         new SplittableAttributeSpec(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -311,7 +311,8 @@ class LdmlConvertRules {
 
     /**
      * There are a handful of attribute values that are more properly represented as an array of
-     * strings rather than as a single string.
+     * strings rather than as a single string. These are not locked to a specific element, may need
+     * to change the matching algorithm if there are conflicts.
      */
     public static final Set<String> ATTRVALUE_AS_ARRAY_SET =
             Builder.with(new HashSet<String>())
@@ -320,6 +321,7 @@ class LdmlConvertRules {
                     .add("contains")
                     .add("systems")
                     .add("origin")
+                    .add("component") // for parentLocales - may need to be more specific here
                     .add("values") // for unitIdComponents - may need to be more specific here
                     .freeze();
 
@@ -382,6 +384,11 @@ class LdmlConvertRules {
             PatternCache.get(
                     "(grammaticalCase|grammaticalGender|grammaticalDefiniteness|nameOrderLocales|component)");
 
+    /**
+     * Indicates that the child value of this element needs to be separated into array items. For
+     * example: {@code <weekOfPreference ordering="weekOfDate weekOfMonth" locales="en bn ja ka"/>}
+     * becomes {@code {"en":["weekOfDate","weekOfMonth"],"bn":["weekOfDate","weekOfMonth"]} }
+     */
     public static final Set<String> CHILD_VALUE_IS_SPACESEP_ARRAY =
             ImmutableSet.of("weekOfPreference", "calendarPreferenceData");
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -287,7 +287,6 @@ class LdmlConvertRules {
                 "measurementSystem-category-temperature", "territories", "type"),
         new SplittableAttributeSpec("paperSize", "territories", "type"),
         new SplittableAttributeSpec("parentLocale", "locales", "parent"),
-        new SplittableAttributeSpec("parentLocale", "component", null),
         new SplittableAttributeSpec(
                 "collations", "locales", "parent"), // parentLocale component=collations
         new SplittableAttributeSpec(
@@ -381,7 +380,7 @@ class LdmlConvertRules {
     /** These objects values should be output as arrays. */
     public static final Pattern VALUE_IS_SPACESEP_ARRAY =
             PatternCache.get(
-                    "(grammaticalCase|grammaticalGender|grammaticalDefiniteness|nameOrderLocales)");
+                    "(grammaticalCase|grammaticalGender|grammaticalDefiniteness|nameOrderLocales|component)");
 
     public static final Set<String> CHILD_VALUE_IS_SPACESEP_ARRAY =
             ImmutableSet.of("weekOfPreference", "calendarPreferenceData");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LogicalGrouping;
 import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.SupplementalDataInfo.ParentLocaleComponent;
 import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 
@@ -806,7 +807,8 @@ public class GenerateProductionData {
                 parent2child.put(parent, locale);
             }
             if (isAnnotationsDir) {
-                String simpleParent = LocaleIDParser.getParent(locale, true);
+                String simpleParent =
+                        LocaleIDParser.getParent(locale, ParentLocaleComponent.collations);
                 if (simpleParent != null && (parent == null || simpleParent != parent)) {
                     parent2child.put(simpleParent, locale);
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -396,7 +396,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
     private static ConcurrentHashMap<String, CLDRLocale> stringToLoc = new ConcurrentHashMap<>();
 
     /**
-     * Return the parent locale of this item. Null if no parent (root has no parent)
+     * Return the parent locale of this item, using component=main. Null if no parent (root has no
+     * parent)
      *
      * @return the parent locale, or null
      *     <p>Use lazy initialization for parentLocale, since getInstance calling itself recursively
@@ -422,7 +423,10 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         return result;
     }
 
-    /** Returns true if other is equal to or is an ancestor of this, false otherwise */
+    /**
+     * Returns true if other is equal to or is an ancestor of this, using component=main, false
+     * otherwise
+     */
     public boolean childOf(CLDRLocale other) {
         if (other == null) return false;
         if (other == this) return true;
@@ -432,7 +436,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
     }
 
     /**
-     * Return an iterator that will iterate over locale, parent, parent etc, finally reaching root.
+     * Return an iterator that will iterate over locale, parent, parent etc, using component=main,
+     * finally reaching root.
      *
      * @return
      */

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Factory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Factory.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 import org.unicode.cldr.test.TestCache;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRLocale.SublocaleProvider;
+import org.unicode.cldr.util.SupplementalDataInfo.ParentLocaleComponent;
 import org.unicode.cldr.util.XMLSource.ResolvingSource;
 
 /**
@@ -150,7 +151,12 @@ public abstract class Factory implements SublocaleProvider {
         String currentLocaleID = localeID;
         Set<String> availableLocales = this.getAvailable();
         while (!availableLocales.contains(currentLocaleID) && !"root".equals(currentLocaleID)) {
-            currentLocaleID = LocaleIDParser.getParent(currentLocaleID, ignoreExplicitParentLocale);
+            currentLocaleID =
+                    LocaleIDParser.getParent(
+                            currentLocaleID,
+                            ignoreExplicitParentLocale
+                                    ? ParentLocaleComponent.collations
+                                    : ParentLocaleComponent.main);
         }
         return make(currentLocaleID, true, madeWithMinimalDraftStatus);
     }
@@ -197,7 +203,12 @@ public abstract class Factory implements SublocaleProvider {
             XMLSource source = file.dataSource;
             registerXmlSource(source);
             sourceList.add(source);
-            curLocale = LocaleIDParser.getParent(curLocale, ignoreExplicitParentLocale);
+            curLocale =
+                    LocaleIDParser.getParent(
+                            curLocale,
+                            ignoreExplicitParentLocale
+                                    ? ParentLocaleComponent.collations
+                                    : ParentLocaleComponent.main);
         }
         return new ResolvingSource(sourceList);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -3164,16 +3164,18 @@ public class SupplementalDataInfo {
         return parentLocalesSkipNonLikely.contains(component);
     }
 
-    public String getExplicitParentLocale(String loc) {
-        return getExplicitParentLocale(loc, ParentLocaleComponent.main);
-    }
-
     public String getExplicitParentLocale(String loc, ParentLocaleComponent component) {
         return parentLocales.get(component).get(loc);
     }
 
-    //  These are not used by the current code.
+    //  These are not (now) used by the current code.
     //  They should not be used, because the answer is incorrect for parentLocalesSkipNonLikely
+    //
+    //    public String getExplicitParentLocale(String loc) {
+    //        return getExplicitParentLocale(loc, ParentLocaleComponent.main);
+    //    }
+    //
+
     //
     //    public Set<String> getExplicitChildren() {
     //        return getExplicitChildren(ParentLocaleComponent.main);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -62,6 +62,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.tool.SubdivisionNames;
@@ -1259,7 +1260,8 @@ public class SupplementalDataInfo {
 
         validityInfo = CldrUtility.protectCollection(validityInfo);
         attributeValidityInfo = CldrUtility.protectCollection(attributeValidityInfo);
-        parentLocales = Collections.unmodifiableMap(parentLocales);
+        parentLocales = CldrUtility.protectCollection(parentLocales);
+        parentLocalesSkipNonLikely = ImmutableSet.copyOf(parentLocalesSkipNonLikely);
         languageGroups = ImmutableSetMultimap.copyOf(languageGroups);
 
         grammarLocaleToTargetToFeatureToValues =
@@ -1874,25 +1876,49 @@ public class SupplementalDataInfo {
             }
         }
 
+        public static final String NONLIKELYSCRIPT = "nonlikelyScript";
+
         private void handleParentLocales(XPathParts parts) {
-            if (parts.getAttributeValue(1, "component") != null) {
-                // CLDR-16253 added component-specific parents, which we ignore for now.
-                // TODO(CLDR-16361): Figure out how to handle these in CLDR itself.
+            // CLDR-16253 added component-specific parents, which we ignore for now.
+            // TODO(CLDR-16361): Figure out how to handle these in CLDR itself.
+            String componentsString = parts.getAttributeValue(1, "component");
+            Set<ParentLocaleComponent> components;
+            if (componentsString == null) {
+                components = ImmutableSet.of(ParentLocaleComponent.main);
+            } else {
+                components =
+                        split_space
+                                .splitToStream(componentsString)
+                                .map(x -> ParentLocaleComponent.fromString(x))
+                                .collect(Collectors.toSet());
+            }
+            if (!parts.getElement(-1).equals("parentLocale")) {
+                // If there is no parentLocale element , that means we have nothing to add
+                // Since we have pre-populated the parentLocales with component -> empty map,
+                // there is nothing more to do, and we can exit.
+                // We have parsed the components, however, so they are valid
                 return;
             }
             String parent = parts.getAttributeValue(-1, "parent");
             String locales = parts.getAttributeValue(-1, "locales");
-            String[] pl = locales.split(" ");
-            for (int i = 0; i < pl.length; i++) {
-                String old = parentLocales.put(pl[i], parent);
-                if (old != null) {
-                    throw new IllegalArgumentException(
-                            "Locale "
-                                    + pl[i]
-                                    + " cannot have two parents: "
-                                    + old
-                                    + " and "
-                                    + parent);
+
+            for (ParentLocaleComponent component : components) {
+                Map<String, String> componentParentLocales = parentLocales.get(component);
+                if (locales.equals(NONLIKELYSCRIPT)) {
+                    parentLocalesSkipNonLikely.add(component);
+                    continue;
+                }
+                for (String childLocale : split_space.split(locales)) {
+                    String old = componentParentLocales.put(childLocale, parent);
+                    if (old != null) {
+                        throw new IllegalArgumentException(
+                                "Locale "
+                                        + childLocale
+                                        + " cannot have two parents: "
+                                        + old
+                                        + " and "
+                                        + parent);
+                    }
                 }
             }
         }
@@ -2378,7 +2404,15 @@ public class SupplementalDataInfo {
     private Map<String, String> likelyOrigins = new TreeMap<>();
     // make public temporarily until we resolve.
     private SortedSet<CoverageLevelInfo> coverageLevels = new TreeSet<>();
-    private Map<String, String> parentLocales = new HashMap<>();
+    private Map<ParentLocaleComponent, Map<String, String>> parentLocales = new HashMap<>();
+
+    { // Prefill, since we know we will need these
+        Arrays.stream(ParentLocaleComponent.values())
+                .forEach(x -> parentLocales.put(x, new HashMap<>()));
+    }
+
+    private Set<ParentLocaleComponent> parentLocalesSkipNonLikely =
+            EnumSet.noneOf(ParentLocaleComponent.class);
     private Map<String, List<String>> calendarPreferences = new HashMap<>();
     private Map<String, CoverageVariableInfo> localeSpecificVariables = new TreeMap<>();
     private VariableReplacer coverageVariables = new VariableReplacer();
@@ -3112,16 +3146,49 @@ public class SupplementalDataInfo {
         return targetPlurals;
     }
 
-    public String getExplicitParentLocale(String loc) {
-        return parentLocales.get(loc);
+    public enum ParentLocaleComponent {
+        main,
+        collations,
+        segmentations,
+        grammaticalFeatures,
+        plurals;
+
+        public static ParentLocaleComponent fromString(String s) {
+            return s == null
+                    ? ParentLocaleComponent.main // handle empty
+                    : ParentLocaleComponent.valueOf(s);
+        }
     }
 
-    public Set<String> getExplicitChildren() {
-        return parentLocales.keySet();
+    public boolean parentLocalesSkipNonLikely(ParentLocaleComponent component) {
+        return parentLocalesSkipNonLikely.contains(component);
     }
+
+    public String getExplicitParentLocale(String loc) {
+        return getExplicitParentLocale(loc, ParentLocaleComponent.main);
+    }
+
+    public String getExplicitParentLocale(String loc, ParentLocaleComponent component) {
+        return parentLocales.get(component).get(loc);
+    }
+
+    //  These are not used by the current code.
+    //  They should not be used, because the answer is incorrect for parentLocalesSkipNonLikely
+    //
+    //    public Set<String> getExplicitChildren() {
+    //        return getExplicitChildren(ParentLocaleComponent.main);
+    //    }
+    //
+    //    public Set<String> getExplicitChildren(ParentLocaleComponent component) {
+    //        return parentLocales.get(component).keySet();
+    //    }
 
     public Collection<String> getExplicitParents() {
-        return parentLocales.values();
+        return getExplicitParents(ParentLocaleComponent.main);
+    }
+
+    public Collection<String> getExplicitParents(ParentLocaleComponent component) {
+        return parentLocales.get(component).values();
     }
 
     public static final class ApprovalRequirementMatcher {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -38,6 +38,7 @@ import org.unicode.cldr.util.Iso639Data.Type;
 import org.unicode.cldr.util.LanguageTagCanonicalizer;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LanguageTagParser.Format;
+import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleValidator;
 import org.unicode.cldr.util.LocaleValidator.AllowedMatch;
 import org.unicode.cldr.util.LocaleValidator.AllowedValid;
@@ -336,8 +337,7 @@ public class TestLocale extends TestFmwkPlus {
             // ROOT_PARENT_DEFAULT_CONTENT_EXCEPTIONS.
 
             if (hasScript && !hasRegion) {
-                boolean parentIsRoot =
-                        "root".equals(supplementalDataInfo.getExplicitParentLocale(locale));
+                boolean parentIsRoot = "root".equals(LocaleIDParser.getParent(locale));
                 if (parentIsRoot == isDefaultContent
                         && !ROOT_PARENT_DEFAULT_CONTENT_EXCEPTIONS.contains(locale)) {
                     errln(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLocaleIDParser.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLocaleIDParser.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.unicode.cldr.util.SupplementalDataInfo.ParentLocaleComponent;
 
 public class TestLocaleIDParser {
     @ParameterizedTest(name = "{index}: {0}")
@@ -41,7 +42,7 @@ public class TestLocaleIDParser {
         String loc = locid;
         for (final String link : chain.split("\\|")) {
             assertEquals(link, loc, "Fallback chain for " + locid);
-            final String newLoc = LocaleIDParser.getParent(loc, true);
+            final String newLoc = LocaleIDParser.getParent(loc, ParentLocaleComponent.collations);
             // make sure we are not stuck
             assertNotEquals(loc, newLoc, "Error: getParent() returned the same value");
             loc = newLoc;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
@@ -73,6 +73,7 @@ public class TestSupplementalDataInfo {
             {"main", "ru_Cyrl_RU", "ru_Cyrl", "ru", "root"},
             {"main", "ru_Latn_RU", "ru_Latn", "root"},
             {"main", "sr_Cyrl_ME", "sr_Cyrl", "sr", "root"},
+            {"main", "hi_Latn", "en_IN", "en_001", "en", "root"},
             {"plurals", "ru_Cyrl_RU", "ru_Cyrl", "ru", "root"},
             {"plurals", "ru_Latn_RU", "ru_Latn", "ru", "root"},
             {"plurals", "zh_Hant_MO", "zh_Hant", "zh", "root"},

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
@@ -8,6 +8,7 @@ import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.util.ULocale;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.SupplementalDataInfo.ApprovalRequirementMatcher;
+import org.unicode.cldr.util.SupplementalDataInfo.ParentLocaleComponent;
 
 public class TestSupplementalDataInfo {
     @Test
@@ -62,5 +63,30 @@ public class TestSupplementalDataInfo {
         assertNotNull(mtrules, "mt rules");
         assertTrue(mtrules.getKeywords().contains("two"), "mt did not have two");
         assertEquals(2.0, mtrules.getUniqueKeywordValue("two"), "mt unique value for 'two'");
+    }
+
+    @Test
+    void TestParentLocales() {
+        final SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
+        String[][] tests = {
+            {"main", "zh_Hant_MO", "zh_Hant_HK", "zh_Hant", "root"},
+            {"main", "ru_Cyrl_RU", "ru_Cyrl", "ru", "root"},
+            {"main", "ru_Latn_RU", "ru_Latn", "root"},
+            {"main", "sr_Cyrl_ME", "sr_Cyrl", "sr", "root"},
+            {"plurals", "ru_Cyrl_RU", "ru_Cyrl", "ru", "root"},
+            {"plurals", "ru_Latn_RU", "ru_Latn", "ru", "root"},
+            {"plurals", "zh_Hant_MO", "zh_Hant", "zh", "root"},
+            {"collations", "sr_Cyrl_ME", "sr_ME", "sr", "root"},
+        };
+        for (String[] test : tests) {
+            ParentLocaleComponent component = ParentLocaleComponent.fromString(test[0]);
+            String child = test[1];
+            for (int i = 2; i < test.length; ++i) {
+                final String expected = test[i];
+                String parent = LocaleIDParser.getParent(child, component);
+                assertEquals(expected, parent, component + "/" + child);
+                child = parent;
+            }
+        }
     }
 }


### PR DESCRIPTION
CLDR-17336

This turned out to be a bit more work than anticipated; not that many lines but spread over a few files. I'll mention the highlights below.

common/dtd/ldmlSupplemental.dtd
- modified to allow multiple components (and add plurals & grammaticalFeatures)
- allow nonlikelyScript as a single value for locale=

common/supplemental/supplementalData.xml
- Make the changes in the ticket, to use nonlikelyScript
- Remove the redundancies, add grammaticalFeatures, plurals

docs/ldml/tr35.md
- document the changes, removing the complexities of having the other components overlay the main one.

### The rest of the items are making the code work 

tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
- Tell JSON that the components have multiple elements. (The error message is very helpful, but could use some more guidance in the file for which place to fix. I put the change into SPLITTABLE_ATTRS instead of the ones mentioned.)

tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
tools/cldr-code/src/main/java/org/unicode/cldr/util/Factory.java
tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLocaleIDParser.java
- There was a hack to turn off 'main' inheritance, now uses 'collations' because that was the previous use case.
- BTW I don't understand why it was used for isAnnotationsDir??

tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
- document that the getParent method returns the *main* parent. (That is the normally expected one.)

tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleIDParser.java
- replaced the boolean ignoreParentLocale by the enum component
- cleaned up the code a bit.

tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
- when we added components before, for ICU4X, we didn't actually retrieve the data (so fixing this ticket will also fix CLDR-16361)
- makes parentLocales be a map of maps, so that the parentLocales are segmented by component
- a little code cleanup, but not too much
- fixed the api to access the new information

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
- fixed three tests to work properly
- The issue was that they were expecting the nonlikely parents to be explicitly in the data,
whereas now they are part of LocaleIDParser.getParent()
- For one of the tests I went to the extra effort to use CLDRLocale. 
It is sometimes clumsy because not all apis accept them (eg likely subtags)

tools/cldr-code/src/test/java/org/unicode/cldr/util/TestSupplementalDataInfo.java
- added a test that the nonlikelyScript locales work property for main, 
and that plurals and collations have their defined behavior.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
