### PR TITLE
CLDR-17389 Revert Dutch time zone names

### DIFF
--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -10056,9 +10056,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Alaska">
 				<long>
-					<generic>Alaska Time</generic>
-					<standard>Alaska Standard Time</standard>
-					<daylight>Alaska Daylight Time</daylight>
+					<generic>Alaska-tijd</generic>
+					<standard>Alaska-standaardtijd</standard>
+					<daylight>Alaska-zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">AKT</generic>
@@ -10075,16 +10075,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Amazon">
 				<long>
-					<generic>Amazon Time</generic>
-					<standard>Amazon Standard Time</standard>
-					<daylight>Amazon Summer Time</daylight>
+					<generic>Amazone-tijd</generic>
+					<standard>Amazone-standaardtijd</standard>
+					<daylight>Amazone-zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="America_Central">
 				<long>
-					<generic>Central Time</generic>
-					<standard>Central Standard Time</standard>
-					<daylight>Central Daylight Time</daylight>
+					<generic>Central-tijd</generic>
+					<standard>Central-standaardtijd</standard>
+					<daylight>Central-zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">CT</generic>
@@ -10094,9 +10094,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="America_Eastern">
 				<long>
-					<generic>Eastern Time</generic>
-					<standard>Eastern Standard Time</standard>
-					<daylight>Eastern Daylight Time</daylight>
+					<generic>Eastern-tijd</generic>
+					<standard>Eastern-standaardtijd</standard>
+					<daylight>Eastern-zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">ET</generic>
@@ -10106,9 +10106,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="America_Mountain">
 				<long>
-					<generic>Mountain Time</generic>
-					<standard>Mountain Standard Time</standard>
-					<daylight>Mountain Daylight Time</daylight>
+					<generic>Mountain-tijd</generic>
+					<standard>Mountain-standaardtijd</standard>
+					<daylight>Mountain-zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">MT</generic>
@@ -10118,9 +10118,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="America_Pacific">
 				<long>
-					<generic>Pacific Time</generic>
-					<standard>Pacific Standard Time</standard>
-					<daylight>Pacific Daylight Time</daylight>
+					<generic>Pacific-tijd</generic>
+					<standard>Pacific-standaardtijd</standard>
+					<daylight>Pacific-zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">PT</generic>
@@ -10165,16 +10165,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Argentina">
 				<long>
-					<generic>Argentina Time</generic>
-					<standard>Argentina Standard Time</standard>
-					<daylight>Argentina Summer Time</daylight>
+					<generic>Argentijnse tijd</generic>
+					<standard>Argentijnse standaardtijd</standard>
+					<daylight>Argentijnse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina_Western">
 				<long>
-					<generic>Western Argentina Time</generic>
-					<standard>Western Argentina Standard Time</standard>
-					<daylight>Western Argentina Summer Time</daylight>
+					<generic>West-Argentijnse tijd</generic>
+					<standard>West-Argentijnse standaardtijd</standard>
+					<daylight>West-Argentijnse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Armenia">
@@ -10186,9 +10186,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Atlantic">
 				<long>
-					<generic>Atlantic Time</generic>
-					<standard>Atlantic Standard Time</standard>
-					<daylight>Atlantic Daylight Time</daylight>
+					<generic>Atlantic-tijd</generic>
+					<standard>Atlantic-standaardtijd</standard>
+					<daylight>Atlantic-zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">AT</generic>
@@ -10252,14 +10252,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Bolivia">
 				<long>
-					<standard>Bolivia Time</standard>
+					<standard>Boliviaanse tijd</standard>
 				</long>
 			</metazone>
 			<metazone type="Brasilia">
 				<long>
-					<generic>Brasilia Time</generic>
-					<standard>Brasilia Standard Time</standard>
-					<daylight>Brasilia Summer Time</daylight>
+					<generic>Braziliaanse tijd</generic>
+					<standard>Braziliaanse standaardtijd</standard>
+					<daylight>Braziliaanse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Brunei">
@@ -10293,9 +10293,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Chile">
 				<long>
-					<generic>Chile Time</generic>
-					<standard>Chile Standard Time</standard>
-					<daylight>Chile Summer Time</daylight>
+					<generic>Chileense tijd</generic>
+					<standard>Chileense standaardtijd</standard>
+					<daylight>Chileense zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="China">
@@ -10324,9 +10324,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Colombia">
 				<long>
-					<generic>Colombia Time</generic>
-					<standard>Colombia Standard Time</standard>
-					<daylight>Colombia Summer Time</daylight>
+					<generic>Colombiaanse tijd</generic>
+					<standard>Colombiaanse standaardtijd</standard>
+					<daylight>Colombiaanse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cook">
@@ -10338,9 +10338,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Cuba">
 				<long>
-					<generic>Cuba Time</generic>
-					<standard>Cuba Standard Time</standard>
-					<daylight>Cuba Daylight Time</daylight>
+					<generic>Cubaanse tijd</generic>
+					<standard>Cubaanse standaardtijd</standard>
+					<daylight>Cubaanse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Davis">
@@ -10360,14 +10360,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Easter">
 				<long>
-					<generic>Easter Island Time</generic>
-					<standard>Easter Island Standard Time</standard>
-					<daylight>Easter Island Summer Time</daylight>
+					<generic>Paaseilandse tijd</generic>
+					<standard>Paaseilandse standaardtijd</standard>
+					<daylight>Paaseilandse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Ecuador">
 				<long>
-					<standard>Ecuador Time</standard>
+					<standard>Ecuadoraanse tijd</standard>
 				</long>
 			</metazone>
 			<metazone type="Europe_Central">
@@ -10413,9 +10413,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Falkland">
 				<long>
-					<generic>Falkland Islands Time</generic>
-					<standard>Falkland Islands Standard Time</standard>
-					<daylight>Falkland Islands Summer Time</daylight>
+					<generic>Falklandeilandse tijd</generic>
+					<standard>Falklandeilandse standaardtijd</standard>
+					<daylight>Falklandeilandse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Fiji">
@@ -10427,7 +10427,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="French_Guiana">
 				<long>
-					<standard>French Guiana Time</standard>
+					<standard>Frans-Guyaanse tijd</standard>
 				</long>
 			</metazone>
 			<metazone type="French_Southern">
@@ -10437,7 +10437,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Galapagos">
 				<long>
-					<standard>Galapagos Time</standard>
+					<standard>Galapagoseilandse tijd</standard>
 				</long>
 			</metazone>
 			<metazone type="Gambier">
@@ -10467,16 +10467,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Greenland_Eastern">
 				<long>
-					<generic>East Greenland Time</generic>
-					<standard>East Greenland Standard Time</standard>
-					<daylight>East Greenland Summer Time</daylight>
+					<generic>Oost-Groenlandse tijd</generic>
+					<standard>Oost-Groenlandse standaardtijd</standard>
+					<daylight>Oost-Groenlandse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Greenland_Western">
 				<long>
-					<generic>West Greenland Time</generic>
-					<standard>West Greenland Standard Time</standard>
-					<daylight>West Greenland Summer Time</daylight>
+					<generic>West-Groenlandse tijd</generic>
+					<standard>West-Groenlandse standaardtijd</standard>
+					<daylight>West-Groenlandse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Guam">
@@ -10491,14 +10491,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Guyana">
 				<long>
-					<standard>Guyana Time</standard>
+					<standard>Guyaanse tijd</standard>
 				</long>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
-					<generic>Hawaii-Aleutian Time</generic>
-					<standard>Hawaii-Aleutian Standard Time</standard>
-					<daylight>Hawaii-Aleutian Daylight Time</daylight>
+					<generic>Hawaii-Aleoetische tijd</generic>
+					<standard>Hawaii-Aleoetische standaardtijd</standard>
+					<daylight>Hawaii-Aleoetische zomertijd</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">HAT</generic>
@@ -10684,9 +10684,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Mexico_Pacific">
 				<long>
-					<generic>Mexican Pacific Time</generic>
-					<standard>Mexican Pacific Standard Time</standard>
-					<daylight>Mexican Pacific Daylight Time</daylight>
+					<generic>Mexicaanse Pacific-tijd</generic>
+					<standard>Mexicaanse Pacific-standaardtijd</standard>
+					<daylight>Mexicaanse Pacific-zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Mongolia">
@@ -10734,9 +10734,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Newfoundland">
 				<long>
-					<generic>Newfoundland Time</generic>
-					<standard>Newfoundland Standard Time</standard>
-					<daylight>Newfoundland Daylight Time</daylight>
+					<generic>Newfoundland-tijd</generic>
+					<standard>Newfoundland-standaardtijd</standard>
+					<daylight>Newfoundland-zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Niue">
@@ -10753,9 +10753,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Noronha">
 				<long>
-					<generic>Fernando de Noronha Time</generic>
-					<standard>Fernando de Noronha Standard Time</standard>
-					<daylight>Fernando de Noronha Summer Time</daylight>
+					<generic>Fernando de Noronha-tijd</generic>
+					<standard>Fernando de Noronha-standaardtijd</standard>
+					<daylight>Fernando de Noronha-zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="North_Mariana">
@@ -10796,16 +10796,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Paraguay">
 				<long>
-					<generic>Paraguay Time</generic>
-					<standard>Paraguay Standard Time</standard>
-					<daylight>Paraguay Summer Time</daylight>
+					<generic>Paraguayaanse tijd</generic>
+					<standard>Paraguayaanse standaardtijd</standard>
+					<daylight>Paraguayaanse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Peru">
 				<long>
-					<generic>Peru Time</generic>
-					<standard>Peru Standard Time</standard>
-					<daylight>Peru Summer Time</daylight>
+					<generic>Peruaanse tijd</generic>
+					<standard>Peruaanse standaardtijd</standard>
+					<daylight>Peruaanse zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Philippines">
@@ -10822,9 +10822,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Pierre_Miquelon">
 				<long>
-					<generic>St. Pierre &amp; Miquelon Time</generic>
-					<standard>St. Pierre &amp; Miquelon Standard Time</standard>
-					<daylight>St. Pierre &amp; Miquelon Daylight Time</daylight>
+					<generic>Saint Pierre en Miquelon-tijd</generic>
+					<standard>Saint Pierre en Miquelon-standaardtijd</standard>
+					<daylight>Saint Pierre en Miquelon-zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Pitcairn">
@@ -10958,8 +10958,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Uruguay">
 				<long>
-					<generic>Uruguay Time</generic>
-					<standard>Uruguay Standard Time</standard>
+					<generic>Uruguayaanse tijd</generic>
+					<standard>Uruguayaanse standaardtijd</standard>
 					<daylight>Uruguayaanse zomertijd</daylight>
 				</long>
 			</metazone>
@@ -11027,7 +11027,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Yukon">
 				<long>
-					<standard>Yukon Time</standard>
+					<standard>Yukon-tijd</standard>
 				</long>
 			</metazone>
 		</timeZoneNames>


### PR DESCRIPTION
CLDR-17389 

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

CLDR 44 introduced the changes in time zone names for Dutch, mainly in America's region. Those changes implemented English time zone name translations, instead of the Dutch ones.

Per the discussion in TC, it is agreed to revert the time zone names back to pre-44 values

ALLOW_MANY_COMMITS=true
