### PR TITLE
CLDR-17424 MFv2 spec: link fix, style improvement

### DIFF
--- a/docs/ldml/tr35-messageFormat.md
+++ b/docs/ldml/tr35-messageFormat.md
@@ -113,14 +113,14 @@ The LDML specification is divided into the following parts:
       * [The `:number` function](#the-number-function)
         * [Operands](#operands)
         * [Options](#options)
-          * [Default Value of `select` Option](#default-value-of-select-option)
-          * [Percent Style](#percent-style)
+        * [Default Value of `select` Option](#default-value-of-select-option)
+        * [Percent Style](#percent-style)
         * [Selection](#selection)
       * [The `:integer` function](#the-integer-function)
         * [Operands](#operands)
         * [Options](#options)
-          * [Default Value of `select` Option](#default-value-of-select-option)
-          * [Percent Style](#percent-style)
+        * [Default Value of `select` Option](#default-value-of-select-option)
+        * [Percent Style](#percent-style)
         * [Selection](#selection)
       * [Number Operands](#number-operands)
       * [Digit Size Options](#digit-size-options)
@@ -131,8 +131,6 @@ The LDML specification is divided into the following parts:
       * [The `:datetime` function](#the-datetime-function)
         * [Operands](#operands)
         * [Options](#options)
-          * [Style Options](#style-options)
-          * [Field Options](#field-options)
       * [The `:date` function](#the-date-function)
         * [Operands](#operands)
         * [Options](#options)
@@ -374,7 +372,7 @@ This part of the MessageFormat specification defines the syntax for a _message_,
 along with the concepts and terminology needed when processing a _message_
 during the [formatting](./formatting.md) of a _message_ at runtime.
 
-The complete formal syntax of a _message_ is described by the [ABNF](./message.abnf).
+The complete formal syntax of a _message_ is described by the [ABNF](#complete-abnf).
 
 #### Well-formed vs. Valid Messages
 
@@ -2307,7 +2305,7 @@ The _function_ `:integer` performs selection as described in [Number Selection](
 ##### Number Operands
 
 The _operand_ of a number function is either an implementation-defined type or
-a literal whose contents match the `number-literal` production in the [ABNF](#messageabnf).
+a literal whose contents match the `number-literal` production in the [ABNF](#complete-abnf).
 All other values produce an _Invalid Expression_ error.
 
 > For example, in Java, any subclass of `java.lang.Number` plus the primitive
@@ -2319,7 +2317,7 @@ All other values produce an _Invalid Expression_ error.
 > [!NOTE]
 > String values passed as variables in the _formatting context_'s
 > _input mapping_ can be formatted as numeric values as long as their
-> contents match the `number-literal` production in the [ABNF](#messageabnf).
+> contents match the `number-literal` production in the [ABNF](#complete-abnf).
 >
 > For example, if the value of the variable `num` were the string
 > `-1234.567`, it would behave identically to the local
@@ -2663,7 +2661,7 @@ When the offset is not present, implementations SHOULD use a floating time type
 For more information, see [Working with Timezones](https://w3c.github.io/timezone).
 
 > [!IMPORTANT]
-> The [ABNF](#messageabnf) and [syntax](#syntax) of MF2
+> The [ABNF](#complete-abnf) and [syntax](#syntax) of MF2
 > do not formally define date/time literals.
 > This means that a _message_ can be syntactically valid but produce
 > an _Operand Mismatch Error_ at runtime.

--- a/tools/scripts/tr-archive/archive.js
+++ b/tools/scripts/tr-archive/archive.js
@@ -142,7 +142,7 @@ async function renderit(infile) {
   // put this last
   body.appendChild(getScript({
     // This invokes anchor.js
-    code: `anchors.add('h1, h2, h3, h4, h5, h6, caption');`
+    code: `anchors.add('h1, h2, h3, h4, h5, h6, caption, dfn');`
   }));
 
   // Now, fixup captions

--- a/tools/scripts/tr-archive/tr35.css
+++ b/tools/scripts/tr-archive/tr35.css
@@ -1,2 +1,31 @@
 /* tr35.css */
 
+.markdown-alert {
+    border-left: 0.25em;
+    padding-left: .5em;
+    border-left-style: solid;
+}
+
+.markdown-alert-title {
+    font-weight: bold;
+}
+
+.markdown-alert-title svg {
+    margin-right: .5em;
+}
+
+.markdown-alert-note {
+    border-color: blue;
+}
+
+.markdown-alert-note .markdown-alert-title {
+    color: blue;
+}
+
+.markdown-alert-important {
+    border-color: blueviolet;
+}
+
+.markdown-alert-important .markdown-alert-title {
+    color: blueviolet;
+}


### PR DESCRIPTION
CLDR-17424

- [ ] This PR completes the ticket.
- linkify `<dfn>` elements
- fix more internal broken links
- improve style for `[!NOTE]` and `[!IMPORTANT]` (see image)

fyi @aphillips

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

![image](https://github.com/unicode-org/cldr/assets/855219/463703e6-51a8-40ec-9166-1ba7179641dd)

ALLOW_MANY_COMMITS=true

