### PR TITLE
CLDR-15649 Dashboard using filters

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDash.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDash.mjs
@@ -306,7 +306,9 @@ function getFetchError() {
 function setData(json) {
   cldrProgress.updateVoterCompletion(json);
   const newData = convertData(json);
-  viewSetDataCallback(newData);
+  if (viewSetDataCallback) {
+    viewSetDataCallback(newData);
+  }
   return newData;
 }
 
@@ -339,7 +341,7 @@ function updatePath(dashData, json) {
       if (!json.notifications?.length) {
         // The path no longer has any notifications, so remove the entry
         dashData.removeEntry(dashEntry);
-        return;
+        return dashData; // for unit test
       }
       // Clear attributes that might have changed or disappeared as a result of voting.
       // They will be updated/restored from the json.

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -26,7 +26,7 @@ import * as cldrXPathUtils from "./cldrXpathUtils.mjs";
 const HEADER_ID_PREFIX = "header_";
 const ROW_ID_PREFIX = "row_"; // formerly "r@"
 
-const CLDR_TABLE_DEBUG = true;
+const CLDR_TABLE_DEBUG = false;
 
 /*
  * NO_WINNING_VALUE indicates the server delivered path data without a valid winning value.

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -13,7 +13,7 @@ import * as cldrSurvey from "./cldrSurvey.mjs";
 import * as cldrTable from "./cldrTable.mjs";
 import * as cldrText from "./cldrText.mjs";
 
-const CLDR_VOTE_DEBUG = true;
+const CLDR_VOTE_DEBUG = false;
 
 /**
  * The special "vote level" selected by the user, or zero for default.

--- a/tools/cldr-apps/js/test/TestCldrDash.mjs
+++ b/tools/cldr-apps/js/test/TestCldrDash.mjs
@@ -40,32 +40,56 @@ describe("cldrDash.updatePath", function () {
     // json0 has 1 entry for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
     // json1 has 3 entries for 710b6e70773e5764
 
-    // the resulting data should have 3 entries for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
-    const data = cldrDash.updatePath(json0, json1);
-    assert.strictEqual(countEntriesForPath(data, "710b6e70773e5764"), 3);
-    assert.strictEqual(countEntriesForPath(data, "64a8a83fbacdf836"), 1);
+    // the resulting data should have 1 (combined) entry for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
+    // DashData should never have more than one entry per path
+    const data0 = cldrDash.setData(json0);
+    const data1 = cldrDash.updatePath(data0, json1);
+    assert.strictEqual(countEntriesForPath(data1, "710b6e70773e5764"), 1);
+    assert.strictEqual(countEntriesForPath(data1, "64a8a83fbacdf836"), 1);
+    // the entry for 710b6e70773e5764 should have 3 notifications
+    assert.strictEqual(countNotificationsForEntry(data1, "710b6e70773e5764"), 3);
+    // the entry for 64a8a83fbacdf836 should have 1 notification
+    assert.strictEqual(countNotificationsForEntry(data1, "64a8a83fbacdf836"), 1);
   });
 
   it("should remove entries", function () {
     // json0 has 1 entry for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
     // json2 has 0 entries for 710b6e70773e5764
     // the resulting data should have 0 entries for 710b6e70773e5764 and 1 entry for 64a8a83fbacdf836
-    const data = cldrDash.updatePath(json0, json2);
-    assert.strictEqual(countEntriesForPath(data, "710b6e70773e5764"), 0);
-    assert.strictEqual(countEntriesForPath(data, "64a8a83fbacdf836"), 1);
+    const data0 = cldrDash.setData(json0);
+    const data2 = cldrDash.updatePath(data0, json2);
+    assert.strictEqual(countEntriesForPath(data2, "710b6e70773e5764"), 0);
+    assert.strictEqual(countEntriesForPath(data2, "64a8a83fbacdf836"), 1);
+    // the entry for 64a8a83fbacdf836 should have 1 notification
+    assert.strictEqual(countNotificationsForEntry(data2, "64a8a83fbacdf836"), 1);
   });
 });
 
+/**
+ * Count the number of entries for the given path in the given DashData; should be 0 or 1
+ *
+ * @param {Object} data the object of class DashData
+ * @param {String} xpstrid the xpath hex string id
+ * @returns the number of entries found in the data for this xpath
+ */
 function countEntriesForPath(data, xpstrid) {
   let count = 0;
-  for (let catData of data.notifications) {
-    for (let group of catData.groups) {
-      for (let entry of group.entries) {
-        if (entry.xpstrid === xpstrid) {
-          ++count;
-        }
-      }
+  for (let entry of data.entries) {
+    if (entry.xpstrid === xpstrid) {
+      ++count;
     }
   }
   return count;
+}
+
+/**
+ * Count the number of notifications for the given path in the given DashData
+ *
+ * @param {Object} data the object of class DashData
+ * @param {String} xpstrid the xpath hex string id
+ * @returns the number of notification categories found in the DashEntry for this xpath
+ */
+function countNotificationsForEntry(data, xpstrid) {
+  const entry = data.pathIndex[xpstrid];
+  return entry.cats.size;
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -239,6 +239,9 @@ public class Dashboard {
                         sm.getSupplementalDataInfo(), sourceFactory, new STUsersChoice(sm));
         EnumSet<NotificationCategory> choiceSet =
                 VettingViewer.getDashboardNotificationCategories(usersOrg);
+        if (UserRegistry.userIsTC(user)) {
+            choiceSet.remove(NotificationCategory.abstained);
+        }
         VettingParameters args = new VettingParameters(choiceSet, locale, coverageLevel);
         args.setUserAndOrganization(user.id, usersOrg);
         args.setFiles(locale, sourceFactory, sm.getDiskFactory());


### PR DESCRIPTION
-Add checkbox next to each notification category in Dashboard header

-The category is hidden if the checkbox is unchecked

-Error and Missing notifications still cannot be hidden with pre-existing right-side path-specific checkboxes, but they can be hidden categorically using the new checkboxes

-Show each path with notifications only once in Dashboard

-If a path has more than one notification, combine them on one line

-Perform data conversion on the front end; http response still has multiple notifications per path

-Refactor to avoid http code in Vue; call cldrAjax.mjs from cldrDash.mjs not from DashboardWidget.vue

-New classes DashData and DashEntry in cldrDash.mjs

-Use new method dashData.addEntriesFromJson for both whole-page json and single-path json

-Make hover titles clearer for circled abbreviations like EC for English Changed

-As before, always hide Abstained notifications if user is TC, but implement on the back end instead of the front end (simpler and more efficient)

-Update and extend the unit test TestCldrDash.mjs, since DashData is now different format from json

-Turn off debug-logging in cldrTable (CLDR_TABLE_DEBUG) and cldrVote (CLDR_VOTE_DEBUG)

CLDR-15649

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
