### PR TITLE
CLDR-17482 Fix million compact number issue in Italian

### DIFF
--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -5274,11 +5274,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000" count="one">↑↑↑</pattern>
 					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 Mio</pattern>
+					<pattern type="1000000" count="other">0 Mln</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 Mio</pattern>
+					<pattern type="10000000" count="other">00 Mln</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 Mio</pattern>
+					<pattern type="100000000" count="other">000 Mln</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000" count="other">0 Mrd</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
@@ -5328,11 +5328,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000" count="one">↑↑↑</pattern>
 					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 Mio ¤</pattern>
+					<pattern type="1000000" count="other">0 Mln ¤</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 Mio ¤</pattern>
+					<pattern type="10000000" count="other">00 Mln ¤</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 Mio ¤</pattern>
+					<pattern type="100000000" count="other">000 Mln ¤</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000" count="other">0 Mrd ¤</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>


### PR DESCRIPTION
CLDR-17482

Revert 'Mio' to 'Mln' in Italian compact numbers

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
