### PR TITLE
CLDR-17147 In dateTimePattern examples with short date, use abbreviated not full zone

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2335,9 +2335,13 @@ public class ExampleGenerator {
             // ldml/dates/calendars/calendar[@type="*"]/dateTimeFormats/dateTimeFormatLength[@type="*"]/dateTimeFormat[@type="atTime"]/pattern[@type="standard"]
             String formatType =
                     parts.findAttributeValue("dateTimeFormat", "type"); // "standard" or "atTime"
+            String length =
+                    parts.findAttributeValue(
+                            "dateTimeFormatLength", "type"); // full, long, medium, short
 
             // For all types, show
-            // - date (of same length) with a single full time
+            // - date (of same length) with a single full time, or long time (abbreviated zone) if
+            // the date is short
             // - date (of same length) with a single short time
             // For the standard patterns, add
             // - date (of same length) with a short time range
@@ -2369,19 +2373,22 @@ public class ExampleGenerator {
                 return "";
             }
             String timeFormatXPathPrefix = timeFormatXPathForPrefix.substring(0, tfLengthOffset);
-            String timeFullFormatXPath =
-                    timeFormatXPathPrefix.concat(
-                            "timeFormatLength[@type=\"full\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
+            String timeLongerFormatXPath =
+                    (!length.equals("short"))
+                            ? timeFormatXPathPrefix.concat(
+                                    "timeFormatLength[@type=\"full\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]")
+                            : timeFormatXPathPrefix.concat(
+                                    "timeFormatLength[@type=\"long\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
             String timeShortFormatXPath =
                     timeFormatXPathPrefix.concat(
                             "timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
 
-            String timeFormatValue = cldrFile.getWinningValue(timeFullFormatXPath);
-            parts = XPathParts.getFrozenInstance(cldrFile.getFullXPath(timeFullFormatXPath));
+            String timeFormatValue = cldrFile.getWinningValue(timeLongerFormatXPath);
+            parts = XPathParts.getFrozenInstance(cldrFile.getFullXPath(timeLongerFormatXPath));
             String timeNumbersOverride = parts.findAttributeValue("pattern", "numbers");
-            SimpleDateFormat tff =
+            SimpleDateFormat tlf =
                     icuServiceBuilder.getDateFormat(calendar, timeFormatValue, timeNumbersOverride);
-            tff.setTimeZone(ZONE_SAMPLE);
+            tlf.setTimeZone(ZONE_SAMPLE);
 
             timeFormatValue = cldrFile.getWinningValue(timeShortFormatXPath);
             parts = XPathParts.getFrozenInstance(cldrFile.getFullXPath(timeShortFormatXPath));
@@ -2399,7 +2406,7 @@ public class ExampleGenerator {
             List<String> examples = new ArrayList<>();
 
             String dfResult = df.format(DATE_SAMPLE);
-            String tffResult = tff.format(DATE_SAMPLE);
+            String tlfResult = tlf.format(DATE_SAMPLE);
             String tsfResult = tsf.format(DATE_SAMPLE); // DATE_SAMPLE is in the afternoon
 
             // Handle date plus a single full time.
@@ -2414,7 +2421,7 @@ public class ExampleGenerator {
                                     value,
                                     (Object[])
                                             new String[] {
-                                                setBackground("'" + tffResult + "'"),
+                                                setBackground("'" + tlfResult + "'"),
                                                 setBackground("'" + dfResult + "'")
                                             }));
             examples.add(dtf.format(DATE_SAMPLE));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -802,7 +802,7 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/dateTimeFormatLength[@type=\"long\"]/dateTimeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
         checkValue(
                 "DateTimeCombo short std",
-                "〖❬9/5/99❭, ❬1:25:59 PM Eastern Standard Time❭〗〖❬9/5/99❭, ❬1:25 PM❭〗〖❬9/5/99❭, ❬7:00 AM – 1:25 PM❭〗〖❬today❭, ❬7:00 AM – 1:25 PM❭〗",
+                "〖❬9/5/99❭, ❬1:25:59 PM EST❭〗〖❬9/5/99❭, ❬1:25 PM❭〗〖❬9/5/99❭, ❬7:00 AM – 1:25 PM❭〗〖❬today❭, ❬7:00 AM – 1:25 PM❭〗",
                 exampleGenerator,
                 "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/dateTimeFormatLength[@type=\"short\"]/dateTimeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
         checkValue(


### PR DESCRIPTION
CLDR-17147

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17147)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In the dateTimePattern examples that were originally added per [CLDR-15622](https://unicode-org.atlassian.net/browse/CLDR-15622), change the examples that combine short date with full time to instead use long time (abbreviated zone) per Mark's review comment on the PR for that original ticket, PR [#2977](https://github.com/unicode-org/cldr/pull/2977)

(The ticket for this current PR is a clone of the original ticket specifically to address this issue)

ALLOW_MANY_COMMITS=true


[CLDR-15622]: https://unicode-org.atlassian.net/browse/CLDR-15622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ