### PR TITLE
CLDR-17481 re-enable directly loading Test.html

### DIFF
--- a/tools/cldr-apps/js/package.json
+++ b/tools/cldr-apps/js/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build-test": "webpack --config webpack-test.config.js",
+    "watch-test": "npm run build-test -- --watch",
     "test": "npm run nonbrowser-test && npm run browser-test",
     "nonbrowser-test": "mocha --reporter spec test/nonbrowser/test-*.mjs",
     "browser-test": "npm run build-test && mocha-headless-chrome -f test/Test.html",

--- a/tools/cldr-apps/js/test/Test.html
+++ b/tools/cldr-apps/js/test/Test.html
@@ -16,17 +16,14 @@
       "
     >
       <h1>CLDR SurveyTool JavaScript Tests</h1>
-      <script>
-        if (location.protocol === "file:") {
-          document.write(
-            "<h1>Error</h1><p>The protocol should be <b>html:</b>, not <b>file:</b><br />A server is required; see <b>run.sh</b></p>"
-          );
-        }
-      </script>
-      <p>
-        <em>Important:</em> run with run.sh; open the browser console to check
+      <ul>
+        <li>in the 'js' directory, run <code>npm i</code> to install</li>
+        <li>To rebuild, run <code>npm run build-test</code></li>
+        <li>If you want to continuously compile, keep <code>npm run watch-test</code> (control-C to cancel)</li>
+        <li>open the browser console to check
         for errors/warnings that are otherwise invisible!
-      </p>
+        </li>
+      </ul>
       <p><em>References:</em></p>
       <ul>
         <li>

--- a/tools/cldr-apps/js/test/Test.html
+++ b/tools/cldr-apps/js/test/Test.html
@@ -43,7 +43,7 @@
       </ul>
     </div>
     <div id="mocha" style="margin-top: 12pt"></div>
-    <script src="https://unpkg.com/chai/chai.js"></script>
+    <script src="https://unpkg.com/chai@4.3.6/chai.js"></script>
     <script src="https://unpkg.com/mocha/mocha.js"></script>
     <script class="mocha-init">
       mocha.setup("bdd");

--- a/tools/cldr-apps/js/test/run.sh
+++ b/tools/cldr-apps/js/test/run.sh
@@ -1,8 +1,0 @@
-
-# This needs to be run from the cldr folder
-# Optionally, to run this as cldrtestjs, you may have in .bash_profile:
-# alias cldrtestjs='cd [path/to/cldr] && sh tools/cldr-apps/js-unittest/run.sh'
-cd tools/cldr-apps/js
-npm run build-test
-cd ../../..
-npx http-server -p 8008 -o tools/cldr-apps/js/test/Test.html

--- a/tools/cldr-apps/js/test/run.sh
+++ b/tools/cldr-apps/js/test/run.sh
@@ -1,9 +1,8 @@
 
 # This needs to be run from the cldr folder
-# "http-server" can be installed by "npm install --global http-server"
 # Optionally, to run this as cldrtestjs, you may have in .bash_profile:
 # alias cldrtestjs='cd [path/to/cldr] && sh tools/cldr-apps/js-unittest/run.sh'
 cd tools/cldr-apps/js
 npm run build-test
 cd ../../..
-http-server -p 8008 -o tools/cldr-apps/js/test/Test.html
+npx http-server -p 8008 -o tools/cldr-apps/js/test/Test.html


### PR DESCRIPTION
CLDR-17481

- [X] This PR completes the ticket.
- run.sh not needed. Just npm run install build-test and then load Test.html

ALLOW_MANY_COMMITS=true
