### PR TITLE
CLDR-17435 add timezone attributes for the 2024 currency changes in CW,SX

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -363,8 +363,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="PTE" from="1911-05-22" to="1975-07-05"/>
         </region>
         <region iso3166="CW">
-            <currency iso4217="XCG" from="2024-03-31"/>
-            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30"/>
+            <currency iso4217="XCG" from="2024-03-31" tz="America/Curacao"/>
+            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30" to-tz="America/Curacao"/>
         </region>
         <region iso3166="CX">
             <currency iso4217="AUD" from="1966-02-14"/>
@@ -996,8 +996,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="SVC" from="1919-11-11" to="2001-01-01"/>
         </region>
         <region iso3166="SX">
-            <currency iso4217="XCG" from="2024-03-31"/>
-            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30"/>
+            <currency iso4217="XCG" from="2024-03-31" tz="America/Lower_Princes"/>
+            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30" to-tz="America/Lower_Princes"/>
         </region>
         <region iso3166="SY">
             <currency iso4217="SYP" from="1948-01-01"/>


### PR DESCRIPTION
CLDR-17435

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17435)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add the timezone attributes for the 2024 currency changes in CA and SX. Per https://unicode-org.atlassian.net/browse/CLDR-17282 we decided to add the timezone attributes for all currency changes from 2022-01-01 and later. I should have mentioned that when reviewing https://github.com/unicode-org/cldr/pull/3471 but did not, so we add the attributes with this PR.

ALLOW_MANY_COMMITS=true
