### PR TITLE
CLDR-17553 Change default numbering system for ar.xml to latn.  For a…

### DIFF
--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -6000,7 +6000,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		</timeZoneNames>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>arab</defaultNumberingSystem>
+		<defaultNumberingSystem>latn</defaultNumberingSystem>
 		<defaultNumberingSystem alt="latn">latn</defaultNumberingSystem>
 		<otherNumberingSystems>
 			<native>arab</native>

--- a/common/main/ar_AE.xml
+++ b/common/main/ar_AE.xml
@@ -47,7 +47,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</fields>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>latn</defaultNumberingSystem>
+		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_BH.xml
+++ b/common/main/ar_BH.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="BH"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_DJ.xml
+++ b/common/main/ar_DJ.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="DJ"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<currencies>
 			<currency type="DJF">
 				<symbol>Fdj</symbol>

--- a/common/main/ar_DZ.xml
+++ b/common/main/ar_DZ.xml
@@ -81,7 +81,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>latn</defaultNumberingSystem>
+		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_EG.xml
+++ b/common/main/ar_EG.xml
@@ -17,7 +17,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</languages>
 	</localeDisplayNames>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_EH.xml
+++ b/common/main/ar_EH.xml
@@ -12,6 +12,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="EH"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>latn</defaultNumberingSystem>
+		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
 	</numbers>
 </ldml>

--- a/common/main/ar_ER.xml
+++ b/common/main/ar_ER.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="ER"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<currencies>
 			<currency type="ERN">
 				<symbol>Nfk</symbol>

--- a/common/main/ar_IL.xml
+++ b/common/main/ar_IL.xml
@@ -44,6 +44,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 	</numbers>
 </ldml>

--- a/common/main/ar_IQ.xml
+++ b/common/main/ar_IQ.xml
@@ -108,7 +108,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_JO.xml
+++ b/common/main/ar_JO.xml
@@ -108,7 +108,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_KM.xml
+++ b/common/main/ar_KM.xml
@@ -44,7 +44,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<currencies>
 			<currency type="KMF">
 				<symbol>CF</symbol>

--- a/common/main/ar_KW.xml
+++ b/common/main/ar_KW.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="KW"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_LB.xml
+++ b/common/main/ar_LB.xml
@@ -111,7 +111,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
 			<group>.</group>

--- a/common/main/ar_LY.xml
+++ b/common/main/ar_LY.xml
@@ -52,7 +52,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>latn</defaultNumberingSystem>
+		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
 			<group>.</group>

--- a/common/main/ar_MA.xml
+++ b/common/main/ar_MA.xml
@@ -109,7 +109,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>latn</defaultNumberingSystem>
+		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_MR.xml
+++ b/common/main/ar_MR.xml
@@ -111,7 +111,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
 			<group>.</group>

--- a/common/main/ar_OM.xml
+++ b/common/main/ar_OM.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="OM"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_PS.xml
+++ b/common/main/ar_PS.xml
@@ -108,6 +108,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 	</numbers>
 </ldml>

--- a/common/main/ar_QA.xml
+++ b/common/main/ar_QA.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="QA"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_SA.xml
+++ b/common/main/ar_SA.xml
@@ -1375,7 +1375,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</timeZoneNames>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<minimumGroupingDigits draft="contributed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="arab">
 			<decimal>↑↑↑</decimal>

--- a/common/main/ar_SD.xml
+++ b/common/main/ar_SD.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="SD"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_SO.xml
+++ b/common/main/ar_SO.xml
@@ -15,7 +15,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<exemplarCharacters type="numbers">[\u200E \- ‑ , . ٪ ‰ + 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 	</characters>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="latn">
 			<percentSign draft="contributed">٪</percentSign>
 		</symbols>

--- a/common/main/ar_SS.xml
+++ b/common/main/ar_SS.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="SS"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<currencies>
 			<currency type="GBP">
 				<symbol>GB£</symbol>

--- a/common/main/ar_SY.xml
+++ b/common/main/ar_SY.xml
@@ -108,7 +108,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_TD.xml
+++ b/common/main/ar_TD.xml
@@ -12,6 +12,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="TD"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 	</numbers>
 </ldml>

--- a/common/main/ar_TN.xml
+++ b/common/main/ar_TN.xml
@@ -81,7 +81,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 	</dates>
 	<numbers>
-		<defaultNumberingSystem>latn</defaultNumberingSystem>
+		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>

--- a/common/main/ar_YE.xml
+++ b/common/main/ar_YE.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<territory type="YE"/>
 	</identity>
 	<numbers>
-		<defaultNumberingSystem>↑↑↑</defaultNumberingSystem>
+		<defaultNumberingSystem>arab</defaultNumberingSystem>
 		<symbols numberSystem="arab">
 			<decimal draft="contributed">↑↑↑</decimal>
 			<group draft="contributed">↑↑↑</group>


### PR DESCRIPTION
…ll Arabic locales whose default numbering system

was "↑↑↑", change it to "arab".  For all Arabic locales whose default numbering system was "↑↑↑", change it to "latn".

CLDR-17553

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17553)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
