### PR TITLE
CLDR-15649 Dashboard using filters, show spinner while updating visibility

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrErrorSubtypes.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrErrorSubtypes.mjs
@@ -147,7 +147,7 @@ function reloadMapHandler(json) {
   }
   el.innerHTML = html;
   if (json.err) {
-    const b = cldrDom.createLinkToFn('special_error_subtypes', load, 'button');
+    const b = cldrDom.createLinkToFn("special_error_subtypes", load, "button");
     el.appendChild(b);
   }
 }


### PR DESCRIPTION
-The spinner replaces the Dashboard rows until Vue updates the DOM to reflect checkbox change

-Format cldrErrorSubtypes.mjs (from another ticket)

CLDR-15649

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
