### PR TITLE
CLDR-17420 Fix UnitConverter.parseUnitId for special, add tests & regen unit test files

### DIFF
--- a/common/testData/units/unitPreferencesTest.txt
+++ b/common/testData/units/unitPreferencesTest.txt
@@ -2,7 +2,7 @@
 # Test data for unit preferences
 #  Copyright © 1991-2024 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
-#  SPDX-License-Identifier: Unicode-DFS-2016
+#  SPDX-License-Identifier: Unicode-3.0
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 #
 # Format:

--- a/common/testData/units/unitsTest.txt
+++ b/common/testData/units/unitsTest.txt
@@ -1,7 +1,7 @@
 # Test data for unit conversions
 #  Copyright © 1991-2024 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
-#  SPDX-License-Identifier: Unicode-DFS-2016
+#  SPDX-License-Identifier: Unicode-3.0
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 #
 # Format:
@@ -182,6 +182,7 @@ resolution	;	pixel-per-inch	;	pixel-per-meter	;	5,000/127 * x	;	39370.08
 resolution	;	dot-per-centimeter	;	pixel-per-meter	;	100 * x	;	100000.0
 resolution	;	pixel-per-centimeter	;	pixel-per-meter	;	100 * x	;	100000.0
 solid-angle	;	steradian	;	square-revolution	;	4,290,444,930,214,144/169379976663492169 * x	;	25.3303
+speed	;	beaufort	;	meter-per-second	;	special:beaufort(x)	;	58.6
 speed	;	kilometer-per-hour	;	meter-per-second	;	2.5/9 * x	;	277.7778
 speed	;	mile-per-hour	;	meter-per-second	;	0.44704 * x	;	447.04
 speed	;	knot	;	meter-per-second	;	4.63/9 * x	;	514.4444

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -798,6 +798,14 @@ public class UnitConverter implements Freezable<UnitConverter> {
      */
     public ConversionInfo parseUnitId(
             String derivedUnit, Output<String> metricUnit, boolean showYourWork) {
+        // First check whether we are dealing with a special mapping
+        Output<String> testBaseUnit = new Output<>();
+        ConversionInfo testInfo = getUnitInfo(derivedUnit, testBaseUnit);
+        if (testInfo != null && testInfo.special != null) {
+            metricUnit.value = testBaseUnit.value;
+            return new ConversionInfo(testInfo.special, testInfo.specialInverse);
+        }
+        // Not a special mapping, proceed as usual
         metricUnit.value = null;
 
         UnitId outputUnit = new UnitId(UNIT_COMPARATOR);
@@ -891,8 +899,6 @@ public class UnitConverter implements Freezable<UnitConverter> {
                     unit = baseUnit;
                 }
                 for (int p = 1; p <= power; ++p) {
-                    // TODO CLDR-16329 additional PR or follow-on ticket, how to handle special
-                    // here?
                     String title = "";
                     if (value.equals(Rational.ONE)) {
                         if (showYourWork) System.out.println("\t(already base unit)");
@@ -913,12 +919,10 @@ public class UnitConverter implements Freezable<UnitConverter> {
                                         + numerator.divide(denominator).doubleValue());
                 }
                 // create cleaned up target unitid
-                // TODO CLDR-16329 additional PR or follow-on ticket, how to handle special here?
                 outputUnit.add(continuations, unit, inNumerator, power);
                 power = 1;
             }
         }
-        // TODO CLDR-16329 additional PR or follow-on ticket, how to handle special here?
         metricUnit.value = outputUnit.toString();
         return new ConversionInfo(numerator.divide(denominator), offset);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -669,7 +669,7 @@ public class TestUnits extends TestFmwk {
         assertEquals("Units without Quantity", Collections.emptySet(), noQuantity);
     }
 
-    static final Set<String> NOT_CONVERTABLE = ImmutableSet.of("generic", "beaufort");
+    static final Set<String> NOT_CONVERTABLE = ImmutableSet.of("generic");
 
     private void checkUnitConvertability(
             UnitConverter converter,
@@ -1146,6 +1146,7 @@ public class TestUnits extends TestFmwk {
                     "radian",
                     "revolution",
                     "electronvolt",
+                    "beaufort",
                     // quasi-metric
                     "dunam",
                     "mile-scandinavian",
@@ -1300,6 +1301,21 @@ public class TestUnits extends TestFmwk {
                 "kilogram-meter-per-square-second",
                 "17281869297 / 2500000000"
             },
+            {"1", "beaufort", "meter-per-second", "0.95"}, // 19/20
+            {"4", "beaufort", "meter-per-second", "6.75"}, // 27/4
+            {"7", "beaufort", "meter-per-second", "15.55"}, // 311/20
+            {"10", "beaufort", "meter-per-second", "26.5"}, // 53/2
+            {"13", "beaufort", "meter-per-second", "39.15"}, // 783/20
+            {"1", "beaufort", "mile-per-hour", "11875 / 5588"}, // 2.125089...
+            {"4", "beaufort", "mile-per-hour", "84375 / 5588"}, // 15.099319971367215
+            {"7", "beaufort", "mile-per-hour", "194375 / 5588"}, // 34.784359341445956
+            {"10", "beaufort", "mile-per-hour", "165625 / 2794"}, // 59.27881...
+            {"13", "beaufort", "mile-per-hour", "489375 / 5588"}, // 87.576056...
+            {"1", "meter-per-second", "beaufort", "1"},
+            {"7", "meter-per-second", "beaufort", "4"},
+            {"16", "meter-per-second", "beaufort", "7"},
+            {"27", "meter-per-second", "beaufort", "10"},
+            {"39", "meter-per-second", "beaufort", "13"},
         };
         int count = 0;
         for (String[] test : tests) {


### PR DESCRIPTION
CLDR-17420

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17420)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

This is a followup to PR [#3487](https://github.com/unicode-org/cldr/pull/3487) for CLDR-16329

The main thing I had to do here was fix UnitConverter.parseUnitId() to handle special mappings (which also eliminated 3 TODOs in UnitConverter.java). I also added some beaufort cases to TestUnits.TestSpecialCases() and regenerated the units test data files.

ALLOW_MANY_COMMITS=true
