### PR TITLE
CLDR-17459 Add grammar for point and kilocalorie

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -751,13 +751,12 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
                     "dot", // fallback is pixel
                     "dot-per-centimeter", // fallback is pixel
                     "dunam", // language-specific
-                    "astronomical-unit", // specialized
                     "nautical-mile", // US/UK specific
                     "knot", // US/UK specific
+                    "astronomical-unit", // specialized
                     "dalton", // specialized
-                    "electronvolt", // specialized
-                    "kilocalorie",
-                    "point");
+                    "electronvolt" // specialized
+                    );
 
     public static Set<String> getSpecialsToTranslate() {
         return INCLUDE_OTHER;


### PR DESCRIPTION
CLDR-17459

This is done by removing them from an exception list.

That is, units are metric or metric_adjacent automatically have additional paths added for grammar support. These were on an exception list that suppressed that. By removing them from that list, they will have grammar paths added in locales that support grammar differences in units.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
