### PR TITLE
CLDR-16909 kbd: move out of techpreview

### DIFF
--- a/docs/charts/keyboard/static/keyboard-chart.js
+++ b/docs/charts/keyboard/static/keyboard-chart.js
@@ -94,7 +94,7 @@ function getKeyboardKeys(id) {
     {
       // add implied import
       "@_base": "cldr",
-      "@_path": "techpreview/keys-Latn-implied.xml",
+      "@_path": "45/keys-Latn-implied.xml",
     },
     ...(_KeyboardData.keyboards[id].keyboard3.keys.import || []),
   ];

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -8,12 +8,6 @@
 
 For the full header, summary, and status, see [Part 1: Core](tr35.md).
 
-#### _Important Note_
-
-> This is a technical preview of a future version of the LDML Part 7. See [_Status_](#status), below.
->
-> There are breaking changes, see [Compatibility Notice](#compatibility-notice)
-
 ### _Summary_
 
 This document describes parts of an XML format (_vocabulary_) for the exchange of structured locale data. This format is used in the [Unicode Common Locale Data Repository](https://www.unicode.org/cldr/).
@@ -27,12 +21,19 @@ See <https://cldr.unicode.org> for up-to-date CLDR release data.
 
 ### _Status_
 
-This document is a _technical preview_ of the Keyboard standard.
+_This is a draft document which may be updated, replaced, or superseded by other documents at any time.
+Publication does not imply endorsement by the Unicode Consortium.
+This is not a stable document; it is inappropriate to cite this document as other than a work in progress._
 
-To process earlier XML files, use the data and specification from v43.1, found at <https://www.unicode.org/reports/tr35/tr35-69/tr35.html>
+<!-- _This document has been reviewed by Unicode members and other interested parties, and has been approved for publication by the Unicode Consortium.
+This is a stable document and may be used as reference material or cited as a normative reference by other specifications._ -->
 
-The CLDR [Keyboard Workgroup][keyboard-workgroup] is currently
-developing this technical preview to the CLDR keyboard specification.
+> _**A Unicode Technical Standard (UTS)** is an independent specification. Conformance to the Unicode Standard does not imply conformance to any UTS._
+
+_Please submit corrigenda and other comments with the CLDR bug reporting form [[Bugs](tr35.md#Bugs)]. Related information that is useful in understanding this document is found in the [References](tr35.md#References). For the latest version of the Unicode Standard see [[Unicode](tr35.md#Unicode)]. For a list of current Unicode Technical Reports see [[Reports](tr35.md#Reports)]. For more information about versions of the Unicode Standard, see [[Versions](tr35.md#Versions)]._
+
+
+See also [Compatibility Notice](#compatibility-notice).
 
 ## <a name="Parts" href="#Parts">Parts</a>
 
@@ -49,16 +50,12 @@ The LDML specification is divided into the following parts:
 
 ## <a name="Contents" href="#Contents">Contents of Part 7, Keyboards</a>
 
-  * [_Important Note_](#important-note)
-  * [_Summary_](#summary)
-  * [_Status_](#status)
-* [Parts](#Parts)
-* [Contents of Part 7, Keyboards](#Contents)
 * [Keyboards](#keyboards)
 * [Goals and Non-goals](#goals-and-non-goals)
   * [Compatibility Notice](#compatibility-notice)
   * [Accessibility](#accessibility)
 * [Definitions](#definitions)
+* [Notation](#notation)
   * [Escaping](#escaping)
   * [UnicodeSet Escaping](#unicodeset-escaping)
   * [UTS18 Escaping](#uts18-escaping)
@@ -98,6 +95,7 @@ The LDML specification is divided into the following parts:
   * [Element: import](#element-import)
   * [Element: displays](#element-displays)
   * [Element: display](#element-display)
+    * [Non-spacing marks on keytops](#non-spacing-marks-on-keytops)
   * [Element: displayOptions](#element-displayoptions)
   * [Element: forms](#element-forms)
   * [Element: form](#element-form)
@@ -105,6 +103,7 @@ The LDML specification is divided into the following parts:
   * [Element: scanCodes](#element-scancodes)
   * [Element: layers](#element-layers)
   * [Element: layer](#element-layer)
+    * [Layer Modifier Sets](#layer-modifier-sets)
     * [Layer Modifier Components](#layer-modifier-components)
     * [Modifier Left- and Right- keys](#modifier-left--and-right--keys)
     * [Layer Modifier Matching](#layer-modifier-matching)
@@ -203,9 +202,12 @@ Note that in parts of this document, the format `@x` is used to indicate the _at
 
 ### Compatibility Notice
 
-> 👉 Note: CLDR-TC has agreed that the changes required were too extensive to maintain compatibility. For this reason, the `ldmlKeyboard3.dtd` DTD used here is _not_ compatible with DTDs from prior versions of CLDR such as v43 and prior.
+> A major rewrite of this specification, called "Keyboard 3.0", was introduced in CLDR v45.
+> The changes required were too extensive to maintain compatibility. For this reason, the `ldmlKeyboard3.dtd` DTD is _not_ compatible with DTDs from prior versions of CLDR such as v43 and prior.
 >
 > To process earlier XML files, use the data and specification from v43.1, found at <https://www.unicode.org/reports/tr35/tr35-69/tr35.html>
+>
+> `ldmlKeyboard.dtd` continues to be made available in CLDR, however, it will not be updated.
 
 ### Accessibility
 
@@ -310,10 +312,10 @@ Attribute values escaped in this manner are annotated with the `<!--@ALLOWS_UESC
 
 * In the future, new layouts will be included in the CLDR repository, as a way for new layouts to be distributed in a cross-platorm manner. The process for this repository of layouts has not yet been defined, see the [CLDR Keyboard Workgroup Page][keyboard-workgroup] for up-to-date information.
 
-* Layouts have version metadata to indicate their specification compliance versi​​on number. For this tech preview, the value used must be `techpreview`. When the the specification is out of tech preview, a specific CLDR version number will be used. See [`cldrVersion`](tr35-info.md#version-information).
+* Layouts have version metadata to indicate their specification compliance versi​​on number, such as `45`. See [`cldrVersion`](tr35-info.md#version-information).
 
 ```xml
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" conformsTo="techpreview"/>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" conformsTo="45"/>
 ```
 
 > _Note_: Unlike other LDML files, layouts are designed to be used outside of the CLDR source tree.  As such, they do not contain DOCTYPE entries.
@@ -636,13 +638,13 @@ This is the top level element. All other elements defined below are under this e
 
 _Attribute:_ `conformsTo` (required)
 
-This attribute distinguishes the keyboard from prior versions,
-and it also specifies the minimum CLDR version required.
+This attribute value distinguishes the keyboard from prior versions,
+and it also specifies the minimum CLDR major version required.
 
-For purposes of this current draft specification, the value should always be `techpreview`.
+This attribute value must be a whole number of `45` or greater. See [`cldrVersion`](tr35-info.md#version-information)
 
 ```xml
-<keyboard3 … conformsTo="techpreview"/>
+<keyboard3 … conformsTo="45"/>
 ```
 
 _Attribute:_ `locale` (required)
@@ -1074,7 +1076,7 @@ Thus, the implied keys behave as if the following import were present.
 ```xml
 <keyboard3>
     <keys>
-        <import base="cldr" path="techpreview/keys-Latn-implied.xml" />
+        <import base="cldr" path="45/keys-Latn-implied.xml" />
     </keys>
 </keyboard3>
 ```
@@ -1195,7 +1197,7 @@ If two identical elements are defined, the later element will take precedence, t
 
 **Syntax**
 ```xml
-<import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+<import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
 ```
 > <small>
 >
@@ -1214,7 +1216,7 @@ _Attribute:_ `base`
 
 _Attribute:_ `path` (required)
 
-> If `base` is `cldr`, then the `path` must start with a CLDR version (such as `techpreview`) representing the CLDR version to pull imports from. The imports are located in the `keyboard/import` subdirectory of the CLDR source repository.
+> If `base` is `cldr`, then the `path` must start with a CLDR major version (such as `45`) representing the CLDR version to pull imports from. The imports are located in the `keyboard/import` subdirectory of the CLDR source repository.
 > Implementations are not required to have all CLDR versions available to them.
 >
 > If `base` is omitted, then `path` is an absolute or relative file path.
@@ -1226,7 +1228,7 @@ _Attribute:_ `path` (required)
 <!-- in a keyboard xml file-->
 …
 <transforms type="simple">
-    <import base="cldr" path="techpreview/transforms-example.xml"/>
+    <import base="cldr" path="45/transforms-example.xml"/>
     <transform from="` " to="`" />
     <transform from="^ " to="^" />
 </transforms>
@@ -1497,7 +1499,7 @@ There is an implied set of `<form>` elements corresponding to the default forms,
 ```xml
 <keyboard3>
     <forms>
-        <import base="cldr" path="techpreview/scanCodes-implied.xml" /> <!-- the version will match the current conformsTo of the file -->
+        <import base="cldr" path="45/scanCodes-implied.xml" /> <!-- the version will match the current conformsTo of the file -->
     </forms>
 </keyboard3>
 ```
@@ -2876,6 +2878,8 @@ The following are the design principles for the IDs.
 
 ## Keyboard Test Data
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
 Keyboard Test Data allows the keyboard author to provide regression test data to validate the repertoire and behavior of a keyboard. Tooling can run these regression tests against an implementation, and can also be used as part of the development cycle to validate that keyboard changes do not deviate from expected behavior.  In the interest of complete coverage, tooling could also indicate whether all keys and gestures in a layout are exercised by the test data.
 
 Test data files have a separate DTD, named `ldmlKeyboardTest3.dtd`.  Note that multiple test data files can refer to the same keyboard. Test files should be named similarly to the keyboards which they test, such as `fr_test.xml` to test `fr.xml`.
@@ -2886,6 +2890,8 @@ The following describes the structure of a keyboard test file.
 
 ### Test Doctype
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboardTest3 SYSTEM "../dtd/ldmlKeyboardTest3.dtd">
@@ -2894,6 +2900,8 @@ The following describes the structure of a keyboard test file.
 The top level element is named `keyboardTest`.
 
 ### Test Element: keyboardTest
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
 
 > <small>
 >
@@ -2904,7 +2912,7 @@ This is the top level element.
 
 _Attribute:_ `conformsTo` (required)
 
-The `conformsTo` attribute value here is the same as on the [`<keyboard3>`](#element-keyboard3) element.
+The `conformsTo` attribute value here is a fixed value of `techpreview`, because the test data is a Technical Preview.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -2915,6 +2923,8 @@ The `conformsTo` attribute value here is the same as on the [`<keyboard3>`](#ele
 ```
 
 ### Test Element: info
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
 
 > <small>
 >
@@ -2942,6 +2952,8 @@ This attribute value specifies a name for this overall test file. These names co
 ```
 
 ### Test Element: repertoire
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
 
 > <small>
 >
@@ -2994,6 +3006,9 @@ Note: CLDR’s extensive [exemplar set](tr35-general.md#Character_Elements) data
 
 ### Test Element: tests
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
 > <small>
 >
 > Parents: [keyboardTest](#test-element-keyboardtest)
@@ -3029,6 +3044,9 @@ This attribute value specifies a unique name for this suite of tests. These name
 
 ### Test Element: test
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
 > <small>
 >
 > Parents: [tests](#test-element-tests)
@@ -3054,6 +3072,8 @@ This attribute value specifies a unique name for this particular test. These nam
 
 ### Test Element: startContext
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
 This element specifies pre-existing text in a document, as if prior to the user’s insertion point. This is useful for testing transforms and reordering. If not specified, the startContext can be considered to be the empty string ("").
 
 > <small>
@@ -3077,6 +3097,9 @@ Specifies the starting context. This text may be escaped with `\u` notation, see
 
 
 ### Test Element: keystroke
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
 
 > <small>
 >
@@ -3123,6 +3146,9 @@ This attribute value specifies that a multi-tap gesture should be performed on t
 
 ### Test Element: emit
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
 > <small>
 >
 > Parents: [test](#test-element-test)
@@ -3152,6 +3178,9 @@ This attribute value may be escaped with `\u` notation, see [Escaping](#escaping
 
 ### Test Element: backspace
 
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
+
 > <small>
 >
 > Parents: [test](#test-element-test)
@@ -3170,6 +3199,9 @@ This element contains a backspace action, as if the user typed the backspace key
 ```
 
 ### Test Element: check
+
+> **NOTE**: The Keyboard Test Data format is a technical preview, it is subject to revision in future versions of CLDR.
+
 
 > <small>
 >

--- a/keyboards/3.0/bn.xml
+++ b/keyboards/3.0/bn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="bn" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="bn" conformsTo="45">
     <!--
         History:
           Based on
@@ -19,8 +19,8 @@
     </displays>
 
     <keys>
-        <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
-        <import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+        <import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
+        <import base="cldr" path="45/keys-Zyyy-currency.xml" />
 
         <key id="1" output="১" />
         <key id="2" output="২" />

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -7,7 +7,7 @@
 
 	Also NOTE: this is really a test keyboard.  CLDR-12026 will be for the real new azerty keyboard
 -->
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="fr-t-k0-azerty" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="fr-t-k0-azerty" conformsTo="45">
 	<locales>
 		<locale id="br" /> <!-- example of including Breton -->
 	</locales>
@@ -36,8 +36,8 @@
 	</displays>
 
 	<keys>
-		<import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
 
 		<!-- switch keys -->
 		<key id="shift" layerId="shift" />

--- a/keyboards/3.0/fr-t-k0-azerty.xml
+++ b/keyboards/3.0/fr-t-k0-azerty.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    This file is part of the CLDR Keyboard Technical Preview.
-    This is a sample data file.
-    This file is subject to change.
-    Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information.
-
-	Also NOTE: this is really a test keyboard.  CLDR-12026 will be for the real new azerty keyboard
+    See CLDR-12026 for the real new azerty keyboard
 -->
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="fr-t-k0-azerty" conformsTo="45">
 	<locales>

--- a/keyboards/3.0/ja-Latn.xml
+++ b/keyboards/3.0/ja-Latn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="ja-Latn" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="ja-Latn" conformsTo="45">
 	<locales>
 		<locale id="en" />
 	</locales>
@@ -7,8 +7,8 @@
 	<info name="Romaji (JIS)" />
 
 	<keys>
-		<import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
 	</keys>
 
 	<layers formId="jis">

--- a/keyboards/3.0/mt-t-k0-47key.xml
+++ b/keyboards/3.0/mt-t-k0-47key.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt-t-k0-47key" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt-t-k0-47key" conformsTo="45">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -9,8 +9,8 @@
 
     <keys>
         <!-- imports -->
-        <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
-        <import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+        <import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
+        <import base="cldr" path="45/keys-Zyyy-currency.xml" />
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/keyboards/3.0/mt.xml
+++ b/keyboards/3.0/mt.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    This file is part of the CLDR Keyboard Technical Preview.
-    This is a sample data file.
-    This file is subject to change.
-    Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information.
+Copyright © 1991-2024 Unicode, Inc.
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
     <locales>

--- a/keyboards/3.0/mt.xml
+++ b/keyboards/3.0/mt.xml
@@ -5,7 +5,7 @@
     This file is subject to change.
     Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information.
 -->
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -15,8 +15,8 @@
 
     <keys>
         <!-- imports -->
-        <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
-        <import base="cldr" path="techpreview/keys-Zyyy-currency.xml"/>
+        <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
+        <import base="cldr" path="45/keys-Zyyy-currency.xml"/>
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/keyboards/3.0/pcm.xml
+++ b/keyboards/3.0/pcm.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="pcm" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="pcm" conformsTo="45">
   <version number="1.0.0" />
   <info name="Naijíriá Píjin" />
   <keys>
-    <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
-    <import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+    <import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
+    <import base="cldr" path="45/keys-Zyyy-currency.xml" />
     <key id="grave" output="\u{300}" />
     <key id="backquote" output="`" />
     <key id="acute" output="\u{301}" />

--- a/keyboards/3.0/pt-t-k0-abnt2.xml
+++ b/keyboards/3.0/pt-t-k0-abnt2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="pt-t-k0-abnt2" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="pt-t-k0-abnt2" conformsTo="45">
 	<locales>
 		<locale id="pt" />
 	</locales>
@@ -14,8 +14,8 @@
 	</displays>
 
 	<keys>
-		<import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="techpreview/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
 
 		<!-- TODO: using the proposed deadkey format -->
 		<key id="d-acute"  output="\m{acute}"/>

--- a/keyboards/README.md
+++ b/keyboards/README.md
@@ -1,4 +1,0 @@
-#### _Important Note_
-
-> The CLDR [Keyboard Subcommittee](https://cldr.unicode.org/index/keyboard-workgroup) is currently
-> developing major changes to the CLDR keyboard specification. Please view the subcommittee page for the most recent information.

--- a/keyboards/dtd/ldmlKeyboard3.dtd
+++ b/keyboards/dtd/ldmlKeyboard3.dtd
@@ -1,52 +1,42 @@
 <!--
 Copyright © 1991-2024 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
-SPDX-License-Identifier: Unicode-DFS-2016
+SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
-<!-- Important Note:
-
-The CLDR Keyboard Subcommittee is currently developing major changes to the CLDR keyboard specification.
-Please view the subcommittee page for the most recent information.
-<https://cldr.unicode.org/index/keyboard-workgroup> -->
+<!-- Note: This DTD is not compatible with prior versions of the keyboard data.
+     See ldmlKeyboard.dtd  and CLDR v43 and prior. -->
 
 <!ELEMENT keyboard3 ( import*, locales?, version?, info, settings?, displays?, keys?, flicks?, forms?, layers*, variables?, transforms*, special* ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST keyboard3 locale CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-wellformed-->
-<!ATTLIST keyboard3 conformsTo (techpreview) #REQUIRED >
-    <!--@MATCH:any-->
+<!ATTLIST keyboard3 conformsTo (45) #REQUIRED >
+    <!--@MATCH:version-->
     <!--@METADATA-->
 <!ATTLIST keyboard3 xmlns CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@METADATA-->
 
 <!ELEMENT import EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST import path CDATA #REQUIRED >
     <!--@MATCH:any-->
 <!ATTLIST import base (cldr) #IMPLIED >
 
 <!ELEMENT locales ( locale* ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT locale EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST locale id CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-wellformed-->
 
 <!ELEMENT version EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST version number CDATA #IMPLIED >
     <!--@MATCH:semver-->
     <!--@VALUE-->
-<!ATTLIST version cldrVersion CDATA #FIXED "techpreview" >
-    <!-- Note: post techpreview, change cldrVersion to MATCH:version -->
-    <!--@MATCH:any-->
+<!ATTLIST version cldrVersion CDATA #FIXED "45" >
+    <!--@MATCH:version-->
     <!--@METADATA-->
 
 <!ELEMENT info EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST info name CDATA #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
@@ -62,15 +52,12 @@ Please view the subcommittee page for the most recent information.
 
 <!ELEMENT settings EMPTY >
     <!--@ORDERED-->
-    <!--@TECHPREVIEW-->
 <!ATTLIST settings normalization (disabled) #IMPLIED >
     <!--@VALUE-->
 
 <!ELEMENT displays ( import*, display*, displayOptions*, special* ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT display EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST display keyId NMTOKEN #IMPLIED >
     <!--@MATCH:any-->
 <!ATTLIST display output CDATA #IMPLIED >
@@ -82,20 +69,16 @@ Please view the subcommittee page for the most recent information.
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT displayOptions EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST displayOptions baseCharacter CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->
     <!--@ALLOWS_UESC-->
 
 <!ELEMENT special ANY >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT keys ( import*, key*, special* ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT key EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST key id NMTOKEN #REQUIRED >
     <!--@MATCH:any-->
 <!ATTLIST key flickId NMTOKEN #IMPLIED >
@@ -127,12 +110,10 @@ Please view the subcommittee page for the most recent information.
 <!ELEMENT flicks ( import*, flick*, special* ) >
 
 <!ELEMENT flick ( flickSegment+, special* ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST flick id NMTOKEN #REQUIRED >
     <!--@MATCH:any-->
 
 <!ELEMENT flickSegment EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST flickSegment directions NMTOKENS #REQUIRED >
     <!--@MATCH:regex/(n|e|s|w|ne|nw|se|sw)([ ]+(n|e|s|w|ne|nw|se|sw))*-->
 <!ATTLIST flickSegment keyId NMTOKEN #REQUIRED >
@@ -140,28 +121,23 @@ Please view the subcommittee page for the most recent information.
     <!--@VALUE-->
 
 <!ELEMENT forms ( import*, form*, special* ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT form ( scanCodes+, special* ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST form id NMTOKEN #IMPLIED >
     <!--@MATCH:any-->
 
 <!ELEMENT scanCodes EMPTY >
-    <!--@TECHPREVIEW-->
 <!ATTLIST scanCodes codes NMTOKENS #REQUIRED >
     <!--@MATCH:regex/[0-9a-fA-F]{2}( [0-9a-fA-F]{2})*-->
     <!--@VALUE-->
 
 <!ELEMENT layers ( import*, layer*, special* ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST layers formId NMTOKEN #REQUIRED >
     <!--@MATCH:any-->
 <!ATTLIST layers minDeviceWidth CDATA #IMPLIED >
     <!--@MATCH:range/1~999-->
 
 <!ELEMENT layer ( row+, special* ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST layer id NMTOKEN #IMPLIED >
     <!--@MATCH:any-->
 <!ATTLIST layer modifiers NMTOKENS #IMPLIED >
@@ -169,13 +145,11 @@ Please view the subcommittee page for the most recent information.
 
 <!ELEMENT row EMPTY >
     <!--@ORDERED-->
-    <!--@TECHPREVIEW-->
 <!ATTLIST row keys NMTOKENS #REQUIRED >
     <!--@MATCH:any-->
     <!--@VALUE-->
 
 <!ELEMENT variables ( import*, string*, set*, uset*, special* ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT string EMPTY >
 <!ATTLIST string id NMTOKEN #REQUIRED >
@@ -201,12 +175,10 @@ Please view the subcommittee page for the most recent information.
     <!--@VALUE-->
 
 <!ELEMENT transforms ( import*, transformGroup*, special* ) >
-    <!--@TECHPREVIEW-->
 <!ATTLIST transforms type (simple | backspace) #REQUIRED >
     <!--@MATCH:literal/simple, backspace-->
 
 <!ELEMENT transformGroup ( import*, ( transform* | reorder* ), special* ) >
-    <!--@TECHPREVIEW-->
 
 <!ELEMENT transform EMPTY >
     <!--@ORDERED-->
@@ -221,7 +193,6 @@ Please view the subcommittee page for the most recent information.
 
 <!ELEMENT reorder EMPTY >
     <!--@ORDERED-->
-    <!--@TECHPREVIEW-->
 <!ATTLIST reorder before CDATA #IMPLIED >
     <!--@MATCH:any-->
     <!--@VALUE-->

--- a/keyboards/dtd/ldmlKeyboard3.xsd
+++ b/keyboards/dtd/ldmlKeyboard3.xsd
@@ -7,14 +7,11 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
 <!--
   Copyright © 1991-2024 Unicode, Inc.
   For terms of use, see http://www.unicode.org/copyright.html
-  SPDX-License-Identifier: Unicode-DFS-2016
+  SPDX-License-Identifier: Unicode-3.0
   CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 --><!--
-  Important Note:
-
-  The CLDR Keyboard Subcommittee is currently developing major changes to the CLDR keyboard specification.
-  Please view the subcommittee page for the most recent information.
-  <https://cldr.unicode.org/index/keyboard-workgroup>
+  Note: This DTD is not compatible with prior versions of the keyboard data.
+  See ldmlKeyboard.dtd  and CLDR v43 and prior.
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
   <xs:element name="keyboard3">
     <xs:complexType>
@@ -37,16 +34,17 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="conformsTo" use="required">
         <xs:simpleType>
           <xs:restriction base="xs:token">
-            <xs:enumeration value="techpreview"/>
+            <xs:enumeration value="45"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-
-
-
-
+  
+  
+  
+  
+  
   <xs:element name="import">
     <xs:complexType>
       <xs:attribute name="path" use="required"/>
@@ -59,8 +57,7 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-
-
+  
   <xs:element name="locales">
     <xs:complexType>
       <xs:sequence>
@@ -68,32 +65,28 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="locale">
     <xs:complexType>
       <xs:attribute name="id" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
+  
   <xs:element name="version">
     <xs:complexType>
       <xs:attribute name="number"/>
-      <xs:attribute default="techpreview" name="cldrVersion">
+      <xs:attribute default="45" name="cldrVersion">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:enumeration value="techpreview"/>
+            <xs:enumeration value="45"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-
-
-
-  <!-- Note: post techpreview, change cldrVersion to MATCH:version -->
-
-
+  
+  
+  
+  
   <xs:element name="info">
     <xs:complexType>
       <xs:attribute name="name" use="required"/>
@@ -102,15 +95,14 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="indicator"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
+  
+  
   <xs:element name="settings">
     <xs:complexType>
       <xs:attribute name="normalization">
@@ -122,9 +114,8 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-
-
-
+  
+  
   <xs:element name="displays">
     <xs:complexType>
       <xs:sequence>
@@ -135,7 +126,6 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="display">
     <xs:complexType>
       <xs:attribute name="keyId" type="xs:NMTOKEN"/>
@@ -143,24 +133,21 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="display" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
   <xs:element name="displayOptions">
     <xs:complexType>
       <xs:attribute name="baseCharacter"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
+  
+  
+  
   <xs:element name="special" type="any"/>
-
   <xs:element name="keys">
     <xs:complexType>
       <xs:sequence>
@@ -170,7 +157,6 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="key">
     <xs:complexType>
       <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
@@ -197,24 +183,23 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="width"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
   <xs:element name="flicks">
     <xs:complexType>
       <xs:sequence>
@@ -233,18 +218,16 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
+  
   <xs:element name="flickSegment">
     <xs:complexType>
       <xs:attribute name="directions" type="xs:NMTOKENS" use="required"/>
       <xs:attribute name="keyId" type="xs:NMTOKEN" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
+  
+  
+  
   <xs:element name="forms">
     <xs:complexType>
       <xs:sequence>
@@ -254,7 +237,6 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="form">
     <xs:complexType>
       <xs:sequence>
@@ -264,16 +246,14 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="id" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
-
-
+  
   <xs:element name="scanCodes">
     <xs:complexType>
       <xs:attribute name="codes" type="xs:NMTOKENS" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
+  
+  
   <xs:element name="layers">
     <xs:complexType>
       <xs:sequence>
@@ -285,9 +265,8 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="minDeviceWidth"/>
     </xs:complexType>
   </xs:element>
-
-
-
+  
+  
   <xs:element name="layer">
     <xs:complexType>
       <xs:sequence>
@@ -298,18 +277,16 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       <xs:attribute name="modifiers" type="xs:NMTOKENS"/>
     </xs:complexType>
   </xs:element>
-
-
-
+  
+  
   <xs:element name="row">
     <xs:complexType>
       <xs:attribute name="keys" type="xs:NMTOKENS" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
+  
+  
+  
   <xs:element name="variables">
     <xs:complexType>
       <xs:sequence>
@@ -321,36 +298,35 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="string">
     <xs:complexType>
       <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
       <xs:attribute name="value" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
+  
+  
+  
+  
   <xs:element name="set">
     <xs:complexType>
       <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
       <xs:attribute name="value" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
+  
+  
+  
+  
   <xs:element name="uset">
     <xs:complexType>
       <xs:attribute name="id" type="xs:NMTOKEN" use="required"/>
       <xs:attribute name="value" use="required"/>
     </xs:complexType>
   </xs:element>
-
-
-
+  
+  
+  
   <xs:element name="transforms">
     <xs:complexType>
       <xs:sequence>
@@ -368,8 +344,7 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-
-
+  
   <xs:element name="transformGroup">
     <xs:complexType>
       <xs:sequence>
@@ -382,20 +357,19 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="transform">
     <xs:complexType>
       <xs:attribute name="from" use="required"/>
       <xs:attribute name="to"/>
     </xs:complexType>
   </xs:element>
-
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
+  
   <xs:element name="reorder">
     <xs:complexType>
       <xs:attribute name="before"/>

--- a/keyboards/dtd/ldmlKeyboardTest3.dtd
+++ b/keyboards/dtd/ldmlKeyboardTest3.dtd
@@ -1,17 +1,12 @@
 <!--
 Copyright © 1991-2024 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
-SPDX-License-Identifier: Unicode-DFS-2016
+SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <!-- Important Note:
 
-The CLDR Keyboard Workgroup is currently developing major changes to the
-CLDR keyboard specification.
-
-This DTD is a work in progress.
-
-Please see CLDR-15034 for the latest information. -->
+This DTD describes a technical preview of Keyboard Test Data -->
 
 <!ELEMENT keyboardTest3 ( info, repertoire*, tests*, special* ) >
     <!--@TECHPREVIEW-->

--- a/keyboards/dtd/ldmlKeyboardTest3.xsd
+++ b/keyboards/dtd/ldmlKeyboardTest3.xsd
@@ -7,17 +7,12 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
 <!--
   Copyright © 1991-2024 Unicode, Inc.
   For terms of use, see http://www.unicode.org/copyright.html
-  SPDX-License-Identifier: Unicode-DFS-2016
+  SPDX-License-Identifier: Unicode-3.0
   CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 --><!--
   Important Note:
   
-  The CLDR Keyboard Workgroup is currently developing major changes to the
-  CLDR keyboard specification.
-  
-  This DTD is a work in progress.
-  
-  Please see CLDR-15034 for the latest information.
+  This DTD describes a technical preview of Keyboard Test Data
 --><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
   <xs:element name="keyboardTest3">
     <xs:complexType>

--- a/keyboards/import/README.md
+++ b/keyboards/import/README.md
@@ -3,10 +3,10 @@
 The XML files in this directory are importable using the keyboard syntax as follows:
 
 ```xml
-<import base="cldr" path="techpreview/somefile.xml"/>
+<import base="cldr" path="45/somefile.xml"/>
 ```
 
-As an experiment, a naming convention is being attempted:
+This is the naming convention being used:
 
 - _type_`-`_script_`-`_description_`.xml`
 
@@ -16,11 +16,8 @@ So,
 
 - `keys-Zyyy-punctuation.xml` is of [script](https://www.unicode.org/iso15924/iso15924-codes.html) `Zyyy`, aka "Common".
 
-
 See [tr35-keyboard.md](../../docs/ldml/tr35-keyboards.md#Element_import)
 
-## Copyright
+## Copyright and License
 
-Copyright &copy; 2022 Unicode, Inc.
-All rights reserved.
-[Terms of use](http://www.unicode.org/copyright.html)
+See the top level [README.md](../../README.md#copyright--licenses)

--- a/keyboards/import/keys-Zyyy-currency.xml
+++ b/keyboards/import/keys-Zyyy-currency.xml
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright © 1991-2023 Unicode, Inc.
-For terms of use, see http://www.unicode.org/copyright.html
-SPDX-License-Identifier: Unicode-DFS-2016
+Copyright © 1991-2024 Unicode, Inc.
+SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
--->
-<!--
-    This file is part of the CLDR Keyboard Technical Preview.
-    This is a sample of how imports can be used.
-    This file is subject to change.
-    Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information.
 -->
 <!DOCTYPE keys SYSTEM "../dtd/ldmlKeyboard3.dtd">
 <keys>

--- a/keyboards/import/keys-Zyyy-punctuation.xml
+++ b/keyboards/import/keys-Zyyy-punctuation.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    This file is part of the CLDR Keyboard Technical Preview.
-    This is a sample of how imports can be used.
-    This file is subject to change.
-    Please see https://cldr.unicode.org/index/keyboard-workgroup for the latest information.
+Copyright © 1991-2024 Unicode, Inc.
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <!DOCTYPE keys SYSTEM "../dtd/ldmlKeyboard3.dtd">
 <keys>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/KeyboardFlatten.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/KeyboardFlatten.java
@@ -83,8 +83,8 @@ public class KeyboardFlatten {
         final String path = getPath(item);
         System.err.println("Import: " + base + ":" + path);
         if (base.equals("cldr")) {
-            if (path.startsWith("techpreview/")) {
-                final String subpath = path.replaceFirst("techpreview/", "");
+            if (path.startsWith("45/")) {
+                final String subpath = path.replaceFirst("45/", "");
                 final File importDir =
                         new File(
                                 CLDRConfig.getInstance().getCldrBaseDirectory(),

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -1692,10 +1692,8 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                     // <!ATTLIST version number CDATA #REQUIRED >
                     // <!ATTLIST version cldrVersion CDATA #FIXED "24" >
                     if (attribute.equals("cldrVersion") && (qName.equals("version"))) {
-                        if (!value.equals("techpreview")) { // TODO: Keyboard techpreview
-                            ((SimpleXMLSource) target.dataSource)
-                                    .setDtdVersionInfo(VersionInfo.getInstance(value));
-                        }
+                        ((SimpleXMLSource) target.dataSource)
+                                .setDtdVersionInfo(VersionInfo.getInstance(value));
                     } else {
                         putAndFixDeprecatedAttribute(qName, attribute, value);
                     }

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-missing.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-missing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -9,7 +9,7 @@
     <keys>
         <!-- imports -->
         <!-- Error - import does not exist. -->
-        <import base="cldr" path="techpreview/keys-Zyyy-DOESNOTEXIST.xml"/>
+        <import base="cldr" path="45/keys-Zyyy-DOESNOTEXIST.xml"/>
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownbase.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownbase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -9,7 +9,7 @@
     <keys>
         <!-- imports -->
         <!-- Error - unknown version. -->
-        <import base="UNKNOWN" path="techpreview/keys-Zyyy-punctuation.xml"/>
+        <import base="UNKNOWN" path="45/keys-Zyyy-punctuation.xml"/>
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownver.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-wrongparent.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-wrongparent.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="techpreview">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
     <locales>
         <!-- Error - can't import 'keys' into a 'locales' section. -->
-        <import base="cldr" path="techpreview/keys-Zyyy-punctuation.xml"/>
+        <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
     </locales>


### PR DESCRIPTION
CLDR-16909

- Move Keyboard out of techpreview
- `techpreview` is no longer an acceptable version number for `conformsTo=..` or for the import path.
- remove some hacks that enabled `techpreview`
- fixup the spec and other docs

**NOTE** As discussed earlier, the keyboard _test_ data (`ldmlKeyboardTest3.dtd`) remains in techpreview. I've added some additional notes to make this clear in the DTD and in the spec.

- [X] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
