### PR TITLE
CLDR-17566 fix to GitHub Pages build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,10 @@
+
 name: Publish to gh-pages
+
+permissions:
+  pages: write
+  deployments: write
+  id-token: write
 
 on:
   push:
@@ -53,22 +59,16 @@ jobs:
       - name: Build Jekyll part of the site
         run: |
           gem install bundler github-pages kramdown-parser-gfm  # should pull in jekyll, etc.
-          jekyll build -s docs -d _site
+          cd docs &&  github-pages build && mkdir -vp ../_site/ldml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Rearrange stuff
         run: 'cp -vr tools/scripts/tr-archive/dist/* ./_site/ldml/ && cp tools/scripts/tr-archive/reports-v2.css ./_site/'
       - name: Deploy to GitHub Pages (main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: Cecilapp/GitHub-Pages-deploy@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # email: username@domain.tld
-          build_dir: _site               # optional
-          branch: gh-pages                # optional
-          # cname: domain.tld              # optional
-          # jekyll: no                     # optional
-          commit_message: CLDR-00000 Automated Build of Pages # optional
+        uses: actions/upload-pages-artifact@v2
       - name: Deploy to Smoketest
+        if: github.repository == 'unicode-org/cldr'
         shell: bash
         env:
           RSA_KEY_CCC: ${{ secrets.RSA_KEY_CCC }}
@@ -86,6 +86,16 @@ jobs:
           rsync -cav --delete-after -e "ssh -o UserKnownHostsFile=${HOME}/.knownhosts -i ${HOME}/.key -p ${CCC_PORT}" ./_site/ ${CCC_USER}@${CCC_HOST}:spec/$(basename ${GITHUB_REF_NAME})/
           echo "::endgroup::"
           echo "Now go to https://cldr-smoke.unicode.org/spec/"$(basename ${GITHUB_REF_NAME})
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
 
 # only run one of these at a time
 concurrency:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,8 +1,19 @@
 name: CLDR LDML
+title: CLDR LDML
 
 markdown: kramdown
 input: GFM
 
+destination: ../_site
+
 # Google Analytics
 ga_tracking: UA-7672775-1
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings
+
+exclude:
+  - charts/keyboard/node_modules
+  - charts/keyboard/node
+  - ldml
+
+#include:
+#  - site/


### PR DESCRIPTION
CLDR-17566

Looking at #3650 I realized that some subdirectories were not getting build properly. This fixes the build to use `github-pages build` instead of raw `jekyll`.  FYI @lianghai

- [ ] This PR completes the ticket.

To review, see: (note srl URL)

- https://srl295.github.io/cldr/site/downloads/cldr-45.html
- https://srl295.github.io/cldr/ (LDML spec should be same as usual)
- https://srl295.github.io/cldr/dev/generate-emoji-paths.html

These are broken in current main, for example <https://unicode-org.github.io/cldr/dev/generate-emoji-paths.html> and <https://unicode-org.github.io/cldr/site/downloads/cldr-45.html> are dead links.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
