### PR TITLE
CLDR-15954 Update spec for unit preferences

### DIFF
--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -1134,7 +1134,12 @@ while "6 foot 1 inch" has approximately the right accuracy.
 
 ## Testing
 
-The [unitsTest.txt](https://github.com/unicode-org/cldr/blob/main/common/testData/units/unitsTest.txt) file supplies a list of all the CLDR units with conversions, for testing implementations. Instructions for use are supplied in the header of the file.
+The files in the directory [cldr/common/testData/units/](https://github.com/unicode-org/cldr/tree/main/common/testData/units) are provided for testing implementations. 
+1. The [unitsTest.txt](https://github.com/unicode-org/cldr/blob/main/common/testData/units/unitsTest.txt) file supplies a list of all the CLDR units with conversions
+2. The [unitPreferencesTest.txt](https://github.com/unicode-org/cldr/blob/main/common/testData/units/unitPreferencesTest.txt) file supplied tests for user preferences
+3. The [unitLocalePreferencesTest.txt](https://github.com/unicode-org/cldr/blob/main/common/testData/units/unitLocalePreferencesTest.txt) file provides examples for testing the interactions between locale identifiers and unit preferences. 
+
+Instructions for use are supplied in the header of the file.
 
 ## <a name="Unit_Preferences" href="#Unit_Preferences">Unit Preferences</a>
 
@@ -1168,6 +1173,7 @@ If any key-values are invalid, then they are ignored. Thus the following constru
 | -ms-stanford | invalid unit system |
 | -rg-aazzzz | invalid region 'AA' ‡|
 | -AA | invalid region 'AA'|
+
 ‡ Only the region portion is currently used, so in -rg-usabcdef the "abcdef" is ignored, whether or not it is valid.
 
 The following algorithm is used to compute the override units, regions, and category. 

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -1131,10 +1131,14 @@ If a number is negative, then only the highest unit shows the minus sign: eg, "-
 If one of the units is zero, then it is normally omitted: eg, "3 feet" instead of "3 feet 0 inches".
 However, when all of the units would be omitted, then the highest unit is shown with zero: eg "0 feet".
 
-Implementations may offer mechanisms to control the precision of the formatted mixed unit. For example:
-* an implementation could apply the precision of a number formatter to the final unit. 
-* an implementation could allow a percentage precision; 
-thus 1612 meters with ±1% precision would be represented by **1 mile** rather than **1 mile 9 feet**. 
+Implementations may offer mechanisms to control the precision of the formatted mixed unit. Examples include, but are not limited to:
+* An implementation could apply the precision of a number formatter to the final unit.
+  However, this mechanisim has a couple of disadvantages, such as matching precision across user preferences. For example, suppose the input amount is 1.5254 and the precision is 2 decimals.
+    * Locale A uses decimal degrees and gets 1.53°.
+    * Locale B uses degrees, minutes, seconds, and gets 1° 31′ 31.44″
+	* Locale B has an unnecessarily precise result: the equivalent of 1.52540 in precision.
+* An implementation could allow a percentage precision; 
+  thus 1612 meters with ±1% precision would be represented by **1 mile** rather than **1 mile 9 feet**. 
 
 The default behavior is to round the lowest unit to the nearest integer.
 Thus 1.99959 degree-and-arc-minute-and-arc-second would be (before rounding) **1 degree 59 minutes 58.524 seconds**.
@@ -1143,8 +1147,8 @@ After rounding it would be **1 degree 59 minutes 59 seconds**.
 If the lowest unit would round to zero, or round up to the size of the next higher unit, then the next higher unit is rounded instead, recursively.
 Thus 1.999862 degree-and-arc-minute-and-arc-second would be (before rounding) **1 degree 59 minutes 59.5032 degrees**.
 After rounding the last unit it would be **1 degree 59 minutes 60 seconds**, which rounds up to **1 degree 60 minutes**, which rounds up to  **2 degrees**.
-This can be determined before computing the lower units:
-for example, if the remainder in degrees is below 1/120 degrees or above 119/120 degrees, then the degrees can be rounded without computing the minutes. 
+This behavior can be determined before having to compute the lower units:
+for example, where rounding to the second, if the remainder in degrees is below 1/120 degrees or above 119/120 degrees, then the degrees can be rounded without computing the minutes or seconds. 
 
 ## Testing
 

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -1136,7 +1136,7 @@ Implementations may offer mechanisms to control the precision of the formatted m
 * an implementation could allow a percentage precision; 
 thus 1612 meters with ±1% precision would be represented by **1 mile** rather than **1 mile 9 feet**. 
 
-The default behavior is to round the lowest unit to the nearest integer. 
+The default behavior is to round the lowest unit to the nearest integer.
 Thus 1.99959 degree-and-arc-minute-and-arc-second would be (before rounding) **1 degree 59 minutes 58.524 seconds**.
 After rounding it would be **1 degree 59 minutes 59 seconds**. 
 
@@ -1183,7 +1183,7 @@ If any key-values are invalid, then they are ignored. Thus the following constru
 
 | subtags | reason |
 | --- | --- |
-| -me-smoot | invalid unit |
+| -mu-smoot | invalid unit |
 | -ms-stanford | invalid unit system |
 | -rg-aazzzz | invalid region 'AA' ‡|
 | -AA | invalid region 'AA'|
@@ -1221,20 +1221,25 @@ A **category** is determined as follows from the input unit:
 
 1. From the input unit, use the conversion data in [baseUnit](tr35-info.html#Unit_Conversion) and let the **input base unit** be the baseUnit attribute value.
     * eg, for `pound-force` the baseUnit is `kilogram-meter-per-square-second`.
-2. If there is no such base unit (such as for a an unusual unit like `ampere-pound-per-foot-square-minute`), convert the input unit to a combination of base units, reduce to lowest terms, and normalize. Let the **input base unit** be that value.
-    * eg, `ampere-pound-per-foot-square-minute` -> `kilogram-ampere-per-meter-square-second`
+2. If there is no such base unit (such as for a an unusual unit like `ampere-pound-per-foot-square-minute`), 
+   convert the input unit to a combination of base units, reduce to lowest terms, and normalize.
+   Let the **input base unit** be that value.
+       * eg, `ampere-pound-per-foot-square-minute` ⇒ `kilogram-ampere-per-meter-square-second`
 3. If the **input base unit** has a unitQuantity element, then let the **category** be the quantity attribute value.
-    * eg, `force` from `<unitQuantity baseUnit='kilogram-meter-per-square-second' quantity='force'/>`
-3. If the **input base unit** does not have a unitQuantity, let the output unit be the input base unit. An implementation may also set it to an equivalent metric/SI unit, as in the example below. This terminates the algorithm; there is no need to use the unit preferences information.
-	* That is, an implementation can use shorter units as long as long as the combination is equivalent in value.    
-	* For example, for `ampere-pound-per-foot-square-minute` an implementation could return `kilogram-ampere-per-meter-square-second` or `pascal-ampere`.
+       * eg, `force` from `<unitQuantity baseUnit='kilogram-meter-per-square-second' quantity='force'/>`
+4. If the **input base unit** does not have a unitQuantity, let the output unit be the input base unit.
+   An implementation may also set it to an equivalent metric/SI unit, as in the example below.
+   This terminates the algorithm; there is no need to use the unit preferences information.
+      * For example, for `ampere-pound-per-foot-square-minute` an implementation could return `kilogram-ampere-per-meter-square-second` or `pascal-ampere`.
+      * That is, an implementation can use shorter metric/SI units as long as long as the combination is equivalent in value.    
 
 ### <a name="Unit_Preferences_Data" href="#Unit_Preferences_Data">Unit Preferences Data</a>
 
 The CLDR data is intended to map from a particular usage — e.g. measuring the height of a person or the fuel consumption of an automobile — to the unit or combination of units typically used for that usage in a given region. Considerations for such a mapping include:
 
-* The list of possible usages large and open-ended, and will be extended in the future.
-* Even for a given usage such a measuring a road distance, there are multiple ranges in use. For example, one set of units may be used for indicating the distance to the next city (kilometers or miles), while another may be used for indicating the distance to the next exit (meters, yards, or feet).
+* The list of possible usages is large and open-ended, and will be extended in the future.
+* Even for a given usage such a measuring a road distance, there are different choices of units based on the particular distance.
+  For example, one set of units may be used for indicating the distance to the next city (kilometers or miles), while another may be used for indicating the distance to the next exit (meters, yards, or feet).
 * There are also differences between more formal usage (official signage, medical records) and more informal usage (conversation, texting).
 * For some usages, the measurement may be expressed using a sequence of units, such as “1 meter, 78 centimeters” or “12 stone, 2 pounds”.
 
@@ -1255,7 +1260,7 @@ The DTD structure is as follows:
 
 | Term | Description |
 |---|---|
-| category | A unit quantity, such as “area” or “length”. See Unit Conversion |
+| category | A unit quantity, such as “area” or “length”. See [Unit Conversion](#Unit_Conversion) |
 | usage | A type of usage, such as person-height. |
 | regions | One or more region identifiers (macroregions or regions), such as 001, US. (Note that this field may be extended in the future to also include subdivision identifiers and/or language identifiers, such as usca, and de-CH.) |
 | geq | A threshold value, in a unit determined by the unitPreference element value. The unitPreference element is only used for values higher than this value (and lower than any higher value).<br/>The value must be non-negative. For picking negative units (-3 meters), use the absolute value to pick the unit. |
@@ -1383,6 +1388,7 @@ For completeness, when comparing doubles to the geq values:
 <unitPreference regions="US">teaspoon</unitPreference>
 ```
 
+## Unit APIs
 APIs should clearly allow for both the use of unit preferences with the above process, and for the _invariant use_ of a unit measure.
 That is, while an application will usually want to obey the preferences for the locale or in the locale ID, there will definitely be instances where it will want to not use them.
 For example, in showing the weather, an application may want to show:

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -4007,6 +4007,9 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
   * In [Supplemental Currency Data](tr35-numbers.md#Supplemental_Currency_Data), for the `currency` element, added attributes `tz` and `to-tz` to clarify the `from` and `to` dates.
 
 * Part 6: [Supplemental][Supplemental](tr35-info.md#Contents)
+  * In [Mixed Units](tr35-info.html#mixed-units), clarified some aspects of mixed units, such as foot-and-inch. 
+  * In [Testing](tr35-info.html#testing), listed the additional test files.
+  * In [tr35-info.html#Unit_Preferences_Overrides](tr35-info.html#Unit_Preferences_Overrides), added handling of edge cases, such as where there is no quantity for a unit, or no preference data for a quantity. Clarified how to handle invalid subtags, and the usage of each of the subtags that affect unit preferences. 
   * In [Conversion Data](tr35-info.md#conversion-data), added the `special` attribute for `convertUnit`, used for handling beaufort.
 
 * Part 7: [Keyboards]

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -4006,10 +4006,13 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 * Part 3: [Numbers](tr35-numbers.md#Contents)
   * In [Supplemental Currency Data](tr35-numbers.md#Supplemental_Currency_Data), for the `currency` element, added attributes `tz` and `to-tz` to clarify the `from` and `to` dates.
 
-* Part 6: [Supplemental][Supplemental](tr35-info.md#Contents)
-  * In [Mixed Units](tr35-info.html#mixed-units), clarified some aspects of mixed units, such as foot-and-inch. 
+* Part 6: [Supplemental](tr35-info.md#Contents)
+  * In [Mixed Units](tr35-info.html#mixed-units), clarified many aspects of mixed units (such as foot-and-inch), 
+    including how to handle rounding and precision. 
   * In [Testing](tr35-info.html#testing), listed the additional test files.
-  * In [tr35-info.html#Unit_Preferences_Overrides](tr35-info.html#Unit_Preferences_Overrides), added handling of edge cases, such as where there is no quantity for a unit, or no preference data for a quantity. Clarified how to handle invalid subtags, and the usage of each of the subtags that affect unit preferences. 
+  * In [Unit Preferences Overrides](tr35-info.html#Unit_Preferences_Overrides), added handling of edge cases,
+    such as where there is no quantity for a unit, or no preference data for a quantity.
+    Also clarified how to handle invalid subtags, and the usage of each of the subtags that affect unit preferences. 
   * In [Conversion Data](tr35-info.md#conversion-data), added the `special` attribute for `convertUnit`, used for handling beaufort.
 
 * Part 7: [Keyboards]


### PR DESCRIPTION
CLDR-15954

Clarify the algorithm for unit preferences to catch edge cases.

1. What to do with unitpreferences if there is no quantity for a unit, or no preferences for a quantity. Emphasizes the use of likelysubtags. It more explicit about edge cases when comparing input values to geq values (negative numbers, infinity, NaN). Provides more of a step-by-step approach to handling the subtags that have an impact (no change in effect, but much clearer). Moves examples to better places.
2. Edge cases (but important ones) for mixed units: handling negatives and rounding. One change is to be less prescriptive about the way that precision is handled, giving us a chance to work that our more in the future (because the current advice really doesn't work well.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
4. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
