### PR TITLE
CLDR-17492 Temporarily point to a fixed snapshot

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -25,7 +25,9 @@
 			SNAPSHOT for the ICU version that we want, so this should only need updating
 			when the ICU version changes e.g. from 74.0.1, to 74.1, to 75.0.1, then to 75.1.
 			You can use github actions in icu to manually push the latest SNAPSHOT version. -->
-		<icu4j.version>76.0.1-SNAPSHOT</icu4j.version>
+		<!-- <icu4j.version>76.0.1-SNAPSHOT</icu4j.version> -->
+		<!-- Temporary, so that the refactoring of cldr-utilities does not break this. -->
+		<icu4j.version>76.0.1-20240429.164423-1</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.1.0</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
Use a specific SNAPSHOT so that the cldr-utilities refactoring does not break the functionality.

Once the changes land in ICU, we will publish a new version. Then back here I update the package, and go back to using 76.0.1-SNAPSHOT, in one single commit.

CLDR-17492

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
