### PR TITLE
CLDR-11593 Fix URL that ST date symbols page uses for sidebar info

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -95,7 +95,7 @@ public abstract class CLDRURLS {
     public static final String DATE_TIME_HELP =
             "https://cldr.unicode.org/translation/date-time/date-time-names#h.ewzjebmpoi4k";
     public static final String DATE_TIME_NAMES =
-            "https://cldr.unicode.org/translation/date-time/datetime-names";
+            "https://cldr.unicode.org/translation/date-time/date-time-names";
     public static final String DATE_TIME_NAMES_CYCLIC =
             "https://cldr.unicode.org/translation/date-time/date-time-names#h.h0vy2eyzcj0n";
     public static final String DATE_TIME_NAMES_FIELD =


### PR DESCRIPTION
CLDR-11593

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

The CLDR ticket was mainly about updating the information for quarters in https://cldr.unicode.org/translation/date-time/date-time-names. But then I noticed that the Survey Tool sidebar link to that page from the date symbols & formats pages (e.g. for Gregorian) was wrong, so this PR fixes that.

ALLOW_MANY_COMMITS=true
