### PR TITLE
CLDR-16900 Shorten server response if unchanged; bug fix, refactor

### DIFF
--- a/tools/cldr-apps/js/src/views/AnnouncePanel.vue
+++ b/tools/cldr-apps/js/src/views/AnnouncePanel.vue
@@ -83,7 +83,8 @@ export default {
   created() {
     this.canAnnounce = cldrAnnounce.canAnnounce();
     this.canChooseAllOrgs = cldrAnnounce.canChooseAllOrgs();
-    cldrAnnounce.refresh(this.setData);
+    cldrAnnounce.resetSchedule();
+    cldrAnnounce.refresh(this.setData, this.setCounts);
   },
 
   methods: {
@@ -92,24 +93,16 @@ export default {
         this.pleaseLogIn = true;
       } else {
         this.announcementData = data;
-        this.updateCounts();
       }
+    },
+
+    setCounts(unreadCount, totalCount) {
+      this.unreadCount = unreadCount;
+      this.totalCount = totalCount;
     },
 
     checkmarkChanged(event, announcement) {
       cldrAnnounce.saveCheckmark(event.target.checked, announcement);
-      this.updateCounts();
-    },
-
-    updateCounts() {
-      this.totalCount = this.announcementData.announcements.length;
-      let checkedCount = 0;
-      for (let announcement of this.announcementData.announcements) {
-        if (announcement.checked) {
-          ++checkedCount;
-        }
-      }
-      this.unreadCount = this.totalCount - checkedCount;
     },
 
     startCompose() {
@@ -137,7 +130,7 @@ export default {
           message: "Your announcement was not posted: " + errMessage,
         });
       }
-      cldrAnnounce.refresh(this.setData);
+      cldrAnnounce.refresh(this.setData, this.setCounts);
     },
   },
 };

--- a/tools/cldr-apps/js/test/Test.html
+++ b/tools/cldr-apps/js/test/Test.html
@@ -19,9 +19,13 @@
       <ul>
         <li>in the 'js' directory, run <code>npm i</code> to install</li>
         <li>To rebuild, run <code>npm run build-test</code></li>
-        <li>If you want to continuously compile, keep <code>npm run watch-test</code> (control-C to cancel)</li>
-        <li>open the browser console to check
-        for errors/warnings that are otherwise invisible!
+        <li>
+          If you want to continuously compile, keep
+          <code>npm run watch-test</code> (control-C to cancel)
+        </li>
+        <li>
+          open the browser console to check for errors/warnings that are
+          otherwise invisible!
         </li>
       </ul>
       <p><em>References:</em></p>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
@@ -59,7 +59,12 @@ public class Announcements {
                                         mediaType = "application/json",
                                         schema = @Schema(implementation = STError.class))),
             })
-    public Response getAnnouncements(@HeaderParam(Auth.SESSION_HEADER) String sessionString) {
+    public Response getAnnouncements(
+            @HeaderParam(Auth.SESSION_HEADER) String sessionString,
+            @QueryParam("alreadyGotId")
+                    @Schema(description = "The client already got this announcement ID")
+                    @DefaultValue("0")
+                    int alreadyGotId) {
         CookieSession session = Auth.getSession(sessionString);
         if (session == null) {
             return Auth.noSessionResponse();
@@ -70,6 +75,9 @@ public class Announcements {
         session.userDidAction();
         if (SurveyMain.isBusted() || !SurveyMain.wasInitCalled() || !SurveyMain.triedToStartUp()) {
             return STError.surveyNotQuiteReady();
+        }
+        if (alreadyGotId != 0 && alreadyGotId == AnnouncementData.getMostRecentAnnouncementId()) {
+            return Response.notModified().build();
         }
         AnnouncementResponse response = new AnnouncementResponse(session.user);
         return Response.ok(response).build();


### PR DESCRIPTION
-Refactor (encapsulate) to calculate unread/total counts in only one place; new callbackSetCounts

-On front end, remember the last announcement ID fetched (alreadyGotId)

-On back end, respond with 304 Not Modified if alreadyGotId matches

-Do not report 304 Not Modified response as error; log it to console only if debugging enabled

-New front-end method resetSchedule prevents delay and prevents 304 response

-Format Test.html (not specific to this ticket; unrelated PR left it unformatted)

-Comments

CLDR-16900

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
