### PR TITLE
CLDR-15216 Add light-speed

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -7514,6 +7514,11 @@ annotations.
 				<unitPattern count="one">{0} knot</unitPattern>
 				<unitPattern count="other">{0} knots</unitPattern>
 			</unit>
+			<unit type="speed-light-speed">
+				<displayName>light</displayName>
+				<unitPattern count="other">{0} light</unitPattern>
+				<unitPattern count="other">{0} light</unitPattern>
+			</unit>
 			<unit type="speed-beaufort">
 				<displayName>Beaufort</displayName>
 				<unitPattern count="one">Beaufort {0}</unitPattern>
@@ -8593,6 +8598,11 @@ annotations.
 				<unitPattern count="one">{0} kn</unitPattern>
 				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
+			<unit type="speed-light-speed">
+				<displayName>light</displayName>
+				<unitPattern count="other">{0} light</unitPattern>
+				<unitPattern count="other">{0} light</unitPattern>
+			</unit>
 			<unit type="speed-beaufort">
 				<displayName>Bft</displayName>
 				<unitPattern count="one">B {0}</unitPattern>
@@ -9669,7 +9679,12 @@ annotations.
 				<unitPattern count="one">{0}kn</unitPattern>
 				<unitPattern count="other">{0}kn</unitPattern>
 			</unit>
-			<unit type="speed-beaufort">
+			<unit type="speed-light-speed">
+				<displayName>light</displayName>
+				<unitPattern count="other">{0}light</unitPattern>
+				<unitPattern count="other">{0}light</unitPattern>
+			</unit>
+ 			<unit type="speed-beaufort">
 				<displayName>Bft</displayName>
 				<unitPattern count="one">B{0}</unitPattern>
 				<unitPattern count="other">B{0}</unitPattern>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -7516,7 +7516,7 @@ annotations.
 			</unit>
 			<unit type="speed-light-speed">
 				<displayName>light</displayName>
-				<unitPattern count="other">{0} light</unitPattern>
+				<unitPattern count="one">{0} light</unitPattern>
 				<unitPattern count="other">{0} light</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
@@ -8600,7 +8600,7 @@ annotations.
 			</unit>
 			<unit type="speed-light-speed">
 				<displayName>light</displayName>
-				<unitPattern count="other">{0} light</unitPattern>
+				<unitPattern count="one">{0} light</unitPattern>
 				<unitPattern count="other">{0} light</unitPattern>
 			</unit>
 			<unit type="speed-beaufort">
@@ -9681,7 +9681,7 @@ annotations.
 			</unit>
 			<unit type="speed-light-speed">
 				<displayName>light</displayName>
-				<unitPattern count="other">{0}light</unitPattern>
+				<unitPattern count="one">{0}light</unitPattern>
 				<unitPattern count="other">{0}light</unitPattern>
 			</unit>
  			<unit type="speed-beaufort">

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5615,6 +5615,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>kn</displayName>
 				<unitPattern count="other">{0} kn</unitPattern>
 			</unit>
+			<unit type="speed-light-speed">
+				<displayName>light</displayName>
+				<unitPattern count="other">{0} light</unitPattern>
+			</unit>
 			<unit type="speed-beaufort">
 				<displayName>Bft</displayName>
 				<unitPattern count="other">B {0}</unitPattern>

--- a/common/supplemental/units.xml
+++ b/common/supplemental/units.xml
@@ -348,8 +348,8 @@ For terms of use, see http://www.unicode.org/copyright.html
        
         <!-- speed -->
         <convertUnit source='knot' baseUnit='meter-per-second' factor='1852/3600' systems="ussystem uksystem si_acceptable"/>
+        <convertUnit source='light-speed' baseUnit='meter-per-second' factor='speed_of_light_meters_per_second' systems="ussystem uksystem si_acceptable"/>
         <convertUnit source='beaufort' baseUnit='meter-per-second' special='beaufort' systems="metric_adjacent"/>
-
         
         <!-- magnetic-induction -->
         <convertUnit source='tesla' baseUnit='kilogram-per-square-second-ampere' systems='si metric prefixable'/>

--- a/common/validity/unit.xml
+++ b/common/validity/unit.xml
@@ -241,6 +241,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			volume-koku
 			mass-fun
 			duration-night
+			speed-light-speed
 		</id>
 		<id type='unit' idStatus='deprecated'>
 			acceleration-meter-per-second-squared

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1869,6 +1869,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
                                         "volume-sai",
                                         "volume-to-jp",
                                         "volume-koku",
+                                        "speed-light-speed",
                                         "mass-fun",
                                         "duration-night"))
                         .freeze();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -3926,7 +3926,8 @@ public class TestUnits extends TestFmwk {
                                         "arc-second",
                                         "arc-minute",
                                         "degree",
-                                        "electronvolt"),
+                                        "electronvolt",
+                                        "light-speed"),
                                 UnitSystem.metric,
                                 true), //
                         new UnitSystemInvariant(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -3882,7 +3882,7 @@ public class TestUnits extends TestFmwk {
                     || cldrSystems.contains(UnitSystem.si) && !nistSystems.contains(UnitSystem.si)
                     || cldrSystems.contains(UnitSystem.si_acceptable)
                             && !nistSystems.contains(UnitSystem.si_acceptable)) {
-                if (unit.equals("100-kilometer")) {
+                if (unit.equals("100-kilometer") || unit.equals("light-speed")) {
                     continue;
                 }
                 fails.add(
@@ -4459,14 +4459,32 @@ public class TestUnits extends TestFmwk {
             {"item-per-1e9-item", "item-per-item", "1/1000000000"},
             {"item-per-1e9", "item", "1/1000000000"},
         };
+        checkConversionToBase(tests);
+    }
+
+    public void checkConversionToBase(String[][] tests) {
+        int count = 0;
         for (String[] test : tests) {
+            ++count;
             Output<String> metric = new Output<>();
             final String inputUnit = test[0];
             final String expectedTarget = test[1];
             final Rational expectedFactor = Rational.of(test[2]);
             ConversionInfo unitId1 = converter.parseUnitId(inputUnit, metric, DEBUG);
-            assertEquals(inputUnit, expectedTarget, metric.value);
-            assertEquals(inputUnit, expectedFactor, unitId1.factor);
+            assertEquals(count + ")\t" + inputUnit + " to base", expectedTarget, metric.value);
+            assertEquals(count + ")\t" + inputUnit + " factor", expectedFactor, unitId1.factor);
         }
+    }
+
+    public void testLightSpeed() {
+        String[][] tests = {
+            {"light-speed", "meter-per-second", "299792458"},
+            {"light-speed-second", "meter-second-per-second", "299792458"},
+            {"light-speed-minute", "meter-second-per-second", "299792458*60"},
+            {"light-speed-hour", "meter-second-per-second", "299792458*3600"},
+            {"light-speed-day", "meter-second-per-second", "299792458*86400"},
+            {"light-speed-week", "meter-second-per-second", "299792458*604800"},
+        };
+        checkConversionToBase(tests);
     }
 }


### PR DESCRIPTION
CLDR-15216

To be used as a component of the names "light-second", "light-minute", etc.
See https://en.wikipedia.org/wiki/Light-second. Note that we would only have translators handle 1 item, and give instructions for the format in the context of being followed by duration.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
