### PR TITLE
CLDR-17490 XCG transition is in 2025, not 2024

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -363,8 +363,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="PTE" from="1911-05-22" to="1975-07-05"/>
         </region>
         <region iso3166="CW">
-            <currency iso4217="XCG" from="2024-03-31" tz="America/Curacao"/>
-            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30" to-tz="America/Curacao"/>
+            <currency iso4217="XCG" from="2025-03-31" tz="America/Curacao"/>
+            <currency iso4217="ANG" from="2010-10-10" to="2025-06-30" to-tz="America/Curacao"/>
         </region>
         <region iso3166="CX">
             <currency iso4217="AUD" from="1966-02-14"/>
@@ -996,8 +996,8 @@ The printed version of ISO-4217:2001
             <currency iso4217="SVC" from="1919-11-11" to="2001-01-01"/>
         </region>
         <region iso3166="SX">
-            <currency iso4217="XCG" from="2024-03-31" tz="America/Lower_Princes"/>
-            <currency iso4217="ANG" from="2010-10-10" to="2024-06-30" to-tz="America/Lower_Princes"/>
+            <currency iso4217="XCG" from="2025-03-31" tz="America/Lower_Princes"/>
+            <currency iso4217="ANG" from="2010-10-10" to="2025-06-30" to-tz="America/Lower_Princes"/>
         </region>
         <region iso3166="SY">
             <currency iso4217="SYP" from="1948-01-01"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLevel.java
@@ -98,6 +98,9 @@ public class TestLevel {
         final Level expect = Level.MODERN;
         assertTrue(
                 expect.isAtLeast(l),
-                () -> String.format("cov for %s is %s expected ≤ %s", code, l, expect));
+                () ->
+                        String.format(
+                                "Coverage for modern currency %s: %s, expected ≤ %s",
+                                code, l, expect));
     }
 }


### PR DESCRIPTION
- Latest amendment: https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-176.pdf
- PR #3471 had the dates in 2024

CLDR-17490

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
