### PR TITLE
CLDR-17665 remove beaufort from GenerateUnitTestData.NOT_CONVERTABLE; 17665

### DIFF
--- a/common/testData/units/unitsTest.txt
+++ b/common/testData/units/unitsTest.txt
@@ -151,6 +151,8 @@ mass	;	ton	;	kilogram	;	907.18474 * x	;	907184.7
 mass	;	tonne	;	kilogram	;	1,000 * x	;	1000000.0
 mass	;	earth-mass	;	kilogram	;	5,972,200,000,000,000,000,000,000 * x	;	5.9722E27
 mass	;	solar-mass	;	kilogram	;	1,988,470,000,000,000,000,000,000,000,000 * x	;	1.98847E33
+night-duration	;	night	;	night	;	1 * x	;	1,000.00
+portion	;	portion-per-1e9	;	portion	;	0.000000001 * x	;	1.0E-6
 portion	;	permillion	;	portion	;	0.000001 * x	;	0.001
 portion	;	permyriad	;	portion	;	0.0001 * x	;	0.1
 portion	;	permille	;	portion	;	0.001 * x	;	1.0
@@ -187,6 +189,7 @@ speed	;	kilometer-per-hour	;	meter-per-second	;	2.5/9 * x	;	277.7778
 speed	;	mile-per-hour	;	meter-per-second	;	0.44704 * x	;	447.04
 speed	;	knot	;	meter-per-second	;	4.63/9 * x	;	514.4444
 speed	;	meter-per-second	;	meter-per-second	;	1 * x	;	1,000.00
+speed	;	light-speed	;	meter-per-second	;	299,792,458 * x	;	2.997925E11
 substance-amount	;	item	;	item	;	1 * x	;	1,000.00
 substance-amount	;	mole	;	item	;	602,214,076,000,000,000,000,000 * x	;	6.022141E26
 temperature	;	rankine	;	kelvin	;	5/9 * x	;	555.5556

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateUnitTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateUnitTestData.java
@@ -46,7 +46,7 @@ public class GenerateUnitTestData {
     private static final SupplementalDataInfo SDI = SupplementalDataInfo.getInstance();
     private static final UnitConverter converter = SDI.getUnitConverter();
     private static final String TEST_SEP = ";\t";
-    private static final Set<String> NOT_CONVERTABLE = ImmutableSet.of("generic", "beaufort");
+    private static final Set<String> NOT_CONVERTABLE = ImmutableSet.of("generic");
     private static final Rational R1000 = Rational.of(1000);
 
     private static final Map<String, String> CORE_TO_TYPE;


### PR DESCRIPTION
CLDR-17665

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17665)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Remove `beaufort` from the NOT_CONVERTABLE list in  GenerateUnitTestData since that is no longer correct, then regenerate the unit test data. This regen left alone (as expected) the `unitsTest.txt` entry for `beaufort` which had been manually added in PR [#3562](https://github.com/unicode-org/cldr/pull/3562). It also added entries for 3 new units:
- night
- portion-per-1e9
- light-speed 

ALLOW_MANY_COMMITS=true
