### PR TITLE
CLDR-17407 check for anomalies and fix

### DIFF
--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -144,7 +144,6 @@ th ;	modern ;	Thai
 ti ;	basic ;	Tigrinya
 tk ;	modern ;	Turkmen
 to ;	basic ;	Tongan
-tok ;	basic ;	Toki Pona
 tr ;	modern ;	Turkish
 tt ;	basic ;	Tatar
 ug ;	basic ;	Uyghur

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -939,12 +939,14 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/displayName"/>
 		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/gender"/>
 		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/perUnitPattern"/>
-		<!-- Then make Beaufort explicitly  comprehensive for other regions -->
+		<!-- Then make Beaufort explicitly  comprehensive for other regions
+		This does not appear to be working.
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/displayName"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/gender"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/perUnitPattern"/>
+		-->
 		<!-- Then handle other units -->
 
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute']"/>
@@ -956,13 +958,13 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@gender='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute']"/>
-
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/unitPattern[@count='%anyAttribute']"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/displayName"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/gender"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/perUnitPattern"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/unitPrefixPattern"/>
+
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/unitPattern[@count='%anyAttribute']"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/displayName"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/gender"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/perUnitPattern"/>
 
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='calendar'][@type='%calendarType80']"/>
 

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -939,14 +939,12 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/displayName"/>
 		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/gender"/>
 		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/perUnitPattern"/>
-		<!-- Then make Beaufort explicitly  comprehensive for other regions
-		This does not appear to be working.
+		<!-- Then make Beaufort explicitly  comprehensive for other regions -->
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/displayName"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/gender"/>
 		<coverageLevel value="comprehensive" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/perUnitPattern"/>
-		-->
 		<!-- Then handle other units -->
 
 		<coverageLevel inLanguage="en" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%unitsEnglish']/unitPattern[@count='%anyAttribute']"/>
@@ -958,13 +956,13 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@gender='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute'][@case='%anyAttribute']"/>
 		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/compoundUnitPattern1[@count='%anyAttribute']"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/unitPrefixPattern"/>
 
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/unitPattern[@count='%anyAttribute']"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/displayName"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/gender"/>
-		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='(?!speed-beaufort)%anyAttribute']/perUnitPattern"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/unitPattern[@count='%anyAttribute']"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/displayName"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/gender"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='%anyAttribute']/perUnitPattern"/>
+		<coverageLevel value="modern" match="units/unitLength[@type='%unitLengths']/compoundUnit[@type='%anyAttribute']/unitPrefixPattern"/>
 
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='calendar'][@type='%calendarType80']"/>
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -149,6 +149,10 @@ public class StandardCodes {
         return type_code_data.get(type);
     }
 
+    public Set<String> getCodes(CodeType type) {
+        return type_code_data.get(type).keySet();
+    }
+
     /**
      * Get at the language registry values, as a Map from label to value.
      *
@@ -275,7 +279,7 @@ public class StandardCodes {
                     case script:
                         return sd.getCLDRScriptCodes();
                     case tzid:
-                        break; // nothing special
+                        return sd.getCLDRTimezoneCodes();
                     default:
                         for (Iterator<String> it = result.iterator(); it.hasNext(); ) {
                             String code = it.next();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4,6 +4,8 @@ import static org.unicode.cldr.util.PathUtilities.getNormalizedPathString;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -74,6 +76,7 @@ import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
 import org.unicode.cldr.util.Rational.RationalParser;
+import org.unicode.cldr.util.StandardCodes.CodeType;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData.Type;
 import org.unicode.cldr.util.SupplementalDataInfo.NumberingSystemInfo.NumberingSystemType;
@@ -981,6 +984,10 @@ public class SupplementalDataInfo {
     public Map<Row.R2<String, String>, String> bcp47Since = new TreeMap<>();
     public Map<Row.R2<String, String>, String> bcp47Preferred = new TreeMap<>();
     public Map<Row.R2<String, String>, String> bcp47Deprecated = new TreeMap<>();
+
+    Map<String, Map<String, Bcp47KeyInfo>> bcp47KeyToSubtypeToInfo = new TreeMap<>();
+    Map<String, Map<String, String>> bcp47KeyToAliasToSubtype = new TreeMap<>();
+
     public Map<String, String> bcp47ValueType = new TreeMap<>();
 
     public Map<String, Row.R2<String, String>> validityInfo = new LinkedHashMap<>();
@@ -1145,6 +1152,34 @@ public class SupplementalDataInfo {
         this.validity = Validity.getInstance(directory.toString() + "/../validity/");
     } // hide
 
+    public static class Bcp47KeyInfo {
+        public Bcp47KeyInfo(
+                Set<String> aliases,
+                String description,
+                String since,
+                String preferred,
+                String deprecated) {
+            this.description = description;
+            this.deprecated = !(deprecated == null || deprecated.equals("false"));
+            this.preferred = preferred;
+            this.since = since == null ? null : VersionInfo.getInstance(since);
+            this.aliases = aliases;
+        }
+
+        final String description;
+        final VersionInfo since;
+        final String preferred;
+        final boolean deprecated;
+        final Set<String> aliases;
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "{description=«%s» since=%s preferred=%s deprecated=%s aliases=%s}",
+                    description, since, preferred, deprecated, aliases);
+        }
+    }
+
     private void makeStuffSafe() {
         // now make stuff safe
         allLanguages.addAll(languageToPopulation.keySet());
@@ -1224,19 +1259,54 @@ public class SupplementalDataInfo {
         }
         typeToLocaleToDayPeriodInfo = CldrUtility.protectCollection(typeToLocaleToDayPeriodInfo);
         languageMatch = CldrUtility.protectCollection(languageMatch);
-        bcp47Key2Subtypes.freeze();
+
         bcp47Extension2Keys.freeze();
-        bcp47Aliases.freeze();
+        bcp47Key2Subtypes.freeze();
+        CldrUtility.protectCollection(bcp47ValueType);
         if (bcp47Key2Subtypes.isEmpty()) {
             throw new InternalError(
                     "No BCP47 key 2 subtype data was loaded from bcp47 dir "
                             + getBcp47Directory().getAbsolutePath());
         }
+
+        bcp47Aliases.freeze();
         CldrUtility.protectCollection(bcp47Descriptions);
         CldrUtility.protectCollection(bcp47Since);
         CldrUtility.protectCollection(bcp47Preferred);
         CldrUtility.protectCollection(bcp47Deprecated);
-        CldrUtility.protectCollection(bcp47ValueType);
+
+        // create clean structure
+
+        for (Entry<String, Set<String>> entry : bcp47Extension2Keys.keyValuesSet()) {
+            for (String key : entry.getValue()) {
+                Map<String, Bcp47KeyInfo> subtypeToInfo = bcp47KeyToSubtypeToInfo.get(key);
+                if (subtypeToInfo == null) {
+                    bcp47KeyToSubtypeToInfo.put(key, subtypeToInfo = new TreeMap<>());
+                }
+                Map<String, String> aliasToRegular = bcp47KeyToAliasToSubtype.get(key);
+                if (aliasToRegular == null) {
+                    bcp47KeyToAliasToSubtype.put(key, aliasToRegular = new TreeMap<>());
+                }
+                for (String subtype : bcp47Key2Subtypes.get(key)) {
+                    final R2<String, String> pair = R2.of(key, subtype);
+                    final Set<String> aliases = bcp47Aliases.get(pair);
+                    final Bcp47KeyInfo info =
+                            new Bcp47KeyInfo(
+                                    aliases,
+                                    bcp47Descriptions.get(pair),
+                                    bcp47Since.get(pair),
+                                    bcp47Preferred.get(pair),
+                                    bcp47Deprecated.get(pair));
+                    subtypeToInfo.put(subtype, info);
+                    final Map<String, String> aliasToRegularFinal = aliasToRegular;
+                    if (aliases != null) {
+                        aliases.forEach(x -> aliasToRegularFinal.put(x, subtype));
+                    }
+                }
+            }
+        }
+        bcp47KeyToSubtypeToInfo = CldrUtility.protectCollection(bcp47KeyToSubtypeToInfo);
+        bcp47KeyToAliasToSubtype = CldrUtility.protectCollection(bcp47KeyToAliasToSubtype);
 
         CoverageLevelInfo.fixEU(coverageLevels, this);
         coverageLevels = Collections.unmodifiableSortedSet(coverageLevels);
@@ -5172,5 +5242,35 @@ public class SupplementalDataInfo {
 
     public Set<String> getUnitPrefixes() {
         return unitPrefixInfo.keySet();
+    }
+
+    Supplier<Set<String>> goodTimezones =
+            Suppliers.memoize(
+                    new Supplier<Set<String>>() {
+                        @Override
+                        public Set<String> get() {
+                            Set<String> availableLongTz = sc.getAvailableCodes(CodeType.tzid);
+                            Map<String, String> aliasToRegular = bcp47KeyToAliasToSubtype.get("tz");
+                            Map<String, Bcp47KeyInfo> subtypeToInfo =
+                                    bcp47KeyToSubtypeToInfo.get("tz");
+                            Set<String> result =
+                                    availableLongTz.stream()
+                                            .filter(
+                                                    x -> {
+                                                        String shortId = aliasToRegular.get(x);
+                                                        Bcp47KeyInfo info =
+                                                                subtypeToInfo.get(shortId);
+                                                        if (info.deprecated) {
+                                                            System.out.println("deprecated: " + x);
+                                                        }
+                                                        return info.deprecated;
+                                                    })
+                                            .collect(Collectors.toUnmodifiableSet());
+                            return result;
+                        }
+                    });
+
+    public Set<String> getCLDRTimezoneCodes() {
+        return goodTimezones.get();
     }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -207,7 +207,7 @@ Google	; nn	; Modern ; Nynorsk
 Google	;	no	;	modern	;	T2	Norwegian (Bokmål)
 Google	;	or	;	modern	;	T5	Odia
 Google	;	pa	;	modern	;	T4.1	Punjabi
-Google	;	pcm	;	modern	;	Nigerian Pidgin
+Google	;	pcm	;	moderate	;	Nigerian Pidgin
 Google	;	pl	;	modern	;	T1	Polish
 Google	;	ps	;	modern	;	T5	Pashto
 Google	;	pt	;	modern	;	T1	Brazilian Portuguese
@@ -283,7 +283,7 @@ Apple	;	kn	;	modern
 Apple	;	ko	;	modern
 Apple	;	lt	;	modern
 Apple	;	lv	;	modern
-Apple	;	mi	;	modern
+Apple	;	mi	;	moderate
 Apple	;	mk	;	modern
 Apple	;	ml	;	modern
 Apple	;	mr	;	modern
@@ -485,7 +485,7 @@ Cldr  ; cv  ; basic
 Cldr	;	en_AU	;	modern
 Cldr	;	es_MX	;	modern
 Cldr	;	fr_CA	;	modern
-Cldr  ; mi  ; modern
+Cldr  ; mi  ; moderate
 Cldr	;	zh_Hant_HK	;	modern
 
 #Cldr	other (from Google)
@@ -516,7 +516,7 @@ Cldr	; su ; basic ; Sundanese (script TBD)
 Cldr  ; ks_Deva ; basic ; Kashmiri (Devanagari)
 Cldr	; sd_Deva ; basic ; Sindhi (Devanagari script)
 # Cldr	; cad ; basic ; Caddo
-Cldr	; pcm ; modern ; Nigerian Pidgin
+Cldr	; pcm ; moderate ; Nigerian Pidgin
 
 Cldr	;	bgc	;	basic	;	Haryanvi
 Cldr	;	bho	;	basic	;	Bhojpuri

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -840,14 +840,12 @@ public class TestExampleGenerator extends TestFmwk {
 
     public void Test4897() {
         ExampleGenerator exampleGenerator = getExampleGenerator("it");
+        final CLDRFile cldrFile = exampleGenerator.getCldrFile();
         for (String xpath :
                 With.in(
-                        exampleGenerator
-                                .getCldrFile()
-                                .iterator(
-                                        "//ldml/dates/timeZoneNames",
-                                        exampleGenerator.getCldrFile().getComparator()))) {
-            String value = exampleGenerator.getCldrFile().getStringValue(xpath);
+                        cldrFile.iterator(
+                                "//ldml/dates/timeZoneNames", cldrFile.getComparator()))) {
+            String value = cldrFile.getStringValue(xpath);
             String actual = exampleGenerator.getExampleHtml(xpath, value);
             if (actual == null) {
                 if (!xpath.contains("singleCountries") && !xpath.contains("gmtZeroFormat")) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ public class TestStandardCodes {
     void testTimezoneExclusions() {
         SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
         Set<String> timezones = sdi.getCLDRTimezoneCodes();
+        assertTrue(timezones.contains("Europe/Andorra"));
         assertFalse(timezones.contains("America/Nipigon"));
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
@@ -1,8 +1,11 @@
 package org.unicode.cldr.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Set;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -29,5 +32,12 @@ public class TestStandardCodes {
                         String.format(
                                 "Expected getTargetCoverageLevel(%s)=%s but was %s",
                                 locale, expectLevel, actualLevel));
+    }
+
+    @Test
+    void testTimezoneExclusions() {
+        SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
+        Set<String> timezones = sdi.getCLDRTimezoneCodes();
+        assertFalse(timezones.contains("America/Nipigon"));
     }
 }


### PR DESCRIPTION
CLDR-17407

Regenerated the coverage and charts while doing this.

common/properties/coverageLevels.txt
- Toki Pona dropped from Basic

common/supplemental/coverageLevels.xml
- modified because the previous method for skipping beaufort was not working

tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
- Made the CODE_FALLBACK not include deprecated timezones (eg Currie). Guts are in SupplementalDataInfo

tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
- While doing this, added some internal structure to make it easier to get BCP47 data. The old mechanism, searching for pairs is awkward to use.
- Also added a backmapping from the aliases (eg long TZ names) to the subtype (eg the short TZ names)
- goodTimezones takes the available codes, and subtracts those that are deprecated, by getting their shortIds, then looking up in the BCP47 info.

tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
- Dropped Nigerian Pidgin and Maori targets to moderate for v45 (they were really bad). Will let TC know about this change, so that they can be bumped up again for v46 if they are really targets.

tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
- added quick test


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
