### PR TITLE
CLDR-17459 Add units for grammar

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -187,7 +187,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: run CLDR console check
-        run: java -DCLDR_GITHUB_ANNOTATIONS=true -DCLDR_DIR=$(pwd) -Xmx6g -jar tools/cldr-code/target/cldr-code.jar check -S common,seed -e -z FINAL_TESTING
+        run: java -DCLDR_GITHUB_ANNOTATIONS=true -DCLDR_DIR=$(pwd) -Xmx6g -jar tools/cldr-code/target/cldr-code.jar check -S common,seed -e -z BUILD
   deploy:
     # don't run deploy on manual builds!
     if: github.repository == 'unicode-org/cldr' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.inputs.git-ref == ''

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -289,7 +289,7 @@ For terms of use, see http://www.unicode.org/copyright.html
         <convertUnit source='pascal' baseUnit='kilogram-per-meter-square-second' systems="si metric prefixable"/>
         <convertUnit source='bar' baseUnit='kilogram-per-meter-square-second' factor='100000' systems="si_acceptable metric prefixable"/>
         <convertUnit source='atmosphere' baseUnit='kilogram-per-meter-square-second' factor='101325' systems="ussystem uksystem "/>
-        <convertUnit source='gasoline-energy-density' baseUnit='kilogram-per-meter-square-second' factor='33.705 * 3600 * 1000/gal_to_m3'  systems="metric_adjacent ussystem uksystem" description="Constructed so that 1 gallon-gasoline-energy-density = 33.705 kWh as per https://www3.epa.gov/otaq/gvg/learn-more-technology.htm"/>
+        <convertUnit source='gasoline-energy-density' baseUnit='kilogram-per-meter-square-second' factor='33.705 * 3600 * 1000/gal_to_m3'  systems="ussystem uksystem" description="Constructed so that 1 gallon-gasoline-energy-density = 33.705 kWh as per https://www3.epa.gov/otaq/gvg/learn-more-technology.htm"/>
 
         <!-- pressure-per-length -->
         <convertUnit source='ofhg' baseUnit='kilogram-per-square-meter-square-second' factor='13595.1*gravity' systems="metric_adjacent uksystem ussystem"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -745,21 +745,19 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
                     "month",
                     "year");
 
+    // To see a list of the results for double-checking, run TestUnits with TestUnitsToTranslate -v
     static final Set<String> EXCLUDE_GRAMMAR =
             Set.of(
-                    "point",
-                    "dunam",
-                    "dot",
-                    "astronomical-unit",
-                    "nautical-mile",
-                    "knot",
-                    "dalton",
+                    "dot", // fallback is pixel
+                    "dot-per-centimeter", // fallback is pixel
+                    "dunam", // language-specific
+                    "astronomical-unit", // specialized
+                    "nautical-mile", // US/UK specific
+                    "knot", // US/UK specific
+                    "dalton", // specialized
+                    "electronvolt", // specialized
                     "kilocalorie",
-                    "electronvolt",
-                    // The following may be reinstated after 45.
-                    "dot-per-centimeter",
-                    "millimeter-ofhg",
-                    "milligram-ofglucose-per-deciliter");
+                    "point");
 
     public static Set<String> getSpecialsToTranslate() {
         return INCLUDE_OTHER;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -3544,7 +3544,22 @@ public class TestUnits extends TestFmwk {
         has_grammar_X,
         add_grammar,
         skip_grammar,
-        skip_trans
+        skip_trans("\t— specific langs poss.)");
+
+        private TranslationStatus() {
+            outName = name();
+        }
+
+        private final String outName;
+
+        private TranslationStatus(String extra) {
+            outName = name() + extra;
+        }
+
+        @Override
+        public String toString() {
+            return outName;
+        }
     }
 
     /**
@@ -3555,7 +3570,8 @@ public class TestUnits extends TestFmwk {
         Set<String> toTranslate = GrammarInfo.getUnitsToAddGrammar();
         final CLDRConfig config = CLDRConfig.getInstance();
         final UnitConverter converter = config.getSupplementalDataInfo().getUnitConverter();
-        Map<String, TranslationStatus> shortUnitToTranslationStatus40 = new TreeMap<>();
+        Map<String, TranslationStatus> shortUnitToTranslationStatus40 =
+                new TreeMap<>(converter.getShortUnitIdComparator());
         for (String longUnit :
                 Validity.getInstance().getStatusToCodes(LstrType.unit).get(Status.regular)) {
             String shortUnit = converter.getShortId(longUnit);
@@ -3588,9 +3604,9 @@ public class TestUnits extends TestFmwk {
             TranslationStatus status40 = entry.getValue();
             if (isVerbose())
                 System.out.println(
-                        shortUnit
+                        converter.getQuantityFromUnit(shortUnit, false)
                                 + "\t"
-                                + converter.getQuantityFromUnit(shortUnit, false)
+                                + shortUnit
                                 + "\t"
                                 + converter.getSystemsEnum(shortUnit)
                                 + "\t"


### PR DESCRIPTION
CLDR-17459

Added grammar to some units that were skipped earlier.
The breakdown is at https://docs.google.com/spreadsheets/d/1soBtcb3SwNaCMg3maD0vvbWqqimco4ZKpdtSpB7NJ1E/edit#gid=0

Also
- added a comparator for units, to help in examining the result. (And are needed for another ticket.)
- set gasoline-per-mile to not be metric_adjacent

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
DISABLE_JIRA_ISSUE_MATCH=true
