### PR TITLE
CLDR-17532 update max search keywords

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
@@ -35,9 +35,9 @@ public class CheckWidths extends CheckCLDR {
     private static UnitWidthUtil UNIT_WIDTHS_UTIL = UnitWidthUtil.getInstance();
 
     /** Controls for the warning about too many components, and for when to cause error. */
-    public static final int WARN_COMPONENTS_PER_ANNOTATION = 7;
+    public static final int WARN_COMPONENTS_PER_ANNOTATION = 10;
 
-    public static final int MAX_COMPONENTS_PER_ANNOTATION = 16;
+    public static final int MAX_COMPONENTS_PER_ANNOTATION = 30;
 
     SupplementalDataInfo supplementalData;
 


### PR DESCRIPTION
CLDR-17532

Reset the CheckWidths for emoji search keywords. This is a large max, to allow the extra values from https://unicode-org.atlassian.net/browse/CLDR-17349 One-off import of additional Emoji keyword data from WhatsApp into CLDR as part of v46 cycle

After CLDR-17349 has been merged we can fine-tune the values.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
