### PR TITLE
CLDR-17483 add Ladin (lld) variants

### DIFF
--- a/common/main/lld_ANPEZO.xml
+++ b/common/main/lld_ANPEZO.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="lld"/>
+		<variant type="ANPEZO"/>
+	</identity>
+	<characters>
+		<exemplarCharacters>[a-z à á â è é ê ë ì í î ò ó ô ö ù ú ü ć ś]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[û ß ä ã å ç ï ð ñ õ ý ÿ ā ă ą ĉ ċ č ē ė ě ğ ī ń ň ō ŏ ő ŕ ř ŝ ş ū ů ű ź ż ž]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[% + \- . 0-9 ‑ ‰]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[. \: \- ; ? ! ' ’ , / &gt; &lt; „ “ ” « » @ ( ) \[ \] \{ \} # * \&amp;]</exemplarCharacters>
+	</characters>
+</ldml>

--- a/common/main/lld_FASCIA.xml
+++ b/common/main/lld_FASCIA.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="lld"/>
+		<variant type="FASCIA"/>
+	</identity>
+	<characters>
+		<exemplarCharacters>[a-z à á â è é ê ë ì í î ò ó ô ö ù ú ü ć ś]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[û ß ä ã å ç ï ð ñ õ ý ÿ ā ă ą ĉ ċ č ē ė ě ğ ī ń ň ō ŏ ő ŕ ř ŝ ş ū ů ű ź ż ž]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[% + \- . 0-9 ‑ ‰]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[. \: \- ; ? ! ' ’ , / &gt; &lt; „ “ ” « » @ ( ) \[ \] \{ \} # * \&amp;]</exemplarCharacters>
+	</characters>
+</ldml>

--- a/common/main/lld_FODOM.xml
+++ b/common/main/lld_FODOM.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="lld"/>
+		<variant type="FODOM"/>
+	</identity>
+	<characters>
+		<exemplarCharacters>[a-z à á â è é ê ë ì í î ò ó ô ö ù ú ü ć ś]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[û ß ä ã å ç ï ð ñ õ ý ÿ ā ă ą ĉ ċ č ē ė ě ğ ī ń ň ō ŏ ő ŕ ř ŝ ş ū ů ű ź ż ž]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[% + \- . 0-9 ‑ ‰]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[. \: \- ; ? ! ' ’ , / &gt; &lt; „ “ ” « » @ ( ) \[ \] \{ \} # * \&amp;]</exemplarCharacters>
+	</characters>
+</ldml>

--- a/common/main/lld_GHERD.xml
+++ b/common/main/lld_GHERD.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="lld"/>
+		<variant type="GHERD"/>
+	</identity>
+	<characters>
+		<exemplarCharacters>[a-z à â è é ë ì ò ó ô ö ù ü ć ś]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[ì ò ù û ś ß ä ã å ç ï ð ñ õ ý ÿ ā ă ą ĉ ċ č ē ė ě ğ ī ń ň ō ŏ ő ŕ ř ŝ ş ū ů ű ź ż ž]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[% + \- . 0-9 ‑ ‰]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[. \: \- ; ? ! ' ’ , / &gt; &lt; „ “ ” « » @ ( ) \[ \] \{ \} # * \&amp;]</exemplarCharacters>
+	</characters>
+</ldml>

--- a/common/main/lld_GHERD.xml
+++ b/common/main/lld_GHERD.xml
@@ -8,7 +8,7 @@
 	</identity>
 	<characters>
 		<exemplarCharacters>[a-z à â è é ë ì ò ó ô ö ù ü ć ś]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[ì ò ù û ś ß ä ã å ç ï ð ñ õ ý ÿ ā ă ą ĉ ċ č ē ė ě ğ ī ń ň ō ŏ ő ŕ ř ŝ ş ū ů ű ź ż ž]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[á ê ú û í î ß ä ã å ç ï ð ñ õ ý ÿ ā ă ą ĉ ċ č ē ė ě ğ ī ń ň ō ŏ ő ŕ ř ŝ ş ū ů ű ź ż ž]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[% + \- . 0-9 ‑ ‰]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[. \: \- ; ? ! ' ’ , / &gt; &lt; „ “ ” « » @ ( ) \[ \] \{ \} # * \&amp;]</exemplarCharacters>
 	</characters>

--- a/common/main/lld_VALBADIA.xml
+++ b/common/main/lld_VALBADIA.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="lld"/>
+		<variant type="VALBADIA"/>
+	</identity>
+</ldml>

--- a/common/validity/variant.xml
+++ b/common/validity/variant.xml
@@ -14,13 +14,13 @@
 	<idValidity>
 		<id type='variant' idStatus='regular'>		<!-- 110 items -->
 			1606nict 1694acad 1901 1959acad 1994 1996
-			abl1943 akuapem alalc97 aluku ao1990 aranes arkaika asante auvern
+			abl1943 akuapem alalc97 aluku anpezo ao1990 aranes arkaika asante auvern
 			baku1926 balanka barla basiceng bauddha bciav bcizbl biscayan biske blasl bohoric boont bornholm
 			cisaup colb1945 cornu creiss
 			dajnko
 			ekavsk emodeng
-			fonipa fonkirsh fonnapa fonupa fonxsamp
-			gallo gascon grclass grital grmistr
+			fascia fodom fonipa fonkirsh fonnapa fonupa fonxsamp
+			gallo gascon gherd grclass grital grmistr
 			hepburn hognorsk hsistemo
 			ijekavsk itihasa ivanchov
 			jauer jyutping
@@ -34,7 +34,7 @@
 			scotland scouse simple solba sotav spanglis surmiran sursilv sutsilv synnejyl
 			tarask tongyong tunumiit
 			uccor ucrcor ulster unifon
-			vaidika valencia vallader vecdruka vivaraup
+			vaidika valbadia valencia vallader vecdruka vivaraup
 			wadegile
 			xsistemo
 		</id>


### PR DESCRIPTION
CLDR-17483

- [ ] This PR completes the ticket.

This PR and the previous PR (#3643) should complete the ticket. The previous PR added lld.xml and lld_IT.xml. This PR adds:
lld_ANPEZO.xml
lld_FASCIA.xml
lld_FODOM.xml
lld_GHERD.xml
lld_VALBADIA.xml
for the anpezo, fascia, fodom, gherd and valbadia variants. Note that the valbadia file has only the identity block, since this variant is used as the default for lld.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
