### PR TITLE
CLDR-17566 Converting brs-copy-en_gb-to-en_001 to markdown

### DIFF
--- a/docs/site/downloads/brs-copy-en_gb-to-en_001.md
+++ b/docs/site/downloads/brs-copy-en_gb-to-en_001.md
@@ -1,0 +1,27 @@
+---
+title: Copy en_GB to en_001
+---
+
+
+# BRS: Copy en\_GB to en\_001
+
+The program **CompareEn.java** can be used to copy data from en\_GB up to en\_001.
+
+Options:
+
+-   \-u (uplevel) — move elements from en\_GB into en\_oo1. By default, the output directory is common/main and common/annotations in trunk
+    -   If not present, just write a comparison to Generated/cldr/comparison/en.txt   
+-   \-v (verbose) — provide verbose output
+    
+1.  Run with no options first.
+    1.  That generates a file that indicates what changes would be made.   
+    2.  Put that file in a spreadsheet     
+    3.  Post to the CLDR TC for review.     
+    4.  You'll then want to retract any items that shouldn't be copied.     
+    5.  Change CompareEn.java if there are paths that should be skipped in the future.      
+2.  Once you agree on the results, you'll run -u. 
+    1.  That will modify your local copy of en\_oo1.xml      
+    2.  Then do a diff with HEAD to make sure it matches expectations   
+    3.  Then check in en\_oo1.xml and CompareEn.java
+
+![Unicode copyright](https://www.unicode.org/img/hb_notice.gif)


### PR DESCRIPTION
CLDR-17566

Part of the [CLDR --> GFM conversion project](https://docs.google.com/document/d/1NoQX0zqSYqU4CUuNijTWKQaphE4SCuHl6Bej2C4mb58/edit)

Converting https://cldr.unicode.org/development/brs-copy-en_gb-to-en_001

View text diffs [here](https://docs.google.com/document/d/11V8rDc2I3ZlKXzR3vbnychNLg8zTlIzXcAFtFsWtrqg/edit?usp=sharing)

ALLOW_MANY_COMMITS=true

