### PR TITLE
CLDR-10772 ST examples for month names, in appropriate format

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -812,6 +812,30 @@ public class TestExampleGenerator extends TestFmwk {
                 "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/dateTimeFormatLength[@type=\"long\"]/dateTimeFormat[@type=\"atTime\"]/pattern[@type=\"standard\"]");
     }
 
+    public void TestDateSymbols() {
+        ExampleGenerator exampleGenerator = getExampleGenerator("cs");
+        checkValue(
+                "cs format wide",
+                "〖5. června 1999〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"6\"]");
+        checkValue(
+                "cs format abbreviated",
+                "〖5. čvn 1999〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"abbreviated\"]/month[@type=\"6\"]");
+        checkValue(
+                "cs stand-alone wide",
+                "〖červen 1999〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"stand-alone\"]/monthWidth[@type=\"wide\"]/month[@type=\"6\"]");
+        checkValue(
+                "cs stand-alone abbreviated",
+                "〖čvn 1999〗",
+                exampleGenerator,
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"stand-alone\"]/monthWidth[@type=\"abbreviated\"]/month[@type=\"6\"]");
+    }
+
     public void TestMinimumGroupingExamples() {
         ExampleGenerator exampleGeneratorEn = getExampleGenerator("en"); // min grouping 1
         ExampleGenerator exampleGeneratorEs = getExampleGenerator("es"); // min grouping 2


### PR DESCRIPTION
CLDR-10772

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-10772)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add ST examples for month names showing them in appropriate context: format months in a format with day number (currently winning format for skeleton yMMMMd), and stand-alone months in a format without (currently winning format for skeleton yMMMM)

ALLOW_MANY_COMMITS=true
