### PR TITLE
CLDR-17304 expand logKnownIssues to quell remaining SEVERE errors

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -478,7 +478,7 @@ public class TestCheckCLDR extends TestFmwk {
         return oldLevel;
     }
 
-    /** undo the effect of a popCheckLevel */
+    /** undo the effect of a pushCheckLevel */
     public void popCheckLevel(java.util.logging.Level oldLevel) {
         if (oldLevel != null) {
             CheckCLDR.setLoggerLevel(oldLevel);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -467,13 +467,26 @@ public class TestCheckCLDR extends TestFmwk {
         checkLocale(test, localeID, "?", null);
     }
 
-    public void TestAllLocales() {
+    /** adjust the logging level of checks */
+    public java.util.logging.Level pushCheckLevel() {
         java.util.logging.Level oldLevel = null;
         if (logKnownIssue(
                 "CLDR-17320",
-                "turning off CheckCLDR logging to avoid 2,000 log messages, please fix internal stack traces")) {
+                "turning off CheckCLDR logging to avoid thousands of log messages, please fix internal stack traces")) {
             oldLevel = CheckCLDR.setLoggerLevel(java.util.logging.Level.OFF);
         }
+        return oldLevel;
+    }
+
+    /** undo the effect of a popCheckLevel */
+    public void popCheckLevel(java.util.logging.Level oldLevel) {
+        if (oldLevel != null) {
+            CheckCLDR.setLoggerLevel(oldLevel);
+        }
+    }
+
+    public void TestAllLocales() {
+        java.util.logging.Level oldLevel = pushCheckLevel();
         CheckCLDR test = CheckCLDR.getCheckAll(factory, INDIVIDUAL_TESTS);
         CheckCLDR.setDisplayInformation(english);
         Set<String> unique = new HashSet<>();
@@ -493,18 +506,18 @@ public class TestCheckCLDR extends TestFmwk {
         // (And in fact this test seems faster without it)
         locales.forEach(locale -> checkLocale(test, locale, null, unique));
         logln("Count:\t" + locales.size());
-        if (oldLevel != null) {
-            CheckCLDR.setLoggerLevel(oldLevel);
-        }
+        popCheckLevel(oldLevel);
     }
 
     public void TestA() {
+        final java.util.logging.Level oldLevel = pushCheckLevel();
 
         CheckCLDR test = CheckCLDR.getCheckAll(factory, INDIVIDUAL_TESTS);
         CheckCLDR.setDisplayInformation(english);
         Set<String> unique = new HashSet<>();
 
         checkLocale(test, "ko", null, unique);
+        popCheckLevel(oldLevel);
     }
 
     public void checkLocale(


### PR DESCRIPTION
- updates LogKnownIssues to CLDR-17320 to catch all other cases

CLDR-17304

- [ ] This PR completes the ticket.

This quells the rest of the SEVERE errors and stacktraces as a logKnownIssue.  There was already a logKnownIssue in place, this just expands it to apply to the other callers.


ALLOW_MANY_COMMITS=true
