### PR TITLE
CLDR-17106 add more fixed candidate items

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -29,9 +29,6 @@ import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.PathValueInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
-import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
-import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
-import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
 import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SurveyToolStatus;
 import org.unicode.cldr.util.VoteResolver.Status;
@@ -566,8 +563,7 @@ public class DataPage {
 
         /** check to see if there are any 'fixed' values, i.e. no freeform input is allowed. */
         public void addFixedCandidates() {
-            Collection<String> candidates = getFixedCandidates();
-            // Could have other XPaths here
+            Collection<String> candidates = stFactory.getFixedCandidates(locale, xpath);
 
             if (candidates == null || candidates.isEmpty()) {
                 return;
@@ -576,18 +572,6 @@ public class DataPage {
             for (final String candidate : candidates) {
                 addItem(candidate, "fixed");
             }
-        }
-
-        private Collection<String> getFixedCandidates() {
-            if (PatternCache.get("^//ldml/units/unitLength.*/unit.*/gender")
-                    .matcher(xpath)
-                    .matches()) {
-                return grammarInfo.get(
-                        GrammaticalTarget.nominal,
-                        GrammaticalFeature.grammaticalGender,
-                        GrammaticalScope.units);
-            }
-            return Collections.emptySet();
         }
 
         /**
@@ -1445,6 +1429,7 @@ public class DataPage {
     private final XPathMatcher matcher;
     private final PageId pageId;
     private CLDRFile diskFile;
+    private final STFactory stFactory;
 
     private static final boolean DEBUG_DATA_PAGE = false;
     private String creationTime = null; // only used if DEBUG_DATA_PAGE
@@ -1456,7 +1441,9 @@ public class DataPage {
         this.sm = sm;
         this.matcher = matcher;
         xpathPrefix = prefix;
-        ballotBox = sm.getSTFactory().ballotBoxForLocale(locale);
+        this.stFactory = sm.getSTFactory();
+        ballotBox = stFactory.ballotBoxForLocale(locale);
+
         this.pageId = pageId;
 
         if (DEBUG_DATA_PAGE) {
@@ -1465,7 +1452,6 @@ public class DataPage {
                             .format(Calendar.getInstance().getTime());
             System.out.println("🌴 Created new DataPage for loc " + loc + " at " + creationTime);
         }
-        grammarInfo = sm.getSupplementalDataInfo().getGrammarInfo(locale.getBaseName());
     }
 
     /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DiskDataCache.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DiskDataCache.java
@@ -1,24 +1,49 @@
 package org.unicode.cldr.web;
 
+import static org.unicode.cldr.web.FixedCandidateProvider.forEnumWithFixedXpath;
+
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.GrammarInfo;
+import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
+import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
+import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
 import org.unicode.cldr.util.PathHeader;
+import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.util.personname.PersonNameFormatter;
+import org.unicode.cldr.web.FixedCandidateProvider.PatternCacheCandidateProvider;
 
 /** Cache for on-disk immutable data. */
 public class DiskDataCache {
     static final Logger logger = Logger.getLogger(DiskDataCache.class.getSimpleName());
 
     private final Factory factory;
-    private final CLDRFile english;
+    private final CLDRFile english; // TODO: Unused?
     private final PathHeader.Factory phf;
+    final SupplementalDataInfo sdi;
+
+    final List<FixedCandidateProvider> personNameProviders =
+            ImmutableList.of(
+                    forEnumWithFixedXpath(
+                            "//ldml/personNames/parameterDefault[@parameter=\"formality\"]",
+                            PersonNameFormatter.Formality.values()),
+                    forEnumWithFixedXpath(
+                            "//ldml/personNames/parameterDefault[@parameter=\"length\"]",
+                            PersonNameFormatter.Length.values()));
 
     /** this is the immutable cousin of STFactory.PerLocaleData, for the on-disk data */
     class DiskDataEntry {
@@ -27,18 +52,57 @@ public class DiskDataCache {
         final CLDRFile diskFile;
         final Set<String> pathsForFile;
 
+        private final List<FixedCandidateProvider> fixedCandidateProviders = new LinkedList<>();
+
         public DiskDataEntry(CLDRLocale locale) {
             this.locale = locale;
             diskData = factory.makeSource(locale.getBaseName()).freeze();
             diskFile = factory.make(locale.getBaseName(), true).freeze();
             pathsForFile = getPathHeaderFactory().pathsForFile(diskFile);
+
+            addFixedCandidateProviders();
+        }
+
+        private void addFixedCandidateProviders() {
+            // Add all Candidate Providers here
+            fixedCandidateProviders.add(new GrammarCandidateProvider());
+            fixedCandidateProviders.addAll(personNameProviders);
+        }
+
+        /** Candidate provider for a regex */
+        class GrammarCandidateProvider extends PatternCacheCandidateProvider {
+            final GrammarInfo grammarInfo = sdi.getGrammarInfo(locale.getBaseName());
+
+            public GrammarCandidateProvider() {
+                super("^//ldml/units/unitLength.*/unit.*gender");
+            }
+
+            @Override
+            protected Collection<String> getCandidates() {
+                return grammarInfo.get(
+                        GrammaticalTarget.nominal,
+                        GrammaticalFeature.grammaticalGender,
+                        GrammaticalScope.units);
+            }
+        }
+
+        /**
+         * @returns a list of values (or empty list) of any 'fixed' candidates for this xpath
+         */
+        Collection<String> getFixedCandidates(final String xpath) {
+            for (final FixedCandidateProvider fcp : fixedCandidateProviders) {
+                final Collection<String> r = fcp.apply(xpath);
+                if (r != null) return r;
+            }
+            return Collections.emptySet();
         }
     }
 
-    public DiskDataCache(Factory f, CLDRFile english) {
+    public DiskDataCache(Factory f, CLDRFile english, SupplementalDataInfo sdi) {
         this.factory = f;
         this.english = english;
         this.phf = PathHeader.getFactory(english);
+        this.sdi = sdi;
     }
 
     public PathHeader.Factory getPathHeaderFactory() {
@@ -51,7 +115,7 @@ public class DiskDataCache {
                             new CacheLoader<CLDRLocale, DiskDataEntry>() {
 
                                 @Override
-                                public DiskDataEntry load(CLDRLocale l) throws Exception {
+                                public DiskDataEntry load(@Nonnull CLDRLocale l) throws Exception {
                                     return new DiskDataEntry(l);
                                 }
                             });

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/FixedCandidateProvider.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/FixedCandidateProvider.java
@@ -1,0 +1,84 @@
+package org.unicode.cldr.web;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.unicode.cldr.util.PatternCache;
+
+abstract class FixedCandidateProvider
+        implements java.util.function.Function<String, Collection<String>> {
+    /**
+     * @returns a list of values (or null if not applicable) of any 'fixed' candidates for this
+     *     XPath
+     */
+    public abstract Collection<String> apply(String xpath);
+
+    /** helper function to convert an Enum to an array of strings */
+    static final <T extends Enum<T>> Collection<String> enumValueStrings(T forValues[]) {
+        final List<String> l = new ArrayList<String>(forValues.length);
+        for (final T t : forValues) {
+            l.add(t.toString());
+        }
+        return ImmutableList.copyOf(l);
+    }
+
+    /** Candidate provider using a Pattern Cache */
+    abstract static class PatternCacheCandidateProvider extends FixedCandidateProvider {
+        final Pattern pattern;
+
+        public PatternCacheCandidateProvider(String patternString) {
+            pattern = PatternCache.get(patternString);
+        }
+
+        public Collection<String> apply(String xpath) {
+            if (pattern.matcher(xpath).matches()) {
+                return getCandidates();
+            } else {
+                return null; // not applicable
+            }
+        }
+
+        protected abstract Collection<String> getCandidates();
+    }
+    /** Candidate provider for a single string (not regex) */
+    abstract static class StringCandidateProvider extends FixedCandidateProvider {
+        final String pattern;
+
+        public StringCandidateProvider(String xpath) {
+            pattern = xpath;
+        }
+
+        public Collection<String> apply(String xpath) {
+            if (pattern.equals(xpath)) {
+                return getCandidates();
+            } else {
+                return null; // not applicable
+            }
+        }
+
+        protected abstract Collection<String> getCandidates();
+    }
+
+    /** create a provider that matches an fixed XPath and returns a set of values */
+    public static <T extends Enum<T>> FixedCandidateProvider forEnumWithFixedXpath(
+            String xpath, T[] values) {
+        return new EnumStringCandidateProvider(
+                xpath, FixedCandidateProvider.enumValueStrings(values));
+    }
+
+    private static class EnumStringCandidateProvider extends StringCandidateProvider {
+        private final Collection<String> values;
+
+        @Override
+        protected Collection<String> getCandidates() {
+            return values;
+        }
+
+        EnumStringCandidateProvider(final String xpath, final Collection<String> values) {
+            super(xpath);
+            this.values = values;
+        }
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -19,6 +19,7 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -341,7 +342,6 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             readonly = isReadOnlyLocale(locale);
             stamp = mintLocaleStamp(locale);
             pathsForFile = diskDataEntry.pathsForFile;
-
             if (readonly) {
                 rFile = diskDataEntry.diskFile;
                 xmlsource = diskDataEntry.diskData;
@@ -1219,7 +1219,9 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             progress.update("reload all users");
             sm.reg.getVoterInfoList();
             progress.update("setup pathheader factory");
-            diskDataCache = new DiskDataCache(sm.getDiskFactory(), sm.getEnglishFile());
+            diskDataCache =
+                    new DiskDataCache(
+                            sm.getDiskFactory(), sm.getEnglishFile(), sm.getSupplementalDataInfo());
         }
     }
 
@@ -1977,5 +1979,9 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
     public static List<CheckStatus> removeExcludedChecks(List<CheckStatus> tests) {
         tests.removeIf((status) -> status.getSubtype() == Subtype.coverageLevel);
         return tests;
+    }
+
+    public Collection<String> getFixedCandidates(CLDRLocale locale, String xpath) {
+        return diskDataCache.get(locale).getFixedCandidates(xpath);
     }
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -2734,14 +2734,17 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         ctx.redirect(vurl);
     }
 
-    private SupplementalDataInfo supplementalDataInfo = null;
+    private Supplier<SupplementalDataInfo> supplementalDataInfo =
+            Suppliers.memoize(
+                    () -> {
+                        final SupplementalDataInfo newSdi =
+                                SupplementalDataInfo.getInstance(getSupplementalDirectory());
+                        newSdi.setAsDefaultInstance();
+                        return newSdi;
+                    });
 
-    public final synchronized SupplementalDataInfo getSupplementalDataInfo() {
-        if (supplementalDataInfo == null) {
-            supplementalDataInfo = SupplementalDataInfo.getInstance(getSupplementalDirectory());
-            supplementalDataInfo.setAsDefaultInstance();
-        }
-        return supplementalDataInfo;
+    public final SupplementalDataInfo getSupplementalDataInfo() {
+        return supplementalDataInfo.get();
     }
 
     File getSupplementalDirectory() {


### PR DESCRIPTION
- restructure DataPage / DiskDataCache to hold the candidate providers
- add a FixedCandidateProvider structure, designed to allow quick additions of future fixed candidates.

CLDR-17106

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
