### PR TITLE
CLDR-17459 Prepare for adding units with constants

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -1698,7 +1698,8 @@ public class SupplementalDataInfo {
             final String quantity = parts.getAttributeValue(-1, "quantity");
             final String status = parts.getAttributeValue(-1, "status");
             if (unitConverter == null) {
-                unitConverter = new UnitConverter(rationalParser, validity);
+                unitConverter =
+                        new UnitConverter(rationalParser, validity, x -> getUnitIdComponentType(x));
             }
             unitConverter.addQuantityInfo(baseUnit, quantity, status);
             return true;


### PR DESCRIPTION
CLDR-17459

This is putting the groundwork in place for doing CLDR-17298, so ideally we would be able to merge today to allow for that additional PR.

It allow for units that use arbitrary constant integers, instead of limited cases like `100-kilometer`. So units like `items-per-12-cubic-meter` or `portion-per-12` all work.

In so doing, the code was moved from using the Continuations class to the UnitParser. The UnitParser has been around for a little while, with a test to ensure that the same results are obtained as using the older code. It is stricter, though, with more checks to make sure the spec grammar is followed, and drawing its data from units.xml. The changeover required a bit of finessing, because some of the UnitConverter code needs to be called in SupplementalDataInfo, and there was a cycle that had to be avoided (notes below).

At the very end of all of the files to review, TestUnits.testFactorsInUnits() has some examples of the various possible uses of constants.

tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java

- the code `new UnitConverter(rationalParser, validity)` was changed to `new UnitConverter(rationalParser, validity, x -> getUnitIdComponentType(x))`, to get around the cycle

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java

- the UnitConverter freeze() was subdivided to call subfunctions, for clarity.
- some unnecessary code was removed (UnitIterator), Multimap<String, Continuation> continuations, ...
- The constant format is defined: static final Pattern CONSTANT = Pattern.compile("[0-9]+([eE][0-9]+)?");
- parseUnitId is modified to know about those constants 
- UnitId adds a factor (numerator and denominator). Note that one can also have nonsense units like kilogram-10-kilowatt-per-12-meter-12-second. The constants are coalesced, normalizing to be at the front of the numerator/denominator in processes, eg 10-kilogram-kilowatt-per-144-meter-second.
- Some code is commented out, but will be removed in a later PR.

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitParser.java

- This has a few changes to remove the direct accesses to SupplementalDataInfo, and make it a SimpleIterator (which enables easy iteration.
- The parsing was changed to store the UnitIdComponentType in the instance, with a getter, to make iteration easier.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java

- xxx used in some tests is changed to x-foo (the proper form for a private-use unit)
- The external data test is modified so that unconvertible units from NIST are handled with warnings (currently only 'pole')
- UnitOrdering, TestUnitParserAgainstContinuations are dropped, unnecessary at this point

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
