### PR TITLE
CLDR-17461 Forum posts in vetting view, boost performance, change icons

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrForum.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForum.mjs
@@ -432,6 +432,7 @@ function loadHandlerForSubmit(data) {
       cldrLoad.reloadV(); // main Forum page
     } else {
       cldrForumPanel.updatePosts(null); // Info Panel
+      cldrSurvey.expediteStatusUpdate(); // update forum icons (👁️‍🗨️, 💬) in the main table
     }
   } else {
     const post = $(".post").first();

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
@@ -80,10 +80,9 @@ const statusActionTable = {
 /**
  * How often to fetch updates. Default 15s.
  * Used only for delay in calling updateStatus.
- * @property timerSpeed
  */
-let timerSpeed = 15000; // 15 seconds
-let fastTimerSpeed = 3000; // 3 seconds
+const timerSpeed = 15000; // 15 seconds
+const fastTimerSpeed = 3000; // 3 seconds
 let statusTimeout = null;
 
 let overridedir = null;

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -531,7 +531,7 @@ function reallyUpdateRow(tr, theRow) {
   /*
    * Set up the "comparison cell", a.k.a. the "English" column.
    */
-  if (comparisonCell && !comparisonCell.isSetup) {
+  if (comparisonCell) {
     updateRowEnglishComparisonCell(tr, theRow, comparisonCell);
   }
 
@@ -750,6 +750,7 @@ function updateRowCodeCell(tr, theRow, cell) {
  * Called by updateRow.
  */
 function updateRowEnglishComparisonCell(tr, theRow, cell) {
+  cldrDom.removeAllChildNodes(cell);
   let trHint = theRow.translationHint; // sometimes null
   if (theRow.displayName) {
     cell.appendChild(
@@ -1119,7 +1120,9 @@ function appendTranslationHintIcon(parent, text, loc) {
 
 function appendForumStatus(parent, forumStatus, loc) {
   const el = document.createElement("span");
-  el.textContent = "💬" + (forumStatus.hasOpenPosts ? "?" : ".");
+  el.textContent = forumStatus.hasOpenPosts
+    ? cldrText.get("forum_path_has_open_posts_icon")
+    : cldrText.get("forum_path_has_only_closed_posts_icon");
   el.title =
     cldrText.get("forum_path_has_posts") +
     (forumStatus.hasOpenPosts

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -360,9 +360,11 @@ const strings = {
   forum_remember_vote:
     "⚠️ Please remember to vote – submitting a forum post does NOT cause any actual vote to be made.",
 
-  forum_path_has_posts: "This item has forum posts, ",
+  forum_path_has_posts: "This item has one or more forum posts, ",
   forum_path_has_open_posts: "some of which are open",
   forum_path_has_only_closed_posts: "all of which are closed",
+  forum_path_has_open_posts_icon: "👁️‍🗨️",
+  forum_path_has_only_closed_posts_icon: "💬",
 
   generic_nolocale: "No locale chosen.",
   defaultContent_msg:


### PR DESCRIPTION
-Add a cache localeForumStatusMap in SurveyForum.java

-New class SurveyForum.LocaleForumStatus

-Get all the status for a locale with a single sql call

-Clear the cache for a locale when a post is added/closed

-Revise icons in the Comparison (English) column: 👁️‍🗨️ and 💬

-👁️‍🗨️ means: This item has one or more forum posts, some of which are open

-💬 means: This item has one or more forum posts, all of which are closed

-Change let to const for two items in cldrSurvey.mjs; remove @property

-Call updateRowEnglishComparisonCell even if isSetup, and always removeAllChildNodes; old optimization assumed the cell contents never changed

CLDR-17461

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
