### PR TITLE
CLDR-16734 ie, add relative day ±2 (unconfirmed)

### DIFF
--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -1720,9 +1720,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day">
 				<displayName draft="unconfirmed">die</displayName>
+				<relative type="-2" draft="unconfirmed">anteyer</relative>
 				<relative type="-1" draft="unconfirmed">yer</relative>
 				<relative type="0" draft="unconfirmed">hodie</relative>
 				<relative type="1" draft="unconfirmed">deman</relative>
+				<relative type="2" draft="unconfirmed">posdeman</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">pos {0} dies</relativeTimePattern>
 				</relativeTime>
@@ -1732,9 +1734,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName draft="unconfirmed">↑↑↑</displayName>
+				<relative type="-2" draft="unconfirmed">↑↑↑</relative>
 				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
 				<relative type="0" draft="unconfirmed">↑↑↑</relative>
 				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="2" draft="unconfirmed">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">↑↑↑</relativeTimePattern>
 				</relativeTime>
@@ -1744,9 +1748,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName draft="unconfirmed">d</displayName>
+				<relative type="-2" draft="unconfirmed">↑↑↑</relative>
 				<relative type="-1" draft="unconfirmed">↑↑↑</relative>
 				<relative type="0" draft="unconfirmed">↑↑↑</relative>
 				<relative type="1" draft="unconfirmed">↑↑↑</relative>
+				<relative type="2" draft="unconfirmed">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="other" draft="unconfirmed">pos {0} d</relativeTimePattern>
 				</relativeTime>


### PR DESCRIPTION
CLDR-16734

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In ie, add relative day ±2 (unconfirmed, like al of the relative fields there), obtained from online Interlingue dictionary [The English - Interlingue dictionary | Glosbe](https://glosbe.com/en/ie). This (per Mark) is the easiest way to make these fields appear in Survey Tool for Interlingue.

ALLOW_MANY_COMMITS=true
