### PR TITLE
CLDR-15954 Add test of unit preferences test

### DIFF
--- a/common/testData/units/unitLocalePreferencesTest.txt
+++ b/common/testData/units/unitLocalePreferencesTest.txt
@@ -1,0 +1,42 @@
+# Test data for unit locale preferences
+#  Copyright © 1991-2024 Unicode, Inc.
+#  For terms of use, see http://www.unicode.org/copyright.html
+#  SPDX-License-Identifier: Unicode-3.0
+#  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+#
+# Format:
+#	input-unit; amount; usage;	languageTag; expected-unit; expected-amount # comment
+#
+#   • The amounts are both rationals
+#   • The comment is optional (if it isn't present the # can be omitted)
+#
+# Use: Convert the Input amount & unit according to the Usage and Locale.
+#	 The result should match the Expected amount and unit.
+#
+#	 The input and expected output units are unit identifers; in particular, the output does not have further processing:
+#		 • no localization
+#
+fahrenheit;	1;	default;	en-u-rg-uszzzz-ms-ussystem-mu-celsius;	celsius;	-155/9	# mu > ms > rg > (likely) region
+fahrenheit;	1;	default;	en-u-rg-uszzzz-ms-ussystem-mu-celsius;	celsius;	-155/9
+fahrenheit;	1;	default;	en-u-rg-uszzzz-ms-metric;	celsius;	-155/9
+fahrenheit;	1;	default;	en-u-rg-dezzzz;	celsius;	-155/9
+fahrenheit;	1;	default;	en-DE;	celsius;	-155/9	# explicit region > likely region
+fahrenheit;	1;	default;	en-US;	fahrenheit;	1
+fahrenheit;	1;	default;	en;	fahrenheit;	1	# likely region = US
+gallon-imperial;	2.5;	fluid;	en-u-rg-uszzzz-ms-metric;	liter;	11.365225
+gallon-imperial;	2.5;	fluid;	en-u-rg-dezzzz;	liter;	11.365225
+gallon-imperial;	2.5;	fluid;	en-DE;	liter;	11.365225
+gallon-imperial;	2.5;	fluid;	en-US-u-rg-uszzzz-ms-uksystem;	gallon-imperial;	2.5	# ms-uksystem should behave like GB
+gallon-imperial;	2.5;	fluid;	en-u-rg-gbzzzz;	gallon-imperial;	2.5
+gallon-imperial;	2.5;	fluid;	en-GB;	gallon-imperial;	2.5
+gallon-imperial;	2.5;	fluid;	en-u-rg-uszzzz-ms-ussystem;	gallon;	1,420,653,125/473176473
+gallon-imperial;	2.5;	fluid;	en-u-rg-uszzzz;	gallon;	1,420,653,125/473176473
+gallon-imperial;	2.5;	fluid;	en-US;	gallon;	1,420,653,125/473176473
+gallon-imperial;	2.5;	fluid;	en;	gallon;	1,420,653,125/473176473	# likely region = US
+ampere;	2.5;	default;	en;	ampere;	2.5	# an input unit whose quantity has no preference data should get base units
+pound-force-foot;	12,345;	default;	en;	kilowatt-hour;	0.004649325714486427205
+kilocandela;	1;	default;	en;	candela;	1,000	# an input unit whose quantity has no preference data should get base units
+candela-per-byte;	1;	default;	en;	candela-per-bit;	0.125	# an input unit that has no quantity should get base units
+candela-per-cubic-foot;	1;	default;	en;	candela-per-cubic-meter;	1,953,125,000/55306341	# an input unit that has no quantity should get base units
+foot;	1;	default;	de-u-mu-celsius;	centimeter;	30.48	# a -mu unit that is not convertible from the input unit should get ignored
+#pound;	28;	default;	en-u-mu-stone;	stone;	2 # only temperature units are supported

--- a/common/testData/units/unitPreferencesTest.txt
+++ b/common/testData/units/unitPreferencesTest.txt
@@ -2,7 +2,7 @@
 # Test data for unit preferences
 #  Copyright © 1991-2024 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
-#  SPDX-License-Identifier: Unicode-DFS-2016
+#  SPDX-License-Identifier: Unicode-3.0
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 #
 # Format:
@@ -22,7 +22,7 @@
 #		 • no formatted with the skeleton
 #		 • no suppression of zero values (for secondary -and- units such as pound in stone-and-pound)
 #
-# Generation: Set GENERATE_TESTS in TestUnits.java to regenerate unitPreferencesTest.txt.
+# Generation: Use GenerateUnitTestData.java to regenerate unitPreferencesTest.txt.
 
 area;	default;	001;	1100000;	1100000.0;	square-meter;	11/10;	1.1;	square-kilometer
 area;	default;	001;	1000000;	1000000.0;	square-meter;	1;	1.0;	square-kilometer

--- a/common/testData/units/unitsTest.txt
+++ b/common/testData/units/unitsTest.txt
@@ -1,7 +1,7 @@
 # Test data for unit conversions
 #  Copyright © 1991-2024 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
-#  SPDX-License-Identifier: Unicode-DFS-2016
+#  SPDX-License-Identifier: Unicode-3.0
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 #
 # Format:
@@ -12,7 +12,7 @@
 #   round to 4 decimal digits before comparing.
 # Note that certain conversions are approximate, such as degrees to radians
 #
-# Generation: Set GENERATE_TESTS in TestUnits.java to regenerate unitsTest.txt.
+# Generation: Use GenerateUnitTestData.java to regenerate unitsTest.txt.
 
 acceleration	;	meter-per-square-second	;	meter-per-square-second	;	1 * x	;	1,000.00
 acceleration	;	g-force	;	meter-per-square-second	;	9.80665 * x	;	9806.65

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -755,7 +755,11 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
                     "knot",
                     "dalton",
                     "kilocalorie",
-                    "electronvolt");
+                    "electronvolt",
+                    // The following may be reinstated after 45.
+                    "dot-per-centimeter",
+                    "millimeter-ofhg",
+                    "milligram-ofglucose-per-deciliter");
 
     public static Set<String> getSpecialsToTranslate() {
         return INCLUDE_OTHER;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
@@ -32,10 +32,19 @@ import java.util.regex.Pattern;
  *
  * @author markdavis
  */
-public final class Rational implements Comparable<Rational> {
+public final class Rational extends Number implements Comparable<Rational> {
+    private static final long serialVersionUID = 1L;
     private static final Pattern INT_POWER_10 = Pattern.compile("10*");
     public final BigInteger numerator;
     public final BigInteger denominator;
+
+    static final BigInteger BI_TWO = BigInteger.valueOf(2);
+    static final BigInteger BI_FIVE = BigInteger.valueOf(5);
+    static final BigInteger BI_MINUS_ONE = BigInteger.valueOf(-1);
+    static final BigInteger BI_TEN = BigInteger.valueOf(10);
+
+    static final BigDecimal BD_TWO = BigDecimal.valueOf(2);
+    static final BigDecimal BD_FIVE = BigDecimal.valueOf(5);
 
     // Constraints:
     //   always stored in normalized form.
@@ -44,16 +53,18 @@ public final class Rational implements Comparable<Rational> {
     //   if numerator is zero, denominator is 1 or 0
     //   if denominator is zero, numerator is 1, -1, or 0
 
-    public static final Rational ZERO = Rational.of(0);
-    public static final Rational ONE = Rational.of(1);
-    public static final Rational TWO = Rational.of(2);
+    // NOTE, the constructor doesn't do any checking, so everything other than these goes
+    // through Rational.of(...)
+    public static final Rational ZERO = new Rational(BigInteger.ZERO, BigInteger.ONE);
+    public static final Rational ONE = new Rational(BigInteger.ONE, BigInteger.ONE);
+    public static final Rational NaN = new Rational(BigInteger.ZERO, BigInteger.ZERO);
+    public static final Rational INFINITY = new Rational(BigInteger.ONE, BigInteger.ZERO);
+
     public static final Rational NEGATIVE_ONE = ONE.negate();
-
-    public static final Rational INFINITY = Rational.of(1, 0);
     public static final Rational NEGATIVE_INFINITY = INFINITY.negate();
-    public static final Rational NaN = Rational.of(0, 0);
 
-    public static final Rational TEN = Rational.of(10, 1);
+    public static final Rational TWO = new Rational(BI_TWO, BigInteger.ONE);
+    public static final Rational TEN = new Rational(BI_TEN, BigInteger.ONE);
     public static final Rational TENTH = TEN.reciprocal();
 
     public static final char REPTEND_MARKER = '˙';
@@ -202,18 +213,41 @@ public final class Rational implements Comparable<Rational> {
     }
 
     public static Rational of(long numerator, long denominator) {
-        return new Rational(BigInteger.valueOf(numerator), BigInteger.valueOf(denominator));
+        return Rational.of(BigInteger.valueOf(numerator), BigInteger.valueOf(denominator));
     }
 
     public static Rational of(long numerator) {
-        return new Rational(BigInteger.valueOf(numerator), BigInteger.ONE);
+        return Rational.of(BigInteger.valueOf(numerator), BigInteger.ONE);
     }
 
     public static Rational of(BigInteger numerator, BigInteger denominator) {
-        return new Rational(numerator, denominator);
+        int dComparison = denominator.compareTo(BigInteger.ZERO);
+        if (dComparison == 0) {
+            // catch equivalents to NaN, -INF, +INF
+            // 0/0 => NaN
+            // +/0 => INF
+            // -/0 => -INF
+            int nComparison = numerator.compareTo(BigInteger.ZERO);
+            return nComparison < 0 ? NEGATIVE_INFINITY : nComparison > 0 ? INFINITY : NaN;
+        } else {
+            // reduce to lowest form
+            BigInteger gcd = numerator.gcd(denominator);
+            if (gcd.compareTo(BigInteger.ONE) > 0) {
+                numerator = numerator.divide(gcd);
+                denominator = denominator.divide(gcd);
+            }
+            if (dComparison < 0) {
+                // ** NOTE: is already reduced, so safe to use constructor
+                return new Rational(numerator, denominator);
+            } else {
+                // ** NOTE: is already reduced, so safe to use constructor
+                return new Rational(numerator.negate(), denominator.negate());
+            }
+        }
     }
 
     public static Rational of(BigInteger numerator) {
+        // ** NOTE: is already reduced, so safe to use constructor
         return new Rational(numerator, BigInteger.ONE);
     }
 
@@ -236,56 +270,47 @@ public final class Rational implements Comparable<Rational> {
     }
 
     public Rational add(Rational other) {
-        BigInteger gcd_den = denominator.gcd(other.denominator);
-        return new Rational(
-                numerator
-                        .multiply(other.denominator)
-                        .divide(gcd_den)
-                        .add(other.numerator.multiply(denominator).divide(gcd_den)),
-                denominator.multiply(other.denominator).divide(gcd_den));
+        BigInteger newNumerator =
+                numerator.multiply(other.denominator).add(other.numerator.multiply(denominator));
+        BigInteger newDenominator = denominator.multiply(other.denominator);
+        return Rational.of(newNumerator, newDenominator);
     }
 
     public Rational subtract(Rational other) {
-        BigInteger gcd_den = denominator.gcd(other.denominator);
-        return new Rational(
+        BigInteger newNumerator =
                 numerator
                         .multiply(other.denominator)
-                        .divide(gcd_den)
-                        .subtract(other.numerator.multiply(denominator).divide(gcd_den)),
-                denominator.multiply(other.denominator).divide(gcd_den));
+                        .subtract(other.numerator.multiply(denominator));
+        BigInteger newDenominator = denominator.multiply(other.denominator);
+        return Rational.of(newNumerator, newDenominator);
     }
 
     public Rational multiply(Rational other) {
-        BigInteger gcd_num_oden = numerator.gcd(other.denominator);
-        boolean isZero = gcd_num_oden.equals(BigInteger.ZERO);
-        BigInteger smallNum = isZero ? numerator : numerator.divide(gcd_num_oden);
-        BigInteger smallODen = isZero ? other.denominator : other.denominator.divide(gcd_num_oden);
+        BigInteger newNumerator = numerator.multiply(other.numerator);
+        BigInteger newDenominator = denominator.multiply(other.denominator);
+        return Rational.of(newNumerator, newDenominator);
+    }
 
-        BigInteger gcd_den_onum = denominator.gcd(other.numerator);
-        isZero = gcd_den_onum.equals(BigInteger.ZERO);
-        BigInteger smallONum = isZero ? other.numerator : other.numerator.divide(gcd_den_onum);
-        BigInteger smallDen = isZero ? denominator : denominator.divide(gcd_den_onum);
-
-        return new Rational(smallNum.multiply(smallONum), smallDen.multiply(smallODen));
+    public Rational divide(Rational other) {
+        BigInteger newNumerator = numerator.multiply(other.denominator);
+        BigInteger newDenominator = denominator.multiply(other.numerator);
+        return Rational.of(newNumerator, newDenominator);
     }
 
     public Rational pow(int i) {
-        return new Rational(numerator.pow(i), denominator.pow(i));
+        return Rational.of(numerator.pow(i), denominator.pow(i));
     }
 
     public static Rational pow10(int i) {
         return i > 0 ? TEN.pow(i) : TENTH.pow(-i);
     }
 
-    public Rational divide(Rational other) {
-        return multiply(other.reciprocal());
-    }
-
     public Rational reciprocal() {
-        return new Rational(denominator, numerator);
+        return Rational.of(denominator, numerator);
     }
 
     public Rational negate() {
+        // ** NOTE: is already reduced, so safe to use constructor
         return new Rational(numerator.negate(), denominator);
     }
 
@@ -298,17 +323,24 @@ public final class Rational implements Comparable<Rational> {
         }
     }
 
+    public BigDecimal toBigDecimal() {
+        return toBigDecimal(MathContext.DECIMAL128); // prevent failures due to repeating fractions
+    }
+
+    @Override
     public double doubleValue() {
         if (denominator.equals(BigInteger.ZERO) && numerator.equals(BigInteger.ZERO)) {
             return Double.NaN;
         }
-        return new BigDecimal(numerator)
-                .divide(new BigDecimal(denominator), MathContext.DECIMAL64)
-                .doubleValue();
+        return toBigDecimal(MathContext.DECIMAL64).doubleValue();
     }
 
-    public BigDecimal toBigDecimal() {
-        return toBigDecimal(MathContext.UNLIMITED);
+    @Override
+    public float floatValue() {
+        if (denominator.equals(BigInteger.ZERO) && numerator.equals(BigInteger.ZERO)) {
+            return Float.NaN;
+        }
+        return toBigDecimal(MathContext.DECIMAL32).floatValue();
     }
 
     public static Rational of(BigDecimal bigDecimal) {
@@ -320,14 +352,20 @@ public final class Rational implements Comparable<Rational> {
         final int scale = bigDecimal.scale();
         final BigInteger unscaled = bigDecimal.unscaledValue();
         if (scale == 0) {
+            // ** NOTE: is already reduced, so safe to use constructor
             return new Rational(unscaled, BigInteger.ONE);
         } else if (scale >= 0) {
-            return new Rational(unscaled, BigDecimal.ONE.movePointRight(scale).toBigInteger());
+            return Rational.of(unscaled, BigDecimal.ONE.movePointRight(scale).toBigInteger());
         } else {
+            // ** NOTE: is already reduced, so safe to use constructor
             return new Rational(
                     unscaled.multiply(BigDecimal.ONE.movePointLeft(scale).toBigInteger()),
                     BigInteger.ONE);
         }
+    }
+
+    public static Rational of(double doubleValue) {
+        return of(new BigDecimal(doubleValue));
     }
 
     public enum FormatStyle {
@@ -495,13 +533,6 @@ public final class Rational implements Comparable<Rational> {
     public Rational abs() {
         return numerator.signum() >= 0 ? this : this.negate();
     }
-
-    static final BigInteger BI_TWO = BigInteger.valueOf(2);
-    static final BigInteger BI_FIVE = BigInteger.valueOf(5);
-    static final BigInteger BI_MINUS_ONE = BigInteger.valueOf(-1);
-
-    static final BigDecimal BD_TWO = BigDecimal.valueOf(2);
-    static final BigDecimal BD_FIVE = BigDecimal.valueOf(5);
 
     /**
      * Goal is to be able to display rationals in a short but exact form, like 1,234,567/3 or
@@ -727,5 +758,19 @@ public final class Rational implements Comparable<Rational> {
 
     public boolean approximatelyEquals(Rational b) {
         return approximatelyEquals(b, EPSILON);
+    }
+
+    public boolean approximatelyEquals(Number b) {
+        return approximatelyEquals(Rational.of(b.doubleValue()), EPSILON);
+    }
+
+    @Override
+    public int intValue() {
+        return toBigDecimal().intValue();
+    }
+
+    @Override
+    public long longValue() {
+        return toBigDecimal().longValue();
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitPreferences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitPreferences.java
@@ -2,19 +2,25 @@ package org.unicode.cldr.util;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import com.ibm.icu.impl.locale.XCldrStub.ImmutableMap;
 import com.ibm.icu.util.Freezable;
+import com.ibm.icu.util.Output;
+import com.ibm.icu.util.ULocale;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import org.unicode.cldr.tool.LikelySubtags;
+import org.unicode.cldr.util.UnitConverter.ConversionInfo;
 
 public class UnitPreferences implements Freezable<UnitPreferences> {
     Map<String, Map<String, Multimap<Set<String>, UnitPreference>>> quantityToUsageToRegionsToInfo =
@@ -93,8 +99,9 @@ public class UnitPreferences implements Freezable<UnitPreferences> {
         Rational newGeq = geq == null || geq.isEmpty() ? Rational.ONE : Rational.of(geq);
         final UnitPreference newUnitPref = new UnitPreference(newGeq, unit, skeleton);
 
-        regionsToInfo.put(
-                ImmutableSet.copyOf(new TreeSet<>(SPLIT_SPACE.splitToList(regions))), newUnitPref);
+        final ImmutableSet<String> regionSet =
+                ImmutableSet.copyOf(new TreeSet<>(SPLIT_SPACE.splitToList(regions)));
+        boolean old = regionsToInfo.put(regionSet, newUnitPref);
     }
 
     boolean frozen;
@@ -195,33 +202,41 @@ public class UnitPreferences implements Freezable<UnitPreferences> {
      *
      * @return
      */
-    public Map<String, Map<String, Map<String, UnitPreference>>> getFastMap(
-            UnitConverter converter) {
-        Map<String, Map<String, Map<String, UnitPreference>>> result = new LinkedHashMap<>();
+    private Map<String, Map<String, Multimap<String, UnitPreference>>> getRawFastMap() {
+        UnitConverter converter = SupplementalDataInfo.getInstance().getUnitConverter();
+        Map<String, Map<String, Multimap<String, UnitPreference>>> result = new LinkedHashMap<>();
         for (Entry<String, Map<String, Multimap<Set<String>, UnitPreference>>> entry1 :
                 quantityToUsageToRegionsToInfo.entrySet()) {
             String quantity = entry1.getKey();
-            Map<String, Map<String, UnitPreference>> result2 = new LinkedHashMap<>();
+            Map<String, Multimap<String, UnitPreference>> result2 = new LinkedHashMap<>();
             result.put(quantity, result2);
 
             for (Entry<String, Multimap<Set<String>, UnitPreference>> entry2 :
                     entry1.getValue().entrySet()) {
                 String usage = entry2.getKey();
-                Map<String, UnitPreference> result3 = new LinkedHashMap<>();
+                Multimap<String, UnitPreference> result3 = LinkedHashMultimap.create();
                 result2.put(usage, result3);
+
+                // split the regions
                 for (Entry<Set<String>, Collection<UnitPreference>> entry :
                         entry2.getValue().asMap().entrySet()) {
                     Set<String> regions = entry.getKey();
+                    int len = entry.getValue().size();
                     for (UnitPreference up : entry.getValue()) {
                         String unit = SPLIT_AND.split(up.unit).iterator().next(); // first unit
                         quantity = converter.getQuantityFromUnit(unit, false);
                         String baseUnit = converter.getBaseUnitFromQuantity(quantity);
-                        Rational geq = converter.parseRational(String.valueOf(up.geq));
-                        Rational value = converter.convert(geq, unit, baseUnit, false);
-                        if (value.equals(Rational.NaN)) {
-                            converter.convert(geq, unit, baseUnit, true); // debug
+                        Rational baseGeq;
+                        if (--len == 0) { // set last value to least possible
+                            baseGeq = Rational.NEGATIVE_INFINITY;
+                        } else {
+                            Rational geq = converter.parseRational(String.valueOf(up.geq));
+                            baseGeq = converter.convert(geq, unit, baseUnit, false);
+                            if (baseGeq.equals(Rational.NaN)) {
+                                converter.convert(geq, unit, baseUnit, true); // debug
+                            }
                         }
-                        UnitPreference up2 = new UnitPreference(value, up.unit, up.skeleton);
+                        UnitPreference up2 = new UnitPreference(baseGeq, up.unit, up.skeleton);
                         for (String region : regions) {
                             result3.put(region, up2);
                         }
@@ -229,10 +244,123 @@ public class UnitPreferences implements Freezable<UnitPreferences> {
                 }
             }
         }
-        return ImmutableMap.copyOf(result);
+        return CldrUtility.protectCollection(result);
+    }
+
+    Supplier<Map<String, Map<String, Multimap<String, UnitPreference>>>>
+            quantityToUsageToRegionToInfo = Suppliers.memoize(() -> getRawFastMap());
+
+    public Map<String, Map<String, Multimap<String, UnitPreference>>> getFastMap() {
+        return quantityToUsageToRegionToInfo.get();
+    }
+
+    public UnitPreference getUnitPreference(
+            Rational sourceAmount, String sourceUnit, String usage, ULocale locale) {
+        UnitConverter converter = SupplementalDataInfo.getInstance().getUnitConverter();
+        sourceUnit = converter.fixDenormalized(sourceUnit);
+
+        String mu = locale.getUnicodeLocaleType("mu");
+        // TODO if the value is not a unit, skip
+        if (mu != null) {
+            Rational conversion = converter.convert(sourceAmount, sourceUnit, mu, false);
+            if (!conversion.equals(Rational.NaN)) { // if we could successfully convert
+                return new UnitPreference(conversion, mu, null);
+            }
+        }
+        String region = resolveRegion(locale);
+
+        return getUnitPreference(sourceAmount, sourceUnit, usage, region);
+    }
+
+    public UnitPreference getUnitPreference(
+            Rational sourceAmount, String sourceUnit, String usage, String region) {
+        UnitConverter converter = SupplementalDataInfo.getInstance().getUnitConverter();
+        String quantity = converter.getQuantityFromUnit(sourceUnit, false);
+
+        Map<String, Multimap<String, UnitPreference>> usageToRegionsToInfo =
+                getFastMap().get(quantity);
+
+        // If there is no quantity among the preferences,
+        // return the metric UnitPreference
+        if (usageToRegionsToInfo == null) {
+            String standardUnit = converter.getStandardUnit(sourceUnit);
+            if (!sourceUnit.equals(standardUnit)) {
+                Rational conversion =
+                        converter.convert(sourceAmount, sourceUnit, standardUnit, false);
+                return new UnitPreference(conversion, standardUnit, null);
+            }
+            return new UnitPreference(sourceAmount, sourceUnit, null);
+        }
+
+        Multimap<String, UnitPreference> regionToInfo = usageToRegionsToInfo.get(usage);
+
+        if (regionToInfo == null) {
+            regionToInfo = usageToRegionsToInfo.get("default");
+        }
+
+        // normalize for matching
+        sourceAmount = sourceAmount.abs();
+        if (sourceAmount.equals(Rational.NaN)) {
+            sourceAmount = Rational.NEGATIVE_ONE;
+        }
+
+        Collection<UnitPreference> infoList = regionToInfo.get(region);
+        if (infoList == null || infoList.isEmpty()) {
+            infoList = regionToInfo.get("001");
+        }
+
+        Output<String> baseUnitOutput = new Output<>();
+        ConversionInfo sourceConversionInfo =
+                converter.parseUnitId(sourceUnit, baseUnitOutput, false);
+        Rational baseValue = sourceConversionInfo.convert(sourceAmount);
+
+        for (UnitPreference info : infoList) { // data is built to always terminate
+            if (baseValue.compareTo(info.geq) >= 0) {
+                return info;
+            }
+        }
+        throw new IllegalArgumentException("Fast map should always terminate");
+    }
+
+    public String resolveRegion(ULocale locale) {
+        // https://unicode.org/reports/tr35/tr35-info.html#Unit_Preferences
+        // en-u-rg-uszzzz-ms-ussystem
+        String ms = locale.getUnicodeLocaleType("ms");
+        if (ms != null) {
+            switch (ms) {
+                case "metric":
+                    return "001";
+                case "uksystem":
+                    return "GB";
+                case "ussystem":
+                    return "US";
+                default:
+                    throw new IllegalArgumentException(
+                            "Illegal ms value in: " + locale.toLanguageTag());
+            }
+        }
+        String rg = locale.getUnicodeLocaleType("rg");
+        if (rg != null) {
+            // TODO: check for illegal rg value
+            return rg.substring(0, 2).toUpperCase(Locale.ROOT);
+        }
+        String region = locale.getCountry();
+        if (!region.isEmpty()) {
+            return region;
+        }
+        LikelySubtags LIKELY = new LikelySubtags();
+        String maximized = LIKELY.maximize(locale.toLanguageTag());
+        if (maximized != null) {
+            return ULocale.getCountry(maximized);
+        }
+        return "001";
     }
 
     public Set<String> getUsages() {
         return usages;
+    }
+
+    public Set<String> getQuantities() {
+        return getFastMap().keySet();
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Units.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Units.java
@@ -109,10 +109,12 @@ public class Units {
     }
 
     public static String getShort(String longUnit) {
-        return LONG_TO_SHORT.get(longUnit);
+        String result = LONG_TO_SHORT.get(longUnit);
+        return result == null ? longUnit : result;
     }
 
     public static String getLong(String shortId) {
-        return LONG_TO_SHORT.inverse().get(shortId);
+        String result = LONG_TO_SHORT.inverse().get(shortId);
+        return result == null ? shortId : result;
     }
 }


### PR DESCRIPTION
CLDR-15954

The main goal was to add tests of test files, for verification. It grew a bit as I discovered and fixed problems.

common/testData/units/unitLocalePreferencesTest.txt
- new test file to check problems in following the spec with locales

common/testData/units/unitPreferencesTest.txt
common/testData/units/unitsTest.txt
- New SPDX id
- Fixed the pointer to generation program.

tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateUnitTestData.java
- addition of 'public void generateUnitLocalePreferences() {' to generate the new test data file
- and some utility methods
- refactoring a bit

tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
- keep the current behavior for which units get grammar.
- needed because of a fix in XXX

tools/cldr-code/src/main/java/org/unicode/cldr/util/Rational.java
- some general cleanup of Rational, for issues noticed in building test data
- Also made Rational inherit from Number.
- NaN was not behaving as expected. Reorganized so that the constructor is simple, and the Rational.of() does more checks
- That also touches add(), subtract(), ... which are made simpler and more robust
- Changed toBigDecimal(), doubleValue() to be cleaner; added floatValue()
- Added utilities of(double), intValue(), longValue(), approximatelyEquals(Number)

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
- the code for getSystemsEnum(String unit) wasn't following the comments, thus getting the wrong answer for some compound units.
- added a format method, factoring out code that needed to be in various places.

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitPreferences.java
- made the fast map be a safe singleton (well, memoized):
    - Supplier<Map<String, Map<String, Multimap<String, UnitPreference>>>> quantityToUsageToRegionToInfo = Suppliers.memoize(() -> getRawFastMap());
- fixed the smallest value to be zero, so that the algorithm to get the preferences didn't have to special-case the least item.
- moved code from test/generation to here for getting unitPreferences
- added API to get all the quantities

tools/cldr-code/src/main/java/org/unicode/cldr/util/Units.java
- fixed get short/long to work for either case, because MeasureUnit may or might not have a prefix.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
- Added Rational tests for NaN, INF
- Added testQuantitiesMissingFromPreferences(), to identify when quantities we don't have in preferences
- Added test of the unitPreferencesTest.txt, unitsTest.txt, and (new) unitLocalePreferencesTest.txt data files
- Also added a testUnitLocalePreferencesTestIcu() so that we could see how ICU was doing without waiting for integration (it is under a flag, so not normally run).


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
