### PR TITLE
CLDR-16998 Fix Formatting

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -3805,9 +3805,10 @@ _Example:_
 
 > source="ja-Latn-fonipa-hepburn-heploc"
 >
-> rule  =`\<languageAlias type="und-hepburn-heploc" replacement="und-alalc97">`
+> rule  =`<languageAlias type="und-hepburn-heploc" replacement="und-alalc97">`
 >
 > result="ja-Latn-alalc97-fonipa"
+>
 > (note that CLDR canonical order of variants is alphabetical)
 
 ##### Territory Exception

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1661,9 +1661,9 @@ __Lateral Inheritance__ is where resources are inherited from within the same lo
 
 | Element @Attribute          | Source | Context |
 | ---------------- | ------ | ------- |
-| currency @pattern | currencyFormat   | numberSystem = defaultNumberingSystem, unless otherwise specified*<br/>currencyFormatLength type=none, unless otherwise specified<br/>currencyFormat type="standard", unless otherwise specified |
-| currency @decimal | symbols @decimal  | numberSystem = defaultNumberingSystem, unless otherwise specified |
-| currency @group   | symbols @group    | numberSystem = defaultNumberingSystem, unless otherwise specified |
+| `currency` `@pattern` | `currencyFormat`   | `numberSystem` = `defaultNumberingSystem`, unless otherwise specified*<br/>`currencyFormatLength` type=none, unless otherwise specified<br/>`currencyFormat` `type="standard"`, unless otherwise specified |
+| `currency` `@decimal` | `symbols` `@decimal`  | `numberSystem` = `defaultNumberingSystem`, unless otherwise specified |
+| `currency` `@group`   | `symbols` `@group`    | `numberSystem` = `defaultNumberingSystem`, unless otherwise specified |
 
 >\* The "unless otherwise specified" clause is for when an API or other context indicates a different choice, such as currencyFormat type="accounting".
 
@@ -1673,11 +1673,11 @@ The following attributes use lateral inheritance for **all elements** with the D
 
 | Attribute  | Fallback                               | Exception Elements          |
 | ---------- | -------------------------------------- | --------------------------- |
-| alt        | __no alt attribute__                   | _none_                      |
-| case       | "nominative" → ∅                       | caseMinimalPairs            |
-| gender     | default_gender(locale) → ∅             | genderMinimalPairs          |
-| count      | plural_rules(locale, x) → "other" → ∅  | minDays, pluralMinimalPairs |
-| ordinal    | plural_rules(locale, x) → "other" → ∅  | ordinalMinimalPairs         |
+| `alt`        | __no alt attribute__                   | _none_                      |
+| `case`       | "nominative" → ∅                       | `caseMinimalPairs`            |
+| `gender`     | default_gender(locale) → ∅             | `genderMinimalPairs`          |
+| `count`      | plural_rules(locale, x) → "other" → ∅  | `minDays`, `pluralMinimalPairs` |
+| `ordinal`    | plural_rules(locale, x) → "other" → ∅  | `ordinalMinimalPairs`         |
 
 The gender fallback is to neuter if the locale has a neuter gender, otherwise masculine. This may be extended in the future if necessary. See also [Part 2, Grammatical Features](tr35-general.md#Grammatical_Features).
 
@@ -3803,13 +3803,12 @@ A matching rule can be used to transform the source fields as follows
 
 _Example:_
 
-> source=ja-Latn-fonipa-hepburn-heploc
+> source="ja-Latn-fonipa-hepburn-heploc"
 >
-> rule  ="\<languageAlias type="und-hepburn-heploc"
+> rule  =`\<languageAlias type="und-hepburn-heploc" replacement="und-alalc97">`
 >
-> replacement="und-alalc97">"
->
-> result="ja-Latn-alalc97-fonipa" // note that CLDR canonical order of variants is alphabetical
+> result="ja-Latn-alalc97-fonipa"
+> (note that CLDR canonical order of variants is alphabetical)
 
 ##### Territory Exception
 


### PR DESCRIPTION
CLDR-16998

Took the suggestion to use monospacing in two of the suggested sections. The https://unicode.org/reports/tr35/#Key_And_Type_Definitions_ was more complicated, and would benefit less so that wasn't done.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
