### PR TITLE
CLDR-17434 fix markdown lint warnings

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,7 +43,7 @@ jobs:
         run: 'cd tools/scripts/tr-archive/ && npm run extract-link-targets || (echo Warning, please fix these ; true)'
       - name: Lint Markdown
         # Warn, don't fail yet
-        run: npx markdownlint-cli *.md {specs,docs}/*.md $(find .github -name '*.md') || (echo Warning, please fix these ; true)
+        run: npx markdownlint-cli *.md {specs,docs}/*.md || (echo Warning, please fix these ; true)
       - name: Note any changes
         run: git status ; git diff
       - uses: ruby/setup-ruby@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,26 @@
 
 The CLDR project consists of 3 aspects:
 
-1. **Data:** We rely on contributions by native language speakers that are most commonly used currently in the given country/region. Most data is collected through the Survey Tool. See [How to contribute][].
-    - If you are not a native language speaker, but have evidence of CLDR data being incorrect, file a [Jira][] ticket to report the issue.
-    - For data that is not collected in the [Survey Tool], such as [supplemental data][], file a [Jira][] ticket and provide evidence for changing the data.
+1. **Data:** We rely on contributions by native language speakers
+that are most commonly used currently in the given country/region.
+Most data is collected through the Survey Tool. See [How to contribute][].
+    - If you are not a native language speaker,
+	but have evidence of CLDR data being incorrect,
+	file a [Jira][] ticket to report the issue.
+    - For data that is not collected in the [Survey Tool],
+	such as [supplemental data][], file a [Jira][] ticket
+	and provide evidence for changing the data.
 2. **Internationalization structure:** Requires a ticket to be changed.
-    - For structural issues, note that many issues may be due to misunderstandings of the LDML spec. For example, `<pattern>¤#,##0.00</pattern>` has a specialized format where each character represents a special function.
-    - File a [Jira][] ticket and provide evidence for the spec issues or to establish a new structure.
-    - If your organization is not a [Unicode member][], consider becoming a member and work as a CLDR technical committee member.
-3. **CLDR internal tooling** such as adding new tests or fixing tooling that enable CLDR builds and releases. See [CLDR Developer][] introduction.
+    - For structural issues, note that many issues may be
+	due to misunderstandings of the LDML spec.
+	For example, `<pattern>¤#,##0.00</pattern>` has a specialized format
+	where each character represents a special function.
+    - File a [Jira][] ticket and provide evidence for the spec issues
+	or to establish a new structure.
+    - If your organization is not a [Unicode member][], consider becoming
+	a member and working as a CLDR technical committee member.
+3. **CLDR internal tooling** such as adding new tests or fixing tooling that
+enable CLDR builds and releases. See [CLDR Developer][] introduction.
     - To contribute in internal tooling, [Contact][] us.
     - See [Tools source][] and [Repository Organization][]
 
@@ -32,8 +44,11 @@ The CLDR project consists of 3 aspects:
 
 For all PRs these steps are required before the PR is merged:
 
-- The PR and commits must reference a [Jira][] ticket which has been accepted by the CLDR-TC. Open a ticket if there is not already a relevant one open.
-- A Contributor License Agreement (CLA) must be signed. For more information, see [Contributor License Agreement](#contributor-license-agreement), below.
+- The PR and commits must reference a [Jira][] ticket
+which has been accepted by the CLDR-TC.
+Open a ticket if there is not already a relevant one open.
+- A Contributor License Agreement (CLA) must be signed. For more information,
+see [Contributor License Agreement](#contributor-license-agreement), below.
 - All tests must pass (See below)
 - The PR must be reviewed by a TC member.
 - The PR should have a single commit, and the first line of the commit must
@@ -65,31 +80,39 @@ Unless otherwise noted in the [`LICENSE`](./LICENSE) file, this project is relea
 For setup details, see [Maven Setup][].
 Builds are done with Maven:
 
-```
-mvn test --file=tools/pom.xml
-```
+    mvn test --file=tools/pom.xml
 
 ## Tests
 
-For more detail, and how to run the tests locally, see [Running Tests][] on the CLDR development site.
+For more detail, and how to run the tests locally,
+see [Running Tests][] on the CLDR development site.
 
 ### Automatic Test Runs
 
-Tests are automatically run once a commit is pushed to GitHub and when a PR is opened requesting changes to CLDR. You will see the status check next to each commit's hash, it will show as a circle, x, or checkmark. (●✖✔). For GitHub documentation, see [About Status Checks][]. You can click on these indicators anywhere they appear for more details.
+Tests are automatically run once a commit is pushed to GitHub and when a PR
+ is opened requesting changes to CLDR.
+ You will see the status check next to each commit's hash,
+ it will show as a circle, x, or checkmark. (●✖✔).
+ For GitHub documentation, see [About Status Checks][].
+ You can click on these indicators anywhere they appear for more details.
 
 Briefly:
 
-- ● An orange circle indicates that information is not available yet, such as a test that is still running or has not started yet.
-- ✖ A red X indicates a failure or a warning. Depending on the type of issue, merging might be blocked.
+- ● An orange circle indicates that information is not available yet,
+such as a test that is still running or has not started yet.
+- ✖ A red X indicates a failure or a warning. Depending on the type of issue,
+merging might be blocked.
 - ✔ A green checkmark indicates success.
 
 ![Commit Checks](./docs/img/commit-checks.png)
 
-Similarly, in a PR, certain checks are marked as “Required.” All required checks must succeed before merging is allowed.
+Similarly, in a PR, certain checks are marked as “Required.”
+All required checks must succeed before merging is allowed.
 
 ![PR Checks](./docs/img/pr-checks.png)
 
-If a test or status check does not pass, see [Running Tests][] on the CLDR development site.
+If a test or status check does not pass, see [Running Tests][]
+on the CLDR development site.
 
 ## Copyright
 
@@ -113,3 +136,5 @@ All rights reserved. [Terms of use][]
 [sign-cla]: https://cla-assistant.io/unicode-org/.github
 [osi-Unicode-License-3.0]: https://opensource.org/license/unicode-license-v3/
 [unicode-license]: https://www.unicode.org/license.txt
+[CLDR Developer]: https://cldr.unicode.org/development/new-cldr-developers
+[Contact]: https://www.unicode.org/reporting.html


### PR DESCRIPTION
CLDR-17434

- [ ] This PR completes the ticket.

[Later edit] It seems that separate action will be needed to shorten the lines for the CLA section, as the source for that is elsewhere.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
