### PR TITLE
CLDR-13864 Add night unit

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -7021,6 +7021,12 @@ annotations.
 				<unitPattern count="other">{0} days</unitPattern>
 				<perUnitPattern>{0} per day</perUnitPattern>
 			</unit>
+			<unit type="duration-night">
+				<displayName>nights</displayName>
+				<unitPattern count="one">{0} night</unitPattern>
+				<unitPattern count="other">{0} nights</unitPattern>
+				<perUnitPattern>{0}/night</perUnitPattern>
+			</unit>
 			<unit type="duration-hour">
 				<displayName>hours</displayName>
 				<unitPattern count="one">{0} hour</unitPattern>
@@ -8094,6 +8100,12 @@ annotations.
 				<unitPattern count="other">{0} days</unitPattern>
 				<perUnitPattern>{0}/d</perUnitPattern>
 			</unit>
+			<unit type="duration-night">
+				<displayName>nights</displayName>
+				<unitPattern count="one">{0} night</unitPattern>
+				<unitPattern count="other">{0} nights</unitPattern>
+				<perUnitPattern>{0}/night</perUnitPattern>
+			</unit>
 			<unit type="duration-hour">
 				<displayName>hours</displayName>
 				<unitPattern count="one">{0} hr</unitPattern>
@@ -9163,6 +9175,12 @@ annotations.
 				<unitPattern count="one">{0}d</unitPattern>
 				<unitPattern count="other">{0}d</unitPattern>
 				<perUnitPattern>{0}/d</perUnitPattern>
+			</unit>
+			<unit type="duration-night">
+				<displayName>nights</displayName>
+				<unitPattern count="one">{0}night</unitPattern>
+				<unitPattern count="other">{0}nights</unitPattern>
+				<perUnitPattern>{0}/night</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
 				<displayName>hour</displayName>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5222,6 +5222,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-day-person">
 				<alias source="locale" path="../unit[@type='duration-day']"/>
 			</unit>
+			<unit type="duration-night">
+				<displayName>night</displayName>
+				<unitPattern count="other">{0} night</unitPattern>
+				<perUnitPattern>{0}/night</perUnitPattern>
+			</unit>
 			<unit type="duration-hour">
 				<displayName>hr</displayName>
 				<unitPattern count="other">{0} h</unitPattern>

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -110,7 +110,11 @@ For terms of use, see http://www.unicode.org/copyright.html
         <unitQuantity baseUnit='second' quantity='duration' status='simple'/> <!-- use duration because 'time' can mean absolute time -->
         <unitQuantity baseUnit='second-ampere' quantity='electric-charge'/>
 
+        <!-- special duration, because months..years are not comparable to seconds -->
         <unitQuantity baseUnit='year' quantity='year-duration' status='simple'/> <!-- non-SI but here for ordering -->
+        
+        <!-- special duration, because nights are not comparable to seconds -->
+        <unitQuantity baseUnit='night' quantity='night-duration' status='simple'/>
         
         <unitQuantity baseUnit='ampere' quantity='electric-current' status='simple'/>
         <unitQuantity baseUnit='ampere-per-square-meter' quantity='current-density'/>
@@ -141,7 +145,6 @@ For terms of use, see http://www.unicode.org/copyright.html
         <unitQuantity baseUnit='pixel-per-meter' quantity='resolution'/>
 
         <unitQuantity baseUnit='em' quantity='typewidth' status='simple'/>
-        
     </unitQuantities>    
     <convertUnits>
         <!-- Values where possible from:
@@ -237,6 +240,9 @@ For terms of use, see http://www.unicode.org/copyright.html
         <convertUnit source='year-person' baseUnit='year' systems="person_age"/>
         <convertUnit source='decade' baseUnit='year' factor='10' systems="metric_adjacent ussystem uksystem astronomical"/>
         <convertUnit source='century' baseUnit='year' factor='100' systems="metric_adjacent ussystem uksystem astronomical"/>
+        
+        <!-- night-duration -->
+        <convertUnit source='night' baseUnit='night' systems="metric_adjacent uksystem ussystem"/>
         
         <!-- electric-current -->
         <convertUnit source='ampere' baseUnit='ampere' systems="si metric prefixable"/>

--- a/common/validity/unit.xml
+++ b/common/validity/unit.xml
@@ -240,6 +240,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			volume-to-jp
 			volume-koku
 			mass-fun
+			duration-night
 		</id>
 		<id type='unit' idStatus='deprecated'>
 			acceleration-meter-per-second-squared

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1869,7 +1869,8 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                                         "volume-sai",
                                         "volume-to-jp",
                                         "volume-koku",
-                                        "mass-fun"))
+                                        "mass-fun",
+                                        "duration-night"))
                         .freeze();
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -231,6 +231,14 @@ public class UnitConverter implements Freezable<UnitConverter> {
                     }
                 }
                 String quantity = getQuantityFromUnit(base.value, false);
+                if (quantity == null) {
+                    if (base.value.equals("night")) {
+                        quantity = "duration";
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Can't get quantity from : " + base.value);
+                    }
+                }
                 Integer quantityNumericOrder = quantityComparator.getNumericOrder(quantity);
                 if (quantityNumericOrder == null) { // try the inverse
                     if (base.value.equals("meter-per-cubic-meter")) { // HACK

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -124,7 +124,8 @@ public class UnitConverter implements Freezable<UnitConverter> {
                     "pixel",
                     "em",
                     "revolution",
-                    "portion");
+                    "portion",
+                    "night");
 
     public void addQuantityInfo(String baseUnit, String quantity, String status) {
         if (baseUnitToQuantity.containsKey(baseUnit)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -891,6 +891,7 @@ public class TestUnits extends TestFmwk {
                     .put("newton-meter", "torque")
                     .put("pound-force-foot", "torque")
                     .put("solar-luminosity", "light")
+                    .put("night", "duration")
                     .build();
 
     public void TestUnitCategory() {
@@ -4627,13 +4628,18 @@ public class TestUnits extends TestFmwk {
                 actualUnit = e.getMessage();
                 actualValueFloat = Float.NaN;
             }
-            if (assertEquals(
-                    String.format(
-                            "ICU unit pref, %s %s %s %s",
-                            sourceUnit, sourceAmount, usage, languageTag),
-                    expectedUnit,
-                    actualUnit)) {
-                assertEquals("ICU value", (float) expectedAmount, actualValueFloat);
+            if (!expectedUnit.equals(actualUnit)) {
+                if (!logKnownIssue("CLDR-17581", "No null from unitPreferences")) {
+
+                    assertEquals(
+                            String.format(
+                                    "ICU unit pref, %s %s %s %s",
+                                    sourceUnit, sourceAmount, usage, languageTag),
+                            expectedUnit,
+                            actualUnit);
+                }
+            } else if (assertEquals("ICU value", (float) expectedAmount, actualValueFloat)) {
+                // no other action
             } else if (!comment.isBlank()) {
                 warnln(comment);
             }


### PR DESCRIPTION
CLDR-13864

Adds unit `night`, as in "Your hotel reservation is for 3 nights". Because it is metric_adjacent, will get grammar

Adds to the normal places: en.xml, root.xml, units.xml, unit.xml

Because night is not convertible to either seconds or months, it has a new quantity. That is reflected in: units.xml, DtdData.java, UnitConverter.java, TestUnits.java

Also changes checkUnitLocalePreferencesTestIcu to not cause an error in testing the preferences test data file, with a CLDR-17581 LogKnownIssue.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
