### PR TITLE
CLDR-17346 ConsoleCheckCLDR fixes

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -1781,9 +1781,9 @@ public class ConsoleCheckCLDR {
     private static void showValue(
             CLDRFile cldrFile,
             String prettyPath,
-            String localeID,
+            final String localeID,
             String example,
-            String path,
+            final String path,
             String value,
             String fullPath,
             String statusString,
@@ -2031,27 +2031,30 @@ public class ConsoleCheckCLDR {
         final File base = new File(CLDRPaths.BASE_DIRECTORY);
         final String loc = locPath.getFirst();
         final String path = locPath.getSecond();
-        String subdir = "main";
-        if (path.startsWith("//ldml/annotations")) {
-            subdir = "annotations";
-        } else if (path.startsWith("//ldml/subdivisions")) {
-            subdir = "subdivisions";
-        }
-        File inCommon = new File(base, "common");
-        File subsub = new File(inCommon, subdir);
-        if (subsub.isDirectory()) {
-            File subFile = new File(subsub, loc + ".xml");
-            if (subFile.canRead())
-                return subFile.getAbsolutePath().substring(base.getAbsolutePath().length() + 1);
-        }
+        if (path != null) {
+            String subdir = "main";
+            if (path.startsWith("//ldml/annotations")) {
+                subdir = "annotations";
+            } else if (path.startsWith("//ldml/subdivisions")) {
+                subdir = "subdivisions";
+            }
+            File inCommon = new File(base, "common");
+            File subsub = new File(inCommon, subdir);
+            if (subsub.isDirectory()) {
+                File subFile = new File(subsub, loc + ".xml");
+                if (subFile.canRead())
+                    return subFile.getAbsolutePath().substring(base.getAbsolutePath().length() + 1);
+            }
 
-        File inSeed = new File(base, "seed");
-        subsub = new File(inSeed, subdir);
-        if (subsub.isDirectory()) {
-            File subFile = new File(subsub, loc + ".xml");
-            if (subFile.canRead())
-                return subFile.getAbsolutePath().substring(base.getAbsolutePath().length() + 1);
+            File inSeed = new File(base, "seed");
+            subsub = new File(inSeed, subdir);
+            if (subsub.isDirectory()) {
+                File subFile = new File(subsub, loc + ".xml");
+                if (subFile.canRead())
+                    return subFile.getAbsolutePath().substring(base.getAbsolutePath().length() + 1);
+            }
         }
+        // no XPath - could be an entire-locale error.
         return loc + ".xml";
     }
 


### PR DESCRIPTION
CLDR-17346

- fix ConcurrentModificationException in CheckCLDR - the `allFilters` was initialized in an unsafe way.  This has been latent for five monthgs in CLDR-7277
- also fixed another issue in the GitHub err reporting

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
