### PR TITLE
CLDR-17216 improve docs and tooling for keyboard charts

### DIFF
--- a/docs/charts/keyboard/README.md
+++ b/docs/charts/keyboard/README.md
@@ -14,9 +14,17 @@ The Keyboard Charts are now built as client-side JavaScript tables.
 
 Run this from the command line in the top level directory:
 
-- `mvn --file=tools/pom.xml -pl :cldr-keyboard-charts com.github.eirslett:frontend-maven-plugin:npm`
+- `mvn --file=tools/pom.xml -pl :cldr-keyboard-charts integration-test`
+
+## To build from Eclipse
+
+- Right-click on the `pom.xml` in `docs/charts/keyboards` (it will show as "cldr-keyboard-charts")
+- Choose **Run As... - Maven Build**
+- Change the **goal** to `integration-test`
+- Choose Run
 
 ## Trying them out
 
 - `npm run serve` will serve the charts locally on <http://localhost:3000>
+- Or view the [`index.html`](./index.html) file located in the same directory as this README
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKeyboardCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKeyboardCharts.java
@@ -30,8 +30,9 @@ public class GenerateKeyboardCharts {
             return;
         }
         final File staticTarg = new File(mainDir, "keyboard/static");
-        if (staticTarg.mkdirs()) {
-            System.err.println("Created: " + staticTarg);
+        final File staticDataTarg = new File(mainDir, "keyboard/static/data");
+        if (staticDataTarg.mkdirs()) {
+            System.err.println("Created: " + staticDataTarg);
         }
         System.out.println("Copying: " + kbdStatic + " to " + staticTarg);
 


### PR DESCRIPTION
CLDR-17216

- GenerateKeyboardCharts wasn't creating a subdirectory prior to  copying. Fixed
- Corrected readme and added eclipse instructions

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
