### PR TITLE
CLDR-17529 v45 spec: add keyboard names for spec attribution

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -4087,6 +4087,8 @@ Special thanks to the following people for their continuing overall contribution
 * Rich Gillam for work on Person Names.
 * Alex Kolisnychenko for work on Person Names.
 * Mike McKenna for work on Person Names.
+* Ross Cruickshank for work on keyboards.
+* Tex Texin for work on keyboards.
 
 
 Other contributors to CLDR are listed on the [CLDR Project Page](https://www.unicode.org/cldr/).

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -4087,8 +4087,10 @@ Special thanks to the following people for their continuing overall contribution
 * Rich Gillam for work on Person Names.
 * Alex Kolisnychenko for work on Person Names.
 * Mike McKenna for work on Person Names.
-* Ross Cruickshank for work on keyboards.
-* Tex Texin for work on keyboards.
+* Ross Cruickshank for work on Keyboards.
+* Tex Texin for work on Keyboards.
+* Joshua A. Horton for work on Keyboards.
+* Marc Durdin for work on Keyboards.
 
 
 Other contributors to CLDR are listed on the [CLDR Project Page](https://www.unicode.org/cldr/).


### PR DESCRIPTION
CLDR-17529

- [x] This PR completes the ticket.

Missed these in the final tag

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
