### PR TITLE
CLDR-15696 Revert Polish day units (except per) to dzień forms, updating inflections accordingly

### DIFF
--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -9159,28 +9159,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} na tydzień</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<gender>feminine</gender>
+				<gender draft="contributed">inanimate</gender>
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">{0} dobę</unitPattern>
-				<unitPattern count="one" case="dative">{0} dobie</unitPattern>
-				<unitPattern count="one" case="genitive">{0} doby</unitPattern>
-				<unitPattern count="one" case="instrumental">{0} dobą</unitPattern>
-				<unitPattern count="one" case="locative">{0} dobie</unitPattern>
-				<unitPattern count="one" case="vocative">{0} dobo</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="dative" draft="contributed">{0} dniowi</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} dnia</unitPattern>
+				<unitPattern count="one" case="instrumental" draft="contributed">{0} dniem</unitPattern>
+				<unitPattern count="one" case="locative" draft="contributed">{0} dniu</unitPattern>
+				<unitPattern count="one" case="vocative" draft="contributed">{0} dniu</unitPattern>
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="dative">{0} dobom</unitPattern>
-				<unitPattern count="few" case="genitive">{0} dób</unitPattern>
-				<unitPattern count="few" case="instrumental">{0} dobami</unitPattern>
-				<unitPattern count="few" case="locative">{0} dobach</unitPattern>
+				<unitPattern count="few" case="dative" draft="contributed">{0} dniom</unitPattern>
+				<unitPattern count="few" case="genitive" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="few" case="instrumental" draft="contributed">{0} dniami</unitPattern>
+				<unitPattern count="few" case="locative" draft="contributed">{0} dniach</unitPattern>
 				<unitPattern count="few" case="vocative">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="many" case="dative">{0} dobom</unitPattern>
+				<unitPattern count="many" case="dative" draft="contributed">{0} dniom</unitPattern>
 				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
-				<unitPattern count="many" case="instrumental">{0} dobami</unitPattern>
-				<unitPattern count="many" case="locative">{0} dobach</unitPattern>
+				<unitPattern count="many" case="instrumental" draft="contributed">{0} dniami</unitPattern>
+				<unitPattern count="many" case="locative" draft="contributed">{0} dniach</unitPattern>
 				<unitPattern count="many" case="vocative">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<unitPattern count="other" case="accusative">↑↑↑</unitPattern>
@@ -9192,13 +9192,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0} na dobę</perUnitPattern>
 			</unit>
 			<unit type="duration-day-person">
-				<gender>feminine</gender>
+				<gender draft="contributed">inanimate</gender>
 				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="one" case="accusative">{0} dobę</unitPattern>
-				<unitPattern count="one" case="genitive">{0} doby</unitPattern>
+				<unitPattern count="one" case="accusative" draft="contributed">↑↑↑</unitPattern>
+				<unitPattern count="one" case="genitive" draft="contributed">{0} dnia</unitPattern>
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="few" case="accusative">↑↑↑</unitPattern>
-				<unitPattern count="few" case="genitive">{0} dób</unitPattern>
+				<unitPattern count="few" case="genitive" draft="contributed">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="many" case="accusative">↑↑↑</unitPattern>
 				<unitPattern count="many" case="genitive">↑↑↑</unitPattern>
@@ -12505,11 +12505,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/tydz.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>doby</displayName>
-				<unitPattern count="one">{0} doba</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">{0} dób</unitPattern>
-				<unitPattern count="other">{0} doby</unitPattern>
+				<displayName draft="contributed">dzień</displayName>
+				<unitPattern count="one" draft="contributed">{0} dzień</unitPattern>
+				<unitPattern count="few" draft="contributed">{0} dni</unitPattern>
+				<unitPattern count="many" draft="contributed">{0} dni</unitPattern>
+				<unitPattern count="other" draft="contributed">{0} dnia</unitPattern>
 				<perUnitPattern>{0}/dobę</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
@@ -13945,7 +13945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<perUnitPattern>{0}/t.</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
-				<displayName>doba</displayName>
+				<displayName draft="contributed">dzień</displayName>
 				<unitPattern count="one">{0} d.</unitPattern>
 				<unitPattern count="few">{0} d.</unitPattern>
 				<unitPattern count="many">{0} d.</unitPattern>


### PR DESCRIPTION
CLDR-15696

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-15696)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Revert Polish day units to dzień forms as in CLDR 37 (except the per day forms, which should continue to use dobę*); update the inflections* accordingly. The * information is all from Marek Pepke in the ticket.

ALLOW_MANY_COMMITS=true
