### PR TITLE
Fix Ukrainian translation for the symbol ⁉ (annotations/interrobang)

### DIFF
--- a/common/annotations/uk.xml
+++ b/common/annotations/uk.xml
@@ -3627,7 +3627,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="♾" type="tts">нескінченність</annotation>
 		<annotation cp="‼">! | !! | бенгбенг | лігатура | оклик | подвійний знак оклику | розділовий знак</annotation>
 		<annotation cp="‼" type="tts">подвійний знак оклику</annotation>
-		<annotation cp="⁉">! | !? | ? | знак оклику | знак олкику і питання | знак питання | інтеробенг | лігатура з ! і ? | оклик | питання | пунктуація | розділовий знак</annotation>
+		<annotation cp="⁉">! | !? | ? | знак оклику | знак оклику і питання | знак питання | інтеробенг | лігатура з ! і ? | оклик | питання | пунктуація | розділовий знак</annotation>
 		<annotation cp="⁉" type="tts">знак олкику і питання</annotation>
 		<annotation cp="❓">? | знак питання | питання | пунктуація | розділовий знак | червоний знак питання</annotation>
 		<annotation cp="❓" type="tts">червоний знак питання</annotation>


### PR DESCRIPTION
This pull request fixes an error in the Ukrainian translation of the symbol ⁉ **annotations/interrobang**.
Fixed incorrect order of two letters: ``кл'' instead of ``лк``.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
