### PR TITLE
CLDR-13523 add test for valid short day length; fix resulting data errs

### DIFF
--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -2246,13 +2246,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">Lin</day>
-							<day type="mon">Lun</day>
-							<day type="tue">Mar</day>
-							<day type="wed">Miy</day>
-							<day type="thu">Huw</day>
-							<day type="fri">Biy</day>
-							<day type="sat">Sab</day>
+							<day type="sun">Li</day>
+							<day type="mon">Lu</day>
+							<day type="tue">Ma</day>
+							<day type="wed">Mi</day>
+							<day type="thu">Hu</day>
+							<day type="fri">Bi</day>
+							<day type="sat">Sa</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">↑↑↑</day>

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -1262,7 +1262,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="mon">↑↑↑</day>
 							<day type="tue">↑↑↑</day>
 							<day type="wed">↑↑↑</day>
-							<day type="thu">बृहस्पति</day>
+							<day type="thu">↑↑↑</day>
 							<day type="fri">↑↑↑</day>
 							<day type="sat">↑↑↑</day>
 						</dayWidth>

--- a/common/main/mgo.xml
+++ b/common/main/mgo.xml
@@ -221,13 +221,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">1</day>
-							<day type="mon">2</day>
-							<day type="tue">3</day>
-							<day type="wed">4</day>
-							<day type="thu">5</day>
-							<day type="fri">6</day>
-							<day type="sat">7</day>
+							<day type="sun">A1</day>
+							<day type="mon">A2</day>
+							<day type="tue">A3</day>
+							<day type="wed">A4</day>
+							<day type="thu">A5</day>
+							<day type="fri">A6</day>
+							<day type="sat">A7</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">Aneg 1</day>
@@ -250,13 +250,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="narrow">
-							<day type="sun">A1</day>
-							<day type="mon">A2</day>
-							<day type="tue">A3</day>
-							<day type="wed">A4</day>
-							<day type="thu">A5</day>
-							<day type="fri">A6</day>
-							<day type="sat">A7</day>
+							<day type="sun">1</day>
+							<day type="mon">2</day>
+							<day type="tue">3</day>
+							<day type="wed">4</day>
+							<day type="thu">5</day>
+							<day type="fri">6</day>
+							<day type="sat">7</day>
 						</dayWidth>
 						<dayWidth type="short">
 							<day type="sun">↑↑↑</day>

--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -339,13 +339,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="short">
-							<day type="sun">Sun</day>
-							<day type="mon">Mon</day>
-							<day type="tue">Tue</day>
-							<day type="wed">Wed</day>
-							<day type="thu">Thu</day>
-							<day type="fri">Fri</day>
-							<day type="sat">Sat</day>
+							<day type="sun">↑↑↑</day>
+							<day type="mon">↑↑↑</day>
+							<day type="tue">↑↑↑</day>
+							<day type="wed">↑↑↑</day>
+							<day type="thu">↑↑↑</day>
+							<day type="fri">↑↑↑</day>
+							<day type="sat">↑↑↑</day>
 						</dayWidth>
 						<dayWidth type="wide">
 							<day type="sun">रविवासरः</day>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -3363,7 +3363,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<day type="sun">↑↑↑</day>
 							<day type="mon">↑↑↑</day>
 							<day type="tue">↑↑↑</day>
-							<day type="wed">Arbaco</day>
+							<day type="wed">↑↑↑</day>
 							<day type="thu">↑↑↑</day>
 							<day type="fri">↑↑↑</day>
 							<day type="sat">↑↑↑</day>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -913,6 +913,7 @@ public abstract class CheckCLDR implements CheckAccessor {
             missingLanguage,
             namePlaceholderProblem,
             missingSpaceBetweenNameFields,
+            shortDateFieldInconsistentLength,
             illegalParameterValue,
             illegalAnnotationCode,
             illegalCharacter;
@@ -939,6 +940,7 @@ public abstract class CheckCLDR implements CheckAccessor {
                         Subtype.inconsistentPeriods,
                         Subtype.abbreviatedDateFieldTooWide,
                         Subtype.narrowDateFieldTooWide,
+                        Subtype.shortDateFieldInconsistentLength,
                         Subtype.coverageLevel);
 
         public static Set<Subtype> errorCodesPath =


### PR DESCRIPTION
CLDR-13523

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-13523)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

CheckDates had tests that abbreviated date symbols were no longer than wide (error), and that narrow date symbols were no longer than abbreviated (warning). But there was no test for short date symbols (only present in weekday names). Added a test that short days are no longer than abbreviated, and no shorter than narrow (both errors). Checked the with width both with a glyph width estimate (as used for the other tests) and a string length test, since the test was too sensitive otherwise (e.g. it failed on letter case differences).

Ran the test and fixed the resulting new data errors:
- `fil`: replaced current standalone narrow (same as abbreviated) with format short (shorter)
- `mai`: replaced the one provided short value (which was too long) with ↑↑↑ like the other short values, to inherit from abbreviated.
- `mgo`: swapped the narrow (in standalone) and short (in format) forms to get the right length ordering.
- `sa`: replace short (English abbreviated names) with inheritance from abbreviated (in Sanskrit)
- `so`: replaced the one provided standalone short value (too long) with ↑↑↑ like the other standalone short values, to inherit from format short which inherits from format abbreviated.

ALLOW_MANY_COMMITS=true
