### PR TITLE
CLDR-17367 cldr-json: put unitPrefixes into units.json

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_supplemental.txt
@@ -31,7 +31,7 @@ section=references ; path=//cldr/supplemental/references/.* ; package=core
 section=telephoneCodeData ; path=//cldr/supplemental/telephoneCodeData/.* ; package=core
 section=windowsZones ; path=//cldr/supplemental/windowsZones/.* ; package=core
 section=aliases ; path=//cldr/supplemental/metadata/alias/(language|script|subdivision|territory|variant|zone)Alias.* ; package=core
-section=units ; path=//cldr/supplemental/(unitConstants|unitQuantities|convertUnits).* ; package=core
+section=units ; path=//cldr/supplemental/(unitConstants|unitQuantities|convertUnits|unitPrefixes).* ; package=core
 section=unitsMetadata ; path=//cldr/supplemental/metadata/.*/(unitAlias|usageAlias).* ; package=core
 section=unitIdComponents ; path=//cldr/supplemental/unitIdComponents/.* ; package=core
 


### PR DESCRIPTION
- data from CLDR-16939

CLDR-17367

- [ ] This PR completes the ticket.

extract from `cldr-json/cldr-core/supplemental/units.json`: 

```json
{
  "supplemental": {
    "version": {
      "_unicodeVersion": "15.1.0",
      "_cldrVersion": "45"
    },
    "unitPrefixes": {
      "atto": {
        "_symbol": "a",
        "_power10": "-18"
      },
      "centi": {
        "_symbol": "c",
        "_power10": "-2"
      },
      "deci": {
        "_symbol": "d",
        "_power10": "-1"
      },
      "deka": {
        "_symbol": "da",
        "_power10": "1"
      },
      "exa": {
        "_symbol": "E",
        "_power10": "18"
      },
```

ALLOW_MANY_COMMITS=true
