### PR TITLE
CLDR-17341 v45: kbd spec: editorial improvements

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -243,7 +243,7 @@ Keyboard implementations will typically consist of two parts:
 
 **Keyboard layout:** A layout is the overall keyboard configuration for a particular locale. Within a keyboard layout, there is a single base map, one or more key maps and zero or more transforms.
 
-**Layer** is an arrangement of keys on a touch keyboard. A touch keyboard is made up of a set of layers. Each layer may have a different key layout, unlike with a hardware keyboard, and may not correspond directly to a hardware keyboard's modifier keys. A layer is accessed via a switch key. See also touch keyboard, modifier, switch.
+**Layer** is an arrangement of keys on a touch keyboard. A touch keyboard is made up of a set of layers. Each layer may have a different key layout, unlike with a hardware keyboard, and may not correspond directly to a hardware keyboard's modifier keys. A layer is accessed via a layer-switching key. See also touch keyboard and modifier.
 
 **Long-press key:** also known as a “child key”. A secondary key that is invoked from a top level key on a touch keyboard. Secondary keys typically provide access to variants of the top level key, such as accented variants (a => á, à, ä, ã)
 
@@ -1031,11 +1031,11 @@ _Attribute:_ `output` (optional)
 > The `output` attribute may also contain the `\m{…}` syntax to reference a marker. See [Markers](#markers). Implementations may highlight a displayed marker, such as with a lighter text color, or a yellow highlight.
 > String variables may be substituted. See [String variables](#element-string)
 
-_Attribute:_ `id` (optional)
+_Attribute:_ `keyId` (optional)
 
 > Specifies the `key` id. This is useful for keys which do not produce any output (no `output=` value), such as a shift key.
 >
-> This attribute must match `[A-Za-z0-9][A-Za-z0-9-]*`
+> Must match `[A-Za-z0-9][A-Za-z0-9_-]*`
 
 _Attribute:_ `display` (required)
 
@@ -1472,6 +1472,9 @@ _Attribute:_ `id` (required)
 
 > This attribute specifies the form id. The value may not be `touch`.
 
+> Must match `[A-Za-z0-9][A-Za-z0-9_-]*`
+
+
 ***Syntax***
 
 ```xml
@@ -1604,10 +1607,10 @@ A `layer` element describes the configuration of keys on a particular layer of a
 
 _Attribute_ `id` (required for `touch`)
 
-> The `id` attribute identifies the layer for touch layouts.  This identifier specifies the layout as the target for layer switching, as specified by the `switch=` attribute on the [`<key>`](#element-key) element.
+> The `id` attribute identifies the layer for touch layouts.  This identifier specifies the layout as the target for layer switching, as specified by the `layerId=` attribute on the [`<key>`](#element-key) element.
 > Touch layouts must have one `layer` with `id="base"` to serve as the base layer.
 >
-> Must match `[A-Za-z0-9][A-Za-z0-9-]*`
+> Must match `[A-Za-z0-9][A-Za-z0-9_-]*`
 
 _Attribute:_ `modifiers` (required for `hardware`)
 

--- a/keyboards/dtd/ldmlKeyboard3.dtd
+++ b/keyboards/dtd/ldmlKeyboard3.dtd
@@ -124,7 +124,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT form ( scanCodes+, special* ) >
 <!ATTLIST form id NMTOKEN #IMPLIED >
-    <!--@MATCH:any-->
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9_-]*-->
 
 <!ELEMENT scanCodes EMPTY >
 <!ATTLIST scanCodes codes NMTOKENS #REQUIRED >
@@ -133,13 +133,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT layers ( import*, layer*, special* ) >
 <!ATTLIST layers formId NMTOKEN #REQUIRED >
-    <!--@MATCH:any-->
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9_-]*-->
 <!ATTLIST layers minDeviceWidth CDATA #IMPLIED >
     <!--@MATCH:range/1~999-->
 
 <!ELEMENT layer ( row+, special* ) >
 <!ATTLIST layer id NMTOKEN #IMPLIED >
-    <!--@MATCH:any-->
+    <!--@MATCH:regex/[A-Za-z0-9][A-Za-z0-9_-]*-->
 <!ATTLIST layer modifiers NMTOKENS #IMPLIED >
     <!--@MATCH:regex/(none|([A-Za-z0-9]+)( [A-Za-z0-9]+)*)-->
 


### PR DESCRIPTION
thanks @miloush for the feedback.

- 16. Remove reference to 'switch'.  Fix reference to `id` that should have been `keyId`.

- 17. layer and form id should include underscore. Fixed, also updated layerId and formId which reference them.   `form/@id`, `layer/@formId`, `layer/@id` all have updated regex in dtd.  Add support for underscore in the id.

CLDR-17341


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
