### PR TITLE
CLDR-16900 Avoid 304 Not Modified; instead use boolean json.unchanged

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAnnounce.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAnnounce.mjs
@@ -82,23 +82,15 @@ async function refresh(viewCallbackSetData, viewCallbackSetCounts) {
     .then(cldrAjax.handleFetchErrors)
     .then((r) => r.json())
     .then(setPosts)
-    .catch(handleErrorOrNotModified);
-}
-
-function handleErrorOrNotModified(e) {
-  if (e.message === "Not Modified") {
-    // 304
-    if (CLDR_ANNOUNCE_DEBUG) {
-      console.log("cldrAnnounce got " + e.message);
-    }
-  } else {
-    console.error(e);
-  }
+    .catch(console.error);
 }
 
 function setPosts(json) {
-  thePosts = json;
   schedule.setResponseTime();
+  if (json.unchanged) {
+    return;
+  }
+  thePosts = json;
   setAlreadyGotId(thePosts);
   const totalCount = thePosts.announcements?.length || 0;
   let checkedCount = 0;

--- a/tools/cldr-apps/js/test/run.sh
+++ b/tools/cldr-apps/js/test/run.sh
@@ -1,0 +1,8 @@
+# This needs to be run from the cldr folder
+# Optionally, to run this as cldrtestjs, you may have in .bash_profile:
+# alias cldrtestjs='cd [path/to/cldr] && sh tools/cldr-apps/js-unittest/run.sh'
+cd tools/cldr-apps/js
+npm install
+npm run build-test
+cd ../../..
+npx open-cli tools/cldr-apps/js/test/Test.html

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
@@ -76,22 +76,29 @@ public class Announcements {
         if (SurveyMain.isBusted() || !SurveyMain.wasInitCalled() || !SurveyMain.triedToStartUp()) {
             return STError.surveyNotQuiteReady();
         }
-        if (alreadyGotId != 0 && alreadyGotId == AnnouncementData.getMostRecentAnnouncementId()) {
-            return Response.notModified().build();
-        }
-        AnnouncementResponse response = new AnnouncementResponse(session.user);
+        Boolean unchanged =
+                (alreadyGotId != 0
+                        && alreadyGotId == AnnouncementData.getMostRecentAnnouncementId());
+        AnnouncementResponse response = new AnnouncementResponse(session.user, unchanged);
         return Response.ok(response).build();
     }
 
     @Schema(description = "List of announcements")
     public static final class AnnouncementResponse {
+        @Schema(description = "unchanged")
+        public boolean unchanged;
+
         @Schema(description = "announcements")
         public Announcement[] announcements;
 
-        public AnnouncementResponse(UserRegistry.User user) {
-            List<Announcement> announcementList = new ArrayList<>();
-            AnnouncementData.get(user, announcementList);
-            announcements = announcementList.toArray(new Announcement[0]);
+        public AnnouncementResponse(UserRegistry.User user, Boolean unchanged) {
+            this.unchanged = unchanged;
+
+            if (!unchanged) {
+                List<Announcement> announcementList = new ArrayList<>();
+                AnnouncementData.get(user, announcementList);
+                announcements = announcementList.toArray(new Announcement[0]);
+            }
         }
     }
 


### PR DESCRIPTION
-Standard usage of 304 would involve adding headers and getting cached json from browser; this is more efficient

-Also restore and revise tools/cldr-apps/js/test/run.sh for convenience (CLDR-17481)

CLDR-16900

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
