### PR TITLE
CLDR-17403 Fix typo, add examples

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2131,7 +2131,13 @@ There are related types of data and processing that are easy to confuse:
 <tr><th rowspan="4">LikelySubtags</th>
     <td colspan="2">Provides most likely full subtag (script and region) in the absence of other information. A core component of LocaleMatching.</td></tr>
         <tr><td><i>Example:</i></td>
-            <td>addLikelySubtags(zh) ⇒ zh-Hans-CN<br/>addLikelySubtags(zh-TW) ⇒ zh-Hant-TW<br/>minimize(zh-Hans, favorRegion) ⇒ zh-TW</td></tr>
+            <td>addLikelySubtags(zh) ⇒ zh-Hans-CN<br/>
+				addLikelySubtags(zh-TW) ⇒ zh-Hant-TW<br/>
+				addLikelySubtags(zh-Hant) ⇒ zh-Hant-TW<br/>
+				minimize(zh-Hans-CN, favorRegion|favorScript) ⇒ zh<br/>
+				minimize(zh-Hant-TW, favorRegion) ⇒ zh-TW<br/>
+				minimize(zh-Hant-TW, favorScript) ⇒ zh-Hant
+			</td></tr>
         <tr><td><i>Data:</i></td>
             <td>likelySubtags.xml &lt;likelySubtags&gt;</td></tr>
         <tr><td><i>Spec:</i></td>


### PR DESCRIPTION
CLDR-17403

Note that the previous version had "minimize(zh-Hans, favorRegion) ⇒ zh-TW", which clearly needs "Hant" instead of "Hans".

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
