### PR TITLE
CLDR-16900 Fix bugs in the previous PR

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSchedule.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSchedule.mjs
@@ -36,6 +36,10 @@ export class FetchSchedule {
     }
   }
 
+  reset() {
+    this.lastRequestTime = this.lastResponseTime = 0;
+  }
+
   /**
    * Is it too soon to make a request?
    *
@@ -44,8 +48,9 @@ export class FetchSchedule {
   tooSoon() {
     const now = Date.now();
     if (
-      now < this.lastResponseTime + this.refreshMillis ||
-      now < this.lastRequestTime + this.refreshMillis
+      this.lastRequestTime &&
+      (now < this.lastResponseTime + this.refreshMillis ||
+        now < this.lastRequestTime + this.refreshMillis)
     ) {
       if (this.debug) {
         console.log(


### PR DESCRIPTION
-Check whether user is logged in before calling schedule.tooSoon

-When the Announcements page gets opened, fetch immediately, since previous fetch only set unread count

-New method cldrSchedule.reset facilitates immediate re-fetch

-In cldrSchedule.tooSoon return false if this.lastRequestTime is zero (reset or not yet set)

-Comments

CLDR-16900

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
