### PR TITLE
CLDR-17336 Fix spec ambiguity surrounding parentLocales

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -1841,6 +1841,8 @@ The `parentLocale` element is used to override the normal inheritance when acces
 For case 1, there is a special attribute and value, `localeRules="nonlikelyScript"`,
 which specifies **all locales** of the form `lang_script`,
 wherever the `script` is **not** the likely script for `lang`.
+
+Note:
 For migration, the previous short list of locales (a subset of the nonlikelyScript locales) is retained,
 but those locales are slated for removal in the future.
 For example, `ru_Latn` is not included in the short list but is included (programmatically) in the rule.
@@ -1848,10 +1850,6 @@ For example, `ru_Latn` is not included in the short list but is included (progra
 ```xml
 <parentLocale parent="root" localeRules="nonlikelyScript" locales="az_Arab az_Cyrl bal_Latn … yue_Hans zh_Hant"/>/>
 ```
-
-The `localeRules` is used for the main component, for example.
-It is not used to components where text is not mixed,
-such as the collations component or the plurals component.
 
 For case 2, the children and parent share the same primary language, but the region is changed.
 For example:
@@ -1865,14 +1863,20 @@ For a locale like `zh_Hant` in the example above,
 the `parentLocale` element would dictate the parent as `root` when referring to main locale data,
 but for collation data, the parent locale should still be `zh`,
 even though the `parentLocale` element is present for that locale.
-To address this, components can have their own fallback rules that inherit from the common rules
-and add additional parents that supplement or override the common rules:
+To address this, components can have their own fallback rules that override the common rules:
 
 ```xml
-<parentLocales component="segmentations">
-  <parentLocale parent="zh" locales="zh_Hant"/>
+<parentLocales component="collations">
+  <parentLocale parent="sr_ME" locales="sr_Cyrl_ME"/>
+  <parentLocale parent="zh_Hant" locales="yue yue_Hant"/>
+  <parentLocale parent="zh_Hans" locales="yue_CN yue_Hans yue_Hans_CN"/>
 </parentLocales>
 ```
+
+Note:
+The special attribute `localeRules="nonlikelyScript"` is used for the main component.
+It is not used to components where text is not mixed,
+such as the collations component or the plurals component.
 
 Note: When components were first introduced, the component-specific parent locales were be merged with the main parent locales.
 This was determined to be an error, and the component-specific parent locales are now not merged,


### PR DESCRIPTION
CLDR-17336

- [x] This PR completes the ticket.

I fixed an ambiguous part of the spec where it said component parent locales "inherit" from the root component, only to be followed by a `Note` that this behavior was changed. I have now fully removed the text about inheriting from the root component and only "overriding".

I also moved the paragraph about components overriding `localeRules` to the section where components are introduced, because that paragraph references the concept of components.

CC @robertbastian 