### PR TITLE
CLDR-17442 Fix coverage to handle beaufort

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -59,7 +59,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -837,7 +836,7 @@ public class SupplementalDataInfo {
         }
     }
 
-    public static class CoverageLevelInfo implements Comparable<CoverageLevelInfo> {
+    public static class CoverageLevelInfo {
         public final String match;
         public final Level value;
         public final Pattern inLanguage;
@@ -868,15 +867,6 @@ public class SupplementalDataInfo {
             result.remove("");
             inTerritorySetInternal = result;
             return Collections.unmodifiableSet(result);
-        }
-
-        @Override
-        public int compareTo(CoverageLevelInfo o) {
-            if (value == o.value) {
-                return match.compareTo(o.match);
-            } else {
-                return value.compareTo(o.value);
-            }
         }
 
         public static void fixEU(Collection<CoverageLevelInfo> targets, SupplementalDataInfo info) {
@@ -1313,7 +1303,7 @@ public class SupplementalDataInfo {
         bcp47KeyToAliasToSubtype = CldrUtility.protectCollection(bcp47KeyToAliasToSubtype);
 
         CoverageLevelInfo.fixEU(coverageLevels, this);
-        coverageLevels = Collections.unmodifiableSortedSet(coverageLevels);
+        coverageLevels = CldrUtility.protectCollection(coverageLevels);
 
         measurementData = CldrUtility.protectCollection(measurementData);
 
@@ -2486,7 +2476,7 @@ public class SupplementalDataInfo {
     private Map<String, String> likelySubtags = new TreeMap<>();
     private Map<String, String> likelyOrigins = new TreeMap<>();
     // make public temporarily until we resolve.
-    private SortedSet<CoverageLevelInfo> coverageLevels = new TreeSet<>();
+    private Set<CoverageLevelInfo> coverageLevels = new LinkedHashSet<>();
     private Map<ParentLocaleComponent, Map<String, String>> parentLocales = new HashMap<>();
 
     { // Prefill, since we know we will need these
@@ -2776,7 +2766,7 @@ public class SupplementalDataInfo {
         return numberingSystems.get(numberingSystem).type;
     }
 
-    public SortedSet<CoverageLevelInfo> getCoverageLevelInfo() {
+    public Set<CoverageLevelInfo> getCoverageLevelInfo() {
         return coverageLevels;
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -225,6 +225,9 @@ public class TestCLDRFile extends TestFmwk {
                 final CLDRFile cldrFile = fullCldrFactory.make(locale, true);
                 Set<String> sorted2 = new TreeSet<>(cldrFile.getExtraPaths());
                 for (String path : sorted2) {
+                    if (path.contains("speed-beaufort")) {
+                        continue; // special case
+                    }
                     if (path.contains("/gender")
                             || path.contains("@gender")
                             || path.contains("@case")) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -156,4 +156,28 @@ public class TestCoverage extends TestFmwkPlus {
             errln("\t" + title + ": " + diff);
         }
     }
+
+    public void testBeaufort() {
+        // locale, path, expected coverage
+        String[][] tests = {
+            {
+                "am",
+                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"speed-beaufort\"]/displayName",
+                "comprehensive"
+            },
+            {
+                "de",
+                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"speed-beaufort\"]/displayName",
+                "modern"
+            },
+        };
+        for (String[] test : tests) {
+            String locale = test[0];
+            String path = test[1];
+            Level expected = Level.fromString(test[2]);
+            CoverageLevel2 coverageLevel = CoverageLevel2.getInstance(sdi, locale);
+            Level actual = coverageLevel.getLevel(path);
+            assertEquals(String.format("locale:%s, path:%s", locale, path), expected, actual);
+        }
+    }
 }


### PR DESCRIPTION
CLDR-17442

I tracked down the problem, which was that the coverage level rules were being sorted, which reordered the comprehensive beaufort rules **after** modern.

This should never have been the case; the rules are meant to be processed in order.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
