### PR TITLE
CLDR-17371 fix ElementAttributeInfo to use DoctypeXmlStreamWrapper

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ElementAttributeInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ElementAttributeInfo.java
@@ -135,13 +135,14 @@ public class ElementAttributeInfo {
             is.setSystemId(filename);
             // xmlReader.setContentHandler(me);
             // xmlReader.setErrorHandler(me);
-            xmlReader.parse(is);
+            xmlReader.parse(DoctypeXmlStreamWrapper.wrap(is));
             this.elementAttribute2Data =
                     Collections.unmodifiableMap(getElementAttribute2Data()); // TODO, protect rows
             getElement2Children().freeze();
             getElement2Parents().freeze();
             getElement2Attributes().freeze();
         } catch (Exception e) {
+            // TODO: why is this being caught here?
             e.printStackTrace();
         } finally {
             fis.close();


### PR DESCRIPTION
CLDR-17371

- [ ] This PR completes the ticket.

Wasn't a test failure, but fixes an otherwise ignored error.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
