### PR TITLE
CLDR-16034 Check for pairing bidi markup chars (illegal); remove 2 (unpaired) RLO in ff_Adlm

### DIFF
--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -716,7 +716,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="BS">𞤄𞤢𞤸𞤢𞤥𞤢𞥄𞤧</territory>
 			<territory type="BT">𞤄𞤵𞥅𞤼𞤢𞥄𞤲</territory>
 			<territory type="BV">𞤅𞤵𞤪𞤭𞥅𞤪𞤫 𞤄𞤵𞥅𞤾𞤫𞥅</territory>
-			<territory type="BW">‮𞤄𞤮𞤼𞤧𞤵𞤱𞤢𞥄𞤲𞤢</territory>
+			<territory type="BW">𞤄𞤮𞤼𞤧𞤵𞤱𞤢𞥄𞤲𞤢</territory>
 			<territory type="BY">𞤄𞤫𞤤𞤢𞤪𞤵𞥅𞤧</territory>
 			<territory type="BZ">𞤄𞤫𞤤𞤭𞥅𞥁</territory>
 			<territory type="CA">𞤑𞤢𞤲𞤢𞤣𞤢𞥄</territory>
@@ -8603,7 +8603,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>𞤐𞤵𞥅𞤳</exemplarCity>
 			</zone>
 			<zone type="America/Scoresbysund">
-				<exemplarCity>‮𞤋𞤼𞥆𞤮𞤳𞤮𞤪𞤼𞤮𞥅𞤪𞤥𞤭𞥅𞤼</exemplarCity>
+				<exemplarCity>𞤋𞤼𞥆𞤮𞤳𞤮𞤪𞤼𞤮𞥅𞤪𞤥𞤭𞥅𞤼</exemplarCity>
 			</zone>
 			<zone type="America/Danmarkshavn">
 				<exemplarCity>𞤁𞤢𞥄𞤲𞤥𞤢𞤪𞤳𞥃𞤢𞥄𞤾𞤲</exemplarCity>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -902,7 +902,8 @@ public abstract class CheckCLDR implements CheckAccessor {
             namePlaceholderProblem,
             missingSpaceBetweenNameFields,
             illegalParameterValue,
-            illegalAnnotationCode;
+            illegalAnnotationCode,
+            illegalCharacter;
 
             @Override
             public String toString() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -51,8 +51,10 @@ import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 
 public class CheckForExemplars extends FactoryCheckCLDR {
-    private static final UnicodeSet RTL_CONTROLS =
-            new UnicodeSet("[\\u061C\\u200E\\u200F\\u202A-\\u202D\\u2066-\\u2069]");
+    private static final UnicodeSet RTL_CONTROLS = new UnicodeSet("[\\u061C\\u200E\\u200F]");
+
+    private static final UnicodeSet ILLEGAL_RTL_CONTROLS =
+            new UnicodeSet("[\\u202A-\\u202E\\u2066-\\u2069]");
 
     private static final UnicodeSet RTL = new UnicodeSet("[[:bc=AL:][:bc=R:]]");
 
@@ -318,6 +320,9 @@ public class CheckForExemplars extends FactoryCheckCLDR {
             // if (path.indexOf("/calendar") >= 0 && path.indexOf("gregorian") <= 0) return this;
         }
 
+        // Check all paths for illegal characters, even EXEMPLAR_SKIPS
+        checkIllegalCharacters(path, value, result);
+
         if (containsPart(path, EXEMPLAR_SKIPS)) {
             return this;
         }
@@ -566,6 +571,20 @@ public class CheckForExemplars extends FactoryCheckCLDR {
         // .setMessage("This item must not contain two space characters in a row."));
         // }
         return this;
+    }
+
+    // Check for characters that are always illegal in values.
+    // Currently those are just the paired bidi marks.
+    private void checkIllegalCharacters(String path, String value, List<CheckStatus> result) {
+        if (ILLEGAL_RTL_CONTROLS.containsSome(value)) {
+            result.add(
+                    new CheckStatus()
+                            .setCause(this)
+                            .setMainType(CheckStatus.errorType)
+                            .setSubtype(Subtype.illegalCharacter)
+                            .setMessage(
+                                    "Bidi markup can only include LRM RLM ALM, not paired characters such as FSI PDI"));
+        }
     }
 
     private String checkAndReplacePlaceholders(


### PR DESCRIPTION
CLDR-16034

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16034)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add test to check for bidi markup chars that are intended to be used in pairs; these are illegal in CLDR values )only LRM, RLM, ALM are ok). Then run test to find any issues; remove two (unpaired) RLO in ff_Adlm.xml

ALLOW_MANY_COMMITS=true
