### PR TITLE
CLDR-16900 Limit frequency of announce and completion requests

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSchedule.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSchedule.mjs
@@ -1,0 +1,67 @@
+/*
+ * cldrSchedule: for Survey Tool scheduling of http requests.
+ */
+
+export class FetchSchedule {
+  /**
+   * Construct a new FetchSchedule object
+   *
+   * @param {String} description description or name of caller
+   * @param {Number} refreshSeconds postpone requests until this many seconds have elapsed since last request/response
+   * @param {Boolean} debug whether to log debugging info to console
+   * @returns the new FetchSchedule object
+   */
+  constructor(description, refreshSeconds, debug) {
+    this.description = description;
+    this.refreshMillis = refreshSeconds * 1000;
+    this.debug = debug;
+    this.lastRequestTime = this.lastResponseTime = 0;
+  }
+
+  setRequestTime() {
+    this.lastRequestTime = Date.now();
+    if (this.debug) {
+      console.log(
+        this.description + " set lastRequestTime = " + this.lastRequestTime
+      );
+    }
+  }
+
+  setResponseTime() {
+    this.lastResponseTime = Date.now();
+    if (this.debug) {
+      console.log(
+        this.description + " set lastResponseTime = " + this.lastResponseTime
+      );
+    }
+  }
+
+  /**
+   * Is it too soon to make a request?
+   *
+   * @returns true if it is too soon, else false
+   */
+  tooSoon() {
+    const now = Date.now();
+    if (
+      now < this.lastResponseTime + this.refreshMillis ||
+      now < this.lastRequestTime + this.refreshMillis
+    ) {
+      if (this.debug) {
+        console.log(
+          this.description +
+            " postponing request: less than " +
+            this.refreshMillis / 1000 +
+            " seconds elapsed; now = " +
+            now
+        );
+      }
+      return true;
+    } else {
+      if (this.debug) {
+        console.log(this.description + " will make a request; now = " + now);
+      }
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
-This PR only changes the front end

-New module cldrSchedule with class FetchSchedule used by both cldrAnnounce and cldrProgress

-Old code in cldrProgress mistakenly had && for condition on time since last request/response

-New code in cldrSchedule has || instead of &&

CLDR-16900

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
