### PR TITLE
CLDR-17467 kbd: disallow empty match

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2300,6 +2300,10 @@ The following are additions to standard Regex syntax.
 
 #### Disallowed Regex Features
 
+- **Matching an empty string**
+
+    Transforms may not match an empty string. For example, `<transform from=""/>` or `<transform from="X{0,1}"/>` are not allowed and must be flagged as an error to keyboard authors.
+
 - **Unicode properties**
 
     `\p{property}` `\P{property}`


### PR DESCRIPTION
CLDR-17467

- disallow empty matches in transform, such as `<transform from=""/>`

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
