### PR TITLE
CLDR-17540 update SupplementalDataInfo reader to not use reentrant XPathParts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXPathParts.java
@@ -5,7 +5,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-/** Like {@link XPathParts} but does not depend on DTDs, etc. Safe for use at startup. */
+/**
+ * Similar to {@link XPathParts} but does not depend on DTDs, etc. Doesn't cache, so most
+ * appropriate for one-time data loading where paths will be unique. Safe for use during static
+ * init. API conforms to {@link XPathValue}
+ */
 public class SimpleXPathParts extends XPathParser {
 
     private final class Element {
@@ -14,6 +18,14 @@ public class SimpleXPathParts extends XPathParser {
 
         public Element(String name) {
             this.name = name;
+        }
+
+        public Map<String, String> getAttributes() {
+            return attributes;
+        }
+
+        public boolean containsAttribute(String attribute) {
+            return attributes.containsKey(attribute);
         }
     }
 
@@ -27,12 +39,50 @@ public class SimpleXPathParts extends XPathParser {
         return elements.get(i).name;
     }
 
+    /**
+     * Search for an element within the path.
+     *
+     * @param elementName the element to look for
+     * @return element number if found, else -1 if not found
+     */
+    public int findElement(String elementName) {
+        for (int i = 0; i < elements.size(); ++i) {
+            Element e = elements.get(i);
+            if (!e.name.equals(elementName)) {
+                continue;
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    @Override
+    public boolean containsElement(String elementName) {
+        return findElement(elementName) >= 0;
+    }
+
     @Override
     public String getAttributeValue(int i, String attribute) {
         if (i < 0) {
             i = elements.size() + i;
         }
         return elements.get(i).attributes.get(attribute);
+    }
+
+    @Override
+    public Map<String, String> getAttributes(int elementIndex) {
+        return elements.get(elementIndex >= 0 ? elementIndex : elementIndex + size())
+                .getAttributes();
+    }
+
+    @Override
+    public boolean containsAttribute(String attribute) {
+        for (final Element e : elements) {
+            if (e.containsAttribute(attribute)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -55,12 +105,18 @@ public class SimpleXPathParts extends XPathParser {
     }
 
     /**
-     * for API compatibility
+     * Parse an XPath string into a read-only structure.
      *
      * @param xpath
-     * @return
+     * @return the parsed XPath
      */
-    static SimpleXPathParts getFrozenInstance(String xpath) {
+    static XPathValue getFrozenInstance(String xpath) {
+        // return the abstract class
         return new SimpleXPathParts(xpath);
+    }
+
+    @Override
+    public int size() {
+        return elements.size();
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXPathParts.java
@@ -30,6 +30,7 @@ public class SimpleXPathParts extends XPathParser {
     }
 
     final List<Element> elements = new LinkedList<>();
+    private final String xpath;
 
     @Override
     public String getElement(int i) {
@@ -101,7 +102,13 @@ public class SimpleXPathParts extends XPathParser {
     }
 
     SimpleXPathParts(String xpath) {
+        this.xpath = xpath;
         handleParse(xpath, true);
+    }
+
+    @Override
+    public String toString() {
+        return xpath;
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -547,7 +547,7 @@ public class SupplementalDataInfo {
         public final String digits;
         public final String rules;
 
-        public NumberingSystemInfo(XPathParts parts) {
+        public NumberingSystemInfo(XPathValue parts) {
             name = parts.getAttributeValue(-1, "id");
             digits = parts.getAttributeValue(-1, "digits");
             rules = parts.getAttributeValue(-1, "rules");
@@ -1372,7 +1372,7 @@ public class SupplementalDataInfo {
         @Override
         public void handlePathValue(String path, String value) {
             try {
-                XPathParts parts = XPathParts.getFrozenInstance(path);
+                XPathValue parts = SimpleXPathParts.getFrozenInstance(path);
                 String level0 = parts.getElement(0);
                 String level1 = parts.size() < 2 ? null : parts.getElement(1);
                 String level2 = parts.size() < 3 ? null : parts.getElement(2);
@@ -1533,7 +1533,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        private boolean handleUnitPrefix(XPathParts parts) {
+        private boolean handleUnitPrefix(XPathValue parts) {
             //      <unitPrefix type='quecto' symbol='q' power10='-30'/>
             String power10 = parts.getAttributeValue(-1, "power10");
             String power2 = parts.getAttributeValue(-1, "power2");
@@ -1549,13 +1549,13 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handlePersonNamesDefaults(String value, XPathParts parts) {
+        private boolean handlePersonNamesDefaults(String value, XPathValue parts) {
             personNameOrder.putAll(
                     Order.from(parts.getAttributeValue(-1, "order")), split_space.split(value));
             return true;
         }
 
-        private boolean handleUnitUnitIdComponents(XPathParts parts) {
+        private boolean handleUnitUnitIdComponents(XPathValue parts) {
             //      <unitIdComponent type="prefix" values="arc british dessert fluid light
             // nautical"/>
             UnitIdComponentType type =
@@ -1569,7 +1569,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleGrammaticalData(String value, XPathParts parts) {
+        private boolean handleGrammaticalData(String value, XPathValue parts) {
             /*
             <!ATTLIST grammaticalFeatures targets NMTOKENS #REQUIRED >
             <!ATTLIST grammaticalFeatures locales NMTOKENS #REQUIRED >
@@ -1638,7 +1638,7 @@ public class SupplementalDataInfo {
          *<unitPreference regions="001" draft="unconfirmed">square-centimeter</unitPreference>
          */
 
-        private boolean handleUnitPreferences(XPathParts parts, String value) {
+        private boolean handleUnitPreferences(XPathValue parts, String value) {
             String geq = parts.getAttributeValue(-1, "geq");
             String small = parts.getAttributeValue(-2, "scope");
             if (small != null) {
@@ -1654,14 +1654,14 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleLanguageGroups(String value, XPathParts parts) {
+        private boolean handleLanguageGroups(String value, XPathValue parts) {
             String parent = parts.getAttributeValue(-1, "parent");
             List<String> children = WHITESPACE_SPLTTER.splitToList(value);
             languageGroups.putAll(parent, children);
             return true;
         }
 
-        private boolean handleMeasurementData(String level2, XPathParts parts) {
+        private boolean handleMeasurementData(String level2, XPathValue parts) {
             /**
              * <measurementSystem type="US" territories="LR MM US"/> <paperSize type="A4"
              * territories="001"/>
@@ -1679,7 +1679,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleUnitConstants(XPathParts parts) {
+        private boolean handleUnitConstants(XPathValue parts) {
             //      <unitConstant constant="ft2m" value="0.3048"/>
 
             final String constant = parts.getAttributeValue(-1, "constant");
@@ -1689,7 +1689,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleUnitQuantities(XPathParts parts) {
+        private boolean handleUnitQuantities(XPathValue parts) {
             //      <unitQuantity quantity='wave-number' baseUnit='reciprocal-meter'/>
 
             final String baseUnit = parts.getAttributeValue(-1, "baseUnit");
@@ -1702,7 +1702,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleUnitConversion(XPathParts parts) {
+        private boolean handleUnitConversion(XPathValue parts) {
             // <convertUnit source='acre' target='square-meter' factor='ft2m^2 * 43560'/>
 
             final String source = parts.getAttributeValue(-1, "source");
@@ -1719,7 +1719,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleTimeData(XPathParts parts) {
+        private boolean handleTimeData(XPathValue parts) {
             /** <hours preferred="H" allowed="H" regions="IL RU"/> */
             String preferred = parts.getAttributeValue(-1, "preferred");
             PreferredAndAllowedHour preferredAndAllowedHour =
@@ -1734,7 +1734,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleBcp47(String level1, XPathParts parts) {
+        private boolean handleBcp47(String level1, XPathValue parts) {
             if (level1.equals("version")
                     || level1.equals("generation")
                     || level1.equals("cldrVersion")) {
@@ -1822,7 +1822,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleLanguageMatcher(XPathParts parts) {
+        private boolean handleLanguageMatcher(XPathValue parts) {
             String type = parts.getAttributeValue(2, "type");
             String alt = parts.getAttributeValue(2, "alt");
             if (alt != null) {
@@ -1867,7 +1867,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleCodeMappings(String level2, XPathParts parts) {
+        private boolean handleCodeMappings(String level2, XPathValue parts) {
             if (level2.equals("territoryCodes")) {
                 // <territoryCodes type="VU" numeric="548" alpha3="VUT"/>
                 String type = parts.getAttributeValue(-1, "type");
@@ -1892,7 +1892,7 @@ public class SupplementalDataInfo {
             return false;
         }
 
-        private void handleNumberingSystems(XPathParts parts) {
+        private void handleNumberingSystems(XPathValue parts) {
             NumberingSystemInfo ns = new NumberingSystemInfo(parts);
             numberingSystems.put(ns.name, ns);
             if (ns.type == NumberingSystemType.numeric) {
@@ -1900,7 +1900,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        private void handleCoverageLevels(XPathParts parts) {
+        private void handleCoverageLevels(XPathValue parts) {
             if (parts.containsElement("approvalRequirement")) {
                 approvalRequirements.add(parts.toString());
             } else if (parts.containsElement("coverageLevel")) {
@@ -1944,7 +1944,7 @@ public class SupplementalDataInfo {
 
         public static final String NONLIKELYSCRIPT = "nonlikelyScript";
 
-        private void handleParentLocales(XPathParts parts) {
+        private void handleParentLocales(XPathValue parts) {
             // CLDR-16253 added component-specific parents, which we ignore for now.
             // TODO(CLDR-16361): Figure out how to handle these in CLDR itself.
             String componentsString = parts.getAttributeValue(1, "component");
@@ -1996,7 +1996,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        private void handleCalendarPreferenceData(XPathParts parts) {
+        private void handleCalendarPreferenceData(XPathValue parts) {
             String territoryString = parts.getAttributeValue(-1, "territories");
             String orderingString = parts.getAttributeValue(-1, "ordering");
             String[] calendars = orderingString.split(" ");
@@ -2007,7 +2007,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        private void handleLikelySubtags(XPathParts parts) {
+        private void handleLikelySubtags(XPathValue parts) {
             String from = parts.getAttributeValue(-1, "from");
             String to = parts.getAttributeValue(-1, "to");
             String origin = parts.getAttributeValue(-1, "origin");
@@ -2035,7 +2035,7 @@ public class SupplementalDataInfo {
         /**
          * Only called if level2 = mapTimezones. Level 1 might be metaZones or might be windowsZones
          */
-        private boolean handleMetazoneData(String level3, XPathParts parts) {
+        private boolean handleMetazoneData(String level3, XPathValue parts) {
             if (level3.equals("mapZone")) {
                 String maintype = parts.getAttributeValue(2, "type");
                 if (maintype == null) {
@@ -2069,7 +2069,7 @@ public class SupplementalDataInfo {
         }
 
         private Collection<String> getSpaceDelimited(
-                int index, String attribute, Collection<String> defaultValue, XPathParts parts) {
+                int index, String attribute, Collection<String> defaultValue, XPathValue parts) {
             String temp = parts.getAttributeValue(index, attribute);
             Collection<String> elements =
                     temp == null ? defaultValue : Arrays.asList(temp.split("\\s+"));
@@ -2086,7 +2086,7 @@ public class SupplementalDataInfo {
          * <usesMetazone from="1991-09-22 20:00" mzone="Armenia"/>
          */
 
-        private boolean handleMetazoneInfo(String level3, XPathParts parts) {
+        private boolean handleMetazoneInfo(String level3, XPathValue parts) {
             if (level3.equals("timezone")) {
                 String zone = parts.getAttributeValue(3, "type");
                 String mzone = parts.getAttributeValue(4, "mzone");
@@ -2099,8 +2099,8 @@ public class SupplementalDataInfo {
             return false;
         }
 
-        private boolean handleMetadata(String level2, String value, XPathParts parts) {
-            if (parts.contains("defaultContent")) {
+        private boolean handleMetadata(String level2, String value, XPathValue parts) {
+            if (parts.containsElement("defaultContent")) {
                 String defContent = parts.getAttributeValue(-1, "locales").trim();
                 String[] defLocales = defContent.split("\\s+");
                 defaultContentLocales =
@@ -2187,7 +2187,7 @@ public class SupplementalDataInfo {
             return false;
         }
 
-        private boolean handleTerritoryInfo(XPathParts parts) {
+        private boolean handleTerritoryInfo(XPathValue parts) {
 
             // <territoryInfo>
             // <territory type="AD" gdp="1840000000" literacyPercent="100"
@@ -2308,7 +2308,7 @@ public class SupplementalDataInfo {
             return true;
         }
 
-        private boolean handleCurrencyData(String level2, XPathParts parts) {
+        private boolean handleCurrencyData(String level2, XPathValue parts) {
             if (level2.equals("fractions")) {
                 // <info iso4217="ADP" digits="0" rounding="0" cashRounding="5"/>
                 currencyToCurrencyNumberInfo.put(
@@ -2339,7 +2339,7 @@ public class SupplementalDataInfo {
             return false;
         }
 
-        private void handleTelephoneCodeData(XPathParts parts) {
+        private void handleTelephoneCodeData(XPathValue parts) {
             // element 2: codesByTerritory territory [draft] [references]
             String terr = parts.getAttributeValue(2, "territory");
             // element 3: telephoneCountryCode code [from] [to] [draft] [references] [alt]
@@ -2358,7 +2358,7 @@ public class SupplementalDataInfo {
             tcSet.add(tcInfo);
         }
 
-        private void handleTerritoryContainment(XPathParts parts) {
+        private void handleTerritoryContainment(XPathValue parts) {
             // <group type="001" contains="002 009 019 142 150"/>
             final String container = parts.getAttributeValue(-1, "type");
             final List<String> contained =
@@ -2379,7 +2379,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        private void handleSubdivisionContainment(XPathParts parts) {
+        private void handleSubdivisionContainment(XPathValue parts) {
             //      <subgroup type="AL" subtype="04" contains="FR MK LU"/>
             final String country = parts.getAttributeValue(-1, "type");
             final String subtype = parts.getAttributeValue(-1, "subtype");
@@ -2394,7 +2394,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        private void handleLanguageData(XPathParts parts) {
+        private void handleLanguageData(XPathValue parts) {
             // <languageData>
             // <language type="aa" scripts="Latn" territories="DJ ER ET"/> <!--
             // Reflecting submitted data, cldrbug #1013 -->
@@ -3273,7 +3273,7 @@ public class SupplementalDataInfo {
         }
 
         ApprovalRequirementMatcher(String xpath) {
-            XPathParts parts = XPathParts.getFrozenInstance(xpath);
+            XPathValue parts = SimpleXPathParts.getFrozenInstance(xpath);
             if (parts.containsElement("approvalRequirement")) {
                 requiredVotes = getRequiredVotes(parts);
                 String localeAttrib = parts.getAttributeValue(-1, "locales");
@@ -3311,7 +3311,7 @@ public class SupplementalDataInfo {
             }
         }
 
-        static int getRequiredVotes(XPathParts parts) {
+        static int getRequiredVotes(XPathValue parts) {
             String votesStr = parts.getAttributeValue(-1, "votes");
             if (votesStr.charAt(0) == '=') {
                 votesStr = votesStr.substring(1);
@@ -3583,7 +3583,7 @@ public class SupplementalDataInfo {
     private transient DayPeriodInfo.Type lastDayPeriodType = null;
     private transient DayPeriodInfo.Builder dayPeriodBuilder = new DayPeriodInfo.Builder();
 
-    private void addDayPeriodPath(XPathParts path) {
+    private void addDayPeriodPath(XPathValue path) {
         // ldml/dates/calendars/calendar[@type="gregorian"]/dayPeriods/dayPeriodContext[@type="format"]/dayPeriodWidth[@type="wide"]/dayPeriod[@type="am"]
         /*
          * <supplementalData>
@@ -3681,7 +3681,7 @@ public class SupplementalDataInfo {
     static String lastPluralRangesLocales = null;
     static PluralRanges lastPluralRanges = null;
 
-    private boolean addPluralPath(XPathParts path, String value) {
+    private boolean addPluralPath(XPathValue path, String value) {
         /*
         * Adding
         <pluralRanges locales="am">
@@ -4767,7 +4767,7 @@ public class SupplementalDataInfo {
 
     public boolean isDeprecated(DtdType type, String path) {
 
-        XPathParts parts = XPathParts.getFrozenInstance(path);
+        XPathValue parts = SimpleXPathParts.getFrozenInstance(path);
         for (int i = 0; i < parts.size(); ++i) {
             String element = parts.getElement(i);
             if (isDeprecated(type, element, "*", "*")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Caches values for fast lookup.
  *
- * <p>For use at static init time, or anywhere a simpler API can be used, see {@link
+ * <p>(If caching isn't needed, such as with supplemental data at static init time, see {@link
  * SimpleXPathParts#getFrozenInstance(String)}
  */
 public final class XPathParts extends XPathParser

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathParts.java
@@ -34,6 +34,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * //ldml/characters/exemplarCharacters[@type="auxiliary"] and a list of Element objects that depend
  * on xPath. Each Element object has an "element" string such as "ldml", "characters", or
  * "exemplarCharacters", plus attributes such as a Map from key "type" to value "auxiliary".
+ *
+ * <p>Caches values for fast lookup.
+ *
+ * <p>For use at static init time, or anywhere a simpler API can be used, see {@link
+ * SimpleXPathParts#getFrozenInstance(String)}
  */
 public final class XPathParts extends XPathParser
         implements Freezable<XPathParts>, Comparable<XPathParts> {
@@ -58,12 +63,7 @@ public final class XPathParts extends XPathParser
 
     /** See if the xpath contains an element */
     public boolean containsElement(String element) {
-        for (int i = 0; i < elements.size(); ++i) {
-            if (elements.get(i).getElement().equals(element)) {
-                return true;
-            }
-        }
-        return false;
+        return findElement(element) >= 0;
     }
 
     /**
@@ -362,6 +362,7 @@ public final class XPathParts extends XPathParser
     }
 
     /** Does this xpath contain the attribute at all? */
+    @Override
     public boolean containsAttribute(String attribute) {
         for (int i = 0; i < elements.size(); ++i) {
             Element element = elements.get(i);
@@ -381,7 +382,7 @@ public final class XPathParts extends XPathParser
         return false;
     }
 
-    /** How many elements are in this xpath? */
+    @Override
     public int size() {
         return elements.size();
     }
@@ -938,13 +939,11 @@ public final class XPathParts extends XPathParser
     }
 
     /**
-     * Determines if an elementName is contained in the path.
-     *
-     * @param elementName
-     * @return
+     * @deprecated use {@link #containsElement(String)}
      */
+    @Deprecated
     public boolean contains(String elementName) {
-        return findElement(elementName) >= 0;
+        return containsElement(elementName);
     }
 
     /** add a relative path to this XPathParts. */

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathValue.java
@@ -27,4 +27,7 @@ public interface XPathValue {
 
     /** Does this xpath contain the attribute at all? */
     public boolean containsAttribute(String attribute);
+
+    /** return the original string */
+    public String toString();
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathValue.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XPathValue.java
@@ -1,14 +1,30 @@
 package org.unicode.cldr.util;
 
+import java.util.Map;
+
 /** This is an interface for a read-only XPath. */
 public interface XPathValue {
+    /** How many elements are in this xpath? */
+    int size();
 
     /** Get the nth element. Negative values are from end */
     String getElement(int i);
+
+    /** See if the xpath contains an element */
+    public boolean containsElement(String element);
+
+    /**
+     * Get the attributes for the nth element (negative index is from end). Returns null or an empty
+     * map if there's nothing. PROBLEM: exposes internal map
+     */
+    public Map<String, String> getAttributes(int elementIndex);
 
     /**
      * Get the attributeValue for the attrbute at the nth element (negative index is from end).
      * Returns null if there's nothing.
      */
     String getAttributeValue(int i, String string);
+
+    /** Does this xpath contain the attribute at all? */
+    public boolean containsAttribute(String attribute);
 }


### PR DESCRIPTION
note this is for v46 - see also #3631 

- clarify distinction between XPathParts and SimpleXPathParts
- push XPathParts.size() and other API up to XPathValue.size()
- use SimpleXPathParts instead of XPathParts in SupplementalDataInfo

CLDR-17540

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
