### PR TITLE
CLDR-13224 remove translation hint for MK, add hints for some newer languages

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/translation-hints/hints.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/translation-hints/hints.txt
@@ -88,6 +88,30 @@ PATH: //ldml/localeDisplayNames/scripts/script[@type="Aran"]
 HINT: special code identifies non-standard Myanmar encoding for use with Zawgyi font
 PATH: //ldml/localeDisplayNames/scripts/script[@type="Qaag"]
 
+HINT: also referred to as "Tsilhqot’in"
+PATH: //ldml/localeDisplayNames/languages/language[@type="clc"]
+
+HINT: also referred to as "Inuinnaqtun"
+PATH: //ldml/localeDisplayNames/languages/language[@type="ikt"]
+
+HINT: previously referred to as "Kwakiutl"
+PATH: //ldml/localeDisplayNames/languages/language[@type="kwk"]
+
+HINT: also referred to as "Montagnais"
+PATH: //ldml/localeDisplayNames/languages/language[@type="moe"]
+
+HINT: also referred to as "Severn Ojibwa"
+PATH: //ldml/localeDisplayNames/languages/language[@type="ojs"]
+
+HINT: also referred to as "Nsyilxcən"
+PATH: //ldml/localeDisplayNames/languages/language[@type="oka"]
+
+HINT: also referred to as "Maliseet–Passamaquoddy"
+PATH: //ldml/localeDisplayNames/languages/language[@type="pqm"]
+
+HINT: also referred to as "Southern Puget Sound Salish"
+PATH: //ldml/localeDisplayNames/languages/language[@type="slh"]
+
 HINT: specifically, Mandarin Chinese
 PATH: //ldml/localeDisplayNames/languages/language[@type="zh"]
 
@@ -253,7 +277,6 @@ PATH: //ldml/localeDisplayNames/territories/territory[@type="FK"][@alt="variant"
 PATH: //ldml/localeDisplayNames/territories/territory[@type="FM"]
 PATH: //ldml/localeDisplayNames/territories/territory[@type="HK"]
 PATH: //ldml/localeDisplayNames/territories/territory[@type="HK"][@alt="short"]
-PATH: //ldml/localeDisplayNames/territories/territory[@type="MK"]
 PATH: //ldml/localeDisplayNames/territories/territory[@type="MM"]
 PATH: //ldml/localeDisplayNames/territories/territory[@type="MM"][@alt="short"]
 PATH: //ldml/localeDisplayNames/territories/territory[@type="MO"]


### PR DESCRIPTION
CLDR-13224

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-13224)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Remove translation hint for MK (old change, and the English name kinda says it all), and add translation hints for some recently added language codes that are referred to using multiple names in English

ALLOW_MANY_COMMITS=true
