### PR TITLE
CLDR-16941 Improve coverage for non-latn default/native number symbols/patterns

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -1278,7 +1278,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST coverageLevel inLanguage CDATA #IMPLIED >
     <!--@MATCH:any-->
 <!ATTLIST coverageLevel inScript CDATA #IMPLIED >
-    <!--@MATCH:validity/script-->
+    <!--@MATCH:any-->
 <!ATTLIST coverageLevel inTerritory CDATA #IMPLIED >
     <!--@MATCH:any-->
 <!ATTLIST coverageLevel value CDATA #REQUIRED >

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -180,24 +180,42 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageVariable key="%anyAttribute" value='([^\x{22}]++)'/>
 
-		<!-- Number system coverage by language; default number system items at various levels, native system items all at modern -->
-		<coverageVariable key="%arabDefaultLanguages" value="(ar|ckb)"/>
-		<coverageVariable key="%arabextDefaultLanguages" value="(fa|ks|lrc|pa|ps|ur|uz)"/>
-		<coverageVariable key="%arabextNativeLanguages" value="(mzn|ug)"/>
-		<coverageVariable key="%bengDefaultLanguages" value="(as|bn)"/>
-		<coverageVariable key="%devaDefaultLanguages" value="(mr|ne)"/>
-		<coverageVariable key="%devaNativeLanguages" value="(brx|hi|kok)"/>
-		<coverageVariable key="%gujrNativeLanguages" value="(gu)"/>
-		<coverageVariable key="%guruNativeLanguages" value="(pa)"/>
-		<coverageVariable key="%hanidecNativeLanguages" value="(yue|zh)"/>
+		<!-- Number system coverage by language and/or script; default number system items at various levels, native & finance system items all at modern -->
+		<coverageVariable key="%adlmDefaultScripts" value="(Adlm)"/>
+		<coverageVariable key="%arabDefaultLanguages" value="(ar|ckb|sd|sdh)"/> <!-- && inScript="Arab" to disambiguate languages in multiple scripts -->
+		<coverageVariable key="%arabNativeLanguages" value="(dv|ha)"/> <!-- && inScript="Arab" -->
+		<coverageVariable key="%arabextDefaultLanguages" value="(az|bgn|fa|ks|lrc|mzn|pa|ps|ur|uz)"/> <!-- && inScript="Arab" -->
+		<coverageVariable key="%arabextNativeLanguages" value="(trw|ug)"/> <!-- && inScript="Arab" -->
+		<coverageVariable key="%arabextAllLanguages" value="(az|bgn|fa|ks|lrc|mzn|pa|ps|trw|ug|ur|uz)"/> <!-- union of default  & native, for display name -->
+		<coverageVariable key="%bengDefaultScripts" value="(Beng)"/> <!-- e.g. mni can be written in Beng or Mtei -->
+		<coverageVariable key="%cakmDefaultScripts" value="(Cakm)"/>
+		<coverageVariable key="%devaDefaultLanguages" value="(bgc|bho|mr|ne|raj|sa|sat)"/> <!-- && inScript="Deva" to disambiguate languages in multiple scripts -->
+		<coverageVariable key="%devaNativeLanguages" value="(brx|doi|hi|kok|kxv|mai|xnr)"/> <!-- && inScript="Deva" -->
+		<coverageVariable key="%gujrNativeScripts" value="(Gujr)"/>
+		<coverageVariable key="%guruNativeScripts" value="(Guru)"/> <!-- e.g. pa can be written in Guru or Arab -->
+		<coverageVariable key="%hanidecNativeLanguages" value="(yue|zh)"/> <!-- regardless of script, Hans or Hant -->
+		<coverageVariable key="%hansfinFinanceScripts" value="(Hans)"/>
+		<coverageVariable key="%hantfinFinanceScripts" value="(Hant)"/>
+		<coverageVariable key="%hmnpDefaultScripts" value="(Hmnp)"/>
+		<coverageVariable key="%jpanfinFinanceLanguages" value="(ja)"/>
+		<coverageVariable key="%javaNativeLanguages" value="(jv)"/>
+		<coverageVariable key="%khmrNativeLanguages" value="(km)"/>
 		<coverageVariable key="%kndaNativeLanguages" value="(kn)"/>
+		<coverageVariable key="%laooNativeLanguages" value="(lo)"/>
 		<coverageVariable key="%mlymNativeLanguages" value="(ml)"/>
+		<coverageVariable key="%mongNativeScripts" value="(Mong)"/> <!-- native for mn only when in Mong -->
+		<coverageVariable key="%mteiDefaultScripts" value="(Mtei)"/> <!-- default for mni only when in Mtei -->
 		<coverageVariable key="%mymrDefaultLanguages" value="(my)"/>
-		<coverageVariable key="%oryaNativeLanguages" value="(or)"/>
+		<coverageVariable key="%nkooDefaultLanguages" value="(nqo)"/>
+		<coverageVariable key="%nkooNativeScripts" value="(Nkoo)"/> <!-- native for other languages when in Nkoo, such as bm -->
+		<coverageVariable key="%olckDefaultScripts" value="(Olck)"/> <!-- default for sat only when in Olck -->
+		<coverageVariable key="%oryaNativeScripts" value="(Orya)"/> <!-- native for or, and kxv only when in Orya -->
 		<coverageVariable key="%tamldecNativeLanguages" value="(ta)"/>
-		<coverageVariable key="%teluNativeLanguages" value="(te)"/>
+		<coverageVariable key="%teluNativeScripts" value="(Telu)"/> <!-- native for te, and kxv only when in Telu -->
+		<coverageVariable key="%thaiNativeLanguages" value="(th)"/>
 		<coverageVariable key="%tibtDefaultLanguages" value="(dz)"/>
 		<coverageVariable key="%tibtNativeLanguages" value="(bo)"/>
+		<coverageVariable key="%vaiiNativeLanguages" value="(vai)"/> <!-- regardless of script -->
 
 		<!-- Additional variables for the restructuring -->
 
@@ -265,11 +283,12 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inLanguage="%traditionalCollationLanguages"	match="localeDisplayNames/types/type[@key='collation'][@type='traditional']"/>
 		<coverageLevel	value="moderate"	inLanguage="%CJK_Languages"	match="localeDisplayNames/types/type[@key='collation'][@type='unihan']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/types/type[@key='numbers'][@type='latn']"/>
-		<coverageLevel	value="moderate"	inLanguage="zh"	match="localeDisplayNames/types/type[@key='numbers'][@type='(han(s|t)(fin)?|hanidec)']"/>
+		<coverageLevel	value="moderate"	inLanguage="%hanidecNativeLanguages"	match="localeDisplayNames/types/type[@key='numbers'][@type='(han(s|t)(fin)?|hanidec)']"/>
 		<coverageLevel	value="moderate"	inScript="Arab"	match="localeDisplayNames/types/type[@key='numbers'][@type='arab']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="localeDisplayNames/types/type[@key='numbers'][@type='arabext']"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextAllLanguages"	match="localeDisplayNames/types/type[@key='numbers'][@type='arabext']"/>
 		<coverageLevel	value="moderate"	inScript="Armn"	match="localeDisplayNames/types/type[@key='numbers'][@type='armn(low)?']"/>
 		<coverageLevel	value="moderate"	inScript="Beng"	match="localeDisplayNames/types/type[@key='numbers'][@type='beng']"/>
+		<coverageLevel	value="moderate"	inScript="Cakm"	match="localeDisplayNames/types/type[@key='numbers'][@type='cakm']"/>
 		<coverageLevel	value="moderate"	inScript="Deva"	match="localeDisplayNames/types/type[@key='numbers'][@type='deva']"/>
 		<coverageLevel	value="moderate"	inScript="Ethi"	match="localeDisplayNames/types/type[@key='numbers'][@type='ethi']"/>
 		<coverageLevel	value="moderate"	inLanguage="%CJK_Languages"	match="localeDisplayNames/types/type[@key='numbers'][@type='fullwide']"/>
@@ -277,17 +296,21 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inScript="Grek"	match="localeDisplayNames/types/type[@key='numbers'][@type='grek(low)?']"/>
 		<coverageLevel	value="moderate"	inScript="Gujr"	match="localeDisplayNames/types/type[@key='numbers'][@type='gujr']"/>
 		<coverageLevel	value="moderate"	inScript="Guru"	match="localeDisplayNames/types/type[@key='numbers'][@type='guru']"/>
-		<coverageLevel	value="moderate"	inScript="Guru"	match="localeDisplayNames/types/type[@key='numbers'][@type='guru']"/>
 		<coverageLevel	value="moderate"	inScript="Hebr"	match="localeDisplayNames/types/type[@key='numbers'][@type='hebr']"/>
+		<coverageLevel	value="moderate"	inScript="Hmnp"	match="localeDisplayNames/types/type[@key='numbers'][@type='hmnp']"/>
 		<coverageLevel	value="moderate"	inLanguage="ja"	match="localeDisplayNames/types/type[@key='numbers'][@type='jpan(fin)?']"/>
+		<coverageLevel	value="moderate"	inLanguage="jv"	match="localeDisplayNames/types/type[@key='numbers'][@type='java']"/>
 		<coverageLevel	value="moderate"	inScript="Khmr"	match="localeDisplayNames/types/type[@key='numbers'][@type='khmr']"/>
 		<coverageLevel	value="moderate"	inScript="Knda"	match="localeDisplayNames/types/type[@key='numbers'][@type='knda']"/>
 		<coverageLevel	value="moderate"	inScript="Laoo"	match="localeDisplayNames/types/type[@key='numbers'][@type='laoo']"/>
 		<coverageLevel	value="moderate"	inScript="Mlym"	match="localeDisplayNames/types/type[@key='numbers'][@type='mlym']"/>
 		<coverageLevel	value="moderate"	inScript="Mong"	match="localeDisplayNames/types/type[@key='numbers'][@type='mong']"/>
+		<coverageLevel	value="moderate"	inScript="Mtei"	match="localeDisplayNames/types/type[@key='numbers'][@type='mtei']"/>
 		<coverageLevel	value="moderate"	inScript="Mymr"	match="localeDisplayNames/types/type[@key='numbers'][@type='mymr(shan)?']"/>
+		<coverageLevel	value="moderate"	inScript="Nkoo"	match="localeDisplayNames/types/type[@key='numbers'][@type='nkoo']"/>
+		<coverageLevel	value="moderate"	inScript="Olck"	match="localeDisplayNames/types/type[@key='numbers'][@type='olck']"/>
 		<coverageLevel	value="moderate"	inScript="Orya"	match="localeDisplayNames/types/type[@key='numbers'][@type='orya']"/>
-		<coverageLevel	value="moderate"	inScript="Taml"	match="localeDisplayNames/types/type[@key='numbers'][@type='taml']"/>
+		<coverageLevel	value="moderate"	inScript="Taml"	match="localeDisplayNames/types/type[@key='numbers'][@type='taml(dec)?']"/>
 		<coverageLevel	value="moderate"	inScript="Telu"	match="localeDisplayNames/types/type[@key='numbers'][@type='telu']"/>
 		<coverageLevel	value="moderate"	inScript="Thai"	match="localeDisplayNames/types/type[@key='numbers'][@type='thai']"/>
 		<coverageLevel	value="moderate"	inScript="Tibt"	match="localeDisplayNames/types/type[@key='numbers'][@type='tibt']"/>
@@ -423,42 +446,66 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="numbers/symbols[@numberSystem='latn']/percentSign"/>
 		<coverageLevel	value="basic"	 	match="numbers/symbols[@numberSystem='latn']/plusSign"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/decimal"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/group"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/minusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/percentSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/symbols[@numberSystem='arab']/plusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/symbols[@numberSystem='arabext']/decimal"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/symbols[@numberSystem='arabext']/group"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/symbols[@numberSystem='arabext']/minusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/symbols[@numberSystem='arabext']/percentSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/symbols[@numberSystem='arabext']/plusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/symbols[@numberSystem='beng']/decimal"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/symbols[@numberSystem='beng']/group"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/symbols[@numberSystem='beng']/minusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/symbols[@numberSystem='beng']/percentSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/symbols[@numberSystem='beng']/plusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/symbols[@numberSystem='deva']/decimal"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/symbols[@numberSystem='deva']/group"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/symbols[@numberSystem='deva']/minusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/symbols[@numberSystem='deva']/percentSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/symbols[@numberSystem='deva']/plusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/symbols[@numberSystem='khmr']/decimal"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/symbols[@numberSystem='khmr']/group"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/symbols[@numberSystem='khmr']/minusSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/symbols[@numberSystem='khmr']/percentSign"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/symbols[@numberSystem='khmr']/plusSign"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/symbols[@numberSystem='adlm']/decimal"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/symbols[@numberSystem='adlm']/group"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/symbols[@numberSystem='adlm']/minusSign"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/symbols[@numberSystem='adlm']/percentSign"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/symbols[@numberSystem='adlm']/plusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arab']/decimal"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arab']/group"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arab']/minusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arab']/percentSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arab']/plusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arabext']/decimal"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arabext']/group"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arabext']/minusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arabext']/percentSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/symbols[@numberSystem='arabext']/plusSign"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/symbols[@numberSystem='beng']/decimal"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/symbols[@numberSystem='beng']/group"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/symbols[@numberSystem='beng']/minusSign"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/symbols[@numberSystem='beng']/percentSign"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/symbols[@numberSystem='beng']/plusSign"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/symbols[@numberSystem='cakm']/decimal"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/symbols[@numberSystem='cakm']/group"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/symbols[@numberSystem='cakm']/minusSign"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/symbols[@numberSystem='cakm']/percentSign"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/symbols[@numberSystem='cakm']/plusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/symbols[@numberSystem='deva']/decimal"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/symbols[@numberSystem='deva']/group"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/symbols[@numberSystem='deva']/minusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/symbols[@numberSystem='deva']/percentSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/symbols[@numberSystem='deva']/plusSign"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/symbols[@numberSystem='hmnp']/decimal"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/symbols[@numberSystem='hmnp']/group"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/symbols[@numberSystem='hmnp']/minusSign"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/symbols[@numberSystem='hmnp']/percentSign"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/symbols[@numberSystem='hmnp']/plusSign"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/symbols[@numberSystem='mtei']/decimal"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/symbols[@numberSystem='mtei']/group"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/symbols[@numberSystem='mtei']/minusSign"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/symbols[@numberSystem='mtei']/percentSign"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/symbols[@numberSystem='mtei']/plusSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/symbols[@numberSystem='mymr']/decimal"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/symbols[@numberSystem='mymr']/group"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/symbols[@numberSystem='mymr']/minusSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/symbols[@numberSystem='mymr']/percentSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/symbols[@numberSystem='mymr']/plusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/symbols[@numberSystem='nkoo']/decimal"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/symbols[@numberSystem='nkoo']/group"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/symbols[@numberSystem='nkoo']/minusSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/symbols[@numberSystem='nkoo']/percentSign"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/symbols[@numberSystem='nkoo']/plusSign"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/symbols[@numberSystem='olck']/decimal"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/symbols[@numberSystem='olck']/group"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/symbols[@numberSystem='olck']/minusSign"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/symbols[@numberSystem='olck']/percentSign"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/symbols[@numberSystem='olck']/plusSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/decimal"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/group"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/minusSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/percentSign"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/symbols[@numberSystem='tibt']/plusSign"/>
-
 
 		<coverageLevel	value="basic"	 	match="numbers/decimalFormats[@numberSystem='latn']/decimalFormatLength/decimalFormat%stdPattern"/>
 		<coverageLevel	value="basic"	 	match="numbers/percentFormats[@numberSystem='latn']/percentFormatLength/percentFormat%stdPattern"/>
@@ -466,47 +513,80 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="numbers/currencyFormats[@numberSystem='latn']/unitPattern[@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='khmr']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='khmr']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength/currencyFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='beng']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='beng']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='khmr']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='khmr']/decimalFormatLength/decimalFormat%stdPattern"/>
+	
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='adlm']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='adlm']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/decimalFormats[@numberSystem='beng']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/decimalFormats[@numberSystem='beng']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='cakm']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='cakm']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/decimalFormats[@numberSystem='hmnp']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/decimalFormats[@numberSystem='hmnp']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/decimalFormats[@numberSystem='mtei']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/decimalFormats[@numberSystem='mtei']/decimalFormatLength/decimalFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='mymr']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='mymr']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='nkoo']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='nkoo']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/decimalFormats[@numberSystem='olck']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/decimalFormats[@numberSystem='olck']/decimalFormatLength/decimalFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='tibt']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/decimalFormats[@numberSystem='tibt']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/percentFormats[@numberSystem='arab']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/percentFormats[@numberSystem='arabext']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/percentFormats[@numberSystem='beng']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/percentFormats[@numberSystem='deva']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/percentFormats[@numberSystem='khmr']/percentFormatLength/percentFormat%stdPattern"/>
+
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/percentFormats[@numberSystem='adlm']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/percentFormats[@numberSystem='arab']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/percentFormats[@numberSystem='arabext']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/percentFormats[@numberSystem='beng']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/percentFormats[@numberSystem='cakm']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/percentFormats[@numberSystem='deva']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/percentFormats[@numberSystem='hmnp']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/percentFormats[@numberSystem='mtei']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/percentFormats[@numberSystem='mymr']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/percentFormats[@numberSystem='nkoo']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/percentFormats[@numberSystem='olck']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/percentFormats[@numberSystem='tibt']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='arab']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='arabext']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%bengDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='beng']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='deva']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	inLanguage="%khmrDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='khmr']/scientificFormatLength/scientificFormat%stdPattern"/>
+
+		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/scientificFormats[@numberSystem='adlm']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/scientificFormats[@numberSystem='arab']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/scientificFormats[@numberSystem='arabext']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/scientificFormats[@numberSystem='beng']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/scientificFormats[@numberSystem='cakm']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/scientificFormats[@numberSystem='deva']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/scientificFormats[@numberSystem='hmnp']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/scientificFormats[@numberSystem='mtei']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='mymr']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='nkoo']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/scientificFormats[@numberSystem='olck']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/scientificFormats[@numberSystem='tibt']/scientificFormatLength/scientificFormat%stdPattern"/>
 
 		<!-- *********************
@@ -549,50 +629,61 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inTerritory="EU" value="moderate" match="numbers/currencies/currency[@type='%currency60_EU']/displayName"/>
 		<coverageLevel inTerritory="EU" value="moderate" match="numbers/currencies/currency[@type='%currency60_EU']/displayName[@count='%anyAttribute']"/>
 
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='arabext']/decimal"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='arabext']/group"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='arabext']/plusSign"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='arabext']/minusSign"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='arabext']/percentSign"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='arabext']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='arabext']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='deva']/decimal"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='deva']/group"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='deva']/plusSign"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='deva']/minusSign"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='deva']/percentSign"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='deva']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='deva']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='gujr']/decimal"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='gujr']/group"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='gujr']/plusSign"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='gujr']/minusSign"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='gujr']/percentSign"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='gujr']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='gujr']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='gujr']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='gujr']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='gujr']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='gujr']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='guru']/decimal"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='guru']/group"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='guru']/plusSign"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='guru']/minusSign"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='guru']/percentSign"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='guru']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='guru']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='guru']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='guru']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='guru']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='guru']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arab']/decimal"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arab']/group"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arab']/plusSign"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arab']/minusSign"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arab']/percentSign"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/scientificFormats[@numberSystem='arab']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/percentFormats[@numberSystem='arab']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="moderate" match="numbers/decimalFormats[@numberSystem='arab']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arabext']/decimal"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arabext']/group"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arabext']/plusSign"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arabext']/minusSign"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/symbols[@numberSystem='arabext']/percentSign"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/scientificFormats[@numberSystem='arabext']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/percentFormats[@numberSystem='arabext']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="moderate" match="numbers/decimalFormats[@numberSystem='arabext']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/symbols[@numberSystem='deva']/decimal"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/symbols[@numberSystem='deva']/group"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/symbols[@numberSystem='deva']/plusSign"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/symbols[@numberSystem='deva']/minusSign"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/symbols[@numberSystem='deva']/percentSign"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/scientificFormats[@numberSystem='deva']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/percentFormats[@numberSystem='deva']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="moderate" match="numbers/decimalFormats[@numberSystem='deva']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='gujr']/decimal"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='gujr']/group"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='gujr']/plusSign"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='gujr']/minusSign"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='gujr']/percentSign"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='gujr']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='gujr']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='gujr']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='gujr']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/percentFormats[@numberSystem='gujr']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='gujr']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='guru']/decimal"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='guru']/group"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='guru']/plusSign"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='guru']/minusSign"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='guru']/percentSign"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='guru']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='guru']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='guru']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='guru']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/percentFormats[@numberSystem='guru']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%guruNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='guru']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='hanidec']/decimal"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='hanidec']/group"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='hanidec']/plusSign"/>
@@ -603,6 +694,47 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='hanidec']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='hanidec']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='hanidec']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hansfin']/decimal"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hansfin']/group"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hansfin']/plusSign"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hansfin']/minusSign"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hansfin']/percentSign"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='hansfin']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='hansfin']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='hansfin']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/percentFormats[@numberSystem='hansfin']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='hansfin']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hantfin']/decimal"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hantfin']/group"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hantfin']/plusSign"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hantfin']/minusSign"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/symbols[@numberSystem='hantfin']/percentSign"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='hantfin']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='hantfin']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='hantfin']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/percentFormats[@numberSystem='hantfin']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='hantfin']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/symbols[@numberSystem='jpanfin']/decimal"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/symbols[@numberSystem='jpanfin']/group"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/symbols[@numberSystem='jpanfin']/plusSign"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/symbols[@numberSystem='jpanfin']/minusSign"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/symbols[@numberSystem='jpanfin']/percentSign"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='jpanfin']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='jpanfin']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='jpanfin']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='jpanfin']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='jpanfin']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='java']/decimal"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='java']/group"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='java']/plusSign"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='java']/minusSign"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='java']/percentSign"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='java']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='java']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='java']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='java']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='java']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='java']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel inLanguage="%khmrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='khmr']/decimal"/>
 		<coverageLevel inLanguage="%khmrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='khmr']/group"/>
 		<coverageLevel inLanguage="%khmrNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='khmr']/plusSign"/>
@@ -625,6 +757,17 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%kndaNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='knda']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel inLanguage="%kndaNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='knda']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%kndaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='knda']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='laoo']/decimal"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='laoo']/group"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='laoo']/plusSign"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='laoo']/minusSign"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='laoo']/percentSign"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='laoo']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='laoo']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='laoo']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='laoo']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='laoo']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='laoo']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='mlym']/decimal"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='mlym']/group"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='mlym']/plusSign"/>
@@ -636,17 +779,39 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='mlym']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='mlym']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='mlym']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='orya']/decimal"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='orya']/group"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='orya']/plusSign"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='orya']/minusSign"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='orya']/percentSign"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='orya']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='orya']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='orya']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='orya']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='orya']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='orya']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='mong']/decimal"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='mong']/group"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='mong']/plusSign"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='mong']/minusSign"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='mong']/percentSign"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='mong']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='mong']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='mong']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='mong']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/percentFormats[@numberSystem='mong']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%mongNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='mong']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='nkoo']/decimal"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='nkoo']/group"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='nkoo']/plusSign"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='nkoo']/minusSign"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='nkoo']/percentSign"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='nkoo']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='nkoo']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/percentFormats[@numberSystem='nkoo']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='nkoo']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='orya']/decimal"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='orya']/group"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='orya']/plusSign"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='orya']/minusSign"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='orya']/percentSign"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='orya']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='orya']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='orya']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='orya']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/percentFormats[@numberSystem='orya']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='orya']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='tamldec']/decimal"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='tamldec']/group"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='tamldec']/plusSign"/>
@@ -658,17 +823,28 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='tamldec']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='tamldec']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='tamldec']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='telu']/decimal"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='telu']/group"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='telu']/plusSign"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='telu']/minusSign"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='telu']/percentSign"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='telu']/decimalFormatLength/decimalFormat%stdPattern"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='telu']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='telu']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='telu']/scientificFormatLength/scientificFormat%stdPattern"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='telu']/percentFormatLength/percentFormat%stdPattern"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='telu']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='telu']/decimal"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='telu']/group"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='telu']/plusSign"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='telu']/minusSign"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/symbols[@numberSystem='telu']/percentSign"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='telu']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='telu']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/currencyFormats[@numberSystem='telu']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/scientificFormats[@numberSystem='telu']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/percentFormats[@numberSystem='telu']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inScript="%teluNativeScripts" value="moderate" match="numbers/decimalFormats[@numberSystem='telu']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='thai']/decimal"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='thai']/group"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='thai']/plusSign"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='thai']/minusSign"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='thai']/percentSign"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='thai']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='thai']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='thai']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='thai']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='thai']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='thai']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='tibt']/decimal"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='tibt']/group"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='tibt']/plusSign"/>
@@ -680,6 +856,17 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='tibt']/scientificFormatLength/scientificFormat%stdPattern"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='tibt']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='tibt']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='vaii']/decimal"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='vaii']/group"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='vaii']/plusSign"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='vaii']/minusSign"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/symbols[@numberSystem='vaii']/percentSign"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='vaii']/decimalFormatLength/decimalFormat%stdPattern"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='vaii']/currencyFormatLength/currencyFormat%stdPattern"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/currencyFormats[@numberSystem='vaii']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/scientificFormats[@numberSystem='vaii']/scientificFormatLength/scientificFormat%stdPattern"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='vaii']/percentFormatLength/percentFormat%stdPattern"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='vaii']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/appendItems/appendItem[@request='Timezone']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
@@ -812,42 +999,73 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="dates/fields/field[@type='minute']/relative[@type='0']"/>
 		<coverageLevel value="modern" match="dates/fields/field[@type='second']/relative[@type='0']"/>
 		<coverageLevel value="modern" match="dates/fields/field[@type='quarter']/relative[@type='(-1|0|1)']"/>
-		<coverageLevel inLanguage="%arabDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arab']/approximatelySign"/>
-		<coverageLevel inLanguage="%arabDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arab']/exponential"/>
-		<coverageLevel inLanguage="%arabDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arab']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%arabDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arab']/perMille"/>
-		<coverageLevel inLanguage="%arabDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arab']/infinity"/>
-		<coverageLevel inLanguage="%arabDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arab']/nan"/>
-		<coverageLevel inLanguage="%arabextDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/approximatelySign"/>
-		<coverageLevel inLanguage="%arabextDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/exponential"/>
-		<coverageLevel inLanguage="%arabextDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%arabextDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/perMille"/>
-		<coverageLevel inLanguage="%arabextDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/infinity"/>
-		<coverageLevel inLanguage="%arabextDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/nan"/>
-		<coverageLevel inLanguage="%bengDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='beng']/approximatelySign"/>
-		<coverageLevel inLanguage="%bengDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='beng']/exponential"/>
-		<coverageLevel inLanguage="%bengDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='beng']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%bengDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='beng']/perMille"/>
-		<coverageLevel inLanguage="%bengDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='beng']/infinity"/>
-		<coverageLevel inLanguage="%bengDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='beng']/nan"/>
-		<coverageLevel inLanguage="%devaDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/approximatelySign"/>
-		<coverageLevel inLanguage="%devaDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/exponential"/>
-		<coverageLevel inLanguage="%devaDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%devaDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/perMille"/>
-		<coverageLevel inLanguage="%devaDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/infinity"/>
-		<coverageLevel inLanguage="%devaDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/nan"/>
-		<coverageLevel inLanguage="%khmrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/approximatelySign"/>
-		<coverageLevel inLanguage="%khmrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/exponential"/>
-		<coverageLevel inLanguage="%khmrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%khmrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/perMille"/>
-		<coverageLevel inLanguage="%khmrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/infinity"/>
-		<coverageLevel inLanguage="%khmrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/nan"/>
+
+		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/approximatelySign"/>
+		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/exponential"/>
+		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/superscriptingExponent"/>
+		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/perMille"/>
+		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/infinity"/>
+		<coverageLevel inScript="%adlmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='adlm']/nan"/>
+		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/approximatelySign"/>
+		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/exponential"/>
+		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/perMille"/>
+		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/infinity"/>
+		<coverageLevel inLanguage="%arabDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/nan"/>
+		<coverageLevel inLanguage="%arabextDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/approximatelySign"/>
+		<coverageLevel inLanguage="%arabextDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/exponential"/>
+		<coverageLevel inLanguage="%arabextDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%arabextDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/perMille"/>
+		<coverageLevel inLanguage="%arabextDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/infinity"/>
+		<coverageLevel inLanguage="%arabextDefaultLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/nan"/>
+		<coverageLevel inScript="%bengDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='beng']/approximatelySign"/>
+		<coverageLevel inScript="%bengDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='beng']/exponential"/>
+		<coverageLevel inScript="%bengDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='beng']/superscriptingExponent"/>
+		<coverageLevel inScript="%bengDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='beng']/perMille"/>
+		<coverageLevel inScript="%bengDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='beng']/infinity"/>
+		<coverageLevel inScript="%bengDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='beng']/nan"/>
+		<coverageLevel inScript="%cakmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='cakm']/approximatelySign"/>
+		<coverageLevel inScript="%cakmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='cakm']/exponential"/>
+		<coverageLevel inScript="%cakmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='cakm']/superscriptingExponent"/>
+		<coverageLevel inScript="%cakmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='cakm']/perMille"/>
+		<coverageLevel inScript="%cakmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='cakm']/infinity"/>
+		<coverageLevel inScript="%cakmDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='cakm']/nan"/>
+		<coverageLevel inLanguage="%devaDefaultLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/approximatelySign"/>
+		<coverageLevel inLanguage="%devaDefaultLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/exponential"/>
+		<coverageLevel inLanguage="%devaDefaultLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%devaDefaultLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/perMille"/>
+		<coverageLevel inLanguage="%devaDefaultLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/infinity"/>
+		<coverageLevel inLanguage="%devaDefaultLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/nan"/>
+		<coverageLevel inScript="%hmnpDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='hmnp']/approximatelySign"/>
+		<coverageLevel inScript="%hmnpDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='hmnp']/exponential"/>
+		<coverageLevel inScript="%hmnpDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='hmnp']/superscriptingExponent"/>
+		<coverageLevel inScript="%hmnpDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='hmnp']/perMille"/>
+		<coverageLevel inScript="%hmnpDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='hmnp']/infinity"/>
+		<coverageLevel inScript="%hmnpDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='hmnp']/nan"/>
+		<coverageLevel inScript="%mteiDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='mtei']/approximatelySign"/>
+		<coverageLevel inScript="%mteiDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='mtei']/exponential"/>
+		<coverageLevel inScript="%mteiDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='mtei']/superscriptingExponent"/>
+		<coverageLevel inScript="%mteiDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='mtei']/perMille"/>
+		<coverageLevel inScript="%mteiDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='mtei']/infinity"/>
+		<coverageLevel inScript="%mteiDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='mtei']/nan"/>
 		<coverageLevel inLanguage="%mymrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='mymr']/approximatelySign"/>
 		<coverageLevel inLanguage="%mymrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='mymr']/exponential"/>
 		<coverageLevel inLanguage="%mymrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='mymr']/superscriptingExponent"/>
 		<coverageLevel inLanguage="%mymrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='mymr']/perMille"/>
 		<coverageLevel inLanguage="%mymrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='mymr']/infinity"/>
 		<coverageLevel inLanguage="%mymrDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='mymr']/nan"/>
+		<coverageLevel inLanguage="%nkooDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='nkoo']/approximatelySign"/>
+		<coverageLevel inLanguage="%nkooDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='nkoo']/exponential"/>
+		<coverageLevel inLanguage="%nkooDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='nkoo']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%nkooDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='nkoo']/perMille"/>
+		<coverageLevel inLanguage="%nkooDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='nkoo']/infinity"/>
+		<coverageLevel inLanguage="%nkooDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='nkoo']/nan"/>
+		<coverageLevel inScript="%olckDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='olck']/approximatelySign"/>
+		<coverageLevel inScript="%olckDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='olck']/exponential"/>
+		<coverageLevel inScript="%olckDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='olck']/superscriptingExponent"/>
+		<coverageLevel inScript="%olckDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='olck']/perMille"/>
+		<coverageLevel inScript="%olckDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='olck']/infinity"/>
+		<coverageLevel inScript="%olckDefaultScripts" value="modern" match="numbers/symbols[@numberSystem='olck']/nan"/>
 		<coverageLevel inLanguage="%tibtDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/approximatelySign"/>
 		<coverageLevel inLanguage="%tibtDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/exponential"/>
 		<coverageLevel inLanguage="%tibtDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/superscriptingExponent"/>
@@ -855,36 +1073,66 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%tibtDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/infinity"/>
 		<coverageLevel inLanguage="%tibtDefaultLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/nan"/>
 
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/approximatelySign"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/exponential"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/perMille"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/infinity"/>
-		<coverageLevel inLanguage="%arabextNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='arabext']/nan"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/approximatelySign"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/exponential"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/perMille"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/infinity"/>
-		<coverageLevel inLanguage="%devaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='deva']/nan"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='gujr']/approximatelySign"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='gujr']/exponential"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='gujr']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='gujr']/perMille"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='gujr']/infinity"/>
-		<coverageLevel inLanguage="%gujrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='gujr']/nan"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='guru']/approximatelySign"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='guru']/exponential"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='guru']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='guru']/perMille"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='guru']/infinity"/>
-		<coverageLevel inLanguage="%guruNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='guru']/nan"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/approximatelySign"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/exponential"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/perMille"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/infinity"/>
+		<coverageLevel inLanguage="%arabNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arab']/nan"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/approximatelySign"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/exponential"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/perMille"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/infinity"/>
+		<coverageLevel inLanguage="%arabextNativeLanguages" inScript="Arab" value="modern" match="numbers/symbols[@numberSystem='arabext']/nan"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/approximatelySign"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/exponential"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/perMille"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/infinity"/>
+		<coverageLevel inLanguage="%devaNativeLanguages" inScript="Deva" value="modern" match="numbers/symbols[@numberSystem='deva']/nan"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="modern" match="numbers/symbols[@numberSystem='gujr']/approximatelySign"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="modern" match="numbers/symbols[@numberSystem='gujr']/exponential"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="modern" match="numbers/symbols[@numberSystem='gujr']/superscriptingExponent"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="modern" match="numbers/symbols[@numberSystem='gujr']/perMille"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="modern" match="numbers/symbols[@numberSystem='gujr']/infinity"/>
+		<coverageLevel inScript="%gujrNativeScripts" value="modern" match="numbers/symbols[@numberSystem='gujr']/nan"/>
+		<coverageLevel inScript="%guruNativeScripts" value="modern" match="numbers/symbols[@numberSystem='guru']/approximatelySign"/>
+		<coverageLevel inScript="%guruNativeScripts" value="modern" match="numbers/symbols[@numberSystem='guru']/exponential"/>
+		<coverageLevel inScript="%guruNativeScripts" value="modern" match="numbers/symbols[@numberSystem='guru']/superscriptingExponent"/>
+		<coverageLevel inScript="%guruNativeScripts" value="modern" match="numbers/symbols[@numberSystem='guru']/perMille"/>
+		<coverageLevel inScript="%guruNativeScripts" value="modern" match="numbers/symbols[@numberSystem='guru']/infinity"/>
+		<coverageLevel inScript="%guruNativeScripts" value="modern" match="numbers/symbols[@numberSystem='guru']/nan"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='hanidec']/approximatelySign"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='hanidec']/exponential"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='hanidec']/superscriptingExponent"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='hanidec']/perMille"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='hanidec']/infinity"/>
 		<coverageLevel inLanguage="%hanidecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='hanidec']/nan"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hansfin']/approximatelySign"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hansfin']/exponential"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hansfin']/superscriptingExponent"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hansfin']/perMille"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hansfin']/infinity"/>
+		<coverageLevel inScript="%hansfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hansfin']/nan"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hantfin']/approximatelySign"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hantfin']/exponential"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hantfin']/superscriptingExponent"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hantfin']/perMille"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hantfin']/infinity"/>
+		<coverageLevel inScript="%hantfinFinanceScripts" value="modern" match="numbers/symbols[@numberSystem='hantfin']/nan"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="modern" match="numbers/symbols[@numberSystem='jpanfin']/approximatelySign"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="modern" match="numbers/symbols[@numberSystem='jpanfin']/exponential"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="modern" match="numbers/symbols[@numberSystem='jpanfin']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="modern" match="numbers/symbols[@numberSystem='jpanfin']/perMille"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="modern" match="numbers/symbols[@numberSystem='jpanfin']/infinity"/>
+		<coverageLevel inLanguage="%jpanfinFinanceLanguages" value="modern" match="numbers/symbols[@numberSystem='jpanfin']/nan"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='java']/approximatelySign"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='java']/exponential"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='java']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='java']/perMille"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='java']/infinity"/>
+		<coverageLevel inLanguage="%javaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='java']/nan"/>
 		<coverageLevel inLanguage="%khmrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/approximatelySign"/>
 		<coverageLevel inLanguage="%khmrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/exponential"/>
 		<coverageLevel inLanguage="%khmrNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='khmr']/superscriptingExponent"/>
@@ -897,36 +1145,66 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%kndaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='knda']/perMille"/>
 		<coverageLevel inLanguage="%kndaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='knda']/infinity"/>
 		<coverageLevel inLanguage="%kndaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='knda']/nan"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='laoo']/approximatelySign"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='laoo']/exponential"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='laoo']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='laoo']/perMille"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='laoo']/infinity"/>
+		<coverageLevel inLanguage="%laooNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='laoo']/nan"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='mlym']/approximatelySign"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='mlym']/exponential"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='mlym']/superscriptingExponent"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='mlym']/perMille"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='mlym']/infinity"/>
 		<coverageLevel inLanguage="%mlymNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='mlym']/nan"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='orya']/approximatelySign"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='orya']/exponential"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='orya']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='orya']/perMille"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='orya']/infinity"/>
-		<coverageLevel inLanguage="%oryaNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='orya']/nan"/>
+		<coverageLevel inScript="%mongNativeScripts" value="modern" match="numbers/symbols[@numberSystem='mong']/approximatelySign"/>
+		<coverageLevel inScript="%mongNativeScripts" value="modern" match="numbers/symbols[@numberSystem='mong']/exponential"/>
+		<coverageLevel inScript="%mongNativeScripts" value="modern" match="numbers/symbols[@numberSystem='mong']/superscriptingExponent"/>
+		<coverageLevel inScript="%mongNativeScripts" value="modern" match="numbers/symbols[@numberSystem='mong']/perMille"/>
+		<coverageLevel inScript="%mongNativeScripts" value="modern" match="numbers/symbols[@numberSystem='mong']/infinity"/>
+		<coverageLevel inScript="%mongNativeScripts" value="modern" match="numbers/symbols[@numberSystem='mong']/nan"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="modern" match="numbers/symbols[@numberSystem='nkoo']/approximatelySign"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="modern" match="numbers/symbols[@numberSystem='nkoo']/exponential"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="modern" match="numbers/symbols[@numberSystem='nkoo']/superscriptingExponent"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="modern" match="numbers/symbols[@numberSystem='nkoo']/perMille"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="modern" match="numbers/symbols[@numberSystem='nkoo']/infinity"/>
+		<coverageLevel inScript="%nkooNativeScripts" value="modern" match="numbers/symbols[@numberSystem='nkoo']/nan"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="modern" match="numbers/symbols[@numberSystem='orya']/approximatelySign"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="modern" match="numbers/symbols[@numberSystem='orya']/exponential"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="modern" match="numbers/symbols[@numberSystem='orya']/superscriptingExponent"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="modern" match="numbers/symbols[@numberSystem='orya']/perMille"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="modern" match="numbers/symbols[@numberSystem='orya']/infinity"/>
+		<coverageLevel inScript="%oryaNativeScripts" value="modern" match="numbers/symbols[@numberSystem='orya']/nan"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tamldec']/approximatelySign"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tamldec']/exponential"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tamldec']/superscriptingExponent"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tamldec']/perMille"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tamldec']/infinity"/>
 		<coverageLevel inLanguage="%tamldecNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tamldec']/nan"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='telu']/approximatelySign"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='telu']/exponential"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='telu']/superscriptingExponent"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='telu']/perMille"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='telu']/infinity"/>
-		<coverageLevel inLanguage="%teluNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='telu']/nan"/>
+		<coverageLevel inScript="%teluNativeScripts" value="modern" match="numbers/symbols[@numberSystem='telu']/approximatelySign"/>
+		<coverageLevel inScript="%teluNativeScripts" value="modern" match="numbers/symbols[@numberSystem='telu']/exponential"/>
+		<coverageLevel inScript="%teluNativeScripts" value="modern" match="numbers/symbols[@numberSystem='telu']/superscriptingExponent"/>
+		<coverageLevel inScript="%teluNativeScripts" value="modern" match="numbers/symbols[@numberSystem='telu']/perMille"/>
+		<coverageLevel inScript="%teluNativeScripts" value="modern" match="numbers/symbols[@numberSystem='telu']/infinity"/>
+		<coverageLevel inScript="%teluNativeScripts" value="modern" match="numbers/symbols[@numberSystem='telu']/nan"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='thai']/approximatelySign"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='thai']/exponential"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='thai']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='thai']/perMille"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='thai']/infinity"/>
+		<coverageLevel inLanguage="%thaiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='thai']/nan"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/approximatelySign"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/exponential"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/superscriptingExponent"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/perMille"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/infinity"/>
 		<coverageLevel inLanguage="%tibtNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='tibt']/nan"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='vaii']/approximatelySign"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='vaii']/exponential"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='vaii']/superscriptingExponent"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='vaii']/perMille"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='vaii']/infinity"/>
+		<coverageLevel inLanguage="%vaiiNativeLanguages" value="modern" match="numbers/symbols[@numberSystem='vaii']/nan"/>
 
 		<coverageLevel value="modern" match="numbers/decimalFormats[@numberSystem='latn']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 		<coverageLevel value="modern" match="numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -1348,4 +1348,106 @@ public class TestCoverageLevel extends TestFmwkPlus {
             }
         }
     }
+
+    public void TestNumberElementsCoverage() {
+        class NumPathCoverageItem {
+            public String numPath;
+            public Level defaultLevel;
+            public Level nativeLevel;
+            public Level financeLevel;
+
+            public NumPathCoverageItem(
+                    String path, Level defLevel, Level natLevel, Level finLevel) {
+                numPath = path;
+                defaultLevel = defLevel;
+                nativeLevel = natLevel;
+                financeLevel = finLevel;
+            }
+        }
+        final NumPathCoverageItem[] testItems = {
+            // number element path, then expected max coverage levels if  xxxx is replaced
+            // respectively by the default, native, and financial number system.
+            new NumPathCoverageItem(
+                    "//ldml/numbers/currencyFormats[@numberSystem=\"xxxx\"]/currencyFormatLength/currencyFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
+                    Level.MODERATE,
+                    Level.MODERATE,
+                    Level.MODERATE),
+            new NumPathCoverageItem(
+                    "//ldml/numbers/decimalFormats[@numberSystem=\"xxxx\"]/decimalFormatLength/decimalFormat[@type=\"standard\"]/pattern[@type=\"standard\"]",
+                    Level.MODERATE,
+                    Level.MODERATE,
+                    Level.MODERATE),
+            new NumPathCoverageItem(
+                    "//ldml/numbers/symbols[@numberSystem=\"xxxx\"]/decimal",
+                    Level.MODERATE,
+                    Level.MODERATE,
+                    Level.MODERATE),
+            new NumPathCoverageItem(
+                    "//ldml/numbers/symbols[@numberSystem=\"xxxx\"]/group",
+                    Level.MODERATE,
+                    Level.MODERATE,
+                    Level.MODERATE),
+            new NumPathCoverageItem(
+                    "//ldml/numbers/symbols[@numberSystem=\"xxxx\"]/infinity",
+                    Level.MODERN,
+                    Level.MODERN,
+                    Level.MODERN),
+            new NumPathCoverageItem(
+                    "//ldml/numbers/symbols[@numberSystem=\"xxxx\"]/perMille",
+                    Level.MODERN,
+                    Level.MODERN,
+                    Level.MODERN),
+        };
+        org.unicode.cldr.util.Factory factory = testInfo.getCldrFactory();
+        for (String localeId : factory.getAvailable()) {
+            CLDRFile cldrFile = factory.make(localeId, true);
+            String defaultNumberSystem =
+                    cldrFile.getStringValue("//ldml/numbers/defaultNumberingSystem");
+            String nativeNumberSystem =
+                    cldrFile.getStringValue("//ldml/numbers/otherNumberingSystems/native");
+            String financeNumberSystem =
+                    cldrFile.getStringValue(
+                            "//ldml/numbers/otherNumberingSystems/finance"); // could be null
+            for (NumPathCoverageItem item : testItems) {
+                String pathForDefault = item.numPath.replace("xxxx", defaultNumberSystem);
+                Level defaultLevel = SDI.getCoverageLevel(pathForDefault, localeId);
+                if (defaultLevel.compareTo(item.defaultLevel) > 0) {
+                    errln(
+                            localeId
+                                    + ", path "
+                                    + pathForDefault
+                                    + ", expected coverage for default system to be "
+                                    + item.defaultLevel.toString()
+                                    + " or lower, but got "
+                                    + defaultLevel.toString());
+                }
+                String pathForNative = item.numPath.replace("xxxx", nativeNumberSystem);
+                Level nativeLevel = SDI.getCoverageLevel(pathForNative, localeId);
+                if (nativeLevel.compareTo(item.nativeLevel) > 0) {
+                    errln(
+                            localeId
+                                    + ", path "
+                                    + pathForNative
+                                    + ", expected coverage for native system to be "
+                                    + item.nativeLevel.toString()
+                                    + " or lower, but got "
+                                    + nativeLevel.toString());
+                }
+                if (financeNumberSystem != null) {
+                    String pathForFinance = item.numPath.replace("xxxx", financeNumberSystem);
+                    Level financeLevel = SDI.getCoverageLevel(pathForFinance, localeId);
+                    if (financeLevel.compareTo(item.financeLevel) > 0) {
+                        errln(
+                                localeId
+                                        + ", path "
+                                        + pathForFinance
+                                        + ", expected coverage for finance system to be "
+                                        + item.financeLevel.toString()
+                                        + " or lower, but got "
+                                        + financeLevel.toString());
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
CLDR-16941

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16941)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

1. Improve coverage for number system symbols and patterns belonging to non-`latn` default, native, and finance numbering systems in all locales. In some cases we select coverage by script instead of or in addition to language, to disambiguate cases where languages are written in multiple scripts.
2. Add a unit test to verify that various number symbols and patterns are at the desired coverage level for each of the two or three number systems (default, native, and possibly finance) specified in a locale, for all locales. This currently takes some time (25 sec on my machine), maybe could be sped up.
3. Whet this does not do is group collections of number symbols or patterns into sets. That would require coverage variables with alternate values for elements in paths, which is currently not supported. We can discuss for a future enhancement, this would have performance impact.

ALLOW_MANY_COMMITS=true
