### PR TITLE
CLDR-17610 fix keyboard chart path in keyboard action

### DIFF
--- a/.github/workflows/keyboard.yml
+++ b/.github/workflows/keyboard.yml
@@ -34,8 +34,8 @@ jobs:
             ${{ runner.os }}-nodekbd-
             nodekbd-
       - name: Install kmc
-        run: npm install -g @keymanapp/kmc@beta
+        run: npm install -g @keymanapp/kmc@alpha
       - name: Compile Keyboards
         run: kmc --error-reporting build keyboards/3.0/*.xml
       - name: Run Kbd Charts
-        run: 'cd docs/charts/keyboard && npm ci && npm run build'
+        run: 'cd docs/charts/keyboards && npm ci && npm run build'


### PR DESCRIPTION
- fix keyboard charts path in keyboard checker script - see #3691 
- use kmc alpha (18.x) version for v46 for keyboard check

CLDR-17610

ALLOW_MANY_COMMITS=true
