### PR TITLE
CLDR-17582 Cleanup English annotations

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -16,21 +16,21 @@ annotations.
 		<language type="en"/>
 	</identity>
 	<annotations>
-		<annotation cp="{">brace | bracket | curly brace | curly bracket | gullwing | open curly bracket</annotation>
+		<annotation cp="{">brace | bracket | curly | gullwing | open</annotation>
 		<annotation cp="{" type="tts">open curly bracket</annotation>
-		<annotation cp="🏻">light skin tone | skin tone | type 1–2</annotation>
+		<annotation cp="🏻">1–2 | light | skin | tone | type</annotation>
 		<annotation cp="🏻" type="tts">light skin tone</annotation>
-		<annotation cp="🏼">medium-light skin tone | skin tone | type 3</annotation>
+		<annotation cp="🏼">3 | medium-light | skin | tone | type</annotation>
 		<annotation cp="🏼" type="tts">medium-light skin tone</annotation>
-		<annotation cp="🏽">medium skin tone | skin tone | type 4</annotation>
+		<annotation cp="🏽">4 | medium | skin | tone | type</annotation>
 		<annotation cp="🏽" type="tts">medium skin tone</annotation>
-		<annotation cp="🏾">medium-dark skin tone | skin tone | type 5</annotation>
+		<annotation cp="🏾">5 | medium-dark | skin | tone | type</annotation>
 		<annotation cp="🏾" type="tts">medium-dark skin tone</annotation>
-		<annotation cp="🏿">dark skin tone | skin tone | type 6</annotation>
+		<annotation cp="🏿">6 | dark | skin | tone | type</annotation>
 		<annotation cp="🏿" type="tts">dark skin tone</annotation>
 		<annotation cp="‾">overline | overstrike | vinculum</annotation>
 		<annotation cp="‾" type="tts">overline</annotation>
-		<annotation cp="_">dash | line | low dash | low line | underdash | underline</annotation>
+		<annotation cp="_">dash | line | low | underdash | underline</annotation>
 		<annotation cp="_" type="tts">low line</annotation>
 		<annotation cp="-">dash | hyphen | hyphen-minus | minus</annotation>
 		<annotation cp="-" type="tts">hyphen-minus</annotation>
@@ -40,9 +40,9 @@ annotations.
 		<annotation cp="–" type="tts">en dash</annotation>
 		<annotation cp="—">dash | em</annotation>
 		<annotation cp="—" type="tts">em dash</annotation>
-		<annotation cp="―">bar | dash | horizontal bar | line</annotation>
+		<annotation cp="―">bar | dash | horizontal | line</annotation>
 		<annotation cp="―" type="tts">horizontal bar</annotation>
-		<annotation cp="・">dots | interpunct | katakana | katakana middle dot | middot</annotation>
+		<annotation cp="・">dot | dots | interpunct | katakana | middle | middot</annotation>
 		<annotation cp="・" type="tts">katakana middle dot</annotation>
 		<!-- causes tool breakage
 			 <annotation cp="">whitespace</annotation>
@@ -56,121 +56,121 @@ annotations.
 		<annotation cp="、" type="tts">ideographic comma</annotation>
 		<annotation cp=";">semi-colon | semicolon</annotation>
 		<annotation cp=";" type="tts">semicolon</annotation>
-		<annotation cp="؛">arabic | arabic semicolon | semi-colon</annotation>
+		<annotation cp="؛">arabic | semi-colon | semicolon</annotation>
 		<annotation cp="؛" type="tts">arabic semicolon</annotation>
 		<annotation cp=":">colon</annotation>
 		<annotation cp=":" type="tts">colon</annotation>
-		<annotation cp="!">bang | exclamation | exclamation mark | exclamation point</annotation>
+		<annotation cp="!">bang | exclamation | mark | point</annotation>
 		<annotation cp="!" type="tts">exclamation mark</annotation>
-		<annotation cp="¡">bang | exclamation | exclamation mark | exclamation point | inverted | inverted exclamation mark</annotation>
+		<annotation cp="¡">bang | exclamation | inverted | mark | point</annotation>
 		<annotation cp="¡" type="tts">inverted exclamation mark</annotation>
-		<annotation cp="?">question | question mark</annotation>
+		<annotation cp="?">mark | question</annotation>
 		<annotation cp="?" type="tts">question mark</annotation>
-		<annotation cp="¿">inverted | inverted question mark | question | question mark</annotation>
+		<annotation cp="¿">inverted | mark | question</annotation>
 		<annotation cp="¿" type="tts">inverted question mark</annotation>
-		<annotation cp="؟">arabic | arabic question mark | question | question mark</annotation>
+		<annotation cp="؟">arabic | mark | question</annotation>
 		<annotation cp="؟" type="tts">arabic question mark</annotation>
 		<annotation cp="‽">interabang | interrobang</annotation>
 		<annotation cp="‽" type="tts">interrobang</annotation>
-		<annotation cp=".">dot | full stop | period</annotation>
+		<annotation cp=".">dot | full | period | stop</annotation>
 		<annotation cp="." type="tts">period</annotation>
 		<annotation cp="…">dots | ellipsis | omission</annotation>
 		<annotation cp="…" type="tts">ellipsis</annotation>
-		<annotation cp="。">full stop | ideographic | period</annotation>
+		<annotation cp="。">full | ideographic | period | stop</annotation>
 		<annotation cp="。" type="tts">ideographic period</annotation>
 		<annotation cp="·">dot | interpunct | middle | middot</annotation>
 		<annotation cp="·" type="tts">middle dot</annotation>
-		<annotation cp="'">apostrophe | quote | single quote | typewriter apostrophe</annotation>
+		<annotation cp="'">apostrophe | quote | single | typewriter</annotation>
 		<annotation cp="'" type="tts">typewriter apostrophe</annotation>
-		<annotation cp="‘">apostrophe | left apostrophe | quote | single quote | smart quote</annotation>
+		<annotation cp="‘">apostrophe | left | quote | single | smart</annotation>
 		<annotation cp="‘" type="tts">left apostrophe</annotation>
-		<annotation cp="’">apostrophe | quote | right apostrophe | single quote | smart quote</annotation>
+		<annotation cp="’">apostrophe | quote | right | single | smart</annotation>
 		<annotation cp="’" type="tts">right apostrophe</annotation>
-		<annotation cp="‚">apostrophe | low quote | low right apostrophe | quote</annotation>
+		<annotation cp="‚">apostrophe | low | quote | right</annotation>
 		<annotation cp="‚" type="tts">low right apostrophe</annotation>
-		<annotation cp="“">double quote | left quotation mark | quotation | quote | smart quotation</annotation>
+		<annotation cp="“">double | left | mark | quotation | quote | smart</annotation>
 		<annotation cp="“" type="tts">left quotation mark</annotation>
-		<annotation cp="”">double quote | quotation | quote | right quotation mark | smart quotation</annotation>
+		<annotation cp="”">double | mark | quotation | quote | right | smart</annotation>
 		<annotation cp="”" type="tts">right quotation mark</annotation>
-		<annotation cp="„">double quote | low quotation | low right quotation mark | quotation | quote | smart quotation</annotation>
+		<annotation cp="„">double | low | mark | quotation | quote | right | smart</annotation>
 		<annotation cp="„" type="tts">low right quotation mark</annotation>
-		<annotation cp="«">angle | brackets | carets | chevron | left | left guillemet | quote</annotation>
+		<annotation cp="«">angle | brackets | carets | chevron | guillemet | left | quote</annotation>
 		<annotation cp="«" type="tts">left guillemet</annotation>
-		<annotation cp="»">angle | brackets | carets | chevron | quote | right | right guillemet</annotation>
+		<annotation cp="»">angle | brackets | carets | chevron | guillemet | quote | right</annotation>
 		<annotation cp="»" type="tts">right guillemet</annotation>
-		<annotation cp=")">bracket | close parenthesis | paren | parens | parenthesis | round bracket</annotation>
+		<annotation cp=")">bracket | close | paren | parens | parenthesis | round</annotation>
 		<annotation cp=")" type="tts">close parenthesis</annotation>
-		<annotation cp="[">bracket | crotchet | open square bracket | square bracket</annotation>
+		<annotation cp="[">bracket | crotchet | open | square</annotation>
 		<annotation cp="[" type="tts">open square bracket</annotation>
-		<annotation cp="]">bracket | close square bracket | crotchet | square bracket</annotation>
+		<annotation cp="]">bracket | close | crotchet | square</annotation>
 		<annotation cp="]" type="tts">close square bracket</annotation>
-		<annotation cp="}">brace | bracket | close curly bracket | curly brace | curly bracket | gullwing</annotation>
+		<annotation cp="}">brace | bracket | close | curly | gullwing</annotation>
 		<annotation cp="}" type="tts">close curly bracket</annotation>
-		<annotation cp="〈">angle bracket | bracket | chevron | diamond brackets | open angle bracket | pointy bracket | tuple</annotation>
+		<annotation cp="〈">angle | bracket | brackets | chevron | diamond | open | pointy | tuple</annotation>
 		<annotation cp="〈" type="tts">open angle bracket</annotation>
-		<annotation cp="〉">angle bracket | bracket | chevron | close angle bracket | diamond brackets | pointy bracket | tuple</annotation>
+		<annotation cp="〉">angle | bracket | brackets | chevron | close | diamond | pointy | tuple</annotation>
 		<annotation cp="〉" type="tts">close angle bracket</annotation>
-		<annotation cp="《">bracket | double angle bracket | open double angle bracket</annotation>
+		<annotation cp="《">angle | bracket | double | open</annotation>
 		<annotation cp="《" type="tts">open double angle bracket</annotation>
-		<annotation cp="》">bracket | close double angle bracket | double angle bracket</annotation>
+		<annotation cp="》">angle | bracket | close | double</annotation>
 		<annotation cp="》" type="tts">close double angle bracket</annotation>
-		<annotation cp="「">bracket | corner bracket | open corner bracket</annotation>
+		<annotation cp="「">bracket | corner | open</annotation>
 		<annotation cp="「" type="tts">open corner bracket</annotation>
-		<annotation cp="」">bracket | close corner bracket | corner bracket</annotation>
+		<annotation cp="」">bracket | close | corner</annotation>
 		<annotation cp="」" type="tts">close corner bracket</annotation>
-		<annotation cp="『">bracket | hollow corner bracket | open hollow corner bracket</annotation>
+		<annotation cp="『">bracket | corner | hollow | open</annotation>
 		<annotation cp="『" type="tts">open hollow corner bracket</annotation>
-		<annotation cp="』">bracket | close hollow corner bracket | hollow corner bracket</annotation>
+		<annotation cp="』">bracket | close | corner | hollow</annotation>
 		<annotation cp="』" type="tts">close hollow corner bracket</annotation>
-		<annotation cp="【">bracket | lens bracket | lenticular bracket | open black lens bracket</annotation>
+		<annotation cp="【">black | bracket | lens | lenticular | open</annotation>
 		<annotation cp="【" type="tts">open black lens bracket</annotation>
-		<annotation cp="】">bracket | close black lens bracket | lens bracket | lenticular bracket</annotation>
+		<annotation cp="】">black | bracket | close | lens | lenticular</annotation>
 		<annotation cp="】" type="tts">close black lens bracket</annotation>
-		<annotation cp="〔">bracket | open tortoise shell bracket | shell bracket | tortoise shell bracket</annotation>
+		<annotation cp="〔">bracket | open | shell | tortoise</annotation>
 		<annotation cp="〔" type="tts">open tortoise shell bracket</annotation>
-		<annotation cp="〕">bracket | close tortoise shell bracket | shell bracket | tortoise shell bracket</annotation>
+		<annotation cp="〕">bracket | close | shell | tortoise</annotation>
 		<annotation cp="〕" type="tts">close tortoise shell bracket</annotation>
-		<annotation cp="〖">bracket | hollow lens bracket | hollow lenticular bracket | open hollow lens bracket</annotation>
+		<annotation cp="〖">bracket | hollow | lens | lenticular | open</annotation>
 		<annotation cp="〖" type="tts">open hollow lens bracket</annotation>
-		<annotation cp="〗">bracket | close hollow lens bracket | hollow lens bracket | hollow lenticular bracket</annotation>
+		<annotation cp="〗">bracket | close | hollow | lens | lenticular</annotation>
 		<annotation cp="〗" type="tts">close hollow lens bracket</annotation>
 		<annotation cp="§">paragraph | part | section | silcrow</annotation>
 		<annotation cp="§" type="tts">section</annotation>
-		<annotation cp="¶">alinea | paragraph | paragraph mark | paraph | pilcrow</annotation>
+		<annotation cp="¶">alinea | mark | paragraph | paraph | pilcrow</annotation>
 		<annotation cp="¶" type="tts">paragraph mark</annotation>
-		<annotation cp="@">ampersat | arobase | arroba | at mark | at sign | at-sign | commercial at | strudel</annotation>
+		<annotation cp="@">ampersat | arobase | arroba | at | at-sign | commercial | mark | sign | strudel</annotation>
 		<annotation cp="@" type="tts">at-sign</annotation>
 		<annotation cp="*">asterisk | star | wildcard</annotation>
 		<annotation cp="*" type="tts">asterisk</annotation>
 		<annotation cp="/">oblique | slash | solidus | stroke | virgule | whack</annotation>
 		<annotation cp="/" type="tts">slash</annotation>
-		<annotation cp="\">backslash | reverse solidus | whack</annotation>
+		<annotation cp="\">backslash | reverse | solidus | whack</annotation>
 		<annotation cp="\" type="tts">backslash</annotation>
 		<annotation cp="&amp;">ampersand | and | et</annotation>
 		<annotation cp="&amp;" type="tts">ampersand</annotation>
-		<annotation cp="#">hash | hash sign | hashtag | lb | number | pound</annotation>
+		<annotation cp="#">hash | hashtag | lb | number | pound | sign</annotation>
 		<annotation cp="#" type="tts">hash sign</annotation>
-		<annotation cp="%">per cent | per-cent | percent</annotation>
+		<annotation cp="%">cent | per | per-cent | percent</annotation>
 		<annotation cp="%" type="tts">percent</annotation>
-		<annotation cp="‰">per mil | per mille | permil | permille</annotation>
+		<annotation cp="‰">mil | mille | per | permil | permille</annotation>
 		<annotation cp="‰" type="tts">per mille</annotation>
-		<annotation cp="†">dagger | dagger sign | obelisk | obelus</annotation>
+		<annotation cp="†">dagger | obelisk | obelus | sign</annotation>
 		<annotation cp="†" type="tts">dagger sign</annotation>
-		<annotation cp="‡">dagger | double | double dagger sign | obelisk | obelus</annotation>
+		<annotation cp="‡">dagger | double | obelisk | obelus | sign</annotation>
 		<annotation cp="‡" type="tts">double dagger sign</annotation>
 		<annotation cp="•">bullet | dot</annotation>
 		<annotation cp="•" type="tts">bullet</annotation>
-		<annotation cp="‧">dash | hyphen | hyphenation point | point</annotation>
+		<annotation cp="‧">dash | hyphen | hyphenation | point</annotation>
 		<annotation cp="‧" type="tts">hyphenation point</annotation>
 		<annotation cp="′">prime</annotation>
 		<annotation cp="′" type="tts">prime</annotation>
-		<annotation cp="″">double prime | prime</annotation>
+		<annotation cp="″">double | prime</annotation>
 		<annotation cp="″" type="tts">double prime</annotation>
-		<annotation cp="‴">prime | triple prime</annotation>
+		<annotation cp="‴">prime | triple</annotation>
 		<annotation cp="‴" type="tts">triple prime</annotation>
 		<annotation cp="‸">caret</annotation>
 		<annotation cp="‸" type="tts">caret</annotation>
-		<annotation cp="※">reference mark</annotation>
+		<annotation cp="※">mark | reference</annotation>
 		<annotation cp="※" type="tts">reference mark</annotation>
 		<annotation cp="⁂">asterism | dinkus | stars</annotation>
 		<annotation cp="⁂" type="tts">asterism</annotation>
@@ -178,7 +178,7 @@ annotations.
 		<annotation cp="`" type="tts">grave accent</annotation>
 		<annotation cp="´">accent | acute | tone</annotation>
 		<annotation cp="´" type="tts">acute accent</annotation>
-		<annotation cp="^">accent | caret | chevron | circumflex | control | hat | pointer | power | wedge | xor sign</annotation>
+		<annotation cp="^">accent | caret | chevron | circumflex | control | hat | pointer | power | sign | wedge | xor</annotation>
 		<annotation cp="^" type="tts">circumflex accent</annotation>
 		<annotation cp="¨">diaeresis | tréma | umlaut</annotation>
 		<annotation cp="¨" type="tts">diaeresis</annotation>
@@ -186,243 +186,243 @@ annotations.
 		<annotation cp="°" type="tts">degree</annotation>
 		<annotation cp="℗">copyright | recording | sound</annotation>
 		<annotation cp="℗" type="tts">sound recording copyright</annotation>
-		<annotation cp="←">arrow | left | left-pointing arrow</annotation>
+		<annotation cp="←">arrow | left | left-pointing</annotation>
 		<annotation cp="←" type="tts">left-pointing arrow</annotation>
-		<annotation cp="↚">leftwards arrow stroke</annotation>
+		<annotation cp="↚">arrow | leftwards | stroke</annotation>
 		<annotation cp="↚" type="tts">leftwards arrow stroke</annotation>
-		<annotation cp="→">arrow | right | right-pointing arrow</annotation>
+		<annotation cp="→">arrow | right | right-pointing</annotation>
 		<annotation cp="→" type="tts">right-pointing arrow</annotation>
-		<annotation cp="↛">rightwards arrow stroke</annotation>
+		<annotation cp="↛">arrow | rightwards | stroke</annotation>
 		<annotation cp="↛" type="tts">rightwards arrow stroke</annotation>
-		<annotation cp="↑">arrow | up | up-pointing arrow</annotation>
+		<annotation cp="↑">arrow | up | up-pointing</annotation>
 		<annotation cp="↑" type="tts">up-pointing arrow</annotation>
-		<annotation cp="↓">arrow | down | down-pointing arrow</annotation>
+		<annotation cp="↓">arrow | down | down-pointing</annotation>
 		<annotation cp="↓" type="tts">down-pointing arrow</annotation>
-		<annotation cp="↜">leftwards wave arrow</annotation>
+		<annotation cp="↜">arrow | leftwards | wave</annotation>
 		<annotation cp="↜" type="tts">leftwards wave arrow</annotation>
-		<annotation cp="↝">rightwards wave arrow</annotation>
+		<annotation cp="↝">arrow | rightwards | wave</annotation>
 		<annotation cp="↝" type="tts">rightwards wave arrow</annotation>
-		<annotation cp="↞">leftwards two headed arrow</annotation>
+		<annotation cp="↞">arrow | headed | leftwards | two</annotation>
 		<annotation cp="↞" type="tts">leftwards two headed arrow</annotation>
-		<annotation cp="↟">upwards two headed arrow</annotation>
+		<annotation cp="↟">arrow | headed | two | upwards</annotation>
 		<annotation cp="↟" type="tts">upwards two headed arrow</annotation>
-		<annotation cp="↠">rightwards two headed arrow</annotation>
+		<annotation cp="↠">arrow | headed | rightwards | two</annotation>
 		<annotation cp="↠" type="tts">rightwards two headed arrow</annotation>
-		<annotation cp="↡">downwards two headed arrow</annotation>
+		<annotation cp="↡">arrow | downwards | headed | two</annotation>
 		<annotation cp="↡" type="tts">downwards two headed arrow</annotation>
-		<annotation cp="↢">leftwards arrow tail</annotation>
+		<annotation cp="↢">arrow | leftwards | tail</annotation>
 		<annotation cp="↢" type="tts">leftwards arrow tail</annotation>
-		<annotation cp="↣">rightwards arrow tail</annotation>
+		<annotation cp="↣">arrow | rightwards | tail</annotation>
 		<annotation cp="↣" type="tts">rightwards arrow tail</annotation>
-		<annotation cp="↤">leftwards arrow from bar</annotation>
+		<annotation cp="↤">arrow | bar | from | leftwards</annotation>
 		<annotation cp="↤" type="tts">leftwards arrow from bar</annotation>
-		<annotation cp="↥">upwards arrow from bar</annotation>
+		<annotation cp="↥">arrow | bar | from | upwards</annotation>
 		<annotation cp="↥" type="tts">upwards arrow from bar</annotation>
-		<annotation cp="↦">rightwards arrow from bar</annotation>
+		<annotation cp="↦">arrow | bar | from | rightwards</annotation>
 		<annotation cp="↦" type="tts">rightwards arrow from bar</annotation>
-		<annotation cp="↧">downwards arrow from bar</annotation>
+		<annotation cp="↧">arrow | bar | downwards | from</annotation>
 		<annotation cp="↧" type="tts">downwards arrow from bar</annotation>
-		<annotation cp="↨">up down arrow with base</annotation>
+		<annotation cp="↨">arrow | base | down | up | with</annotation>
 		<annotation cp="↨" type="tts">up down arrow with base</annotation>
-		<annotation cp="↫">leftwards arrow loop</annotation>
+		<annotation cp="↫">arrow | leftwards | loop</annotation>
 		<annotation cp="↫" type="tts">leftwards arrow loop</annotation>
-		<annotation cp="↬">rightwards arrow loop</annotation>
+		<annotation cp="↬">arrow | loop | rightwards</annotation>
 		<annotation cp="↬" type="tts">rightwards arrow loop</annotation>
-		<annotation cp="↭">left right wave arrow</annotation>
+		<annotation cp="↭">arrow | left | right | wave</annotation>
 		<annotation cp="↭" type="tts">left right wave arrow</annotation>
-		<annotation cp="↯">downwards zigzag arrow | zigzag</annotation>
+		<annotation cp="↯">arrow | downwards | zigzag</annotation>
 		<annotation cp="↯" type="tts">downwards zigzag arrow</annotation>
-		<annotation cp="↰">upwards arrow tip leftwards</annotation>
+		<annotation cp="↰">arrow | leftwards | tip | upwards</annotation>
 		<annotation cp="↰" type="tts">upwards arrow tip leftwards</annotation>
-		<annotation cp="↱">upwards arrow tip rightwards</annotation>
+		<annotation cp="↱">arrow | rightwards | tip | upwards</annotation>
 		<annotation cp="↱" type="tts">upwards arrow tip rightwards</annotation>
-		<annotation cp="↲">downwards arrow tip leftwards</annotation>
+		<annotation cp="↲">arrow | downwards | leftwards | tip</annotation>
 		<annotation cp="↲" type="tts">downwards arrow tip leftwards</annotation>
-		<annotation cp="↳">downwards arrow tip rightwards</annotation>
+		<annotation cp="↳">arrow | downwards | rightwards | tip</annotation>
 		<annotation cp="↳" type="tts">downwards arrow tip rightwards</annotation>
-		<annotation cp="↴">rightwards arrow corner downwards</annotation>
+		<annotation cp="↴">arrow | corner | downwards | rightwards</annotation>
 		<annotation cp="↴" type="tts">rightwards arrow corner downwards</annotation>
-		<annotation cp="↵">downwards arrow corner leftwards</annotation>
+		<annotation cp="↵">arrow | corner | downwards | leftwards</annotation>
 		<annotation cp="↵" type="tts">downwards arrow corner leftwards</annotation>
-		<annotation cp="↶">anticlockwise top semicircle arrow</annotation>
+		<annotation cp="↶">anticlockwise | arrow | semicircle | top</annotation>
 		<annotation cp="↶" type="tts">anticlockwise top semicircle arrow</annotation>
-		<annotation cp="↷">clockwise top semicircle arrow</annotation>
+		<annotation cp="↷">arrow | clockwise | semicircle | top</annotation>
 		<annotation cp="↷" type="tts">clockwise top semicircle arrow</annotation>
-		<annotation cp="↸">north west arrow long bar</annotation>
+		<annotation cp="↸">arrow | bar | long | north | west</annotation>
 		<annotation cp="↸" type="tts">north west arrow long bar</annotation>
-		<annotation cp="↹">arrow | bar | leftwards | leftwards over rightwards arrow bars | rightwards</annotation>
+		<annotation cp="↹">arrow | bar | bars | leftwards | over | rightwards</annotation>
 		<annotation cp="↹" type="tts">leftwards over rightwards arrow bars</annotation>
-		<annotation cp="↺">anticlockwise open circle arrow</annotation>
+		<annotation cp="↺">anticlockwise | arrow | circle | open</annotation>
 		<annotation cp="↺" type="tts">anticlockwise open circle arrow</annotation>
-		<annotation cp="↻">clockwise open circle arrow</annotation>
+		<annotation cp="↻">arrow | circle | clockwise | open</annotation>
 		<annotation cp="↻" type="tts">clockwise open circle arrow</annotation>
-		<annotation cp="↼">barb | leftwards harpoon barb upwards</annotation>
+		<annotation cp="↼">barb | harpoon | leftwards | upwards</annotation>
 		<annotation cp="↼" type="tts">leftwards harpoon barb upwards</annotation>
-		<annotation cp="↽">leftwards harpoon barb downwards</annotation>
+		<annotation cp="↽">barb | downwards | harpoon | leftwards</annotation>
 		<annotation cp="↽" type="tts">leftwards harpoon barb downwards</annotation>
-		<annotation cp="↾">barb | upwards harpoon barb rightwards</annotation>
+		<annotation cp="↾">barb | harpoon | rightwards | upwards</annotation>
 		<annotation cp="↾" type="tts">upwards harpoon barb rightwards</annotation>
-		<annotation cp="↿">barb | upwards harpoon barb leftwards</annotation>
+		<annotation cp="↿">barb | harpoon | leftwards | upwards</annotation>
 		<annotation cp="↿" type="tts">upwards harpoon barb leftwards</annotation>
-		<annotation cp="⇀">barb | rightwards harpoon barb upwards</annotation>
+		<annotation cp="⇀">barb | harpoon | rightwards | upwards</annotation>
 		<annotation cp="⇀" type="tts">rightwards harpoon barb upwards</annotation>
-		<annotation cp="⇁">barb | rightwards harpoon barb downwards</annotation>
+		<annotation cp="⇁">barb | downwards | harpoon | rightwards</annotation>
 		<annotation cp="⇁" type="tts">rightwards harpoon barb downwards</annotation>
-		<annotation cp="⇂">barb | downwards harpoon barb rightwards</annotation>
+		<annotation cp="⇂">barb | downwards | harpoon | rightwards</annotation>
 		<annotation cp="⇂" type="tts">downwards harpoon barb rightwards</annotation>
-		<annotation cp="⇃">barb | downwards harpoon barb leftwards</annotation>
+		<annotation cp="⇃">barb | downwards | harpoon | leftwards</annotation>
 		<annotation cp="⇃" type="tts">downwards harpoon barb leftwards</annotation>
-		<annotation cp="⇄">rightwards arrow over leftwards arrow</annotation>
+		<annotation cp="⇄">arrow | leftwards | over | rightwards</annotation>
 		<annotation cp="⇄" type="tts">rightwards arrow over leftwards arrow</annotation>
-		<annotation cp="⇅">arrow | down | up | up-pointing and down-pointing arrows</annotation>
+		<annotation cp="⇅">and | arrow | arrows | down | down-pointing | up | up-pointing</annotation>
 		<annotation cp="⇅" type="tts">up-pointing and down-pointing arrows</annotation>
-		<annotation cp="⇆">arrow | left | left-pointing over right-pointing arrows | right</annotation>
+		<annotation cp="⇆">arrow | arrows | left | left-pointing | over | right | right-pointing</annotation>
 		<annotation cp="⇆" type="tts">left-pointing over right-pointing arrows</annotation>
-		<annotation cp="⇇">leftwards paired arrows</annotation>
+		<annotation cp="⇇">arrows | leftwards | paired</annotation>
 		<annotation cp="⇇" type="tts">leftwards paired arrows</annotation>
-		<annotation cp="⇈">upwards paired arrows</annotation>
+		<annotation cp="⇈">arrows | paired | upwards</annotation>
 		<annotation cp="⇈" type="tts">upwards paired arrows</annotation>
-		<annotation cp="⇉">rightwards paired arrows</annotation>
+		<annotation cp="⇉">arrows | paired | rightwards</annotation>
 		<annotation cp="⇉" type="tts">rightwards paired arrows</annotation>
-		<annotation cp="⇊">downwards paired arrows</annotation>
+		<annotation cp="⇊">arrows | downwards | paired</annotation>
 		<annotation cp="⇊" type="tts">downwards paired arrows</annotation>
-		<annotation cp="⇋">leftwards harpoon over rightwards harpoon</annotation>
+		<annotation cp="⇋">harpoon | leftwards | over | rightwards</annotation>
 		<annotation cp="⇋" type="tts">leftwards harpoon over rightwards harpoon</annotation>
-		<annotation cp="⇌">rightwards harpoon over leftwards harpoon</annotation>
+		<annotation cp="⇌">harpoon | leftwards | over | rightwards</annotation>
 		<annotation cp="⇌" type="tts">rightwards harpoon over leftwards harpoon</annotation>
-		<annotation cp="⇐">leftwards double arrow</annotation>
+		<annotation cp="⇐">arrow | double | leftwards</annotation>
 		<annotation cp="⇐" type="tts">leftwards double arrow</annotation>
-		<annotation cp="⇍">leftwards double arrow stroke</annotation>
+		<annotation cp="⇍">arrow | double | leftwards | stroke</annotation>
 		<annotation cp="⇍" type="tts">leftwards double arrow stroke</annotation>
-		<annotation cp="⇑">upwards double arrow</annotation>
+		<annotation cp="⇑">arrow | double | upwards</annotation>
 		<annotation cp="⇑" type="tts">upwards double arrow</annotation>
-		<annotation cp="⇒">rightwards double arrow</annotation>
+		<annotation cp="⇒">arrow | double | rightwards</annotation>
 		<annotation cp="⇒" type="tts">rightwards double arrow</annotation>
-		<annotation cp="⇏">rightwards double arrow stroke</annotation>
+		<annotation cp="⇏">arrow | double | rightwards | stroke</annotation>
 		<annotation cp="⇏" type="tts">rightwards double arrow stroke</annotation>
-		<annotation cp="⇓">downwards double arrow</annotation>
+		<annotation cp="⇓">arrow | double | downwards</annotation>
 		<annotation cp="⇓" type="tts">downwards double arrow</annotation>
-		<annotation cp="⇔">left right double arrow</annotation>
+		<annotation cp="⇔">arrow | double | left | right</annotation>
 		<annotation cp="⇔" type="tts">left right double arrow</annotation>
-		<annotation cp="⇎">left right double arrow stroke</annotation>
+		<annotation cp="⇎">arrow | double | left | right | stroke</annotation>
 		<annotation cp="⇎" type="tts">left right double arrow stroke</annotation>
-		<annotation cp="⇖">north west double arrow</annotation>
+		<annotation cp="⇖">arrow | double | north | west</annotation>
 		<annotation cp="⇖" type="tts">north west double arrow</annotation>
-		<annotation cp="⇗">north east double arrow</annotation>
+		<annotation cp="⇗">arrow | double | east | north</annotation>
 		<annotation cp="⇗" type="tts">north east double arrow</annotation>
-		<annotation cp="⇘">south east double arrow</annotation>
+		<annotation cp="⇘">arrow | double | east | south</annotation>
 		<annotation cp="⇘" type="tts">south east double arrow</annotation>
-		<annotation cp="⇙">south west double arrow</annotation>
+		<annotation cp="⇙">arrow | double | south | west</annotation>
 		<annotation cp="⇙" type="tts">south west double arrow</annotation>
-		<annotation cp="⇚">leftwards triple arrow</annotation>
+		<annotation cp="⇚">arrow | leftwards | triple</annotation>
 		<annotation cp="⇚" type="tts">leftwards triple arrow</annotation>
-		<annotation cp="⇛">rightwards triple arrow</annotation>
+		<annotation cp="⇛">arrow | rightwards | triple</annotation>
 		<annotation cp="⇛" type="tts">rightwards triple arrow</annotation>
-		<annotation cp="⇜">leftwards squiggle arrow</annotation>
+		<annotation cp="⇜">arrow | leftwards | squiggle</annotation>
 		<annotation cp="⇜" type="tts">leftwards squiggle arrow</annotation>
-		<annotation cp="⇝">rightwards squiggle arrow</annotation>
+		<annotation cp="⇝">arrow | rightwards | squiggle</annotation>
 		<annotation cp="⇝" type="tts">rightwards squiggle arrow</annotation>
-		<annotation cp="⇞">upwards arrow double stroke</annotation>
+		<annotation cp="⇞">arrow | double | stroke | upwards</annotation>
 		<annotation cp="⇞" type="tts">upwards arrow double stroke</annotation>
-		<annotation cp="⇟">downwards arrow double stroke</annotation>
+		<annotation cp="⇟">arrow | double | downwards | stroke</annotation>
 		<annotation cp="⇟" type="tts">downwards arrow double stroke</annotation>
-		<annotation cp="⇠">leftwards dashed arrow</annotation>
+		<annotation cp="⇠">arrow | dashed | leftwards</annotation>
 		<annotation cp="⇠" type="tts">leftwards dashed arrow</annotation>
-		<annotation cp="⇡">upwards dashed arrow</annotation>
+		<annotation cp="⇡">arrow | dashed | upwards</annotation>
 		<annotation cp="⇡" type="tts">upwards dashed arrow</annotation>
-		<annotation cp="⇢">rightwards dashed arrow</annotation>
+		<annotation cp="⇢">arrow | dashed | rightwards</annotation>
 		<annotation cp="⇢" type="tts">rightwards dashed arrow</annotation>
-		<annotation cp="⇣">downwards dashed arrow</annotation>
+		<annotation cp="⇣">arrow | dashed | downwards</annotation>
 		<annotation cp="⇣" type="tts">downwards dashed arrow</annotation>
-		<annotation cp="⇤">leftwards arrow bar</annotation>
+		<annotation cp="⇤">arrow | bar | leftwards</annotation>
 		<annotation cp="⇤" type="tts">leftwards arrow bar</annotation>
-		<annotation cp="⇥">rightwards arrow bar</annotation>
+		<annotation cp="⇥">arrow | bar | rightwards</annotation>
 		<annotation cp="⇥" type="tts">rightwards arrow bar</annotation>
-		<annotation cp="⇦">leftwards hollow arrow</annotation>
+		<annotation cp="⇦">arrow | hollow | leftwards</annotation>
 		<annotation cp="⇦" type="tts">leftwards hollow arrow</annotation>
-		<annotation cp="⇧">upwards hollow arrow</annotation>
+		<annotation cp="⇧">arrow | hollow | upwards</annotation>
 		<annotation cp="⇧" type="tts">upwards hollow arrow</annotation>
-		<annotation cp="⇨">rightwards hollow arrow</annotation>
+		<annotation cp="⇨">arrow | hollow | rightwards</annotation>
 		<annotation cp="⇨" type="tts">rightwards hollow arrow</annotation>
-		<annotation cp="⇩">downwards hollow arrow</annotation>
+		<annotation cp="⇩">arrow | downwards | hollow</annotation>
 		<annotation cp="⇩" type="tts">downwards hollow arrow</annotation>
-		<annotation cp="⇪">upwards hollow arrow from bar</annotation>
+		<annotation cp="⇪">arrow | bar | from | hollow | upwards</annotation>
 		<annotation cp="⇪" type="tts">upwards hollow arrow from bar</annotation>
-		<annotation cp="⇵">downwards arrow leftwards upwards arrow</annotation>
+		<annotation cp="⇵">arrow | downwards | leftwards | upwards</annotation>
 		<annotation cp="⇵" type="tts">downwards arrow leftwards upwards arrow</annotation>
-		<annotation cp="∀">all | any | for all | given | universal</annotation>
+		<annotation cp="∀">all | any | for | given | universal</annotation>
 		<annotation cp="∀" type="tts">for all</annotation>
-		<annotation cp="∂">differential | partial differential</annotation>
+		<annotation cp="∂">differential | partial</annotation>
 		<annotation cp="∂" type="tts">partial differential</annotation>
-		<annotation cp="∃">there exists</annotation>
+		<annotation cp="∃">exists | there</annotation>
 		<annotation cp="∃" type="tts">there exists</annotation>
-		<annotation cp="∅">empty set | mathematics | set operator</annotation>
+		<annotation cp="∅">empty | mathematics | operator | set</annotation>
 		<annotation cp="∅" type="tts">empty set</annotation>
 		<annotation cp="∆">increment | triangle</annotation>
 		<annotation cp="∆" type="tts">increment</annotation>
 		<annotation cp="∇">nabla | triangle</annotation>
 		<annotation cp="∇" type="tts">nabla</annotation>
-		<annotation cp="∈">contains | element | element of | membership | set</annotation>
+		<annotation cp="∈">contains | element | membership | of | set</annotation>
 		<annotation cp="∈" type="tts">element of</annotation>
-		<annotation cp="∉">element | not an element</annotation>
+		<annotation cp="∉">an | element | not</annotation>
 		<annotation cp="∉" type="tts">not an element</annotation>
-		<annotation cp="∋">contains as member | element</annotation>
+		<annotation cp="∋">as | contains | element | member</annotation>
 		<annotation cp="∋" type="tts">contains as member</annotation>
-		<annotation cp="∎">end proof | halmos | q.e.d. | qed | tombstone</annotation>
+		<annotation cp="∎">end | halmos | proof | q.e.d. | qed | tombstone</annotation>
 		<annotation cp="∎" type="tts">end proof</annotation>
-		<annotation cp="∏">logic | n-ary product | product</annotation>
+		<annotation cp="∏">logic | n-ary | product</annotation>
 		<annotation cp="∏" type="tts">n-ary product</annotation>
-		<annotation cp="∑">mathematics | n-ary summation | summation</annotation>
+		<annotation cp="∑">mathematics | n-ary | summation</annotation>
 		<annotation cp="∑" type="tts">n-ary summation</annotation>
-		<annotation cp="+">add | plus | plus sign</annotation>
+		<annotation cp="+">add | plus | sign</annotation>
 		<annotation cp="+" type="tts">plus sign</annotation>
 		<annotation cp="±">plus-minus</annotation>
 		<annotation cp="±" type="tts">plus-minus</annotation>
-		<annotation cp="÷">divide | division | division sign | obelus</annotation>
+		<annotation cp="÷">divide | division | obelus | sign</annotation>
 		<annotation cp="÷" type="tts">division sign</annotation>
-		<annotation cp="×">multiplication | multiplication sign | multiply | times</annotation>
+		<annotation cp="×">multiplication | multiply | sign | times</annotation>
 		<annotation cp="×" type="tts">multiplication sign</annotation>
-		<annotation cp="&lt;">less than | less-than | open tag | tag</annotation>
+		<annotation cp="&lt;">less | less-than | open | tag | than</annotation>
 		<annotation cp="&lt;" type="tts">less-than</annotation>
-		<annotation cp="≮">inequality | mathematics | not less-than</annotation>
+		<annotation cp="≮">inequality | less-than | mathematics | not</annotation>
 		<annotation cp="≮" type="tts">not less-than</annotation>
 		<annotation cp="=">equal | equals</annotation>
 		<annotation cp="=" type="tts">equal</annotation>
-		<annotation cp="≠">inequality | inequation | not equal</annotation>
+		<annotation cp="≠">equal | inequality | inequation | not</annotation>
 		<annotation cp="≠" type="tts">not equal</annotation>
-		<annotation cp="&gt;">close tag | greater than | greater-than | tag</annotation>
+		<annotation cp="&gt;">close | greater | greater-than | tag | than</annotation>
 		<annotation cp="&gt;" type="tts">greater-than</annotation>
-		<annotation cp="≯">inequality | mathematics | not greater-than</annotation>
+		<annotation cp="≯">greater-than | inequality | mathematics | not</annotation>
 		<annotation cp="≯" type="tts">not greater-than</annotation>
 		<annotation cp="¬">negation | not</annotation>
 		<annotation cp="¬" type="tts">negation</annotation>
-		<annotation cp="|">bar | line | pike | pipe | sheffer stroke | stick | stroke | vbar | vertical bar | vertical line</annotation>
+		<annotation cp="|">bar | line | pike | pipe | sheffer | stick | stroke | vbar | vertical</annotation>
 		<annotation cp="|" type="tts">vertical line</annotation>
 		<annotation cp="~">tilde</annotation>
 		<annotation cp="~" type="tts">tilde</annotation>
-		<annotation cp="−">minus | minus sign | subtract</annotation>
+		<annotation cp="−">minus | sign | subtract</annotation>
 		<annotation cp="−" type="tts">minus sign</annotation>
 		<annotation cp="⁻">minus | superscript</annotation>
 		<annotation cp="⁻" type="tts">superscript minus</annotation>
 		<annotation cp="∓">minus-or-plus | plus-minus</annotation>
 		<annotation cp="∓" type="tts">minus-or-plus</annotation>
-		<annotation cp="∕">division slash | slash | stroke | virgule</annotation>
+		<annotation cp="∕">division | slash | stroke | virgule</annotation>
 		<annotation cp="∕" type="tts">division slash</annotation>
-		<annotation cp="⁄">fraction slash | stroke | virgule</annotation>
+		<annotation cp="⁄">fraction | slash | stroke | virgule</annotation>
 		<annotation cp="⁄" type="tts">fraction slash</annotation>
-		<annotation cp="∗">asterisk operator | star</annotation>
+		<annotation cp="∗">asterisk | operator | star</annotation>
 		<annotation cp="∗" type="tts">asterisk operator</annotation>
-		<annotation cp="∘">composition | operator | ring operator</annotation>
+		<annotation cp="∘">composition | operator | ring</annotation>
 		<annotation cp="∘" type="tts">ring operator</annotation>
-		<annotation cp="∙">bullet operator | operator</annotation>
+		<annotation cp="∙">bullet | operator</annotation>
 		<annotation cp="∙" type="tts">bullet operator</annotation>
 		<annotation cp="√">radical | radix | root | square | surd</annotation>
 		<annotation cp="√" type="tts">square root</annotation>
 		<annotation cp="∝">proportional | proportionality</annotation>
 		<annotation cp="∝" type="tts">proportional</annotation>
-		<annotation cp="∞">infinity | infinity sign</annotation>
+		<annotation cp="∞">infinity | sign</annotation>
 		<annotation cp="∞" type="tts">infinity sign</annotation>
-		<annotation cp="∟">mathematics | right angle</annotation>
+		<annotation cp="∟">angle | mathematics | right</annotation>
 		<annotation cp="∟" type="tts">right angle</annotation>
 		<annotation cp="∠">acute | angle</annotation>
 		<annotation cp="∠" type="tts">angle</annotation>
@@ -430,7 +430,7 @@ annotations.
 		<annotation cp="∣" type="tts">divides</annotation>
 		<annotation cp="∥">parallel</annotation>
 		<annotation cp="∥" type="tts">parallel</annotation>
-		<annotation cp="∧">ac | atque | logical and | wedge</annotation>
+		<annotation cp="∧">ac | and | atque | logical | wedge</annotation>
 		<annotation cp="∧" type="tts">logical and</annotation>
 		<annotation cp="∩">intersection | set</annotation>
 		<annotation cp="∩" type="tts">intersection</annotation>
@@ -438,9 +438,9 @@ annotations.
 		<annotation cp="∪" type="tts">union</annotation>
 		<annotation cp="∫">calculus | integral</annotation>
 		<annotation cp="∫" type="tts">integral</annotation>
-		<annotation cp="∬">calculus | double integral</annotation>
+		<annotation cp="∬">calculus | double | integral</annotation>
 		<annotation cp="∬" type="tts">double integral</annotation>
-		<annotation cp="∮">contour integral</annotation>
+		<annotation cp="∮">contour | integral</annotation>
 		<annotation cp="∮" type="tts">contour integral</annotation>
 		<annotation cp="∴">logic | therefore</annotation>
 		<annotation cp="∴" type="tts">therefore</annotation>
@@ -450,582 +450,577 @@ annotations.
 		<annotation cp="∶" type="tts">ratio</annotation>
 		<annotation cp="∷">proportion | proportionality</annotation>
 		<annotation cp="∷" type="tts">proportion</annotation>
-		<annotation cp="∼">operator | tilde operator</annotation>
+		<annotation cp="∼">operator | tilde</annotation>
 		<annotation cp="∼" type="tts">tilde operator</annotation>
-		<annotation cp="∽">reversed tilde | tilde</annotation>
+		<annotation cp="∽">reversed | tilde</annotation>
 		<annotation cp="∽" type="tts">reversed tilde</annotation>
-		<annotation cp="∾">inverted lazy s</annotation>
+		<annotation cp="∾">inverted | lazy | s</annotation>
 		<annotation cp="∾" type="tts">inverted lazy s</annotation>
-		<annotation cp="≃">asymptote | asymptotically equal | mathematics</annotation>
+		<annotation cp="≃">asymptote | asymptotically | equal | mathematics</annotation>
 		<annotation cp="≃" type="tts">asymptotically equal</annotation>
-		<annotation cp="≅">approximately equal | congruence | equality | isomorphism | mathematics</annotation>
+		<annotation cp="≅">approximately | congruence | equal | equality | isomorphism | mathematics</annotation>
 		<annotation cp="≅" type="tts">approximately equal</annotation>
-		<annotation cp="≈">almost equal | approximate | approximation</annotation>
+		<annotation cp="≈">almost | approximate | approximation | equal</annotation>
 		<annotation cp="≈" type="tts">almost equal</annotation>
-		<annotation cp="≌">all equal | equality | mathematics</annotation>
+		<annotation cp="≌">all | equal | equality | mathematics</annotation>
 		<annotation cp="≌" type="tts">all equal</annotation>
-		<annotation cp="≒">approximately equal the image</annotation>
+		<annotation cp="≒">approximately | equal | image | the</annotation>
 		<annotation cp="≒" type="tts">approximately equal the image</annotation>
-		<annotation cp="≖">equality | mathematics | ring in equal</annotation>
+		<annotation cp="≖">equal | equality | in | mathematics | ring</annotation>
 		<annotation cp="≖" type="tts">ring in equal</annotation>
-		<annotation cp="≡">exact | identical | identical to | triple</annotation>
+		<annotation cp="≡">exact | identical | to | triple</annotation>
 		<annotation cp="≡" type="tts">identical to</annotation>
-		<annotation cp="≣">equality | mathematics | strictly equivalent</annotation>
+		<annotation cp="≣">equality | equivalent | mathematics | strictly</annotation>
 		<annotation cp="≣" type="tts">strictly equivalent</annotation>
-		<annotation cp="≤">equal | equals | inequality | less-than | less-than or equal</annotation>
+		<annotation cp="≤">equal | equals | inequality | less-than | or</annotation>
 		<annotation cp="≤" type="tts">less-than or equal</annotation>
-		<annotation cp="≥">equal | equals | greater-than | greater-than or equal | inequality</annotation>
+		<annotation cp="≥">equal | equals | greater-than | inequality | or</annotation>
 		<annotation cp="≥" type="tts">greater-than or equal</annotation>
-		<annotation cp="≦">inequality | less-than over equal | mathematics</annotation>
+		<annotation cp="≦">equal | inequality | less-than | mathematics | over</annotation>
 		<annotation cp="≦" type="tts">less-than over equal</annotation>
-		<annotation cp="≧">greater-than over equal | inequality | mathematics</annotation>
+		<annotation cp="≧">equal | greater-than | inequality | mathematics | over</annotation>
 		<annotation cp="≧" type="tts">greater-than over equal</annotation>
-		<annotation cp="≪">inequality | mathematics | much less-than</annotation>
+		<annotation cp="≪">inequality | less-than | mathematics | much</annotation>
 		<annotation cp="≪" type="tts">much less-than</annotation>
-		<annotation cp="≫">inequality | mathematics | much greater-than</annotation>
+		<annotation cp="≫">greater-than | inequality | mathematics | much</annotation>
 		<annotation cp="≫" type="tts">much greater-than</annotation>
 		<annotation cp="≬">between</annotation>
 		<annotation cp="≬" type="tts">between</annotation>
-		<annotation cp="≳">greater-than equivalent | inequality | mathematics</annotation>
+		<annotation cp="≳">equivalent | greater-than | inequality | mathematics</annotation>
 		<annotation cp="≳" type="tts">greater-than equivalent</annotation>
-		<annotation cp="≺">mathematics | precedes | set operator</annotation>
+		<annotation cp="≺">mathematics | operator | precedes | set</annotation>
 		<annotation cp="≺" type="tts">precedes</annotation>
-		<annotation cp="≻">mathematics | set operator | succeeds</annotation>
+		<annotation cp="≻">mathematics | operator | set | succeeds</annotation>
 		<annotation cp="≻" type="tts">succeeds</annotation>
-		<annotation cp="⊁">does not succeed | mathematics | set operator</annotation>
+		<annotation cp="⊁">does | mathematics | not | operator | set | succeed</annotation>
 		<annotation cp="⊁" type="tts">does not succeed</annotation>
-		<annotation cp="⊂">set | subset | subset of</annotation>
+		<annotation cp="⊂">of | set | subset</annotation>
 		<annotation cp="⊂" type="tts">subset of</annotation>
-		<annotation cp="⊃">mathematics | set operator | superset</annotation>
+		<annotation cp="⊃">mathematics | operator | set | superset</annotation>
 		<annotation cp="⊃" type="tts">superset</annotation>
-		<annotation cp="⊆">subset equal</annotation>
+		<annotation cp="⊆">equal | subset</annotation>
 		<annotation cp="⊆" type="tts">subset equal</annotation>
-		<annotation cp="⊇">equality | mathematics | superset equal</annotation>
+		<annotation cp="⊇">equal | equality | mathematics | superset</annotation>
 		<annotation cp="⊇" type="tts">superset equal</annotation>
-		<annotation cp="⊕">circled plus | plus</annotation>
+		<annotation cp="⊕">circled | plus</annotation>
 		<annotation cp="⊕" type="tts">circled plus</annotation>
-		<annotation cp="⊖">circled minus | erosion | symmetric difference</annotation>
+		<annotation cp="⊖">circled | difference | erosion | minus | symmetric</annotation>
 		<annotation cp="⊖" type="tts">circled minus</annotation>
-		<annotation cp="⊗">circled times | product | tensor</annotation>
+		<annotation cp="⊗">circled | product | tensor | times</annotation>
 		<annotation cp="⊗" type="tts">circled times</annotation>
-		<annotation cp="⊘">circled division slash | division-like | mathematics</annotation>
+		<annotation cp="⊘">circled | division | division-like | mathematics | slash</annotation>
 		<annotation cp="⊘" type="tts">circled division slash</annotation>
-		<annotation cp="⊙">circled dot operator | operator | XNOR</annotation>
+		<annotation cp="⊙">circled | dot | operator | XNOR</annotation>
 		<annotation cp="⊙" type="tts">circled dot operator</annotation>
-		<annotation cp="⊚">circled ring operator</annotation>
+		<annotation cp="⊚">circled | operator | ring</annotation>
 		<annotation cp="⊚" type="tts">circled ring operator</annotation>
-		<annotation cp="⊛">asterisk | circled asterisk operator | operator</annotation>
+		<annotation cp="⊛">asterisk | circled | operator</annotation>
 		<annotation cp="⊛" type="tts">circled asterisk operator</annotation>
-		<annotation cp="⊞">addition-like | mathematics | squared plus</annotation>
+		<annotation cp="⊞">addition-like | mathematics | plus | squared</annotation>
 		<annotation cp="⊞" type="tts">squared plus</annotation>
-		<annotation cp="⊟">mathematics | squared minus | subtraction-like</annotation>
+		<annotation cp="⊟">mathematics | minus | squared | subtraction-like</annotation>
 		<annotation cp="⊟" type="tts">squared minus</annotation>
-		<annotation cp="⊥">eet | falsum | tack | up tack</annotation>
+		<annotation cp="⊥">eet | falsum | tack | up</annotation>
 		<annotation cp="⊥" type="tts">up tack</annotation>
-		<annotation cp="⊮">does not force</annotation>
+		<annotation cp="⊮">does | force | not</annotation>
 		<annotation cp="⊮" type="tts">does not force</annotation>
-		<annotation cp="⊰">mathematics | precedes under relation | set operator</annotation>
+		<annotation cp="⊰">mathematics | operator | precedes | relation | set | under</annotation>
 		<annotation cp="⊰" type="tts">precedes under relation</annotation>
-		<annotation cp="⊱">mathematics | set operator | succeeds under relation</annotation>
+		<annotation cp="⊱">mathematics | operator | relation | set | succeeds | under</annotation>
 		<annotation cp="⊱" type="tts">succeeds under relation</annotation>
-		<annotation cp="⋭">does not contain as normal subgroup equal | group theory | mathematics</annotation>
+		<annotation cp="⋭">as | contain | does | equal | group | mathematics | normal | not | subgroup | theory</annotation>
 		<annotation cp="⋭" type="tts">does not contain as normal subgroup equal</annotation>
 		<annotation cp="⊶">original</annotation>
 		<annotation cp="⊶" type="tts">original</annotation>
-		<annotation cp="⊹">hermitian conjugate matrix | mathematics | self-adjoint matrix | square matrix</annotation>
+		<annotation cp="⊹">conjugate | hermitian | mathematics | matrix | self-adjoint | square</annotation>
 		<annotation cp="⊹" type="tts">hermitian conjugate matrix</annotation>
-		<annotation cp="⊿">mathematics | right triangle | right-angled triangle</annotation>
+		<annotation cp="⊿">mathematics | right | right-angled | triangle</annotation>
 		<annotation cp="⊿" type="tts">right triangle</annotation>
-		<annotation cp="⋁">disjunction | logic | n-ary logical or</annotation>
+		<annotation cp="⋁">disjunction | logic | logical | n-ary | or</annotation>
 		<annotation cp="⋁" type="tts">n-ary logical or</annotation>
-		<annotation cp="⋂">intersection | mathematics | n-ary intersection | set operator</annotation>
+		<annotation cp="⋂">intersection | mathematics | n-ary | operator | set</annotation>
 		<annotation cp="⋂" type="tts">n-ary intersection</annotation>
-		<annotation cp="⋃">mathematics | n-ary union | set operator | union</annotation>
+		<annotation cp="⋃">mathematics | n-ary | operator | set | union</annotation>
 		<annotation cp="⋃" type="tts">n-ary union</annotation>
-		<annotation cp="⋅">dot operator | operator</annotation>
+		<annotation cp="⋅">dot | operator</annotation>
 		<annotation cp="⋅" type="tts">dot operator</annotation>
-		<annotation cp="⋆">operator | star operator</annotation>
+		<annotation cp="⋆">operator | star</annotation>
 		<annotation cp="⋆" type="tts">star operator</annotation>
-		<annotation cp="⋈">binary operator | bowtie | natural join</annotation>
+		<annotation cp="⋈">binary | bowtie | join | natural | operator</annotation>
 		<annotation cp="⋈" type="tts">natural join</annotation>
-		<annotation cp="⋒">double intersection | intersection | mathematics | set operator</annotation>
+		<annotation cp="⋒">double | intersection | mathematics | operator | set</annotation>
 		<annotation cp="⋒" type="tts">double intersection</annotation>
-		<annotation cp="⋘">inequality | mathematics | very much less-than</annotation>
+		<annotation cp="⋘">inequality | less-than | mathematics | much | very</annotation>
 		<annotation cp="⋘" type="tts">very much less-than</annotation>
-		<annotation cp="⋙">inequality | mathematics | very much greater-than</annotation>
+		<annotation cp="⋙">greater-than | inequality | mathematics | much | very</annotation>
 		<annotation cp="⋙" type="tts">very much greater-than</annotation>
-		<annotation cp="⋮">ellipsis | mathematics | vertical ellipsis</annotation>
+		<annotation cp="⋮">ellipsis | mathematics | vertical</annotation>
 		<annotation cp="⋮" type="tts">vertical ellipsis</annotation>
-		<annotation cp="⋯">ellipsis | midline horizontal ellipsis</annotation>
+		<annotation cp="⋯">ellipsis | horizontal | midline</annotation>
 		<annotation cp="⋯" type="tts">midline horizontal ellipsis</annotation>
-		<annotation cp="⋰">ellipsis | mathematics | up right diagonal ellipsis</annotation>
+		<annotation cp="⋰">diagonal | ellipsis | mathematics | right | up</annotation>
 		<annotation cp="⋰" type="tts">up right diagonal ellipsis</annotation>
-		<annotation cp="⋱">down right diagonal ellipsis | ellipsis | mathematics</annotation>
+		<annotation cp="⋱">diagonal | down | ellipsis | mathematics | right</annotation>
 		<annotation cp="⋱" type="tts">down right diagonal ellipsis</annotation>
-		<annotation cp="■">filled square</annotation>
+		<annotation cp="■">filled | square</annotation>
 		<annotation cp="■" type="tts">filled square</annotation>
-		<annotation cp="□">hollow square</annotation>
+		<annotation cp="□">hollow | square</annotation>
 		<annotation cp="□" type="tts">hollow square</annotation>
-		<annotation cp="▢">hollow square with rounded corners</annotation>
+		<annotation cp="▢">corners | hollow | rounded | square | with</annotation>
 		<annotation cp="▢" type="tts">hollow square with rounded corners</annotation>
-		<annotation cp="▣">hollow square containing filled square</annotation>
+		<annotation cp="▣">containing | filled | hollow | square</annotation>
 		<annotation cp="▣" type="tts">hollow square containing filled square</annotation>
-		<annotation cp="▤">square with horizontal fill</annotation>
+		<annotation cp="▤">fill | horizontal | square | with</annotation>
 		<annotation cp="▤" type="tts">square with horizontal fill</annotation>
-		<annotation cp="▥">square with vertical fill</annotation>
+		<annotation cp="▥">fill | square | vertical | with</annotation>
 		<annotation cp="▥" type="tts">square with vertical fill</annotation>
-		<annotation cp="▦">square orthogonal crosshatch fill</annotation>
+		<annotation cp="▦">crosshatch | fill | orthogonal | square</annotation>
 		<annotation cp="▦" type="tts">square orthogonal crosshatch fill</annotation>
-		<annotation cp="▧">square upper left lower right fill</annotation>
+		<annotation cp="▧">fill | left | lower | right | square | upper</annotation>
 		<annotation cp="▧" type="tts">square upper left lower right fill</annotation>
-		<annotation cp="▨">square upper right lower left fill</annotation>
+		<annotation cp="▨">fill | left | lower | right | square | upper</annotation>
 		<annotation cp="▨" type="tts">square upper right lower left fill</annotation>
-		<annotation cp="▩">square diagonal crosshatch fill</annotation>
+		<annotation cp="▩">crosshatch | diagonal | fill | square</annotation>
 		<annotation cp="▩" type="tts">square diagonal crosshatch fill</annotation>
-		<annotation cp="▬">filled rectangle</annotation>
+		<annotation cp="▬">filled | rectangle</annotation>
 		<annotation cp="▬" type="tts">filled rectangle</annotation>
-		<annotation cp="▭">hollow rectangle</annotation>
+		<annotation cp="▭">hollow | rectangle</annotation>
 		<annotation cp="▭" type="tts">hollow rectangle</annotation>
-		<annotation cp="▮">filled vertical rectangle</annotation>
+		<annotation cp="▮">filled | rectangle | vertical</annotation>
 		<annotation cp="▮" type="tts">filled vertical rectangle</annotation>
-		<annotation cp="▰">filled parallelogram</annotation>
+		<annotation cp="▰">filled | parallelogram</annotation>
 		<annotation cp="▰" type="tts">filled parallelogram</annotation>
-		<annotation cp="▲">arrow | filled | filled up-pointing triangle | triangle | up</annotation>
+		<annotation cp="▲">arrow | filled | triangle | up | up-pointing</annotation>
 		<annotation cp="▲" type="tts">filled up-pointing triangle</annotation>
-		<annotation cp="△">hollow up-pointing triangle</annotation>
+		<annotation cp="△">hollow | triangle | up-pointing</annotation>
 		<annotation cp="△" type="tts">hollow up-pointing triangle</annotation>
-		<annotation cp="▴">filled up-pointing small triangle</annotation>
+		<annotation cp="▴">filled | small | triangle | up-pointing</annotation>
 		<annotation cp="▴" type="tts">filled up-pointing small triangle</annotation>
-		<annotation cp="▵">hollow up-pointing small triangle</annotation>
+		<annotation cp="▵">hollow | small | triangle | up-pointing</annotation>
 		<annotation cp="▵" type="tts">hollow up-pointing small triangle</annotation>
-		<annotation cp="▷">hollow right-pointing triangle</annotation>
+		<annotation cp="▷">hollow | right-pointing | triangle</annotation>
 		<annotation cp="▷" type="tts">hollow right-pointing triangle</annotation>
-		<annotation cp="▸">filled right-pointing small triangle</annotation>
+		<annotation cp="▸">filled | right-pointing | small | triangle</annotation>
 		<annotation cp="▸" type="tts">filled right-pointing small triangle</annotation>
-		<annotation cp="▹">hollow right-pointing small triangle</annotation>
+		<annotation cp="▹">hollow | right-pointing | small | triangle</annotation>
 		<annotation cp="▹" type="tts">hollow right-pointing small triangle</annotation>
-		<annotation cp="►">filled right-pointing pointer</annotation>
+		<annotation cp="►">filled | pointer | right-pointing</annotation>
 		<annotation cp="►" type="tts">filled right-pointing pointer</annotation>
-		<annotation cp="▻">hollow right-pointing pointer</annotation>
+		<annotation cp="▻">hollow | pointer | right-pointing</annotation>
 		<annotation cp="▻" type="tts">hollow right-pointing pointer</annotation>
-		<annotation cp="▼">arrow | down | filled | filled down-pointing triangle | triangle</annotation>
+		<annotation cp="▼">arrow | down | down-pointing | filled | triangle</annotation>
 		<annotation cp="▼" type="tts">filled down-pointing triangle</annotation>
-		<annotation cp="▽">hollow down-pointing triangle</annotation>
+		<annotation cp="▽">down-pointing | hollow | triangle</annotation>
 		<annotation cp="▽" type="tts">hollow down-pointing triangle</annotation>
-		<annotation cp="▾">filled down-pointing small triangle</annotation>
+		<annotation cp="▾">down-pointing | filled | small | triangle</annotation>
 		<annotation cp="▾" type="tts">filled down-pointing small triangle</annotation>
-		<annotation cp="▿">hollow down-pointing small triangle</annotation>
+		<annotation cp="▿">down-pointing | hollow | small | triangle</annotation>
 		<annotation cp="▿" type="tts">hollow down-pointing small triangle</annotation>
-		<annotation cp="◁">hollow left-pointing triangle</annotation>
+		<annotation cp="◁">hollow | left-pointing | triangle</annotation>
 		<annotation cp="◁" type="tts">hollow left-pointing triangle</annotation>
-		<annotation cp="◂">filled left-pointing small triangle</annotation>
+		<annotation cp="◂">filled | left-pointing | small | triangle</annotation>
 		<annotation cp="◂" type="tts">filled left-pointing small triangle</annotation>
-		<annotation cp="◃">hollow left-pointing small triangle</annotation>
+		<annotation cp="◃">hollow | left-pointing | small | triangle</annotation>
 		<annotation cp="◃" type="tts">hollow left-pointing small triangle</annotation>
-		<annotation cp="◄">filled left-pointing pointer</annotation>
+		<annotation cp="◄">filled | left-pointing | pointer</annotation>
 		<annotation cp="◄" type="tts">filled left-pointing pointer</annotation>
-		<annotation cp="◅">hollow left-pointing pointer</annotation>
+		<annotation cp="◅">hollow | left-pointing | pointer</annotation>
 		<annotation cp="◅" type="tts">hollow left-pointing pointer</annotation>
-		<annotation cp="◆">filled diamond</annotation>
+		<annotation cp="◆">diamond | filled</annotation>
 		<annotation cp="◆" type="tts">filled diamond</annotation>
-		<annotation cp="◇">hollow diamond</annotation>
+		<annotation cp="◇">diamond | hollow</annotation>
 		<annotation cp="◇" type="tts">hollow diamond</annotation>
-		<annotation cp="◈">hollow diamond containing filled diamond</annotation>
+		<annotation cp="◈">containing | diamond | filled | hollow</annotation>
 		<annotation cp="◈" type="tts">hollow diamond containing filled diamond</annotation>
-		<annotation cp="◉">circled dot | concentric cicles filled | fisheye | hollow circle containing filled circle | ward</annotation>
+		<annotation cp="◉">cicles | circle | circled | concentric | containing | dot | filled | fisheye | hollow | ward</annotation>
 		<annotation cp="◉" type="tts">hollow circle containing filled circle</annotation>
 		<annotation cp="◊">diamond | lozenge | rhombus</annotation>
 		<annotation cp="◊" type="tts">lozenge</annotation>
-		<annotation cp="○">circle | hollow circle | ring</annotation>
+		<annotation cp="○">circle | hollow | ring</annotation>
 		<annotation cp="○" type="tts">hollow circle</annotation>
-		<annotation cp="◌">dotted circle</annotation>
+		<annotation cp="◌">circle | dotted</annotation>
 		<annotation cp="◌" type="tts">dotted circle</annotation>
-		<annotation cp="◍">circle with vertical fill</annotation>
+		<annotation cp="◍">circle | fill | vertical | with</annotation>
 		<annotation cp="◍" type="tts">circle with vertical fill</annotation>
-		<annotation cp="◎">concentric circles | double circle | target</annotation>
+		<annotation cp="◎">circle | circles | concentric | double | target</annotation>
 		<annotation cp="◎" type="tts">concentric circles</annotation>
-		<annotation cp="●">circle | filled circle</annotation>
+		<annotation cp="●">circle | filled</annotation>
 		<annotation cp="●" type="tts">filled circle</annotation>
-		<annotation cp="◐">circle left half filled</annotation>
+		<annotation cp="◐">circle | filled | half | left</annotation>
 		<annotation cp="◐" type="tts">circle left half filled</annotation>
-		<annotation cp="◑">circle right half filled</annotation>
+		<annotation cp="◑">circle | filled | half | right</annotation>
 		<annotation cp="◑" type="tts">circle right half filled</annotation>
-		<annotation cp="◒">circle lower half filled</annotation>
+		<annotation cp="◒">circle | filled | half | lower</annotation>
 		<annotation cp="◒" type="tts">circle lower half filled</annotation>
-		<annotation cp="◓">circle upper half filled</annotation>
+		<annotation cp="◓">circle | filled | half | upper</annotation>
 		<annotation cp="◓" type="tts">circle upper half filled</annotation>
-		<annotation cp="◔">circle upper right quadrant filled</annotation>
+		<annotation cp="◔">circle | filled | quadrant | right | upper</annotation>
 		<annotation cp="◔" type="tts">circle upper right quadrant filled</annotation>
-		<annotation cp="◕">circle all but upper left quadrant filled</annotation>
+		<annotation cp="◕">all | but | circle | filled | left | quadrant | upper</annotation>
 		<annotation cp="◕" type="tts">circle all but upper left quadrant filled</annotation>
-		<annotation cp="◖">left half filled circle</annotation>
+		<annotation cp="◖">circle | filled | half | left</annotation>
 		<annotation cp="◖" type="tts">left half filled circle</annotation>
-		<annotation cp="◗">right half filled circle</annotation>
+		<annotation cp="◗">circle | filled | half | right</annotation>
 		<annotation cp="◗" type="tts">right half filled circle</annotation>
-		<annotation cp="◘">inverse bullet</annotation>
+		<annotation cp="◘">bullet | inverse</annotation>
 		<annotation cp="◘" type="tts">inverse bullet</annotation>
-		<annotation cp="◙">filled square containing hollow circle | inverse hollow circle</annotation>
+		<annotation cp="◙">circle | containing | filled | hollow | inverse | square</annotation>
 		<annotation cp="◙" type="tts">filled square containing hollow circle</annotation>
-		<annotation cp="◜">upper left quadrant circular arc</annotation>
+		<annotation cp="◜">arc | circular | left | quadrant | upper</annotation>
 		<annotation cp="◜" type="tts">upper left quadrant circular arc</annotation>
-		<annotation cp="◝">upper right quadrant circular arc</annotation>
+		<annotation cp="◝">arc | circular | quadrant | right | upper</annotation>
 		<annotation cp="◝" type="tts">upper right quadrant circular arc</annotation>
-		<annotation cp="◞">lower right quadrant circular arc</annotation>
+		<annotation cp="◞">arc | circular | lower | quadrant | right</annotation>
 		<annotation cp="◞" type="tts">lower right quadrant circular arc</annotation>
-		<annotation cp="◟">lower left quadrant circular arc</annotation>
+		<annotation cp="◟">arc | circular | left | lower | quadrant</annotation>
 		<annotation cp="◟" type="tts">lower left quadrant circular arc</annotation>
-		<annotation cp="◠">upper half circle</annotation>
+		<annotation cp="◠">circle | half | upper</annotation>
 		<annotation cp="◠" type="tts">upper half circle</annotation>
-		<annotation cp="◡">lower half circle</annotation>
+		<annotation cp="◡">circle | half | lower</annotation>
 		<annotation cp="◡" type="tts">lower half circle</annotation>
-		<annotation cp="◢">filled lower right triangle</annotation>
+		<annotation cp="◢">filled | lower | right | triangle</annotation>
 		<annotation cp="◢" type="tts">filled lower right triangle</annotation>
-		<annotation cp="◣">filled lower left triangle</annotation>
+		<annotation cp="◣">filled | left | lower | triangle</annotation>
 		<annotation cp="◣" type="tts">filled lower left triangle</annotation>
-		<annotation cp="◤">filled upper left triangle</annotation>
+		<annotation cp="◤">filled | left | triangle | upper</annotation>
 		<annotation cp="◤" type="tts">filled upper left triangle</annotation>
-		<annotation cp="◥">filled upper right triangle</annotation>
+		<annotation cp="◥">filled | right | triangle | upper</annotation>
 		<annotation cp="◥" type="tts">filled upper right triangle</annotation>
-		<annotation cp="◦">hollow bullet</annotation>
+		<annotation cp="◦">bullet | hollow</annotation>
 		<annotation cp="◦" type="tts">hollow bullet</annotation>
-		<annotation cp="◯">circle | large hollow circle | ring</annotation>
+		<annotation cp="◯">circle | hollow | large | ring</annotation>
 		<annotation cp="◯" type="tts">large hollow circle</annotation>
-		<annotation cp="◳">hollow square upper right quadrant</annotation>
+		<annotation cp="◳">hollow | quadrant | right | square | upper</annotation>
 		<annotation cp="◳" type="tts">hollow square upper right quadrant</annotation>
-		<annotation cp="◷">hollow circle with upper right quadrant</annotation>
+		<annotation cp="◷">circle | hollow | quadrant | right | upper | with</annotation>
 		<annotation cp="◷" type="tts">hollow circle with upper right quadrant</annotation>
-		<annotation cp="◿">lower right triangle</annotation>
+		<annotation cp="◿">lower | right | triangle</annotation>
 		<annotation cp="◿" type="tts">lower right triangle</annotation>
 		<annotation cp="♪">eighth | music | note</annotation>
 		<annotation cp="♪" type="tts">eighth note</annotation>
-		<annotation cp="⨧">plus subscript two</annotation>
+		<annotation cp="⨧">plus | subscript | two</annotation>
 		<annotation cp="⨧" type="tts">plus subscript two</annotation>
-		<annotation cp="⨯">vector cross product</annotation>
+		<annotation cp="⨯">cross | product | vector</annotation>
 		<annotation cp="⨯" type="tts">vector cross product</annotation>
-		<annotation cp="⨼">interior product</annotation>
+		<annotation cp="⨼">interior | product</annotation>
 		<annotation cp="⨼" type="tts">interior product</annotation>
-		<annotation cp="⩣">logical or double underbar</annotation>
+		<annotation cp="⩣">double | logical | or | underbar</annotation>
 		<annotation cp="⩣" type="tts">logical or double underbar</annotation>
-		<annotation cp="⩽">less-than slanted equal</annotation>
+		<annotation cp="⩽">equal | less-than | slanted</annotation>
 		<annotation cp="⩽" type="tts">less-than slanted equal</annotation>
-		<annotation cp="⪍">less-than above similar equal</annotation>
+		<annotation cp="⪍">above | equal | less-than | similar</annotation>
 		<annotation cp="⪍" type="tts">less-than above similar equal</annotation>
-		<annotation cp="⪚">double-line equal greater-than | inequality | mathematics</annotation>
+		<annotation cp="⪚">double-line | equal | greater-than | inequality | mathematics</annotation>
 		<annotation cp="⪚" type="tts">double-line equal greater-than</annotation>
-		<annotation cp="⪺">succeeds above not almost equal</annotation>
+		<annotation cp="⪺">above | almost | equal | not | succeeds</annotation>
 		<annotation cp="⪺" type="tts">succeeds above not almost equal</annotation>
 		<annotation cp="♭">bemolle | flat | music | note</annotation>
 		<annotation cp="♭" type="tts">flat</annotation>
 		<annotation cp="♯">dièse | diesis | music | note | sharp</annotation>
 		<annotation cp="♯" type="tts">sharp</annotation>
-		<!-- start hand-generated lines from E16 -->
 		<annotation cp="🪉">cupid | harp | instrument | love | music | orchestra</annotation>
 		<annotation cp="🪉" type="tts">harp</annotation>
-		<annotation cp="🪏">dig | hole | scoop | shovel | spade</annotation>
+		<annotation cp="🪏">dig | hole | scoop | shovel | spade | bury | snow | garden | plant</annotation>
 		<annotation cp="🪏" type="tts">shovel</annotation>
-		<annotation cp="🪾">barren | drought | leafless tree | winter</annotation>
+		<annotation cp="🪾">barren | drought | leafless | tree | winter | bare | branches | wood | dead | trunk</annotation>
 		<annotation cp="🪾" type="tts">leafless tree</annotation>
-		<annotation cp="🫆">fingerprint | forensics | identity | safety</annotation>
+		<annotation cp="🫆">fingerprint | forensics | identity | safety | clue | crime | trace | mystery | detective | print</annotation>
 		<annotation cp="🫆" type="tts">fingerprint</annotation>
-		<annotation cp="🫜">beet | garden | root | turnip | vegetable</annotation>
+		<annotation cp="🫜">beet | garden | root | turnip | vegetable | radish | food | salad | vegetarian</annotation>
 		<annotation cp="🫜" type="tts">root vegetable</annotation>
-		<annotation cp="🫟">holi | paint | spill | splatter | stain</annotation>
+		<annotation cp="🫟">holi | paint | spill | splatter | stain | drip | mess | liquid | ink</annotation>
 		<annotation cp="🫟" type="tts">splatter</annotation>
-		<annotation cp="🫩">exhausted | face with bags under eyes | sleepy | tired</annotation>
+		<annotation cp="🫩">bags | exhausted | eyes | face | sleepy | tired | fatigued | bored | weary | late</annotation>
 		<annotation cp="🫩" type="tts">face with bags under eyes</annotation>
-		<!-- end hand-generated lines from E16 -->
-		<annotation cp="😀">cheerful | cheery | face | grin | grinning face | happy | laugh | nice | smile | smiling | teeth</annotation>
+		<annotation cp="😀">cheerful | cheery | face | grin | grinning | happy | laugh | nice | smile | smiling | teeth</annotation>
 		<annotation cp="😀" type="tts">grinning face</annotation>
-		<annotation cp="😃">awesome | face | grin | grinning face with big eyes | happy | mouth | open | smile | smiling | smiling face with open mouth | teeth | yay</annotation>
+		<annotation cp="😃">awesome | big | eyes | face | grin | grinning | happy | mouth | open | smile | smiling | teeth | yay</annotation>
 		<annotation cp="😃" type="tts">grinning face with big eyes</annotation>
-		<annotation cp="😄">eye | face | grin | grinning face with smiling eyes | happy | laugh | lol | mouth | open | smile | smiling | smiling face with open mouth and smiling eyes</annotation>
+		<annotation cp="😄">eye | eyes | face | grin | grinning | happy | laugh | lol | mouth | open | smile | smiling</annotation>
 		<annotation cp="😄" type="tts">grinning face with smiling eyes</annotation>
-		<annotation cp="😁">beaming face with smiling eyes | eye | face | grin | grinning face with smiling eyes | happy | nice | smile | smiling | teeth</annotation>
+		<annotation cp="😁">beaming | eye | eyes | face | grin | grinning | happy | nice | smile | smiling | teeth</annotation>
 		<annotation cp="😁" type="tts">beaming face with smiling eyes</annotation>
-		<annotation cp="😆">face | grinning squinting face | haha | hahaha | happy | laugh | lol | mouth | open | rofl | satisfied | smile | smiling | smiling face with open mouth and closed eyes</annotation>
+		<annotation cp="😆">closed | eyes | face | grinning | haha | hahaha | happy | laugh | lol | mouth | open | rofl | smile | smiling | squinting</annotation>
 		<annotation cp="😆" type="tts">grinning squinting face</annotation>
-		<annotation cp="😅">cold | dejected | excited | face | grinning face with sweat | nervous | open | smile | smiling face with open mouth and cold sweat | stress | stressed | sweat</annotation>
+		<annotation cp="😅">cold | dejected | excited | face | grinning | mouth | nervous | open | smile | smiling | stress | stressed | sweat</annotation>
 		<annotation cp="😅" type="tts">grinning face with sweat</annotation>
-		<annotation cp="🤣">crying | face | floor | funny | haha | happy | hehe | hilarious | joy | laugh | laughing | laughter | lmao | lmfao | lol | lolol | lololol | rofl | roflmao | rolling | rolling on the floor laughing | rotfl | tear | tears</annotation>
+		<annotation cp="🤣">crying | face | floor | funny | haha | happy | hehe | hilarious | joy | laugh | lmao | lol | rofl | roflmao | rolling | tear</annotation>
 		<annotation cp="🤣" type="tts">rolling on the floor laughing</annotation>
-		<annotation cp="😂">crying | face | face with tears of joy | feels | funny | haha | hahaha | happy | hehe | hilarious | joy | laugh | laughing | laughter | lmao | lmfao | lol | lolol | lololol | rofl | roflmao | tear | tears</annotation>
+		<annotation cp="😂">crying | face | feels | funny | haha | happy | hehe | hilarious | joy | laugh | lmao | lol | rofl | roflmao | tear</annotation>
 		<annotation cp="😂" type="tts">face with tears of joy</annotation>
-		<annotation cp="🙂">face | happy | slightly smiling face | smile | smiling</annotation>
+		<annotation cp="🙂">face | happy | slightly | smile | smiling</annotation>
 		<annotation cp="🙂" type="tts">slightly smiling face</annotation>
 		<annotation cp="🙃">face | hehe | smile | upside-down</annotation>
 		<annotation cp="🙃" type="tts">upside-down face</annotation>
-		<!-- Generated lines from Emoji Data v14, using GenerateCldrData.java -->
-		<annotation cp="🫠">disappear | dissolve | embarrassed | haha | heat | hot | liquid | lol | melt | melting | melting face | sarcasm | sarcastic</annotation> <!-- 1FAE0 -->
+		<annotation cp="🫠">disappear | dissolve | embarrassed | face | haha | heat | hot | liquid | lol | melt | melting | sarcasm | sarcastic</annotation> <!-- 1FAE0 -->
 		<annotation cp="🫠" type="tts">melting face</annotation>
 		<annotation cp="😉">face | flirt | heartbreaker | sexy | slide | tease | wink | winking | winks</annotation>
 		<annotation cp="😉" type="tts">winking face</annotation>
-		<annotation cp="😊">blush | eye | face | glad | satisfied | smile | smiling | smiling face with smiling eyes</annotation>
+		<annotation cp="😊">blush | eye | eyes | face | glad | satisfied | smile | smiling</annotation>
 		<annotation cp="😊" type="tts">smiling face with smiling eyes</annotation>
-		<annotation cp="😇">angel | angelic | angels | blessed | face | fairy tale | fairytale | fantasy | halo | happy | innocent | peaceful | smile | smiling | smiling face with halo | spirit</annotation>
+		<annotation cp="😇">angel | angelic | angels | blessed | face | fairy | fairytale | fantasy | halo | happy | innocent | peaceful | smile | smiling | spirit | tale</annotation>
 		<annotation cp="😇" type="tts">smiling face with halo</annotation>
-		<annotation cp="🥰">adore | crush | face | heart | hearts | i love you | ily | in love | love | romance | smile | smiling face with 3 hearts | smiling face with hearts | smiling hearts</annotation>
+		<annotation cp="🥰">3 | adore | crush | face | heart | hearts | ily | love | romance | smile | smiling | you</annotation>
 		<annotation cp="🥰" type="tts">smiling face with hearts</annotation>
-		<annotation cp="😍">143 | bae | eye | face | feels | heart | hearts | ily | in love | kisses | love | loving | romance | romantic | smile | smiling face with heart-eyes | xoxo</annotation>
+		<annotation cp="😍">143 | bae | eye | face | feels | heart-eyes | hearts | ily | kisses | love | romance | romantic | smile | xoxo</annotation>
 		<annotation cp="😍" type="tts">smiling face with heart-eyes</annotation>
 		<annotation cp="🤩">excited | eyes | face | grinning | smile | star | star-struck | starry-eyed | wow</annotation>
 		<annotation cp="🤩" type="tts">star-struck</annotation>
-		<annotation cp="😘">143 | adorbs | bae | face | face blowing a kiss | flirt | heart | ily | kiss | kisses | love | love you | lover | miss you | morning | muah | night | romance | romantic | smooch | smooches | xoxo</annotation>
+		<annotation cp="😘">adorbs | bae | blowing | face | flirt | heart | ily | kiss | love | lover | miss | muah | romantic | smooch | xoxo | you</annotation>
 		<annotation cp="😘" type="tts">face blowing a kiss</annotation>
-		<annotation cp="😗">143 | date | dating | face | flirt | ily | kiss | kisses | kissing | love | love you | smooch | smooches | xoxo</annotation>
+		<annotation cp="😗">143 | date | dating | face | flirt | ily | kiss | love | smooch | smooches | xoxo | you</annotation>
 		<annotation cp="😗" type="tts">kissing face</annotation>
 		<annotation cp="☺">face | happy | outlined | relaxed | smile | smiling</annotation>
 		<annotation cp="☺" type="tts">smiling face</annotation>
-		<annotation cp="😚">143 | bae | blush | closed | date | dating | eye | face | flirt | ily | kiss | kisses | kissing face with closed eyes | smooches | xoxo</annotation>
+		<annotation cp="😚">143 | bae | blush | closed | date | dating | eye | eyes | face | flirt | ily | kisses | kissing | smooches | xoxo</annotation>
 		<annotation cp="😚" type="tts">kissing face with closed eyes</annotation>
-		<annotation cp="😙">143 | closed eyes | date | dating | eye | face | flirt | ily | kiss | kisses | kissing face with smiling eyes | love | night | smile</annotation>
+		<annotation cp="😙">143 | closed | date | dating | eye | eyes | face | flirt | ily | kiss | kisses | kissing | love | night | smile | smiling</annotation>
 		<annotation cp="😙" type="tts">kissing face with smiling eyes</annotation>
-		<annotation cp="🥲">glad | grateful | happy | joy | pain | proud | relieved | smile | smiley | smiling | smiling face with tear | tear | touched</annotation>
+		<annotation cp="🥲">face | glad | grateful | happy | joy | pain | proud | relieved | smile | smiley | smiling | tear | touched</annotation>
 		<annotation cp="🥲" type="tts">smiling face with tear</annotation>
-		<annotation cp="😋">delicious | eat | face | face savoring food | food | full | hungry | savour | savouring | smile | smiling | tasty | um | yum | yummy</annotation>
+		<annotation cp="😋">delicious | eat | face | food | full | hungry | savor | smile | smiling | tasty | um | yum | yummy</annotation>
 		<annotation cp="😋" type="tts">face savoring food</annotation>
-		<annotation cp="😛">awesome | cool | face | face with stuck-out tongue | face with tongue | nice | party | sweet | tongue</annotation>
+		<annotation cp="😛">awesome | cool | face | nice | party | stuck-out | sweet | tongue</annotation>
 		<annotation cp="😛" type="tts">face with tongue</annotation>
-		<annotation cp="😜">crazy | epic | eye | face | face with stuck-out tongue and winking eye | fun | funny | joke | loopy | nutty | party | tongue | wacky | weirdo | wink | winking face with tongue | yolo</annotation>
+		<annotation cp="😜">crazy | epic | eye | face | funny | joke | loopy | nutty | party | stuck-out | tongue | wacky | weirdo | wink | winking | yolo</annotation>
 		<annotation cp="😜" type="tts">winking face with tongue</annotation>
-		<annotation cp="🤪">crazy | crazy face | eye | eyes | goofy | large | small | zany face</annotation>
+		<annotation cp="🤪">crazy | eye | eyes | face | goofy | large | small | zany</annotation>
 		<annotation cp="🤪" type="tts">zany face</annotation>
-		<annotation cp="😝">eye | face | face with stuck-out tongue and closed eyes | gross | horrible | omg | squinting face with tongue | taste | tongue | whatever | yolo</annotation>
+		<annotation cp="😝">closed | eye | eyes | face | gross | horrible | omg | squinting | stuck-out | taste | tongue | whatever | yolo</annotation>
 		<annotation cp="😝" type="tts">squinting face with tongue</annotation>
-		<annotation cp="🤑">face | money | money-mouth face | mouth | paid</annotation>
+		<annotation cp="🤑">face | money | money-mouth | mouth | paid</annotation>
 		<annotation cp="🤑" type="tts">money-mouth face</annotation>
-		<annotation cp="🤗">face | hands | hug | hugging | open hands | smiling face | smiling face with open hands</annotation>
+		<annotation cp="🤗">face | hands | hug | hugging | open | smiling</annotation>
 		<annotation cp="🤗" type="tts">smiling face with open hands</annotation>
-		<annotation cp="🤭">face with hand over mouth | giggle | giggling | oops | secret | shock | sudden realization | surprise | whoops</annotation>
+		<annotation cp="🤭">face | giggle | giggling | hand | mouth | oops | realization | secret | shock | sudden | surprise | whoops</annotation>
 		<annotation cp="🤭" type="tts">face with hand over mouth</annotation>
-		<annotation cp="🫢">amazement | awe | disbelief | embarrass | face with open eyes and hand over mouth | gasp | omg | quiet | scared | shock | shocked | surprise</annotation> <!-- 1FAE2 -->
+		<annotation cp="🫢">amazement | awe | disbelief | embarrass | eyes | face | gasp | hand | mouth | omg | open | over | quiet | scared | shock | surprise</annotation> <!-- 1FAE2 -->
 		<annotation cp="🫢" type="tts">face with open eyes and hand over mouth</annotation>
-		<annotation cp="🫣">captivated | embarrass | face with peeking eye | hide | hiding | peek | peeking | peep | scared | shy | stare</annotation> <!-- 1FAE3 -->
+		<annotation cp="🫣">captivated | embarrass | eye | face | hide | hiding | peek | peeking | peep | scared | shy | stare</annotation> <!-- 1FAE3 -->
 		<annotation cp="🫣" type="tts">face with peeking eye</annotation>
-		<annotation cp="🤫">be quiet | quiet | shh | shush | shushing face</annotation>
+		<annotation cp="🤫">face | quiet | shh | shush | shushing</annotation>
 		<annotation cp="🤫" type="tts">shushing face</annotation>
 		<annotation cp="🤔">chin | consider | face | hmm | ponder | pondering | thinking | wondering</annotation>
 		<annotation cp="🤔" type="tts">thinking face</annotation>
-		<annotation cp="🫡">good luck | OK | respect | salute | saluting face | sunny | troops | yes | yes ma’am | yes sir</annotation> <!-- 1FAE1 -->
+		<annotation cp="🫡">face | good | luck | ma’am | OK | respect | salute | saluting | sir | troops | yes</annotation> <!-- 1FAE1 -->
 		<annotation cp="🫡" type="tts">saluting face</annotation>
-		<annotation cp="🤐">face | keep my mouth shut | mouth | not telling | quiet | secret | zip | zipper | zipper-mouth face</annotation>
+		<annotation cp="🤐">face | keep | mouth | quiet | secret | shut | zip | zipper | zipper-mouth</annotation>
 		<annotation cp="🤐" type="tts">zipper-mouth face</annotation>
-		<annotation cp="🤨">colbert emoji | disapproval | disbelief | distrust | face with raised eyebrow | hmm | mild surprise | scepticism | skeptic | skeptical | surprise | what</annotation>
+		<annotation cp="🤨">disapproval | disbelief | distrust | emoji | eyebrow | face | hmm | mild | raised | skepticism | skeptic | skeptical | surprise | what</annotation>
 		<annotation cp="🤨" type="tts">face with raised eyebrow</annotation>
-		<annotation cp="😐">awk | awkward | bad | basic | blank | dead | deadpan | expressionless | face | fine | jealous | jel | jelly | meh | neutral | not amused | not funny | not impressed | not laughing | shade | straight face | uh | uh oh | unamused | unhappy | unimpressed | whatever</annotation>
+		<annotation cp="😐">awkward | blank | deadpan | expressionless | face | fine | jealous | meh | neutral | oh | shade | straight | unamused | unhappy | unimpressed | whatever</annotation>
 		<annotation cp="😐" type="tts">neutral face</annotation>
-		<annotation cp="😑">awk | awkward | bad | basic | cost | dead | expressionless | face | fine | inexpressive | jealous | jel | jelly | meh | no | not impressed | omg | straight face | uh | uh oh | unexpressive | unhappy | unimpressed | whatever | wtf</annotation>
+		<annotation cp="😑">awkward | dead | expressionless | face | fine | inexpressive | jealous | meh | not | oh | omg | straight | uh | unhappy | unimpressed | whatever</annotation>
 		<annotation cp="😑" type="tts">expressionless face</annotation>
-		<annotation cp="😶">awkward | blank | cant even | expressionless | face | face without mouth | mouth | mouthless | mute | quiet | secret | silence | silent | speechless</annotation>
+		<annotation cp="😶">awkward | blank | expressionless | face | mouth | mouthless | mute | quiet | secret | silence | silent | speechless</annotation>
 		<annotation cp="😶" type="tts">face without mouth</annotation>
-		<annotation cp="🫥">depressed | disappear | dotted line face | hidden | hide | introvert | invisible | meh | whatever | wtv</annotation> <!-- 1FAE5 -->
+		<annotation cp="🫥">depressed | disappear | dotted | face | hidden | hide | introvert | invisible | line | meh | whatever | wtv</annotation> <!-- 1FAE5 -->
 		<annotation cp="🫥" type="tts">dotted line face</annotation>
-		<annotation cp="😶‍🌫">absentminded | face in clouds | face in the fog | head in clouds</annotation> <!-- 1F636 200D 1F32B FE0F: face in clouds -->
+		<annotation cp="😶‍🌫">absentminded | clouds | face | fog | head</annotation> <!-- 1F636 200D 1F32B FE0F: face in clouds -->
 		<annotation cp="😶‍🌫" type="tts">face in clouds</annotation>
-		<annotation cp="😏">boss | dapper | eyebrows | face | flirt | homie | kidding | leer | shade | slick | slide | sly | smirk | smirking face | smug | snicker | suave | suspicious | swag | swagger | wink</annotation>
+		<annotation cp="😏">boss | dapper | face | flirt | homie | kidding | leer | shade | slick | sly | smirk | smug | snicker | suave | suspicious | swag</annotation>
 		<annotation cp="😏" type="tts">smirking face</annotation>
-		<annotation cp="😒">... | bored | coolstorybro | face | fine | jealous | jel | jelly | pissed | smh | ugh | uhh | unamused | unhappy | weird | whatever</annotation>
+		<annotation cp="😒">... | bored | face | fine | jealous | jel | jelly | pissed | smh | ugh | uhh | unamused | unhappy | weird | whatever</annotation>
 		<annotation cp="😒" type="tts">unamused face</annotation>
-		<annotation cp="🙄">eyeroll | eyes | face | face with rolling eyes | rolling | shade | ugh | whatever</annotation>
+		<annotation cp="🙄">eyeroll | eyes | face | rolling | shade | ugh | whatever</annotation>
 		<annotation cp="🙄" type="tts">face with rolling eyes</annotation>
-		<annotation cp="😬">awk | awkward | dentist | face | grimace | grimacing face | grinning | nothing | smile | smiling</annotation>
+		<annotation cp="😬">awk | awkward | dentist | face | grimace | grimacing | grinning | smile | smiling</annotation>
 		<annotation cp="😬" type="tts">grimacing face</annotation>
-		<annotation cp="😮‍💨">blow | blowing | exhale | exhausted | face exhaling | gasp | groan | relief | sigh | smiley | smoke | whisper | whistle</annotation> <!-- 1F62E 200D 1F4A8 -->
+		<annotation cp="😮‍💨">blow | blowing | exhale | exhaling | exhausted | face | gasp | groan | relief | sigh | smiley | smoke | whisper | whistle</annotation> <!-- 1F62E 200D 1F4A8 -->
 		<annotation cp="😮‍💨" type="tts">face exhaling</annotation>
-		<annotation cp="🤥">face | liar | lie | lying face | pinocchio</annotation>
+		<annotation cp="🤥">face | liar | lie | lying | pinocchio</annotation>
 		<annotation cp="🤥" type="tts">lying face</annotation>
-		<!-- Generated lines from Emoji Data v15, using GenerateCldrData.java -->
 		<annotation cp="🫨">crazy | daze | earthquake | face | omg | panic | shaking | shock | surprise | vibrate | whoa | wow</annotation> <!-- 1FAE8 -->
 		<annotation cp="🫨" type="tts">shaking face</annotation>
-		<!-- Generated lines from Emoji Data v15.1, using GenerateCldrData.java -->
-		<annotation cp="🙂‍↔">head shaking horizontally | no | shake</annotation> <!-- 1F642 200D 2194 -->
+		<annotation cp="🙂‍↔">head | horizontally | no | shake | shaking</annotation> <!-- 1F642 200D 2194 -->
 		<annotation cp="🙂‍↔" type="tts">head shaking horizontally</annotation>
-		<annotation cp="🙂‍↕">head shaking vertically | nod | yes</annotation> <!-- 1F642 200D 2195 -->
+		<annotation cp="🙂‍↕">head | nod | shaking | vertically | yes</annotation> <!-- 1F642 200D 2195 -->
 		<annotation cp="🙂‍↕" type="tts">head shaking vertically</annotation>
 		<annotation cp="😌">calm | face | peace | relief | relieved | zen</annotation>
 		<annotation cp="😌" type="tts">relieved face</annotation>
 		<annotation cp="😔">awful | bored | dejected | died | disappointed | face | losing | lost | pensive | sad | sucks</annotation>
 		<annotation cp="😔" type="tts">pensive face</annotation>
-		<annotation cp="😪">crying | face | good night | sad | sleep | sleeping | sleepy face | tired</annotation>
+		<annotation cp="😪">crying | face | good | night | sad | sleep | sleeping | sleepy | tired</annotation>
 		<annotation cp="😪" type="tts">sleepy face</annotation>
 		<annotation cp="🤤">drooling | face</annotation>
 		<annotation cp="🤤" type="tts">drooling face</annotation>
-		<annotation cp="😴">bed | bedtime | face | good night | goodnight | nap | night | sleep | sleeping | tired | whatever | yawn | zz | ZZZ | zzzz</annotation>
+		<annotation cp="😴">bed | bedtime | face | good | goodnight | nap | night | sleep | sleeping | tired | whatever | yawn | zzz</annotation>
 		<annotation cp="😴" type="tts">sleeping face</annotation>
-		<annotation cp="😷">cold | dentist | dermatologist | doctor | dr | face | face with medical mask | germs | mask | medicine | sick</annotation>
+		<annotation cp="😷">cold | dentist | dermatologist | doctor | dr | face | germs | mask | medical | medicine | sick</annotation>
 		<annotation cp="😷" type="tts">face with medical mask</annotation>
-		<annotation cp="🤒">face | face with thermometer | ill | sick | thermometer</annotation>
+		<annotation cp="🤒">face | ill | sick | thermometer</annotation>
 		<annotation cp="🤒" type="tts">face with thermometer</annotation>
-		<annotation cp="🤕">bandage | face | face with head-bandage | hurt | injury | ouch</annotation>
+		<annotation cp="🤕">bandage | face | head-bandage | hurt | injury | ouch</annotation>
 		<annotation cp="🤕" type="tts">face with head-bandage</annotation>
 		<annotation cp="🤢">face | gross | nasty | nauseated | sick | vomit</annotation>
 		<annotation cp="🤢" type="tts">nauseated face</annotation>
-		<annotation cp="🤮">ew | face vomiting | gross | puke | sick | spew | throw up | vomit</annotation>
+		<annotation cp="🤮">barf | ew | face | gross | puke | sick | spew | throw | up | vomit | vomiting</annotation>
 		<annotation cp="🤮" type="tts">face vomiting</annotation>
-		<annotation cp="🤧">face | fever | flu | gesundheit | sick | sneeze | sneezing face</annotation>
+		<annotation cp="🤧">face | fever | flu | gesundheit | sick | sneeze | sneezing</annotation>
 		<annotation cp="🤧" type="tts">sneezing face</annotation>
-		<annotation cp="🥵">dying | face | feverish | heat stroke | hot | panting | red-faced | sweating | tongue out</annotation>
+		<annotation cp="🥵">dying | face | feverish | heat | hot | panting | red-faced | stroke | sweating | tongue</annotation>
 		<annotation cp="🥵" type="tts">hot face</annotation>
-		<annotation cp="🥶">blue | blue-faced | cold | cold teeth | face | freezing | frostbite | icicles | subzero</annotation>
+		<annotation cp="🥶">blue | blue-faced | cold | face | freezing | frostbite | icicles | subzero | teeth</annotation>
 		<annotation cp="🥶" type="tts">cold face</annotation>
-		<annotation cp="🥴">dizzy | drunk | intoxicated | tipsy | uneven eyes | wavy mouth | woozy face</annotation>
+		<annotation cp="🥴">dizzy | drunk | eyes | face | intoxicated | mouth | tipsy | uneven | wavy | woozy</annotation>
 		<annotation cp="🥴" type="tts">woozy face</annotation>
-		<annotation cp="😵">crossed-out eyes | dead | dizzy | face | face with crossed-out eyes | feels | knocked out | sick | tired</annotation>
+		<annotation cp="😵">crossed-out | dead | dizzy | eyes | face | feels | knocked | out | sick | tired</annotation>
 		<annotation cp="😵" type="tts">face with crossed-out eyes</annotation>
-		<annotation cp="😵‍💫">confused | dizzy | face with spiral eyes | hypnotized | omg | smiley | spiral | trouble | whoa | woah | woozy</annotation> <!-- 1F635 200D 1F4AB -->
+		<annotation cp="😵‍💫">confused | dizzy | eyes | face | hypnotized | omg | smiley | spiral | trouble | whoa | woah | woozy</annotation> <!-- 1F635 200D 1F4AB -->
 		<annotation cp="😵‍💫" type="tts">face with spiral eyes</annotation>
-		<annotation cp="🤯">explode | exploding head | mind blown | mindblown | no way | shocked</annotation>
+		<annotation cp="🤯">blown | explode | exploding | head | mind | mindblown | no | shocked | way</annotation>
 		<annotation cp="🤯" type="tts">exploding head</annotation>
 		<annotation cp="🤠">cowboy | cowgirl | face | hat</annotation>
 		<annotation cp="🤠" type="tts">cowboy hat face</annotation>
-		<annotation cp="🥳">birthday | celebrate | celebration | excited | face | happy bday | happy birthday | hat | hooray | horn | party | partying face</annotation>
+		<annotation cp="🥳">bday | birthday | celebrate | celebration | excited | face | happy | hat | hooray | horn | party | partying</annotation>
 		<annotation cp="🥳" type="tts">partying face</annotation>
-		<annotation cp="🥸">disguise | disguised face | eyebrow | face | glasses | incognito | moustache | mustache | nose | person | spy | tache | tash</annotation>
+		<annotation cp="🥸">disguise | eyebrow | face | glasses | incognito | moustache | mustache | nose | person | spy | tache | tash</annotation>
 		<annotation cp="🥸" type="tts">disguised face</annotation>
-		<annotation cp="😎">awesome | beach | bright | bro | chillin | cool | eye | eyewear | face | fly | glasses | rad | relaxed | shades | slay | smile | smiling face with sunglasses | stunner | style | sun | sunglasses | swag | swagger | win | winning | yeah</annotation>
+		<annotation cp="😎">awesome | beach | bright | bro | chilling | cool | face | rad | relaxed | shades | slay | smile | style | sunglasses | swag | win</annotation>
 		<annotation cp="😎" type="tts">smiling face with sunglasses</annotation>
 		<annotation cp="🤓">brainy | clever | expert | face | geek | gifted | glasses | intelligent | nerd | smart</annotation>
 		<annotation cp="🤓" type="tts">nerd face</annotation>
-		<annotation cp="🧐">classy | face | face with monocle | fancy | monocle | rich | stuffy | wealthy</annotation>
+		<annotation cp="🧐">classy | face | fancy | monocle | rich | stuffy | wealthy</annotation>
 		<annotation cp="🧐" type="tts">face with monocle</annotation>
-		<annotation cp="😕">befuddled | confused | confusing | dunno | face | frown | hm | i dunno | meh | not sure | sad | sorry</annotation>
+		<annotation cp="😕">befuddled | confused | confusing | dunno | face | frown | hm | meh | not | sad | sorry | sure</annotation>
 		<annotation cp="😕" type="tts">confused face</annotation>
-		<annotation cp="🫤">confused | confusion | disappointed | doubt | doubtful | face with diagonal mouth | frustrated | frustration | meh | skeptical | unsure | whatever | wtv</annotation> <!-- 1FAE4 -->
+		<annotation cp="🫤">confused | confusion | diagonal | disappointed | doubt | doubtful | face | frustrated | frustration | meh | mouth | skeptical | unsure | whatever | wtv</annotation> <!-- 1FAE4 -->
 		<annotation cp="🫤" type="tts">face with diagonal mouth</annotation>
 		<annotation cp="😟">anxious | butterflies | face | nerves | nervous | sad | stress | stressed | surprised | worried | worry</annotation>
 		<annotation cp="😟" type="tts">worried face</annotation>
-		<annotation cp="🙁">face | frown | sad | slightly frowning face</annotation>
+		<annotation cp="🙁">face | frown | frowning | sad | slightly</annotation>
 		<annotation cp="🙁" type="tts">slightly frowning face</annotation>
-		<annotation cp="☹">face | frown | frowning face | sad</annotation>
+		<annotation cp="☹">face | frown | frowning | sad</annotation>
 		<annotation cp="☹" type="tts">frowning face</annotation>
-		<annotation cp="😮">face | face with open mouth | forgot | i dont believe you | mouth | omg | open | shocked | surprised | sympathy | unbelievable | unreal | whoa | woah | wow</annotation>
+		<annotation cp="😮">believe | face | forgot | mouth | omg | open | shocked | surprised | sympathy | unbelievable | unreal | whoa | wow | you</annotation>
 		<annotation cp="😮" type="tts">face with open mouth</annotation>
 		<annotation cp="😯">epic | face | hushed | omg | stunned | surprised | whoa | woah</annotation>
 		<annotation cp="😯" type="tts">hushed face</annotation>
-		<annotation cp="😲">astonished | cost | face | gtfo | no way | omfg | omg | shocked | totally | wtf</annotation>
+		<annotation cp="😲">astonished | cost | face | no | omg | shocked | totally | way</annotation>
 		<annotation cp="😲" type="tts">astonished face</annotation>
-		<annotation cp="😳">amazed | awk | awkward | blame | dazed | dead | disbelief | embarrassed | exercise | face | flushed | geez | heat | hot | impressed | jeez | that’s crazy | what | wow</annotation>
+		<annotation cp="😳">amazed | awkward | crazy | dazed | dead | disbelief | embarrassed | face | flushed | geez | heat | hot | impressed | jeez | what | wow</annotation>
 		<annotation cp="😳" type="tts">flushed face</annotation>
-		<annotation cp="🥺">begging | big eyes | face | mercy | pleading face | please | pretty please | puppy eyes | sad | why not</annotation>
+		<annotation cp="🥺">begging | big | eyes | face | mercy | not | pleading | please | pretty | puppy | sad | why</annotation>
 		<annotation cp="🥺" type="tts">pleading face</annotation>
-		<annotation cp="🥹">admiration | angry | aw | aww | cry | embarrassed | face holding back tears | feelings | grateful | gratitude | please | proud | resist | sad | sadness | tears of joy</annotation> <!-- 1F979 -->
+		<annotation cp="🥹">admiration | aww | back | cry | embarrassed | face | feelings | grateful | gratitude | holding | joy | please | proud | resist | sad | tears</annotation> <!-- 1F979 -->
 		<annotation cp="🥹" type="tts">face holding back tears</annotation>
-		<annotation cp="😦">caught off guard | face | frown | frowning face with open mouth | mouth | open | scared | scary | suprise | what | wow</annotation>
+		<annotation cp="😦">caught | face | frown | frowning | guard | mouth | open | scared | scary | surprise | what | wow</annotation>
 		<annotation cp="😦" type="tts">frowning face with open mouth</annotation>
-		<annotation cp="😧">anguished | face | forgot | scared | scary | stressed | suprise | unhappy | what | wow</annotation>
+		<annotation cp="😧">anguished | face | forgot | scared | scary | stressed | surprise | unhappy | what | wow</annotation>
 		<annotation cp="😧" type="tts">anguished face</annotation>
 		<annotation cp="😨">afraid | anxious | blame | face | fear | fearful | scared | worried</annotation>
 		<annotation cp="😨" type="tts">fearful face</annotation>
-		<annotation cp="😰">anxious face with sweat | blue | cold | eek | face | face with open mouth and cold sweat | mouth | nervous | open | rushed | scared | sweat | yikes</annotation>
+		<annotation cp="😰">anxious | blue | cold | eek | face | mouth | nervous | open | rushed | scared | sweat | yikes</annotation>
 		<annotation cp="😰" type="tts">anxious face with sweat</annotation>
-		<annotation cp="😥">anxious | close call | complicated | disappointed | disappointed but relieved face | face | not this time | relieved | sad | sad but relieved face | sweat | whew</annotation>
+		<annotation cp="😥">anxious | call | close | complicated | disappointed | face | not | relieved | sad | sweat | time | whew</annotation>
 		<annotation cp="😥" type="tts">sad but relieved face</annotation>
 		<annotation cp="😢">awful | cry | crying | face | feels | miss | sad | tear | triste | unhappy</annotation>
 		<annotation cp="😢" type="tts">crying face</annotation>
-		<annotation cp="😭">bawling | cry | crying | face | loudly crying face | sad | sob | tear | tears | unhappy</annotation>
+		<annotation cp="😭">bawling | cry | crying | face | loudly | sad | sob | tear | tears | unhappy</annotation>
 		<annotation cp="😭" type="tts">loudly crying face</annotation>
-		<annotation cp="😱">epic | face | face screaming in fear | fear | fearful | munch | scared | scream | screamer | shocked | surprised | woah</annotation>
+		<annotation cp="😱">epic | face | fear | fearful | munch | scared | scream | screamer | screaming | shocked | surprised | woah</annotation>
 		<annotation cp="😱" type="tts">face screaming in fear</annotation>
 		<annotation cp="😖">annoyed | confounded | confused | cringe | distraught | face | feels | frustrated | mad | sad</annotation>
 		<annotation cp="😖" type="tts">confounded face</annotation>
-		<annotation cp="😣">concentrate | concentration | face | focus | headache | persevere | persevering face</annotation>
+		<annotation cp="😣">concentrate | concentration | face | focus | headache | persevere | persevering</annotation>
 		<annotation cp="😣" type="tts">persevering face</annotation>
 		<annotation cp="😞">awful | blame | dejected | disappointed | face | fail | losing | sad | unhappy</annotation>
 		<annotation cp="😞" type="tts">disappointed face</annotation>
-		<annotation cp="😓">cold | downcast face with sweat | face | face with cold sweat | feels | headache | nervous | sad | scared | sweat | that was close | yikes</annotation>
+		<annotation cp="😓">close | cold | downcast | face | feels | headache | nervous | sad | scared | sweat | yikes</annotation>
 		<annotation cp="😓" type="tts">downcast face with sweat</annotation>
 		<annotation cp="😩">crying | face | fail | feels | hungry | mad | nooo | sad | sleepy | tired | unhappy | weary</annotation>
 		<annotation cp="😩" type="tts">weary face</annotation>
 		<annotation cp="😫">cost | face | feels | nap | sad | sneeze | tired</annotation>
 		<annotation cp="😫" type="tts">tired face</annotation>
-		<annotation cp="🥱">bedtime | bored | face | goodnight | nap | night | sleep | sleepy | tired | whatever | yawn | yawning face | zz | zzz | zzzz</annotation>
+		<annotation cp="🥱">bedtime | bored | face | goodnight | nap | night | sleep | sleepy | tired | whatever | yawn | yawning | zzz</annotation>
 		<annotation cp="🥱" type="tts">yawning face</annotation>
-		<annotation cp="😤">anger | angry | face | face with steam from nose | feels | fume | fuming | furious | fury | mad | steam | triumph | unhappy | won</annotation>
+		<annotation cp="😤">anger | angry | face | feels | fume | fuming | furious | fury | mad | nose | steam | triumph | unhappy | won</annotation>
 		<annotation cp="😤" type="tts">face with steam from nose</annotation>
 		<annotation cp="😡">anger | angry | enraged | face | feels | mad | maddening | pouting | rage | red | shade | unhappy | upset</annotation>
 		<annotation cp="😡" type="tts">enraged face</annotation>
 		<annotation cp="😠">anger | angry | blame | face | feels | frustrated | mad | maddening | rage | shade | unhappy | upset</annotation>
 		<annotation cp="😠" type="tts">angry face</annotation>
-		<annotation cp="🤬">censor | cursing | cussing | face with symbols on mouth | mad | pissed | swearing</annotation>
+		<annotation cp="🤬">censor | cursing | cussing | face | mad | mouth | pissed | swearing | symbols</annotation>
 		<annotation cp="🤬" type="tts">face with symbols on mouth</annotation>
-		<annotation cp="😈">devil | evil | face | fairy tale | fairytale | fantasy | horns | purple face | shade | smile | smiling face with horns</annotation>
+		<annotation cp="😈">demon | devil | evil | face | fairy | fairytale | fantasy | horns | purple | shade | smile | smiling | tale</annotation>
 		<annotation cp="😈" type="tts">smiling face with horns</annotation>
-		<annotation cp="👿">angry face with horns | demon | devil | evil | face | fairy tale | fairytale | fantasy | imp | mischievous | purple face | shade</annotation>
+		<annotation cp="👿">angry | demon | devil | evil | face | fairy | fairytale | fantasy | horns | imp | mischievous | purple | shade | tale</annotation>
 		<annotation cp="👿" type="tts">angry face with horns</annotation>
-		<annotation cp="💀">body | dead | death | face | fairy tale | fairytale | i’m dead | lmao | monster | skull | yolo</annotation>
+		<annotation cp="💀">body | dead | death | face | fairy | fairytale | i’m | lmao | monster | skull | tale | yolo</annotation>
 		<annotation cp="💀" type="tts">skull</annotation>
-		<annotation cp="☠">bone | crossbones | dead | death | face | monster | skull | skull and crossbones</annotation>
+		<annotation cp="☠">bone | crossbones | dead | death | face | monster | skull</annotation>
 		<annotation cp="☠" type="tts">skull and crossbones</annotation>
-		<annotation cp="💩">bs | comic | doo doo | dung | face | fml | monster | pile of poo | poo | poop | smelly | smh | stink | stinks | stinky | turd</annotation>
+		<annotation cp="💩">bs | comic | doo | dung | face | fml | monster | pile | poo | poop | smelly | smh | stink | stinks | stinky | turd</annotation>
 		<annotation cp="💩" type="tts">pile of poo</annotation>
 		<annotation cp="🤡">clown | face</annotation>
 		<annotation cp="🤡" type="tts">clown face</annotation>
-		<annotation cp="👹">creature | devil | face | fairy tale | fairytale | fantasy | mask | monster | ogre | scary</annotation>
+		<annotation cp="👹">creature | devil | face | fairy | fairytale | fantasy | mask | monster | ogre | scary | tale</annotation>
 		<annotation cp="👹" type="tts">ogre</annotation>
-		<annotation cp="👺">angry | creature | face | fairy tale | fairytale | fantasy | goblin | mask | mean | monster</annotation>
+		<annotation cp="👺">angry | creature | face | fairy | fairytale | fantasy | goblin | mask | mean | monster | tale</annotation>
 		<annotation cp="👺" type="tts">goblin</annotation>
-		<annotation cp="👻">boo | creature | excited | face | fairy tale | fairytale | fantasy | ghost | halloween | haunting | monster | scary | silly</annotation>
+		<annotation cp="👻">boo | creature | excited | face | fairy | fairytale | fantasy | ghost | halloween | haunting | monster | scary | silly | tale</annotation>
 		<annotation cp="👻" type="tts">ghost</annotation>
-		<annotation cp="👽">alien | creature | extraterrestrial | face | fairy tale | fairytale | fantasy | monster | space | ufo</annotation>
+		<annotation cp="👽">alien | creature | extraterrestrial | face | fairy | fairytale | fantasy | monster | space | tale | ufo</annotation>
 		<annotation cp="👽" type="tts">alien</annotation>
-		<annotation cp="👾">alien | creature | extraterrestrial | face | fairy tale | fairytale | fantasy | game | gamer | games | monster | pixellated | space | ufo</annotation>
+		<annotation cp="👾">alien | creature | extraterrestrial | face | fairy | fairytale | fantasy | game | gamer | games | monster | pixelated | space | tale | ufo</annotation>
 		<annotation cp="👾" type="tts">alien monster</annotation>
 		<annotation cp="🤖">face | monster | robot</annotation>
 		<annotation cp="🤖" type="tts">robot</annotation>
-		<annotation cp="😺">animal | cat | face | grinning | mouth | open | smile | smiling cat face with open mouth</annotation>
+		<annotation cp="😺">animal | cat | face | grinning | mouth | open | smile | smiling</annotation>
 		<annotation cp="😺" type="tts">grinning cat</annotation>
-		<annotation cp="😸">animal | cat | eye | face | grin | grinning cat face with smiling eyes | grinning cat with smiling eyes | smile</annotation>
+		<annotation cp="😸">animal | cat | eye | eyes | face | grin | grinning | smile | smiling</annotation>
 		<annotation cp="😸" type="tts">grinning cat with smiling eyes</annotation>
-		<annotation cp="😹">animal | cat | cat face with tears of joy | cat with tears of joy | face | joy | laugh | laughing | lol | tear</annotation>
+		<annotation cp="😹">animal | cat | face | joy | laugh | laughing | lol | tear | tears</annotation>
 		<annotation cp="😹" type="tts">cat with tears of joy</annotation>
-		<annotation cp="😻">animal | cat | eye | face | heart | love | smile | smiling cat face with heart-eyes | smiling cat with heart-eyes</annotation>
+		<annotation cp="😻">animal | cat | eye | face | heart | heart-eyes | love | smile | smiling</annotation>
 		<annotation cp="😻" type="tts">smiling cat with heart-eyes</annotation>
-		<annotation cp="😼">animal | cat | cat face with wry smile | cat with wry smile | face | ironic | smile | wry</annotation>
+		<annotation cp="😼">animal | cat | face | ironic | smile | wry</annotation>
 		<annotation cp="😼" type="tts">cat with wry smile</annotation>
-		<annotation cp="😽">animal | cat | eye | face | kiss | kissing cat | kissing cat face with closed eyes</annotation>
+		<annotation cp="😽">animal | cat | closed | eye | eyes | face | kiss | kissing</annotation>
 		<annotation cp="😽" type="tts">kissing cat</annotation>
 		<annotation cp="🙀">animal | cat | face | oh | surprised | weary</annotation>
 		<annotation cp="🙀" type="tts">weary cat</annotation>
-		<annotation cp="😿">animal | cat | cry | crying cat | crying cat face | face | sad | tear</annotation>
+		<annotation cp="😿">animal | cat | cry | crying | face | sad | tear</annotation>
 		<annotation cp="😿" type="tts">crying cat</annotation>
 		<annotation cp="😾">animal | cat | face | pouting</annotation>
 		<annotation cp="😾" type="tts">pouting cat</annotation>
-		<annotation cp="🙈">animal | cant watch | embarrassed | evil | face | forbidden | forgot | gesture | hide | monkey | no | nono | not | omg | prohibited | scared | secret | see | see-no-evil monkey | smh</annotation>
+		<annotation cp="🙈">can’t | embarrassed | evil | face | forbidden | forgot | gesture | hide | monkey | no | omg | prohibited | scared | secret | smh | watch</annotation>
 		<annotation cp="🙈" type="tts">see-no-evil monkey</annotation>
-		<annotation cp="🙉">animal | ears | evil | face | forbidden | gesture | hear | hear-no-evil monkey | listen | monkey | no | not | prohibited | secret | shh | tmi</annotation>
+		<annotation cp="🙉">animal | ears | evil | face | forbidden | gesture | hear | listen | monkey | no | not | prohibited | secret | shh | tmi</annotation>
 		<annotation cp="🙉" type="tts">hear-no-evil monkey</annotation>
-		<annotation cp="🙊">animal | evil | face | forbidden | gesture | monkey | no | not | oops | prohibited | quiet | secret | speak | speak-no-evil monkey | stealth</annotation>
+		<annotation cp="🙊">animal | evil | face | forbidden | gesture | monkey | no | not | oops | prohibited | quiet | secret | speak | stealth</annotation>
 		<annotation cp="🙊" type="tts">speak-no-evil monkey</annotation>
 		<annotation cp="💌">heart | letter | love | mail | romance | valentine</annotation>
 		<annotation cp="💌" type="tts">love letter</annotation>
-		<annotation cp="💘">143 | adorbs | arrow | cupid | date | emotion | heart | heart with arrow | ily | love | romance | valentine</annotation>
+		<annotation cp="💘">143 | adorbs | arrow | cupid | date | emotion | heart | ily | love | romance | valentine</annotation>
 		<annotation cp="💘" type="tts">heart with arrow</annotation>
-		<annotation cp="💝">143 | anniversary | emotion | heart | heart with ribbon | ily | kisses | ribbon | valentine | xoxo</annotation>
+		<annotation cp="💝">143 | anniversary | emotion | heart | ily | kisses | ribbon | valentine | xoxo</annotation>
 		<annotation cp="💝" type="tts">heart with ribbon</annotation>
-		<annotation cp="💖">143 | emotion | excited | good night | heart | ily | kisses | morning | sparkle | sparkling | xoxo</annotation>
+		<annotation cp="💖">143 | emotion | excited | good | heart | ily | kisses | morning | night | sparkle | sparkling | xoxo</annotation>
 		<annotation cp="💖" type="tts">sparkling heart</annotation>
 		<annotation cp="💗">143 | emotion | excited | growing | heart | heartpulse | ily | kisses | muah | nervous | pulse | xoxo</annotation>
 		<annotation cp="💗" type="tts">growing heart</annotation>
 		<annotation cp="💓">143 | beating | cardio | emotion | heart | heartbeat | ily | love | pulsating | pulse</annotation>
 		<annotation cp="💓" type="tts">beating heart</annotation>
-		<annotation cp="💞">143 | adorbs | anniversary | emotion | heart | revolving | revolving hearts</annotation>
+		<annotation cp="💞">143 | adorbs | anniversary | emotion | heart | hearts | revolving</annotation>
 		<annotation cp="💞" type="tts">revolving hearts</annotation>
-		<annotation cp="💕">143 | anniversary | date | dating | emotion | heart | hearts | ily | kisses | love | loving | two hearts | xoxo</annotation>
+		<annotation cp="💕">143 | anniversary | date | dating | emotion | heart | hearts | ily | kisses | love | loving | two | xoxo</annotation>
 		<annotation cp="💕" type="tts">two hearts</annotation>
-		<annotation cp="💟">143 | emotion | heart | heart decoration | purple heart | white hearth</annotation>
+		<annotation cp="💟">143 | decoration | emotion | heart | hearth | purple | white</annotation>
 		<annotation cp="💟" type="tts">heart decoration</annotation>
-		<annotation cp="❣">exclamation | heart exclamation | heavy heart exclamation | mark | punctuation</annotation>
+		<annotation cp="❣">exclamation | heart | heavy | mark | punctuation</annotation>
 		<annotation cp="❣" type="tts">heart exclamation</annotation>
-		<annotation cp="💔">break | broken | broken heart | crushed | emotion | heartbroken | lonely | sad</annotation>
+		<annotation cp="💔">break | broken | crushed | emotion | heart | heartbroken | lonely | sad</annotation>
 		<annotation cp="💔" type="tts">broken heart</annotation>
-		<annotation cp="❤‍🔥">burn | heart | heart on fire | love | lust | sacred heart</annotation> <!-- 2764 200D 1F525 -->
+		<annotation cp="❤‍🔥">burn | fire | heart | love | lust | sacred</annotation> <!-- 2764 200D 1F525 -->
 		<annotation cp="❤‍🔥" type="tts">heart on fire</annotation>
-		<annotation cp="❤‍🩹">healthier | improving | mending | mending heart | recovering | recuperating | well</annotation> <!-- 2764 200D 1FA79 -->
+		<annotation cp="❤‍🩹">healthier | heart | improving | mending | recovering | recuperating | well</annotation> <!-- 2764 200D 1FA79 -->
 		<annotation cp="❤‍🩹" type="tts">mending heart</annotation>
-		<annotation cp="❤">emotion | heart | love | red heart</annotation>
+		<annotation cp="❤">emotion | heart | love | red</annotation>
 		<annotation cp="❤" type="tts">red heart</annotation>
 		<annotation cp="🩷">143 | adorable | cute | emotion | heart | ily | like | love | pink | special | sweet</annotation> <!-- 1FA77 -->
 		<annotation cp="🩷" type="tts">pink heart</annotation>
-		<annotation cp="🧡">orange | orange heart</annotation>
+		<annotation cp="🧡">143 | heart | orange</annotation>
 		<annotation cp="🧡" type="tts">orange heart</annotation>
 		<annotation cp="💛">143 | cardiac | emotion | heart | ily | love | yellow</annotation>
 		<annotation cp="💛" type="tts">yellow heart</annotation>
@@ -1033,151 +1028,151 @@ annotations.
 		<annotation cp="💚" type="tts">green heart</annotation>
 		<annotation cp="💙">143 | blue | emotion | heart | ily | love | romance</annotation>
 		<annotation cp="💙" type="tts">blue heart</annotation>
-		<annotation cp="🩵">143 | cute | cyan | emotion | heart | ily | light blue | light blue heart | like | love | sky blue | special | teal</annotation> <!-- 1FA75 -->
+		<annotation cp="🩵">143 | blue | cute | cyan | emotion | heart | ily | light | like | love | sky | special | teal</annotation> <!-- 1FA75 -->
 		<annotation cp="🩵" type="tts">light blue heart</annotation>
 		<annotation cp="💜">143 | bestest | emotion | heart | ily | love | purple</annotation>
 		<annotation cp="💜" type="tts">purple heart</annotation>
-		<annotation cp="🤎">brown | heart</annotation>
+		<annotation cp="🤎">143 | brown | heart</annotation>
 		<annotation cp="🤎" type="tts">brown heart</annotation>
 		<annotation cp="🖤">black | evil | heart | wicked</annotation>
 		<annotation cp="🖤" type="tts">black heart</annotation>
 		<annotation cp="🩶">143 | emotion | gray | grey | heart | ily | love | silver | slate | special</annotation> <!-- 1FA76 -->
 		<annotation cp="🩶" type="tts">grey heart</annotation>
-		<annotation cp="🤍">heart | white</annotation>
+		<annotation cp="🤍">143 | heart | white</annotation>
 		<annotation cp="🤍" type="tts">white heart</annotation>
-		<annotation cp="💋">dating | emotion | heart | kiss | kiss mark | kissing | lips | romance | sexy</annotation>
+		<annotation cp="💋">dating | emotion | heart | kiss | kissing | lips | mark | romance | sexy</annotation>
 		<annotation cp="💋" type="tts">kiss mark</annotation>
-		<annotation cp="💯">100 | a+ | agree | bruh | clearly | definitely | faithful | fleek | full | hbd | homie | hundred | hundred points | keep it 100 | kidding | on point | perfect score | score | true | truth | yup</annotation>
+		<annotation cp="💯">100 | a+ | agree | clearly | definitely | faithful | fleek | full | hundred | keep | perfect | point | score | TRUE | truth | yup</annotation>
 		<annotation cp="💯" type="tts">hundred points</annotation>
-		<annotation cp="💢">anger symbol | angry | comic | mad | upset</annotation>
+		<annotation cp="💢">anger | angry | comic | mad | symbol | upset</annotation>
 		<annotation cp="💢" type="tts">anger symbol</annotation>
 		<annotation cp="💥">bomb | boom | collide | collision | comic | explode</annotation>
 		<annotation cp="💥" type="tts">collision</annotation>
-		<annotation cp="💫">comic | dizzy | shining | shooting star | star | stars</annotation>
+		<annotation cp="💫">comic | dizzy | shining | shooting | star | stars</annotation>
 		<annotation cp="💫" type="tts">dizzy</annotation>
-		<annotation cp="💦">comic | drip | droplet | droplets | drops | splashing | squirt | sweat | water | wet | work out | workout</annotation>
+		<annotation cp="💦">comic | drip | droplet | droplets | drops | splashing | squirt | sweat | water | wet | work | workout</annotation>
 		<annotation cp="💦" type="tts">sweat droplets</annotation>
-		<annotation cp="💨">cloud | comic | dash | dashing away | fart | fast | gone | gotta go | running | smoke</annotation>
+		<annotation cp="💨">away | cloud | comic | dash | dashing | fart | fast | go | gone | gotta | running | smoke</annotation>
 		<annotation cp="💨" type="tts">dashing away</annotation>
 		<annotation cp="🕳">hole</annotation>
 		<annotation cp="🕳" type="tts">hole</annotation>
 		<annotation cp="💬">balloon | bubble | comic | dialog | message | sms | speech | talk | text | typing</annotation>
 		<annotation cp="💬" type="tts">speech balloon</annotation>
-		<annotation cp="👁‍🗨">balloon | bubble | eye | eye in speech bubble | speech | witness</annotation>
+		<annotation cp="👁‍🗨">balloon | bubble | eye | speech | witness</annotation>
 		<annotation cp="👁‍🗨" type="tts">eye in speech bubble</annotation>
-		<annotation cp="🗨">balloon | bubble | dialog | left speech bubble | speech</annotation>
+		<annotation cp="🗨">balloon | bubble | dialog | left | speech</annotation>
 		<annotation cp="🗨" type="tts">left speech bubble</annotation>
-		<annotation cp="🗯">angry | balloon | bubble | mad | right anger bubble</annotation>
+		<annotation cp="🗯">anger | angry | balloon | bubble | mad | right</annotation>
 		<annotation cp="🗯" type="tts">right anger bubble</annotation>
-		<annotation cp="💭">balloon | bubble | cartoon | cloud | comic | daydream | decisions | dream | dreams | idea | invent | invention | realize | think | thinking | thought | thoughts | wonder</annotation>
+		<annotation cp="💭">balloon | bubble | cartoon | cloud | comic | daydream | decisions | dream | idea | invent | invention | realize | think | thoughts | wonder</annotation>
 		<annotation cp="💭" type="tts">thought balloon</annotation>
-		<annotation cp="💤">comic | good night | goodnight | night | sleep | sleeping | sleepy | tired | zz | ZZZ | zzzz</annotation>
+		<annotation cp="💤">comic | good | goodnight | night | sleep | sleeping | sleepy | tired | zzz</annotation>
 		<annotation cp="💤" type="tts">ZZZ</annotation>
-		<annotation cp="👋">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | outtie | ttfn | ttyl | u there? | wave | waving | yo</annotation>
+		<annotation cp="👋">bye | cya | g2g | greetings | gtg | hand | hello | hey | hi | later | outtie | ttfn | ttyl | wave | yo | you</annotation>
 		<annotation cp="👋" type="tts">waving hand</annotation>
-		<annotation cp="🤚">backhand | raised | raised back of hand</annotation>
+		<annotation cp="🤚">back | backhand | hand | raised</annotation>
 		<annotation cp="🤚" type="tts">raised back of hand</annotation>
-		<annotation cp="🖐">finger | hand | hand with fingers splayed | raised hand with fingers splayed | splayed | stop</annotation>
+		<annotation cp="🖐">finger | fingers | hand | raised | splayed | stop</annotation>
 		<annotation cp="🖐" type="tts">hand with fingers splayed</annotation>
-		<annotation cp="✋">five | hand | high 5 | high five | raised hand | stop</annotation>
+		<annotation cp="✋">5 | five | hand | high | raised | stop</annotation>
 		<annotation cp="✋" type="tts">raised hand</annotation>
-		<annotation cp="🖖">finger | hand | hands | spock | vulcan | vulcan salute</annotation>
+		<annotation cp="🖖">finger | hand | hands | salute | spock | vulcan</annotation>
 		<annotation cp="🖖" type="tts">vulcan salute</annotation>
-		<annotation cp="🫱">hand | handshake | hold | reach | right | rightward | rightwards hand | shake</annotation> <!-- 1FAF1 -->
+		<annotation cp="🫱">hand | handshake | hold | reach | right | rightward | rightwards | shake</annotation> <!-- 1FAF1 -->
 		<annotation cp="🫱" type="tts">rightwards hand</annotation>
-		<annotation cp="🫲">hand | handshake | hold | left | leftward | leftwards hand | reach | shake</annotation> <!-- 1FAF2 -->
+		<annotation cp="🫲">hand | handshake | hold | left | leftward | leftwards | reach | shake</annotation> <!-- 1FAF2 -->
 		<annotation cp="🫲" type="tts">leftwards hand</annotation>
-		<annotation cp="🫳">dismiss | drop | dropped | hand | palm down hand | pick | pick up | shoo</annotation> <!-- 1FAF3 -->
+		<annotation cp="🫳">dismiss | down | drop | dropped | hand | palm | pick | shoo | up</annotation> <!-- 1FAF3 -->
 		<annotation cp="🫳" type="tts">palm down hand</annotation>
-		<annotation cp="🫴">beckon | catch | come | don’t know | hand | hold | lift | offer | palm up hand | tell me</annotation> <!-- 1FAF4 -->
+		<annotation cp="🫴">beckon | catch | come | hand | hold | know | lift | me | offer | palm | tell</annotation> <!-- 1FAF4 -->
 		<annotation cp="🫴" type="tts">palm up hand</annotation>
-		<annotation cp="🫷">block | halt | hand | high five | hold | leftward | leftwards pushing hand | pause | push | refuse | slap five | stop | wait</annotation> <!-- 1FAF7 -->
+		<annotation cp="🫷">block | five | halt | hand | high | hold | leftward | leftwards | pause | push | pushing | refuse | slap | stop | wait</annotation> <!-- 1FAF7 -->
 		<annotation cp="🫷" type="tts">leftwards pushing hand</annotation>
-		<annotation cp="🫸">block | halt | hand | high five | hold | pause | push | refuse | rightward | rightwards pushing hand | slap five | stop | wait</annotation> <!-- 1FAF8 -->
+		<annotation cp="🫸">block | five | halt | hand | high | hold | pause | push | pushing | refuse | rightward | rightwards | slap | stop | wait</annotation> <!-- 1FAF8 -->
 		<annotation cp="🫸" type="tts">rightwards pushing hand</annotation>
-		<annotation cp="👌">awesome | bet | dope | fleek | for sure | fosho | got it | gotcha | hand | legit | OK | okay | pinch | rad | sure | sweet | three</annotation>
+		<annotation cp="👌">awesome | bet | dope | fleek | fosho | got | gotcha | hand | legit | OK | okay | pinch | rad | sure | sweet | three</annotation>
 		<annotation cp="👌" type="tts">OK hand</annotation>
-		<annotation cp="🤌">fingers | hand | hand gesture | hold on | huh | interrogation | patience | pinched | relax | sarcastic | ugh | what | zip it</annotation>
+		<annotation cp="🤌">fingers | gesture | hand | hold | huh | interrogation | patience | pinched | relax | sarcastic | ugh | what | zip</annotation>
 		<annotation cp="🤌" type="tts">pinched fingers</annotation>
-		<annotation cp="🤏">fingers | little bit | pinching hand | small | small amount | sort of</annotation>
+		<annotation cp="🤏">amount | bit | fingers | hand | little | pinching | small | sort</annotation>
 		<annotation cp="🤏" type="tts">pinching hand</annotation>
 		<annotation cp="✌">hand | peace | v | victory</annotation>
 		<annotation cp="✌" type="tts">victory hand</annotation>
-		<annotation cp="🤞">cross | crossed fingers | finger | fingers crossed | hand | luck</annotation>
+		<annotation cp="🤞">cross | crossed | finger | fingers | hand | luck</annotation>
 		<annotation cp="🤞" type="tts">crossed fingers</annotation>
-		<annotation cp="🫰">&lt;3 | expensive | hand | hand with index finger and thumb crossed | heart | love | money | snap</annotation> <!-- 1FAF0 -->
+		<annotation cp="🫰">&lt;3 | crossed | expensive | finger | hand | heart | index | love | money | snap | thumb</annotation> <!-- 1FAF0 -->
 		<annotation cp="🫰" type="tts">hand with index finger and thumb crossed</annotation>
-		<annotation cp="🤟">hand | i love you | ILY | love-you gesture | three fingers</annotation>
+		<annotation cp="🤟">fingers | gesture | hand | ILY | love | love-you | three | you</annotation>
 		<annotation cp="🤟" type="tts">love-you gesture</annotation>
-		<annotation cp="🤘">finger | hand | horns | rock-on | sign of the horns</annotation>
+		<annotation cp="🤘">finger | hand | horns | rock-on | sign</annotation>
 		<annotation cp="🤘" type="tts">sign of the horns</annotation>
-		<annotation cp="🤙">call | call me hand | hand | hang loose | Shaka</annotation>
+		<annotation cp="🤙">call | hand | hang | loose | me | Shaka</annotation>
 		<annotation cp="🤙" type="tts">call me hand</annotation>
-		<annotation cp="👈">backhand | backhand index pointing left | finger | hand | index | left | point</annotation>
+		<annotation cp="👈">backhand | finger | hand | index | left | point | pointing</annotation>
 		<annotation cp="👈" type="tts">backhand index pointing left</annotation>
-		<annotation cp="👉">backhand | backhand index pointing right | finger | hand | index | point | right</annotation>
+		<annotation cp="👉">backhand | finger | hand | index | point | pointing | right</annotation>
 		<annotation cp="👉" type="tts">backhand index pointing right</annotation>
-		<annotation cp="👆">backhand | backhand index pointing up | finger | hand | index | point | up</annotation>
+		<annotation cp="👆">backhand | finger | hand | index | point | pointing | up</annotation>
 		<annotation cp="👆" type="tts">backhand index pointing up</annotation>
-		<annotation cp="🖕">finger | hand | middle finger</annotation>
+		<annotation cp="🖕">finger | hand | middle</annotation>
 		<annotation cp="🖕" type="tts">middle finger</annotation>
-		<annotation cp="👇">backhand | backhand index pointing down | down | finger | hand | index | point</annotation>
+		<annotation cp="👇">backhand | down | finger | hand | index | point | pointing</annotation>
 		<annotation cp="👇" type="tts">backhand index pointing down</annotation>
-		<annotation cp="☝">finger | hand | index | index pointing up | point | this | up</annotation>
+		<annotation cp="☝">finger | hand | index | point | pointing | this | up</annotation>
 		<annotation cp="☝" type="tts">index pointing up</annotation>
-		<annotation cp="🫵">finger | hand | index pointing at the viewer | point | poke | you</annotation> <!-- 1FAF5 -->
+		<annotation cp="🫵">at | finger | hand | index | pointing | poke | viewer | you</annotation> <!-- 1FAF5 -->
 		<annotation cp="🫵" type="tts">index pointing at the viewer</annotation>
-		<annotation cp="👍">+1 | awesome | dope | fleek | for sure | fosho | good | gotcha | great | hand | legit | like | nice | okay | rad | sure | thumb | thumbs up | tubular | up | yeah | yes</annotation>
+		<annotation cp="👍">+1 | good | hand | like | thumb | up | yes</annotation>
 		<annotation cp="👍" type="tts">thumbs up</annotation>
-		<annotation cp="👎">-1 | bad | dislike | down | hand | no | no good | nope | thumb | thumbs down</annotation>
+		<annotation cp="👎">-1 | bad | dislike | down | good | hand | no | nope | thumb | thumbs</annotation>
 		<annotation cp="👎" type="tts">thumbs down</annotation>
-		<annotation cp="✊">clenched | fist | hand | punch | raised fist | solidarity</annotation>
+		<annotation cp="✊">clenched | fist | hand | punch | raised | solidarity</annotation>
 		<annotation cp="✊" type="tts">raised fist</annotation>
-		<annotation cp="👊">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | oncoming fist | pound | punch | rock | ttyl</annotation>
+		<annotation cp="👊">absolutely | agree | boom | bro | bruh | bump | clenched | correct | fist | hand | knuckle | oncoming | pound | punch | rock | ttyl</annotation>
 		<annotation cp="👊" type="tts">oncoming fist</annotation>
-		<annotation cp="🤛">fist | left-facing fist | leftwards</annotation>
+		<annotation cp="🤛">fist | left-facing | leftwards</annotation>
 		<annotation cp="🤛" type="tts">left-facing fist</annotation>
-		<annotation cp="🤜">fist | right-facing fist | rightwards</annotation>
+		<annotation cp="🤜">fist | right-facing | rightwards</annotation>
 		<annotation cp="🤜" type="tts">right-facing fist</annotation>
-		<annotation cp="👏">applause | approval | awesome | clap | clapping hands | congrats | congratulations | excited | good job | great | hand | homie | nice | prayed | well done | yay</annotation>
+		<annotation cp="👏">applause | approval | awesome | clap | congrats | congratulations | excited | good | great | hand | homie | job | nice | prayed | well | yay</annotation>
 		<annotation cp="👏" type="tts">clapping hands</annotation>
-		<annotation cp="🙌">celebration | gesture | hand | hooray | praise | raised | raising hands</annotation>
+		<annotation cp="🙌">celebration | gesture | hand | hands | hooray | praise | raised | raising</annotation>
 		<annotation cp="🙌" type="tts">raising hands</annotation>
-		<annotation cp="🫶">&lt;3 | hands | heart | love | love you</annotation> <!-- 1FAF6 -->
+		<annotation cp="🫶">&lt;3 | hands | heart | love | you</annotation> <!-- 1FAF6 -->
 		<annotation cp="🫶" type="tts">heart hands</annotation>
-		<annotation cp="👐">hand | hug | jazz hands | open | open hands | swerve</annotation>
+		<annotation cp="👐">hand | hands | hug | jazz | open | swerve</annotation>
 		<annotation cp="👐" type="tts">open hands</annotation>
-		<annotation cp="🤲">cupped hands | dua | palms up together | pray | prayer | wish</annotation>
+		<annotation cp="🤲">cupped | dua | hands | palms | pray | prayer | together | up | wish</annotation>
 		<annotation cp="🤲" type="tts">palms up together</annotation>
 		<annotation cp="🤝">agreement | deal | hand | handshake | meeting | shake</annotation>
 		<annotation cp="🤝" type="tts">handshake</annotation>
-		<annotation cp="🙏">appreciate | ask | beg | blessed | bow | cmon | five | folded | folded hands | gesture | hand | high 5 | high five | please | pray | thank | thank you | thanks | thx</annotation>
+		<annotation cp="🙏">appreciate | ask | beg | blessed | bow | cmon | five | folded | gesture | hand | high | please | pray | thanks | thx</annotation>
 		<annotation cp="🙏" type="tts">folded hands</annotation>
-		<annotation cp="✍">hand | write | writing hand</annotation>
+		<annotation cp="✍">hand | write | writing</annotation>
 		<annotation cp="✍" type="tts">writing hand</annotation>
-		<annotation cp="💅">bored | care | cosmetics | i’m done | makeup | manicure | nail | polish | whatever</annotation>
+		<annotation cp="💅">bored | care | cosmetics | done | i’m | makeup | manicure | nail | polish | whatever</annotation>
 		<annotation cp="💅" type="tts">nail polish</annotation>
 		<annotation cp="🤳">camera | phone | selfie</annotation>
 		<annotation cp="🤳" type="tts">selfie</annotation>
-		<annotation cp="💪">arm | beast | bench press | biceps | body | bodybuilder | bro | comic | curls | flex | flexed biceps | flexing | gains | gym | jacked | muscle | ripped | strong | weightlift | weightlifter</annotation>
+		<annotation cp="💪">arm | beast | bench | biceps | bodybuilder | bro | curls | flex | gains | gym | jacked | muscle | press | ripped | strong | weightlift</annotation>
 		<annotation cp="💪" type="tts">flexed biceps</annotation>
-		<annotation cp="🦾">accessibility | mechanical arm | prosthetic</annotation>
+		<annotation cp="🦾">accessibility | arm | mechanical | prosthetic</annotation>
 		<annotation cp="🦾" type="tts">mechanical arm</annotation>
-		<annotation cp="🦿">accessibility | mechanical leg | prosthetic</annotation>
+		<annotation cp="🦿">accessibility | leg | mechanical | prosthetic</annotation>
 		<annotation cp="🦿" type="tts">mechanical leg</annotation>
-		<annotation cp="🦵">bent leg | foot | kick | knee | leg | limb</annotation>
+		<annotation cp="🦵">bent | foot | kick | knee | leg | limb</annotation>
 		<annotation cp="🦵" type="tts">leg</annotation>
 		<annotation cp="🦶">ankle | feet | foot | kick | stomp</annotation>
 		<annotation cp="🦶" type="tts">foot</annotation>
 		<annotation cp="👂">body | ear | ears | hear | hearing | listen | listening | sound</annotation>
 		<annotation cp="👂" type="tts">ear</annotation>
-		<annotation cp="🦻">accessibility | ear with hearing aid | hard of hearing</annotation>
+		<annotation cp="🦻">accessibility | aid | ear | hard | hearing</annotation>
 		<annotation cp="🦻" type="tts">ear with hearing aid</annotation>
 		<annotation cp="👃">body | nose | noses | nosey | odor | smell | smells</annotation>
 		<annotation cp="👃" type="tts">nose</annotation>
 		<annotation cp="🧠">brain | intelligent | smart</annotation>
 		<annotation cp="🧠" type="tts">brain</annotation>
-		<annotation cp="🫀">anatomical | beat | cardiology | heart | heartbeat | organ | pulse | real heart | red</annotation>
+		<annotation cp="🫀">anatomical | beat | cardiology | heart | heartbeat | organ | pulse | real | red</annotation>
 		<annotation cp="🫀" type="tts">anatomical heart</annotation>
 		<annotation cp="🫁">breath | breathe | exhalation | inhalation | lung | lungs | organ | respiration</annotation>
 		<annotation cp="🫁" type="tts">lungs</annotation>
@@ -1187,111 +1182,111 @@ annotations.
 		<annotation cp="🦴" type="tts">bone</annotation>
 		<annotation cp="👀">body | eye | eyes | face | googly | look | looking | omg | peep | see | seeing</annotation>
 		<annotation cp="👀" type="tts">eyes</annotation>
-		<annotation cp="👁">1 eye | body | eye | one eye</annotation>
+		<annotation cp="👁">1 | body | eye | one</annotation>
 		<annotation cp="👁" type="tts">eye</annotation>
 		<annotation cp="👅">body | lick | slurp | tongue</annotation>
 		<annotation cp="👅" type="tts">tongue</annotation>
 		<annotation cp="👄">beauty | body | kiss | kissing | lips | lipstick | mouth</annotation>
 		<annotation cp="👄" type="tts">mouth</annotation>
-		<annotation cp="🫦">anxious | bite | biting lip | fear | flirt | flirting | kiss | lip | lipstick | nervous | sexy | uncomfortable | worried | worry</annotation> <!-- 1FAE6 -->
+		<annotation cp="🫦">anxious | bite | biting | fear | flirt | flirting | kiss | lip | lipstick | nervous | sexy | uncomfortable | worried | worry</annotation> <!-- 1FAE6 -->
 		<annotation cp="🫦" type="tts">biting lip</annotation>
-		<annotation cp="👶">babies | baby | children | goo goo | infant | newborn | pregnant | young</annotation>
+		<annotation cp="👶">babies | baby | children | goo | infant | newborn | pregnant | young</annotation>
 		<annotation cp="👶" type="tts">baby</annotation>
-		<annotation cp="🧒">child | gender-neutral | kid | unspecified gender | young</annotation>
+		<annotation cp="🧒">bright-eyed | child | grandchild | kid | young | younger</annotation>
 		<annotation cp="🧒" type="tts">child</annotation>
-		<annotation cp="👦">boy | child | kid | young</annotation>
+		<annotation cp="👦">boy | bright-eyed | child | grandson | kid | son | young | younger</annotation>
 		<annotation cp="👦" type="tts">boy</annotation>
-		<annotation cp="👧">bangs | bright-eyed | child | daughter | girl | lady | pigtails | Virgo | young | zodiac</annotation>
+		<annotation cp="👧">bright-eyed | child | daughter | girl | granddaughter | kid | Virgo | young | younger | zodiac</annotation>
 		<annotation cp="👧" type="tts">girl</annotation>
-		<annotation cp="🧑">adult | gender-neutral | person | unspecified gender</annotation>
+		<annotation cp="🧑">adult | person</annotation>
 		<annotation cp="🧑" type="tts">person</annotation>
-		<annotation cp="👱">blond | blond-haired person | blonde | dude | face | hair | human | man | person | person: blond hair</annotation>
+		<annotation cp="👱">blond | blond-haired | human | person</annotation>
 		<annotation cp="👱" type="tts">person: blond hair</annotation>
-		<annotation cp="👨">adult | boy | boyfriend | bro | friend | man</annotation>
+		<annotation cp="👨">adult | bro | man</annotation>
 		<annotation cp="👨" type="tts">man</annotation>
-		<annotation cp="🧔">beard | bearded | bewhiskered | person | person: beard</annotation>
+		<annotation cp="🧔">beard | bearded | person | whiskers</annotation>
 		<annotation cp="🧔" type="tts">person: beard</annotation>
-		<annotation cp="🧔‍♂">beard | man | man: beard</annotation>
+		<annotation cp="🧔‍♂">beard | bearded | man | whiskers</annotation>
 		<annotation cp="🧔‍♂" type="tts">man: beard</annotation>
-		<annotation cp="👱‍♂">blond | blond-haired man | hair | man | man: blond hair</annotation>
+		<annotation cp="👱‍♂">blond | blond-haired | hair | man</annotation>
 		<annotation cp="👱‍♂" type="tts">man: blond hair</annotation>
-		<annotation cp="👩">adult | blonde | blondie | haircut | lady | woman</annotation>
+		<annotation cp="👩">adult | lady | woman</annotation>
 		<annotation cp="👩" type="tts">woman</annotation>
-		<annotation cp="🧔‍♀">beard | woman | woman: beard</annotation>
+		<annotation cp="🧔‍♀">beard | bearded | whiskers | woman</annotation>
 		<annotation cp="🧔‍♀" type="tts">woman: beard</annotation>
-		<annotation cp="👱‍♀">blond-haired woman | blonde | hair | woman | woman: blond hair</annotation>
+		<annotation cp="👱‍♀">blond | blond-haired | blonde | hair | woman</annotation>
 		<annotation cp="👱‍♀" type="tts">woman: blond hair</annotation>
-		<annotation cp="🧓">adult | gender-neutral | old | older adult | older person | unspecified gender</annotation>
+		<annotation cp="🧓">adult | elderly | grandparent | old | person | wise</annotation>
 		<annotation cp="🧓" type="tts">older person</annotation>
-		<annotation cp="👴">adult | bald | elderly | grandfather | grandpa | losing hair | man | old | old dude | wise</annotation>
+		<annotation cp="👴">adult | bald | elderly | gramps | grandfather | grandpa | man | old | wise</annotation>
 		<annotation cp="👴" type="tts">old man</annotation>
-		<annotation cp="👵">adult | bad haircut | blond | blondie | grandma | grandmother | granny | lady | old | wise | woman</annotation>
+		<annotation cp="👵">adult | elderly | grandma | grandmother | granny | lady | old | wise | woman</annotation>
 		<annotation cp="👵" type="tts">old woman</annotation>
-		<annotation cp="🙍">annoyed | disappoint | disgruntled | disturbed | frown | frustrated | gesture | irritated | not happy | person frowning | upset | woman frowning</annotation>
+		<annotation cp="🙍">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | person | upset</annotation>
 		<annotation cp="🙍" type="tts">person frowning</annotation>
-		<annotation cp="🙍‍♂">disgruntled | frown | frowning | gesture | man | upset</annotation>
+		<annotation cp="🙍‍♂">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | man | upset</annotation>
 		<annotation cp="🙍‍♂" type="tts">man frowning</annotation>
-		<annotation cp="🙍‍♀">frowning | gesture | woman</annotation>
+		<annotation cp="🙍‍♀">annoyed | disappointed | disgruntled | disturbed | frown | frowning | frustrated | gesture | irritated | upset | woman</annotation>
 		<annotation cp="🙍‍♀" type="tts">woman frowning</annotation>
-		<annotation cp="🙎">disappoint | downtrodden | frown | gesture | grimace | person pouting | pouting | scowl | sulk | upset | whine | woman pouting</annotation>
+		<annotation cp="🙎">disappointed | downtrodden | frown | grimace | person | pouting | scowl | sulk | upset | whine</annotation>
 		<annotation cp="🙎" type="tts">person pouting</annotation>
-		<annotation cp="🙎‍♂">gesture | man | pouting</annotation>
+		<annotation cp="🙎‍♂">disappointed | downtrodden | frown | grimace | man | pouting | scowl | sulk | upset | whine</annotation>
 		<annotation cp="🙎‍♂" type="tts">man pouting</annotation>
-		<annotation cp="🙎‍♀">gesture | pouting | woman</annotation>
+		<annotation cp="🙎‍♀">disappointed | downtrodden | frown | grimace | pouting | scowl | sulk | upset | whine | woman</annotation>
 		<annotation cp="🙎‍♀" type="tts">woman pouting</annotation>
-		<annotation cp="🙅">exclude | forbidden | gesture | hand | no | nope | not | not a chance | person gesturing NO | prohibit | prohibited | woman gesturing NO</annotation>
+		<annotation cp="🙅">forbidden | gesture | hand | NO | not | person | prohibit</annotation>
 		<annotation cp="🙅" type="tts">person gesturing NO</annotation>
-		<annotation cp="🙅‍♂">forbidden | gesture | hand | man | man gesturing NO | no | nope | not | prohibited</annotation>
+		<annotation cp="🙅‍♂">forbidden | gesture | hand | man | NO | not | prohibit</annotation>
 		<annotation cp="🙅‍♂" type="tts">man gesturing NO</annotation>
-		<annotation cp="🙅‍♀">forbidden | gesture | hand | prohibited | woman | woman gesturing NO</annotation>
+		<annotation cp="🙅‍♀">forbidden | gesture | hand | NO | not | prohibit | woman</annotation>
 		<annotation cp="🙅‍♀" type="tts">woman gesturing NO</annotation>
-		<annotation cp="🙆">exercise | gesture | hand | OK | omg | person gesturing OK | woman gesturing OK</annotation>
+		<annotation cp="🙆">exercise | gesture | gesturing | hand | OK | omg | person</annotation>
 		<annotation cp="🙆" type="tts">person gesturing OK</annotation>
-		<annotation cp="🙆‍♂">exercise | gesture | hand | man | man gesturing OK | OK | omg</annotation>
+		<annotation cp="🙆‍♂">exercise | gesture | gesturing | hand | man | OK | omg</annotation>
 		<annotation cp="🙆‍♂" type="tts">man gesturing OK</annotation>
-		<annotation cp="🙆‍♀">gesture | hand | OK | woman | woman gesturing OK</annotation>
+		<annotation cp="🙆‍♀">exercise | gesture | gesturing | hand | OK | omg | woman</annotation>
 		<annotation cp="🙆‍♀" type="tts">woman gesturing OK</annotation>
-		<annotation cp="💁">fetch | gossip | hair flick | hair flip | hand | help | information | person tipping hand | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman tipping hand</annotation>
+		<annotation cp="💁">fetch | flick | flip | gossip | hand | person | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
 		<annotation cp="💁" type="tts">person tipping hand</annotation>
-		<annotation cp="💁‍♂">fetch | gossip | hair flick | hair flip | hand | help | information | man | sarcasm | sarcastic | sassy | tipping | whatever</annotation>
+		<annotation cp="💁‍♂">fetch | flick | flip | gossip | hand | man | sarcasm | sarcastic | sassy | seriously | tipping | whatever</annotation>
 		<annotation cp="💁‍♂" type="tts">man tipping hand</annotation>
-		<annotation cp="💁‍♀">sassy | tipping hand | woman | woman tipping hand</annotation>
+		<annotation cp="💁‍♀">fetch | flick | flip | gossip | hand | sarcasm | sarcastic | sassy | seriously | tipping | whatever | woman</annotation>
 		<annotation cp="💁‍♀" type="tts">woman tipping hand</annotation>
-		<annotation cp="🙋">gesture | hand | hands | happy | I can help | i know | me | over here | person raising hand | pick me | question | raised | right here | woman raising hand</annotation>
+		<annotation cp="🙋">gesture | hand | here | know | me | person | pick | question | raise | raising</annotation>
 		<annotation cp="🙋" type="tts">person raising hand</annotation>
-		<annotation cp="🙋‍♂">gesture | hand | hands | i know | man | man raising hand | me | person raising hand | question | raised | raising hand</annotation>
+		<annotation cp="🙋‍♂">gesture | hand | here | know | man | me | pick | question | raise | raising</annotation>
 		<annotation cp="🙋‍♂" type="tts">man raising hand</annotation>
-		<annotation cp="🙋‍♀">gesture | raising hand | woman | woman raising hand</annotation>
+		<annotation cp="🙋‍♀">gesture | hand | here | know | me | pick | question | raise | raising | woman</annotation>
 		<annotation cp="🙋‍♀" type="tts">woman raising hand</annotation>
-		<annotation cp="🧏">accessibility | deaf | deaf person | ear | hear</annotation>
+		<annotation cp="🧏">accessibility | deaf | ear | gesture | hear | person</annotation>
 		<annotation cp="🧏" type="tts">deaf person</annotation>
-		<annotation cp="🧏‍♂">deaf | man</annotation>
+		<annotation cp="🧏‍♂">accessibility | deaf | ear | gesture | hear | man</annotation>
 		<annotation cp="🧏‍♂" type="tts">deaf man</annotation>
-		<annotation cp="🧏‍♀">deaf | woman</annotation>
+		<annotation cp="🧏‍♀">accessibility | deaf | ear | gesture | hear | woman</annotation>
 		<annotation cp="🧏‍♀" type="tts">deaf woman</annotation>
-		<annotation cp="🙇">apology | beg | bow | forgive | gesture | man bowing | meditate | meditation | person bowing | pity | regret | sorry</annotation>
+		<annotation cp="🙇">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | person | pity | regret | sorry</annotation>
 		<annotation cp="🙇" type="tts">person bowing</annotation>
-		<annotation cp="🙇‍♂">apology | bowing | favor | gesture | man | sorry</annotation>
+		<annotation cp="🙇‍♂">apology | ask | beg | bow | bowing | favor | forgive | gesture | man | meditate | meditation | pity | regret | sorry</annotation>
 		<annotation cp="🙇‍♂" type="tts">man bowing</annotation>
-		<annotation cp="🙇‍♀">apology | bow | bowing | favor | gesture | meditate | meditation | sorry | woman</annotation>
+		<annotation cp="🙇‍♀">apology | ask | beg | bow | bowing | favor | forgive | gesture | meditate | meditation | pity | regret | sorry | woman</annotation>
 		<annotation cp="🙇‍♀" type="tts">woman bowing</annotation>
-		<annotation cp="🤦">disbelief | exasperation | face | facepalm | not again | oh no | omg | palm | person | person facepalming | shock | smh</annotation>
+		<annotation cp="🤦">again | bewilder | disbelief | exasperation | facepalm | no | not | oh | omg | person | shock | smh</annotation>
 		<annotation cp="🤦" type="tts">person facepalming</annotation>
-		<annotation cp="🤦‍♂">disbelief | exasperation | facepalm | man | man facepalming | not again | oh no | omg | shock | smh</annotation>
+		<annotation cp="🤦‍♂">again | bewilder | disbelief | exasperation | facepalm | man | no | not | oh | omg | shock | smh</annotation>
 		<annotation cp="🤦‍♂" type="tts">man facepalming</annotation>
-		<annotation cp="🤦‍♀">bewilder | disbelief | exasperation | facepalm | not again | oh no | omg | shock | smh | woman | woman facepalming</annotation>
+		<annotation cp="🤦‍♀">again | bewilder | disbelief | exasperation | facepalm | no | not | oh | omg | shock | smh | woman</annotation>
 		<annotation cp="🤦‍♀" type="tts">woman facepalming</annotation>
-		<annotation cp="🤷">doubt | dunno | i dunno | I guess | idk | ignorance | indifference | maybe | person | person shrugging | shrug | whatever | who knows</annotation>
+		<annotation cp="🤷">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | person | shrug | shrugging | whatever | who</annotation>
 		<annotation cp="🤷" type="tts">person shrugging</annotation>
-		<annotation cp="🤷‍♂">doubt | dunno | i dunno | I guess | idk | ignorance | indifference | man | man shrugging | maybe | shrug | whatever | who knows</annotation>
+		<annotation cp="🤷‍♂">doubt | dunno | guess | idk | ignorance | indifference | knows | man | maybe | shrug | shrugging | whatever | who</annotation>
 		<annotation cp="🤷‍♂" type="tts">man shrugging</annotation>
-		<annotation cp="🤷‍♀">doubt | dunno | i dunno | I guess | idk | ignorance | indifference | maybe | shrug | whatever | who knows | woman | woman shrugging</annotation>
+		<annotation cp="🤷‍♀">doubt | dunno | guess | idk | ignorance | indifference | knows | maybe | shrug | shrugging | whatever | who | woman</annotation>
 		<annotation cp="🤷‍♀" type="tts">woman shrugging</annotation>
-		<annotation cp="🧑‍⚕">doctor | health worker | healthcare | nurse | therapist</annotation>
+		<annotation cp="🧑‍⚕">doctor | health | healthcare | nurse | therapist | worker</annotation>
 		<annotation cp="🧑‍⚕" type="tts">health worker</annotation>
-		<annotation cp="👨‍⚕">doctor | healthcare | man | man health worker | nurse | therapist</annotation>
+		<annotation cp="👨‍⚕">doctor | health | healthcare | man | nurse | therapist | worker</annotation>
 		<annotation cp="👨‍⚕" type="tts">man health worker</annotation>
-		<annotation cp="👩‍⚕">doctor | healthcare | nurse | therapist | woman | woman health worker</annotation>
+		<annotation cp="👩‍⚕">doctor | health | healthcare | nurse | therapist | woman | worker</annotation>
 		<annotation cp="👩‍⚕" type="tts">woman health worker</annotation>
 		<annotation cp="🧑‍🎓">graduate | student</annotation>
 		<annotation cp="🧑‍🎓" type="tts">student</annotation>
@@ -1335,25 +1330,25 @@ annotations.
 		<annotation cp="👨‍🏭" type="tts">man factory worker</annotation>
 		<annotation cp="👩‍🏭">assembly | factory | industrial | woman | worker</annotation>
 		<annotation cp="👩‍🏭" type="tts">woman factory worker</annotation>
-		<annotation cp="🧑‍💼">architect | business | manager | office worker | white-collar</annotation>
+		<annotation cp="🧑‍💼">architect | business | manager | office | white-collar | worker</annotation>
 		<annotation cp="🧑‍💼" type="tts">office worker</annotation>
-		<annotation cp="👨‍💼">architect | business | man | man office worker | manager | office | white-collar</annotation>
+		<annotation cp="👨‍💼">architect | business | man | manager | office | white-collar | worker</annotation>
 		<annotation cp="👨‍💼" type="tts">man office worker</annotation>
-		<annotation cp="👩‍💼">architect | business | manager | office | white-collar | woman | woman office worker</annotation>
+		<annotation cp="👩‍💼">architect | business | manager | office | white-collar | woman | worker</annotation>
 		<annotation cp="👩‍💼" type="tts">woman office worker</annotation>
-		<annotation cp="🧑‍🔬">biologist | chemist | engineer | physicist | scientist</annotation>
+		<annotation cp="🧑‍🔬">biologist | chemist | engineer | mathematician | physicist | scientist</annotation>
 		<annotation cp="🧑‍🔬" type="tts">scientist</annotation>
 		<annotation cp="👨‍🔬">biologist | chemist | engineer | man | mathematician | physicist | scientist</annotation>
 		<annotation cp="👨‍🔬" type="tts">man scientist</annotation>
 		<annotation cp="👩‍🔬">biologist | chemist | engineer | mathematician | physicist | scientist | woman</annotation>
 		<annotation cp="👩‍🔬" type="tts">woman scientist</annotation>
-		<annotation cp="🧑‍💻">coder | developer | inventor | software | technologist</annotation>
+		<annotation cp="🧑‍💻">coder | computer | developer | inventor | software | technologist</annotation>
 		<annotation cp="🧑‍💻" type="tts">technologist</annotation>
 		<annotation cp="👨‍💻">coder | computer | developer | inventor | man | software | technologist</annotation>
 		<annotation cp="👨‍💻" type="tts">man technologist</annotation>
 		<annotation cp="👩‍💻">coder | computer | developer | inventor | software | technologist | woman</annotation>
 		<annotation cp="👩‍💻" type="tts">woman technologist</annotation>
-		<annotation cp="🧑‍🎤">actor | entertainer | rock | singer | star</annotation>
+		<annotation cp="🧑‍🎤">actor | entertainer | rock | rockstar | singer | star</annotation>
 		<annotation cp="🧑‍🎤" type="tts">singer</annotation>
 		<annotation cp="👨‍🎤">actor | entertainer | man | rock | rockstar | singer | star</annotation>
 		<annotation cp="👨‍🎤" type="tts">man singer</annotation>
@@ -1371,7 +1366,7 @@ annotations.
 		<annotation cp="👨‍✈" type="tts">man pilot</annotation>
 		<annotation cp="👩‍✈">pilot | plane | woman</annotation>
 		<annotation cp="👩‍✈" type="tts">woman pilot</annotation>
-		<annotation cp="🧑‍🚀">astronaut | rocket</annotation>
+		<annotation cp="🧑‍🚀">astronaut | rocket | space</annotation>
 		<annotation cp="🧑‍🚀" type="tts">astronaut</annotation>
 		<annotation cp="👨‍🚀">astronaut | man | rocket | space</annotation>
 		<annotation cp="👨‍🚀" type="tts">man astronaut</annotation>
@@ -1379,15 +1374,15 @@ annotations.
 		<annotation cp="👩‍🚀" type="tts">woman astronaut</annotation>
 		<annotation cp="🧑‍🚒">fire | firefighter | firetruck</annotation>
 		<annotation cp="🧑‍🚒" type="tts">firefighter</annotation>
-		<annotation cp="👨‍🚒">firefighter | firetruck | man</annotation>
+		<annotation cp="👨‍🚒">fire | firefighter | firetruck | man</annotation>
 		<annotation cp="👨‍🚒" type="tts">man firefighter</annotation>
-		<annotation cp="👩‍🚒">firefighter | firetruck | woman</annotation>
+		<annotation cp="👩‍🚒">fire | firefighter | firetruck | woman</annotation>
 		<annotation cp="👩‍🚒" type="tts">woman firefighter</annotation>
-		<annotation cp="👮">apprehend | arrest | citation | cop | law | officer | police | pulled over | undercover cop</annotation>
+		<annotation cp="👮">apprehend | arrest | citation | cop | law | officer | over | police | pulled | undercover</annotation>
 		<annotation cp="👮" type="tts">police officer</annotation>
-		<annotation cp="👮‍♂">cop | man | officer | police</annotation>
+		<annotation cp="👮‍♂">apprehend | arrest | citation | cop | law | man | officer | over | police | pulled | undercover</annotation>
 		<annotation cp="👮‍♂" type="tts">man police officer</annotation>
-		<annotation cp="👮‍♀">apprehend | arrest | citation | cop | law | officer | police | pulled over | undercover cop | woman</annotation>
+		<annotation cp="👮‍♀">apprehend | arrest | citation | cop | law | officer | over | police | pulled | undercover | woman</annotation>
 		<annotation cp="👮‍♀" type="tts">woman police officer</annotation>
 		<annotation cp="🕵">detective | sleuth | spy</annotation>
 		<annotation cp="🕵" type="tts">detective</annotation>
@@ -1395,206 +1390,205 @@ annotations.
 		<annotation cp="🕵‍♂" type="tts">man detective</annotation>
 		<annotation cp="🕵‍♀">detective | sleuth | spy | woman</annotation>
 		<annotation cp="🕵‍♀" type="tts">woman detective</annotation>
-		<annotation cp="💂">buckingham palace | guard | guardsman | helmet | london</annotation>
+		<annotation cp="💂">buckingham | guard | helmet | london | palace</annotation>
 		<annotation cp="💂" type="tts">guard</annotation>
-		<annotation cp="💂‍♂">guard | man</annotation>
+		<annotation cp="💂‍♂">buckingham | guard | helmet | london | man | palace</annotation>
 		<annotation cp="💂‍♂" type="tts">man guard</annotation>
-		<annotation cp="💂‍♀">buckingham palace | guard | helmet | london | woman</annotation>
+		<annotation cp="💂‍♀">buckingham | guard | helmet | london | palace | woman</annotation>
 		<annotation cp="💂‍♀" type="tts">woman guard</annotation>
 		<annotation cp="🥷">assassin | fight | fighter | hidden | ninja | person | secret | skills | sly | soldier | stealth | war</annotation>
 		<annotation cp="🥷" type="tts">ninja</annotation>
-		<annotation cp="👷">build | construction | fix | hardhat | hat | helmet | man | person | rebuild | remodel | repair | work | worker</annotation>
+		<annotation cp="👷">build | construction | fix | hardhat | hat | man | person | rebuild | remodel | repair | work | worker</annotation>
 		<annotation cp="👷" type="tts">construction worker</annotation>
-		<annotation cp="👷‍♂">construction | man | worker</annotation>
+		<annotation cp="👷‍♂">build | construction | fix | hardhat | hat | man | rebuild | remodel | repair | work | worker</annotation>
 		<annotation cp="👷‍♂" type="tts">man construction worker</annotation>
-		<annotation cp="👷‍♀">construction | hardhat | hat | helmet | woman | work | worker</annotation>
+		<annotation cp="👷‍♀">build | construction | fix | hardhat | hat | man | rebuild | remodel | repair | woman | work | worker</annotation>
 		<annotation cp="👷‍♀" type="tts">woman construction worker</annotation>
-		<annotation cp="🫅">crown | monarch | noble | person with crown | regal | royal | royalty</annotation> <!-- 1FAC5 -->
+		<annotation cp="🫅">crown | monarch | noble | person | regal | royal | royalty</annotation> <!-- 1FAC5 -->
 		<annotation cp="🫅" type="tts">person with crown</annotation>
-		<annotation cp="🤴">prince | royal | royalty</annotation>
+		<annotation cp="🤴">crown | fairy | fairytale | fantasy | king | prince | royal | royalty | tale</annotation>
 		<annotation cp="🤴" type="tts">prince</annotation>
-		<annotation cp="👸">crown | fairy tale | fairytale | fantasy | princess | queen</annotation>
+		<annotation cp="👸">crown | fairy | fairytale | fantasy | princess | queen | royal | royalty | tale</annotation>
 		<annotation cp="👸" type="tts">princess</annotation>
-		<annotation cp="👳">person wearing turban | turban</annotation>
+		<annotation cp="👳">person | turban | wearing</annotation>
 		<annotation cp="👳" type="tts">person wearing turban</annotation>
-		<annotation cp="👳‍♂">man | man wearing turban | turban</annotation>
+		<annotation cp="👳‍♂">man | turban | wearing</annotation>
 		<annotation cp="👳‍♂" type="tts">man wearing turban</annotation>
-		<annotation cp="👳‍♀">turban | woman | woman wearing turban</annotation>
+		<annotation cp="👳‍♀">turban | wearing | woman</annotation>
 		<annotation cp="👳‍♀" type="tts">woman wearing turban</annotation>
-		<annotation cp="👲">cap | gua pi mao | guapimao | hat | person | person with Chinese cap | person with skullcap | skullcap</annotation>
+		<annotation cp="👲">cap | Chinese | gua | guapi | hat | mao | person | pi | skullcap</annotation>
 		<annotation cp="👲" type="tts">person with skullcap</annotation>
-		<annotation cp="🧕">bandana | head kerchief | headscarf | hijab | mantilla | tichel | woman with headscarf</annotation>
+		<annotation cp="🧕">bandana | head | headscarf | hijab | kerchief | mantilla | tichel | woman</annotation>
 		<annotation cp="🧕" type="tts">woman with headscarf</annotation>
-		<annotation cp="🤵">formal | groom | person | person in tuxedo | tuxedo</annotation>
+		<annotation cp="🤵">formal | person | tuxedo | wedding</annotation>
 		<annotation cp="🤵" type="tts">person in tuxedo</annotation>
-		<!-- (more) Generated lines from Emoji Data v13, using GenerateCldrData.java -->
-		<annotation cp="🤵‍♂">man | man in tuxedo | tuxedo</annotation> <!-- 1F935 200D 2642 -->
+		<annotation cp="🤵‍♂">formal | groom | man | tuxedo | wedding</annotation> <!-- 1F935 200D 2642 -->
 		<annotation cp="🤵‍♂" type="tts">man in tuxedo</annotation>
-		<annotation cp="🤵‍♀">tuxedo | woman | woman in tuxedo</annotation> <!-- 1F935 200D 2640 -->
+		<annotation cp="🤵‍♀">formal | tuxedo | wedding | woman</annotation> <!-- 1F935 200D 2640 -->
 		<annotation cp="🤵‍♀" type="tts">woman in tuxedo</annotation>
-		<annotation cp="👰">bride | bride with veil | person | person with veil | veil | wedding</annotation>
+		<annotation cp="👰">person | veil | wedding</annotation>
 		<annotation cp="👰" type="tts">person with veil</annotation>
-		<annotation cp="👰‍♂">man | man with veil | veil</annotation> <!-- 1F470 200D 2642 -->
+		<annotation cp="👰‍♂">man | veil | wedding</annotation> <!-- 1F470 200D 2642 -->
 		<annotation cp="👰‍♂" type="tts">man with veil</annotation>
-		<annotation cp="👰‍♀">veil | woman | woman with veil</annotation> <!-- 1F470 200D 2640 -->
+		<annotation cp="👰‍♀">bride | veil | wedding | woman</annotation> <!-- 1F470 200D 2640 -->
 		<annotation cp="👰‍♀" type="tts">woman with veil</annotation>
 		<annotation cp="🤰">pregnant | woman</annotation>
 		<annotation cp="🤰" type="tts">pregnant woman</annotation>
 		<annotation cp="🫃">belly | bloated | full | man | overeat | pregnant</annotation> <!-- 1FAC3 -->
 		<annotation cp="🫃" type="tts">pregnant man</annotation>
-		<annotation cp="🫄">belly | bloated | full | overeat | pregnant | pregnant person | stuffed</annotation> <!-- 1FAC4 -->
+		<annotation cp="🫄">belly | bloated | full | overeat | person | pregnant | stuffed</annotation> <!-- 1FAC4 -->
 		<annotation cp="🫄" type="tts">pregnant person</annotation>
-		<annotation cp="🤱">baby | breast | breast feeding | breast-feeding | nursing</annotation>
+		<annotation cp="🤱">baby | breast | breast-feeding | feeding | mom | mother | nursing | woman</annotation>
 		<annotation cp="🤱" type="tts">breast-feeding</annotation>
-		<annotation cp="👩‍🍼">baby | feed | feeding | love | mam | mammy | mom | mother | nanny | newborn | nursing | person | woman</annotation> <!-- 1F469 200D 1F37C -->
+		<annotation cp="👩‍🍼">baby | feed | feeding | mom | mother | nanny | newborn | nursing | woman</annotation> <!-- 1F469 200D 1F37C -->
 		<annotation cp="👩‍🍼" type="tts">woman feeding baby</annotation>
-		<annotation cp="👨‍🍼">baby | dad | father | feed | feeding | love | male | man | nanny | newborn | nursing | person</annotation> <!-- 1F468 200D 1F37C -->
+		<annotation cp="👨‍🍼">baby | dad | father | feed | feeding | man | nanny | newborn | nursing</annotation> <!-- 1F468 200D 1F37C -->
 		<annotation cp="👨‍🍼" type="tts">man feeding baby</annotation>
-		<annotation cp="🧑‍🍼">baby | dad | feed | feeding | man | mom | nanny | newborn | nursing | person | woman</annotation> <!-- 1F9D1 200D 1F37C -->
+		<annotation cp="🧑‍🍼">baby | feed | feeding | nanny | newborn | nursing | parent</annotation> <!-- 1F9D1 200D 1F37C -->
 		<annotation cp="🧑‍🍼" type="tts">person feeding baby</annotation>
-		<annotation cp="👼">angel | baby | church | face | fairy tale | fairytale | fantasy</annotation>
+		<annotation cp="👼">angel | baby | church | face | fairy | fairytale | fantasy | tale</annotation>
 		<annotation cp="👼" type="tts">baby angel</annotation>
-		<annotation cp="🎅">celebration | Christmas | claus | fairy tale | fantasy | father | santa</annotation>
+		<annotation cp="🎅">celebration | Christmas | claus | fairy | fantasy | father | holiday | merry | santa | tale | xmas</annotation>
 		<annotation cp="🎅" type="tts">Santa Claus</annotation>
-		<annotation cp="🤶">celebration | Christmas | claus | mother | Mrs. | santa</annotation>
+		<annotation cp="🤶">celebration | Christmas | claus | fairy | fantasy | holiday | merry | mother | Mrs | santa | tale | xmas</annotation>
 		<annotation cp="🤶" type="tts">Mrs. Claus</annotation>
-		<annotation cp="🧑‍🎄">christmas | claus | hat | holiday | merry xmas | mx claus | person | santa | santy | xmas</annotation> <!-- 1F9D1 200D 1F384 -->
-		<annotation cp="🧑‍🎄" type="tts">mx claus</annotation>
-		<annotation cp="🦸">good | hero | heroine | superhero | superpower | superpowers</annotation>
+		<annotation cp="🧑‍🎄">celebration | Christmas | claus | fairy | fantasy | holiday | merry | Mx | santa | tale | xmas</annotation> <!-- 1F9D1 200D 1F384 -->
+		<annotation cp="🧑‍🎄" type="tts">Mx claus</annotation>
+		<annotation cp="🦸">good | hero | superhero | superpower</annotation>
 		<annotation cp="🦸" type="tts">superhero</annotation>
-		<annotation cp="🦸‍♂">good | hero | man | man superhero | superpower</annotation>
+		<annotation cp="🦸‍♂">good | hero | man | superhero | superpower</annotation>
 		<annotation cp="🦸‍♂" type="tts">man superhero</annotation>
-		<annotation cp="🦸‍♀">good | hero | heroine | superpower | woman | woman superhero</annotation>
+		<annotation cp="🦸‍♀">good | hero | heroine | superhero | superpower | woman</annotation>
 		<annotation cp="🦸‍♀" type="tts">woman superhero</annotation>
-		<annotation cp="🦹">bad | criminal | evil | person | superpower | superpowers | supervillain | villain</annotation>
+		<annotation cp="🦹">bad | criminal | evil | superpower | supervillain | villain</annotation>
 		<annotation cp="🦹" type="tts">supervillain</annotation>
-		<annotation cp="🦹‍♂">criminal | evil | man | man supervillain | superpower | villain</annotation>
+		<annotation cp="🦹‍♂">bad | criminal | evil | man | superpower | supervillain | villain</annotation>
 		<annotation cp="🦹‍♂" type="tts">man supervillain</annotation>
-		<annotation cp="🦹‍♀">criminal | evil | superpower | villain | woman | woman supervillain</annotation>
+		<annotation cp="🦹‍♀">bad | criminal | evil | superpower | supervillain | villain | woman</annotation>
 		<annotation cp="🦹‍♀" type="tts">woman supervillain</annotation>
-		<annotation cp="🧙">fantasy | mage | magic | person mage | role play | sorcerer | sorceress | spell | summon | witch | wizard</annotation>
+		<annotation cp="🧙">fantasy | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
 		<annotation cp="🧙" type="tts">mage</annotation>
-		<annotation cp="🧙‍♂">man mage | sorcerer | wizard</annotation>
+		<annotation cp="🧙‍♂">fantasy | mage | magic | man | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard</annotation>
 		<annotation cp="🧙‍♂" type="tts">man mage</annotation>
-		<annotation cp="🧙‍♀">sorceress | witch | woman mage</annotation>
+		<annotation cp="🧙‍♀">fantasy | mage | magic | play | sorcerer | sorceress | sorcery | spell | summon | witch | wizard | woman</annotation>
 		<annotation cp="🧙‍♀" type="tts">woman mage</annotation>
-		<annotation cp="🧚">fairy | fairytale | fantasy | myth | Oberon | person fairy | pixie | Puck | tale | Titania | wings</annotation>
+		<annotation cp="🧚">fairy | fairytale | fantasy | myth | person | pixie | tale | wings</annotation>
 		<annotation cp="🧚" type="tts">fairy</annotation>
-		<annotation cp="🧚‍♂">man fairy | Oberon | Puck</annotation>
+		<annotation cp="🧚‍♂">fairy | fairytale | fantasy | man | myth | Oberon | person | pixie | Puck | tale | wings</annotation>
 		<annotation cp="🧚‍♂" type="tts">man fairy</annotation>
-		<annotation cp="🧚‍♀">Titania | woman fairy</annotation>
+		<annotation cp="🧚‍♀">fairy | fairytale | fantasy | myth | person | pixie | tale | Titania | wings | woman</annotation>
 		<annotation cp="🧚‍♀" type="tts">woman fairy</annotation>
-		<annotation cp="🧛">blood | costume | Dracula | fangs | halloween | person vampire | scary | supernatural | teeth | undead | vampire</annotation>
+		<annotation cp="🧛">blood | fangs | halloween | scary | supernatural | teeth | undead | vampire</annotation>
 		<annotation cp="🧛" type="tts">vampire</annotation>
-		<annotation cp="🧛‍♂">Dracula | man vampire | undead</annotation>
+		<annotation cp="🧛‍♂">blood | fangs | halloween | man | scary | supernatural | teeth | undead | vampire</annotation>
 		<annotation cp="🧛‍♂" type="tts">man vampire</annotation>
-		<annotation cp="🧛‍♀">undead | woman vampire</annotation>
+		<annotation cp="🧛‍♀">blood | fangs | halloween | scary | supernatural | teeth | undead | vampire | woman</annotation>
 		<annotation cp="🧛‍♀" type="tts">woman vampire</annotation>
-		<annotation cp="🧜">fairytale | folklore | mermaid | merman | merperson | merwoman | ocean creatures | siren | trident | under the sea</annotation>
+		<annotation cp="🧜">creature | fairytale | folklore | merperson | ocean | sea | siren | trident</annotation>
 		<annotation cp="🧜" type="tts">merperson</annotation>
-		<annotation cp="🧜‍♂">merman | Triton</annotation>
+		<annotation cp="🧜‍♂">creature | fairytale | folklore | merman | Neptune | ocean | Poseidon | sea | siren | trident | Triton</annotation>
 		<annotation cp="🧜‍♂" type="tts">merman</annotation>
-		<annotation cp="🧜‍♀">mermaid | merwoman</annotation>
+		<annotation cp="🧜‍♀">creature | fairytale | folklore | mermaid | merwoman | ocean | sea | siren | trident</annotation>
 		<annotation cp="🧜‍♀" type="tts">mermaid</annotation>
-		<annotation cp="🧝">elf | elves | enchantment | fantasy | folklore | magical | mystical | mythical | person elf</annotation>
+		<annotation cp="🧝">elf | elves | enchantment | fantasy | folklore | magic | magical | myth</annotation>
 		<annotation cp="🧝" type="tts">elf</annotation>
-		<annotation cp="🧝‍♂">magical | man elf</annotation>
+		<annotation cp="🧝‍♂">elf | elves | enchantment | fantasy | folklore | magic | magical | man | myth</annotation>
 		<annotation cp="🧝‍♂" type="tts">man elf</annotation>
-		<annotation cp="🧝‍♀">magical | woman elf</annotation>
+		<annotation cp="🧝‍♀">elf | elves | enchantment | fantasy | folklore | magic | magical | myth | woman</annotation>
 		<annotation cp="🧝‍♀" type="tts">woman elf</annotation>
-		<annotation cp="🧞">djinn | fantasy | genie | jinn | mystical | mythical | person genie | rub the lamp | wishes</annotation>
+		<annotation cp="🧞">djinn | fantasy | genie | jinn | lamp | myth | rub | wishes</annotation>
 		<annotation cp="🧞" type="tts">genie</annotation>
-		<annotation cp="🧞‍♂">djinn | man genie</annotation>
+		<annotation cp="🧞‍♂">djinn | fantasy | genie | jinn | lamp | man | myth | rub | wishes</annotation>
 		<annotation cp="🧞‍♂" type="tts">man genie</annotation>
-		<annotation cp="🧞‍♀">djinn | woman genie</annotation>
+		<annotation cp="🧞‍♀">djinn | fantasy | genie | jinn | lamp | myth | rub | wishes | woman</annotation>
 		<annotation cp="🧞‍♀" type="tts">woman genie</annotation>
-		<annotation cp="🧟">apocalypse | halloween | horror | person zombie | scary | undead | walking dead | zombie</annotation>
+		<annotation cp="🧟">apocalypse | dead | halloween | horror | scary | undead | walking | zombie</annotation>
 		<annotation cp="🧟" type="tts">zombie</annotation>
-		<annotation cp="🧟‍♂">man zombie | undead | walking dead</annotation>
+		<annotation cp="🧟‍♂">apocalypse | dead | halloween | horror | man | scary | undead | walking | zombie</annotation>
 		<annotation cp="🧟‍♂" type="tts">man zombie</annotation>
-		<annotation cp="🧟‍♀">undead | walking dead | woman zombie</annotation>
+		<annotation cp="🧟‍♀">apocalypse | dead | halloween | horror | scary | undead | walking | woman | zombie</annotation>
 		<annotation cp="🧟‍♀" type="tts">woman zombie</annotation>
-		<annotation cp="🧌">fairy tale | fantasy | monster | troll | trolling</annotation> <!-- 1F9CC -->
+		<annotation cp="🧌">fairy | fantasy | monster | tale | troll | trolling</annotation> <!-- 1F9CC -->
 		<annotation cp="🧌" type="tts">troll</annotation>
-		<annotation cp="💆">face | headache | massage | person getting massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman getting massage</annotation>
+		<annotation cp="💆">face | getting | headache | massage | person | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
 		<annotation cp="💆" type="tts">person getting massage</annotation>
-		<annotation cp="💆‍♂">face | headache | man | man getting massage | massage | relax | relaxing | salon | soothe | tension</annotation>
+		<annotation cp="💆‍♂">face | getting | headache | man | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment</annotation>
 		<annotation cp="💆‍♂" type="tts">man getting massage</annotation>
-		<annotation cp="💆‍♀">face | massage | woman | woman getting massage</annotation>
+		<annotation cp="💆‍♀">face | getting | headache | massage | relax | relaxing | salon | soothe | spa | tension | therapy | treatment | woman</annotation>
 		<annotation cp="💆‍♀" type="tts">woman getting massage</annotation>
-		<annotation cp="💇">barber | beauty | chop | cosmetology | cut hair | groom | hair | haircut | parlor | person getting haircut | shears | style | woman getting haircut</annotation>
+		<annotation cp="💇">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | parlor | person | shears | style</annotation>
 		<annotation cp="💇" type="tts">person getting haircut</annotation>
-		<annotation cp="💇‍♂">barber | beauty | hair | haircut | man | man getting haircut | parlor</annotation>
+		<annotation cp="💇‍♂">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | man | parlor | person | shears | style</annotation>
 		<annotation cp="💇‍♂" type="tts">man getting haircut</annotation>
-		<annotation cp="💇‍♀">haircut | woman | woman getting haircut</annotation>
+		<annotation cp="💇‍♀">barber | beauty | chop | cosmetology | cut | groom | hair | haircut | parlor | person | shears | style | woman</annotation>
 		<annotation cp="💇‍♀" type="tts">woman getting haircut</annotation>
-		<annotation cp="🚶">amble | gait | hike | man walking | pace | pedestrian | person walking | saunter | stride | stroll | swagger | walk | walking</annotation>
+		<annotation cp="🚶">amble | gait | hike | man | pace | pedestrian | person | stride | stroll | walk | walking</annotation>
 		<annotation cp="🚶" type="tts">person walking</annotation>
-		<annotation cp="🚶‍♂">hike | man | man walking | walk</annotation>
+		<annotation cp="🚶‍♂">amble | gait | hike | man | pace | pedestrian | stride | stroll | walk | walking</annotation>
 		<annotation cp="🚶‍♂" type="tts">man walking</annotation>
-		<annotation cp="🚶‍♀">amble | hike | pedestrian | saunter | stride | stroll | swagger | walk | walking | woman</annotation>
+		<annotation cp="🚶‍♀">amble | gait | hike | man | pace | pedestrian | stride | stroll | walk | walking | woman</annotation>
 		<annotation cp="🚶‍♀" type="tts">woman walking</annotation>
-		<annotation cp="🧍">person standing | stand | standing</annotation>
+		<annotation cp="🧍">person | stand | standing</annotation>
 		<annotation cp="🧍" type="tts">person standing</annotation>
-		<annotation cp="🧍‍♂">man | standing</annotation>
+		<annotation cp="🧍‍♂">man | stand | standing</annotation>
 		<annotation cp="🧍‍♂" type="tts">man standing</annotation>
-		<annotation cp="🧍‍♀">standing | woman</annotation>
+		<annotation cp="🧍‍♀">stand | standing | woman</annotation>
 		<annotation cp="🧍‍♀" type="tts">woman standing</annotation>
-		<annotation cp="🧎">kneel | kneeling | knees | on your knees | person kneeling</annotation>
+		<annotation cp="🧎">kneel | kneeling | knees | person</annotation>
 		<annotation cp="🧎" type="tts">person kneeling</annotation>
-		<annotation cp="🧎‍♂">kneeling | man</annotation>
+		<annotation cp="🧎‍♂">kneel | kneeling | knees | man</annotation>
 		<annotation cp="🧎‍♂" type="tts">man kneeling</annotation>
-		<annotation cp="🧎‍♀">kneeling | woman</annotation>
+		<annotation cp="🧎‍♀">kneel | kneeling | knees | woman</annotation>
 		<annotation cp="🧎‍♀" type="tts">woman kneeling</annotation>
-		<annotation cp="🧑‍🦯">accessibility | blind | person with white cane</annotation>
+		<annotation cp="🧑‍🦯">accessibility | blind | cane | person | probing | white</annotation>
 		<annotation cp="🧑‍🦯" type="tts">person with white cane</annotation>
-		<annotation cp="👨‍🦯">accessibility | blind | man | man with probing cane | man with white cane</annotation>
+		<annotation cp="👨‍🦯">accessibility | blind | cane | man | probing | white</annotation>
 		<annotation cp="👨‍🦯" type="tts">man with white cane</annotation>
-		<annotation cp="👩‍🦯">accessibility | blind | woman | woman with probing cane | woman with white cane</annotation>
+		<annotation cp="👩‍🦯">accessibility | blind | cane | probing | white | woman</annotation>
 		<annotation cp="👩‍🦯" type="tts">woman with white cane</annotation>
-		<annotation cp="🧑‍🦼">accessibility | person in motorized wheelchair | wheelchair</annotation>
+		<annotation cp="🧑‍🦼">accessibility | motorized | person | wheelchair</annotation>
 		<annotation cp="🧑‍🦼" type="tts">person in motorized wheelchair</annotation>
-		<annotation cp="👨‍🦼">accessibility | man | man in motorized wheelchair | wheelchair</annotation>
+		<annotation cp="👨‍🦼">accessibility | man | motorized | wheelchair</annotation>
 		<annotation cp="👨‍🦼" type="tts">man in motorized wheelchair</annotation>
-		<annotation cp="👩‍🦼">accessibility | wheelchair | woman | woman in motorized wheelchair</annotation>
+		<annotation cp="👩‍🦼">accessibility | motorized | wheelchair | woman</annotation>
 		<annotation cp="👩‍🦼" type="tts">woman in motorized wheelchair</annotation>
-		<annotation cp="🧑‍🦽">accessibility | person in manual wheelchair | wheelchair</annotation>
+		<annotation cp="🧑‍🦽">accessibility | manual | person | wheelchair</annotation>
 		<annotation cp="🧑‍🦽" type="tts">person in manual wheelchair</annotation>
-		<annotation cp="👨‍🦽">accessibility | man | man in manual wheelchair | wheelchair</annotation>
+		<annotation cp="👨‍🦽">accessibility | man | manual | wheelchair</annotation>
 		<annotation cp="👨‍🦽" type="tts">man in manual wheelchair</annotation>
-		<annotation cp="👩‍🦽">accessibility | wheelchair | woman | woman in manual wheelchair</annotation>
+		<annotation cp="👩‍🦽">accessibility | manual | wheelchair | woman</annotation>
 		<annotation cp="👩‍🦽" type="tts">woman in manual wheelchair</annotation>
-		<annotation cp="🏃">coming | fast | hurry | man running | marathon | move | person running | quick | race | runner | running | rush | speed</annotation>
+		<annotation cp="🏃">fast | hurry | marathon | move | person | quick | race | racing | run | rush | speed</annotation>
 		<annotation cp="🏃" type="tts">person running</annotation>
-		<annotation cp="🏃‍♂">man | marathon | racing | running</annotation>
+		<annotation cp="🏃‍♂">fast | hurry | man | marathon | move | quick | race | racing | run | rush | speed</annotation>
 		<annotation cp="🏃‍♂" type="tts">man running</annotation>
-		<annotation cp="🏃‍♀">coming | fast | hurry | marathon | quick | racing | runner | running | rush | speed | woman</annotation>
+		<annotation cp="🏃‍♀">fast | hurry | marathon | move | quick | race | racing | run | rush | speed | woman</annotation>
 		<annotation cp="🏃‍♀" type="tts">woman running</annotation>
-		<annotation cp="💃">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s dance | salsa | tango | woman</annotation>
+		<annotation cp="💃">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | salsa | tango | woman</annotation>
 		<annotation cp="💃" type="tts">woman dancing</annotation>
-		<annotation cp="🕺">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s dance | man | salsa | tango</annotation>
+		<annotation cp="🕺">dance | dancer | dancing | elegant | festive | flair | flamenco | groove | let’s | man | salsa | tango</annotation>
 		<annotation cp="🕺" type="tts">man dancing</annotation>
-		<annotation cp="🕴">business | person | person in suit levitating | suit</annotation>
+		<annotation cp="🕴">business | levitating | person | suit</annotation>
 		<annotation cp="🕴" type="tts">person in suit levitating</annotation>
-		<annotation cp="👯">bestie | bff | bunny | bunny ear | counterpart | dancer | double | identical | pair | party | partying | people | people with bunny ears | soulmate | twin | twinsies</annotation>
+		<annotation cp="👯">bestie | bff | bunny | counterpart | dancer | double | ear | identical | pair | party | partying | people | soulmate | twin | twinsies</annotation>
 		<annotation cp="👯" type="tts">people with bunny ears</annotation>
-		<annotation cp="👯‍♂">bff | bunny ear | dancer | men | men with bunny ears | party | partying | twinsies</annotation>
+		<annotation cp="👯‍♂">bestie | bff | bunny | counterpart | dancer | double | ear | identical | men | pair | party | partying | people | soulmate | twin | twinsies</annotation>
 		<annotation cp="👯‍♂" type="tts">men with bunny ears</annotation>
-		<annotation cp="👯‍♀">bunny ear | dancer | partying | women | women with bunny ears</annotation>
+		<annotation cp="👯‍♀">bestie | bff | bunny | counterpart | dancer | double | ear | identical | pair | party | partying | people | soulmate | twin | twinsies | women</annotation>
 		<annotation cp="👯‍♀" type="tts">women with bunny ears</annotation>
-		<annotation cp="🧖">day spa | hamam | luxurious | pamper | person in steamy room | relax | sauna | spa | steam room | steambath | steamy | unwind</annotation>
+		<annotation cp="🧖">day | luxurious | pamper | person | relax | room | sauna | spa | steam | steambath | unwind</annotation>
 		<annotation cp="🧖" type="tts">person in steamy room</annotation>
-		<annotation cp="🧖‍♂">man in steamy room | sauna | steam room</annotation>
+		<annotation cp="🧖‍♂">day | luxurious | man | pamper | relax | room | sauna | spa | steam | steambath | unwind</annotation>
 		<annotation cp="🧖‍♂" type="tts">man in steamy room</annotation>
-		<annotation cp="🧖‍♀">sauna | steam room | woman in steamy room</annotation>
+		<annotation cp="🧖‍♀">day | luxurious | pamper | relax | room | sauna | spa | steam | steambath | unwind | woman</annotation>
 		<annotation cp="🧖‍♀" type="tts">woman in steamy room</annotation>
-		<annotation cp="🧗">climb up | climber | climbing | mountain | person climbing | rock climber | scale</annotation>
+		<annotation cp="🧗">climb | climber | climbing | mountain | person | rock | scale | up</annotation>
 		<annotation cp="🧗" type="tts">person climbing</annotation>
-		<annotation cp="🧗‍♂">climber | man climbing</annotation>
+		<annotation cp="🧗‍♂">climb | climber | climbing | man | mountain | rock | scale | up</annotation>
 		<annotation cp="🧗‍♂" type="tts">man climbing</annotation>
-		<annotation cp="🧗‍♀">climber | woman climbing</annotation>
+		<annotation cp="🧗‍♀">climb | climber | climbing | mountain | rock | scale | up | woman</annotation>
 		<annotation cp="🧗‍♀" type="tts">woman climbing</annotation>
-		<annotation cp="🤺">fencer | fencing | person fencing | sword</annotation>
+		<annotation cp="🤺">fencer | fencing | person | sword</annotation>
 		<annotation cp="🤺" type="tts">person fencing</annotation>
 		<annotation cp="🏇">horse | jockey | racehorse | racing | riding | sport</annotation>
 		<annotation cp="🏇" type="tts">horse racing</annotation>
@@ -1602,133 +1596,133 @@ annotations.
 		<annotation cp="⛷" type="tts">skier</annotation>
 		<annotation cp="🏂">ski | snow | snowboard | snowboarder | sport</annotation>
 		<annotation cp="🏂" type="tts">snowboarder</annotation>
-		<annotation cp="🏌">ball | birdie | caddy | driving range | golf | green | person golfing | pga | putt | tee</annotation>
+		<annotation cp="🏌">ball | birdie | caddy | driving | golf | golfing | green | person | pga | putt | range | tee</annotation>
 		<annotation cp="🏌" type="tts">person golfing</annotation>
-		<annotation cp="🏌‍♂">golf | man | man golfing</annotation>
+		<annotation cp="🏌‍♂">ball | birdie | caddy | driving | golf | golfing | green | man | pga | putt | range | tee</annotation>
 		<annotation cp="🏌‍♂" type="tts">man golfing</annotation>
-		<annotation cp="🏌‍♀">ball | driving range | golf | woman | woman golfing</annotation>
+		<annotation cp="🏌‍♀">ball | birdie | caddy | driving | golf | golfing | green | pga | putt | range | tee | woman</annotation>
 		<annotation cp="🏌‍♀" type="tts">woman golfing</annotation>
-		<annotation cp="🏄">beach | ocean | person surfing | sport | surf | surfer | surfing | swell | waves</annotation>
+		<annotation cp="🏄">beach | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
 		<annotation cp="🏄" type="tts">person surfing</annotation>
-		<annotation cp="🏄‍♂">man | surfing</annotation>
+		<annotation cp="🏄‍♂">beach | man | ocean | sport | surf | surfer | surfing | swell | waves</annotation>
 		<annotation cp="🏄‍♂" type="tts">man surfing</annotation>
-		<annotation cp="🏄‍♀">beach | ocean | person surfing | sport | surfer | surfing | waves | woman</annotation>
+		<annotation cp="🏄‍♀">beach | ocean | person | sport | surf | surfer | surfing | swell | waves</annotation>
 		<annotation cp="🏄‍♀" type="tts">woman surfing</annotation>
-		<annotation cp="🚣">boat | canoe | cruise | fishing | lake | oar | paddle | person rowing boat | raft | river | row | rowboat | rowing</annotation>
+		<annotation cp="🚣">boat | canoe | cruise | fishing | lake | oar | paddle | person | raft | river | row | rowboat | rowing</annotation>
 		<annotation cp="🚣" type="tts">person rowing boat</annotation>
-		<annotation cp="🚣‍♂">boat | man | man rowing boat | rowboat</annotation>
+		<annotation cp="🚣‍♂">boat | canoe | cruise | fishing | lake | man | oar | paddle | raft | river | row | rowboat | rowing</annotation>
 		<annotation cp="🚣‍♂" type="tts">man rowing boat</annotation>
-		<annotation cp="🚣‍♀">boat | cruise | fishing | lake | river | row | rowboat | rowing | woman</annotation>
+		<annotation cp="🚣‍♀">boat | canoe | cruise | fishing | lake | oar | paddle | raft | river | row | rowboat | rowing | woman</annotation>
 		<annotation cp="🚣‍♀" type="tts">woman rowing boat</annotation>
-		<annotation cp="🏊">freestyle | person swimming | sport | swim | swimmer | swimming | triathlon</annotation>
+		<annotation cp="🏊">freestyle | person | sport | swim | swimmer | swimming | triathlon</annotation>
 		<annotation cp="🏊" type="tts">person swimming</annotation>
-		<annotation cp="🏊‍♂">man | man swimming | swim</annotation>
+		<annotation cp="🏊‍♂">freestyle | man | sport | swim | swimmer | swimming | triathlon</annotation>
 		<annotation cp="🏊‍♂" type="tts">man swimming</annotation>
-		<annotation cp="🏊‍♀">sport | swim | swimmer | swimming | woman</annotation>
+		<annotation cp="🏊‍♀">freestyle | man | sport | swim | swimmer | swimming | triathlon</annotation>
 		<annotation cp="🏊‍♀" type="tts">woman swimming</annotation>
-		<annotation cp="⛹">athletic | ball | basketball | basketball player | championship | dribble | free throw | man bouncing ball | nothing but net | person bouncing ball</annotation>
+		<annotation cp="⛹">athletic | ball | basketball | bouncing | championship | dribble | net | person | player | throw</annotation>
 		<annotation cp="⛹" type="tts">person bouncing ball</annotation>
-		<annotation cp="⛹‍♂">ball | man | man bouncing ball</annotation>
+		<annotation cp="⛹‍♂">athletic | ball | basketball | bouncing | championship | dribble | man | net | player | throw</annotation>
 		<annotation cp="⛹‍♂" type="tts">man bouncing ball</annotation>
-		<annotation cp="⛹‍♀">ball | basketball | basketball player | woman | woman bouncing ball</annotation>
+		<annotation cp="⛹‍♀">athletic | ball | basketball | bouncing | championship | dribble | net | player | throw | woman</annotation>
 		<annotation cp="⛹‍♀" type="tts">woman bouncing ball</annotation>
-		<annotation cp="🏋">barbell | bodybuilder | deadlift | lifter | person lifting weights | powerlifting | weight | weightlifter | workout</annotation>
+		<annotation cp="🏋">barbell | bodybuilder | deadlift | lifter | lifting | person | powerlifting | weight | weightlifter | weights | workout</annotation>
 		<annotation cp="🏋" type="tts">person lifting weights</annotation>
-		<annotation cp="🏋‍♂">man | man lifting weights | weight lifter</annotation>
+		<annotation cp="🏋‍♂">barbell | bodybuilder | deadlift | lifter | lifting | man | powerlifting | weight | weightlifter | weights | workout</annotation>
 		<annotation cp="🏋‍♂" type="tts">man lifting weights</annotation>
-		<annotation cp="🏋‍♀">lifter | weight | weightlifter | woman | woman lifting weights | workout</annotation>
+		<annotation cp="🏋‍♀">barbell | bodybuilder | deadlift | lifter | lifting | powerlifting | weight | weightlifter | weights | woman | workout</annotation>
 		<annotation cp="🏋‍♀" type="tts">woman lifting weights</annotation>
-		<annotation cp="🚴">bicycle | bicyclist | bike | biking | cycle | cyclist | person biking | riding | sport</annotation>
+		<annotation cp="🚴">bicycle | bicyclist | bike | biking | cycle | cyclist | person | riding | sport</annotation>
 		<annotation cp="🚴" type="tts">person biking</annotation>
-		<annotation cp="🚴‍♂">bicycle | biking | cyclist | man</annotation>
+		<annotation cp="🚴‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | riding | sport</annotation>
 		<annotation cp="🚴‍♂" type="tts">man biking</annotation>
-		<annotation cp="🚴‍♀">bicycle | bicyclist | bike | biking | cyclist | riding | sport | woman</annotation>
+		<annotation cp="🚴‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | riding | sport | woman</annotation>
 		<annotation cp="🚴‍♀" type="tts">woman biking</annotation>
-		<annotation cp="🚵">athletic | bicycle | bicyclist | bike | cyclist | mountain | person mountain biking | riding | sport</annotation>
+		<annotation cp="🚵">bicycle | bicyclist | bike | biking | cycle | cyclist | mountain | person | riding | sport</annotation>
 		<annotation cp="🚵" type="tts">person mountain biking</annotation>
-		<annotation cp="🚵‍♂">bicycle | bike | cyclist | man | man mountain biking | mountain</annotation>
+		<annotation cp="🚵‍♂">bicycle | bicyclist | bike | biking | cycle | cyclist | man | mountain | riding | sport</annotation>
 		<annotation cp="🚵‍♂" type="tts">man mountain biking</annotation>
-		<annotation cp="🚵‍♀">bicycle | bicyclist | bike | biking | cyclist | mountain | riding | sport | woman</annotation>
+		<annotation cp="🚵‍♀">bicycle | bicyclist | bike | biking | cycle | cyclist | mountain | riding | sport | woman</annotation>
 		<annotation cp="🚵‍♀" type="tts">woman mountain biking</annotation>
-		<annotation cp="🤸">active | cartwheel | excited | flip | gymnastics | happy | person | person cartwheeling | somersault</annotation>
+		<annotation cp="🤸">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | person | somersault</annotation>
 		<annotation cp="🤸" type="tts">person cartwheeling</annotation>
-		<annotation cp="🤸‍♂">active | cartwheel | excited | flip | gymnastics | happy | man | man cartwheeling | somersault</annotation>
+		<annotation cp="🤸‍♂">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | man | somersault</annotation>
 		<annotation cp="🤸‍♂" type="tts">man cartwheeling</annotation>
-		<annotation cp="🤸‍♀">active | cartwheel | excited | flip | gymnastics | happy | somersault | woman | woman cartwheeling</annotation>
+		<annotation cp="🤸‍♀">active | cartwheel | cartwheeling | excited | flip | gymnastics | happy | somersault | woman</annotation>
 		<annotation cp="🤸‍♀" type="tts">woman cartwheeling</annotation>
-		<annotation cp="🤼">combat | duel | in the ring | people | wrestle | wrestler | wrestling | wrestling tournament</annotation>
+		<annotation cp="🤼">combat | duel | grapple | people | ring | tournament | wrestle | wrestling</annotation>
 		<annotation cp="🤼" type="tts">people wrestling</annotation>
-		<annotation cp="🤼‍♂">combat | duel | in the ring | men | wrestle | wrestling | wrestling tournament</annotation>
+		<annotation cp="🤼‍♂">combat | duel | grapple | men | ring | tournament | wrestle | wrestling</annotation>
 		<annotation cp="🤼‍♂" type="tts">men wrestling</annotation>
-		<annotation cp="🤼‍♀">combat | duel | grapple | in the ring | women | wrestle | wrestling | wrestling tournament</annotation>
+		<annotation cp="🤼‍♀">combat | duel | grapple | ring | tournament | women | wrestle | wrestling</annotation>
 		<annotation cp="🤼‍♀" type="tts">women wrestling</annotation>
-		<annotation cp="🤽">person | person playing water polo | polo | swimming | water | water sport | waterpolo</annotation>
+		<annotation cp="🤽">person | playing | polo | sport | swimming | water | waterpolo</annotation>
 		<annotation cp="🤽" type="tts">person playing water polo</annotation>
-		<annotation cp="🤽‍♂">man | man playing water polo | swimming | water polo | water sport | waterpolo</annotation>
+		<annotation cp="🤽‍♂">man | playing | polo | sport | swimming | water | waterpolo</annotation>
 		<annotation cp="🤽‍♂" type="tts">man playing water polo</annotation>
-		<annotation cp="🤽‍♀">swimming | water polo | water sport | waterpolo | woman | woman playing water polo</annotation>
+		<annotation cp="🤽‍♀">playing | polo | sport | swimming | water | waterpolo | woman</annotation>
 		<annotation cp="🤽‍♀" type="tts">woman playing water polo</annotation>
-		<annotation cp="🤾">athletics | ball | catch | chuck | handball | hurl | lob | person | person playing handball | pitch | sport | throw | toss</annotation>
+		<annotation cp="🤾">athletics | ball | catch | chuck | handball | hurl | lob | person | pitch | playing | sport | throw | toss</annotation>
 		<annotation cp="🤾" type="tts">person playing handball</annotation>
-		<annotation cp="🤾‍♂">handball | man | man playing handball</annotation>
+		<annotation cp="🤾‍♂">athletics | ball | catch | chuck | handball | hurl | lob | man | pitch | playing | sport | throw | toss</annotation>
 		<annotation cp="🤾‍♂" type="tts">man playing handball</annotation>
-		<annotation cp="🤾‍♀">athletics | ball | catch | chuck | handball | hurl | lob | pitch | sport | throw | toss | woman | woman playing handball</annotation>
+		<annotation cp="🤾‍♀">athletics | ball | catch | chuck | handball | hurl | lob | pitch | playing | sport | throw | toss | woman</annotation>
 		<annotation cp="🤾‍♀" type="tts">woman playing handball</annotation>
-		<annotation cp="🤹">balance | balancing act | handle | juggle | manage | multitask | person | person juggling | skill</annotation>
+		<annotation cp="🤹">act | balance | balancing | handle | juggle | juggling | manage | multitask | person | skill</annotation>
 		<annotation cp="🤹" type="tts">person juggling</annotation>
-		<annotation cp="🤹‍♂">balancing act | handle | juggle | man | man juggling | manage | multitask</annotation>
+		<annotation cp="🤹‍♂">act | balance | balancing | handle | juggle | juggling | man | manage | multitask | skill</annotation>
 		<annotation cp="🤹‍♂" type="tts">man juggling</annotation>
-		<annotation cp="🤹‍♀">juggle | multitask | woman | woman juggling</annotation>
+		<annotation cp="🤹‍♀">act | balance | balancing | handle | juggle | juggling | manage | multitask | skill | woman</annotation>
 		<annotation cp="🤹‍♀" type="tts">woman juggling</annotation>
-		<annotation cp="🧘">cross legged | legs crossed | meditation | peace | person in lotus position | relax | serenity | yoga | yogi | zen</annotation>
+		<annotation cp="🧘">cross | legged | legs | lotus | meditation | peace | person | position | relax | serenity | yoga | yogi | zen</annotation>
 		<annotation cp="🧘" type="tts">person in lotus position</annotation>
-		<annotation cp="🧘‍♂">man in lotus position | meditation | yoga</annotation>
+		<annotation cp="🧘‍♂">cross | legged | legs | lotus | man | meditation | peace | position | relax | serenity | yoga | yogi | zen</annotation>
 		<annotation cp="🧘‍♂" type="tts">man in lotus position</annotation>
-		<annotation cp="🧘‍♀">meditation | woman in lotus position | yoga</annotation>
+		<annotation cp="🧘‍♀">cross | legged | legs | lotus | meditation | peace | position | relax | serenity | woman | yoga | yogi | zen</annotation>
 		<annotation cp="🧘‍♀" type="tts">woman in lotus position</annotation>
-		<annotation cp="🛀">bath | bathtub | person taking bath | tub</annotation>
+		<annotation cp="🛀">bath | bathtub | person | taking | tub</annotation>
 		<annotation cp="🛀" type="tts">person taking bath</annotation>
-		<annotation cp="🛌">bed | bedtime | good night | goodnight | hotel | nap | night | person in bed | sleep | tired | zz | zzz | zzzz</annotation>
+		<annotation cp="🛌">bed | bedtime | good | goodnight | hotel | nap | night | person | sleep | tired | zzz</annotation>
 		<annotation cp="🛌" type="tts">person in bed</annotation>
-		<annotation cp="🧑‍🤝‍🧑">couple | hand | hold | holding hands | people holding hands | person</annotation>
+		<annotation cp="🧑‍🤝‍🧑">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | people | twins</annotation>
 		<annotation cp="🧑‍🤝‍🧑" type="tts">people holding hands</annotation>
-		<annotation cp="👭">bae | bestfriend | bestfriends | bestie | bff | bond | bonding | couple | dating | daughters | everyone | friend | friends | friendship | gay | girls | glbt | glbtq | hand | hold | holding hands | ladies | lesbian | lgbt | lgbtq | lgbtqia | queer | sis | sister | sisters | two women holding hands | woman | women | women holding hands</annotation>
+		<annotation cp="👭">bae | bestie | bff | couple | dating | flirt | friends | girls | hand | hold | sisters | twins | women</annotation>
 		<annotation cp="👭" type="tts">women holding hands</annotation>
-		<annotation cp="👫">bae | couple | dating | everyone | flirt | friend | friends | hand | hold | holding hands | in love | man | man and woman holding hands | woman | woman and man holding hands</annotation>
+		<annotation cp="👫">bae | bestie | bff | couple | dating | flirt | friends | hand | hold | man | twins | woman</annotation>
 		<annotation cp="👫" type="tts">woman and man holding hands</annotation>
-		<annotation cp="👬">bae | boys | couple | dating | everyone | friend | friends | gay | Gemini | glbt | glbtq | hand | hold | holding hands | in love | lgbt | lgbtq | lgbtqia | man | men | men holding hands | queer | twins | two men holding hands | zodiac</annotation>
+		<annotation cp="👬">bae | bestie | bff | boys | brothers | couple | dating | flirt | friends | hand | hold | men | twins</annotation>
 		<annotation cp="👬" type="tts">men holding hands</annotation>
 		<annotation cp="💏">anniversary | babe | bae | couple | date | dating | heart | kiss | love | mwah | person | romance | together | xoxo</annotation>
 		<annotation cp="💏" type="tts">kiss</annotation>
-		<annotation cp="💑">anniversary | babe | bae | couple | couple with heart | dating | heart | kiss | love | love you | person | relationship | romance | together</annotation>
+		<annotation cp="💑">anniversary | babe | bae | couple | dating | heart | kiss | love | person | relationship | romance | together | you</annotation>
 		<annotation cp="💑" type="tts">couple with heart</annotation>
 		<annotation cp="🗣">face | head | silhouette | speak | speaking</annotation>
 		<annotation cp="🗣" type="tts">speaking head</annotation>
-		<annotation cp="👤">bust | bust in silhouette | mysterious | shadow | silhouette</annotation>
+		<annotation cp="👤">bust | mysterious | shadow | silhouette</annotation>
 		<annotation cp="👤" type="tts">bust in silhouette</annotation>
-		<annotation cp="👥">bff | bust | busts in silhouette | everyone | friend | friends | people | silhouette</annotation>
+		<annotation cp="👥">bff | bust | busts | everyone | friend | friends | people | silhouette</annotation>
 		<annotation cp="👥" type="tts">busts in silhouette</annotation>
-		<annotation cp="🫂">comfort | embrace | farewell | friendship | goodbye | hello | hug | hugging | love | people hugging | thanks</annotation>
+		<annotation cp="🫂">comfort | embrace | farewell | friendship | goodbye | hello | hug | hugging | love | people | thanks</annotation>
 		<annotation cp="🫂" type="tts">people hugging</annotation>
 		<annotation cp="👪">child | family</annotation>
 		<annotation cp="👪" type="tts">family</annotation>
-		<annotation cp="🧑‍🧑‍🧒">family: adult, adult, child</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 -->
+		<annotation cp="🧑‍🧑‍🧒">adult | child | family:</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 -->
 		<annotation cp="🧑‍🧑‍🧒" type="tts">family: adult, adult, child</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">family: adult, adult, child, child</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2 -->
+		<annotation cp="🧑‍🧑‍🧒‍🧒">adult | child | child | family</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2 -->
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">family: adult, adult, child, child</annotation>
-		<annotation cp="🧑‍🧒">family: adult, child</annotation> <!-- 1F9D1 200D 1F9D2 -->
+		<annotation cp="🧑‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D2 -->
 		<annotation cp="🧑‍🧒" type="tts">family: adult, child</annotation>
-		<annotation cp="🧑‍🧒‍🧒">family: adult, child, child</annotation> <!-- 1F9D1 200D 1F9D2 200D 1F9D2 -->
+		<annotation cp="🧑‍🧒‍🧒">adult | child | child | family</annotation> <!-- 1F9D1 200D 1F9D2 200D 1F9D2 -->
 		<annotation cp="🧑‍🧒‍🧒" type="tts">family: adult, child, child</annotation>
 		<annotation cp="👣">barefoot | clothing | footprint | footprints | omw | print | walk</annotation>
 		<annotation cp="👣" type="tts">footprints</annotation>
-		<annotation cp="🦰">ginger | red hair | redhead</annotation>
+		<annotation cp="🦰">ginger | hair | red | redhead</annotation>
 		<annotation cp="🦰" type="tts">red hair</annotation>
-		<annotation cp="🦱">afro | curly | curly hair | ringlets</annotation>
+		<annotation cp="🦱">afro | curly | hair | ringlets</annotation>
 		<annotation cp="🦱" type="tts">curly hair</annotation>
 		<annotation cp="🦳">gray | hair | old | white</annotation>
 		<annotation cp="🦳" type="tts">white hair</annotation>
-		<annotation cp="🦲">bald | chemotherapy | hairless | no hair | shaven</annotation>
+		<annotation cp="🦲">bald | chemotherapy | hair | hairless | no | shaven</annotation>
 		<annotation cp="🦲" type="tts">bald</annotation>
 		<annotation cp="🐵">animal | banana | face | monkey</annotation>
 		<annotation cp="🐵" type="tts">monkey face</annotation>
@@ -1760,13 +1754,13 @@ annotations.
 		<annotation cp="🐈" type="tts">cat</annotation>
 		<annotation cp="🐈‍⬛">animal | black | cat | feline | halloween | meow | unlucky</annotation> <!-- 1F408 200D 2B1B -->
 		<annotation cp="🐈‍⬛" type="tts">black cat</annotation>
-		<annotation cp="🦁">alpha | animal | face | Leo | lion | lion order | mane | rawr | roar | safari | strong | zodiac</annotation>
+		<annotation cp="🦁">alpha | animal | face | Leo | lion | mane | order | rawr | roar | safari | strong | zodiac</annotation>
 		<annotation cp="🦁" type="tts">lion</annotation>
-		<annotation cp="🐯">animal | big cat | face | predator | tiger</annotation>
+		<annotation cp="🐯">animal | big | cat | face | predator | tiger</annotation>
 		<annotation cp="🐯" type="tts">tiger face</annotation>
-		<annotation cp="🐅">animal | animals | big cat | predator | tiger | zoo</annotation>
+		<annotation cp="🐅">animal | big | cat | predator | tiger | zoo</annotation>
 		<annotation cp="🐅" type="tts">tiger</annotation>
-		<annotation cp="🐆">animal | animals | big cat | leopard | predator | zoo</annotation>
+		<annotation cp="🐆">animal | big | cat | leopard | predator | zoo</annotation>
 		<annotation cp="🐆" type="tts">leopard</annotation>
 		<annotation cp="🐴">animal | dressage | equine | face | farm | horse | horses</annotation>
 		<annotation cp="🐴" type="tts">horse face</annotation>
@@ -1798,7 +1792,7 @@ annotations.
 		<annotation cp="🐖" type="tts">pig</annotation>
 		<annotation cp="🐗">animal | boar | pig</annotation>
 		<annotation cp="🐗" type="tts">boar</annotation>
-		<annotation cp="🐽">animal | face | farm | nose | pig | smel | snout</annotation>
+		<annotation cp="🐽">animal | face | farm | nose | pig | smell | snout</annotation>
 		<annotation cp="🐽" type="tts">pig nose</annotation>
 		<annotation cp="🐏">animal | Aries | horns | male | ram | sheep | zodiac | zoo</annotation>
 		<annotation cp="🐏" type="tts">ram</annotation>
@@ -1806,9 +1800,9 @@ annotations.
 		<annotation cp="🐑" type="tts">ewe</annotation>
 		<annotation cp="🐐">animal | Capricorn | farm | goat | milk | zodiac</annotation>
 		<annotation cp="🐐" type="tts">goat</annotation>
-		<annotation cp="🐪">animal | camel | desert | dromedary | hump | one hump</annotation>
+		<annotation cp="🐪">animal | camel | desert | dromedary | hump | one</annotation>
 		<annotation cp="🐪" type="tts">camel</annotation>
-		<annotation cp="🐫">animal | bactrian | camel | desert | hump | two hump | two-hump camel</annotation>
+		<annotation cp="🐫">animal | bactrian | camel | desert | hump | two | two-hump</annotation>
 		<annotation cp="🐫" type="tts">two-hump camel</annotation>
 		<annotation cp="🦙">alpaca | animal | guanaco | llama | vicuña | wool</annotation>
 		<annotation cp="🦙" type="tts">llama</annotation>
@@ -1816,7 +1810,7 @@ annotations.
 		<annotation cp="🦒" type="tts">giraffe</annotation>
 		<annotation cp="🐘">animal | elephant</annotation>
 		<annotation cp="🐘" type="tts">elephant</annotation>
-		<annotation cp="🦣">animal | extinction | large | mammoth | tusk | woolly</annotation>
+		<annotation cp="🦣">animal | extinction | large | mammoth | tusk | wooly</annotation>
 		<annotation cp="🦣" type="tts">mammoth</annotation>
 		<annotation cp="🦏">animal | rhinoceros</annotation>
 		<annotation cp="🦏" type="tts">rhinoceros</annotation>
@@ -1844,9 +1838,9 @@ annotations.
 		<annotation cp="🦇" type="tts">bat</annotation>
 		<annotation cp="🐻">animal | bear | face | grizzly | growl | honey</annotation>
 		<annotation cp="🐻" type="tts">bear</annotation>
-		<annotation cp="🐻‍❄">animal | arctic | bear | polar bear | white</annotation> <!-- 1F43B 200D 2744 -->
+		<annotation cp="🐻‍❄">animal | arctic | bear | polar | white</annotation> <!-- 1F43B 200D 2744 -->
 		<annotation cp="🐻‍❄" type="tts">polar bear</annotation>
-		<annotation cp="🐨">animal | australia | bear | down under | face | koala | marsupial</annotation>
+		<annotation cp="🐨">animal | australia | bear | down | face | koala | marsupial | under</annotation>
 		<annotation cp="🐨" type="tts">koala</annotation>
 		<annotation cp="🐼">animal | bamboo | face | panda</annotation>
 		<annotation cp="🐼" type="tts">panda</annotation>
@@ -1858,9 +1852,9 @@ annotations.
 		<annotation cp="🦨" type="tts">skunk</annotation>
 		<annotation cp="🦘">animal | joey | jump | kangaroo | marsupial</annotation>
 		<annotation cp="🦘" type="tts">kangaroo</annotation>
-		<annotation cp="🦡">animal | badger | honey badger | pester</annotation>
+		<annotation cp="🦡">animal | badger | honey | pester</annotation>
 		<annotation cp="🦡" type="tts">badger</annotation>
-		<annotation cp="🐾">feet | paw | paw prints | paws | print</annotation>
+		<annotation cp="🐾">feet | paw | paws | print | prints</annotation>
 		<annotation cp="🐾" type="tts">paw prints</annotation>
 		<annotation cp="🦃">bird | gobble | thanksgiving | turkey</annotation>
 		<annotation cp="🦃" type="tts">turkey</annotation>
@@ -1872,11 +1866,11 @@ annotations.
 		<annotation cp="🐣" type="tts">hatching chick</annotation>
 		<annotation cp="🐤">animal | baby | bird | chick | ornithology</annotation>
 		<annotation cp="🐤" type="tts">baby chick</annotation>
-		<annotation cp="🐥">animal | baby | bird | chick | front-facing baby chick | newborn | ornithology</annotation>
+		<annotation cp="🐥">animal | baby | bird | chick | front-facing | newborn | ornithology</annotation>
 		<annotation cp="🐥" type="tts">front-facing baby chick</annotation>
 		<annotation cp="🐦">animal | bird | ornithology</annotation>
 		<annotation cp="🐦" type="tts">bird</annotation>
-		<annotation cp="🐧">animal | antartica | bird | ornithology | penguin</annotation>
+		<annotation cp="🐧">animal | antarctica | bird | ornithology | penguin</annotation>
 		<annotation cp="🐧" type="tts">penguin</annotation>
 		<annotation cp="🕊">bird | dove | fly | ornithology | peace</annotation>
 		<annotation cp="🕊" type="tts">dove</annotation>
@@ -1884,7 +1878,7 @@ annotations.
 		<annotation cp="🦅" type="tts">eagle</annotation>
 		<annotation cp="🦆">animal | bird | duck | ornithology</annotation>
 		<annotation cp="🦆" type="tts">duck</annotation>
-		<annotation cp="🦢">animal | bird | cygnet | ornithology | swan | ugly duckling</annotation>
+		<annotation cp="🦢">animal | bird | cygnet | duckling | ornithology | swan | ugly</annotation>
 		<annotation cp="🦢" type="tts">swan</annotation>
 		<annotation cp="🦉">animal | bird | ornithology | owl | wise</annotation>
 		<annotation cp="🦉" type="tts">owl</annotation>
@@ -1904,7 +1898,7 @@ annotations.
 		<annotation cp="🐦‍⬛" type="tts">black bird</annotation>
 		<annotation cp="🪿">animal | bird | duck | flock | fowl | gaggle | gander | geese | goose | honk | ornithology | silly</annotation> <!-- 1FABF -->
 		<annotation cp="🪿" type="tts">goose</annotation>
-		<annotation cp="🐦‍🔥">ascend | ascension | emerge | fantasy | firebird | glory | immortal | phoenix | rebirth | reincarnate | reincarnation | reinvent | renewal | revival | revive | rise up | transform</annotation> <!-- 1F426 200D 1F525 -->
+		<annotation cp="🐦‍🔥">ascend | ascension | emerge | fantasy | firebird | glory | immortal | phoenix | rebirth | reincarnation | reinvent | renewal | revival | revive | rise | transform</annotation> <!-- 1F426 200D 1F525 -->
 		<annotation cp="🐦‍🔥" type="tts">phoenix</annotation>
 		<annotation cp="🐸">animal | face | frog</annotation>
 		<annotation cp="🐸" type="tts">frog</annotation>
@@ -1916,13 +1910,13 @@ annotations.
 		<annotation cp="🦎" type="tts">lizard</annotation>
 		<annotation cp="🐍">animal | bearer | Ophiuchus | serpent | snake | zodiac</annotation>
 		<annotation cp="🐍" type="tts">snake</annotation>
-		<annotation cp="🐲">animal | dragon | face | fairy tale | fairytale</annotation>
+		<annotation cp="🐲">animal | dragon | face | fairy | fairytale | tale</annotation>
 		<annotation cp="🐲" type="tts">dragon face</annotation>
-		<annotation cp="🐉">animal | dragon | fairy tale | fairytale | knights</annotation>
+		<annotation cp="🐉">animal | dragon | fairy | fairytale | knights | tale</annotation>
 		<annotation cp="🐉" type="tts">dragon</annotation>
 		<annotation cp="🦕">brachiosaurus | brontosaurus | dinosaur | diplodocus | sauropod</annotation>
 		<annotation cp="🦕" type="tts">sauropod</annotation>
-		<annotation cp="🦖">dinosaur | t rex | T-Rex | Tyrannosaurus Rex</annotation>
+		<annotation cp="🦖">dinosaur | Rex | T | T-Rex | Tyrannosaurus</annotation>
 		<annotation cp="🦖" type="tts">T-Rex</annotation>
 		<annotation cp="🐳">animal | beach | face | ocean | spouting | whale</annotation>
 		<annotation cp="🐳" type="tts">spouting whale</annotation>
@@ -1930,7 +1924,7 @@ annotations.
 		<annotation cp="🐋" type="tts">whale</annotation>
 		<annotation cp="🐬">animal | beach | dolphin | flipper | ocean</annotation>
 		<annotation cp="🐬" type="tts">dolphin</annotation>
-		<annotation cp="🦭">animal | ocean | sea lion | seal</annotation>
+		<annotation cp="🦭">animal | lion | ocean | sea | seal</annotation>
 		<annotation cp="🦭" type="tts">seal</annotation>
 		<annotation cp="🐟">animal | dinner | fish | fishes | fishing | Pisces | zodiac</annotation>
 		<annotation cp="🐟" type="tts">fish</annotation>
@@ -1942,11 +1936,11 @@ annotations.
 		<annotation cp="🦈" type="tts">shark</annotation>
 		<annotation cp="🐙">animal | creature | ocean | octopus</annotation>
 		<annotation cp="🐙" type="tts">octopus</annotation>
-		<annotation cp="🐚">animal | beach | conch | sea shell | shell | spiral</annotation>
+		<annotation cp="🐚">animal | beach | conch | sea | shell | spiral</annotation>
 		<annotation cp="🐚" type="tts">spiral shell</annotation>
-		<annotation cp="🪸">climate change | coral | ocean | reef | sea</annotation> <!-- 1FAB8 -->
+		<annotation cp="🪸">change | climate | coral | ocean | reef | sea</annotation> <!-- 1FAB8 -->
 		<annotation cp="🪸" type="tts">coral</annotation>
-		<annotation cp="🪼">animal | aquarium | burn | invertebrate | jelly | jellyfish | marine | ocean | ouch | plankton | sea | sea life | sting | stinger | tentacles</annotation> <!-- 1FABC -->
+		<annotation cp="🪼">animal | aquarium | burn | invertebrate | jelly | jellyfish | life | marine | ocean | ouch | plankton | sea | sting | stinger | tentacles</annotation> <!-- 1FABC -->
 		<annotation cp="🪼" type="tts">jellyfish</annotation>
 		<annotation cp="🐌">animal | escargot | garden | nature | slug | snail</annotation>
 		<annotation cp="🐌" type="tts">snail</annotation>
@@ -1960,7 +1954,7 @@ annotations.
 		<annotation cp="🐝" type="tts">honeybee</annotation>
 		<annotation cp="🪲">animal | beetle | bug | insect</annotation>
 		<annotation cp="🪲" type="tts">beetle</annotation>
-		<annotation cp="🐞">animal | beetle | garden | insect | lady beetle | ladybird | ladybug | nature</annotation>
+		<annotation cp="🐞">animal | beetle | garden | insect | lady | ladybird | ladybug | nature</annotation>
 		<annotation cp="🐞" type="tts">lady beetle</annotation>
 		<annotation cp="🦗">animal | bug | cricket | grasshopper | insect | Orthoptera</annotation>
 		<annotation cp="🦗" type="tts">cricket</annotation>
@@ -1984,13 +1978,13 @@ annotations.
 		<annotation cp="💐" type="tts">bouquet</annotation>
 		<annotation cp="🌸">blossom | cherry | flower | plant | spring | springtime</annotation>
 		<annotation cp="🌸" type="tts">cherry blossom</annotation>
-		<annotation cp="💮">flower | white flower</annotation>
+		<annotation cp="💮">flower | white</annotation>
 		<annotation cp="💮" type="tts">white flower</annotation>
 		<annotation cp="🪷">beauty | Buddhism | calm | flower | Hinduism | lotus | peace | purity | serenity</annotation> <!-- 1FAB7 -->
 		<annotation cp="🪷" type="tts">lotus</annotation>
 		<annotation cp="🏵">plant | rosette</annotation>
 		<annotation cp="🏵" type="tts">rosette</annotation>
-		<annotation cp="🌹">beauty | elegant | flower | love rose | plant | red | rose | valentine</annotation>
+		<annotation cp="🌹">beauty | elegant | flower | love | plant | red | rose | valentine</annotation>
 		<annotation cp="🌹" type="tts">rose</annotation>
 		<annotation cp="🥀">dying | flower | wilted</annotation>
 		<annotation cp="🥀" type="tts">wilted flower</annotation>
@@ -2006,9 +2000,9 @@ annotations.
 		<annotation cp="🪻" type="tts">hyacinth</annotation>
 		<annotation cp="🌱">plant | sapling | seedling | sprout | young</annotation>
 		<annotation cp="🌱" type="tts">seedling</annotation>
-		<annotation cp="🪴">boring | decor | grow | house | nurturing | plant | pot | potted plant | useless</annotation>
+		<annotation cp="🪴">decor | grow | house | nurturing | plant | pot | potted</annotation>
 		<annotation cp="🪴" type="tts">potted plant</annotation>
-		<annotation cp="🌲">christmas tree | evergreen | forest | pine tree | tree</annotation>
+		<annotation cp="🌲">christmas | evergreen | forest | pine | tree</annotation>
 		<annotation cp="🌲" type="tts">evergreen tree</annotation>
 		<annotation cp="🌳">deciduous | forest | green | habitat | shedding | tree</annotation>
 		<annotation cp="🌳" type="tts">deciduous tree</annotation>
@@ -2016,37 +2010,37 @@ annotations.
 		<annotation cp="🌴" type="tts">palm tree</annotation>
 		<annotation cp="🌵">cactus | desert | drought | nature | plant</annotation>
 		<annotation cp="🌵" type="tts">cactus</annotation>
-		<annotation cp="🌾">ear | grain | grains | plant | rice | sheaf of rice</annotation>
+		<annotation cp="🌾">ear | grain | grains | plant | rice | sheaf</annotation>
 		<annotation cp="🌾" type="tts">sheaf of rice</annotation>
 		<annotation cp="🌿">herb | leaf | plant</annotation>
 		<annotation cp="🌿" type="tts">herb</annotation>
 		<annotation cp="☘">irish | plant | shamrock</annotation>
 		<annotation cp="☘" type="tts">shamrock</annotation>
-		<annotation cp="🍀">4 | clover | four | four-leaf clover | irish | leaf | lucky | plant</annotation>
+		<annotation cp="🍀">4 | clover | four | four-leaf | irish | leaf | lucky | plant</annotation>
 		<annotation cp="🍀" type="tts">four leaf clover</annotation>
 		<annotation cp="🍁">falling | leaf | maple</annotation>
 		<annotation cp="🍁" type="tts">maple leaf</annotation>
-		<annotation cp="🍂">autumn | fall | fallen leaf | falling | leaf</annotation>
+		<annotation cp="🍂">autumn | fall | fallen | falling | leaf</annotation>
 		<annotation cp="🍂" type="tts">fallen leaf</annotation>
-		<annotation cp="🍃">blow | flutter | leaf | leaf fluttering in wind | wind</annotation>
+		<annotation cp="🍃">blow | flutter | fluttering | leaf | wind</annotation>
 		<annotation cp="🍃" type="tts">leaf fluttering in wind</annotation>
-		<annotation cp="🪹">branch | empty nest | home | nest | nesting</annotation> <!-- 1FAB9 -->
+		<annotation cp="🪹">branch | empty | home | nest | nesting</annotation> <!-- 1FAB9 -->
 		<annotation cp="🪹" type="tts">empty nest</annotation>
-		<annotation cp="🪺">bird | branch | egg | eggs | nest | nest with eggs | nesting</annotation> <!-- 1FABA -->
+		<annotation cp="🪺">bird | branch | egg | eggs | nest | nesting</annotation> <!-- 1FABA -->
 		<annotation cp="🪺" type="tts">nest with eggs</annotation>
 		<annotation cp="🍄">fungus | mushroom | toadstool</annotation>
 		<annotation cp="🍄" type="tts">mushroom</annotation>
-		<annotation cp="🍇">dionyses | fruit | grape | grapes</annotation>
+		<annotation cp="🍇">Dionysus | fruit | grape | grapes</annotation>
 		<annotation cp="🍇" type="tts">grapes</annotation>
 		<annotation cp="🍈">cantaloupe | fruit | melon</annotation>
 		<annotation cp="🍈" type="tts">melon</annotation>
 		<annotation cp="🍉">fruit | watermelon</annotation>
 		<annotation cp="🍉" type="tts">watermelon</annotation>
-		<annotation cp="🍊">citrus | fruit | nectarine | orange | tangerine | vitamin c</annotation>
+		<annotation cp="🍊">c | citrus | fruit | nectarine | orange | tangerine | vitamin</annotation>
 		<annotation cp="🍊" type="tts">tangerine</annotation>
 		<annotation cp="🍋">citrus | fruit | lemon | sour</annotation>
 		<annotation cp="🍋" type="tts">lemon</annotation>
-		<annotation cp="🍋‍🟩">acidity | citrus | cocktail | fruit | garnish | green | juice | key lime pie | lime | margarita | mojito | refreshing | salsa | sour | tangy | tequila | tropical | zest</annotation> <!-- 1F34B 200D 1F7E9 -->
+		<annotation cp="🍋‍🟩">acidity | citrus | cocktail | fruit | garnish | key | lime | margarita | mojito | refreshing | salsa | sour | tangy | tequila | tropical | zest</annotation> <!-- 1F34B 200D 1F7E9 -->
 		<annotation cp="🍋‍🟩" type="tts">lime</annotation>
 		<annotation cp="🍌">banana | fruit | potassium</annotation>
 		<annotation cp="🍌" type="tts">banana</annotation>
@@ -2074,7 +2068,7 @@ annotations.
 		<annotation cp="🍅" type="tts">tomato</annotation>
 		<annotation cp="🫒">food | olive</annotation>
 		<annotation cp="🫒" type="tts">olive</annotation>
-		<annotation cp="🥥">coconut | palm | piña colada</annotation>
+		<annotation cp="🥥">coconut | colada | palm | piña</annotation>
 		<annotation cp="🥥" type="tts">coconut</annotation>
 		<annotation cp="🥑">avocado | food | fruit</annotation>
 		<annotation cp="🥑" type="tts">avocado</annotation>
@@ -2084,17 +2078,17 @@ annotations.
 		<annotation cp="🥔" type="tts">potato</annotation>
 		<annotation cp="🥕">carrot | food | vegetable</annotation>
 		<annotation cp="🥕" type="tts">carrot</annotation>
-		<annotation cp="🌽">corn | crops | ear | ear of corn | farm | maize | maze</annotation>
+		<annotation cp="🌽">corn | crops | ear | farm | maize | maze</annotation>
 		<annotation cp="🌽" type="tts">ear of corn</annotation>
 		<annotation cp="🌶">hot | pepper</annotation>
 		<annotation cp="🌶" type="tts">hot pepper</annotation>
-		<annotation cp="🫑">bell pepper | capsicum | food | pepper | vegetable</annotation>
+		<annotation cp="🫑">bell | capsicum | food | pepper | vegetable</annotation>
 		<annotation cp="🫑" type="tts">bell pepper</annotation>
 		<annotation cp="🥒">cucumber | food | pickle | vegetable</annotation>
 		<annotation cp="🥒" type="tts">cucumber</annotation>
-		<annotation cp="🥬">bok choy | burgers | cabbage | kale | leafy green | lettuce | salad</annotation>
+		<annotation cp="🥬">bok | burgers | cabbage | choy | green | kale | leafy | lettuce | salad</annotation>
 		<annotation cp="🥬" type="tts">leafy green</annotation>
-		<annotation cp="🥦">broccoli | wild cabbage</annotation>
+		<annotation cp="🥦">broccoli | cabbage | wild</annotation>
 		<annotation cp="🥦" type="tts">broccoli</annotation>
 		<annotation cp="🧄">flavoring | garlic</annotation>
 		<annotation cp="🧄" type="tts">garlic</annotation>
@@ -2110,11 +2104,11 @@ annotations.
 		<annotation cp="🫚" type="tts">ginger root</annotation>
 		<annotation cp="🫛">beans | beanstalk | edamame | legume | pea | pod | soybean | vegetable | veggie</annotation> <!-- 1FADB -->
 		<annotation cp="🫛" type="tts">pea pod</annotation>
-		<annotation cp="🍄‍🟫">brown mushroom | food | fungi | fungus | mushroom | nature | pizza toppings | portobello | shiitake | shroom | spore | sprout | toppings | truffle | vegetable | vegetarian | veggie</annotation> <!-- 1F344 200D 1F7EB -->
+		<annotation cp="🍄‍🟫">food | fungi | fungus | mushroom | nature | pizza | portobello | shiitake | shroom | spore | sprout | toppings | truffle | vegetable | vegetarian | veggie</annotation> <!-- 1F344 200D 1F7EB -->
 		<annotation cp="🍄‍🟫" type="tts">brown mushroom</annotation>
 		<annotation cp="🍞">bread | carbs | food | grain | loaf | restaurant | toast | wheat</annotation>
 		<annotation cp="🍞" type="tts">bread</annotation>
-		<annotation cp="🥐">bread | breakfast | crescent roll | croissant | food | french | roll</annotation>
+		<annotation cp="🥐">bread | breakfast | crescent | croissant | food | french | roll</annotation>
 		<annotation cp="🥐" type="tts">croissant</annotation>
 		<annotation cp="🥖">baguette | bread | food | french</annotation>
 		<annotation cp="🥖" type="tts">baguette bread</annotation>
@@ -2128,23 +2122,23 @@ annotations.
 		<annotation cp="🥞" type="tts">pancakes</annotation>
 		<annotation cp="🧇">breakfast | indecisive | iron | waffle</annotation>
 		<annotation cp="🧇" type="tts">waffle</annotation>
-		<annotation cp="🧀">cheese | cheese wedge</annotation>
+		<annotation cp="🧀">cheese | wedge</annotation>
 		<annotation cp="🧀" type="tts">cheese wedge</annotation>
-		<annotation cp="🍖">bone | meat | meat on bone</annotation>
+		<annotation cp="🍖">bone | meat</annotation>
 		<annotation cp="🍖" type="tts">meat on bone</annotation>
 		<annotation cp="🍗">bone | chicken | drumstick | hungry | leg | poultry | turkey</annotation>
 		<annotation cp="🍗" type="tts">poultry leg</annotation>
-		<annotation cp="🥩">chop | cut of meat | lambchop | meat | porkchop | red meat | steak</annotation>
+		<annotation cp="🥩">chop | cut | lambchop | meat | porkchop | red | steak</annotation>
 		<annotation cp="🥩" type="tts">cut of meat</annotation>
 		<annotation cp="🥓">bacon | breakfast | food | meat</annotation>
 		<annotation cp="🥓" type="tts">bacon</annotation>
-		<annotation cp="🍔">burger | eat | fast food | food | hamburger | hungry</annotation>
+		<annotation cp="🍔">burger | eat | fast | food | hamburger | hungry</annotation>
 		<annotation cp="🍔" type="tts">hamburger</annotation>
-		<annotation cp="🍟">fast food | food | french | fries</annotation>
+		<annotation cp="🍟">fast | food | french | fries</annotation>
 		<annotation cp="🍟" type="tts">french fries</annotation>
 		<annotation cp="🍕">cheese | food | hungry | pepperoni | pizza | slice</annotation>
 		<annotation cp="🍕" type="tts">pizza</annotation>
-		<annotation cp="🌭">frankfurter | hot dog | hotdog | sausage</annotation>
+		<annotation cp="🌭">dog | frankfurter | hot | hotdog | sausage</annotation>
 		<annotation cp="🌭" type="tts">hot dog</annotation>
 		<annotation cp="🥪">bread | sandwich</annotation>
 		<annotation cp="🥪" type="tts">sandwich</annotation>
@@ -2160,25 +2154,25 @@ annotations.
 		<annotation cp="🧆" type="tts">falafel</annotation>
 		<annotation cp="🥚">breakfast | egg | food</annotation>
 		<annotation cp="🥚" type="tts">egg</annotation>
-		<annotation cp="🍳">breakfast | cooking | egg | fry | frying | over easy | pan | restaurant | sunny side up</annotation>
+		<annotation cp="🍳">breakfast | cooking | easy | egg | fry | frying | over | pan | restaurant | side | sunny | up</annotation>
 		<annotation cp="🍳" type="tts">cooking</annotation>
-		<annotation cp="🥘">casserole | food | paella | pan | shallow | shallow pan of food</annotation>
+		<annotation cp="🥘">casserole | food | paella | pan | shallow</annotation>
 		<annotation cp="🥘" type="tts">shallow pan of food</annotation>
-		<annotation cp="🍲">food | pot | pot of food | soup | stew</annotation>
+		<annotation cp="🍲">food | pot | soup | stew</annotation>
 		<annotation cp="🍲" type="tts">pot of food</annotation>
 		<annotation cp="🫕">cheese | chocolate | fondue | food | melted | pot | ski</annotation>
 		<annotation cp="🫕" type="tts">fondue</annotation>
-		<annotation cp="🥣">bowl with spoon | breakfast | cereal | congee | oatmeal | porridge</annotation>
+		<annotation cp="🥣">bowl | breakfast | cereal | congee | oatmeal | porridge | spoon</annotation>
 		<annotation cp="🥣" type="tts">bowl with spoon</annotation>
 		<annotation cp="🥗">food | green | salad</annotation>
 		<annotation cp="🥗" type="tts">green salad</annotation>
-		<annotation cp="🍿">movie | popcorn</annotation>
+		<annotation cp="🍿">movie | popcorn | pop | corn</annotation>
 		<annotation cp="🍿" type="tts">popcorn</annotation>
 		<annotation cp="🧈">butter | dairy</annotation>
 		<annotation cp="🧈" type="tts">butter</annotation>
 		<annotation cp="🧂">condiment | flavor | mad | salt | salty | shaker | taste | upset</annotation>
 		<annotation cp="🧂" type="tts">salt</annotation>
-		<annotation cp="🥫">can | canned food</annotation>
+		<annotation cp="🥫">can | canned | food</annotation>
 		<annotation cp="🥫" type="tts">canned food</annotation>
 		<annotation cp="🍱">bento | box | food</annotation>
 		<annotation cp="🍱" type="tts">bento box</annotation>
@@ -2202,17 +2196,17 @@ annotations.
 		<annotation cp="🍣" type="tts">sushi</annotation>
 		<annotation cp="🍤">fried | prawn | shrimp | tempura</annotation>
 		<annotation cp="🍤" type="tts">fried shrimp</annotation>
-		<annotation cp="🍥">cake | fish | fish cake with swirl | food | pastry | restaurant | swirl</annotation>
+		<annotation cp="🍥">cake | fish | food | pastry | restaurant | swirl</annotation>
 		<annotation cp="🍥" type="tts">fish cake with swirl</annotation>
-		<annotation cp="🥮">autumn | festival | moon cake | yuèbǐng</annotation>
+		<annotation cp="🥮">autumn | cake | festival | moon | yuèbǐng</annotation>
 		<annotation cp="🥮" type="tts">moon cake</annotation>
 		<annotation cp="🍡">dango | dessert | Japanese | skewer | stick | sweet</annotation>
 		<annotation cp="🍡" type="tts">dango</annotation>
 		<annotation cp="🥟">dumpling | empanada | gyōza | jiaozi | pierogi | potsticker</annotation>
 		<annotation cp="🥟" type="tts">dumpling</annotation>
-		<annotation cp="🥠">fortune cookie | prophecy</annotation>
+		<annotation cp="🥠">cookie | fortune | prophecy</annotation>
 		<annotation cp="🥠" type="tts">fortune cookie</annotation>
-		<annotation cp="🥡">chopsticks | food delivery | oyster pail | takeout box</annotation>
+		<annotation cp="🥡">box | chopsticks | delivery | food | oyster | pail | takeout</annotation>
 		<annotation cp="🥡" type="tts">takeout box</annotation>
 		<annotation cp="🦀">Cancer | crab | zodiac</annotation>
 		<annotation cp="🦀" type="tts">crab</annotation>
@@ -2220,11 +2214,11 @@ annotations.
 		<annotation cp="🦞" type="tts">lobster</annotation>
 		<annotation cp="🦐">food | shellfish | shrimp | small</annotation>
 		<annotation cp="🦐" type="tts">shrimp</annotation>
-		<annotation cp="🦑">animal | food | molusc | squid</annotation>
+		<annotation cp="🦑">animal | food | mollusk | squid</annotation>
 		<annotation cp="🦑" type="tts">squid</annotation>
 		<annotation cp="🦪">diving | oyster | pearl</annotation>
 		<annotation cp="🦪" type="tts">oyster</annotation>
-		<annotation cp="🍦">cream | dessert | food | ice | icecream | restaurant | soft | soft serve | sweet</annotation>
+		<annotation cp="🍦">cream | dessert | food | ice | icecream | restaurant | serve | soft | sweet</annotation>
 		<annotation cp="🍦" type="tts">soft ice cream</annotation>
 		<annotation cp="🍧">dessert | ice | restaurant | shaved | sweet</annotation>
 		<annotation cp="🍧" type="tts">shaved ice</annotation>
@@ -2232,21 +2226,21 @@ annotations.
 		<annotation cp="🍨" type="tts">ice cream</annotation>
 		<annotation cp="🍩">breakfast | dessert | donut | doughnut | food | sweet</annotation>
 		<annotation cp="🍩" type="tts">doughnut</annotation>
-		<annotation cp="🍪">chocolate chip | cookie | dessert | sweet</annotation>
+		<annotation cp="🍪">chip | chocolate | cookie | dessert | sweet</annotation>
 		<annotation cp="🍪" type="tts">cookie</annotation>
-		<annotation cp="🎂">birthday | cake | celebration | dessert | happy bday | happy birthday | pastry | sweet</annotation>
+		<annotation cp="🎂">bday | birthday | cake | celebration | dessert | happy | pastry | sweet</annotation>
 		<annotation cp="🎂" type="tts">birthday cake</annotation>
 		<annotation cp="🍰">cake | dessert | pastry | shortcake | slice | sweet</annotation>
 		<annotation cp="🍰" type="tts">shortcake</annotation>
 		<annotation cp="🧁">bakery | cupcake | dessert | sprinkles | sugar | sweet | treat</annotation>
 		<annotation cp="🧁" type="tts">cupcake</annotation>
-		<annotation cp="🥧">apple pie | filling | fruit | meat | pastry | pie | pumpkin pie | slice of pie</annotation>
+		<annotation cp="🥧">apple | filling | fruit | meat | pastry | pie | pumpkin | slice</annotation>
 		<annotation cp="🥧" type="tts">pie</annotation>
-		<annotation cp="🍫">bar | candy | chocolate | dessert | halloween | sweet | sweet tooth</annotation>
+		<annotation cp="🍫">bar | candy | chocolate | dessert | halloween | sweet | tooth</annotation>
 		<annotation cp="🍫" type="tts">chocolate bar</annotation>
-		<annotation cp="🍬">candy | cavities | dessert | halloween | restaurant | sweet | sweet tooth | wrapper</annotation>
+		<annotation cp="🍬">candy | cavities | dessert | halloween | restaurant | sweet | tooth | wrapper</annotation>
 		<annotation cp="🍬" type="tts">candy</annotation>
-		<annotation cp="🍭">candy | confectionary | dessert | food | lollipop | restaurant | sweet</annotation>
+		<annotation cp="🍭">candy | dessert | food | lollipop | restaurant | sweet</annotation>
 		<annotation cp="🍭" type="tts">lollipop</annotation>
 		<annotation cp="🍮">custard | dessert | pudding | sweet</annotation>
 		<annotation cp="🍮" type="tts">custard</annotation>
@@ -2254,35 +2248,35 @@ annotations.
 		<annotation cp="🍯" type="tts">honey pot</annotation>
 		<annotation cp="🍼">babies | baby | birth | born | bottle | drink | infant | milk | newborn</annotation>
 		<annotation cp="🍼" type="tts">baby bottle</annotation>
-		<annotation cp="🥛">drink | glass | glass of milk | milk</annotation>
+		<annotation cp="🥛">drink | glass | milk</annotation>
 		<annotation cp="🥛" type="tts">glass of milk</annotation>
-		<annotation cp="☕">beverage | cafe | caffeine | coffee | drink | hot | morning | steaming | tea</annotation>
+		<annotation cp="☕">beverage | cafe | caffeine | chai | coffee | drink | hot | morning | steaming | tea</annotation>
 		<annotation cp="☕" type="tts">hot beverage</annotation>
 		<annotation cp="🫖">brew | drink | food | pot | tea | teapot</annotation>
 		<annotation cp="🫖" type="tts">teapot</annotation>
-		<annotation cp="🍵">beverage | cup | drink | oolong | tea | teacup | teacup without handle</annotation>
+		<annotation cp="🍵">beverage | cup | drink | handle | oolong | tea | teacup</annotation>
 		<annotation cp="🍵" type="tts">teacup without handle</annotation>
 		<annotation cp="🍶">bar | beverage | bottle | cup | drink | restaurant | sake</annotation>
 		<annotation cp="🍶" type="tts">sake</annotation>
-		<annotation cp="🍾">bar | bottle | bottle with popping cork | cork | drink | popping</annotation>
+		<annotation cp="🍾">bar | bottle | cork | drink | popping</annotation>
 		<annotation cp="🍾" type="tts">bottle with popping cork</annotation>
 		<annotation cp="🍷">alcohol | bar | beverage | booze | club | drink | drinking | drinks | glass | restaurant | wine</annotation>
 		<annotation cp="🍷" type="tts">wine glass</annotation>
-		<annotation cp="🍸">alcohol | bar | booze | club | cocktail | drink | drinking | drinks | glass | mad men | martini</annotation>
+		<annotation cp="🍸">alcohol | bar | booze | club | cocktail | drink | drinking | drinks | glass | mad | martini | men</annotation>
 		<annotation cp="🍸" type="tts">cocktail glass</annotation>
-		<annotation cp="🍹">alcohol | bar | booze | club | cocktail | drink | drinking | drinks | drunk | mai tai | party | tropical | tropics</annotation>
+		<annotation cp="🍹">alcohol | bar | booze | club | cocktail | drink | drinking | drinks | drunk | mai | party | tai | tropical | tropics</annotation>
 		<annotation cp="🍹" type="tts">tropical drink</annotation>
-		<annotation cp="🍺">alcohol | bar | beer | booze | drink | drinking | drinks | mug | octoberfest | oktoberfest | pint | stein | summer ale</annotation>
+		<annotation cp="🍺">alcohol | ale | bar | beer | booze | drink | drinking | drinks | mug | octoberfest | oktoberfest | pint | stein | summer</annotation>
 		<annotation cp="🍺" type="tts">beer mug</annotation>
-		<annotation cp="🍻">alcohol | bar | beer | booze | bottoms up | cheers | clink | clinking beer mugs | drink | drinking | drinks | mug</annotation>
+		<annotation cp="🍻">alcohol | bar | beer | booze | bottoms | cheers | clink | clinking | drinking | drinks | mugs</annotation>
 		<annotation cp="🍻" type="tts">clinking beer mugs</annotation>
-		<annotation cp="🥂">celebrate | clink | clinking glasses | drink | glass</annotation>
+		<annotation cp="🥂">celebrate | clink | clinking | drink | glass | glasses</annotation>
 		<annotation cp="🥂" type="tts">clinking glasses</annotation>
 		<annotation cp="🥃">glass | liquor | scotch | shot | tumbler | whiskey | whisky</annotation>
 		<annotation cp="🥃" type="tts">tumbler glass</annotation>
-		<annotation cp="🫗">accident | drink | empty | glass | oops | pour | pouring liquid | spill | water</annotation> <!-- 1FAD7 -->
+		<annotation cp="🫗">accident | drink | empty | glass | liquid | oops | pour | pouring | spill | water</annotation> <!-- 1FAD7 -->
 		<annotation cp="🫗" type="tts">pouring liquid</annotation>
-		<annotation cp="🥤">cup with straw | juice | malt | soda | soft drink | water</annotation>
+		<annotation cp="🥤">cup | drink | juice | malt | soda | soft | straw | water</annotation>
 		<annotation cp="🥤" type="tts">cup with straw</annotation>
 		<annotation cp="🧋">boba | bubble | food | milk | pearl | tea</annotation>
 		<annotation cp="🧋" type="tts">bubble tea</annotation>
@@ -2290,59 +2284,59 @@ annotations.
 		<annotation cp="🧃" type="tts">beverage box</annotation>
 		<annotation cp="🧉">drink | mate</annotation>
 		<annotation cp="🧉" type="tts">mate</annotation>
-		<annotation cp="🧊">cold | ice | ice cube | iceberg</annotation>
+		<annotation cp="🧊">cold | cube | ice | iceberg</annotation>
 		<annotation cp="🧊" type="tts">ice</annotation>
 		<annotation cp="🥢">chopsticks | hashi | jeotgarak | kuaizi</annotation>
 		<annotation cp="🥢" type="tts">chopsticks</annotation>
-		<annotation cp="🍽">cooking | dinner | eat | fork | fork and knife with plate | knife | plate</annotation>
+		<annotation cp="🍽">cooking | dinner | eat | fork | knife | plate</annotation>
 		<annotation cp="🍽" type="tts">fork and knife with plate</annotation>
-		<annotation cp="🍴">breakfast | breaky | cooking | cutlery | delicious | dinner | eat | feed | food | fork | fork and knife | hungry | knife | lunch | restaurant | yum | yummy</annotation>
+		<annotation cp="🍴">breakfast | breaky | cooking | cutlery | delicious | dinner | eat | feed | food | fork | hungry | knife | lunch | restaurant | yum | yummy</annotation>
 		<annotation cp="🍴" type="tts">fork and knife</annotation>
 		<annotation cp="🥄">eat | spoon | tableware</annotation>
 		<annotation cp="🥄" type="tts">spoon</annotation>
-		<annotation cp="🔪">chef | cooking | hocho | kitchen knife | knife | tool | weapon</annotation>
+		<annotation cp="🔪">chef | cooking | hocho | kitchen | knife | tool | weapon</annotation>
 		<annotation cp="🔪" type="tts">kitchen knife</annotation>
 		<annotation cp="🫙">condiment | container | empty | jar | nothing | sauce | store</annotation> <!-- 1FAD9 -->
 		<annotation cp="🫙" type="tts">jar</annotation>
 		<annotation cp="🏺">amphora | Aquarius | cooking | drink | jug | tool | weapon | zodiac</annotation>
 		<annotation cp="🏺" type="tts">amphora</annotation>
-		<annotation cp="🌍">Africa | earth | Europe | globe | globe showing Europe-Africa | world</annotation>
+		<annotation cp="🌍">Africa | earth | Europe | Europe-Africa | globe | showing | world</annotation>
 		<annotation cp="🌍" type="tts">globe showing Europe-Africa</annotation>
-		<annotation cp="🌎">Americas | earth | globe | globe showing Americas | world</annotation>
+		<annotation cp="🌎">Americas | earth | globe | showing | world</annotation>
 		<annotation cp="🌎" type="tts">globe showing Americas</annotation>
-		<annotation cp="🌏">Asia | Australia | earth | globe | globe showing Asia-Australia | world</annotation>
+		<annotation cp="🌏">Asia | Asia-Australia | Australia | earth | globe | showing | world</annotation>
 		<annotation cp="🌏" type="tts">globe showing Asia-Australia</annotation>
-		<annotation cp="🌐">earth | globe | globe with meridians | internet | meridians | world | worldwide web</annotation>
+		<annotation cp="🌐">earth | globe | internet | meridians | web | world | worldwide</annotation>
 		<annotation cp="🌐" type="tts">globe with meridians</annotation>
 		<annotation cp="🗺">map | world</annotation>
 		<annotation cp="🗺" type="tts">world map</annotation>
-		<annotation cp="🗾">Japan | map | map of Japan</annotation>
+		<annotation cp="🗾">Japan | map</annotation>
 		<annotation cp="🗾" type="tts">map of Japan</annotation>
 		<annotation cp="🧭">compass | direction | magnetic | navigation | orienteering</annotation>
 		<annotation cp="🧭" type="tts">compass</annotation>
-		<annotation cp="🏔">cold | mountain | snow | snow-capped mountain</annotation>
+		<annotation cp="🏔">cold | mountain | snow | snow-capped</annotation>
 		<annotation cp="🏔" type="tts">snow-capped mountain</annotation>
 		<annotation cp="⛰">mountain</annotation>
 		<annotation cp="⛰" type="tts">mountain</annotation>
 		<annotation cp="🌋">eruption | mountain | nature | volcano</annotation>
 		<annotation cp="🌋" type="tts">volcano</annotation>
-		<annotation cp="🗻">fuji | mount fuji | mountain | nature</annotation>
+		<annotation cp="🗻">fuji | mount | mountain | nature</annotation>
 		<annotation cp="🗻" type="tts">mount fuji</annotation>
 		<annotation cp="🏕">camping</annotation>
 		<annotation cp="🏕" type="tts">camping</annotation>
-		<annotation cp="🏖">beach | beach with umbrella | umbrella</annotation>
+		<annotation cp="🏖">beach | umbrella</annotation>
 		<annotation cp="🏖" type="tts">beach with umbrella</annotation>
 		<annotation cp="🏜">desert</annotation>
 		<annotation cp="🏜" type="tts">desert</annotation>
 		<annotation cp="🏝">desert | island</annotation>
 		<annotation cp="🏝" type="tts">desert island</annotation>
-		<annotation cp="🏞">national park | park</annotation>
+		<annotation cp="🏞">national | park</annotation>
 		<annotation cp="🏞" type="tts">national park</annotation>
 		<annotation cp="🏟">stadium</annotation>
 		<annotation cp="🏟" type="tts">stadium</annotation>
-		<annotation cp="🏛">classical | classical building</annotation>
+		<annotation cp="🏛">building | classical</annotation>
 		<annotation cp="🏛" type="tts">classical building</annotation>
-		<annotation cp="🏗">building construction | construction | crane</annotation>
+		<annotation cp="🏗">building | construction | crane</annotation>
 		<annotation cp="🏗" type="tts">building construction</annotation>
 		<annotation cp="🧱">brick | bricks | clay | mortar | wall</annotation>
 		<annotation cp="🧱" type="tts">brick</annotation>
@@ -2356,15 +2350,15 @@ annotations.
 		<annotation cp="🏘" type="tts">houses</annotation>
 		<annotation cp="🏚">derelict | home | house</annotation>
 		<annotation cp="🏚" type="tts">derelict house</annotation>
-		<annotation cp="🏠">building | country home | home | house | ranch | settle down | simple home | suburban | suburbia | where the heart is</annotation>
+		<annotation cp="🏠">building | country | heart | home | house | ranch | settle | simple | suburban | suburbia | where</annotation>
 		<annotation cp="🏠" type="tts">house</annotation>
-		<annotation cp="🏡">building | country home | garden | home | house | house with garden | ranch | settle down | simple home | suburban | suburbia | where the heart is</annotation>
+		<annotation cp="🏡">building | country | garden | heart | home | house | ranch | settle | simple | suburban | suburbia | where</annotation>
 		<annotation cp="🏡" type="tts">house with garden</annotation>
 		<annotation cp="🏢">building | city | cubical | job | office</annotation>
 		<annotation cp="🏢" type="tts">office building</annotation>
-		<annotation cp="🏣">building | Japanese | Japanese post office | post</annotation>
+		<annotation cp="🏣">building | Japanese | office | post</annotation>
 		<annotation cp="🏣" type="tts">Japanese post office</annotation>
-		<annotation cp="🏤">building | European | post | post office</annotation>
+		<annotation cp="🏤">building | European | office | post</annotation>
 		<annotation cp="🏤" type="tts">post office</annotation>
 		<annotation cp="🏥">building | doctor | hospital | medicine</annotation>
 		<annotation cp="🏥" type="tts">hospital</annotation>
@@ -2374,7 +2368,7 @@ annotations.
 		<annotation cp="🏨" type="tts">hotel</annotation>
 		<annotation cp="🏩">building | hotel | love</annotation>
 		<annotation cp="🏩" type="tts">love hotel</annotation>
-		<annotation cp="🏪">24 | 24 hours | building | convenience | store</annotation>
+		<annotation cp="🏪">24 | building | convenience | hours | store</annotation>
 		<annotation cp="🏪" type="tts">convenience store</annotation>
 		<annotation cp="🏫">building | school</annotation>
 		<annotation cp="🏫" type="tts">school</annotation>
@@ -2386,11 +2380,11 @@ annotations.
 		<annotation cp="🏯" type="tts">Japanese castle</annotation>
 		<annotation cp="🏰">building | castle | European</annotation>
 		<annotation cp="🏰" type="tts">castle</annotation>
-		<annotation cp="💒">chapel | hitched | nuptuals | romance | wedding</annotation>
+		<annotation cp="💒">chapel | hitched | nuptials | romance | wedding</annotation>
 		<annotation cp="💒" type="tts">wedding</annotation>
 		<annotation cp="🗼">Tokyo | tower</annotation>
 		<annotation cp="🗼" type="tts">Tokyo tower</annotation>
-		<annotation cp="🗽">liberty | new york | ny | nyc | statue | Statue of Liberty</annotation>
+		<annotation cp="🗽">liberty | Liberty | new | ny | nyc | statue | Statue | york</annotation>
 		<annotation cp="🗽" type="tts">Statue of Liberty</annotation>
 		<annotation cp="⛪">bless | chapel | Christian | church | cross | religion</annotation>
 		<annotation cp="⛪" type="tts">church</annotation>
@@ -2410,31 +2404,31 @@ annotations.
 		<annotation cp="⛺" type="tts">tent</annotation>
 		<annotation cp="🌁">fog | foggy</annotation>
 		<annotation cp="🌁" type="tts">foggy</annotation>
-		<annotation cp="🌃">night | night with stars | star</annotation>
+		<annotation cp="🌃">night | star | stars</annotation>
 		<annotation cp="🌃" type="tts">night with stars</annotation>
 		<annotation cp="🏙">city | cityscape</annotation>
 		<annotation cp="🏙" type="tts">cityscape</annotation>
-		<annotation cp="🌄">morning | mountain | sun | sunrise | sunrise over mountains</annotation>
+		<annotation cp="🌄">morning | mountains | over | sun | sunrise</annotation>
 		<annotation cp="🌄" type="tts">sunrise over mountains</annotation>
 		<annotation cp="🌅">morning | nature | sun | sunrise</annotation>
 		<annotation cp="🌅" type="tts">sunrise</annotation>
-		<annotation cp="🌆">building | city | cityscape at dusk | dusk | evening | landscape | sun | sunset</annotation>
+		<annotation cp="🌆">at | building | city | cityscape | dusk | evening | landscape | sun | sunset</annotation>
 		<annotation cp="🌆" type="tts">cityscape at dusk</annotation>
 		<annotation cp="🌇">building | dusk | sun | sunset</annotation>
 		<annotation cp="🌇" type="tts">sunset</annotation>
-		<annotation cp="🌉">bridge | bridge at night | night</annotation>
+		<annotation cp="🌉">at | bridge | night</annotation>
 		<annotation cp="🌉" type="tts">bridge at night</annotation>
 		<annotation cp="♨">hot | hotsprings | springs | steaming</annotation>
 		<annotation cp="♨" type="tts">hot springs</annotation>
 		<annotation cp="🎠">carousel | entertainment | horse</annotation>
 		<annotation cp="🎠" type="tts">carousel horse</annotation>
-		<annotation cp="🛝">amusement park | play | playground | playing | slide | sliding | theme park</annotation> <!-- 1F6DD -->
+		<annotation cp="🛝">amusement | park | play | playground | playing | slide | sliding | theme</annotation> <!-- 1F6DD -->
 		<annotation cp="🛝" type="tts">playground slide</annotation>
-		<annotation cp="🎡">amusement | ferris | park | theme park | wheel</annotation>
+		<annotation cp="🎡">amusement | ferris | park | theme | wheel</annotation>
 		<annotation cp="🎡" type="tts">ferris wheel</annotation>
-		<annotation cp="🎢">amusement | coaster | park | roller | theme park</annotation>
+		<annotation cp="🎢">amusement | coaster | park | roller | theme</annotation>
 		<annotation cp="🎢" type="tts">roller coaster</annotation>
-		<annotation cp="💈">barber | fresh cut | haircut | pole | shave</annotation>
+		<annotation cp="💈">barber | cut | fresh | haircut | pole | shave</annotation>
 		<annotation cp="💈" type="tts">barber pole</annotation>
 		<annotation cp="🎪">circus | tent</annotation>
 		<annotation cp="🎪" type="tts">circus tent</annotation>
@@ -2442,15 +2436,15 @@ annotations.
 		<annotation cp="🚂" type="tts">locomotive</annotation>
 		<annotation cp="🚃">car | electric | railway | train | tram | travel | trolleybus</annotation>
 		<annotation cp="🚃" type="tts">railway car</annotation>
-		<annotation cp="🚄">high-speed train | railway | shinkansen | speed | train</annotation>
+		<annotation cp="🚄">high-speed | railway | shinkansen | speed | train</annotation>
 		<annotation cp="🚄" type="tts">high-speed train</annotation>
-		<annotation cp="🚅">bullet | high-speed train with bullet nose | railway | shinkansen | speed | train | travel</annotation>
+		<annotation cp="🚅">bullet | high-speed | nose | railway | shinkansen | speed | train | travel</annotation>
 		<annotation cp="🚅" type="tts">bullet train</annotation>
-		<annotation cp="🚆">arrived | choo choo | railway | train</annotation>
+		<annotation cp="🚆">arrived | choo | railway | train</annotation>
 		<annotation cp="🚆" type="tts">train</annotation>
 		<annotation cp="🚇">metro | subway | travel</annotation>
 		<annotation cp="🚇" type="tts">metro</annotation>
-		<annotation cp="🚈">arrived | light rail | monorail | railway</annotation>
+		<annotation cp="🚈">arrived | light | monorail | rail | railway</annotation>
 		<annotation cp="🚈" type="tts">light rail</annotation>
 		<annotation cp="🚉">railway | station | train</annotation>
 		<annotation cp="🚉" type="tts">station</annotation>
@@ -2478,21 +2472,21 @@ annotations.
 		<annotation cp="🚓" type="tts">police car</annotation>
 		<annotation cp="🚔">car | oncoming | police</annotation>
 		<annotation cp="🚔" type="tts">oncoming police car</annotation>
-		<annotation cp="🚕">cab | cabbie | car | drive | taxi | vehicle | yellow taxi</annotation>
+		<annotation cp="🚕">cab | cabbie | car | drive | taxi | vehicle | yellow</annotation>
 		<annotation cp="🚕" type="tts">taxi</annotation>
-		<annotation cp="🚖">cab | cabbie | cars | drove | hail a cab | oncoming | taxi | yellow cab | yellow taxi</annotation>
+		<annotation cp="🚖">cab | cabbie | cars | drove | hail | oncoming | taxi | yellow</annotation>
 		<annotation cp="🚖" type="tts">oncoming taxi</annotation>
 		<annotation cp="🚗">automobile | car | driving | vehicle</annotation>
 		<annotation cp="🚗" type="tts">automobile</annotation>
 		<annotation cp="🚘">automobile | car | cars | drove | oncoming | vehicle</annotation>
 		<annotation cp="🚘" type="tts">oncoming automobile</annotation>
-		<annotation cp="🚙">car | drive | recreational | sport utility | sport utility vehicle | sportutility | vehicle</annotation>
+		<annotation cp="🚙">car | drive | recreational | sport | sportutility | utility | vehicle</annotation>
 		<annotation cp="🚙" type="tts">sport utility vehicle</annotation>
 		<annotation cp="🛻">automobile | car | flatbed | pick-up | pickup | transportation | truck</annotation>
 		<annotation cp="🛻" type="tts">pickup truck</annotation>
 		<annotation cp="🚚">car | delivery | drive | truck | vehicle</annotation>
 		<annotation cp="🚚" type="tts">delivery truck</annotation>
-		<annotation cp="🚛">articulated lorry | car | drive | lorry | move | semi | truck | vehicle</annotation>
+		<annotation cp="🚛">articulated | car | drive | lorry | move | semi | truck | vehicle</annotation>
 		<annotation cp="🚛" type="tts">articulated lorry</annotation>
 		<annotation cp="🚜">tractor | vehicle</annotation>
 		<annotation cp="🚜" type="tts">tractor</annotation>
@@ -2502,25 +2496,25 @@ annotations.
 		<annotation cp="🏍" type="tts">motorcycle</annotation>
 		<annotation cp="🛵">motor | scooter</annotation>
 		<annotation cp="🛵" type="tts">motor scooter</annotation>
-		<annotation cp="🦽">accessibility | manual wheelchair</annotation>
+		<annotation cp="🦽">accessibility | manual | wheelchair</annotation>
 		<annotation cp="🦽" type="tts">manual wheelchair</annotation>
-		<annotation cp="🦼">accessibility | motorized wheelchair</annotation>
+		<annotation cp="🦼">accessibility | motorized | wheelchair</annotation>
 		<annotation cp="🦼" type="tts">motorized wheelchair</annotation>
-		<annotation cp="🛺">auto rickshaw | tuk tuk</annotation>
+		<annotation cp="🛺">auto | rickshaw | tuk</annotation>
 		<annotation cp="🛺" type="tts">auto rickshaw</annotation>
-		<annotation cp="🚲">bicycle | bike | bike gang | cycle | cycling | cyclist | ride | spin class | spinning</annotation>
+		<annotation cp="🚲">bicycle | bike | class | cycle | cycling | cyclist | gang | ride | spin | spinning</annotation>
 		<annotation cp="🚲" type="tts">bicycle</annotation>
 		<annotation cp="🛴">kick | scooter</annotation>
 		<annotation cp="🛴" type="tts">kick scooter</annotation>
 		<annotation cp="🛹">board | skate | skateboard | skater | wheels</annotation>
 		<annotation cp="🛹" type="tts">skateboard</annotation>
-		<annotation cp="🛼">blades | roller | roller skates | skate | sport</annotation>
+		<annotation cp="🛼">blades | roller | skate | skates | sport</annotation>
 		<annotation cp="🛼" type="tts">roller skate</annotation>
 		<annotation cp="🚏">bus | busstop | stop</annotation>
 		<annotation cp="🚏" type="tts">bus stop</annotation>
 		<annotation cp="🛣">highway | motorway | road</annotation>
 		<annotation cp="🛣" type="tts">motorway</annotation>
-		<annotation cp="🛤">railway | railway track | train</annotation>
+		<annotation cp="🛤">railway | track | train</annotation>
 		<annotation cp="🛤" type="tts">railway track</annotation>
 		<annotation cp="🛢">drum | oil</annotation>
 		<annotation cp="🛢" type="tts">oil drum</annotation>
@@ -2530,9 +2524,9 @@ annotations.
 		<annotation cp="🛞" type="tts">wheel</annotation>
 		<annotation cp="🚨">alarm | alert | beacon | car | emergency | light | police | revolving | siren</annotation>
 		<annotation cp="🚨" type="tts">police car light</annotation>
-		<annotation cp="🚥">horizontal traffic light | intersection | light | signal | stop light | stoplight | traffic</annotation>
+		<annotation cp="🚥">horizontal | intersection | light | signal | stop | stoplight | traffic</annotation>
 		<annotation cp="🚥" type="tts">horizontal traffic light</annotation>
-		<annotation cp="🚦">drove | intersection | light | signal | stop light | stoplight | traffic | vertical traffic light</annotation>
+		<annotation cp="🚦">drove | intersection | light | signal | stop | stoplight | traffic | vertical</annotation>
 		<annotation cp="🚦" type="tts">vertical traffic light</annotation>
 		<annotation cp="🛑">octagonal | sign | stop</annotation>
 		<annotation cp="🛑" type="tts">stop sign</annotation>
@@ -2540,7 +2534,7 @@ annotations.
 		<annotation cp="🚧" type="tts">construction</annotation>
 		<annotation cp="⚓">anchor | ship | tool</annotation>
 		<annotation cp="⚓" type="tts">anchor</annotation>
-		<annotation cp="🛟">buoy | float | life preserver | life saver | lifesaver | rescue | ring buoy | safety | save | swim</annotation> <!-- 1F6DF -->
+		<annotation cp="🛟">buoy | float | life | lifesaver | preserver | rescue | ring | safety | save | saver | swim</annotation> <!-- 1F6DF -->
 		<annotation cp="🛟" type="tts">ring buoy</annotation>
 		<annotation cp="⛵">boat | resort | sailboat | sailing | sea | yacht</annotation>
 		<annotation cp="⛵" type="tts">sailboat</annotation>
@@ -2552,17 +2546,17 @@ annotations.
 		<annotation cp="🛳" type="tts">passenger ship</annotation>
 		<annotation cp="⛴">boat | ferry | passenger</annotation>
 		<annotation cp="⛴" type="tts">ferry</annotation>
-		<annotation cp="🛥">boat | motor boat | motorboat</annotation>
+		<annotation cp="🛥">boat | motor | motorboat</annotation>
 		<annotation cp="🛥" type="tts">motor boat</annotation>
 		<annotation cp="🚢">boat | passenger | ship | travel</annotation>
 		<annotation cp="🚢" type="tts">ship</annotation>
 		<annotation cp="✈">aeroplane | airplane | fly | flying | jet | plane | travel</annotation>
 		<annotation cp="✈" type="tts">airplane</annotation>
-		<annotation cp="🛩">aeroplane | airplane | plane | small airplane</annotation>
+		<annotation cp="🛩">aeroplane | airplane | plane | small</annotation>
 		<annotation cp="🛩" type="tts">small airplane</annotation>
 		<annotation cp="🛫">aeroplane | airplane | check-in | departure | departures | plane</annotation>
 		<annotation cp="🛫" type="tts">airplane departure</annotation>
-		<annotation cp="🛬">aeroplane | airplane | airplane arrival | arrivals | arriving | landing | plane</annotation>
+		<annotation cp="🛬">aeroplane | airplane | arrival | arrivals | arriving | landing | plane</annotation>
 		<annotation cp="🛬" type="tts">airplane arrival</annotation>
 		<annotation cp="🪂">hang-glide | parachute | parasail | skydive</annotation>
 		<annotation cp="🪂" type="tts">parachute</annotation>
@@ -2572,7 +2566,7 @@ annotations.
 		<annotation cp="🚁" type="tts">helicopter</annotation>
 		<annotation cp="🚟">railway | suspension</annotation>
 		<annotation cp="🚟" type="tts">suspension railway</annotation>
-		<annotation cp="🚠">cable | gondola | mountain | mountain cableway | ski lift</annotation>
+		<annotation cp="🚠">cable | cableway | gondola | lift | mountain | ski</annotation>
 		<annotation cp="🚠" type="tts">mountain cableway</annotation>
 		<annotation cp="🚡">aerial | cable | car | gondola | ropeway | tramway</annotation>
 		<annotation cp="🚡" type="tts">aerial tramway</annotation>
@@ -2580,15 +2574,15 @@ annotations.
 		<annotation cp="🛰" type="tts">satellite</annotation>
 		<annotation cp="🚀">launch | rocket | rockets | space | travel</annotation>
 		<annotation cp="🚀" type="tts">rocket</annotation>
-		<annotation cp="🛸">aliens | extra | extra terrestrial | flying saucer | UFO</annotation>
+		<annotation cp="🛸">aliens | extra | flying | saucer | terrestrial | UFO</annotation>
 		<annotation cp="🛸" type="tts">flying saucer</annotation>
 		<annotation cp="🛎">bell | bellhop | hotel</annotation>
 		<annotation cp="🛎" type="tts">bellhop bell</annotation>
-		<annotation cp="🧳">luggage | packing | roller bag | suitcase | travel</annotation>
+		<annotation cp="🧳">bag | luggage | packing | roller | suitcase | travel</annotation>
 		<annotation cp="🧳" type="tts">luggage</annotation>
-		<annotation cp="⌛">hourglass | hourglass done | sand | time | timer</annotation>
+		<annotation cp="⌛">done | hourglass | sand | time | timer</annotation>
 		<annotation cp="⌛" type="tts">hourglass done</annotation>
-		<annotation cp="⏳">hourglass | hourglass not done | hourglass with flowing sand | hours | sand | timer | waiting | yolo</annotation>
+		<annotation cp="⏳">done | flowing | hourglass | hours | not | sand | timer | waiting | yolo</annotation>
 		<annotation cp="⏳" type="tts">hourglass not done</annotation>
 		<annotation cp="⌚">clock | time | watch</annotation>
 		<annotation cp="⌚" type="tts">watch</annotation>
@@ -2598,61 +2592,61 @@ annotations.
 		<annotation cp="⏱" type="tts">stopwatch</annotation>
 		<annotation cp="⏲">clock | timer</annotation>
 		<annotation cp="⏲" type="tts">timer clock</annotation>
-		<annotation cp="🕰">clock | mantelpiece clock | time</annotation>
+		<annotation cp="🕰">clock | mantelpiece | time</annotation>
 		<annotation cp="🕰" type="tts">mantelpiece clock</annotation>
-		<annotation cp="🕛">00 | 12 | 12:00 | clock | o’clock | time | twelve</annotation>
+		<annotation cp="🕛">12 | 12:00 | clock | o’clock | time | twelve</annotation>
 		<annotation cp="🕛" type="tts">twelve o’clock</annotation>
 		<annotation cp="🕧">12 | 12:30 | 30 | clock | thirty | time | twelve | twelve-thirty</annotation>
 		<annotation cp="🕧" type="tts">twelve-thirty</annotation>
-		<annotation cp="🕐">00 | 1 | 1:00 | clock | o’clock | one | time</annotation>
+		<annotation cp="🕐">1 | 1:00 | clock | o’clock | one | time</annotation>
 		<annotation cp="🕐" type="tts">one o’clock</annotation>
 		<annotation cp="🕜">1 | 1:30 | 30 | clock | one | one-thirty | thirty | time</annotation>
 		<annotation cp="🕜" type="tts">one-thirty</annotation>
-		<annotation cp="🕑">00 | 2 | 2:00 | clock | o’clock | time | two</annotation>
+		<annotation cp="🕑">2 | 2:00 | clock | o’clock | time | two</annotation>
 		<annotation cp="🕑" type="tts">two o’clock</annotation>
 		<annotation cp="🕝">2 | 2:30 | 30 | clock | thirty | time | two | two-thirty</annotation>
 		<annotation cp="🕝" type="tts">two-thirty</annotation>
-		<annotation cp="🕒">00 | 3 | 3:00 | clock | o’clock | three | time</annotation>
+		<annotation cp="🕒">3 | 3:00 | clock | o’clock | three | time</annotation>
 		<annotation cp="🕒" type="tts">three o’clock</annotation>
 		<annotation cp="🕞">3 | 3:30 | 30 | clock | thirty | three | three-thirty | time</annotation>
 		<annotation cp="🕞" type="tts">three-thirty</annotation>
-		<annotation cp="🕓">00 | 4 | 4:00 | clock | four | o’clock | time</annotation>
+		<annotation cp="🕓">4 | 4:00 | clock | four | o’clock | time</annotation>
 		<annotation cp="🕓" type="tts">four o’clock</annotation>
 		<annotation cp="🕟">30 | 4 | 4:30 | clock | four | four-thirty | thirty | time</annotation>
 		<annotation cp="🕟" type="tts">four-thirty</annotation>
-		<annotation cp="🕔">00 | 5 | 5:00 | clock | five | o’clock | time</annotation>
+		<annotation cp="🕔">5 | 5:00 | clock | five | o’clock | time</annotation>
 		<annotation cp="🕔" type="tts">five o’clock</annotation>
 		<annotation cp="🕠">30 | 5 | 5:30 | clock | five | five-thirty | thirty | time</annotation>
 		<annotation cp="🕠" type="tts">five-thirty</annotation>
-		<annotation cp="🕕">00 | 6 | 6:00 | clock | o’clock | six | time</annotation>
+		<annotation cp="🕕">6 | 6:00 | clock | o’clock | six | time</annotation>
 		<annotation cp="🕕" type="tts">six o’clock</annotation>
 		<annotation cp="🕡">30 | 6 | 6:30 | clock | six | six-thirty | thirty</annotation>
 		<annotation cp="🕡" type="tts">six-thirty</annotation>
-		<annotation cp="🕖">00 | 7 | 7:00 | clock | o’clock | seven</annotation>
+		<annotation cp="🕖">0 | 7 | 7:00 | clock | o’clock | seven</annotation>
 		<annotation cp="🕖" type="tts">seven o’clock</annotation>
 		<annotation cp="🕢">30 | 7 | 7:30 | clock | seven | seven-thirty | thirty</annotation>
 		<annotation cp="🕢" type="tts">seven-thirty</annotation>
-		<annotation cp="🕗">00 | 8 | 8:00 | clock | eight | o’clock | time</annotation>
+		<annotation cp="🕗">8 | 8:00 | clock | eight | o’clock | time</annotation>
 		<annotation cp="🕗" type="tts">eight o’clock</annotation>
 		<annotation cp="🕣">30 | 8 | 8:30 | clock | eight | eight-thirty | thirty | time</annotation>
 		<annotation cp="🕣" type="tts">eight-thirty</annotation>
-		<annotation cp="🕘">00 | 9 | 9:00 | clock | nine | o’clock | time</annotation>
+		<annotation cp="🕘">9 | 9:00 | clock | nine | o’clock | time</annotation>
 		<annotation cp="🕘" type="tts">nine o’clock</annotation>
 		<annotation cp="🕤">30 | 9 | 9:30 | clock | nine | nine-thirty | thirty | time</annotation>
 		<annotation cp="🕤" type="tts">nine-thirty</annotation>
-		<annotation cp="🕙">00 | 10 | 10:00 | clock | o’clock | ten</annotation>
+		<annotation cp="🕙">0 | 10 | 10:00 | clock | o’clock | ten</annotation>
 		<annotation cp="🕙" type="tts">ten o’clock</annotation>
 		<annotation cp="🕥">10 | 10:30 | 30 | clock | ten | ten-thirty | thirty | time</annotation>
 		<annotation cp="🕥" type="tts">ten-thirty</annotation>
-		<annotation cp="🕚">00 | 11 | 11:00 | clock | eleven | o’clock | time</annotation>
+		<annotation cp="🕚">11 | 11:00 | clock | eleven | o’clock | time</annotation>
 		<annotation cp="🕚" type="tts">eleven o’clock</annotation>
 		<annotation cp="🕦">11 | 11:30 | 30 | clock | eleven | eleven-thirty | thirty | time</annotation>
 		<annotation cp="🕦" type="tts">eleven-thirty</annotation>
-		<annotation cp="🌑">dark | moon | new moon | space</annotation>
+		<annotation cp="🌑">dark | moon | new | space</annotation>
 		<annotation cp="🌑" type="tts">new moon</annotation>
 		<annotation cp="🌒">crescent | dreams | moon | space | waxing</annotation>
 		<annotation cp="🌒" type="tts">waxing crescent moon</annotation>
-		<annotation cp="🌓">first quarter moon | moon | quarter | space</annotation>
+		<annotation cp="🌓">first | moon | quarter | space</annotation>
 		<annotation cp="🌓" type="tts">first quarter moon</annotation>
 		<annotation cp="🌔">gibbous | moon | space | waxing</annotation>
 		<annotation cp="🌔" type="tts">waxing gibbous moon</annotation>
@@ -2660,53 +2654,53 @@ annotations.
 		<annotation cp="🌕" type="tts">full moon</annotation>
 		<annotation cp="🌖">gibbous | moon | space | waning</annotation>
 		<annotation cp="🌖" type="tts">waning gibbous moon</annotation>
-		<annotation cp="🌗">last quarter moon | moon | quarter | space</annotation>
+		<annotation cp="🌗">last | moon | quarter | space</annotation>
 		<annotation cp="🌗" type="tts">last quarter moon</annotation>
 		<annotation cp="🌘">crescent | moon | space | waning</annotation>
 		<annotation cp="🌘" type="tts">waning crescent moon</annotation>
 		<annotation cp="🌙">crescent | moon | ramadan | space</annotation>
 		<annotation cp="🌙" type="tts">crescent moon</annotation>
-		<annotation cp="🌚">face | moon | new moon face | space</annotation>
+		<annotation cp="🌚">face | moon | new | space</annotation>
 		<annotation cp="🌚" type="tts">new moon face</annotation>
-		<annotation cp="🌛">face | first quarter moon face | first quarter moon with face | moon | quarter | space</annotation>
+		<annotation cp="🌛">face | first | moon | quarter | space</annotation>
 		<annotation cp="🌛" type="tts">first quarter moon face</annotation>
-		<annotation cp="🌜">dreams | face | last quarter moon face | last quarter moon with face | moon | quarter</annotation>
+		<annotation cp="🌜">dreams | face | last | moon | quarter</annotation>
 		<annotation cp="🌜" type="tts">last quarter moon face</annotation>
 		<annotation cp="🌡">thermometer | weather</annotation>
 		<annotation cp="🌡" type="tts">thermometer</annotation>
 		<annotation cp="☀">bright | rays | space | sun | sunny | weather</annotation>
 		<annotation cp="☀" type="tts">sun</annotation>
-		<annotation cp="🌝">bright | face | full | full moon with face | moon</annotation>
+		<annotation cp="🌝">bright | face | full | moon</annotation>
 		<annotation cp="🌝" type="tts">full moon face</annotation>
-		<annotation cp="🌞">beach | bright | day | face | heat | shine | sun | sun with face | sunny | sunshine | weather</annotation>
+		<annotation cp="🌞">beach | bright | day | face | heat | shine | sun | sunny | sunshine | weather</annotation>
 		<annotation cp="🌞" type="tts">sun with face</annotation>
-		<annotation cp="🪐">ringed planet | saturn | saturnine</annotation>
+		<annotation cp="🪐">planet | ringed | saturn | saturnine</annotation>
 		<annotation cp="🪐" type="tts">ringed planet</annotation>
-		<annotation cp="⭐">astronomy | star | stars | white medium star</annotation>
+		<annotation cp="⭐">astronomy | medium | star | stars | white</annotation>
 		<annotation cp="⭐" type="tts">star</annotation>
-		<annotation cp="🌟">glittery | glow | glowing star | night | shining | sparkle | star | win</annotation>
+		<annotation cp="🌟">glittery | glow | glowing | night | shining | sparkle | star | win</annotation>
 		<annotation cp="🌟" type="tts">glowing star</annotation>
 		<annotation cp="🌠">falling | night | shooting | space | star</annotation>
 		<annotation cp="🌠" type="tts">shooting star</annotation>
-		<annotation cp="🌌">milky way | space</annotation>
+		<annotation cp="🌌">milky | space | way</annotation>
 		<annotation cp="🌌" type="tts">milky way</annotation>
 		<annotation cp="☁">cloud | weather</annotation>
 		<annotation cp="☁" type="tts">cloud</annotation>
-		<annotation cp="⛅">cloud | cloudy | sun | sun behind cloud | weather</annotation>
+		<annotation cp="⛅">behind | cloud | cloudy | sun | weather</annotation>
 		<annotation cp="⛅" type="tts">sun behind cloud</annotation>
-		<annotation cp="⛈">cloud | cloud with lightning and rain | rain | thunder | thunderstorm</annotation>
+		<annotation cp="⛈">cloud | lightning | rain | thunder | thunderstorm</annotation>
 		<annotation cp="⛈" type="tts">cloud with lightning and rain</annotation>
-		<annotation cp="🌤">cloud | sun | sun behind small cloud | weather</annotation>
+		<annotation cp="🌤">behind | cloud | sun | weather</annotation>
 		<annotation cp="🌤" type="tts">sun behind small cloud</annotation>
-		<annotation cp="🌥">cloud | sun | sun behind large cloud | weather</annotation>
+		<annotation cp="🌥">behind | cloud | sun | weather</annotation>
 		<annotation cp="🌥" type="tts">sun behind large cloud</annotation>
-		<annotation cp="🌦">cloud | rain | sun | sun behind rain cloud | weather</annotation>
+		<annotation cp="🌦">behind | cloud | rain | sun | weather</annotation>
 		<annotation cp="🌦" type="tts">sun behind rain cloud</annotation>
-		<annotation cp="🌧">cloud | cloud with rain | rain | weather</annotation>
+		<annotation cp="🌧">cloud | rain | weather</annotation>
 		<annotation cp="🌧" type="tts">cloud with rain</annotation>
-		<annotation cp="🌨">cloud | cloud with snow | cold | snow | weather</annotation>
+		<annotation cp="🌨">cloud | cold | snow | weather</annotation>
 		<annotation cp="🌨" type="tts">cloud with snow</annotation>
-		<annotation cp="🌩">cloud | cloud with lightning | lightning | weather</annotation>
+		<annotation cp="🌩">cloud | lightning | weather</annotation>
 		<annotation cp="🌩" type="tts">cloud with lightning</annotation>
 		<annotation cp="🌪">cloud | tornado | weather | whirlwind</annotation>
 		<annotation cp="🌪" type="tts">tornado</annotation>
@@ -2716,27 +2710,27 @@ annotations.
 		<annotation cp="🌬" type="tts">wind face</annotation>
 		<annotation cp="🌀">cyclone | dizzy | hurricane | twister | typhoon | weather</annotation>
 		<annotation cp="🌀" type="tts">cyclone</annotation>
-		<annotation cp="🌈">bisexual | gay | genderqueer | glbt | glbtq | lesbian | lgbt | lgbtq | lgbtqia | nature | pride | queer | rain | rainbow | trans | transgender | weather</annotation>
+		<annotation cp="🌈">gay | genderqueer | glbt | glbtq | lesbian | lgbt | lgbtq | lgbtqia | nature | pride | queer | rain | rainbow | trans | transgender | weather</annotation>
 		<annotation cp="🌈" type="tts">rainbow</annotation>
-		<annotation cp="🌂">closed umbrella | clothing | rain | umbrella</annotation>
+		<annotation cp="🌂">closed | clothing | rain | umbrella</annotation>
 		<annotation cp="🌂" type="tts">closed umbrella</annotation>
 		<annotation cp="☂">clothing | rain | umbrella</annotation>
 		<annotation cp="☂" type="tts">umbrella</annotation>
-		<annotation cp="☔">clothing | drop | rain | umbrella | umbrella with rain drops | weather</annotation>
+		<annotation cp="☔">clothing | drop | drops | rain | umbrella | weather</annotation>
 		<annotation cp="☔" type="tts">umbrella with rain drops</annotation>
-		<annotation cp="⛱">rain | sun | umbrella | umbrella on ground</annotation>
+		<annotation cp="⛱">ground | rain | sun | umbrella</annotation>
 		<annotation cp="⛱" type="tts">umbrella on ground</annotation>
-		<annotation cp="⚡">danger | electric | electricity | high voltage | lightning | nature | thunder | thunderbolt | voltage | zap</annotation>
+		<annotation cp="⚡">danger | electric | electricity | high | lightning | nature | thunder | thunderbolt | voltage | zap</annotation>
 		<annotation cp="⚡" type="tts">high voltage</annotation>
 		<annotation cp="❄">cold | snow | snowflake | weather</annotation>
 		<annotation cp="❄" type="tts">snowflake</annotation>
-		<annotation cp="☃">cold | snow | snowman</annotation>
+		<annotation cp="☃">cold | snow | snowman | man</annotation>
 		<annotation cp="☃" type="tts">snowman</annotation>
-		<annotation cp="⛄">cold | snow | snowman | snowman without snow</annotation>
+		<annotation cp="⛄">cold | snow | snowman | man</annotation>
 		<annotation cp="⛄" type="tts">snowman without snow</annotation>
 		<annotation cp="☄">comet | space</annotation>
 		<annotation cp="☄" type="tts">comet</annotation>
-		<annotation cp="🔥">burn | fire | flame | hot | lit | lit af | litaf | tool</annotation>
+		<annotation cp="🔥">af | burn | fire | flame | hot | lit | litaf | tool</annotation>
 		<annotation cp="🔥" type="tts">fire</annotation>
 		<annotation cp="💧">cold | comic | drop | droplet | nature | sad | sweat | tear | water | weather</annotation>
 		<annotation cp="💧" type="tts">droplet</annotation>
@@ -2760,19 +2754,19 @@ annotations.
 		<annotation cp="🎉" type="tts">party popper</annotation>
 		<annotation cp="🎊">ball | celebrate | celebration | confetti | party | woohoo</annotation>
 		<annotation cp="🎊" type="tts">confetti ball</annotation>
-		<annotation cp="🎋">banner | celebration | Japanese | tanabata tree | tree</annotation>
+		<annotation cp="🎋">banner | celebration | Japanese | tanabata | tree</annotation>
 		<annotation cp="🎋" type="tts">tanabata tree</annotation>
-		<annotation cp="🎍">bamboo | celebration | Japanese | pine | pine decoration | plant</annotation>
+		<annotation cp="🎍">bamboo | celebration | decoration | Japanese | pine | plant</annotation>
 		<annotation cp="🎍" type="tts">pine decoration</annotation>
-		<annotation cp="🎎">celebration | doll | festival | Japanese | Japanese dolls</annotation>
+		<annotation cp="🎎">celebration | doll | dolls | festival | Japanese</annotation>
 		<annotation cp="🎎" type="tts">Japanese dolls</annotation>
 		<annotation cp="🎏">carp | celebration | streamer</annotation>
 		<annotation cp="🎏" type="tts">carp streamer</annotation>
 		<annotation cp="🎐">bell | celebration | chime | wind</annotation>
 		<annotation cp="🎐" type="tts">wind chime</annotation>
-		<annotation cp="🎑">celebration | ceremony | moon | moon viewing ceremony</annotation>
+		<annotation cp="🎑">celebration | ceremony | moon | viewing</annotation>
 		<annotation cp="🎑" type="tts">moon viewing ceremony</annotation>
-		<annotation cp="🧧">gift | good luck | hóngbāo | lai see | money | red envelope</annotation>
+		<annotation cp="🧧">envelope | gift | good | hóngbāo | lai | luck | money | red | see</annotation>
 		<annotation cp="🧧" type="tts">red envelope</annotation>
 		<annotation cp="🎀">celebration | ribbon</annotation>
 		<annotation cp="🎀" type="tts">ribbon</annotation>
@@ -2780,7 +2774,7 @@ annotations.
 		<annotation cp="🎁" type="tts">wrapped gift</annotation>
 		<annotation cp="🎗">celebration | reminder | ribbon</annotation>
 		<annotation cp="🎗" type="tts">reminder ribbon</annotation>
-		<annotation cp="🎟">admission | admission tickets | ticket</annotation>
+		<annotation cp="🎟">admission | ticket | tickets</annotation>
 		<annotation cp="🎟" type="tts">admission tickets</annotation>
 		<annotation cp="🎫">admission | stub | ticket</annotation>
 		<annotation cp="🎫" type="tts">ticket</annotation>
@@ -2788,13 +2782,13 @@ annotations.
 		<annotation cp="🎖" type="tts">military medal</annotation>
 		<annotation cp="🏆">champion | champs | prize | slay | sport | trophy | victory | win | winning</annotation>
 		<annotation cp="🏆" type="tts">trophy</annotation>
-		<annotation cp="🏅">award | gold | medal | sports medal | winner</annotation>
+		<annotation cp="🏅">award | gold | medal | sports | winner</annotation>
 		<annotation cp="🏅" type="tts">sports medal</annotation>
-		<annotation cp="🥇">1st place medal | first | gold | medal</annotation>
+		<annotation cp="🥇">1st | first | gold | medal | place</annotation>
 		<annotation cp="🥇" type="tts">1st place medal</annotation>
-		<annotation cp="🥈">2nd place medal | medal | second | silver</annotation>
+		<annotation cp="🥈">2nd | medal | place | second | silver</annotation>
 		<annotation cp="🥈" type="tts">2nd place medal</annotation>
-		<annotation cp="🥉">3rd place medal | bronze | medal | third</annotation>
+		<annotation cp="🥉">3rd | bronze | medal | place | third</annotation>
 		<annotation cp="🥉" type="tts">3rd place medal</annotation>
 		<annotation cp="⚽">ball | football | futbol | soccer | sport</annotation>
 		<annotation cp="⚽" type="tts">soccer ball</annotation>
@@ -2806,13 +2800,13 @@ annotations.
 		<annotation cp="🏀" type="tts">basketball</annotation>
 		<annotation cp="🏐">ball | game | volleyball</annotation>
 		<annotation cp="🏐" type="tts">volleyball</annotation>
-		<annotation cp="🏈">american | ball | football | sport | super bowl</annotation>
+		<annotation cp="🏈">american | ball | bowl | football | sport | super</annotation>
 		<annotation cp="🏈" type="tts">american football</annotation>
 		<annotation cp="🏉">ball | football | rugby | sport</annotation>
 		<annotation cp="🏉" type="tts">rugby football</annotation>
 		<annotation cp="🎾">ball | racquet | sport | tennis</annotation>
 		<annotation cp="🎾" type="tts">tennis</annotation>
-		<annotation cp="🥏">disc | flying disc | ultimate</annotation>
+		<annotation cp="🥏">disc | flying | ultimate</annotation>
 		<annotation cp="🥏" type="tts">flying disc</annotation>
 		<annotation cp="🎳">ball | bowling | game | sport | strike</annotation>
 		<annotation cp="🎳" type="tts">bowling</annotation>
@@ -2824,23 +2818,23 @@ annotations.
 		<annotation cp="🏒" type="tts">ice hockey</annotation>
 		<annotation cp="🥍">ball | goal | lacrosse | sports | stick</annotation>
 		<annotation cp="🥍" type="tts">lacrosse</annotation>
-		<annotation cp="🏓">ball | bat | game | paddle | ping pong | pingpong | table tennis</annotation>
+		<annotation cp="🏓">ball | bat | game | paddle | ping | pingpong | pong | table | tennis</annotation>
 		<annotation cp="🏓" type="tts">ping pong</annotation>
 		<annotation cp="🏸">badminton | birdie | game | racquet | shuttlecock</annotation>
 		<annotation cp="🏸" type="tts">badminton</annotation>
 		<annotation cp="🥊">boxing | glove</annotation>
 		<annotation cp="🥊" type="tts">boxing glove</annotation>
-		<annotation cp="🥋">judo | karate | martial arts | martial arts uniform | taekwondo | uniform</annotation>
+		<annotation cp="🥋">arts | judo | karate | martial | taekwondo | uniform</annotation>
 		<annotation cp="🥋" type="tts">martial arts uniform</annotation>
 		<annotation cp="🥅">goal | net</annotation>
 		<annotation cp="🥅" type="tts">goal net</annotation>
-		<annotation cp="⛳">flag in hole | golf | hole | sport</annotation>
+		<annotation cp="⛳">flag | golf | hole | sport</annotation>
 		<annotation cp="⛳" type="tts">flag in hole</annotation>
 		<annotation cp="⛸">ice | skate | skating</annotation>
 		<annotation cp="⛸" type="tts">ice skate</annotation>
-		<annotation cp="🎣">entertainment | fish | fishing pole | pole | sport</annotation>
+		<annotation cp="🎣">entertainment | fish | fishing | pole | sport</annotation>
 		<annotation cp="🎣" type="tts">fishing pole</annotation>
-		<annotation cp="🤿">diving | diving mask | scuba | snorkeling</annotation>
+		<annotation cp="🤿">diving | mask | scuba | snorkeling</annotation>
 		<annotation cp="🤿" type="tts">diving mask</annotation>
 		<annotation cp="🎽">athletics | running | sash | shirt</annotation>
 		<annotation cp="🎽" type="tts">running shirt</annotation>
@@ -2848,9 +2842,9 @@ annotations.
 		<annotation cp="🎿" type="tts">skis</annotation>
 		<annotation cp="🛷">luge | sled | sledge | sleigh | snow | toboggan</annotation>
 		<annotation cp="🛷" type="tts">sled</annotation>
-		<annotation cp="🥌">curling stone | game | rock</annotation>
+		<annotation cp="🥌">curling | game | rock | stone</annotation>
 		<annotation cp="🥌" type="tts">curling stone</annotation>
-		<annotation cp="🎯">bull | bullseye | dart | direct hit | entertainment | game | hit | target</annotation>
+		<annotation cp="🎯">bull | bullseye | dart | direct | entertainment | game | hit | target</annotation>
 		<annotation cp="🎯" type="tts">bullseye</annotation>
 		<annotation cp="🪀">fluctuate | toy | yo-yo</annotation>
 		<annotation cp="🪀" type="tts">yo-yo</annotation>
@@ -2858,51 +2852,51 @@ annotations.
 		<annotation cp="🪁" type="tts">kite</annotation>
 		<annotation cp="🔫">gun | handgun | pistol | revolver | tool | water | weapon</annotation>
 		<annotation cp="🔫" type="tts">water pistol</annotation>
-		<annotation cp="🎱">8 | 8ball | ball | billiard | eight | game | pool 8 ball</annotation>
+		<annotation cp="🎱">8 | 8ball | ball | billiard | eight | game | pool</annotation>
 		<annotation cp="🎱" type="tts">pool 8 ball</annotation>
-		<annotation cp="🔮">ball | crystal | fairy tale | fairytale | fantasy | fortune | future | magic | tool</annotation>
+		<annotation cp="🔮">ball | crystal | fairy | fairytale | fantasy | fortune | future | magic | tale | tool</annotation>
 		<annotation cp="🔮" type="tts">crystal ball</annotation>
 		<annotation cp="🪄">magic | magician | wand | witch | wizard</annotation>
 		<annotation cp="🪄" type="tts">magic wand</annotation>
-		<annotation cp="🎮">controller | entertainment | game | video game</annotation>
+		<annotation cp="🎮">controller | entertainment | game | video</annotation>
 		<annotation cp="🎮" type="tts">video game</annotation>
-		<annotation cp="🕹">game | joystick | video game | videogame</annotation>
+		<annotation cp="🕹">game | joystick | video | videogame</annotation>
 		<annotation cp="🕹" type="tts">joystick</annotation>
-		<annotation cp="🎰">casino | gamble | gambling | game | slot | slot machine | slots</annotation>
+		<annotation cp="🎰">casino | gamble | gambling | game | machine | slot | slots</annotation>
 		<annotation cp="🎰" type="tts">slot machine</annotation>
 		<annotation cp="🎲">dice | die | entertainment | game</annotation>
 		<annotation cp="🎲" type="tts">game die</annotation>
 		<annotation cp="🧩">clue | interlocking | jigsaw | piece | puzzle</annotation>
 		<annotation cp="🧩" type="tts">puzzle piece</annotation>
-		<annotation cp="🧸">bear | plaything | plush | stuffed | teddy bear | toy</annotation>
+		<annotation cp="🧸">bear | plaything | plush | stuffed | teddy | toy</annotation>
 		<annotation cp="🧸" type="tts">teddy bear</annotation>
-		<annotation cp="🪅">candy | celebrate | celebration | cinco de mayo | festive | party | pinada | pinata | piñata</annotation>
+		<annotation cp="🪅">candy | celebrate | celebration | cinco | de | festive | mayo | party | pinada | pinata | piñata</annotation>
 		<annotation cp="🪅" type="tts">piñata</annotation>
 		<annotation cp="🪩">ball | dance | disco | glitter | mirror | party</annotation> <!-- 1FAA9 -->
 		<annotation cp="🪩" type="tts">mirror ball</annotation>
 		<annotation cp="🪆">babooshka | baboushka | babushka | doll | dolls | matryoshka | nesting | russia</annotation>
 		<annotation cp="🪆" type="tts">nesting dolls</annotation>
-		<annotation cp="♠">card | game | spade | spade suit</annotation>
+		<annotation cp="♠">card | game | spade | suit</annotation>
 		<annotation cp="♠" type="tts">spade suit</annotation>
-		<annotation cp="♥">card | emotion | game | heart | heart suit | hearts</annotation>
+		<annotation cp="♥">card | emotion | game | heart | hearts | suit</annotation>
 		<annotation cp="♥" type="tts">heart suit</annotation>
-		<annotation cp="♦">card | diamond | diamond suit | game</annotation>
+		<annotation cp="♦">card | diamond | game | suit</annotation>
 		<annotation cp="♦" type="tts">diamond suit</annotation>
-		<annotation cp="♣">card | club | club suit | clubs | game</annotation>
+		<annotation cp="♣">card | club | clubs | game | suit</annotation>
 		<annotation cp="♣" type="tts">club suit</annotation>
-		<annotation cp="♟">chess | chess pawn | dupe | expendable</annotation>
+		<annotation cp="♟">chess | dupe | expendable | pawn</annotation>
 		<annotation cp="♟" type="tts">chess pawn</annotation>
 		<annotation cp="🃏">card | game | joker | wildcard</annotation>
 		<annotation cp="🃏" type="tts">joker</annotation>
-		<annotation cp="🀄">game | mahjong | mahjong red dragon | red</annotation>
+		<annotation cp="🀄">dragon | game | mahjong | red</annotation>
 		<annotation cp="🀄" type="tts">mahjong red dragon</annotation>
-		<annotation cp="🎴">card | flower | flower playing cards | game | Japanese | playing</annotation>
+		<annotation cp="🎴">card | cards | flower | game | Japanese | playing</annotation>
 		<annotation cp="🎴" type="tts">flower playing cards</annotation>
-		<annotation cp="🎭">actor | actress | art | entertainment | mask | performing | performing arts | theater | theatre | thespian</annotation>
+		<annotation cp="🎭">actor | actress | art | arts | entertainment | mask | performing | theater | theatre | thespian</annotation>
 		<annotation cp="🎭" type="tts">performing arts</annotation>
-		<annotation cp="🖼">art | frame | framed picture | museum | painting | picture</annotation>
+		<annotation cp="🖼">art | frame | framed | museum | painting | picture</annotation>
 		<annotation cp="🖼" type="tts">framed picture</annotation>
-		<annotation cp="🎨">art | artist palette | artsy | arty | colorful | creative | entertainment | museum | painter | painting | palette</annotation>
+		<annotation cp="🎨">art | artist | artsy | arty | colorful | creative | entertainment | museum | painter | painting | palette</annotation>
 		<annotation cp="🎨" type="tts">artist palette</annotation>
 		<annotation cp="🧵">needle | sewing | spool | string | thread</annotation>
 		<annotation cp="🧵" type="tts">thread</annotation>
@@ -2916,9 +2910,9 @@ annotations.
 		<annotation cp="👓" type="tts">glasses</annotation>
 		<annotation cp="🕶">dark | eye | eyewear | glasses | sunglasses</annotation>
 		<annotation cp="🕶" type="tts">sunglasses</annotation>
-		<annotation cp="🥽">dive | eye protection | goggles | scuba | swimming | welding</annotation>
+		<annotation cp="🥽">dive | eye | goggles | protection | scuba | swimming | welding</annotation>
 		<annotation cp="🥽" type="tts">goggles</annotation>
-		<annotation cp="🥼">clothes | doctor | dr | experiment | jacket | lab coat | scientist | white coat</annotation>
+		<annotation cp="🥼">clothes | coat | doctor | dr | experiment | jacket | lab | scientist | white</annotation>
 		<annotation cp="🥼" type="tts">lab coat</annotation>
 		<annotation cp="🦺">emergency | safety | vest</annotation>
 		<annotation cp="🦺" type="tts">safety vest</annotation>
@@ -2928,11 +2922,11 @@ annotations.
 		<annotation cp="👕" type="tts">t-shirt</annotation>
 		<annotation cp="👖">blue | casual | clothes | clothing | denim | dressed | jeans | pants | shopping | trousers | weekend</annotation>
 		<annotation cp="👖" type="tts">jeans</annotation>
-		<annotation cp="🧣">bundle up | cold | neck | scarf</annotation>
+		<annotation cp="🧣">bundle | cold | neck | scarf | up</annotation>
 		<annotation cp="🧣" type="tts">scarf</annotation>
 		<annotation cp="🧤">gloves | hand</annotation>
 		<annotation cp="🧤" type="tts">gloves</annotation>
-		<annotation cp="🧥">brr | bundle up | coat | cold | jacket</annotation>
+		<annotation cp="🧥">brr | bundle | coat | cold | jacket | up</annotation>
 		<annotation cp="🧥" type="tts">coat</annotation>
 		<annotation cp="🧦">socks | stocking</annotation>
 		<annotation cp="🧦" type="tts">socks</annotation>
@@ -2942,61 +2936,61 @@ annotations.
 		<annotation cp="👘" type="tts">kimono</annotation>
 		<annotation cp="🥻">clothing | dress | sari</annotation>
 		<annotation cp="🥻" type="tts">sari</annotation>
-		<annotation cp="🩱">bathing suit | one-piece swimsuit | swimsuit</annotation>
+		<annotation cp="🩱">bathing | one-piece | suit | swimsuit</annotation>
 		<annotation cp="🩱" type="tts">one-piece swimsuit</annotation>
-		<annotation cp="🩲">bathing suit | briefs | one-piece | swimsuit | underwear</annotation>
+		<annotation cp="🩲">bathing | briefs | one-piece | suit | swimsuit | underwear</annotation>
 		<annotation cp="🩲" type="tts">briefs</annotation>
-		<annotation cp="🩳">bathing suit | pants | shorts | swimsuit | underwear</annotation>
+		<annotation cp="🩳">bathing | pants | shorts | suit | swimsuit | underwear</annotation>
 		<annotation cp="🩳" type="tts">shorts</annotation>
-		<annotation cp="👙">bathing suit | beach | bikini | clothing | pool | swim</annotation>
+		<annotation cp="👙">bathing | beach | bikini | clothing | pool | suit | swim</annotation>
 		<annotation cp="👙" type="tts">bikini</annotation>
-		<annotation cp="👚">blouse | clothes | clothing | collar | dress | dressed | lady | shirt | shopping | woman | woman’s clothes</annotation>
+		<annotation cp="👚">blouse | clothes | clothing | collar | dress | dressed | lady | shirt | shopping | woman | woman’s</annotation>
 		<annotation cp="👚" type="tts">woman’s clothes</annotation>
-		<annotation cp="🪭">clack | clap | cool off | cooling | dance | fan | flirt | flutter | folding hand fan | hot | shy</annotation> <!-- 1FAAD -->
+		<annotation cp="🪭">clack | clap | cool | cooling | dance | fan | flirt | flutter | folding | hand | hot | shy</annotation> <!-- 1FAAD -->
 		<annotation cp="🪭" type="tts">folding hand fan</annotation>
 		<annotation cp="👛">clothes | clothing | coin | dress | fancy | handbag | purse | shopping</annotation>
 		<annotation cp="👛" type="tts">purse</annotation>
 		<annotation cp="👜">bag | clothes | clothing | dress | handbag | lady | purse | shopping</annotation>
 		<annotation cp="👜" type="tts">handbag</annotation>
-		<annotation cp="👝">bag | clothes | clothing | clutch bag | dress | handbag | pouch | purse</annotation>
+		<annotation cp="👝">bag | clothes | clothing | clutch | dress | handbag | pouch | purse</annotation>
 		<annotation cp="👝" type="tts">clutch bag</annotation>
-		<annotation cp="🛍">bag | hotel | shopping | shopping bags</annotation>
+		<annotation cp="🛍">bag | bags | hotel | shopping</annotation>
 		<annotation cp="🛍" type="tts">shopping bags</annotation>
 		<annotation cp="🎒">backpack | backpacking | bag | bookbag | education | rucksack | satchel | school</annotation>
 		<annotation cp="🎒" type="tts">backpack</annotation>
-		<annotation cp="🩴">beach | flip flop | sandal | sandals | shoe | thong sandal | thong sandals | thongs | zōri</annotation>
+		<annotation cp="🩴">beach | flip | flop | sandal | sandals | shoe | thong | thongs | zōri</annotation>
 		<annotation cp="🩴" type="tts">thong sandal</annotation>
-		<annotation cp="👞">brown | clothes | clothing | feet | foot | kick | man | man’s shoe | shoe | shoes | shopping</annotation>
+		<annotation cp="👞">brown | clothes | clothing | feet | foot | kick | man | man’s | shoe | shoes | shopping</annotation>
 		<annotation cp="👞" type="tts">man’s shoe</annotation>
 		<annotation cp="👟">athletic | clothes | clothing | fast | kick | running | shoe | shoes | shopping | sneaker | tennis</annotation>
 		<annotation cp="👟" type="tts">running shoe</annotation>
-		<annotation cp="🥾">backpacking | boot | brown shoe | camping | hiking | outdoors | shoe</annotation>
+		<annotation cp="🥾">backpacking | boot | brown | camping | hiking | outdoors | shoe</annotation>
 		<annotation cp="🥾" type="tts">hiking boot</annotation>
-		<annotation cp="🥿">ballet flat | comfy | flat shoe | flats | slip-on | slipper</annotation>
+		<annotation cp="🥿">ballet | comfy | flat | flats | shoe | slip-on | slipper</annotation>
 		<annotation cp="🥿" type="tts">flat shoe</annotation>
-		<annotation cp="👠">clothes | clothing | dress | fashion | heel | heels | high-heeled shoe | shoe | shoes | shopping | stilletto | woman</annotation>
+		<annotation cp="👠">clothes | clothing | dress | fashion | heel | heels | high-heeled | shoe | shoes | shopping | stiletto | woman</annotation>
 		<annotation cp="👠" type="tts">high-heeled shoe</annotation>
-		<annotation cp="👡">clothing | sandal | shoe | woman | woman’s sandal</annotation>
+		<annotation cp="👡">clothing | sandal | shoe | woman | woman’s</annotation>
 		<annotation cp="👡" type="tts">woman’s sandal</annotation>
-		<annotation cp="🩰">ballet | ballet shoes | dance</annotation>
+		<annotation cp="🩰">ballet | dance | shoes</annotation>
 		<annotation cp="🩰" type="tts">ballet shoes</annotation>
-		<annotation cp="👢">boot | clothes | clothing | dress | shoe | shoes | shopping | woman | woman’s boot</annotation>
+		<annotation cp="👢">boot | clothes | clothing | dress | shoe | shoes | shopping | woman | woman’s</annotation>
 		<annotation cp="👢" type="tts">woman’s boot</annotation>
 		<annotation cp="🪮">Afro | comb | groom | hair | pick</annotation> <!-- 1FAAE -->
 		<annotation cp="🪮" type="tts">hair pick</annotation>
-		<annotation cp="👑">clothing | crown | king | medieval | queen | royal | royal family | royalty | win</annotation>
+		<annotation cp="👑">clothing | crown | family | king | medieval | queen | royal | royalty | win</annotation>
 		<annotation cp="👑" type="tts">crown</annotation>
-		<annotation cp="👒">clothes | clothing | garden party | hat | hats | woman | woman’s hat</annotation>
+		<annotation cp="👒">clothes | clothing | garden | hat | hats | party | woman | woman’s</annotation>
 		<annotation cp="👒" type="tts">woman’s hat</annotation>
 		<annotation cp="🎩">clothes | clothing | fancy | formal | hat | magic | top | tophat</annotation>
 		<annotation cp="🎩" type="tts">top hat</annotation>
 		<annotation cp="🎓">cap | celebration | clothing | education | graduation | hat | scholar</annotation>
 		<annotation cp="🎓" type="tts">graduation cap</annotation>
-		<annotation cp="🧢">baseball cap | bent hat | billed cap | cap | dad cap | dad hat</annotation>
+		<annotation cp="🧢">baseball | bent | billed | cap | dad | hat</annotation>
 		<annotation cp="🧢" type="tts">billed cap</annotation>
 		<annotation cp="🪖">army | helmet | military | soldier | war | warrior</annotation>
 		<annotation cp="🪖" type="tts">military helmet</annotation>
-		<annotation cp="⛑">aid | cross | face | hat | helmet | rescue worker’s helmet</annotation>
+		<annotation cp="⛑">aid | cross | face | hat | helmet | rescue | worker’s</annotation>
 		<annotation cp="⛑" type="tts">rescue worker’s helmet</annotation>
 		<annotation cp="📿">beads | clothing | necklace | prayer | religion</annotation>
 		<annotation cp="📿" type="tts">prayer beads</annotation>
@@ -3004,15 +2998,15 @@ annotations.
 		<annotation cp="💄" type="tts">lipstick</annotation>
 		<annotation cp="💍">diamond | engaged | engagement | married | ring | romance | shiny | sparkling | wedding</annotation>
 		<annotation cp="💍" type="tts">ring</annotation>
-		<annotation cp="💎">diamond | engagement | gem | gem stone | jewel | money | romance | wedding</annotation>
+		<annotation cp="💎">diamond | engagement | gem | jewel | money | romance | stone | wedding</annotation>
 		<annotation cp="💎" type="tts">gem stone</annotation>
-		<annotation cp="🔇">mute | muted speaker | quiet | silent | sound | speaker</annotation>
+		<annotation cp="🔇">mute | muted | quiet | silent | sound | speaker</annotation>
 		<annotation cp="🔇" type="tts">muted speaker</annotation>
-		<annotation cp="🔈">soft | sound | speaker low volume</annotation>
+		<annotation cp="🔈">low | soft | sound | speaker | volume</annotation>
 		<annotation cp="🔈" type="tts">speaker low volume</annotation>
-		<annotation cp="🔉">medium | sound | speaker medium volume</annotation>
+		<annotation cp="🔉">medium | sound | speaker | volume</annotation>
 		<annotation cp="🔉" type="tts">speaker medium volume</annotation>
-		<annotation cp="🔊">high | loud | music | sound | speaker high volume</annotation>
+		<annotation cp="🔊">high | loud | music | sound | speaker | volume</annotation>
 		<annotation cp="🔊" type="tts">speaker high volume</annotation>
 		<annotation cp="📢">address | communication | loud | loudspeaker | public | sound</annotation>
 		<annotation cp="📢" type="tts">loudspeaker</annotation>
@@ -3022,13 +3016,13 @@ annotations.
 		<annotation cp="📯" type="tts">postal horn</annotation>
 		<annotation cp="🔔">bell | break | church | sound</annotation>
 		<annotation cp="🔔" type="tts">bell</annotation>
-		<annotation cp="🔕">bell | bell with slash | forbidden | mute | no | not | prohibited | quiet | silent | sound</annotation>
+		<annotation cp="🔕">bell | forbidden | mute | no | not | prohibited | quiet | silent | slash | sound</annotation>
 		<annotation cp="🔕" type="tts">bell with slash</annotation>
-		<annotation cp="🎼">music | musical score | note | score</annotation>
+		<annotation cp="🎼">music | musical | note | score</annotation>
 		<annotation cp="🎼" type="tts">musical score</annotation>
-		<annotation cp="🎵">music | musical note | note | sound</annotation>
+		<annotation cp="🎵">music | musical | note | sound</annotation>
 		<annotation cp="🎵" type="tts">musical note</annotation>
-		<annotation cp="🎶">music | musical notes | note | notes | sound</annotation>
+		<annotation cp="🎶">music | musical | note | notes | sound</annotation>
 		<annotation cp="🎶" type="tts">musical notes</annotation>
 		<annotation cp="🎙">mic | microphone | music | studio</annotation>
 		<annotation cp="🎙" type="tts">studio microphone</annotation>
@@ -3044,11 +3038,11 @@ annotations.
 		<annotation cp="📻" type="tts">radio</annotation>
 		<annotation cp="🎷">instrument | music | sax | saxophone</annotation>
 		<annotation cp="🎷" type="tts">saxophone</annotation>
-		<annotation cp="🪗">accordion | concertina | instrument | music | squeeze box | squeezebox</annotation>
+		<annotation cp="🪗">accordion | box | concertina | instrument | music | squeeze | squeezebox</annotation>
 		<annotation cp="🪗" type="tts">accordion</annotation>
 		<annotation cp="🎸">guitar | instrument | music | strat</annotation>
 		<annotation cp="🎸" type="tts">guitar</annotation>
-		<annotation cp="🎹">instrument | keyboard | music | musical keyboard | piano</annotation>
+		<annotation cp="🎹">instrument | keyboard | music | musical | piano</annotation>
 		<annotation cp="🎹" type="tts">musical keyboard</annotation>
 		<annotation cp="🎺">instrument | music | trumpet</annotation>
 		<annotation cp="🎺" type="tts">trumpet</annotation>
@@ -3058,15 +3052,15 @@ annotations.
 		<annotation cp="🪕" type="tts">banjo</annotation>
 		<annotation cp="🥁">drum | drumsticks | music</annotation>
 		<annotation cp="🥁" type="tts">drum</annotation>
-		<annotation cp="🪘">beat | conga | drum | instrument | long drum | rhythm</annotation>
+		<annotation cp="🪘">beat | conga | drum | instrument | long | rhythm</annotation>
 		<annotation cp="🪘" type="tts">long drum</annotation>
-		<annotation cp="🪇">cha cha | dance | instrument | maracas | music | party | percussion | rattle | shake | shaker</annotation> <!-- 1FA87 -->
+		<annotation cp="🪇">cha | dance | instrument | maracas | music | party | percussion | rattle | shake | shaker</annotation> <!-- 1FA87 -->
 		<annotation cp="🪇" type="tts">maracas</annotation>
-		<annotation cp="🪈">band | fife | flautist | flute | instrument | marching band | music | orchestra | piccolo | pipe | recorder | woodwind</annotation> <!-- 1FA88 -->
+		<annotation cp="🪈">band | fife | flautist | flute | instrument | marching | music | orchestra | piccolo | pipe | recorder | woodwind</annotation> <!-- 1FA88 -->
 		<annotation cp="🪈" type="tts">flute</annotation>
 		<annotation cp="📱">cell | communication | mobile | phone | telephone</annotation>
 		<annotation cp="📱" type="tts">mobile phone</annotation>
-		<annotation cp="📲">arrow | build | call | cell | communication | mobile | mobile phone with arrow | phone | receive | telephone</annotation>
+		<annotation cp="📲">arrow | build | call | cell | communication | mobile | phone | receive | telephone</annotation>
 		<annotation cp="📲" type="tts">mobile phone with arrow</annotation>
 		<annotation cp="☎">phone | telephone</annotation>
 		<annotation cp="☎" type="tts">telephone</annotation>
@@ -3074,11 +3068,11 @@ annotations.
 		<annotation cp="📞" type="tts">telephone receiver</annotation>
 		<annotation cp="📟">communication | pager</annotation>
 		<annotation cp="📟" type="tts">pager</annotation>
-		<annotation cp="📠">communication | fax | fax machine</annotation>
+		<annotation cp="📠">communication | fax | machine</annotation>
 		<annotation cp="📠" type="tts">fax machine</annotation>
 		<annotation cp="🔋">battery</annotation>
 		<annotation cp="🔋" type="tts">battery</annotation>
-		<annotation cp="🪫">battery | drained | electronic | low battery | low energy | low power</annotation> <!-- 1FAAB -->
+		<annotation cp="🪫">battery | drained | electronic | energy | low | power</annotation> <!-- 1FAAB -->
 		<annotation cp="🪫" type="tts">low battery</annotation>
 		<annotation cp="🔌">electric | electricity | plug</annotation>
 		<annotation cp="🔌" type="tts">electric plug</annotation>
@@ -3090,7 +3084,7 @@ annotations.
 		<annotation cp="🖨" type="tts">printer</annotation>
 		<annotation cp="⌨">computer | keyboard</annotation>
 		<annotation cp="⌨" type="tts">keyboard</annotation>
-		<annotation cp="🖱">computer | computer mouse</annotation>
+		<annotation cp="🖱">computer | mouse</annotation>
 		<annotation cp="🖱" type="tts">computer mouse</annotation>
 		<annotation cp="🖲">computer | trackball</annotation>
 		<annotation cp="🖲" type="tts">trackball</annotation>
@@ -3110,21 +3104,21 @@ annotations.
 		<annotation cp="🎞" type="tts">film frames</annotation>
 		<annotation cp="📽">cinema | film | movie | projector | video</annotation>
 		<annotation cp="📽" type="tts">film projector</annotation>
-		<annotation cp="🎬">action | clapper | clapper board | movie</annotation>
+		<annotation cp="🎬">action | board | clapper | movie</annotation>
 		<annotation cp="🎬" type="tts">clapper board</annotation>
 		<annotation cp="📺">television | tv | video</annotation>
 		<annotation cp="📺" type="tts">television</annotation>
 		<annotation cp="📷">camera | photo | selfie | snap | tbt | trip | video</annotation>
 		<annotation cp="📷" type="tts">camera</annotation>
-		<annotation cp="📸">camera | camera with flash | flash | video</annotation>
+		<annotation cp="📸">camera | flash | video</annotation>
 		<annotation cp="📸" type="tts">camera with flash</annotation>
 		<annotation cp="📹">camcorder | camera | tbt | video</annotation>
 		<annotation cp="📹" type="tts">video camera</annotation>
-		<annotation cp="📼">old school | tape | vcr | vhs | video | videocassette</annotation>
+		<annotation cp="📼">old | school | tape | vcr | vhs | video | videocassette</annotation>
 		<annotation cp="📼" type="tts">videocassette</annotation>
-		<annotation cp="🔍">glass | lab | left-pointing magnifying glass | magnifying | magnifying glass tilted left | science | search | tool</annotation>
+		<annotation cp="🔍">glass | lab | left | left-pointing | magnifying | science | search | tilted | tool</annotation>
 		<annotation cp="🔍" type="tts">magnifying glass tilted left</annotation>
-		<annotation cp="🔎">contact | glass | lab | magnifying | magnifying glass tilted right | right-pointing magnifying glass | science | search | tool</annotation>
+		<annotation cp="🔎">contact | glass | lab | magnifying | right | right-pointing | science | search | tilted | tool</annotation>
 		<annotation cp="🔎" type="tts">magnifying glass tilted right</annotation>
 		<annotation cp="🕯">candle | light</annotation>
 		<annotation cp="🕯" type="tts">candle</annotation>
@@ -3132,11 +3126,11 @@ annotations.
 		<annotation cp="💡" type="tts">light bulb</annotation>
 		<annotation cp="🔦">electric | flashlight | light | tool | torch</annotation>
 		<annotation cp="🔦" type="tts">flashlight</annotation>
-		<annotation cp="🏮">bar | lantern | light | red | red paper lantern | restaurant</annotation>
+		<annotation cp="🏮">bar | lantern | light | paper | red | restaurant</annotation>
 		<annotation cp="🏮" type="tts">red paper lantern</annotation>
-		<annotation cp="🪔">diya | lamp | oil</annotation>
+		<annotation cp="🪔">diya | lamp | oil | light</annotation>
 		<annotation cp="🪔" type="tts">diya lamp</annotation>
-		<annotation cp="📔">book | cover | decorated | education | notebook | notebook with decorative cover | school | writing</annotation>
+		<annotation cp="📔">book | cover | decorated | decorative | education | notebook | school | writing</annotation>
 		<annotation cp="📔" type="tts">notebook with decorative cover</annotation>
 		<annotation cp="📕">book | closed | education</annotation>
 		<annotation cp="📕" type="tts">closed book</annotation>
@@ -3154,23 +3148,23 @@ annotations.
 		<annotation cp="📓" type="tts">notebook</annotation>
 		<annotation cp="📒">ledger | notebook</annotation>
 		<annotation cp="📒" type="tts">ledger</annotation>
-		<annotation cp="📃">curl | document | page | page with curl</annotation>
+		<annotation cp="📃">curl | document | page | paper</annotation>
 		<annotation cp="📃" type="tts">page with curl</annotation>
 		<annotation cp="📜">paper | scroll</annotation>
 		<annotation cp="📜" type="tts">scroll</annotation>
-		<annotation cp="📄">document | page | page facing up</annotation>
+		<annotation cp="📄">document | facing | page | up | paper</annotation>
 		<annotation cp="📄" type="tts">page facing up</annotation>
 		<annotation cp="📰">communication | news | newspaper | paper</annotation>
 		<annotation cp="📰" type="tts">newspaper</annotation>
-		<annotation cp="🗞">news | newspaper | paper | rolled | rolled-up newspaper</annotation>
+		<annotation cp="🗞">news | newspaper | paper | rolled | rolled-up</annotation>
 		<annotation cp="🗞" type="tts">rolled-up newspaper</annotation>
 		<annotation cp="📑">bookmark | mark | marker | tabs</annotation>
 		<annotation cp="📑" type="tts">bookmark tabs</annotation>
 		<annotation cp="🔖">bookmark | mark</annotation>
 		<annotation cp="🔖" type="tts">bookmark</annotation>
-		<annotation cp="🏷">label</annotation>
+		<annotation cp="🏷">label | tag</annotation>
 		<annotation cp="🏷" type="tts">label</annotation>
-		<annotation cp="💰">bag | bank | bet | billion | cash | cash out | cost | dollar | million | money | moneybag | paid | paying | pot of gold | rich | win</annotation>
+		<annotation cp="💰">bag | bank | bet | billion | cash | cost | dollar | gold | million | money | moneybag | paid | paying | pot | rich | win</annotation>
 		<annotation cp="💰" type="tts">money bag</annotation>
 		<annotation cp="🪙">coin | dollar | euro | gold | metal | money | rich | silver | treasure</annotation>
 		<annotation cp="🪙" type="tts">coin</annotation>
@@ -3182,13 +3176,13 @@ annotations.
 		<annotation cp="💶" type="tts">euro banknote</annotation>
 		<annotation cp="💷">bank | banknote | bill | billion | cash | currency | money | note | pound | pounds</annotation>
 		<annotation cp="💷" type="tts">pound banknote</annotation>
-		<annotation cp="💸">bank | banknote | bill | billion | cash | dollar | fly | million | money | money with wings | note | pay | wings</annotation>
+		<annotation cp="💸">bank | banknote | bill | billion | cash | dollar | fly | million | money | note | pay | wings</annotation>
 		<annotation cp="💸" type="tts">money with wings</annotation>
-		<annotation cp="💳">bank | card | cash | charge | charge it | credit | money | pay</annotation>
+		<annotation cp="💳">bank | card | cash | charge | credit | money | pay</annotation>
 		<annotation cp="💳" type="tts">credit card</annotation>
 		<annotation cp="🧾">accounting | bookkeeping | evidence | invoice | proof | receipt</annotation>
 		<annotation cp="🧾" type="tts">receipt</annotation>
-		<annotation cp="💹">bank | chart | chart increasing with yen | currency | graph | growth | market | money | rise | trend | upward | yen</annotation>
+		<annotation cp="💹">bank | chart | currency | graph | growth | increasing | market | money | rise | trend | upward | yen</annotation>
 		<annotation cp="💹" type="tts">chart increasing with yen</annotation>
 		<annotation cp="✉">e-mail | email | envelope | letter</annotation>
 		<annotation cp="✉" type="tts">envelope</annotation>
@@ -3196,29 +3190,29 @@ annotations.
 		<annotation cp="📧" type="tts">e-mail</annotation>
 		<annotation cp="📨">delivering | e-mail | email | envelope | incoming | letter | mail | receive | sent</annotation>
 		<annotation cp="📨" type="tts">incoming envelope</annotation>
-		<annotation cp="📩">arrow | communication | down | e-mail | email | envelope | envelope with arrow | letter | mail | outgoing | send | sent</annotation>
+		<annotation cp="📩">arrow | communication | down | e-mail | email | envelope | letter | mail | outgoing | send | sent</annotation>
 		<annotation cp="📩" type="tts">envelope with arrow</annotation>
 		<annotation cp="📤">box | email | letter | mail | outbox | sent | tray</annotation>
 		<annotation cp="📤" type="tts">outbox tray</annotation>
-		<annotation cp="📥">box | email | inbox | inbox zero | letter | mail | receive | tray</annotation>
+		<annotation cp="📥">box | email | inbox | letter | mail | receive | tray | zero</annotation>
 		<annotation cp="📥" type="tts">inbox tray</annotation>
 		<annotation cp="📦">box | communication | delivery | package | parcel | shipping</annotation>
 		<annotation cp="📦" type="tts">package</annotation>
-		<annotation cp="📫">closed | closed mailbox with raised flag | communication | mail | mailbox | postbox</annotation>
+		<annotation cp="📫">closed | communication | flag | mail | mailbox | postbox | raised</annotation>
 		<annotation cp="📫" type="tts">closed mailbox with raised flag</annotation>
-		<annotation cp="📪">closed | closed mailbox with lowered flag | lowered | mail | mailbox | postbox</annotation>
+		<annotation cp="📪">closed | flag | lowered | mail | mailbox | postbox</annotation>
 		<annotation cp="📪" type="tts">closed mailbox with lowered flag</annotation>
-		<annotation cp="📬">mail | mailbox | open | open mailbox with raised flag | postbox</annotation>
+		<annotation cp="📬">flag | mail | mailbox | open | postbox | raised</annotation>
 		<annotation cp="📬" type="tts">open mailbox with raised flag</annotation>
-		<annotation cp="📭">lowered | mail | mailbox | open | open mailbox with lowered flag | postbox</annotation>
+		<annotation cp="📭">flag | lowered | mail | mailbox | open | postbox</annotation>
 		<annotation cp="📭" type="tts">open mailbox with lowered flag</annotation>
 		<annotation cp="📮">mail | mailbox | postbox</annotation>
 		<annotation cp="📮" type="tts">postbox</annotation>
-		<annotation cp="🗳">ballot | ballot box with ballot | box</annotation>
+		<annotation cp="🗳">ballot | box</annotation>
 		<annotation cp="🗳" type="tts">ballot box with ballot</annotation>
 		<annotation cp="✏">pencil</annotation>
 		<annotation cp="✏" type="tts">pencil</annotation>
-		<annotation cp="✒">black nib | nib | pen</annotation>
+		<annotation cp="✒">black | nib | pen</annotation>
 		<annotation cp="✒" type="tts">black nib</annotation>
 		<annotation cp="🖋">fountain | pen</annotation>
 		<annotation cp="🖋" type="tts">fountain pen</annotation>
@@ -3240,63 +3234,63 @@ annotations.
 		<annotation cp="🗂" type="tts">card index dividers</annotation>
 		<annotation cp="📅">calendar | date</annotation>
 		<annotation cp="📅" type="tts">calendar</annotation>
-		<annotation cp="📆">calendar | tear-off calendar</annotation>
+		<annotation cp="📆">calendar | tear-off</annotation>
 		<annotation cp="📆" type="tts">tear-off calendar</annotation>
-		<annotation cp="🗒">note | pad | spiral | spiral notepad</annotation>
+		<annotation cp="🗒">note | notepad | pad | spiral</annotation>
 		<annotation cp="🗒" type="tts">spiral notepad</annotation>
 		<annotation cp="🗓">calendar | pad | spiral</annotation>
 		<annotation cp="🗓" type="tts">spiral calendar</annotation>
-		<annotation cp="📇">card | index | old school | rolodex</annotation>
+		<annotation cp="📇">card | index | old | rolodex | school</annotation>
 		<annotation cp="📇" type="tts">card index</annotation>
-		<annotation cp="📈">chart | chart increasing | data | graph | growth | trend | up and to the right | upward</annotation>
+		<annotation cp="📈">chart | data | graph | growth | increasing | right | trend | up | upward</annotation>
 		<annotation cp="📈" type="tts">chart increasing</annotation>
-		<annotation cp="📉">chart | chart decreasing | data | down | downward | graph | negative | trend</annotation>
+		<annotation cp="📉">chart | data | decreasing | down | downward | graph | negative | trend</annotation>
 		<annotation cp="📉" type="tts">chart decreasing</annotation>
 		<annotation cp="📊">bar | chart | data | graph</annotation>
 		<annotation cp="📊" type="tts">bar chart</annotation>
-		<annotation cp="📋">clipboard | notes | to do list</annotation>
+		<annotation cp="📋">clipboard | do | list | notes</annotation>
 		<annotation cp="📋" type="tts">clipboard</annotation>
 		<annotation cp="📌">collage | pin | pushpin</annotation>
 		<annotation cp="📌" type="tts">pushpin</annotation>
-		<annotation cp="📍">location | map | pin | pushpin | round pushpin</annotation>
+		<annotation cp="📍">location | map | pin | pushpin | round</annotation>
 		<annotation cp="📍" type="tts">round pushpin</annotation>
 		<annotation cp="📎">paperclip</annotation>
 		<annotation cp="📎" type="tts">paperclip</annotation>
-		<annotation cp="🖇">link | linked paperclips | paperclip</annotation>
+		<annotation cp="🖇">link | linked | paperclip | paperclips</annotation>
 		<annotation cp="🖇" type="tts">linked paperclips</annotation>
-		<annotation cp="📏">angle | math | ruler | straight edge | straight ruler | straightedge</annotation>
+		<annotation cp="📏">angle | edge | math | ruler | straight | straightedge</annotation>
 		<annotation cp="📏" type="tts">straight ruler</annotation>
-		<annotation cp="📐">angle | math | ruler | set | slide rule | triangle | triangular ruler</annotation>
+		<annotation cp="📐">angle | math | rule | ruler | set | slide | triangle | triangular</annotation>
 		<annotation cp="📐" type="tts">triangular ruler</annotation>
 		<annotation cp="✂">cut | cutting | paper | scissors | tool</annotation>
 		<annotation cp="✂" type="tts">scissors</annotation>
 		<annotation cp="🗃">box | card | file</annotation>
 		<annotation cp="🗃" type="tts">card file box</annotation>
-		<annotation cp="🗄">cabinet | file | filing</annotation>
+		<annotation cp="🗄">cabinet | file | filing | paper</annotation>
 		<annotation cp="🗄" type="tts">file cabinet</annotation>
-		<annotation cp="🗑">wastebasket</annotation>
+		<annotation cp="🗑">wastebasket | trash | can | waste | garbage</annotation>
 		<annotation cp="🗑" type="tts">wastebasket</annotation>
 		<annotation cp="🔒">closed | lock | locked | private</annotation>
 		<annotation cp="🔒" type="tts">locked</annotation>
 		<annotation cp="🔓">cracked | lock | open | unlock | unlocked</annotation>
 		<annotation cp="🔓" type="tts">unlocked</annotation>
-		<annotation cp="🔏">ink | lock | locked with pen | nib | pen | privacy</annotation>
+		<annotation cp="🔏">ink | lock | locked | nib | pen | privacy</annotation>
 		<annotation cp="🔏" type="tts">locked with pen</annotation>
-		<annotation cp="🔐">bike lock | closed | key | lock | locked | locked with key | secure</annotation>
+		<annotation cp="🔐">bike | closed | key | lock | locked | secure</annotation>
 		<annotation cp="🔐" type="tts">locked with key</annotation>
-		<annotation cp="🔑">key | keys | lock | major key | password | unlock</annotation>
+		<annotation cp="🔑">key | keys | lock | major | password | unlock</annotation>
 		<annotation cp="🔑" type="tts">key</annotation>
 		<annotation cp="🗝">clue | key | lock | old</annotation>
 		<annotation cp="🗝" type="tts">old key</annotation>
-		<annotation cp="🔨">hammer | home improvement | repairs | tool</annotation>
+		<annotation cp="🔨">hammer | home | improvement | repairs | tool</annotation>
 		<annotation cp="🔨" type="tts">hammer</annotation>
-		<annotation cp="🪓">axe | chop | hatchet | split | wood</annotation>
+		<annotation cp="🪓">ax | axe | chop | hatchet | split | wood</annotation>
 		<annotation cp="🪓" type="tts">axe</annotation>
 		<annotation cp="⛏">hammer | mining | pick | tool</annotation>
 		<annotation cp="⛏" type="tts">pick</annotation>
-		<annotation cp="⚒">hammer | hammer and pick | pick | tool</annotation>
+		<annotation cp="⚒">hammer | pick | tool</annotation>
 		<annotation cp="⚒" type="tts">hammer and pick</annotation>
-		<annotation cp="🛠">hammer | hammer and wrench | spanner | tool | wrench</annotation>
+		<annotation cp="🛠">hammer | spanner | tool | wrench</annotation>
 		<annotation cp="🛠" type="tts">hammer and wrench</annotation>
 		<annotation cp="🗡">dagger | knife | weapon</annotation>
 		<annotation cp="🗡" type="tts">dagger</annotation>
@@ -3306,17 +3300,17 @@ annotations.
 		<annotation cp="💣" type="tts">bomb</annotation>
 		<annotation cp="🪃">boomerang | rebound | repercussion | weapon</annotation>
 		<annotation cp="🪃" type="tts">boomerang</annotation>
-		<annotation cp="🏹">archer | archery | arrow | bow | bow and arrow | Sagittarius | tool | weapon | zodiac</annotation>
+		<annotation cp="🏹">archer | archery | arrow | bow | Sagittarius | tool | weapon | zodiac</annotation>
 		<annotation cp="🏹" type="tts">bow and arrow</annotation>
 		<annotation cp="🛡">shield | weapon</annotation>
 		<annotation cp="🛡" type="tts">shield</annotation>
-		<annotation cp="🪚">carpenter | carpentry saw | cut | lumber | saw | tool | trim</annotation>
+		<annotation cp="🪚">carpenter | carpentry | cut | lumber | saw | tool | trim</annotation>
 		<annotation cp="🪚" type="tts">carpentry saw</annotation>
-		<annotation cp="🔧">home improvement | spanner | tool | wrench</annotation>
+		<annotation cp="🔧">home | improvement | spanner | tool | wrench</annotation>
 		<annotation cp="🔧" type="tts">wrench</annotation>
 		<annotation cp="🪛">flathead | handy | screw | screwdriver | tool</annotation>
 		<annotation cp="🪛" type="tts">screwdriver</annotation>
-		<annotation cp="🔩">bolt | home improvement | nut | nut and bolt | tool</annotation>
+		<annotation cp="🔩">bolt | home | improvement | nut | tool</annotation>
 		<annotation cp="🔩" type="tts">nut and bolt</annotation>
 		<annotation cp="⚙">cog | cogwheel | gear | tool</annotation>
 		<annotation cp="⚙" type="tts">gear</annotation>
@@ -3324,27 +3318,27 @@ annotations.
 		<annotation cp="🗜" type="tts">clamp</annotation>
 		<annotation cp="⚖">balance | justice | Libra | scale | scales | tool | weight | zodiac</annotation>
 		<annotation cp="⚖" type="tts">balance scale</annotation>
-		<annotation cp="🦯">accessibility | blind | probing cane | white cane</annotation>
+		<annotation cp="🦯">accessibility | blind | cane | probing | white</annotation>
 		<annotation cp="🦯" type="tts">white cane</annotation>
 		<annotation cp="🔗">link | links</annotation>
 		<annotation cp="🔗" type="tts">link</annotation>
-		<annotation cp="⛓‍💥">break | breaking | broken chain | chain | cuffs | freedom</annotation> <!-- 26D3 200D 1F4A5 -->
+		<annotation cp="⛓‍💥">break | breaking | broken | chain | cuffs | freedom</annotation> <!-- 26D3 200D 1F4A5 -->
 		<annotation cp="⛓‍💥" type="tts">broken chain</annotation>
 		<annotation cp="⛓">chain | chains</annotation>
 		<annotation cp="⛓" type="tts">chains</annotation>
-		<annotation cp="🪝">catch | crook | curve | ensnare | hook | selling point</annotation>
+		<annotation cp="🪝">catch | crook | curve | ensnare | hook | point | selling</annotation>
 		<annotation cp="🪝" type="tts">hook</annotation>
-		<annotation cp="🧰">box | chest | mechanic | red box | tool | toolbox</annotation>
+		<annotation cp="🧰">box | chest | mechanic | red | tool | toolbox</annotation>
 		<annotation cp="🧰" type="tts">toolbox</annotation>
-		<annotation cp="🧲">attraction | horseshoe | magnet | magnetic | positive negative | u shape</annotation>
+		<annotation cp="🧲">attraction | horseshoe | magnet | magnetic | negative | positive | shape | u</annotation>
 		<annotation cp="🧲" type="tts">magnet</annotation>
 		<annotation cp="🪜">climb | ladder | rung | step</annotation>
 		<annotation cp="🪜" type="tts">ladder</annotation>
 		<annotation cp="⚗">alembic | chemistry | tool</annotation>
 		<annotation cp="⚗" type="tts">alembic</annotation>
-		<annotation cp="🧪">chemist | chemistry | experiment | lab | science | test tube</annotation>
+		<annotation cp="🧪">chemist | chemistry | experiment | lab | science | test | tube</annotation>
 		<annotation cp="🧪" type="tts">test tube</annotation>
-		<annotation cp="🧫">bacteria | biologist | biology | culture | lab | petri dish</annotation>
+		<annotation cp="🧫">bacteria | biologist | biology | culture | dish | lab | petri</annotation>
 		<annotation cp="🧫" type="tts">petri dish</annotation>
 		<annotation cp="🧬">biologist | dna | evolution | gene | genetics | life</annotation>
 		<annotation cp="🧬" type="tts">dna</annotation>
@@ -3354,55 +3348,55 @@ annotations.
 		<annotation cp="🔭" type="tts">telescope</annotation>
 		<annotation cp="📡">aliens | antenna | contact | dish | satellite | science</annotation>
 		<annotation cp="📡" type="tts">satellite antenna</annotation>
-		<annotation cp="💉">doctor | flu shot | medicine | needle | shot | sick | syringe | tool | vaccination</annotation>
+		<annotation cp="💉">doctor | flu | medicine | needle | shot | sick | syringe | tool | vaccination</annotation>
 		<annotation cp="💉" type="tts">syringe</annotation>
-		<annotation cp="🩸">bleed | blood | donation | drop of blood | injury | medicine | menstruation</annotation>
+		<annotation cp="🩸">bleed | blood | donation | drop | injury | medicine | menstruation</annotation>
 		<annotation cp="🩸" type="tts">drop of blood</annotation>
 		<annotation cp="💊">doctor | drugs | medicated | medicine | pill | pills | sick | vitamin</annotation>
 		<annotation cp="💊" type="tts">pill</annotation>
-		<annotation cp="🩹">adhesive bandage | bandage</annotation>
+		<annotation cp="🩹">adhesive | bandage</annotation>
 		<annotation cp="🩹" type="tts">adhesive bandage</annotation>
-		<annotation cp="🩼">cane | crutch | disability | help | hurt | injured | mobility aid | stick</annotation> <!-- 1FA7C -->
+		<annotation cp="🩼">aid | cane | crutch | disability | help | hurt | injured | mobility | stick</annotation> <!-- 1FA7C -->
 		<annotation cp="🩼" type="tts">crutch</annotation>
 		<annotation cp="🩺">doctor | heart | medicine | stethoscope</annotation>
 		<annotation cp="🩺" type="tts">stethoscope</annotation>
 		<annotation cp="🩻">bones | doctor | medical | skeleton | skull | x-ray | xray</annotation> <!-- 1FA7B -->
 		<annotation cp="🩻" type="tts">x-ray</annotation>
-		<annotation cp="🚪">back door | closet | door | front door</annotation>
+		<annotation cp="🚪">back | closet | door | front</annotation>
 		<annotation cp="🚪" type="tts">door</annotation>
 		<annotation cp="🛗">accessibility | elevator | hoist | lift</annotation>
 		<annotation cp="🛗" type="tts">elevator</annotation>
 		<annotation cp="🪞">makeup | mirror | reflection | reflector | speculum</annotation>
 		<annotation cp="🪞" type="tts">mirror</annotation>
-		<annotation cp="🪟">frame | fresh air | opening | transparent | view | window</annotation>
+		<annotation cp="🪟">air | frame | fresh | opening | transparent | view | window</annotation>
 		<annotation cp="🪟" type="tts">window</annotation>
 		<annotation cp="🛏">bed | hotel | sleep</annotation>
 		<annotation cp="🛏" type="tts">bed</annotation>
-		<annotation cp="🛋">couch | couch and lamp | hotel | lamp</annotation>
+		<annotation cp="🛋">couch | hotel | lamp</annotation>
 		<annotation cp="🛋" type="tts">couch and lamp</annotation>
 		<annotation cp="🪑">chair | seat | sit</annotation>
 		<annotation cp="🪑" type="tts">chair</annotation>
 		<annotation cp="🚽">bathroom | toilet</annotation>
 		<annotation cp="🚽" type="tts">toilet</annotation>
-		<annotation cp="🪠">force cup | plumber | plunger | poop | suction | toilet</annotation>
+		<annotation cp="🪠">cup | force | plumber | plunger | poop | suction | toilet</annotation>
 		<annotation cp="🪠" type="tts">plunger</annotation>
 		<annotation cp="🚿">shower | water</annotation>
 		<annotation cp="🚿" type="tts">shower</annotation>
 		<annotation cp="🛁">bath | bathtub</annotation>
 		<annotation cp="🛁" type="tts">bathtub</annotation>
-		<annotation cp="🪤">bait | cheese | lure | mouse trap | mousetrap | snare | trap</annotation>
+		<annotation cp="🪤">bait | cheese | lure | mouse | mousetrap | snare | trap</annotation>
 		<annotation cp="🪤" type="tts">mouse trap</annotation>
 		<annotation cp="🪒">razor | sharp | shave</annotation>
 		<annotation cp="🪒" type="tts">razor</annotation>
-		<annotation cp="🧴">lotion | lotion bottle | moisturizer | shampoo | sunscreen</annotation>
+		<annotation cp="🧴">bottle | lotion | moisturizer | shampoo | sunscreen</annotation>
 		<annotation cp="🧴" type="tts">lotion bottle</annotation>
-		<annotation cp="🧷">diaper | punk rock | safety pin</annotation>
+		<annotation cp="🧷">diaper | pin | punk | rock | safety</annotation>
 		<annotation cp="🧷" type="tts">safety pin</annotation>
 		<annotation cp="🧹">broom | cleaning | sweeping | witch</annotation>
 		<annotation cp="🧹" type="tts">broom</annotation>
 		<annotation cp="🧺">basket | farming | laundry | picnic</annotation>
 		<annotation cp="🧺" type="tts">basket</annotation>
-		<annotation cp="🧻">paper towels | roll of paper | toilet paper</annotation>
+		<annotation cp="🧻">paper | roll | toilet | towels</annotation>
 		<annotation cp="🧻" type="tts">roll of paper</annotation>
 		<annotation cp="🪣">bucket | cask | pail | vat</annotation>
 		<annotation cp="🪣" type="tts">bucket</annotation>
@@ -3414,7 +3408,7 @@ annotations.
 		<annotation cp="🪥" type="tts">toothbrush</annotation>
 		<annotation cp="🧽">absorbing | cleaning | porous | soak | sponge</annotation>
 		<annotation cp="🧽" type="tts">sponge</annotation>
-		<annotation cp="🧯">extinguish | fire | fire extinguisher | quench</annotation>
+		<annotation cp="🧯">extinguish | extinguisher | fire | quench</annotation>
 		<annotation cp="🧯" type="tts">fire extinguisher</annotation>
 		<annotation cp="🛒">cart | shopping | trolley</annotation>
 		<annotation cp="🛒" type="tts">shopping cart</annotation>
@@ -3426,7 +3420,7 @@ annotations.
 		<annotation cp="🪦" type="tts">headstone</annotation>
 		<annotation cp="⚱">ashes | death | funeral | urn</annotation>
 		<annotation cp="⚱" type="tts">funeral urn</annotation>
-		<annotation cp="🧿">bead | blue | charm | evil-eye | nazar | nazar amulet | talisman</annotation>
+		<annotation cp="🧿">amulet | bead | blue | charm | evil-eye | nazar | talisman</annotation>
 		<annotation cp="🧿" type="tts">nazar amulet</annotation>
 		<annotation cp="🪬">amulet | Fatima | fortune | guide | hamsa | hand | Mary | Miriam | palm | protect | protection</annotation> <!-- 1FAAC -->
 		<annotation cp="🪬" type="tts">hamsa</annotation>
@@ -3434,23 +3428,23 @@ annotations.
 		<annotation cp="🗿" type="tts">moai</annotation>
 		<annotation cp="🪧">card | demonstration | notice | picket | placard | plaque | protest | sign</annotation>
 		<annotation cp="🪧" type="tts">placard</annotation>
-		<annotation cp="🪪">credentials | document | ID | identification | identification card | license | security</annotation> <!-- 1FAAA -->
+		<annotation cp="🪪">card | credentials | document | ID | identification | license | security</annotation> <!-- 1FAAA -->
 		<annotation cp="🪪" type="tts">identification card</annotation>
-		<annotation cp="🏧">ATM | ATM sign | automated | bank | cash | money | teller</annotation>
+		<annotation cp="🏧">ATM | automated | bank | cash | money | sign | teller</annotation>
 		<annotation cp="🏧" type="tts">ATM sign</annotation>
-		<annotation cp="🚮">litter | litter bin | litter in bin sign | litterbin</annotation>
+		<annotation cp="🚮">bin | litter | litterbin | sign</annotation>
 		<annotation cp="🚮" type="tts">litter in bin sign</annotation>
 		<annotation cp="🚰">drinking | potable | water</annotation>
 		<annotation cp="🚰" type="tts">potable water</annotation>
-		<annotation cp="♿">access | handicap | wheelchair | wheelchair symbol</annotation>
+		<annotation cp="♿">access | handicap | symbol | wheelchair</annotation>
 		<annotation cp="♿" type="tts">wheelchair symbol</annotation>
-		<annotation cp="🚹">bathroom | lavatory | man | men’s room | restroom | toilet | WC</annotation>
+		<annotation cp="🚹">bathroom | lavatory | man | men’s | restroom | room | toilet | WC</annotation>
 		<annotation cp="🚹" type="tts">men’s room</annotation>
-		<annotation cp="🚺">bathroom | lavatory | restroom | toilet | WC | woman | women’s room</annotation>
+		<annotation cp="🚺">bathroom | lavatory | restroom | room | toilet | WC | woman | women’s</annotation>
 		<annotation cp="🚺" type="tts">women’s room</annotation>
 		<annotation cp="🚻">bathroom | lavatory | restroom | toilet | WC</annotation>
 		<annotation cp="🚻" type="tts">restroom</annotation>
-		<annotation cp="🚼">baby | baby symbol | changing</annotation>
+		<annotation cp="🚼">baby | changing | symbol</annotation>
 		<annotation cp="🚼" type="tts">baby symbol</annotation>
 		<annotation cp="🚾">bathroom | closet | lavatory | restroom | toilet | water | WC</annotation>
 		<annotation cp="🚾" type="tts">water closet</annotation>
@@ -3460,103 +3454,103 @@ annotations.
 		<annotation cp="🛃" type="tts">customs</annotation>
 		<annotation cp="🛄">arrived | baggage | bags | case | checked | claim | journey | packing | plane | ready | travel | trip</annotation>
 		<annotation cp="🛄" type="tts">baggage claim</annotation>
-		<annotation cp="🛅">baggage | case | left luggage | locker | luggage</annotation>
+		<annotation cp="🛅">baggage | case | left | locker | luggage</annotation>
 		<annotation cp="🛅" type="tts">left luggage</annotation>
 		<annotation cp="⚠">caution | warning</annotation>
 		<annotation cp="⚠" type="tts">warning</annotation>
-		<annotation cp="🚸">child | children crossing | crossing | pedestrian | traffic</annotation>
+		<annotation cp="🚸">child | children | crossing | pedestrian | traffic</annotation>
 		<annotation cp="🚸" type="tts">children crossing</annotation>
-		<annotation cp="⛔">do not pass | entry | fail | forbidden | no | not | prohibited | traffic</annotation>
+		<annotation cp="⛔">do | entry | fail | forbidden | no | not | pass | prohibited | traffic</annotation>
 		<annotation cp="⛔" type="tts">no entry</annotation>
 		<annotation cp="🚫">entry | forbidden | no | not | prohibited | smoke</annotation>
 		<annotation cp="🚫" type="tts">prohibited</annotation>
-		<annotation cp="🚳">bicycle | bike | forbidden | no | no bicycles | not | prohibited</annotation>
+		<annotation cp="🚳">bicycle | bicycles | bike | forbidden | no | not | prohibited</annotation>
 		<annotation cp="🚳" type="tts">no bicycles</annotation>
 		<annotation cp="🚭">forbidden | no | not | prohibited | smoke | smoking</annotation>
 		<annotation cp="🚭" type="tts">no smoking</annotation>
-		<annotation cp="🚯">forbidden | litter | no | no littering | not | prohibited</annotation>
+		<annotation cp="🚯">forbidden | litter | littering | no | not | prohibited</annotation>
 		<annotation cp="🚯" type="tts">no littering</annotation>
 		<annotation cp="🚱">dry | non-drinking | non-potable | prohibited | water</annotation>
 		<annotation cp="🚱" type="tts">non-potable water</annotation>
-		<annotation cp="🚷">forbidden | no | no pedestrians | not | pedestrian | prohibited</annotation>
+		<annotation cp="🚷">forbidden | no | not | pedestrian | pedestrians | prohibited</annotation>
 		<annotation cp="🚷" type="tts">no pedestrians</annotation>
-		<annotation cp="📵">cell | forbidden | mobile | no | no mobile phones | not | phone | prohibited | telephone</annotation>
+		<annotation cp="📵">cell | forbidden | mobile | no | not | phone | phones | prohibited | telephone</annotation>
 		<annotation cp="📵" type="tts">no mobile phones</annotation>
-		<annotation cp="🔞">18 | age | eighteen | forbidden | no | no one under eighteen | not | prohibited | restriction | underage</annotation>
+		<annotation cp="🔞">18 | age | eighteen | forbidden | no | not | one | prohibited | restriction | underage</annotation>
 		<annotation cp="🔞" type="tts">no one under eighteen</annotation>
 		<annotation cp="☢">radioactive | sign</annotation>
 		<annotation cp="☢" type="tts">radioactive</annotation>
 		<annotation cp="☣">biohazard | sign</annotation>
 		<annotation cp="☣" type="tts">biohazard</annotation>
-		<annotation cp="⬆">arrow | cardinal | direction | north | up arrow</annotation>
+		<annotation cp="⬆">arrow | cardinal | direction | north | up</annotation>
 		<annotation cp="⬆" type="tts">up arrow</annotation>
-		<annotation cp="↗">arrow | direction | intercardinal | northeast | up-right arrow</annotation>
+		<annotation cp="↗">arrow | direction | intercardinal | northeast | up-right</annotation>
 		<annotation cp="↗" type="tts">up-right arrow</annotation>
-		<annotation cp="➡">arrow | cardinal | direction | east | right arrow</annotation>
+		<annotation cp="➡">arrow | cardinal | direction | east | right</annotation>
 		<annotation cp="➡" type="tts">right arrow</annotation>
-		<annotation cp="↘">arrow | direction | down-right arrow | intercardinal | southeast</annotation>
+		<annotation cp="↘">arrow | direction | down-right | intercardinal | southeast</annotation>
 		<annotation cp="↘" type="tts">down-right arrow</annotation>
 		<annotation cp="⬇">arrow | cardinal | direction | down | south</annotation>
 		<annotation cp="⬇" type="tts">down arrow</annotation>
-		<annotation cp="↙">arrow | direction | down-left arrow | intercardinal | southwest</annotation>
+		<annotation cp="↙">arrow | direction | down-left | intercardinal | southwest</annotation>
 		<annotation cp="↙" type="tts">down-left arrow</annotation>
-		<annotation cp="⬅">arrow | cardinal | direction | left arrow | west</annotation>
+		<annotation cp="⬅">arrow | cardinal | direction | left | west</annotation>
 		<annotation cp="⬅" type="tts">left arrow</annotation>
-		<annotation cp="↖">arrow | direction | intercardinal | northwest | up-left arrow</annotation>
+		<annotation cp="↖">arrow | direction | intercardinal | northwest | up-left</annotation>
 		<annotation cp="↖" type="tts">up-left arrow</annotation>
-		<annotation cp="↕">arrow | up-down arrow</annotation>
+		<annotation cp="↕">arrow | up-down</annotation>
 		<annotation cp="↕" type="tts">up-down arrow</annotation>
-		<annotation cp="↔">arrow | left-right arrow</annotation>
+		<annotation cp="↔">arrow | left-right</annotation>
 		<annotation cp="↔" type="tts">left-right arrow</annotation>
-		<annotation cp="↮">left right arrow stroke</annotation>
+		<annotation cp="↮">arrow | left | right | stroke</annotation>
 		<annotation cp="↮" type="tts">left right arrow stroke</annotation>
-		<annotation cp="↩">arrow | right arrow curving left</annotation>
+		<annotation cp="↩">arrow | curving | left | right</annotation>
 		<annotation cp="↩" type="tts">right arrow curving left</annotation>
-		<annotation cp="↪">arrow | left arrow curving right</annotation>
+		<annotation cp="↪">arrow | curving | left | right</annotation>
 		<annotation cp="↪" type="tts">left arrow curving right</annotation>
-		<annotation cp="⤴">arrow | right arrow curving up</annotation>
+		<annotation cp="⤴">arrow | curving | right | up</annotation>
 		<annotation cp="⤴" type="tts">right arrow curving up</annotation>
-		<annotation cp="⤵">arrow | down | right arrow curving down</annotation>
+		<annotation cp="⤵">arrow | curving | down | right</annotation>
 		<annotation cp="⤵" type="tts">right arrow curving down</annotation>
-		<annotation cp="🔃">arrow | clockwise | clockwise vertical arrows | refresh | reload</annotation>
+		<annotation cp="🔃">arrow | arrows | clockwise | refresh | reload | vertical</annotation>
 		<annotation cp="🔃" type="tts">clockwise vertical arrows</annotation>
-		<annotation cp="🔄">again | anticlockwise | anticlockwise arrows button | arrow | counterclockwise | counterclockwise arrows button | dejavu | refresh | rewind | withershins</annotation>
+		<annotation cp="🔄">again | anticlockwise | arrow | arrows | button | counterclockwise | deja | vu | refresh | rewindershins</annotation>
 		<annotation cp="🔄" type="tts">counterclockwise arrows button</annotation>
 		<annotation cp="🔙">arrow | BACK</annotation>
 		<annotation cp="🔙" type="tts">BACK arrow</annotation>
 		<annotation cp="🔚">arrow | END</annotation>
 		<annotation cp="🔚" type="tts">END arrow</annotation>
-		<annotation cp="🔛">arrow | mark | ON | ON!</annotation>
+		<annotation cp="🔛">arrow | mark | ON!</annotation>
 		<annotation cp="🔛" type="tts">ON! arrow</annotation>
 		<annotation cp="🔜">arrow | brb | omw | SOON</annotation>
 		<annotation cp="🔜" type="tts">SOON arrow</annotation>
 		<annotation cp="🔝">arrow | homie | TOP | up</annotation>
 		<annotation cp="🔝" type="tts">TOP arrow</annotation>
-		<annotation cp="🛐">place of worship | pray | religion | worship</annotation>
+		<annotation cp="🛐">place | pray | religion | worship</annotation>
 		<annotation cp="🛐" type="tts">place of worship</annotation>
-		<annotation cp="⚛">atheist | atom | atom symbol</annotation>
+		<annotation cp="⚛">atheist | atom | symbol</annotation>
 		<annotation cp="⚛" type="tts">atom symbol</annotation>
 		<annotation cp="🕉">Hindu | om | religion</annotation>
 		<annotation cp="🕉" type="tts">om</annotation>
-		<annotation cp="✡">David | Jew | Jewish | judaism | religion | star | star of David</annotation>
+		<annotation cp="✡">David | Jew | Jewish | judaism | religion | star</annotation>
 		<annotation cp="✡" type="tts">star of David</annotation>
-		<annotation cp="☸">Buddhist | dharma | religion | wheel | wheel of dharma</annotation>
+		<annotation cp="☸">Buddhist | dharma | religion | wheel</annotation>
 		<annotation cp="☸" type="tts">wheel of dharma</annotation>
-		<annotation cp="☯">difficult | lives | neither | religion | tao | taoist | total | yang | yin | yinyang</annotation>
+		<annotation cp="☯">difficult | lives | religion | tao | taoist | total | yang | yin | yinyang</annotation>
 		<annotation cp="☯" type="tts">yin yang</annotation>
-		<annotation cp="✝">christ | Christian | cross | latin cross | religion</annotation>
+		<annotation cp="✝">christ | Christian | cross | latin | religion</annotation>
 		<annotation cp="✝" type="tts">latin cross</annotation>
-		<annotation cp="☦">Christian | cross | orthodox cross | religion</annotation>
+		<annotation cp="☦">Christian | cross | orthodox | religion</annotation>
 		<annotation cp="☦" type="tts">orthodox cross</annotation>
-		<annotation cp="☪">islam | Muslim | ramadan | religion | star and crescent</annotation>
+		<annotation cp="☪">crescent | islam | Muslim | ramadan | religion | star</annotation>
 		<annotation cp="☪" type="tts">star and crescent</annotation>
-		<annotation cp="☮">healing | peace | peace symbol | peaceful</annotation>
+		<annotation cp="☮">healing | peace | peaceful | symbol</annotation>
 		<annotation cp="☮" type="tts">peace symbol</annotation>
 		<annotation cp="🕎">candelabrum | candlestick | hanukkah | jewish | judaism | menorah | religion</annotation>
 		<annotation cp="🕎" type="tts">menorah</annotation>
-		<annotation cp="🔯">dotted six-pointed star | fortune | jewish | judaism | star</annotation>
+		<annotation cp="🔯">dotted | fortune | jewish | judaism | six-pointed | star</annotation>
 		<annotation cp="🔯" type="tts">dotted six-pointed star</annotation>
-		<annotation cp="🪯">Deg Tegh Fateh | Khalsa | Khanda | religion | Sikh | Sikhism</annotation> <!-- 1FAAF -->
+		<annotation cp="🪯">Deg | Fateh | Khalsa | Khanda | religion | Sikh | Sikhism | Tegh</annotation> <!-- 1FAAF -->
 		<annotation cp="🪯" type="tts">khanda</annotation>
 		<annotation cp="♈">Aries | horoscope | ram | zodiac</annotation>
 		<annotation cp="♈" type="tts">Aries</annotation>
@@ -3584,47 +3578,47 @@ annotations.
 		<annotation cp="♓" type="tts">Pisces</annotation>
 		<annotation cp="⛎">bearer | Ophiuchus | serpent | snake | zodiac</annotation>
 		<annotation cp="⛎" type="tts">Ophiuchus</annotation>
-		<annotation cp="🔀">arrow | crossed | shuffle tracks button</annotation>
+		<annotation cp="🔀">arrow | button | crossed | shuffle | tracks</annotation>
 		<annotation cp="🔀" type="tts">shuffle tracks button</annotation>
-		<annotation cp="🔁">arrow | clockwise | repeat | repeat button</annotation>
+		<annotation cp="🔁">arrow | button | clockwise | repeat</annotation>
 		<annotation cp="🔁" type="tts">repeat button</annotation>
-		<annotation cp="🔂">arrow | clockwise | once | repeat single button</annotation>
+		<annotation cp="🔂">arrow | button | clockwise | once | repeat | single</annotation>
 		<annotation cp="🔂" type="tts">repeat single button</annotation>
-		<annotation cp="▶">arrow | play | play button | right | triangle</annotation>
+		<annotation cp="▶">arrow | button | play | right | triangle</annotation>
 		<annotation cp="▶" type="tts">play button</annotation>
-		<annotation cp="⏩">arrow | double | fast | fast-forward button | forward</annotation>
+		<annotation cp="⏩">arrow | button | double | fast | fast-forward | forward</annotation>
 		<annotation cp="⏩" type="tts">fast-forward button</annotation>
-		<annotation cp="⏭">arrow | next | next scene | next track button | track | triangle</annotation>
+		<annotation cp="⏭">arrow | button | next | scene | track | triangle</annotation>
 		<annotation cp="⏭" type="tts">next track button</annotation>
-		<annotation cp="⏯">arrow | pause | play | play or pause button | right | triangle</annotation>
+		<annotation cp="⏯">arrow | button | pause | play | right | triangle</annotation>
 		<annotation cp="⏯" type="tts">play or pause button</annotation>
-		<annotation cp="◀">arrow | left | reverse | reverse button | triangle</annotation>
+		<annotation cp="◀">arrow | button | left | reverse | triangle</annotation>
 		<annotation cp="◀" type="tts">reverse button</annotation>
-		<annotation cp="⏪">arrow | double | fast reverse button | rewind</annotation>
+		<annotation cp="⏪">arrow | button | double | fast | reverse | rewind</annotation>
 		<annotation cp="⏪" type="tts">fast reverse button</annotation>
-		<annotation cp="⏮">arrow | last track button | previous scene | previous track | triangle</annotation>
+		<annotation cp="⏮">arrow | button | last | previous | scene | track | triangle</annotation>
 		<annotation cp="⏮" type="tts">last track button</annotation>
-		<annotation cp="🔼">arrow | button | red | up button | upwards button</annotation>
+		<annotation cp="🔼">arrow | button | red | up | upwards</annotation>
 		<annotation cp="🔼" type="tts">upwards button</annotation>
-		<annotation cp="⏫">arrow | double | fast up button</annotation>
+		<annotation cp="⏫">arrow | button | double | fast | up</annotation>
 		<annotation cp="⏫" type="tts">fast up button</annotation>
-		<annotation cp="🔽">arrow | button | down | downwards button | red</annotation>
+		<annotation cp="🔽">arrow | button | down | downwards | red</annotation>
 		<annotation cp="🔽" type="tts">downwards button</annotation>
-		<annotation cp="⏬">arrow | double | down | fast down button</annotation>
+		<annotation cp="⏬">arrow | button | double | down | fast</annotation>
 		<annotation cp="⏬" type="tts">fast down button</annotation>
-		<annotation cp="⏸">bar | double | pause | pause button | vertical</annotation>
+		<annotation cp="⏸">bar | button | double | pause | vertical</annotation>
 		<annotation cp="⏸" type="tts">pause button</annotation>
-		<annotation cp="⏹">square | stop | stop button</annotation>
+		<annotation cp="⏹">button | square | stop</annotation>
 		<annotation cp="⏹" type="tts">stop button</annotation>
-		<annotation cp="⏺">circle | record | record button</annotation>
+		<annotation cp="⏺">button | circle | record</annotation>
 		<annotation cp="⏺" type="tts">record button</annotation>
-		<annotation cp="⏏">eject | eject button</annotation>
+		<annotation cp="⏏">button | eject</annotation>
 		<annotation cp="⏏" type="tts">eject button</annotation>
 		<annotation cp="🎦">camera | cinema | film | movie</annotation>
 		<annotation cp="🎦" type="tts">cinema</annotation>
-		<annotation cp="🔅">brightness | dim | dim button | low</annotation>
+		<annotation cp="🔅">brightness | button | dim | low</annotation>
 		<annotation cp="🔅" type="tts">dim button</annotation>
-		<annotation cp="🔆">bright | bright button | brightness | light</annotation>
+		<annotation cp="🔆">bright | brightness | button | light</annotation>
 		<annotation cp="🔆" type="tts">bright button</annotation>
 		<annotation cp="📶">antenna | bar | bars | cell | communication | mobile | phone | signal | telephone</annotation>
 		<annotation cp="📶" type="tts">antenna bars</annotation>
@@ -3634,46 +3628,45 @@ annotations.
 		<annotation cp="📳" type="tts">vibration mode</annotation>
 		<annotation cp="📴">cell | mobile | off | phone | telephone</annotation>
 		<annotation cp="📴" type="tts">mobile phone off</annotation>
-		<!-- End Generated lines from Emoji Data v15, using GenerateCldrData.java -->
-		<annotation cp="♀">female sign | woman</annotation>
+		<annotation cp="♀">female | sign | woman</annotation>
 		<annotation cp="♀" type="tts">female sign</annotation>
-		<annotation cp="♂">male sign | man</annotation>
+		<annotation cp="♂">male | man | sign</annotation>
 		<annotation cp="♂" type="tts">male sign</annotation>
-		<annotation cp="⚧">transgender | transgender symbol</annotation>
+		<annotation cp="⚧">symbol | transgender</annotation>
 		<annotation cp="⚧" type="tts">transgender symbol</annotation>
 		<annotation cp="✖">× | cancel | multiplication | multiply | sign | x</annotation>
 		<annotation cp="✖" type="tts">multiply</annotation>
-		<annotation cp="➕">+ | heavy plus sign | math | plus | sign</annotation>
+		<annotation cp="➕">+ | plus</annotation>
 		<annotation cp="➕" type="tts">plus</annotation>
-		<annotation cp="➖">- | − | heavy minus sign | math | minus | sign</annotation>
+		<annotation cp="➖">- | − | heavy | math | minus | sign</annotation>
 		<annotation cp="➖" type="tts">minus</annotation>
-		<annotation cp="➗">÷ | divide | division | heavy division sign | math | sign</annotation>
+		<annotation cp="➗">÷ | divide | division | heavy | math | sign</annotation>
 		<annotation cp="➗" type="tts">divide</annotation>
-		<annotation cp="🟰">answer | equal | equality | equals | heavy equals sign | math</annotation> <!-- 1F7F0 -->
+		<annotation cp="🟰">answer | equal | equality | equals | heavy | math | sign</annotation> <!-- 1F7F0 -->
 		<annotation cp="🟰" type="tts">heavy equals sign</annotation>
 		<annotation cp="♾">forever | infinity | unbounded | universal</annotation>
 		<annotation cp="♾" type="tts">infinity</annotation>
-		<annotation cp="‼">! | !! | bangbang | double exclamation mark | exclamation | mark | punctuation</annotation>
+		<annotation cp="‼">! | !! | bangbang | double | exclamation | mark | punctuation</annotation>
 		<annotation cp="‼" type="tts">double exclamation mark</annotation>
 		<annotation cp="⁉">! | !? | ? | exclamation | interrobang | mark | punctuation | question</annotation>
 		<annotation cp="⁉" type="tts">exclamation question mark</annotation>
-		<annotation cp="❓">? | mark | punctuation | question | red question mark</annotation>
+		<annotation cp="❓">? | mark | punctuation | question | red</annotation>
 		<annotation cp="❓" type="tts">red question mark</annotation>
-		<annotation cp="❔">? | mark | outlined | punctuation | question | white question mark</annotation>
+		<annotation cp="❔">? | mark | outlined | punctuation | question | white</annotation>
 		<annotation cp="❔" type="tts">white question mark</annotation>
-		<annotation cp="❕">! | exclamation | mark | outlined | punctuation | white exclamation mark</annotation>
+		<annotation cp="❕">! | exclamation | mark | outlined | punctuation | white</annotation>
 		<annotation cp="❕" type="tts">white exclamation mark</annotation>
-		<annotation cp="❗">! | exclamation | mark | punctuation | red exclamation mark</annotation>
+		<annotation cp="❗">! | exclamation | mark | punctuation | red</annotation>
 		<annotation cp="❗" type="tts">red exclamation mark</annotation>
 		<annotation cp="〰">dash | punctuation | wavy</annotation>
 		<annotation cp="〰" type="tts">wavy dash</annotation>
 		<annotation cp="💱">bank | currency | exchange | money</annotation>
 		<annotation cp="💱" type="tts">currency exchange</annotation>
-		<annotation cp="💲">billion | cash | charge | currency | dollar | heavy dollar sign | million | money | pay</annotation>
+		<annotation cp="💲">billion | cash | charge | currency | dollar | heavy | million | money | pay | sign</annotation>
 		<annotation cp="💲" type="tts">heavy dollar sign</annotation>
-		<annotation cp="⚕">aesculapius | medical symbol | medicine | staff</annotation>
+		<annotation cp="⚕">aesculapius | medical | medicine | staff | symbol</annotation>
 		<annotation cp="⚕" type="tts">medical symbol</annotation>
-		<annotation cp="♻">recycle | recycling symbol</annotation>
+		<annotation cp="♻">recycle | recycling | symbol</annotation>
 		<annotation cp="♻" type="tts">recycling symbol</annotation>
 		<annotation cp="⚜">fleur-de-lis | knights</annotation>
 		<annotation cp="⚜" type="tts">fleur-de-lis</annotation>
@@ -3681,29 +3674,29 @@ annotations.
 		<annotation cp="🔱" type="tts">trident emblem</annotation>
 		<annotation cp="📛">badge | name</annotation>
 		<annotation cp="📛" type="tts">name badge</annotation>
-		<annotation cp="🔰">beginner | chevron | green | Japanese | Japanese symbol for beginner | leaf | tool | yellow</annotation>
+		<annotation cp="🔰">beginner | chevron | green | Japanese | leaf | symbol | tool | yellow</annotation>
 		<annotation cp="🔰" type="tts">Japanese symbol for beginner</annotation>
-		<annotation cp="⭕">circle | heavy large circle | hollow red circle | large | o | red</annotation>
+		<annotation cp="⭕">circle | heavy | hollow | large | o | red</annotation>
 		<annotation cp="⭕" type="tts">hollow red circle</annotation>
 		<annotation cp="✅">✓ | button | check | checked | checkmark | complete | completed | done | fixed | mark | tick</annotation>
 		<annotation cp="✅" type="tts">check mark button</annotation>
-		<annotation cp="☑">✓ | ballot | box | check | check box with check | checked off | done | tick</annotation>
+		<annotation cp="☑">✓ | ballot | box | check | checked | done | off | tick</annotation>
 		<annotation cp="☑" type="tts">check box with check</annotation>
-		<annotation cp="✔">✓ | check | checked | checkmark | done | heavy check mark | mark | tick</annotation>
+		<annotation cp="✔">✓ | check | checked | checkmark | done | heavy | mark | tick</annotation>
 		<annotation cp="✔" type="tts">check mark</annotation>
 		<annotation cp="❌">× | cancel | cross | mark | multiplication | multiply | x</annotation>
 		<annotation cp="❌" type="tts">cross mark</annotation>
-		<annotation cp="❎">× | cross mark button | mark | multiplication | multiply | square | x</annotation>
+		<annotation cp="❎">× | button | cross | mark | multiplication | multiply | square | x</annotation>
 		<annotation cp="❎" type="tts">cross mark button</annotation>
-		<annotation cp="➰">curl | curly loop | loop</annotation>
+		<annotation cp="➰">curl | curly | loop</annotation>
 		<annotation cp="➰" type="tts">curly loop</annotation>
-		<annotation cp="➿">curl | double | double curly loop | loop</annotation>
+		<annotation cp="➿">curl | curly | double | loop</annotation>
 		<annotation cp="➿" type="tts">double curly loop</annotation>
-		<annotation cp="〽">mark | part | part alternation mark</annotation>
+		<annotation cp="〽">alternation | mark | part</annotation>
 		<annotation cp="〽" type="tts">part alternation mark</annotation>
-		<annotation cp="✳">* | asterisk | eight-spoked asterisk</annotation>
+		<annotation cp="✳">* | asterisk | eight-spoked</annotation>
 		<annotation cp="✳" type="tts">eight-spoked asterisk</annotation>
-		<annotation cp="✴">* | eight-pointed star | star</annotation>
+		<annotation cp="✴">* | eight-pointed | star</annotation>
 		<annotation cp="✴" type="tts">eight-pointed star</annotation>
 		<annotation cp="❇">* | sparkle</annotation>
 		<annotation cp="❇" type="tts">sparkle</annotation>
@@ -3711,7 +3704,7 @@ annotations.
 		<annotation cp="©" type="tts">copyright</annotation>
 		<annotation cp="®">R | registered</annotation>
 		<annotation cp="®" type="tts">registered</annotation>
-		<annotation cp="™">mark | TM | trade mark | trademark</annotation>
+		<annotation cp="™">mark | TM | trade | trademark</annotation>
 		<annotation cp="™" type="tts">trade mark</annotation>
 		<annotation cp="🔠">ABCD | input | latin | letters | uppercase</annotation>
 		<annotation cp="🔠" type="tts">input latin uppercase</annotation>
@@ -3719,15 +3712,15 @@ annotations.
 		<annotation cp="🔡" type="tts">input latin lowercase</annotation>
 		<annotation cp="🔢">1234 | input | numbers</annotation>
 		<annotation cp="🔢" type="tts">input numbers</annotation>
-		<annotation cp="🔣">&amp; | % | ♪ | 〒 | input | input symbols</annotation>
+		<annotation cp="🔣">&amp; | % | ♪ | 〒 | input | symbols</annotation>
 		<annotation cp="🔣" type="tts">input symbols</annotation>
 		<annotation cp="🔤">abc | alphabet | input | latin | letters</annotation>
 		<annotation cp="🔤" type="tts">input latin letters</annotation>
-		<annotation cp="🅰">A | A button (blood type) | blood type | button</annotation>
+		<annotation cp="🅰">blood | button | type</annotation>
 		<annotation cp="🅰" type="tts">A button (blood type)</annotation>
-		<annotation cp="🆎">AB | AB button (blood type) | blood type | button</annotation>
+		<annotation cp="🆎">AB | blood | button | type</annotation>
 		<annotation cp="🆎" type="tts">AB button (blood type)</annotation>
-		<annotation cp="🅱">B | B button (blood type) | blood type | button</annotation>
+		<annotation cp="🅱">B | blood | button | type</annotation>
 		<annotation cp="🅱" type="tts">B button (blood type)</annotation>
 		<annotation cp="🆑">button | CL</annotation>
 		<annotation cp="🆑" type="tts">CL button</annotation>
@@ -3735,17 +3728,17 @@ annotations.
 		<annotation cp="🆒" type="tts">COOL button</annotation>
 		<annotation cp="🆓">button | FREE</annotation>
 		<annotation cp="🆓" type="tts">FREE button</annotation>
-		<annotation cp="ℹ">i | information</annotation>
+		<annotation cp="ℹ">I | information</annotation>
 		<annotation cp="ℹ" type="tts">information</annotation>
 		<annotation cp="🆔">button | ID | identity</annotation>
 		<annotation cp="🆔" type="tts">ID button</annotation>
-		<annotation cp="Ⓜ">circle | circled M | M</annotation>
+		<annotation cp="Ⓜ">circle | circled | M</annotation>
 		<annotation cp="Ⓜ" type="tts">circled M</annotation>
 		<annotation cp="🆕">button | NEW</annotation>
 		<annotation cp="🆕" type="tts">NEW button</annotation>
 		<annotation cp="🆖">button | NG</annotation>
 		<annotation cp="🆖" type="tts">NG button</annotation>
-		<annotation cp="🅾">blood type | button | O | O button (blood type)</annotation>
+		<annotation cp="🅾">blood | button | O | type</annotation>
 		<annotation cp="🅾" type="tts">O button (blood type)</annotation>
 		<annotation cp="🆗">button | OK | okay</annotation>
 		<annotation cp="🆗" type="tts">OK button</annotation>
@@ -3757,39 +3750,39 @@ annotations.
 		<annotation cp="🆙" type="tts">UP! button</annotation>
 		<annotation cp="🆚">button | versus | VS</annotation>
 		<annotation cp="🆚" type="tts">VS button</annotation>
-		<annotation cp="🈁">“here” | Japanese | Japanese “here” button | katakana | ココ</annotation>
+		<annotation cp="🈁">button | here | Japanese | katakana</annotation>
 		<annotation cp="🈁" type="tts">Japanese “here” button</annotation>
-		<annotation cp="🈂">“service charge” | Japanese | Japanese “service charge” button | katakana | サ</annotation>
+		<annotation cp="🈂">button | charge | Japanese | katakana | service</annotation>
 		<annotation cp="🈂" type="tts">Japanese “service charge” button</annotation>
-		<annotation cp="🈷">“monthly amount” | ideograph | Japanese | Japanese “monthly amount” button | monthly amount | 月</annotation>
+		<annotation cp="🈷">amount | button | ideograph | Japanese | monthly</annotation>
 		<annotation cp="🈷" type="tts">Japanese “monthly amount” button</annotation>
-		<annotation cp="🈶">“not free of charge” | ideograph | Japanese | Japanese “not free of charge” button | not free of charge | 有</annotation>
+		<annotation cp="🈶">button | charge | free | ideograph | Japanese | not</annotation>
 		<annotation cp="🈶" type="tts">Japanese “not free of charge” button</annotation>
-		<annotation cp="🈯">“reserved” | ideograph | Japanese | Japanese “reserved” button | 指</annotation>
+		<annotation cp="🈯">button | ideograph | Japanese | reserved</annotation>
 		<annotation cp="🈯" type="tts">Japanese “reserved” button</annotation>
-		<annotation cp="🉐">“bargain” | ideograph | Japanese | Japanese “bargain” button | 得</annotation>
+		<annotation cp="🉐">bargain | button | ideograph | Japanese</annotation>
 		<annotation cp="🉐" type="tts">Japanese “bargain” button</annotation>
-		<annotation cp="🈹">“discount” | ideograph | Japanese | Japanese “discount” button | 割</annotation>
+		<annotation cp="🈹">button | discount | ideograph | Japanese</annotation>
 		<annotation cp="🈹" type="tts">Japanese “discount” button</annotation>
-		<annotation cp="🈚">“free of charge” | ideograph | Japanese | Japanese “free of charge” button | 無</annotation>
+		<annotation cp="🈚">button | charge | free | ideograph | Japanese</annotation>
 		<annotation cp="🈚" type="tts">Japanese “free of charge” button</annotation>
-		<annotation cp="🈲">“prohibited” | ideograph | Japanese | Japanese “prohibited” button | 禁</annotation>
+		<annotation cp="🈲">button | ideograph | Japanese | prohibited</annotation>
 		<annotation cp="🈲" type="tts">Japanese “prohibited” button</annotation>
-		<annotation cp="🉑">“acceptable” | ideograph | Japanese | Japanese “acceptable” button | 可</annotation>
+		<annotation cp="🉑">acceptable | button | ideograph | Japanese</annotation>
 		<annotation cp="🉑" type="tts">Japanese “acceptable” button</annotation>
-		<annotation cp="🈸">“application” | ideograph | Japanese | Japanese “application” button | 申</annotation>
+		<annotation cp="🈸">application | button | ideograph | Japanese</annotation>
 		<annotation cp="🈸" type="tts">Japanese “application” button</annotation>
-		<annotation cp="🈴">“passing grade” | ideograph | Japanese | Japanese “passing grade” button | passing grade | 合</annotation>
+		<annotation cp="🈴">button | grade | ideograph | Japanese | passing</annotation>
 		<annotation cp="🈴" type="tts">Japanese “passing grade” button</annotation>
-		<annotation cp="🈳">“vacancy” | ideograph | Japanese | Japanese “vacancy” button | 空</annotation>
+		<annotation cp="🈳">button | ideograph | Japanese | vacancy</annotation>
 		<annotation cp="🈳" type="tts">Japanese “vacancy” button</annotation>
-		<annotation cp="㊗">“congratulations” | ideograph | Japanese | Japanese “congratulations” button | 祝</annotation>
+		<annotation cp="㊗">button | congratulations | ideograph | Japanese</annotation>
 		<annotation cp="㊗" type="tts">Japanese “congratulations” button</annotation>
-		<annotation cp="㊙">“secret” | ideograph | Japanese | Japanese “secret” button | 秘</annotation>
+		<annotation cp="㊙">button | ideograph | Japanese | secret</annotation>
 		<annotation cp="㊙" type="tts">Japanese “secret” button</annotation>
-		<annotation cp="🈺">“open for business” | ideograph | Japanese | Japanese “open for business” button | open for business | 営</annotation>
+		<annotation cp="🈺">business | button | ideograph | Japanese | open</annotation>
 		<annotation cp="🈺" type="tts">Japanese “open for business” button</annotation>
-		<annotation cp="🈵">“no vacancy” | ideograph | Japanese | Japanese “no vacancy” button | no vacancy | 満</annotation>
+		<annotation cp="🈵">button | ideograph | Japanese | no | vacancy</annotation>
 		<annotation cp="🈵" type="tts">Japanese “no vacancy” button</annotation>
 		<annotation cp="🔴">circle | geometric | red</annotation>
 		<annotation cp="🔴" type="tts">red circle</annotation>
@@ -3805,15 +3798,15 @@ annotations.
 		<annotation cp="🟣" type="tts">purple circle</annotation>
 		<annotation cp="🟤">brown | circle</annotation>
 		<annotation cp="🟤" type="tts">brown circle</annotation>
-		<annotation cp="⚫">black circle | circle | geometric</annotation>
+		<annotation cp="⚫">black | circle | geometric</annotation>
 		<annotation cp="⚫" type="tts">black circle</annotation>
-		<annotation cp="⚪">circle | geometric | white circle</annotation>
+		<annotation cp="⚪">circle | geometric | white</annotation>
 		<annotation cp="⚪" type="tts">white circle</annotation>
-		<annotation cp="🟥">red | square</annotation>
+		<annotation cp="🟥">card | penalty | red | square</annotation>
 		<annotation cp="🟥" type="tts">red square</annotation>
 		<annotation cp="🟧">orange | square</annotation>
 		<annotation cp="🟧" type="tts">orange square</annotation>
-		<annotation cp="🟨">square | yellow</annotation>
+		<annotation cp="🟨">card | penalty | square | yellow</annotation>
 		<annotation cp="🟨" type="tts">yellow square</annotation>
 		<annotation cp="🟩">green | square</annotation>
 		<annotation cp="🟩" type="tts">green square</annotation>
@@ -3823,57 +3816,57 @@ annotations.
 		<annotation cp="🟪" type="tts">purple square</annotation>
 		<annotation cp="🟫">brown | square</annotation>
 		<annotation cp="🟫" type="tts">brown square</annotation>
-		<annotation cp="⬛">black large square | geometric | square</annotation>
+		<annotation cp="⬛">black | geometric | large | square</annotation>
 		<annotation cp="⬛" type="tts">black large square</annotation>
-		<annotation cp="⬜">geometric | square | white large square</annotation>
+		<annotation cp="⬜">geometric | large | square | white</annotation>
 		<annotation cp="⬜" type="tts">white large square</annotation>
-		<annotation cp="◼">black medium square | geometric | square</annotation>
+		<annotation cp="◼">black | geometric | medium | square</annotation>
 		<annotation cp="◼" type="tts">black medium square</annotation>
-		<annotation cp="◻">geometric | square | white medium square</annotation>
+		<annotation cp="◻">geometric | medium | square | white</annotation>
 		<annotation cp="◻" type="tts">white medium square</annotation>
-		<annotation cp="◾">black medium-small square | geometric | square</annotation>
+		<annotation cp="◾">black | geometric | medium-small | square</annotation>
 		<annotation cp="◾" type="tts">black medium-small square</annotation>
-		<annotation cp="◽">geometric | square | white medium-small square</annotation>
+		<annotation cp="◽">geometric | medium-small | square | white</annotation>
 		<annotation cp="◽" type="tts">white medium-small square</annotation>
-		<annotation cp="▪">black small square | geometric | square</annotation>
+		<annotation cp="▪">black | geometric | small | square</annotation>
 		<annotation cp="▪" type="tts">black small square</annotation>
-		<annotation cp="▫">geometric | square | white small square</annotation>
+		<annotation cp="▫">geometric | small | square | white</annotation>
 		<annotation cp="▫" type="tts">white small square</annotation>
-		<annotation cp="🔶">diamond | geometric | large orange diamond | orange</annotation>
+		<annotation cp="🔶">diamond | geometric | large | orange</annotation>
 		<annotation cp="🔶" type="tts">large orange diamond</annotation>
-		<annotation cp="🔷">blue | diamond | geometric | large blue diamond</annotation>
+		<annotation cp="🔷">blue | diamond | geometric | large</annotation>
 		<annotation cp="🔷" type="tts">large blue diamond</annotation>
-		<annotation cp="🔸">diamond | geometric | orange | small orange diamond</annotation>
+		<annotation cp="🔸">diamond | geometric | orange | small</annotation>
 		<annotation cp="🔸" type="tts">small orange diamond</annotation>
-		<annotation cp="🔹">blue | diamond | geometric | small blue diamond</annotation>
+		<annotation cp="🔹">blue | diamond | geometric | small</annotation>
 		<annotation cp="🔹" type="tts">small blue diamond</annotation>
-		<annotation cp="🔺">geometric | red | red triangle pointed up</annotation>
+		<annotation cp="🔺">geometric | pointed | red | triangle | up</annotation>
 		<annotation cp="🔺" type="tts">red triangle pointed up</annotation>
-		<annotation cp="🔻">down | geometric | red | red triangle pointed down</annotation>
+		<annotation cp="🔻">down | geometric | pointed | red | triangle</annotation>
 		<annotation cp="🔻" type="tts">red triangle pointed down</annotation>
-		<annotation cp="💠">comic | diamond | diamond with a dot | geometric | inside</annotation>
+		<annotation cp="💠">comic | diamond | dot | geometric</annotation>
 		<annotation cp="💠" type="tts">diamond with a dot</annotation>
 		<annotation cp="🔘">button | geometric | radio</annotation>
 		<annotation cp="🔘" type="tts">radio button</annotation>
-		<annotation cp="🔳">button | geometric | outlined | square | white square button</annotation>
+		<annotation cp="🔳">button | geometric | outlined | square | white</annotation>
 		<annotation cp="🔳" type="tts">white square button</annotation>
-		<annotation cp="🔲">black square button | button | geometric | square</annotation>
+		<annotation cp="🔲">black | button | geometric | square</annotation>
 		<annotation cp="🔲" type="tts">black square button</annotation>
 		<annotation cp="🏁">checkered | chequered | finish | flag | flags | game | race | racing | sport | win</annotation>
 		<annotation cp="🏁" type="tts">chequered flag</annotation>
-		<annotation cp="🚩">construction | flag | golf | post | triangular flag</annotation>
+		<annotation cp="🚩">construction | flag | golf | post | triangular</annotation>
 		<annotation cp="🚩" type="tts">triangular flag</annotation>
-		<annotation cp="🎌">celebration | cross | crossed | crossed flags | Japanese</annotation>
+		<annotation cp="🎌">celebration | cross | crossed | flags | Japanese</annotation>
 		<annotation cp="🎌" type="tts">crossed flags</annotation>
-		<annotation cp="🏴">black flag | waving</annotation>
+		<annotation cp="🏴">black | flag | waving</annotation>
 		<annotation cp="🏴" type="tts">black flag</annotation>
-		<annotation cp="🏳">waving | white flag</annotation>
+		<annotation cp="🏳">flag | waving | white</annotation>
 		<annotation cp="🏳" type="tts">white flag</annotation>
-		<annotation cp="🏳‍🌈">bisexual | gay | genderqueer | glbt | glbtq | lesbian | lgbt | lgbtq | lgbtqia | pride | queer | rainbow | rainbow flag | trans | transgender</annotation>
+		<annotation cp="🏳‍🌈">bisexual | flag | gay | genderqueer | glbt | glbtq | lesbian | lgbt | lgbtq | lgbtqia | pride | queer | rainbow | trans | transgender</annotation>
 		<annotation cp="🏳‍🌈" type="tts">rainbow flag</annotation>
-		<annotation cp="🏳‍⚧">flag | light blue | pink | transgender | white</annotation>
+		<annotation cp="🏳‍⚧">blue | flag | light | pink | transgender | white</annotation>
 		<annotation cp="🏳‍⚧" type="tts">transgender flag</annotation>
-		<annotation cp="🏴‍☠">Jolly Roger | pirate | pirate flag | plunder | treasure</annotation>
+		<annotation cp="🏴‍☠">flag | Jolly | pirate | plunder | Roger | treasure</annotation>
 		<annotation cp="🏴‍☠" type="tts">pirate flag</annotation>
 		<annotation cp="¢">cent</annotation>
 		<annotation cp="¢" type="tts">cent</annotation>
@@ -3885,7 +3878,7 @@ annotations.
 		<annotation cp="¥" type="tts">yen</annotation>
 		<annotation cp="₢">BRB | cruzeiro | currency</annotation>
 		<annotation cp="₢" type="tts">cruzeiro</annotation>
-		<annotation cp="₣">currency | franc | french franc</annotation>
+		<annotation cp="₣">currency | franc | french</annotation>
 		<annotation cp="₣" type="tts">french franc</annotation>
 		<annotation cp="₤">currency | lira</annotation>
 		<annotation cp="₤" type="tts">lira</annotation>
@@ -3895,17 +3888,17 @@ annotations.
 		<annotation cp="₩" type="tts">won</annotation>
 		<annotation cp="€">currency | EUR | euro</annotation>
 		<annotation cp="€" type="tts">euro</annotation>
-		<annotation cp="₰">currency | german penny | pfennig</annotation>
+		<annotation cp="₰">currency | german | penny | pfennig</annotation>
 		<annotation cp="₰" type="tts">german penny</annotation>
 		<annotation cp="₱">peso</annotation>
 		<annotation cp="₱" type="tts">peso</annotation>
 		<annotation cp="₳">ARA | austral | currency</annotation>
 		<annotation cp="₳" type="tts">austral</annotation>
-		<annotation cp="₶">currency | livre tournois</annotation>
+		<annotation cp="₶">currency | livre | tournois</annotation>
 		<annotation cp="₶" type="tts">livre tournois</annotation>
 		<annotation cp="₷">currency | spesmilo</annotation>
 		<annotation cp="₷" type="tts">spesmilo</annotation>
-		<annotation cp="₹">currency | indian rupee | rupee</annotation>
+		<annotation cp="₹">currency | indian | rupee</annotation>
 		<annotation cp="₹" type="tts">indian rupee</annotation>
 		<annotation cp="₽">currency | ruble</annotation>
 		<annotation cp="₽" type="tts">ruble</annotation>
@@ -3921,7 +3914,7 @@ annotations.
 		<annotation cp="²" type="tts">superscript two</annotation>
 		<annotation cp="³">cubed | superscript | three</annotation>
 		<annotation cp="³" type="tts">superscript three</annotation>
-		<annotation cp="µ">measure | micro sign</annotation>
+		<annotation cp="µ">measure | micro | sign</annotation>
 		<annotation cp="µ" type="tts">micro sign</annotation>
 	</annotations>
 </ldml>

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -2620,28 +2620,68 @@ For more information, see version 5.0 or [UTR #51, Unicode Emoji](https://www.un
 <!ATTLIST annotation type (tts) #IMPLIED >
 ```
 
-There are two kinds of annotations: **short names**, and **keywords**.
+There are two kinds of annotations: **short names**, and **search keywords**.
 
-With an attribute `type="tts"`, the value is a **short name**, such as one that can be used for text-to-speech. It should be treated as one of the element values for other purposes.
+With an attribute `type="tts"`, the value is a **short name**, such as one that can be used for text-to-speech. 
+It should be treated as one of the element values for other purposes.
 
-When there is no `type` attribute, the value is a set of **keywords**, delimited by |. Spaces around each element are to be trimmed. The **keywords** are words associated with the character(s) that might be used in searching for the character, or in predictive typing on keyboards. The short name itself can be used as a keyword.
+When there is no `type` attribute, the value is a set of **keywords**, delimited by |. 
+Spaces around each element are to be trimmed. 
+The **keywords** are words associated with the character(s) that might be used in searching for the character, 
+or in predictive typing on keyboards. The short name itself can be used as a keyword.
 
 Here is an example from German:
 
 ```xml
-<annotation cp="👎">schlecht | Hand | Daumen | nach unten</annotation>
+<annotation cp="👎">schlecht | Hand | Daumen | nach | unten</annotation>
 <annotation cp="👎" type="tts">Daumen runter</annotation>
 ```
 
-The `cp` attribute value has two formats: either a single string, or if contained within \[…\] a UnicodeSet. The latter format can contain multiple code points or strings. A code point pr string can occur in multiple annotation element **cp** values, such as the following, which also contains the "thumbs down" character.
+These are intended as search keywords, and not for "triggering" (aka suggesting).
+
+- For triggering, the user is typing out a message and concurrently seeing a few emoji
+  displayed adjacent to the virtual keyboard. Selecting the emoji adds it to the message.
+  For example, you mention your birthday while writing, and an emoji cake pops up.
+  That is typically done with an LLM or similar advanced technology.
+- For searching, the user is looking for an emoji in a search box, 
+  and typing in in words that narrow down a displayed set of emoji.
+  For example, you type 'heart', but that has too many hits, so you add 'blue' and get the set of blue hearts.
+  
+### Usage Model
+
+The usage model for the search keywords is:
+
+- The user types one or more words in an emoji search field.
+- Each word successively narrows a number of emoji in a results box.
+    - heart → 🥰 😘 😻 💌 💘 💝 💖 💗 💓 💞 💕 💟 ❣️ 💔 ❤️‍🔥 ❤️‍🩹 ❤️ 🩷 🧡 💛 💚 💙 🩵 💜 🤎 🖤 🩶 🤍 💋 🫰 🫶 🫀 💏 💑 🏠 🏡 ♥️ 🩺
+    - blue → 🥶 😰 💙 🩵 🫐 👕 👖 📘 🧿 🔵 🟦 🔷 🔹 🏳️‍⚧️
+    - heart blue → 💙 🩵
+- A word with no hits is ignored
+    - [heart | blue | confabulation] is equivalent to [heart | blue]
+- As the user types a word, each character added to the word narrows the results.
+- Whenever the list is short enough to scan, the user will mouse-click on the right emoji — so it doesn’t have to be narrowed too far.
+    - In the following, the user would just click on 🎉 if that works for them.
+    - celebrate → 🥳 🥂 🎈 🎉 🎊 🪅
+- The order of words doesn’t matter.
+
+Multiword search keywords are typically broken up into separate parts, 
+because that works better with the usage model. So [hand | mouth | omg | open | over] covers the phrase "hand over mouth".
+
+### cp attribute
+
+The `cp` attribute value has two formats: either a single string, or if contained within \[…\] a UnicodeSet. 
+The latter format can contain multiple code points or strings. A code point pr string can occur in multiple annotation element **cp** values, such as the following, which also contains the "thumbs down" character.
 
 ```xml
 <annotation cp='[☝✊-✍👆-👐👫-👭💁🖐🖕🖖🙅🙆🙋🙌🙏🤘]'>hand</annotation>
 ```
 
-Both for short names and keywords, values do not have to match between different languages. They should be the most common values that people using _that_ language would associate with those characters. For example, a "black heart" might have the association of "wicked" in English, but not in some other languages.
+Both for short names and keywords, values do not have to match between different languages. 
+They should be the most common values that people using _that_ language would associate with those characters. 
+For example, a "black heart" might have the association of "wicked" in English, but not in some other languages.
 
-The cp value may contain sequences, but does not contain any Emoji or Text Variant (VS15 & VS16) characters. All such characters should be removed before looking up any short names and keywords.
+The cp value may contain sequences, but does not contain any Emoji or Text Variant (VS15 & VS16) characters. 
+All such characters should be removed before looking up any short names and keywords.
 
 ### <a name="SynthesizingNames" href="#SynthesizingNames">Synthesizing Sequence Names</a>
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEmojiAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEmojiAnnotations.java
@@ -1,0 +1,155 @@
+package org.unicode.cldr.tool;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
+import com.ibm.icu.impl.UnicodeMap;
+import com.ibm.icu.text.UnicodeSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.unicode.cldr.util.Annotations;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CodePointEscaper;
+import org.unicode.cldr.util.Emoji;
+import org.unicode.cldr.util.SimpleUnicodeSetFormatter;
+import org.unicode.cldr.util.XPathParts;
+
+public class CheckEmojiAnnotations {
+    private static final Joiner JOIN_BAR = Joiner.on(" | ");
+
+    public static void main(String[] args) {
+        boolean chooseEmoji = true; // false to get the non-emoji
+
+        UnicodeSet rgi = Emoji.getAllRgi();
+        UnicodeSet rgiNoVariant = Emoji.getAllRgiNoES();
+        CLDRFile root = CLDRConfig.getInstance().getAnnotationsFactory().make("en", false);
+        UnicodeSet rootEmoji = new UnicodeSet();
+        for (String path : root) {
+            XPathParts parts = XPathParts.getFrozenInstance(path);
+            String cp = parts.getAttributeValue(-1, "cp");
+            if (cp != null && rgiNoVariant.contains(cp) == chooseEmoji) {
+                rootEmoji.add(cp);
+            }
+        }
+        rootEmoji.freeze();
+
+        UnicodeMap<Annotations> english = Annotations.getData("en");
+        Map<String, UnicodeSet> keywordToEmoji = new TreeMap<>();
+        UnicodeSet allUnclean = new UnicodeSet();
+
+        for (Annotations entry : english.values()) {
+            Set<String> keywords = entry.getKeywords();
+            UnicodeSet emoji = english.getSet(entry);
+            emoji.retainAll(rootEmoji);
+            UnicodeSet emojiRestored = new UnicodeSet();
+            for (String emojiItem : emoji) {
+                emojiRestored.add(Emoji.restoreVariants(emojiItem));
+            }
+            UnicodeSet unclean = new UnicodeSet(emojiRestored).removeAll(rgi);
+            allUnclean.add(unclean);
+
+            emojiRestored = emojiRestored.retainAll(rgi);
+            if (emojiRestored.isEmpty()) {
+                continue;
+            }
+
+            for (String keyword : keywords) {
+                UnicodeSet value = keywordToEmoji.get(keyword);
+                if (value == null) {
+                    keywordToEmoji.put(keyword, value = new UnicodeSet());
+                }
+                value.addAll(emojiRestored);
+            }
+        }
+        CldrUtility.protectCollection(keywordToEmoji);
+
+        int count = 0;
+        System.out.println("### Emoji to Keywords");
+        TreeSet<String> sortedRootEmoji = new TreeSet<>(Emoji.COLLATOR);
+        rootEmoji.addAllTo(sortedRootEmoji);
+        for (String emoji : sortedRootEmoji) {
+            String restored = Emoji.restoreVariants(emoji);
+            Set<String> keywords = english.get(emoji).getKeywords();
+            System.out.println(
+                    ++count + "\t" + restored + "\t" + emoji + "\t" + JOIN_BAR.join(keywords));
+        }
+
+        UnicodeSet toEscape =
+                new UnicodeSet(CodePointEscaper.FORCE_ESCAPE)
+                        .remove(CodePointEscaper.ZWJ.getCodePoint())
+                        .remove(CodePointEscaper.RANGE.getCodePoint())
+                        .freeze();
+        SimpleUnicodeSetFormatter suf = new SimpleUnicodeSetFormatter(null, toEscape);
+
+        allUnclean =
+                allUnclean
+                        .retainAll(rgiNoVariant)
+                        .removeAll(Emoji.SKIN_MODIFIERS)
+                        .removeAll(Emoji.HAIR_MODIFIERS);
+        if (!allUnclean.isEmpty()) {
+            throw new IllegalArgumentException("Missing " + suf.format(allUnclean));
+        }
+
+        System.out.println("### Keywords to Emoji");
+
+        count = 0;
+        for (Entry<String, UnicodeSet> entry : keywordToEmoji.entrySet()) {
+            System.out.println(
+                    ++count + "\t" + entry.getKey() + "\t" + suf.format(entry.getValue()));
+        }
+
+        System.out.println("### Gender Variants");
+
+        for (Set<String> entry : Emoji.getGenderGroups()) {
+            // find common keywords
+            Set<String> common = null;
+            Set<String> cleanEntry = new TreeSet<>();
+            for (String s : entry) {
+                if (!rootEmoji.contains(Emoji.removeVariants(s))) {
+                    continue;
+                }
+                Annotations anno = getAnnotations(english, s);
+                if (anno == null) {
+                    continue;
+                }
+                cleanEntry.add(s);
+                if (common == null) {
+                    System.out.println();
+                    common = new TreeSet<>();
+                    common.addAll(anno.getKeywords());
+                } else {
+                    common.retainAll(anno.getKeywords());
+                }
+            }
+            // now show them
+            if (cleanEntry.size() > 1) {
+                for (String s : cleanEntry) {
+                    Annotations anno = getAnnotations(english, s);
+                    String removed = Emoji.removeVariants(s);
+                    System.out.println(
+                            s
+                                    + "\t"
+                                    + removed
+                                    + "\t"
+                                    + anno.getShortName()
+                                    + "\t"
+                                    + JOIN_BAR.join(common)
+                                    + "\t"
+                                    + JOIN_BAR.join(Sets.difference(anno.getKeywords(), common)));
+                }
+            }
+        }
+    }
+
+    public static Annotations getAnnotations(UnicodeMap<Annotations> english, String s) {
+        Annotations anno = english.get(s);
+        if (anno == null) {
+            anno = english.get(s.replace(Emoji.EMOJI_VARIANT, ""));
+        }
+        return anno;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Emoji.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Emoji.java
@@ -3,12 +3,20 @@ package org.unicode.cldr.util;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
+import com.ibm.icu.text.Collator;
+import com.ibm.icu.text.Transliterator;
+import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -17,17 +25,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.PathHeader.PageId;
 
 public class Emoji {
+    public static final Collator COLLATOR = CLDRConfig.getInstance().getCollator();
     public static final String EMOJI_VARIANT = "\uFE0F";
+    public static final char JOINER = '\u200D';
+    public static final String JOINER_STR = "\u200D";
+
+    public static final String FEMALE = "\u2640";
+    public static final String MALE = "\u2642";
+    public static final String TRANSGENDER = "\u26A7";
+
     public static final String COMBINING_ENCLOSING_KEYCAP = "\u20E3";
     public static final String ZWJ = "\u200D";
     public static final UnicodeSet REGIONAL_INDICATORS = new UnicodeSet(0x1F1E6, 0x1F1FF).freeze();
-    public static final UnicodeSet MODIFIERS = new UnicodeSet("[🏻-🏿]").freeze();
+    public static final UnicodeSet SKIN_MODIFIERS = new UnicodeSet("[🏻-🏿]").freeze();
+    public static final UnicodeSet HAIR_MODIFIERS = new UnicodeSet("[🦰🦱🦳🦲]").freeze();
     public static final UnicodeSet TAGS = new UnicodeSet(0xE0000, 0xE007F).freeze();
     public static final UnicodeSet FAMILY = new UnicodeSet("[\u200D 👦-👩 💋 ❤]").freeze();
     public static final UnicodeSet GENDER = new UnicodeSet().add(0x2640).add(0x2642).freeze();
@@ -53,6 +72,57 @@ public class Emoji {
     static final UnicodeMap<String> emojiToMinorCategory = new UnicodeMap<>();
     static final UnicodeMap<String> toName = new UnicodeMap<>();
 
+    static final UnicodeSet NEUTRAL =
+            new UnicodeSet(
+                            "[⛷⛹🏂-🏄🏇🏊-🏎👤👥👪-👳👶👷👼💁💂💆💇💏💑🕴🕵🗣🙅-🙇🙋🙍🙎🚣🚴-🚶🛀🛌🤦🤰🤱🤵🤷-🤾🦸🦹🧑-🧟]")
+                    .freeze();
+    public static final String ZWJ_HANDSHAKE_ZWJ = JOINER_STR + UTF16.valueOf(0x1F91D) + JOINER_STR;
+    public static final String ZWJ_HEART_ZWJ = JOINER_STR + UTF16.valueOf(0x2764) + JOINER_STR;
+    public static final UnicodeSet FULL_ZWJ_GENDER_MARKERS =
+            new UnicodeSet()
+                    .add(JOINER + FEMALE)
+                    .add(JOINER + MALE)
+                    .add(JOINER + FEMALE + EMOJI_VARIANT)
+                    .add(JOINER + MALE + EMOJI_VARIANT)
+                    .freeze();
+
+    static final Transliterator NEUTER;
+
+    static {
+        final UnicodeMap<String> TO_NEUTRAL =
+                new UnicodeMap<String>()
+                        .put("👦", "🧒")
+                        .put("👧", "🧒")
+                        .put("👨", "🧑")
+                        .put("👩", "🧑")
+                        .put("👴", "🧓")
+                        .put("👵", "🧓")
+                        .put("🤴", "🧑\u200D👑")
+                        .put("👸", "🧑\u200D👑")
+                        .put("🎅", "🧑\u200D🎄")
+                        .put("🤶", "🧑\u200D🎄")
+                        .put("💃", "🧑\u200D🎶")
+                        .put("🕺", "🧑\u200D🎶")
+                        .put("👫", "🧑" + ZWJ_HANDSHAKE_ZWJ + "🧑")
+                        .put("👬", "🧑" + ZWJ_HANDSHAKE_ZWJ + "🧑")
+                        .put("👭", "🧑" + ZWJ_HANDSHAKE_ZWJ + "🧑")
+                        .put(JOINER + FEMALE + EMOJI_VARIANT, "")
+                        .put(JOINER + MALE + EMOJI_VARIANT, "")
+                        .put(JOINER + FEMALE, "")
+                        .put(JOINER + MALE, "")
+                        .freeze();
+        Map<String, String> results =
+                new TreeMap(Ordering.from(SupplementalDataInfo.LENGTH_FIRST).reversed());
+        for (Entry<String, String> entry : TO_NEUTRAL.entrySet()) {
+            results.put(entry.getKey(), entry.getValue());
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Entry<String, String> entry : results.entrySet()) {
+            sb.append(entry.getKey()).append('→').append(entry.getValue()).append(";\n");
+        }
+        NEUTER = Transliterator.createFromRules("foo", sb.toString(), Transliterator.FORWARD);
+    }
+
     static {
         emojiToMajorCategory.setErrorOnReset(true);
         emojiToMinorCategory.setErrorOnReset(true);
@@ -74,8 +144,9 @@ public class Emoji {
     static final UnicodeSet allRgi = new UnicodeSet();
     static final UnicodeSet allRgiNoES = new UnicodeSet();
 
+    static final UnicodeMap<String> restoreVariants = new UnicodeMap<>();
+    static final Set<Set<String>> genderSets;
     // ߘ E1.0 grinning face
-
     static {
         /*
          * Example from emoji-test.txt:
@@ -89,6 +160,7 @@ public class Emoji {
         final Matcher commentMatcher =
                 Pattern.compile("\\s*[\\S]+\\s+(?:E\\d*.\\d+\\s+)(.*)").matcher("");
 
+        Map<String, String> neutralAndGenderedToNeutral = new TreeMap<>();
         for (String line : FileUtilities.in(Emoji.class, "data/emoji/emoji-test.txt")) {
             if (line.startsWith("#")) {
                 line = line.substring(1).trim();
@@ -117,8 +189,22 @@ public class Emoji {
             }
             String type = typeRaw.substring(0, hashPos).trim();
             if (type.startsWith("fully-qualified")) {
+                if (original.contains("♂")) {
+                    int debug = 0;
+                }
                 allRgi.add(original);
-                allRgiNoES.add(original.replace(Emoji.EMOJI_VARIANT, ""));
+                final String variantsRemoved = removeVariants(original);
+                allRgiNoES.add(variantsRemoved);
+                if (!original.equals(variantsRemoved)) {
+                    restoreVariants.put(variantsRemoved, original);
+                }
+                if (!SKIN_MODIFIERS.containsSome(original)) {
+                    String neutral = NEUTER.transform(original);
+                    if (!neutral.equals(original)) {
+                        neutralAndGenderedToNeutral.put(original, neutral);
+                        neutralAndGenderedToNeutral.put(neutral, neutral);
+                    }
+                }
             }
             emojiToMajorCategory.put(original, majorCategory);
             emojiToMinorCategory.put(original, minorCategory);
@@ -154,7 +240,7 @@ public class Emoji {
             if (minimal.contains(COMBINING_ENCLOSING_KEYCAP)
                     || REGIONAL_INDICATORS.containsSome(minimal)
                     || TAGS.containsSome(minimal)
-                    || !singleton && MODIFIERS.containsSome(minimal)
+                    || !singleton && SKIN_MODIFIERS.containsSome(minimal)
                     || !singleton && FAMILY.containsAll(minimal)) {
                 // do nothing
             } else if (minimal.contains(ZWJ)) { // only do certain ZWJ sequences
@@ -170,11 +256,45 @@ public class Emoji {
         }
         emojiToMajorCategory.freeze();
         emojiToMinorCategory.freeze();
-        nonConstructed.add(MODIFIERS); // needed for names
+        nonConstructed.add(SKIN_MODIFIERS); // needed for names
         nonConstructed.freeze();
         toName.freeze();
         allRgi.freeze();
-        allRgiNoES.freeze();
+        allRgiNoES.addAll(SKIN_MODIFIERS).addAll(HAIR_MODIFIERS).freeze();
+        // hack
+        for (String s :
+                new UnicodeSet(
+                        "[#*0-9©®‼⁉™ℹ↔-↙↩↪⌨⏏⏭-⏯ ⏱⏲⏸-⏺Ⓜ▪▫▶◀◻◼☀-☄☎☑☘☝☠☢ ☣☦☪☮☯☸-☺♀♂♟♠♣♥♦♨♻♾⚒⚔-⚗ ⚙⚛⚜⚠⚧⚰⚱⛈⛏⛑⛓⛩⛰⛱⛴⛷-⛹✂"
+                                + "✈✉ ✌✍✏✒✔✖✝✡✳✴❄❇❣❤➡⤴⤵⬅-⬇〰 〽㊗㊙🅰🅱🅾🅿🈂🈷🌡🌤-🌬🌶🍽🎖🎗🎙-🎛🎞 🎟🏋-🏎🏔-🏟🏳🏵🏷🐿👁📽🕉"
+                                + "🕊🕯🕰🕳-🕹🖇 🖊-🖍🖐🖥🖨🖱🖲🖼🗂-🗄🗑-🗓🗜-🗞🗡🗣🗨 🗯🗳🗺🛋🛍-🛏🛠-🛥🛩🛰🛳]")) {
+            restoreVariants.put(s, s + Emoji.EMOJI_VARIANT);
+        }
+        restoreVariants.freeze();
+        Multimap<String, String> neutralToOthers = TreeMultimap.create(COLLATOR, COLLATOR);
+        Multimaps.invertFrom(Multimaps.forMap(neutralAndGenderedToNeutral), neutralToOthers);
+        Set<Set<String>> toGenderGroup = new LinkedHashSet<>();
+        for (Collection<String> set : neutralToOthers.asMap().values()) {
+            TreeSet<String> s = new TreeSet<>(COLLATOR);
+            s.addAll(set);
+            toGenderGroup.add(ImmutableSet.copyOf(s));
+        }
+        genderSets = CldrUtility.protectCollection(toGenderGroup);
+    }
+
+    public static String removeVariants(String original) {
+        return original.replace(Emoji.EMOJI_VARIANT, "");
+    }
+
+    public static Set<Set<String>> getGenderGroups() {
+        return genderSets;
+    }
+
+    public static final String restoreVariants(String source) {
+        String restored = restoreVariants.get(source);
+        if (restored != null) {
+            int debug = 0;
+        }
+        return restored == null ? source : restored;
     }
 
     private static <K, V> void putUnique(Map<K, V> map, K key, V value) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
@@ -64,18 +64,17 @@ public class SimpleUnicodeSetFormatter implements FormatterParser<UnicodeSet> {
     public SimpleUnicodeSetFormatter(
             Comparator<String> col, UnicodeSet forceHex, int maxDisallowRanges) {
         // collate, but preserve non-equivalents
-        this.comparator = ComparatorUtilities.wrapForCodePoints(col);
+        this.comparator = col == null ? COLLATOR : ComparatorUtilities.wrapForCodePoints(col);
         this.forceHex = forceHex == null ? CodePointEscaper.FORCE_ESCAPE : forceHex.freeze();
         this.maxDisallowRanges = maxDisallowRanges;
     }
 
     static final int DEFAULT_MAX = 1024;
+    public static final Comparator<String> COLLATOR =
+            (Comparator) CLDRConfig.getInstance().getCollator();
 
     public static SimpleUnicodeSetFormatter fromIcuLocale(String localeId) {
-        return new SimpleUnicodeSetFormatter(
-                (Comparator) ComparatorUtilities.getIcuCollator(localeId, Collator.IDENTICAL),
-                null,
-                DEFAULT_MAX);
+        return new SimpleUnicodeSetFormatter(COLLATOR, null, DEFAULT_MAX);
     }
 
     public SimpleUnicodeSetFormatter(Comparator<String> col, UnicodeSet forceHex) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,1091 +1,304 @@
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😀"]; new_value=face | grin | grinning face | cheerful | cheery | happy | laugh | nice | smile | smiling | teeth
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😃"]; new_value=face | grinning face with big eyes | mouth | open | smile | awesome | grin | happy | teeth | smiling | yay | smiling face with open mouth
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😄"]; new_value=eye | face | grinning face with smiling eyes | mouth | open | smile | grin | happy | laugh | lol | smiling | smiling face with open mouth & smiling eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😁"]; new_value=beaming face with smiling eyes | eye | face | grin | smile | happy | nice | smiling | teeth | grinning face with smiling eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😆"]; new_value=face | grinning squinting face | laugh | mouth | satisfied | smile | happy | lol | haha | rofl | smiling | open | smiling face with open mouth & closed eyes | hahaha
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😅"]; new_value=cold | face | grinning face with sweat | open | smile | sweat | excited | nervous | dejected | stress | stressed | smiling face with open mouth & cold sweat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤣"]; new_value=face | floor | laugh | rofl | rolling | rolling on the floor laughing | rotfl | laughing | lmao | tears | lol | haha | happy | hehe | hilarious | laughter | lolol | lololol | lmfao | roflmao | tear | crying laughing | funny | joy | crying
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😂"]; new_value=face | face with tears of joy | joy | laugh | tear | crying | feels | haha | happy | hehe | laughing | laughter | hilarious | lol | lolol | lololol | lmao | lmfao | roflmao | rofl | tears | crying laughing | funny | hahaha
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙂"]; new_value=face | slightly smiling face | smile | smiling | happy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙃"]; new_value=face | upside-down | hehe | upside-down face | smile
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫠"]; new_value=disappear | dissolve | liquid | melt | melting face | melting | haha | lol | sarcastic | sarcasm | heat | hot | embarrassed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😉"]; new_value=face | wink | winking face | flirt | heartbreaker | sexy | slide | tease | winking | winks
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😊"]; new_value=blush | eye | face | smile | smiling face with smiling eyes | glad | satisfied | smiling
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😇"]; new_value=angel | face | fantasy | halo | innocent | smiling face with halo | angelic | angels | blessed | peaceful | happy | fairy tale | smile | smiling | spirit | fairytale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥰"]; new_value=adore | crush | hearts | in love | smiling face with hearts | smiling face with 3 hearts | love | ily | i love you | smile | heart | romance | smiling hearts | face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😍"]; new_value=eye | face | love | smile | smiling face with heart-eyes | 143 | bae | feels | heart | hearts | ily | in love | kisses | loving | romance | romantic | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤩"]; new_value=eyes | face | grinning | star | star-struck | starry-eyed | smile | excited | wow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😘"]; new_value=face | face blowing a kiss | kiss | 143 | adorbs | bae | flirt | heart | ily | kisses | love | love you | lover | miss you | morning | muah | night | romance | romantic | smooch | smooches | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😗"]; new_value=face | kiss | kissing face | 143 | date | dating | flirt | ily | love | love you | kisses | kissing | smooch | smooches | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☺"]; new_value=face | outlined | relaxed | smile | smiling face | smiling | happy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😚"]; new_value=closed | eye | face | kiss | kissing face with closed eyes | 143 | bae | blush | date | dating | flirt | ily | kisses | smooches | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😙"]; new_value=eye | face | kiss | kissing face with smiling eyes | smile | 143 | closed eyes | date | dating | flirt | ily | kisses | love | night
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥲"]; new_value=grateful | proud | relieved | smiling | smiling face with tear | tear | touched | smiley | joy | smile | happy | glad | pain
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😋"]; new_value=delicious | face | face savoring food | savouring | smile | yum | food | full | hungry | savour | smiling | eat | yummy | tasty | face savouring delicious food | um
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😛"]; new_value=face | face with tongue | tongue | awesome | cool | nice | sweet | party | face with stuck-out tongue
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😜"]; new_value=eye | face | joke | tongue | wink | winking face with tongue | crazy | epic | fun | funny | loopy | nutty | party | wacky | weirdo | yolo | face with stuck-out tongue & winking eye
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤪"]; new_value=eye | goofy | large | small | zany face | crazy face | crazy | crazy eyes | eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😝"]; new_value=eye | face | horrible | squinting face with tongue | taste | tongue | gross | omg | whatever | yolo | face with stuck-out tongue & closed eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤑"]; new_value=face | money | money-mouth face | mouth | paid
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤗"]; new_value=face | hug | hugging | open hands | smiling face | smiling face with open hands | hugging face | hands
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤭"]; new_value=face with hand over mouth | whoops | shock | sudden realization | surprise | giggle | giggling | oops | secret
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫢"]; new_value=amazement | awe | disbelief | embarrass | face with open eyes and hand over mouth | scared | surprise | omg | gasp | quiet | shocked | shock
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫣"]; new_value=captivated | face with peeking eye | peep | stare | peek | hide | peeking | shy | embarrass | hiding | scared
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤫"]; new_value=quiet | shush | shushing face | shh | be quiet
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤔"]; new_value=face | thinking | hmm | consider | ponder | pondering | thinking face | chin | wondering
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫡"]; new_value=OK | salute | saluting face | sunny | troops | yes | yes sir | yes ma'am | respect | good luck
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤐"]; new_value=face | mouth | zip | zipper | zipper-mouth face | keep my mouth shut | secret | not telling | quiet
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤨"]; new_value=distrust | face with raised eyebrow | skeptic | disapproval | disbelief | mild surprise | scepticism | skeptical | hmm | surprise | what | colbert emoji
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😐"]; new_value=deadpan | face | meh | neutral | awk | awkward | bad | basic | dead | jealous | jel | jelly | expressionless | blank | not impressed | unimpressed | whatever | not amused | unamused | not funny | not laughing | shade | uh | uh oh | neutral face | straight face | unhappy | fine
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😑"]; new_value=expressionless | face | inexpressive | meh | unexpressive | awk | awkward | bad | basic | cost | dead | unhappy | whatever | fine | jealous | jel | jelly | no | omg | uh | uh oh | straight face | wtf | expressionless face | unimpressed | not impressed | uh oh | not impressed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😶"]; new_value=face | face without mouth | mouth | quiet | silent | awkward | cant even | blank | expressionless | secret | mouthless | mute | silence | speechless
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫥"]; new_value=depressed | disappear | dotted line face | hide | introvert | invisible | meh | wtv | whatever | hidden
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😏"]; new_value=face | smirk | smirking face | boss | dapper | eyebrows | flirt | homie | kidding | leer | slick | slide | suspicious | sly | smug | snicker | shade | suave | swag | swagger | wink
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😒"]; new_value=face | unamused | unhappy | ... | bored | coolstorybro | jealous | jel | jelly | pissed | smh | ugh | weird | whatever | fine | uhh | unamused face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙄"]; new_value=eyeroll | eyes | face | face with rolling eyes | rolling | whatever | shade | ugh
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😬"]; new_value=face | grimace | grimacing face | awk | awkward | dentist | grinning | smile | smiling | nothing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😮‍💨"]; new_value=exhale | face exhaling | gasp | groan | relief | whisper | whistle | smiley | sigh | smoke | blow | exhausted | blowing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤥"]; new_value=face | lie | lying face | pinocchio | liar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫨"]; new_value=earthquake | face | shaking | shock | vibrate | omg | panic | daze | whoa | wow | crazy | surprise
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😌"]; new_value=face | relieved | calm | peace | relief | zen | relieved face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😔"]; new_value=dejected | face | pensive | awful | bored | died | losing | sucks | lost | sad | disappointed | pensive face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😪"]; new_value=face | good night | sleep | sleepy face | sleeping | tired | sad | crying
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😴"]; new_value=face | good night | sleep | sleeping face | ZZZ | bed | bedtime | nap | sleeping | tired | whatever | zzz | yawn | goodnight | night | zz | zzzz
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😷"]; new_value=cold | doctor | face | face with medical mask | mask | sick | dentist | dermatologist | dr | germs | medicine
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤕"]; new_value=bandage | face | face with head-bandage | hurt | injury | ouch
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤢"]; new_value=face | nauseated | vomit | gross | nasty | sick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤮"]; new_value=face vomiting | puke | sick | vomit | throw up | spew | gross | ew
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤧"]; new_value=face | gesundheit | sneeze | sneezing face | flu | fever | sick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥵"]; new_value=feverish | heat stroke | hot | hot face | red-faced | sweating | dying | tongue out | panting | face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥶"]; new_value=blue-faced | cold | cold face | freezing | frostbite | icicles | subzero | face | cold teeth | blue
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥴"]; new_value=dizzy | intoxicated | tipsy | uneven eyes | wavy mouth | woozy face | drunk
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😵"]; new_value=crossed-out eyes | dead | face | face with crossed-out eyes | knocked out | dizzy | feels | sick | tired | dizzy face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😵‍💫"]; new_value=dizzy | face with spiral eyes | hypnotized | spiral | trouble | whoa | smiley | omg | woah | woozy | confused
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤯"]; new_value=exploding head | mind blown | shocked | mindblown | no way | explode
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥳"]; new_value=celebration | hat | horn | party | partying face | celebrate | hooray | birthday | excited | face | happy birthday | happy bday
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥸"]; new_value=disguise | disguised face | face | glasses | incognito | nose | person | spy | mustache | moustache | eyebrow | tash | tache
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😎"]; new_value=bright | cool | face | smiling face with sunglasses | sun | sunglasses | awesome | beach | bro | eye | eyewear | fly | chillin | glasses | rad | relaxed | shades | slay | smile | stunner | style | swag | swagger | win | winning | yeah
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤓"]; new_value=face | geek | nerd | nerd face | smart | brainy | intelligent | expert | gifted | glasses | clever
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧐"]; new_value=face | face with monocle | monocle | stuffy | wealthy | fancy | classy | rich
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😕"]; new_value=confused | face | meh | befuddled | confusing | not sure | sorry | frown | i dunno | dunno | hm | sad | confused face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫤"]; new_value=disappointed | face with diagonal mouth | meh | skeptical | unsure | wtv | whatever | doubtful | doubt | frustrated | frustration | confused | confusion
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😟"]; new_value=face | worried | anxious | butterflies | nerves | nervous | stress | sad | surprised | stressed | worry | worried face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙁"]; new_value=face | frown | slightly frowning face | sad
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☹"]; new_value=face | frown | frowning face | sad
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😮"]; new_value=face | face with open mouth | mouth | open | sympathy | forgot | i dont believe you | omg | woah | whoa | wow | surprised | shocked | unreal | unbelievable
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😯"]; new_value=face | hushed | stunned | surprised | epic | omg | woah | whoa | hushed face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😲"]; new_value=astonished | face | shocked | totally | no way | cost | gtfo | omfg | omg | wtf | astonished face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😳"]; new_value=dazed | face | flushed | awk | awkward | blame | dead | disbelief | exercise | heat | hot | geez | jeez | what | that's crazy | wow | amazed | impressed | flushed face | embarrassed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥺"]; new_value=begging | mercy | pleading face | puppy eyes | please | pretty please | sad | why not | face | big eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥹"]; new_value=angry | cry | face holding back tears | proud | resist | sad | aw | aww | please | tears of joy | grateful | admiration | gratitude | sadness | embarrassed | feelings
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😦"]; new_value=face | frown | frowning face with open mouth | mouth | open | caught off guard | wow | what | scared | scary | suprise
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😧"]; new_value=anguished | face | forgot | scared | scary | wow | what | stressed | suprise | unhappy | anguished face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😨"]; new_value=face | fear | fearful | scared | afraid | anxious | blame | worried | fearful face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😰"]; new_value=anxious face with sweat | blue | cold | face | rushed | sweat | eek | mouth | nervous | scared | yikes | open | face with open mouth & cold sweat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😥"]; new_value=disappointed | face | relieved | sad but relieved face | whew | anxious | close call | complicated | sad | not this time | sweat | disappointed but relieved face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😢"]; new_value=cry | crying face | face | sad | tear | awful | crying | feels | miss | triste | unhappy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😭"]; new_value=cry | face | loudly crying face | sad | sob | tear | bawling | crying | tears | unhappy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😱"]; new_value=face | face screaming in fear | fear | munch | scared | scream | epic | fearful | shocked | screamer | surprised | woah
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😖"]; new_value=confounded | face | confused | distraught | feels | frustrated | cringe | mad | sad | confounded face | annoyed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😣"]; new_value=face | persevere | persevering face | concentrate | concentration | focus | headache
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😞"]; new_value=disappointed | face | awful | blame | dejected | fail | losing | sad | unhappy | disappointed face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😓"]; new_value=cold | downcast face with sweat | face | sweat | feels | nervous | sad | headache | scared | that was close | yikes | face with cold sweat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😩"]; new_value=face | tired | weary | crying | fail | feels | sad | sleepy | unhappy | mad | hungry | nooo | weary face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😫"]; new_value=face | tired | cost | feels | nap | sneeze | sad | tired face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥱"]; new_value=bored | tired | yawn | yawning face | sleepy | zzz | goodnight | night | bedtime | face | nap | sleep | whatever | zz | zzzz
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😤"]; new_value=face | face with steam from nose | triumph | won | anger | angry | feels | steam | mad | unhappy | fuming | fume | furious | fury
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😡"]; new_value=angry | enraged | face | mad | pouting | rage | red | anger | feels | maddening | shade | upset | unhappy | pouting face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😠"]; new_value=anger | angry | face | mad | blame | feels | frustrated | maddening | rage | upset | shade | unhappy | angry face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤬"]; new_value=face with symbols on mouth | swearing | cursing | cussing | censor | mad | pissed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😈"]; new_value=face | fairy tale | fantasy | horns | smile | smiling face with horns | shade | fairytale | evil | devil | purple face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👿"]; new_value=angry face with horns | demon | devil | face | fantasy | imp | evil | fairy tale | shade | fairytale | mischievous | purple face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💀"]; new_value=death | face | fairy tale | monster | skull | body | dead | yolo | fairytale | i'm dead | lmao
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☠"]; new_value=crossbones | death | face | monster | skull | skull and crossbones | dead | bone
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💩"]; new_value=dung | face | monster | pile of poo | poo | poop | comic | doo doo | bs | fml | turd | smelly | smh | stinks | stinky | stink
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👹"]; new_value=creature | face | fairy tale | fantasy | monster | ogre | fairytale | devil | mask | scary
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👺"]; new_value=creature | face | fairy tale | fantasy | goblin | monster | fairytale | angry | mean | mask
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👻"]; new_value=creature | face | fairy tale | fantasy | ghost | monster | excited | halloween | scary | haunting | silly | boo | fairytale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👽"]; new_value=alien | creature | extraterrestrial | face | fantasy | ufo | fairy tale | monster | space | fairytale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👾"]; new_value=alien | creature | extraterrestrial | face | monster | ufo | fairy tale | fantasy | game | games | gamer | pixellated | space | fairytale | alien monster
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤖"]; new_value=face | monster | robot | robot face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😺"]; new_value=cat | face | grinning | mouth | open | smile | animal | smiling cat face with open mouth
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😸"]; new_value=cat | eye | face | grin | grinning cat with smiling eyes | smile | animal | grinning cat face with smiling eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😹"]; new_value=cat | cat with tears of joy | face | joy | tear | animal | laugh | laughing | lol | cat face with tears of joy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😻"]; new_value=cat | eye | face | heart | love | smile | smiling cat with heart-eyes | animal | smiling cat face with heart-eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😼"]; new_value=cat | cat with wry smile | face | ironic | smile | wry | animal | cat face with wry smile
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😽"]; new_value=cat | eye | face | kiss | kissing cat | animal | kissing cat face with closed eyes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙀"]; new_value=cat | face | oh | surprised | weary | animal | weary cat face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😿"]; new_value=cat | cry | crying cat | face | sad | tear | animal | crying cat face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="😾"]; new_value=cat | face | pouting | animal | pouting cat face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙈"]; new_value=evil | face | forbidden | monkey | see | see-no-evil monkey | animal | cant watch | forgot | hide | no | nono | omg | prohibited | scared | secret | see no evil | smh | gesture | not | embarrassed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙉"]; new_value=evil | face | forbidden | hear | hear-no-evil monkey | monkey | animal | hear no evil | listen | no | ears | prohibited | secret | shh | tmi | gesture | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙊"]; new_value=evil | face | forbidden | monkey | speak | speak-no-evil monkey | animal | no | oops | prohibited | quiet | secret | speak no evil | stealth | gesture | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💌"]; new_value=heart | letter | love | mail | romance | valentine | love letter
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💘"]; new_value=arrow | cupid | heart with arrow | 143 | adorbs | date | emotion | heart | ily | love | romance | valentine
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💝"]; new_value=heart with ribbon | ribbon | valentine | 143 | anniversary | emotion | heart | ily | kisses | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💖"]; new_value=excited | sparkle | sparkling heart | 143 | emotion | good night | heart | ily | kisses | morning | sparkling | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💗"]; new_value=excited | growing | growing heart | nervous | pulse | 143 | emotion | heart | heartpulse | ily | kisses | muah | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💓"]; new_value=beating | beating heart | heartbeat | pulsating | 143 | cardio | emotion | heart | ily | love | pulse
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💞"]; new_value=revolving | revolving hearts | 143 | adorbs | anniversary | emotion | heart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💕"]; new_value=love | two hearts | 143 | anniversary | date | dating | emotion | heart | hearts | ily | kisses | loving | xoxo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💟"]; new_value=heart | heart decoration | 143 | emotion | white hearth | purple heart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❣"]; new_value=exclamation | heart exclamation | mark | punctuation | heavy heart exclamation
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💔"]; new_value=break | broken | broken heart | crushed | emotion | lonely | sad | heartbroken
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❤"]; new_value=heart | red heart | emotion | love
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩷"]; new_value=cute | heart | like | love | pink | sweet | adorable | special | 143 | emotion | ily
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💛"]; new_value=yellow | yellow heart | 143 | cardiac | emotion | heart | ily | love
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💚"]; new_value=green | green heart | 143 | emotion | heart | ily | love | romantic
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💙"]; new_value=blue | blue heart | 143 | emotion | heart | ily | love | romance
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩵"]; new_value=cyan | heart | light blue | light blue heart | teal | sky blue | like | 143 | emotion | cute | ily | love | special
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💜"]; new_value=purple | purple heart | 143 | bestest | emotion | heart | ily | love
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🖤"]; new_value=black | black heart | evil | wicked | heart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩶"]; new_value=gray | grey heart | heart | silver | slate | grey | 143 | special | emotion | ily | love
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💋"]; new_value=kiss | kiss mark | lips | dating | emotion | heart | kissing | romance | sexy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💯"]; new_value=100 | full | hundred | hundred points | score | a+ | bruh | clearly | faithful | fleek | hbd | homie | kidding | perfect score | true | truth | on point | agree | yup | keep it 100 | definitely
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💢"]; new_value=anger symbol | angry | comic | mad | upset
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💥"]; new_value=boom | collision | comic | bomb | collide | explode
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💫"]; new_value=comic | dizzy | star | shooting star | shining | stars
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💦"]; new_value=comic | splashing | sweat | sweat droplets | droplet | droplets | work out | workout | drip | drops | water | wet | squirt
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💨"]; new_value=comic | dash | dashing away | running | fart | fast | gone | gotta go | smoke | cloud
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💬"]; new_value=balloon | bubble | comic | dialog | speech | message | sms | talk | text | typing | speech balloon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👁‍🗨"]; new_value=balloon | bubble | eye | eye in speech bubble | speech | witness | speech bubble
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💭"]; new_value=balloon | bubble | comic | thought | cartoon | cloud | daydream | decisions | dream | dreams | idea | invent | invention | realize | think | thinking | thoughts | wonder | thought balloon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💤"]; new_value=comic | good night | sleep | ZZZ | sleeping | sleepy | tired | zz | zzz | zzzz | goodnight | night
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👋"]; new_value=hand | wave | waving | cya | g2g | gtg | later | outtie | ttfn | ttyl | waving hand | bye | hi | hey | yo | u there? | hello | greetings
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🖐"]; new_value=finger | hand | hand with fingers splayed | splayed | raised hand with fingers splayed | stop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✋"]; new_value=hand | high 5 | high five | raised hand | five | stop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🖖"]; new_value=finger | hand | spock | vulcan | vulcan salute | hands
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫱"]; new_value=hand | right | rightward | rightwards hand | shake | hold | handshake | right hand | reach
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫲"]; new_value=hand | left | leftward | leftwards hand | shake | hold | handshake | left hand | reach
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫳"]; new_value=dismiss | drop | palm down hand | shoo | dropped | pick | pick up | hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫴"]; new_value=beckon | catch | come | offer | palm up hand | hold | hand | lift | don't know | tell me
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫷"]; new_value=high five | leftward | leftwards pushing hand | push | refuse | stop | wait | slap five | block | halt | pause | hold | hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫸"]; new_value=high five | push | refuse | rightward | rightwards pushing hand | stop | wait | slap five | block | halt | pause | hold | hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👌"]; new_value=hand | OK | awesome | dope | fleek | gotcha | legit | bet | got it | three | sweet | ok | okay | pinch | rad | OK hand | sure | for sure | fosho
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤌"]; new_value=fingers | hand gesture | interrogation | pinched | sarcastic | ugh | huh | hold on | relax | hand | what | patience | zip it
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤏"]; new_value=pinching hand | small amount | fingers | small | little bit | sort of
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✌"]; new_value=hand | v | victory | peace | victory hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤞"]; new_value=cross | crossed fingers | finger | hand | luck | fingers crossed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫰"]; new_value=expensive | hand with index finger and thumb crossed | heart | love | money | snap | <3 | hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤟"]; new_value=hand | ILY | love-you gesture | i love you | three fingers
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👈"]; new_value=backhand | backhand index pointing left | finger | hand | index | point | left
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👉"]; new_value=backhand | backhand index pointing right | finger | hand | index | point | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👆"]; new_value=backhand | backhand index pointing up | finger | hand | point | up | index
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👇"]; new_value=backhand | backhand index pointing down | down | finger | hand | point | index
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☝"]; new_value=finger | hand | index | index pointing up | point | up | this
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫵"]; new_value=index pointing at the viewer | point | you | poke | finger | hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👍"]; new_value=+1 | hand | thumb | thumbs up | up | awesome | dope | fleek | good | gotcha | great | legit | like | okay | rad | tubular | yeah | yes | nice | sure | for sure | fosho
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👎"]; new_value=-1 | down | hand | thumb | thumbs down | bad | dislike | no | no good | nope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✊"]; new_value=clenched | fist | hand | punch | raised fist | solidarity
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👊"]; new_value=clenched | fist | hand | oncoming fist | punch | absolutely | agree | boom | bro | bruh | bump | correct | knuckle | pound | rock | ttyl
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👏"]; new_value=clap | clapping hands | hand | applause | approval | awesome | congrats | congratulations | excited | great | homie | nice | prayed | yay | well done | good job
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙌"]; new_value=celebration | gesture | hand | hooray | raised | raising hands | praise
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫶"]; new_value=heart hands | love | heart | <3 | love you | hands
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👐"]; new_value=hand | open | open hands | jazz hands | hug | swerve
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤲"]; new_value=palms up together | prayer | cupped hands | dua | pray | wish
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤝"]; new_value=agreement | hand | handshake | meeting | shake | deal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙏"]; new_value=ask | folded hands | hand | high 5 | high five | please | pray | thanks | beg | bow | thank | thank you | appreciate | cmon | blessed | thx | five | gesture | folded
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💅"]; new_value=care | cosmetics | manicure | nail | polish | makeup | nail polish | whatever | bored | i'm done
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💪"]; new_value=biceps | comic | flex | flexed biceps | muscle | beast | bench press | body | bro | curls | gym | flexing | bodybuilder | gains | jacked | ripped | strong | weightlift | weightlifter | arm
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦵"]; new_value=kick | leg | limb | bent leg | knee | foot
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦶"]; new_value=foot | kick | stomp | ankle | feet
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👂"]; new_value=body | ear | ears | hear | hearing | listen | listening | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👃"]; new_value=body | nose | noses | nosey | odor | smell | smells
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧠"]; new_value=brain | intelligent | smart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫀"]; new_value=anatomical | cardiology | heart | organ | pulse | beat | heartbeat | red | real heart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫁"]; new_value=breath | exhalation | inhalation | lungs | organ | respiration | lung | breathe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦷"]; new_value=dentist | tooth | teeth | pearly | white
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦴"]; new_value=bone | skeleton | dog | wishbone | bones
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👀"]; new_value=eye | eyes | face | body | peep | googly | look | looking | omg | see | seeing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👁"]; new_value=body | eye | one eye | 1 eye
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👅"]; new_value=body | tongue | lick | slurp
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👄"]; new_value=lips | mouth | beauty | body | kiss | kissing | lipstick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫦"]; new_value=anxious | biting lip | fear | flirting | nervous | uncomfortable | worried | sexy | flirt | lip | bite | lipstick | kiss | worry
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👶"]; new_value=baby | young | babies | children | goo goo | infant | newborn | pregnant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧒"]; new_value=child | gender-neutral | unspecified gender | young | kid
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👦"]; new_value=boy | young | kid | child
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👧"]; new_value=girl | Virgo | young | zodiac | bangs | bright-eyed | daughter | lady | pigtails | child
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👱"]; new_value=blond | blond-haired person | hair | person: blond hair | blonde | dude | man | person | human | face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨"]; new_value=adult | man | boy | boyfriend | bro | friend
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧔"]; new_value=beard | person | person: beard | bearded person | bewhiskered | bearded
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩"]; new_value=adult | woman | blonde | blondie | haircut | lady
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧓"]; new_value=adult | gender-neutral | old | older person | unspecified gender | older adult
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👴"]; new_value=adult | man | old | bald | elderly | losing hair | old man | old dude | grandpa | grandfather | wise
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👵"]; new_value=adult | old | woman | bad haircut | blond | blondie | granny | grandma | grandmother | wise | lady | old woman
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙍"]; new_value=frown | gesture | person frowning | disgruntled | upset | woman frowning | irritated | not happy | disturbed | disappoint | frustrated | annoyed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙍‍♂"]; new_value=frowning | gesture | man | disgruntled | frown | upset | man frowning
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙎"]; new_value=gesture | person pouting | pouting | woman pouting | sulk | scowl | grimace | whine | frown | downtrodden | upset | disappoint
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙎‍♂"]; new_value=gesture | man | pouting | man pouting
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙅"]; new_value=forbidden | gesture | hand | person gesturing NO | prohibited | no | nope | not | woman gesturing NO | prohibit | exclude | not a chance
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙅‍♂"]; new_value=forbidden | gesture | hand | man | man gesturing NO | prohibited | no | nope | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙆"]; new_value=gesture | hand | OK | person gesturing OK | exercise | omg | woman gesturing OK
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙆‍♂"]; new_value=gesture | hand | man | man gesturing OK | OK | exercise | omg
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💁"]; new_value=hand | help | information | person tipping hand | sassy | tipping | fetch | gossip | woman tipping hand | whatever | sarcastic | sarcasm | hair flip | hair flick | seriously
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💁‍♂"]; new_value=man | man tipping hand | sassy | tipping hand | fetch | gossip | hand | help | information | tipping | whatever | sarcastic | sarcasm | hair flip | hair flick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙋"]; new_value=gesture | hand | happy | person raising hand | raised | hands | i know | question | me | woman raising hand | pick me | right here | over here | I can help
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙋‍♂"]; new_value=gesture | man | man raising hand | raising hand | hand | hands | i know | question | raised | me | person raising hand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙇"]; new_value=apology | bow | gesture | person bowing | sorry | meditate | meditation | man bowing | regret | beg | forgive | pity
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🙇‍♀"]; new_value=apology | bowing | favor | gesture | sorry | woman | bow | meditate | meditation | woman bowing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤦"]; new_value=disbelief | exasperation | face | palm | person facepalming | facepalm | person | smh | shock | oh no | not again | omg
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤦‍♂"]; new_value=disbelief | exasperation | facepalm | man | man facepalming | smh | shock | oh no | not again | omg
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤦‍♀"]; new_value=disbelief | exasperation | facepalm | woman | woman facepalming | smh | bewilder | shock | oh no | not again | omg
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤷"]; new_value=doubt | ignorance | indifference | person shrugging | shrug | i dunno | dunno | person | idk | who knows | whatever | I guess | maybe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤷‍♂"]; new_value=doubt | ignorance | indifference | man | man shrugging | shrug | i dunno | dunno | idk | who knows | whatever | I guess | maybe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤷‍♀"]; new_value=doubt | ignorance | indifference | shrug | woman | woman shrugging | i dunno | dunno | idk | who knows | whatever | I guess | maybe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍💼"]; new_value=architect | business | man | man office worker | manager | white-collar | office
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍💼"]; new_value=architect | business | manager | white-collar | woman | woman office worker | office
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍🔬"]; new_value=biologist | chemist | engineer | man | physicist | scientist | mathematician
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍🔬"]; new_value=biologist | chemist | engineer | physicist | scientist | woman | mathematician
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍💻"]; new_value=coder | developer | inventor | man | software | technologist | computer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍💻"]; new_value=coder | developer | inventor | software | technologist | woman | computer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍🎤"]; new_value=actor | entertainer | man | rock | singer | star | rockstar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍🎤"]; new_value=actor | entertainer | rock | singer | star | woman | rockstar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍🚀"]; new_value=astronaut | man | rocket | space
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍🚀"]; new_value=astronaut | rocket | woman | space
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👮"]; new_value=cop | officer | police | police officer | apprehend | arrest | undercover cop | law | citation | pulled over
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👮‍♀"]; new_value=cop | officer | police | woman | police officer | apprehend | arrest | undercover cop | law | citation | pulled over
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕵"]; new_value=detective | sleuth | spy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💂"]; new_value=guard | guardsman | helmet | buckingham palace | london
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💂‍♀"]; new_value=guard | woman | helmet | buckingham palace | london
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥷"]; new_value=fighter | hidden | ninja | stealth | person | soldier | fight | war | sly | secret | skills | assassin
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👷"]; new_value=construction | hat | worker | hardhat | construction worker | work | helmet | man | person | repair | fix | build | remodel | rebuild
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👷‍♀"]; new_value=construction | woman | worker | construction worker | hardhat | hat | work | helmet
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫅"]; new_value=monarch | noble | person with crown | regal | royalty | royal | crown
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤴"]; new_value=prince | royal | royalty
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👸"]; new_value=fairy tale | fantasy | princess | crown | fairytale | queen
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👳"]; new_value=person wearing turban | turban
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👲"]; new_value=cap | gua pi mao | hat | person | person with skullcap | skullcap | person with Chinese cap | guapimao
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧕"]; new_value=headscarf | hijab | mantilla | tichel | woman with headscarf | bandana | head kerchief
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤵"]; new_value=groom | person | person in tuxedo | tuxedo | formal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👰"]; new_value=bride | person | person with veil | veil | wedding | bride with veil
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫃"]; new_value=belly | bloated | full | pregnant | pregnant man | man | overeat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫄"]; new_value=belly | bloated | full | pregnant | pregnant person | overeat | stuffed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤱"]; new_value=baby | breast | breast-feeding | nursing | breast feeding
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍🍼"]; new_value=baby | feeding | nursing | woman | person | newborn | love | nanny | mom | mam | mammy | feed | mother
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍🍼"]; new_value=baby | feeding | man | nursing | person | newborn | love | nanny | dad | feed | male | father
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧑‍🍼"]; new_value=baby | feeding | nursing | person | newborn | nanny | dad | mom | feed | woman | man
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👼"]; new_value=angel | baby | face | fairy tale | fantasy | church | fairytale | baby angel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎅"]; new_value=celebration | Christmas | claus | father | santa | christmas | fairy tale | fantasy | Santa Claus
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤶"]; new_value=celebration | Christmas | claus | mother | Mrs. | santa
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧑‍🎄"]; new_value=christmas | claus | mx claus | person | xmas | merry xmas | holiday | santa | santa claus | hat | santy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦸"]; new_value=good | hero | heroine | superhero | superpower | superpowers
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦹"]; new_value=criminal | evil | superpower | supervillain | villain | bad | superpowers | person
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧙"]; new_value=mage | sorcerer | sorceress | witch | wizard | spell | magic | person mage | role play | fantasy | summon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧚"]; new_value=fairy | Oberon | Puck | Titania | wings | person fairy | tale | pixie | myth | fairytale | fantasy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧛"]; new_value=Dracula | undead | vampire | teeth | fangs | blood | person vampire | supernatural | scary | halloween | costume
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧜"]; new_value=mermaid | merman | merperson | merwoman | folklore | under the sea | ocean creatures | fairytale | siren | trident
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧝"]; new_value=elf | magical | person elf | folklore | fantasy | elves | mystical | enchantment | mythical
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧞"]; new_value=djinn | genie | jinn | person genie | wishes | rub the lamp | mythical | fantasy | mystical
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧟"]; new_value=undead | walking dead | zombie | scary | halloween | person zombie | horror | apocalypse
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧌"]; new_value=fairy tale | fantasy | monster | troll | trolling
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💆"]; new_value=face | massage | person getting massage | salon | soothe | woman getting massage | headache | tension | relaxing | relax | spa | treatment | therapy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💆‍♂"]; new_value=face | man | man getting massage | massage | soothe | salon | headache | tension | relaxing | relax
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💇"]; new_value=barber | beauty | haircut | parlor | person getting haircut | hair | woman getting haircut | cosmetology | chop | shears | cut hair | groom | style
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💇‍♂"]; new_value=haircut | man | man getting haircut | barber | beauty | hair | parlor
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚶"]; new_value=hike | person walking | walk | walking | amble | pedestrian | saunter | stride | stroll | swagger | man walking | gait | pace
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚶‍♀"]; new_value=hike | walk | woman | woman walking | amble | pedestrian | saunter | stride | stroll | swagger | walking
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧎"]; new_value=kneel | kneeling | person kneeling | on your knees | knees
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👨‍🦯"]; new_value=accessibility | blind | man | man with white cane | man with probing cane
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👩‍🦯"]; new_value=accessibility | blind | woman | woman with white cane | woman with probing cane
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏃"]; new_value=marathon | person running | running | fast | hurry | coming | quick | runner | rush | speed | man running | race | move
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏃‍♀"]; new_value=marathon | racing | running | woman | fast | hurry | coming | quick | runner | rush | speed | woman running
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💃"]; new_value=dance | dancing | woman | dancer | elegant | flair | groove | tango | flamenco | salsa | festive | let's dance | woman dancing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕺"]; new_value=dance | dancing | man | dancer | elegant | flair | groove | tango | flamenco | salsa | festive | let's dance | man dancing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕴"]; new_value=business | person | person in suit levitating | suit
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👯"]; new_value=bunny ear | dancer | partying | people with bunny ears | bff | bunny | twinsies | party | twin | people | pair | soulmate | counterpart | identical | double | bestie
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👯‍♂"]; new_value=bunny ear | dancer | men | men with bunny ears | partying | bff | twinsies | party
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧖"]; new_value=person in steamy room | sauna | steam room | hamam | steambath | steamy | relax | unwind | spa | pamper | luxurious | day spa
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧗"]; new_value=climber | person climbing | rock climber | climbing | mountain | climb up | scale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏇"]; new_value=horse | jockey | racehorse | racing | riding | sport | horse racing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏂"]; new_value=ski | snow | snowboard | snowboarder | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏌"]; new_value=ball | golf | person golfing | driving range | putt | caddy | birdie | green | tee | pga
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏌‍♀"]; new_value=golf | woman | woman golfing | ball | driving range
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏄"]; new_value=person surfing | surfing | beach | ocean | sport | surfer | waves | surf | swell
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏄‍♀"]; new_value=surfing | woman | beach | ocean | sport | surfer | waves | person surfing | woman surfing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚣"]; new_value=boat | person rowing boat | rowboat | cruise | fishing | lake | river | row | rowing | canoe | raft | paddle | oar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚣‍♀"]; new_value=boat | rowboat | woman | woman rowing boat | cruise | fishing | lake | river | row | rowing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏊"]; new_value=person swimming | swim | sport | swimming | swimmer | triathlon | freestyle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏊‍♀"]; new_value=swim | woman | woman swimming | sport | swimming | swimmer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛹"]; new_value=ball | person bouncing ball | man bouncing ball | basketball | basketball player | athletic | nothing but net | championship | free throw | dribble
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛹‍♀"]; new_value=ball | woman | woman bouncing ball | basketball | basketball player
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏋"]; new_value=lifter | person lifting weights | weight | weightlifter | workout | bodybuilder | barbell | deadlift | powerlifting
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏋‍♀"]; new_value=weight lifter | woman | woman lifting weights | lifter | weightlifter | workout | weight
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚴"]; new_value=bicycle | biking | cyclist | person biking | bicyclist | bike | riding | sport | cycle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚴‍♀"]; new_value=bicycle | biking | cyclist | woman | bicyclist | bike | riding | sport | woman biking
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚵"]; new_value=bicycle | bicyclist | bike | cyclist | mountain | person mountain biking | riding | sport | athletic
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚵‍♀"]; new_value=bicycle | bike | biking | cyclist | mountain | woman | bicyclist | riding | sport | woman mountain biking
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤸"]; new_value=cartwheel | gymnastics | person cartwheeling | person | flip | active | somersault | happy | excited
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤸‍♂"]; new_value=cartwheel | gymnastics | man | man cartwheeling | flip | active | somersault | happy | excited
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤸‍♀"]; new_value=cartwheel | gymnastics | woman | woman cartwheeling | flip | active | somersault | happy | excited
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤼"]; new_value=people wrestling | wrestle | wrestler | people | wrestling | combat | duel | wrestling tournament | in the ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤼‍♂"]; new_value=men | men wrestling | wrestle | wrestling | combat | duel | wrestling tournament | in the ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤼‍♀"]; new_value=women | women wrestling | wrestle | wrestling | grapple | combat | duel | wrestling tournament | in the ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤽"]; new_value=person playing water polo | polo | water | person | water polo | waterpolo | swimming | water sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤽‍♂"]; new_value=man | man playing water polo | water polo | waterpolo | swimming | water sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤽‍♀"]; new_value=water polo | woman | woman playing water polo | waterpolo | swimming | water sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤾"]; new_value=ball | handball | person playing handball | person | sport | athletics | throw | toss | catch | hurl | pitch | lob | chuck
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤾‍♀"]; new_value=handball | woman | woman playing handball | sport | athletics | throw | toss | ball | catch | hurl | pitch | lob | chuck
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤹"]; new_value=balance | juggle | multitask | person juggling | skill | person | manage | balancing act | handle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤹‍♂"]; new_value=man | multitask | juggle | manage | balancing act | handle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🤹‍♀"]; new_value=multitask | woman | juggle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧘"]; new_value=meditation | person in lotus position | yoga | serenity | legs crossed | cross legged | relax | yogi | cross legged | zen | peace
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛀"]; new_value=bath | bathtub | person taking bath | tub
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛌"]; new_value=good night | hotel | person in bed | sleep | goodnight | night | bed | bedtime | nap | tired | zz | zzz | zzzz
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👭"]; new_value=couple | hand | holding hands | women | women holding hands | bae | bestfriend | bestfriends | bestie | bff | bond | bonding | dating | daughters | everyone | friend | friends | friendship | girls | gay | lesbian | ladies | sis | sister | sisters | woman | hold | lgbt | lgbtq | glbt | queer | glbtq | lgbtqia | two women holding hands
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👫"]; new_value=couple | hand | hold | holding hands | man | woman | woman and man holding hands | bae | dating | everyone | flirt | friend | friends | man and woman holding hands | in love
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👬"]; new_value=couple | Gemini | holding hands | man | men | men holding hands | twins | zodiac | bae | boys | dating | everyone | friend | friends | hand | hold | two men holding hands | gay | in love | queer | lgbt | lgbtq | glbt | glbtq | lgbtqia
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💏"]; new_value=couple | kiss | anniversary | bae | date | heart | love | romance | person | babe | dating | together | xoxo | mwah
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💑"]; new_value=couple | couple with heart | love | anniversary | bae | heart | kiss | romance | person | babe | dating | love you | together | relationship
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗣"]; new_value=face | head | silhouette | speak | speaking | speaking head
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👤"]; new_value=bust | bust in silhouette | silhouette | shadow | mysterious
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👥"]; new_value=bust | busts in silhouette | silhouette | bff | everyone | friend | friends | people
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫂"]; new_value=goodbye | hello | hug | people hugging | thanks | hugging | comfort | farewell | love | friendship | embrace
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👪"]; new_value=family | child
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👣"]; new_value=clothing | footprint | footprints | print | omw | walk | barefoot
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐵"]; new_value=face | monkey | animal | banana | monkey face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐒"]; new_value=monkey | animal | banana
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦍"]; new_value=gorilla | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦧"]; new_value=ape | orangutan | monkey | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐶"]; new_value=dog | face | pet | adorbs | animal | puppies | puppy | dog face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐕"]; new_value=dog | pet | animal | animals | dogs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦮"]; new_value=accessibility | blind | guide | dog | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐕‍🦺"]; new_value=accessibility | assistance | dog | service | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐩"]; new_value=dog | poodle | animal | fluffy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐺"]; new_value=face | wolf | animal | wolf face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦊"]; new_value=face | fox | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦝"]; new_value=curious | raccoon | sly | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐱"]; new_value=cat | face | pet | animal | kitten | kitty | cat face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐈"]; new_value=cat | pet | animal | animals | cats | kitten
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐈‍⬛"]; new_value=black | cat | unlucky | black cat | halloween | animal | feline | meow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦁"]; new_value=face | Leo | lion | zodiac | alpha | animal | lion face | mane | safari | strong | roar | lion order | rawr
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐯"]; new_value=face | tiger | animal | big cat | predator | tiger face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐅"]; new_value=tiger | animal | animals | big cat | predator | zoo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐆"]; new_value=leopard | animal | animals | big cat | predator | zoo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐴"]; new_value=face | horse | animal | dressage | equine | farm | horses | horse face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫎"]; new_value=animal | antlers | elk | mammal | moose | alces | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫏"]; new_value=animal | ass | burro | donkey | mammal | mule | stubborn | hinny | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐎"]; new_value=equestrian | horse | racehorse | racing | animal |farm
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦄"]; new_value=face | unicorn | unicorn face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦓"]; new_value=zebra | stripe | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦌"]; new_value=deer | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦬"]; new_value=bison | buffalo | herd | wisent | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐮"]; new_value=cow | face | animal | farm | milk | moo | cow face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐂"]; new_value=bull | ox | Taurus | zodiac | animal | animals | farm | taurus
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐃"]; new_value=buffalo | water | animal | zoo | water buffalo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐄"]; new_value=cow | animal | animals | farm | milk | moo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐷"]; new_value=face | pig | animal | bacon | farm | pork | pig face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐖"]; new_value=pig | sow | animal | bacon | farm | pork
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐗"]; new_value=boar | pig | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐽"]; new_value=face | nose | pig | animal | farm | smel | snout | pig nose
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐏"]; new_value=Aries | male | ram | sheep | zodiac | animal | aries | horns | zoo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐑"]; new_value=ewe | female | sheep | animal | baa | farm | fluffy | wool | lamb
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐐"]; new_value=Capricorn | goat | zodiac | animal | capricorn | farm | milk
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐪"]; new_value=camel | dromedary | hump | animal | desert | one hump
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐫"]; new_value=bactrian | camel | hump | two-hump camel | animal | desert | two hump
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦙"]; new_value=alpaca | guanaco | llama | vicuña | wool | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦒"]; new_value=giraffe | spots | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐘"]; new_value=elephant | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦣"]; new_value=extinction | large | mammoth | tusk | woolly | animal | woolly mammoth
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦏"]; new_value=rhinoceros | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦛"]; new_value=hippo | hippopotamus | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐭"]; new_value=face | mouse | animal | mouse face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐁"]; new_value=mouse | animal | animals
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐀"]; new_value=rat | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐹"]; new_value=face | hamster | pet | animal | hamster face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐰"]; new_value=bunny | face | pet | rabbit | animal | rabbit face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐇"]; new_value=bunny | pet | rabbit | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐿"]; new_value=chipmunk | squirrel | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦫"]; new_value=beaver | dam | animal | teeth
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦔"]; new_value=hedgehog | spiny | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦇"]; new_value=bat | vampire | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐻"]; new_value=bear | face | animal | grizzly | growl | honey
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐻‍❄"]; new_value=arctic | bear | polar bear | white | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐨"]; new_value=face | koala | marsupial | animal | australia | bear | down under
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐼"]; new_value=face | panda | animal | bamboo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦥"]; new_value=lazy | sloth | slow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦦"]; new_value=fishing | otter | playful | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦨"]; new_value=skunk | stink | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦘"]; new_value=joey | jump | kangaroo | marsupial | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦡"]; new_value=badger | honey badger | pester | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐾"]; new_value=feet | paw | paw prints | print | paws
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦃"]; new_value=bird | turkey | gobble | thanksgiving
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐔"]; new_value=bird | chicken | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐓"]; new_value=bird | rooster | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐣"]; new_value=baby | bird | chick | hatching | animal | egg | hatching chick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐤"]; new_value=baby | bird | chick | animal | baby chick | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐥"]; new_value=baby | bird | chick | front-facing baby chick | animal | newborn | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐦"]; new_value=bird | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐧"]; new_value=bird | penguin | animal | antartica | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕊"]; new_value=bird | dove | fly | peace | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦅"]; new_value=bird | eagle | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦆"]; new_value=bird | duck | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦢"]; new_value=bird | cygnet | swan | ugly duckling | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦉"]; new_value=bird | owl | wise | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦤"]; new_value=dodo | extinction | large | bird | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦩"]; new_value=flamboyant | flamingo | tropical | bird | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦚"]; new_value=bird | ostentatious | peacock | peahen | proud | pretty | colorful | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦜"]; new_value=bird | parrot | pirate | talk | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪽"]; new_value=angelic | aviation | bird | flying | mythology | wing | soar | ascend | heavenly | fly
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐦‍⬛"]; new_value=bird | black | crow | raven | rook | beak | corvid | caw | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪿"]; new_value=bird | fowl | goose | honk | silly | duck | gander | flock | gaggle | geese | animal | ornithology
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐦‍🔥"]; new_value=fantasy | firebird | phoenix | rebirth | reincarnation | rise up | reincarnate | immortal | renewal | revive | revival | emerge | glory | reinvent | transform | ascension | ascend
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐸"]; new_value=face | frog | animal | frog face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐊"]; new_value=crocodile | animal | zoo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐢"]; new_value=terrapin | tortoise | turtle | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦎"]; new_value=lizard | reptile | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐍"]; new_value=bearer | Ophiuchus | serpent | snake | zodiac | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐲"]; new_value=dragon | face | fairy tale | animal | fairytale | dragon face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐉"]; new_value=dragon | fairy tale | animal | knights | fairytale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦕"]; new_value=brachiosaurus | brontosaurus | diplodocus | sauropod | dinosaur
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦖"]; new_value=T-Rex | Tyrannosaurus Rex | dinosaur | t rex
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐳"]; new_value=face | spouting | whale | animal | beach | ocean | spouting whale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐋"]; new_value=whale | animal | beach | ocean
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐬"]; new_value=dolphin | flipper | animal | beach | ocean
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦭"]; new_value=sea lion | seal | ocean | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐟"]; new_value=fish | Pisces | zodiac | animal | dinner | fishes | fishing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐠"]; new_value=fish | tropical | animal | fishes | tropical fish
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐡"]; new_value=blowfish | fish | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦈"]; new_value=fish | shark | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐙"]; new_value=octopus | animal | creature | ocean
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐚"]; new_value=shell | spiral | animal | beach | conch | sea shell | spiral shell
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪸"]; new_value=coral | ocean | reef | sea | climate change
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪼"]; new_value=burn | invertebrate | jelly | jellyfish | marine | ouch | stinger | ocean | tentacles | plankton | aquarium | sea | sea life | sting | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐌"]; new_value=snail | animal | escargot | garden | nature | slug
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐛"]; new_value=bug | insect | animal | garden
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐜"]; new_value=ant | insect | animal | garden
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐝"]; new_value=bee | honeybee | insect | animal | bumblebee | honey | nature | spring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪲"]; new_value=beetle | bug | insect | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🐞"]; new_value=beetle | insect | lady beetle | ladybird | ladybug | animal | garden | nature
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦗"]; new_value=cricket | grasshopper | bug | insect | Orthoptera | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪳"]; new_value=cockroach | insect | pest | roach | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕷"]; new_value=insect | spider | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕸"]; new_value=spider | web | spider web
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦂"]; new_value=Scorpio | scorpion | zodiac | scorpio | Scorpius
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦟"]; new_value=disease | fever | malaria | mosquito | pest | virus | insect | bite
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪰"]; new_value=disease | fly | maggot | pest | rotting | insect | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪱"]; new_value=annelid | earthworm | parasite | worm | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦠"]; new_value=amoeba | bacteria | microbe | virus | science
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💐"]; new_value=bouquet | flower | anniversary | birthday | date | love | plant | romance
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌸"]; new_value=blossom | cherry | flower | plant | spring | springtime | cherry blossom
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪷"]; new_value=Buddhism | flower | Hinduism | lotus | purity | calm | peace | beauty | serenity
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌹"]; new_value=flower | rose | beauty | elegant | love rose | valentine | plant | red
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥀"]; new_value=flower | wilted | dying
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌺"]; new_value=flower | hibiscus | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌻"]; new_value=flower | sun | sunflower | outdoors | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌼"]; new_value=blossom | flower | buttercup | dandelion | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌷"]; new_value=flower | tulip | blossom | growth | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪻"]; new_value=bluebonnet | flower | hyacinth | lavender | lupine | snapdragon | purple | bloom | spring | violet | indigo | lilac | shrub | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌱"]; new_value=seedling | young | plant | sapling | sprout
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪴"]; new_value=boring | grow | house | nurturing | plant | potted plant | useless | pot | decor
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌲"]; new_value=evergreen tree | tree | christmas tree | evergreen | forest | pine tree
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌳"]; new_value=deciduous | shedding | tree | forest | green | habitat | deciduous tree
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌴"]; new_value=palm | tree | beach | plant | tropical | palm tree
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌵"]; new_value=cactus | plant | desert | drought | nature
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌾"]; new_value=ear | grain | rice | sheaf of rice | grains | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌿"]; new_value=herb | leaf | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☘"]; new_value=plant | shamrock | irish
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍀"]; new_value=4 | clover | four | four-leaf clover | leaf | irish | lucky | plant | four leaf clover
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍁"]; new_value=falling | leaf | maple | maple leaf
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍂"]; new_value=fallen leaf | falling | leaf | autumn | fall
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪹"]; new_value=empty nest | nesting | nest | branch | home
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪺"]; new_value=nest with eggs | nesting | nest | branch | egg | eggs | bird
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍄"]; new_value=mushroom | toadstool | fungus
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍇"]; new_value=fruit | grape | grapes | dionyses
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍈"]; new_value=fruit | melon | cantaloupe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍊"]; new_value=fruit | orange | tangerine | citrus | nectarine | vitamin c
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍋"]; new_value=citrus | fruit | lemon | sour
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍋‍🟩"]; new_value=citrus | fruit | lime | tropical | sour | green | juice | tequila | margarita | zest | refreshing | cocktail | garnish | acidity | key lime pie | tangy | salsa | mojito
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍌"]; new_value=banana | fruit | potassium
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍍"]; new_value=fruit | pineapple | colada | pina | tropical
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥭"]; new_value=fruit | mango | tropical | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍎"]; new_value=apple | fruit | red | diet | food | health | ripe | red apple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍏"]; new_value=apple | fruit | green | green apple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫐"]; new_value=berry | bilberry | blue | blueberries | blueberry | berries | fruit | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍅"]; new_value=fruit | tomato | vegetable | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌽"]; new_value=corn | ear | ear of corn | maize | maze | crops | farm
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌶"]; new_value=hot | pepper | hot pepper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫑"]; new_value=bell pepper | capsicum | pepper | vegetable | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥬"]; new_value=bok choy | cabbage | kale | leafy green | lettuce | burgers | salad
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫘"]; new_value=beans | food | kidney | legume | small
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌰"]; new_value=chestnut | plant | almond
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫚"]; new_value=beer | ginger root | root | spice | ginger | herb | natural | health
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫛"]; new_value=beans | edamame | legume | pea | pod | vegetable | beanstalk | veggie | soybean
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍄‍🟫"]; new_value=brown mushroom | food | fungus | nature | vegetable | portobello | mushroom | shroom | truffle | toppings | pizza toppings | veggie | fungi | sprout | shiitake | spore | vegetarian
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍞"]; new_value=bread | loaf | carbs | food | grain | restaurant | toast | wheat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥐"]; new_value=bread | breakfast | croissant | food | french | roll | crescent roll
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫓"]; new_value=arepa | flatbread | lavash | naan | pita | bread | gordita | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥨"]; new_value=pretzel | twisted | convoluted
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥯"]; new_value=bagel | bakery | breakfast | schmear | bread
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍗"]; new_value=bone | chicken | drumstick | leg | poultry | hungry | turkey | poultry leg
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥩"]; new_value=chop | cut of meat | lambchop | porkchop | steak | meat | red meat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍔"]; new_value=burger | hamburger | eat | fast food | food | hungry
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍟"]; new_value=french | fries | fast food | food | french fries
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍕"]; new_value=cheese | pizza | slice | food | hungry | pepperoni
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫔"]; new_value=mexican | tamale | wrapped | pamonha | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍳"]; new_value=breakfast | cooking | egg | frying | pan | fry | over easy | restaurant | sunny side up
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍲"]; new_value=pot | pot of food | stew | food | soup
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫕"]; new_value=cheese | chocolate | fondue | melted | pot | ski | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥣"]; new_value=bowl with spoon | breakfast | cereal | congee | oatmeal | porridge
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍿"]; new_value=popcorn | movie
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧂"]; new_value=condiment | salt | shaker | flavor | taste | salty | upset | mad
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍱"]; new_value=bento | box | food | bento box
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍘"]; new_value=cracker | rice | food | rice cracker
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍙"]; new_value=ball | Japanese | rice | food | rice ball
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍚"]; new_value=cooked | rice | food | cooked rice
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍛"]; new_value=curry | rice | food | curry rice
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍜"]; new_value=bowl | noodle | ramen | steaming | food | pho | chopsticks | steaming bowl | soup
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍝"]; new_value=pasta | spaghetti | food | meatballs | restaurant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍠"]; new_value=potato | roasted | sweet | food | roasted sweet potato
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍢"]; new_value=kebab | oden | seafood | skewer | stick | food | restaurant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍣"]; new_value=sushi | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍤"]; new_value=fried | prawn | shrimp | tempura | fried shrimp
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍥"]; new_value=cake | fish | fish cake with swirl | pastry | swirl | food | restaurant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥡"]; new_value=oyster pail | takeout box | chopsticks | food delivery
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦞"]; new_value=bisque | claws | lobster | seafood | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦑"]; new_value=food | molusc | squid | animal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍦"]; new_value=cream | dessert | ice | icecream | soft | sweet | food | ice cream | restaurant | soft serve | soft ice cream
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍧"]; new_value=dessert | ice | shaved | sweet | restaurant | shaved ice
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍨"]; new_value=cream | dessert | ice | sweet | food | restaurant | ice cream
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍩"]; new_value=breakfast | dessert | donut | doughnut | sweet | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍪"]; new_value=cookie | dessert | sweet | chocolate chip
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎂"]; new_value=birthday | cake | celebration | dessert | pastry | sweet | birthday cake | happy birthday | happy bday
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧁"]; new_value=bakery | cupcake | sweet | dessert | sprinkles | treat | sugar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥧"]; new_value=filling | pastry | pie | fruit | meat | apple pie | pumpkin pie | slice of pie
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍫"]; new_value=bar | chocolate | dessert | sweet | candy | halloween | sweet tooth | chocolate bar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍬"]; new_value=candy | dessert | sweet | cavities | halloween | restaurant | sweet tooth | wrapper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍭"]; new_value=candy | dessert | lollipop | sweet | confectionary | food | restaurant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍯"]; new_value=honey | honeypot | pot | sweet | barrel | bear | food | honey jar | jar | honey pot
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍼"]; new_value=baby | bottle | drink | milk | babies | birth | born | infant | newborn | baby bottle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☕"]; new_value=beverage | coffee | drink | hot | steaming | tea | caffeine | morning | cafe 
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫖"]; new_value=drink | pot | tea | teapot | brew | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍵"]; new_value=beverage | cup | drink | tea | teacup | teacup without handle | oolong
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍶"]; new_value=bar | beverage | bottle | cup | drink | sake | restaurant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍷"]; new_value=bar | beverage | drink | glass | wine | alcohol | booze | club | drinking | drinks | restaurant | wine glass
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍸"]; new_value=bar | cocktail | drink | glass | alcohol | booze | club | drinking | drinks | mad men | martini | cocktail glass
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍹"]; new_value=bar | drink | tropical | alcohol | booze | club | cocktail | drinking | drinks | drunk | mai tai | party | tropics | tropical drink
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍺"]; new_value=bar | beer | drink | mug | alcohol | booze | drinking | drinks | octoberfest | oktoberfest | pint | stein | summer ale | beer mug
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍻"]; new_value=bar | beer | clink | clinking beer mugs | drink | mug | alcohol | booze | bottoms up | cheers | drinking | drinks
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥃"]; new_value=glass | liquor | shot | tumbler | whisky | whiskey | scotch
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫗"]; new_value=drink | empty | glass | pouring liquid | spill | pour | water | accident | oops
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥤"]; new_value=cup with straw | juice | soda | malt | soft drink | water
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧋"]; new_value=bubble | milk | pearl | tea | bubble tea | boba | food
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧃"]; new_value=beverage | box | juice | straw | sweet | juice box
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥢"]; new_value=chopsticks | hashi | jeotgarak | kuaizi
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍽"]; new_value=cooking | fork | fork and knife with plate | knife | plate | dinner | eat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🍴"]; new_value=cooking | cutlery | fork | fork and knife | knife | breakfast | breaky | dinner | eat | feed | food | hungry | lunch | restaurant | yummy | delicious | yum
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥄"]; new_value=spoon | tableware | eat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔪"]; new_value=cooking | hocho | kitchen knife | knife | tool | weapon | chef
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫙"]; new_value=condiment | container | empty | jar | sauce | store | nothing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏺"]; new_value=amphora | Aquarius | cooking | drink | jug | zodiac | tool | weapon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌍"]; new_value=Africa | earth | Europe | globe | globe showing Europe-Africa | world | europe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌐"]; new_value=earth | globe | globe with meridians | meridians | world | internet | worldwide web
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗺"]; new_value=map | world | world map
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧭"]; new_value=compass | magnetic | navigation | orienteering | direction
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌋"]; new_value=eruption | mountain | volcano | nature
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗻"]; new_value=fuji | mount fuji | mountain | nature
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏝"]; new_value=desert | island | desert island
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏗"]; new_value=building construction | construction | crane
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪨"]; new_value=boulder | heavy | rock | solid | stone | tough
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛖"]; new_value=house | hut | roundhouse | yurt | shelter | home
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏘"]; new_value=houses | house
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏚"]; new_value=derelict | house | home | derelict house
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏠"]; new_value=home | house | building | country home | ranch | settle down | simple home | suburban | suburbia | where the heart is
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏡"]; new_value=garden | home | house | house with garden | building | country home | ranch | settle down | simple home | suburban | suburbia | where the heart is
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏢"]; new_value=building | office building | city | cubical | job | office
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏣"]; new_value=Japanese | Japanese post office | post | building
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏤"]; new_value=European | post | post office | building
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏥"]; new_value=doctor | hospital | medicine | building
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏩"]; new_value=hotel | love | building | love hotel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏪"]; new_value=convenience | store | building | 24 | 24 hours | convenience store
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏬"]; new_value=department | store | building | department store
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏯"]; new_value=castle | Japanese | building | Japanese castle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏰"]; new_value=castle | European | building
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💒"]; new_value=chapel | romance | wedding | hitched | nuptuals
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗼"]; new_value=Tokyo | tower | tokyo | Tokyo tower
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗽"]; new_value=liberty | statue | Statue of Liberty | ny | nyc | new york
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛪"]; new_value=Christian | church | cross | religion | bless | chapel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕌"]; new_value=islam | mosque | Muslim | religion | masjid
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕍"]; new_value=Jew | Jewish | religion | synagogue | temple | judaism
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛩"]; new_value=religion | shinto | shrine | shinto shrine
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕋"]; new_value=islam | kaaba | Muslim | religion | hajj | umrah
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌅"]; new_value=morning | sun | sunrise | nature
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌆"]; new_value=city | cityscape at dusk | dusk | evening | landscape | sunset | building | sun
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌇"]; new_value=dusk | sun | sunset | building
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♨"]; new_value=hot | hotsprings | springs | steaming | hot springs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎠"]; new_value=carousel | horse | entertainment | carousel horse
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛝"]; new_value=amusement park | play | playground slide | theme park | slide | playground | sliding | playing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎡"]; new_value=amusement park | ferris | theme park | wheel | ferris wheel | amusement | park
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎢"]; new_value=amusement park | coaster | roller | theme park | amusement | park | roller coaster
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💈"]; new_value=barber | haircut | pole | barber pole | shave | fresh cut
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎪"]; new_value=circus | tent | circus tent
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚂"]; new_value=engine | locomotive | railway | steam | train | caboose | trains | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚃"]; new_value=car | electric | railway | train | tram | trolleybus | travel | railway car
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚄"]; new_value=high-speed train | railway | shinkansen | speed | train
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚅"]; new_value=bullet | railway | shinkansen | speed | train | travel | high-speed train with bullet nose
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚆"]; new_value=railway | train | arrived | choo choo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚇"]; new_value=metro | subway | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚈"]; new_value=light rail | railway | arrived | monorail
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚉"]; new_value=railway | station | train
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚊"]; new_value=tram | trolleybus
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚞"]; new_value=car | mountain | railway | trip | mountain railway
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚋"]; new_value=car | tram | trolleybus | bus | trolley | tram car
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚌"]; new_value=bus | vehicle | school
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚍"]; new_value=bus | oncoming | cars | oncoming bus
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚐"]; new_value=bus | minibus | drive | van | vehicle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚑"]; new_value=ambulance | vehicle | emergency
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚒"]; new_value=engine | fire | truck | fire engine
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚓"]; new_value=car | patrol | police | 5-0 | cops | police car
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚔"]; new_value=car | oncoming | police | oncoming police car
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚕"]; new_value=taxi | vehicle | cab | cabbie | car | drive | yellow taxi
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚖"]; new_value=oncoming | taxi | cab | cabbie | cars | drove | hail a cab | yellow cab | yellow taxi | oncoming taxi
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚗"]; new_value=automobile | car | driving | vehicle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚘"]; new_value=automobile | car | oncoming | cars | drove | vehicle | oncoming automobile
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚙"]; new_value=recreational | sport utility | sport utility vehicle | car | drive | vehicle | sportutility
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛻"]; new_value=pick-up | pickup | truck | car | automobile | pickup truck | flatbed | transportation
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚚"]; new_value=delivery | truck | car | drive | vehicle | delivery truck
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚛"]; new_value=articulated lorry | lorry | semi | truck | car | drive | move | vehicle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏎"]; new_value=car | racing | zoom | racing car
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚲"]; new_value=bicycle | bike | bike gang | cycle | cycling | cyclist | ride | spin class | spinning
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛹"]; new_value=board | skateboard | skater | wheels | skate
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛼"]; new_value=roller | skate | roller skate | blades | roller skates | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚏"]; new_value=bus | stop | busstop | bus stop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛢"]; new_value=drum | oil | oil drum
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛽"]; new_value=diesel | fuel | fuelpump | gas | pump | station | gasoline | gas station | fuel pump
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛞"]; new_value=circle | tire | turn | wheel | vehicle | car
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚨"]; new_value=beacon | car | light | police | revolving | emergency | alert | alarm | siren | police car light
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚥"]; new_value=horizontal traffic light | light | signal | traffic | intersection | stop light | stoplight
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚦"]; new_value=light | signal | traffic | vertical traffic light | drove | intersection | stop light | stoplight
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛟"]; new_value=float | life preserver | life saver | rescue | ring buoy | safety | buoy | swim | lifesaver | save
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛵"]; new_value=boat | resort | sailboat | sea | yacht | sailing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚤"]; new_value=boat | speedboat | billionaire | lake | luxury | millionaire | summer | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛳"]; new_value=passenger | ship | passenger ship
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚢"]; new_value=boat | passenger | ship | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✈"]; new_value=aeroplane | airplane | fly | flying | jet | plane | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛩"]; new_value=aeroplane | airplane | small airplane | plane
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛫"]; new_value=aeroplane | airplane | check-in | departure | departures | plane | airplane departure
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛬"]; new_value=aeroplane | airplane | airplane arrival | arrivals | arriving | landing | plane
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚁"]; new_value=helicopter | vehicle | roflcopter | travel | copter
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚟"]; new_value=railway | suspension | suspension railway
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚠"]; new_value=cable | gondola | mountain | mountain cableway | ski lift
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚡"]; new_value=aerial | cable | car | gondola | tramway | ropeway | aerial tramway
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚀"]; new_value=rocket | space | launch | rockets | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛸"]; new_value=flying saucer | UFO | aliens | extra | extra terrestrial
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛎"]; new_value=bell | bellhop | hotel | bellhop bell
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧳"]; new_value=luggage | packing | travel | suitcase | roller bag
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⌛"]; new_value=hourglass done | sand | timer | hourglass | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⏳"]; new_value=hourglass | hourglass not done | sand | timer | hours | waiting | yolo | hourglass with flowing sand
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⌚"]; new_value=clock | watch | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⏰"]; new_value=alarm | clock | hours | hrs | late | time | waiting | alarm clock
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⏱"]; new_value=clock | stopwatch | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⏲"]; new_value=clock | timer | timer clock
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕰"]; new_value=clock | mantelpiece clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕛"]; new_value=00 | 12 | 12:00 | clock | o’clock | twelve | twelve o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕧"]; new_value=12 | 12:30 | clock | thirty | twelve | twelve-thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕐"]; new_value=00 | 1 | 1:00 | clock | o’clock | one | one o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕜"]; new_value=1 | 1:30 | clock | one | one-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕑"]; new_value=00 | 2 | 2:00 | clock | o’clock | two | two o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕝"]; new_value=2 | 2:30 | clock | thirty | two | two-thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕒"]; new_value=00 | 3 | 3:00 | clock | o’clock | three | three o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕞"]; new_value=3 | 3:30 | clock | thirty | three | three-thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕓"]; new_value=00 | 4 | 4:00 | clock | four | o’clock | four o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕟"]; new_value=4 | 4:30 | clock | four | four-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕔"]; new_value=00 | 5 | 5:00 | clock | five | o’clock | five o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕠"]; new_value=5 | 5:30 | clock | five | five-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕕"]; new_value=00 | 6 | 6:00 | clock | o’clock | six | six o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕡"]; new_value=6 | 6:30 | clock | six | six-thirty | thirty | 30
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕖"]; new_value=00 | 7 | 7:00 | clock | o’clock | seven | seven o’clock
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕢"]; new_value=7 | 7:30 | clock | seven | seven-thirty | thirty | 30
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕗"]; new_value=00 | 8 | 8:00 | clock | eight | o’clock | eight o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕣"]; new_value=8 | 8:30 | clock | eight | eight-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕘"]; new_value=00 | 9 | 9:00 | clock | nine | o’clock | nine o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕤"]; new_value=9 | 9:30 | clock | nine | nine-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕙"]; new_value=00 | 10 | 10:00 | clock | o’clock | ten | ten o’clock
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕥"]; new_value=10 | 10:30 | clock | ten | ten-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕚"]; new_value=00 | 11 | 11:00 | clock | eleven | o’clock | eleven o’clock | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕦"]; new_value=11 | 11:30 | clock | eleven | eleven-thirty | thirty | 30 | time
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌑"]; new_value=dark | moon | new moon | space
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌒"]; new_value=crescent | moon | waxing | dreams | space | waxing crescent moon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌓"]; new_value=first quarter moon | moon | quarter | space
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌔"]; new_value=gibbous | moon | waxing | space | waxing gibbous moon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌕"]; new_value=full | moon | space | full moon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌖"]; new_value=gibbous | moon | waning | space | waning gibbous moon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌗"]; new_value=last quarter moon | moon | quarter | space
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌘"]; new_value=crescent | moon | waning | space | waning crescent moon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌙"]; new_value=crescent | moon | space | ramadan | crescent moon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌚"]; new_value=face | moon | new moon face | space
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌛"]; new_value=face | first quarter moon face | moon | quarter | space | first quarter moon with face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌜"]; new_value=face | last quarter moon face | moon | quarter | dreams | last quarter moon with face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☀"]; new_value=bright | rays | sun | sunny | space | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌝"]; new_value=bright | face | full | moon | full moon with face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌞"]; new_value=bright | face | sun | sun with face | beach | day | heat | shine | sunny | sunshine | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⭐"]; new_value=star | astronomy | stars | white medium star
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌟"]; new_value=glittery | glow | glowing star | shining | sparkle | star | night | win
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌠"]; new_value=falling | shooting | star | night | space | shooting star
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛅"]; new_value=cloud | sun | sun behind cloud | weather | cloudy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛈"]; new_value=cloud | cloud with lightning and rain | rain | thunder | thunderstorm
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌤"]; new_value=cloud | sun | sun behind small cloud | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌥"]; new_value=cloud | sun | sun behind large cloud | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌦"]; new_value=cloud | rain | sun | sun behind rain cloud | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌧"]; new_value=cloud | cloud with rain | rain | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌨"]; new_value=cloud | cloud with snow | cold | snow | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌩"]; new_value=cloud | cloud with lightning | lightning | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌪"]; new_value=cloud | tornado | whirlwind | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌫"]; new_value=cloud | fog | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌬"]; new_value=blow | cloud | face | wind | wind face
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌀"]; new_value=cyclone | dizzy | hurricane | twister | typhoon | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌈"]; new_value=rain | rainbow | nature | pride | queer | lgbt | lgbtq | glbt | glbtq | lgbtqia | gay | lesbian | bisexual | trans | transgender | genderqueer | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☔"]; new_value=clothing | drop | rain | umbrella | umbrella with rain drops | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚡"]; new_value=danger | electric | high voltage | lightning | voltage | zap | electricity | nature | thunder | thunderbolt
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❄"]; new_value=cold | snow | snowflake | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔥"]; new_value=fire | flame | tool | burn | hot | lit | litaf | lit af
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💧"]; new_value=cold | comic | drop | droplet | sweat | nature | sad | tear | water | weather
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🌊"]; new_value=ocean | water | wave | nature | surf | surfer | surfing | water wave
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎃"]; new_value=celebration | halloween | jack | jack-o-lantern | lantern | pumpkin
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎄"]; new_value=celebration | Christmas | tree | christmas | Christmas tree
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎆"]; new_value=celebration | fireworks | boom | entertainment | yolo
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎇"]; new_value=celebration | fireworks | sparkle | sparkler | boom
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧨"]; new_value=dynamite | explosive | firecracker | fireworks | pop | popping | fire | spark | light
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✨"]; new_value=* | sparkle | sparkles | star | magic
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎈"]; new_value=balloon | celebration | birthday | celebrate
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎉"]; new_value=celebration | party | popper | tada | awesome | birthday | celebrate | woohoo | excited | party popper | hooray
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎊"]; new_value=ball | celebration | confetti | celebrate | woohoo | party | confetti ball
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎍"]; new_value=bamboo | celebration | Japanese | pine | pine decoration | plant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎏"]; new_value=carp | celebration | streamer | carp streamer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎐"]; new_value=bell | celebration | chime | wind | wind chime
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎁"]; new_value=box | celebration | gift | present | wrapped | birthday | surprise | christmas | bow | wrapped gift
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎗"]; new_value=celebration | reminder | ribbon | reminder ribbon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎫"]; new_value=admission | ticket | stub
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎖"]; new_value=celebration | medal | military | military medal | award
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏆"]; new_value=prize | trophy | slay | sport | win | winning | victory | champs | champion
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏅"]; new_value=medal | sports medal | winner | award | gold
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚽"]; new_value=ball | football | soccer | futbol | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚾"]; new_value=ball | baseball | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥎"]; new_value=ball | glove | softball | underarm | sports
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏀"]; new_value=ball | basketball | hoop | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏈"]; new_value=american | ball | football | sport | american football | super bowl
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏉"]; new_value=ball | football | rugby | sport | rugby football
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎾"]; new_value=ball | racquet | tennis | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥏"]; new_value=flying disc | ultimate | disc
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎳"]; new_value=ball | bowling | game | sport | strike
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏏"]; new_value=ball | bat | cricket game | game | cricket
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏑"]; new_value=ball | field | game | hockey | stick | field hockey
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏒"]; new_value=game | hockey | ice | puck | stick | ice hockey
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥍"]; new_value=ball | goal | lacrosse | stick | sports
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏓"]; new_value=ball | bat | game | paddle | ping pong | table tennis | pingpong
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛳"]; new_value=flag in hole | golf | hole | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛸"]; new_value=ice | skate | ice skate | skating | ice skating
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎣"]; new_value=fish | fishing pole | pole | entertainment | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎽"]; new_value=athletics | running | sash | shirt | running shirt
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎿"]; new_value=ski | skis | snow | sport
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛷"]; new_value=sled | sledge | sleigh | luge | toboggan | snow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎯"]; new_value=bullseye | dart | direct hit | game | hit | target | bull | entertainment
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎱"]; new_value=8 | ball | billiard | eight | game | pool 8 ball | 8 ball | 8ball
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔮"]; new_value=ball | crystal | fairy tale | fantasy | fortune | tool | future | magic | fairytale | crystal ball
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪄"]; new_value=magic | magic wand | witch | wizard | wand | magician
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎮"]; new_value=controller | game | video game | entertainment
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕹"]; new_value=game | joystick | video game | videogame
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎰"]; new_value=game | slot | slot machine | casino | gamble | gambling | slots
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎲"]; new_value=dice | die | game | entertainment | game die
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧸"]; new_value=plaything | plush | stuffed | teddy bear | toy | bear
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪅"]; new_value=celebration | party | piñata | pinada | pinata | festive | cinco de mayo | celebrate | candy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪩"]; new_value=dance | disco | glitter | mirror ball | party | ball | mirror
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪆"]; new_value=doll | nesting | nesting dolls | russia | dolls | matryoshka | babushka | babooshka | baboushka
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♠"]; new_value=card | game | spade suit | spade
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♥"]; new_value=card | game | heart suit | emotion | heart | hearts
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♦"]; new_value=card | diamond suit | game | diamond
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♣"]; new_value=card | club suit | game | club | clubs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎭"]; new_value=art | mask | performing | performing arts | theater | theatre | actor | actress | entertainment | thespian
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎨"]; new_value=art | artist palette | museum | painting | palette | arty | artsy | colorful | creative | entertainment | painter
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪡"]; new_value=embroidery | needle | sewing | stitches | sutures | tailoring | sew | thread | sewing needle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪢"]; new_value=knot | rope | tangled | tie | twine | twist | cord
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥽"]; new_value=eye protection | goggles | swimming | welding | scuba | dive
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥼"]; new_value=doctor | experiment | lab coat | scientist | white coat | dr | jacket | clothes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👔"]; new_value=clothing | necktie | tie | employed | serious | shirt
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👕"]; new_value=clothing | shirt | t-shirt | tshirt | blue | casual | clothes | collar | dressed | shopping | weekend
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👖"]; new_value=clothing | jeans | pants | trousers | blue | casual | clothes | denim | dressed | shopping | weekend
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧣"]; new_value=neck | scarf | cold | bundle up
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧥"]; new_value=coat | jacket | cold | bundle up | brr
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👗"]; new_value=clothing | dress | clothes | dressed | fancy | shopping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👘"]; new_value=clothing | kimono | comfortable
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩱"]; new_value=bathing suit | one-piece swimsuit | swimsuit
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩳"]; new_value=bathing suit | pants | shorts | underwear | swimsuit
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👙"]; new_value=bikini | clothing | swim | bathing suit | beach | pool
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👚"]; new_value=clothing | woman | woman’s clothes | blouse | clothes | collar | dress | dressed | lady | shirt | shopping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪭"]; new_value=cooling | dance | fan | flutter | folding hand fan | hot | shy | flirt | clack | clap | cool off
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👛"]; new_value=clothing | coin | purse | clothes | dress | fancy | handbag | shopping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👜"]; new_value=bag | clothing | handbag | purse | clothes | dress | lady | shopping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👝"]; new_value=bag | clothing | clutch bag | pouch | clothes | dress | handbag | purse
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎒"]; new_value=backpack | bag | rucksack | satchel | school | backpacking | bookbag | education | school backpack
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩴"]; new_value=beach sandals | sandals | thong sandal | thong sandals | thongs | zōri | beach | flip flop | sandal | shoe
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👞"]; new_value=clothing | man | man’s shoe | shoe | brown | clothes | feet | foot | kick | shoes | shopping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👟"]; new_value=athletic | clothing | running shoe | shoe | sneaker | clothes | fast | kick | running | shoes | shopping | tennis
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥾"]; new_value=backpacking | boot | camping | hiking | shoe | brown shoe | outdoors
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🥿"]; new_value=ballet flat | flat shoe | slip-on | slipper | flats | comfy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👠"]; new_value=clothing | heel | high-heeled shoe | shoe | woman | clothes | dress | shoes | shopping | heels | fashion | stilletto
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👢"]; new_value=boot | clothing | shoe | woman | woman’s boot | clothes | dress | shoes | shopping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪮"]; new_value=Afro | comb | hair | pick | groom | afro
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👑"]; new_value=clothing | crown | king | queen | medieval | royal | royal family | royalty | win
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="👒"]; new_value=clothing | hat | woman | woman’s hat | clothes | garden party | hats
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎩"]; new_value=clothing | hat | top | tophat | clothes | fancy | formal | magic | top hat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎓"]; new_value=cap | celebration | clothing | graduation | hat | education | graduation cap | scholar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧢"]; new_value=baseball cap | billed cap | dad cap | dad hat | bent hat | cap
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪖"]; new_value=army | helmet | military | soldier | warrior | war
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📿"]; new_value=beads | clothing | necklace | prayer | religion | prayer beads
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💄"]; new_value=cosmetics | lipstick | makeup | date
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💍"]; new_value=diamond | ring | engaged | engagement | romance | wedding | married | shiny | sparkling
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💎"]; new_value=diamond | gem | gem stone | jewel | engagement | money | romance | wedding
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔇"]; new_value=mute | muted speaker | quiet | silent | speaker | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔈"]; new_value=soft | speaker low volume | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔉"]; new_value=medium | speaker medium volume | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔊"]; new_value=loud | speaker high volume | high | music | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📢"]; new_value=loud | loudspeaker | public address | communication | sound | public | address
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📣"]; new_value=cheering | megaphone | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📯"]; new_value=horn | post | postal | postal horn
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔔"]; new_value=bell | break | church | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔕"]; new_value=bell | bell with slash | forbidden | mute | quiet | silent | no | prohibited | sound | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎼"]; new_value=music | musical score | score | note
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎵"]; new_value=music | musical note | note | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎶"]; new_value=music | musical notes | note | notes | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎙"]; new_value=mic | microphone | music | studio | studio microphone
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎚"]; new_value=level | music | slider | level slider
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎛"]; new_value=control | knobs | music | control knobs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎤"]; new_value=karaoke | mic | microphone | music | sing | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎧"]; new_value=earbud | headphone | sound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📻"]; new_value=radio | video | entertainment | tbt
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪗"]; new_value=accordion | concertina | squeeze box | instrument | music | squeezebox
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎸"]; new_value=guitar | instrument | music | strat
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎻"]; new_value=instrument | music | violin
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪘"]; new_value=beat | conga | drum | long drum | rhythm | instrument
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪇"]; new_value=instrument | maracas | music | percussion | rattle | shake | dance | party | shaker | cha cha
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪈"]; new_value=fife | flute | music | pipe | recorder | woodwind | flautist | band | marching band | piccolo | orchestra | instrument
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📱"]; new_value=cell | mobile | phone | telephone | communication | mobile phone
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📲"]; new_value=arrow | cell | mobile | mobile phone with arrow | phone | receive | build | communication | telephone | call
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📞"]; new_value=phone | receiver | telephone | communication | voip | telephone receiver
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📟"]; new_value=pager | communication
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📠"]; new_value=fax | fax machine | communication
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪫"]; new_value=electronic | low battery | low energy | battery | drained | low power
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔌"]; new_value=electric | electricity | plug | electric plug
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💻"]; new_value=computer | laptop | pc | personal | office | laptop computer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🖥"]; new_value=computer | desktop | desktop computer | monitor
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💽"]; new_value=computer | disk | minidisk | optical | computer disk
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💾"]; new_value=computer | disk | floppy | floppy disk
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💿"]; new_value=CD | computer | disk | optical | blu-ray | cd | dvd | optical disk
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📀"]; new_value=Blu-ray | computer | disk | DVD | optical | blu-ray | cd | dvd
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧮"]; new_value=abacus | calculation | calculator
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎥"]; new_value=camera | cinema | movie | film | hollywood | bollywood | record | movie camera
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎞"]; new_value=cinema | film | frames | movie | film frames
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📽"]; new_value=cinema | film | movie | projector | video | film projector
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🎬"]; new_value=clapper | clapper board | movie | action
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📷"]; new_value=camera | video | photo | selfie | snap | tbt | trip
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📹"]; new_value=camera | video | camcorder | tbt | video camera
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📼"]; new_value=tape | vhs | video | videocassette | old school | vcr
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔍"]; new_value=glass | magnifying | magnifying glass tilted left | search | tool | lab | science | left-pointing magnifying glass
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔎"]; new_value=glass | magnifying | magnifying glass tilted right | search | tool | contact | lab | science | right-pointing magnifying glass
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💡"]; new_value=bulb | comic | electric | idea | light | light bulb
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏮"]; new_value=bar | lantern | light | red | red paper lantern | restaurant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📔"]; new_value=book | cover | decorated | notebook | notebook with decorative cover | education | school | writing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📕"]; new_value=book | closed | education | closed book
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📖"]; new_value=book | open | education | fantasy | knowledge | library | novels | reading | open book
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📗"]; new_value=book | green | education | fantasy | library | reading | green book
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📘"]; new_value=blue | book | education | fantasy | library | reading | blue book
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📙"]; new_value=book | orange | education | fantasy | library | reading | orange book
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📚"]; new_value=book | books | education | fantasy | knowledge | library | novels | reading | school | study
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📰"]; new_value=news | newspaper | paper | communication
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📑"]; new_value=bookmark | mark | marker | tabs | bookmark tabs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💰"]; new_value=bag | dollar | money | moneybag | bank | bet | billion | cash | cost | million | paid | paying | cash out | pot of gold | rich | win | money bag
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪙"]; new_value=coin | gold | metal | money | silver | treasure | dollar | rich | euro
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💴"]; new_value=banknote | bill | currency | money | note | yen | bank | yen banknote
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💵"]; new_value=banknote | bill | currency | dollar | money | note | bank | dollar banknote
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💶"]; new_value=banknote | bill | currency | euro | money | note | bank | 100 | rich | euro banknote
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💷"]; new_value=banknote | bill | currency | money | note | pound | bank | billion | cash | pounds | pound banknote
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💸"]; new_value=banknote | bill | fly | money | money with wings | wings | bank | billion | cash | dollar | million | pay | note
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💳"]; new_value=card | credit | money | bank | cash | charge | charge it | pay | credit card
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧾"]; new_value=accounting | bookkeeping | evidence | proof | receipt | invoice
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💹"]; new_value=chart | chart increasing with yen | graph | growth | money | yen | bank | currency | market | rise | trend | upward
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✉"]; new_value=email | envelope | letter | e-mail
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📨"]; new_value=e-mail | email | envelope | incoming | letter | receive | delivering | mail | sent | incoming envelope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📩"]; new_value=arrow | e-mail | email | envelope | envelope with arrow | outgoing | communication | letter | mail | send | sent | down
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📤"]; new_value=box | letter | mail | outbox | sent | tray | email | outbox tray
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📥"]; new_value=box | inbox | letter | mail | receive | tray | email | inbox zero | inbox tray
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📦"]; new_value=box | package | parcel | communication | delivery | shipping
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📫"]; new_value=closed | closed mailbox with raised flag | mail | mailbox | postbox | communication
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🖋"]; new_value=fountain | pen | fountain pen
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📝"]; new_value=memo | pencil | communication | media | notes
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💼"]; new_value=briefcase | office
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📁"]; new_value=file | folder | file folder
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📂"]; new_value=file | folder | open | open file folder
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗂"]; new_value=card | dividers | index | card index dividers
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗓"]; new_value=calendar | pad | spiral | spiral calendar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📇"]; new_value=card | index | rolodex | old school | card index
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📈"]; new_value=chart | chart increasing | graph | growth | trend | upward | data | up and to the right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📉"]; new_value=chart | chart decreasing | down | graph | trend | data | downward | negative
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📊"]; new_value=bar | chart | graph | data | bar chart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📋"]; new_value=clipboard | notes | to do list
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📌"]; new_value=pin | pushpin | collage
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📍"]; new_value=pin | pushpin | round pushpin | location | map
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📏"]; new_value=ruler | straight edge | straight ruler | angle | math | straightedge
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📐"]; new_value=ruler | set | triangle | triangular ruler | angle | math | slide rule
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✂"]; new_value=cutting | scissors | tool | cut | paper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗃"]; new_value=box | card | file | card file box
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗄"]; new_value=cabinet | file | filing | file cabinet
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔒"]; new_value=closed | locked | lock | private
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔓"]; new_value=lock | open | unlock | unlocked | cracked
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔐"]; new_value=closed | key | lock | locked with key | secure | bike lock | locked
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔑"]; new_value=key | lock | password | keys | major key | unlock
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗝"]; new_value=clue | key | lock | old | old key
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔨"]; new_value=hammer | tool | home improvement | repairs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛏"]; new_value=mining | pick | tool | hammer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚔"]; new_value=crossed | swords | weapon | crossed swords
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💣"]; new_value=bomb | comic | boom | dangerous | explosion | hot
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪃"]; new_value=boomerang | rebound | repercussion | weapon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏹"]; new_value=archer | arrow | bow | bow and arrow | Sagittarius | zodiac | tool | weapon | archery
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪚"]; new_value=carpenter | carpentry saw | lumber | saw | tool | trim | cut
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔧"]; new_value=spanner | tool | wrench | home improvement
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪛"]; new_value=screw | screwdriver | tool | handy | flathead
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔩"]; new_value=bolt | nut | nut and bolt | tool | home improvement
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚖"]; new_value=balance | justice | Libra | scale | zodiac | tool | scales | weight | balance scale
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🦯"]; new_value=accessibility | blind | white cane | probing cane
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔗"]; new_value=link | links
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧰"]; new_value=chest | mechanic | tool | toolbox | box | red box
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧲"]; new_value=attraction | horseshoe | magnet | magnetic | u shape | positive negative
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪜"]; new_value=climb | ladder | rung | step | step ladder
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔬"]; new_value=microscope | science | tool | experiment | lab
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔭"]; new_value=science | telescope | tool | contact | extraterrestrial
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📡"]; new_value=antenna | dish | satellite | aliens | contact | science | satellite antenna
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💉"]; new_value=medicine | needle | shot | sick | syringe | doctor | flu shot | tool | vaccination
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩸"]; new_value=bleed | blood donation | drop of blood | injury | medicine | menstruation | blood | donation
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💊"]; new_value=doctor | medicine | pill | sick | drugs | pills | medicated | vitamin
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩼"]; new_value=cane | crutch | disability | hurt | mobility aid | stick | help | injured
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🩻"]; new_value=bones | doctor | medical | skeleton | x-ray | skull | xray
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚪"]; new_value=door | back door | closet | front door
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪞"]; new_value=mirror | reflection | reflector | speculum | makeup
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚽"]; new_value=toilet | bathroom
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪠"]; new_value=force cup | plumber | plunger | suction | toilet | poop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪤"]; new_value=bait | mouse trap | mousetrap | snare | trap | lure | cheese
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧼"]; new_value=bar | bathing | cleaning | lather | soap | soapdish | clean
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🫧"]; new_value=bubbles | burp | clean | soap | underwater | bubble | pearl | floating
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪥"]; new_value=bathroom | brush | clean | dental | hygiene | teeth | toothbrush | toiletry
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧽"]; new_value=absorbing | cleaning | porous | sponge | soak
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚰"]; new_value=coffin | death | vampire | dead
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪦"]; new_value=cemetery | grave | graveyard | headstone | tombstone | dead | tomb | memorial | rip
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚱"]; new_value=ashes | death | funeral | urn | funeral urn
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🧿"]; new_value=bead | charm | evil-eye | nazar | nazar amulet | talisman | blue
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪬"]; new_value=amulet | Fatima | hamsa | hand | Mary | Miriam | protection | protect | palm | fortune | guide
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🗿"]; new_value=face | moai | moyai | statue | stoneface | travel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪧"]; new_value=demonstration | picket | placard | protest | sign | notice | card | plaque
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪪"]; new_value=credentials | ID | identification card | license | security | document | identification
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏧"]; new_value=ATM | ATM sign | automated | bank | teller | atm | cash | money
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚮"]; new_value=litter | litter bin | litter in bin sign | litterbin
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚰"]; new_value=drinking | potable | water | potable water
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♿"]; new_value=access | wheelchair symbol | wheelchair | handicap
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚹"]; new_value=bathroom | lavatory | man | men’s room | restroom | toilet | WC | wc
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚺"]; new_value=bathroom | lavatory | restroom | toilet | WC | woman | women’s room | wc
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚾"]; new_value=bathroom | closet | lavatory | restroom | toilet | water | WC | wc | water closet
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛂"]; new_value=control | passport | passport control
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛃"]; new_value=customs | packing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛄"]; new_value=baggage | claim | arrived | bags | case | checked | journey | packing | plane | ready | travel | trip | baggage claim
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛅"]; new_value=baggage | left luggage | locker | luggage | case
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚠"]; new_value=warning | caution
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⛔"]; new_value=entry | forbidden | no | not | prohibited | traffic | do not pass | fail | no entry
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚫"]; new_value=entry | forbidden | no | not | prohibited | smoke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚳"]; new_value=bicycle | bike | forbidden | no | no bicycles | prohibited | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚭"]; new_value=forbidden | no | not | prohibited | smoking | smoke | no smoking
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚱"]; new_value=non-drinking | non-potable | water | dry | prohibited | non-potable water
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📵"]; new_value=cell | forbidden | mobile | no | no mobile phones | phone | prohibited | telephone | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔞"]; new_value=18 | age restriction | eighteen | no one under eighteen | prohibited | underage | forbidden | no | not | age | restriction
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⬇"]; new_value=arrow | cardinal | direction | down | south | down arrow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔃"]; new_value=arrow | clockwise | clockwise vertical arrows | reload | refresh
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔄"]; new_value=anticlockwise | arrow | counterclockwise | counterclockwise arrows button | withershins | again | dejavu | refresh | rewind | anticlockwise arrows button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔙"]; new_value=arrow | BACK | back | BACK arrow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔚"]; new_value=arrow | END | end | END arrow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔛"]; new_value=arrow | mark | ON | ON! | ON! arrow | on
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔜"]; new_value=arrow | SOON | brb | omw | SOON arrow | soon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔝"]; new_value=arrow | TOP | up | homie | top | TOP arrow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛐"]; new_value=place of worship | religion | worship | pray
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✡"]; new_value=David | Jew | Jewish | religion | star | star of David | david | judaism
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☸"]; new_value=Buddhist | dharma | religion | wheel | wheel of dharma | buddhist
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☯"]; new_value=religion | tao | taoist | yang | yin | difficult | lives | neither | total | yin yang | yinyang
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✝"]; new_value=Christian | cross | latin cross | religion | christ | christian
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☦"]; new_value=Christian | cross | orthodox cross | religion | christian
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☪"]; new_value=islam | Muslim | religion | star and crescent | ramadan
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☮"]; new_value=peace | peace symbol | healing | peaceful
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🕎"]; new_value=candelabrum | candlestick | menorah | religion | hanukkah | jewish | judaism
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔯"]; new_value=dotted six-pointed star | fortune | star | jewish | judaism
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🪯"]; new_value=khanda | religion | Sikh | Khanda | Sikhism | Khalsa | Deg Tegh Fateh
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♈"]; new_value=Aries | ram | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♉"]; new_value=bull | ox | Taurus | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♊"]; new_value=Gemini | twins | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♋"]; new_value=Cancer | crab | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♌"]; new_value=Leo | lion | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♍"]; new_value=Virgo | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♎"]; new_value=balance | justice | Libra | scales | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♏"]; new_value=Scorpio | scorpion | scorpius | zodiac | horoscope | scorpio | Scorpius
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♐"]; new_value=archer | Sagittarius | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♑"]; new_value=Capricorn | goat | zodiac | capricorn | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♒"]; new_value=Aquarius | bearer | water | zodiac | aquarius | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♓"]; new_value=fish | Pisces | zodiac | horoscope
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⏭"]; new_value=arrow | next scene | next track | next track button | triangle | next | track
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔼"]; new_value=arrow | button | upwards button | red | up button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔽"]; new_value=arrow | button | down | downwards button | red | down button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔆"]; new_value=bright | bright button | brightness | light
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📶"]; new_value=antenna | antenna bars | bar | cell | mobile | phone | bars | communication | signal | telephone
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🛜"]; new_value=computer | internet | network | wi-fi | wifi | wireless | wlan | router | connectivity | hotspot | broadband | smartphone
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📳"]; new_value=cell | mobile | mode | phone | telephone | vibration | communication | vibration mode
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📴"]; new_value=cell | mobile | off | phone | telephone | mobile phone off
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="➕"]; new_value=+ | math | plus | sign | heavy plus sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="➖"]; new_value=- | − | math | minus | sign | heavy minus sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="➗"]; new_value=÷ | divide | division | math | sign | heavy division sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🟰"]; new_value=equality | heavy equals sign | math | equal | equals | answer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‼"]; new_value=! | !! | bangbang | double exclamation mark | exclamation | mark | punctuation
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⁉"]; new_value=! | !? | ? | exclamation | interrobang | mark | punctuation | question | exclamation question mark
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❓"]; new_value=? | mark | punctuation | question | red question mark | question mark
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❔"]; new_value=? | mark | outlined | punctuation | question | white question mark | question mark
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❗"]; new_value=! | exclamation | mark | punctuation | red exclamation mark | exclamation mark
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〰"]; new_value=dash | punctuation | wavy | wavy dash
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💱"]; new_value=bank | currency | exchange | money | currency exchange
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="💲"]; new_value=currency | dollar | heavy dollar sign | money | billion | cash | charge | million | pay
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⚜"]; new_value=fleur-de-lis | knights
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔱"]; new_value=anchor | emblem | ship | tool | trident | poseidon | trident emblem
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="📛"]; new_value=badge | name | name badge
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔰"]; new_value=beginner | chevron | Japanese | Japanese symbol for beginner | leaf | green | tool | yellow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⭕"]; new_value=circle | hollow red circle | large | o | red | heavy large circle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✅"]; new_value=✓ | button | check | mark | checked | complete | completed | done | fixed | checkmark | tick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="☑"]; new_value=✓ | box | check | check box with check | ballot | checked off | done | tick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="✔"]; new_value=✓ | check | mark | checked | done | checkmark | heavy check mark | tick
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="❎"]; new_value=× | cross mark button | mark | square | x | multiplication | multiply
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="™"]; new_value=mark | TM | trade mark | trademark | tm
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔠"]; new_value=ABCD | input | latin | letters | uppercase | input latin uppercase
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔡"]; new_value=abcd | input | latin | letters | lowercase | input latin lowercase
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔢"]; new_value=1234 | input | numbers | input numbers
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔤"]; new_value=abc | alphabet | input | latin | letters | input latin letters
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🅰"]; new_value=A | A button (blood type) | blood type | a | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆎"]; new_value=AB | AB button (blood type) | blood type | button | AB button | ab
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🅱"]; new_value=B | B button (blood type) | blood type | button | B button | b
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆑"]; new_value=CL | CL button | button | cl
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆒"]; new_value=COOL | COOL button | cool | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆓"]; new_value=FREE | FREE button | free | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆔"]; new_value=ID | ID button | identity | id | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="Ⓜ"]; new_value=circle | circled M | M | m
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆕"]; new_value=NEW | NEW button | new | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆖"]; new_value=NG | NG button | ng | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🅾"]; new_value=blood type | O | O button (blood type) | o | button | O button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆗"]; new_value=OK | OK button | ok | okay | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🅿"]; new_value=P | P button | parking | button | p
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆘"]; new_value=help | SOS | SOS button | button | sos
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆙"]; new_value=mark | UP | UP! | UP! button | up | button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🆚"]; new_value=versus | VS | VS button | button | vs
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🈷"]; new_value=“monthly amount” | ideograph | Japanese | Japanese “monthly amount” button | 月 | monthly amount
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🈶"]; new_value=“not free of charge” | ideograph | Japanese | Japanese “not free of charge” button | 有 | not free of charge
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🈴"]; new_value=“passing grade” | ideograph | Japanese | Japanese “passing grade” button | 合 | passing grade
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🈺"]; new_value=“open for business” | ideograph | Japanese | Japanese “open for business” button | 営 | open for business
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🈵"]; new_value=“no vacancy” | ideograph | Japanese | Japanese “no vacancy” button | 満 | no vacancy
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔴"]; new_value=circle | geometric | red | red circle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔵"]; new_value=blue | circle | geometric | blue circle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🔘"]; new_value=button | geometric | radio | radio button
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏁"]; new_value=checkered | chequered | chequered flag | racing | finish | flag | flags | game | race | sport | win
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🚩"]; new_value=post | triangular flag | construction | flag | golf
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="🏳‍🌈"]; new_value=pride | rainbow | rainbow flag | queer | lgbt | lgbtq | glbt | glbtq | lgbtqia | gay | lesbian | trans | transgender | genderqueer | bisexual
-
-locale=el; action=add; new_path=//ldml/annotations/annotation[@cp="🙄"][@draft="contributed"]; new_value=αναποδογυριστά | βλέμμα αποδοκιμασίας | μάτια | πρόσωπο | γύρισμα των ματιών | πρόσωπο με γυρισμένα μάτια | όντως | έλεος | τέλος πάντων | ότι πεις
-locale=fil; action=add; new_path=//ldml/annotations/annotation[@cp="👱"][@draft="contributed"]; new_value=blond | buhok | lalaki | tao | taong may blond na buhok | blonde ang buhok | taong may blonde na buhok | mukha
-locale=kn; action=add; new_path=//ldml/annotations/annotation[@cp="😸"][@draft="contributed"]; new_value=ಕಣ್ಣು | ನಗು | ನಗುತ್ತಿರುವ ಕಣ್ಣುಗಳೊಂದಿಗೆ ನಗುತ್ತಿರುವ ಬೆಕ್ಕು | ನಗುವ ಕಣ್ಣುಗಳಿರುವ ನಗುವ ಬೆಕ್ಕು | ಬೆಕ್ಕು | ಮುಖ | ಮುಗುಳ್ನಗೆ | ಬೆಕ್ಕಿನ ಮುಖ | ಹಲ್ಲು ಕಿರಿದು ನಗುತ್ತಿರುವ ಕಣ್ಣುಗಳು | ಪ್ರಾಣಿ | ಹಲ್ಲು ಕಿಸಿದು ನಗು | ನಗುವ ಕಣ್ಣಿನೊಂದಿಗೆ ಹಲ್ಲು ಕಿಸಿಯುವ ಬೆಕ್ಕು
+# Modify non-emoji
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="_"]; new_value=dash | line | low | underdash | underline
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="―"]; new_value=bar | dash | horizontal | line
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="・"]; new_value=dot | dots | interpunct | katakana | middle | middot
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="؛"]; new_value=arabic | semi-colon | semicolon
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="!"]; new_value=bang | exclamation | mark | point
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¡"]; new_value=bang | exclamation | inverted | mark | point
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="?"]; new_value=mark | question
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¿"]; new_value=inverted | mark | question
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="؟"]; new_value=arabic | mark | question
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="."]; new_value=dot | full | period | stop
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="。"]; new_value=full | ideographic | period | stop
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="'"]; new_value=apostrophe | quote | single | typewriter
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‘"]; new_value=apostrophe | left | quote | single | smart
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="’"]; new_value=apostrophe | quote | right | single | smart
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‚"]; new_value=apostrophe | low | quote | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="“"]; new_value=double | left | mark | quotation | quote | smart
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="”"]; new_value=double | mark | quotation | quote | right | smart
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="„"]; new_value=double | low | mark | quotation | quote | right | smart
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="«"]; new_value=angle | brackets | carets | chevron | guillemet | left | quote
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="»"]; new_value=angle | brackets | carets | chevron | guillemet | quote | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp=")"]; new_value=bracket | close | paren | parens | parenthesis | round
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="["]; new_value=bracket | crotchet | open | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="]"]; new_value=bracket | close | crotchet | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="{"]; new_value=brace | bracket | curly | gullwing | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="}"]; new_value=brace | bracket | close | curly | gullwing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〈"]; new_value=angle | bracket | brackets | chevron | diamond | open | pointy | tuple
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〉"]; new_value=angle | bracket | brackets | chevron | close | diamond | pointy | tuple
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="《"]; new_value=angle | bracket | double | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="》"]; new_value=angle | bracket | close | double
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="「"]; new_value=bracket | corner | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="」"]; new_value=bracket | close | corner
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="『"]; new_value=bracket | corner | hollow | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="』"]; new_value=bracket | close | corner | hollow
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="【"]; new_value=black | bracket | lens | lenticular | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="】"]; new_value=black | bracket | close | lens | lenticular
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〔"]; new_value=bracket | open | shell | tortoise
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〕"]; new_value=bracket | close | shell | tortoise
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〖"]; new_value=bracket | hollow | lens | lenticular | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〗"]; new_value=bracket | close | hollow | lens | lenticular
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¶"]; new_value=alinea | mark | paragraph | paraph | pilcrow
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="@"]; new_value=ampersat | arobase | arroba | at | at-sign | commercial | mark | sign | strudel
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="\"]; new_value=backslash | reverse | solidus | whack
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="%"]; new_value=cent | per | per-cent | percent
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‰"]; new_value=mil | mille | per | permil | permille
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="†"]; new_value=dagger | obelisk | obelus | sign
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‡"]; new_value=dagger | double | obelisk | obelus | sign
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‧"]; new_value=dash | hyphen | hyphenation | point
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="″"]; new_value=double | prime
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‴"]; new_value=prime | triple
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="※"]; new_value=mark | reference
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="^"]; new_value=accent | caret | chevron | circumflex | control | hat | pointer | power | sign | wedge | xor
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="←"]; new_value=arrow | left | left-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↚"]; new_value=arrow | leftwards | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="→"]; new_value=arrow | right | right-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↛"]; new_value=arrow | rightwards | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↑"]; new_value=arrow | up | up-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↓"]; new_value=arrow | down | down-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↜"]; new_value=arrow | leftwards | wave
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↝"]; new_value=arrow | rightwards | wave
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↞"]; new_value=arrow | headed | leftwards | two
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↟"]; new_value=arrow | headed | two | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↠"]; new_value=arrow | headed | rightwards | two
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↡"]; new_value=arrow | downwards | headed | two
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↢"]; new_value=arrow | leftwards | tail
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↣"]; new_value=arrow | rightwards | tail
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↤"]; new_value=arrow | bar | from | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↥"]; new_value=arrow | bar | from | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↦"]; new_value=arrow | bar | from | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↧"]; new_value=arrow | bar | downwards | from
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↨"]; new_value=arrow | base | down | up | with
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↫"]; new_value=arrow | leftwards | loop
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↬"]; new_value=arrow | loop | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↭"]; new_value=arrow | left | right | wave
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↯"]; new_value=arrow | downwards | zigzag
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↰"]; new_value=arrow | leftwards | tip | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↱"]; new_value=arrow | rightwards | tip | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↲"]; new_value=arrow | downwards | leftwards | tip
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↳"]; new_value=arrow | downwards | rightwards | tip
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↴"]; new_value=arrow | corner | downwards | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↵"]; new_value=arrow | corner | downwards | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↶"]; new_value=anticlockwise | arrow | semicircle | top
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↷"]; new_value=arrow | clockwise | semicircle | top
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↸"]; new_value=arrow | bar | long | north | west
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↹"]; new_value=arrow | bar | bars | leftwards | over | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↺"]; new_value=anticlockwise | arrow | circle | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↻"]; new_value=arrow | circle | clockwise | open
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↼"]; new_value=barb | harpoon | leftwards | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↽"]; new_value=barb | downwards | harpoon | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↾"]; new_value=barb | harpoon | rightwards | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↿"]; new_value=barb | harpoon | leftwards | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇀"]; new_value=barb | harpoon | rightwards | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇁"]; new_value=barb | downwards | harpoon | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇂"]; new_value=barb | downwards | harpoon | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇃"]; new_value=barb | downwards | harpoon | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇄"]; new_value=arrow | leftwards | over | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇅"]; new_value=and | arrow | arrows | down | down-pointing | up | up-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇆"]; new_value=arrow | arrows | left | left-pointing | over | right | right-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇇"]; new_value=arrows | leftwards | paired
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇈"]; new_value=arrows | paired | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇉"]; new_value=arrows | paired | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇊"]; new_value=arrows | downwards | paired
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇋"]; new_value=harpoon | leftwards | over | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇌"]; new_value=harpoon | leftwards | over | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇐"]; new_value=arrow | double | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇍"]; new_value=arrow | double | leftwards | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇑"]; new_value=arrow | double | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇒"]; new_value=arrow | double | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇏"]; new_value=arrow | double | rightwards | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇓"]; new_value=arrow | double | downwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇔"]; new_value=arrow | double | left | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇎"]; new_value=arrow | double | left | right | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇖"]; new_value=arrow | double | north | west
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇗"]; new_value=arrow | double | east | north
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇘"]; new_value=arrow | double | east | south
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇙"]; new_value=arrow | double | south | west
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇚"]; new_value=arrow | leftwards | triple
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇛"]; new_value=arrow | rightwards | triple
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇜"]; new_value=arrow | leftwards | squiggle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇝"]; new_value=arrow | rightwards | squiggle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇞"]; new_value=arrow | double | stroke | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇟"]; new_value=arrow | double | downwards | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇠"]; new_value=arrow | dashed | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇡"]; new_value=arrow | dashed | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇢"]; new_value=arrow | dashed | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇣"]; new_value=arrow | dashed | downwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇤"]; new_value=arrow | bar | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇥"]; new_value=arrow | bar | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇦"]; new_value=arrow | hollow | leftwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇧"]; new_value=arrow | hollow | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇨"]; new_value=arrow | hollow | rightwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇩"]; new_value=arrow | downwards | hollow
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇪"]; new_value=arrow | bar | from | hollow | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇵"]; new_value=arrow | downwards | leftwards | upwards
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∀"]; new_value=all | any | for | given | universal
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∂"]; new_value=differential | partial
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∃"]; new_value=exists | there
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∅"]; new_value=empty | mathematics | operator | set
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∈"]; new_value=contains | element | membership | of | set
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∉"]; new_value=an | element | not
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∋"]; new_value=as | contains | element | member
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∎"]; new_value=end | halmos | proof | q.e.d. | qed | tombstone
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∏"]; new_value=logic | n-ary | product
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∑"]; new_value=mathematics | n-ary | summation
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="+"]; new_value=add | plus | sign
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="÷"]; new_value=divide | division | obelus | sign
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="×"]; new_value=multiplication | multiply | sign | times
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="<"]; new_value=less | less-than | open | tag | than
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≮"]; new_value=inequality | less-than | mathematics | not
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≠"]; new_value=equal | inequality | inequation | not
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp=">"]; new_value=close | greater | greater-than | tag | than
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≯"]; new_value=greater-than | inequality | mathematics | not
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="|"]; new_value=bar | line | pike | pipe | sheffer | stick | stroke | vbar | vertical
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="−"]; new_value=minus | sign | subtract
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∕"]; new_value=division | slash | stroke | virgule
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⁄"]; new_value=fraction | slash | stroke | virgule
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∗"]; new_value=asterisk | operator | star
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∘"]; new_value=composition | operator | ring
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∙"]; new_value=bullet | operator
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∞"]; new_value=infinity | sign
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∟"]; new_value=angle | mathematics | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∧"]; new_value=ac | and | atque | logical | wedge
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∬"]; new_value=calculus | double | integral
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∮"]; new_value=contour | integral
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∼"]; new_value=operator | tilde
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∽"]; new_value=reversed | tilde
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∾"]; new_value=inverted | lazy | s
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≃"]; new_value=asymptote | asymptotically | equal | mathematics
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≅"]; new_value=approximately | congruence | equal | equality | isomorphism | mathematics
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≈"]; new_value=almost | approximate | approximation | equal
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≌"]; new_value=all | equal | equality | mathematics
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≒"]; new_value=approximately | equal | image | the
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≖"]; new_value=equal | equality | in | mathematics | ring
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≡"]; new_value=exact | identical | to | triple
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≣"]; new_value=equality | equivalent | mathematics | strictly
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≤"]; new_value=equal | equals | inequality | less-than | or
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≥"]; new_value=equal | equals | greater-than | inequality | or
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≦"]; new_value=equal | inequality | less-than | mathematics | over
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≧"]; new_value=equal | greater-than | inequality | mathematics | over
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≪"]; new_value=inequality | less-than | mathematics | much
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≫"]; new_value=greater-than | inequality | mathematics | much
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≳"]; new_value=equivalent | greater-than | inequality | mathematics
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≺"]; new_value=mathematics | operator | precedes | set
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≻"]; new_value=mathematics | operator | set | succeeds
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊁"]; new_value=does | mathematics | not | operator | set | succeed
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊂"]; new_value=of | set | subset
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊃"]; new_value=mathematics | operator | set | superset
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊆"]; new_value=equal | subset
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊇"]; new_value=equal | equality | mathematics | superset
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊕"]; new_value=circled | plus
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊖"]; new_value=circled | difference | erosion | minus | symmetric
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊗"]; new_value=circled | product | tensor | times
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊘"]; new_value=circled | division | division-like | mathematics | slash
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊙"]; new_value=circled | dot | operator | XNOR
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊚"]; new_value=circled | operator | ring
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊛"]; new_value=asterisk | circled | operator
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊞"]; new_value=addition-like | mathematics | plus | squared
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊟"]; new_value=mathematics | minus | squared | subtraction-like
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊥"]; new_value=eet | falsum | tack | up
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊮"]; new_value=does | force | not
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊰"]; new_value=mathematics | operator | precedes | relation | set | under
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊱"]; new_value=mathematics | operator | relation | set | succeeds | under
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋭"]; new_value=as | contain | does | equal | group | mathematics | normal | not | subgroup | theory
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊹"]; new_value=conjugate | hermitian | mathematics | matrix | self-adjoint | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊿"]; new_value=mathematics | right | right-angled | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋁"]; new_value=disjunction | logic | logical | n-ary | or
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋂"]; new_value=intersection | mathematics | n-ary | operator | set
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋃"]; new_value=mathematics | n-ary | operator | set | union
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋅"]; new_value=dot | operator
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋆"]; new_value=operator | star
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋈"]; new_value=binary | bowtie | join | natural | operator
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋒"]; new_value=double | intersection | mathematics | operator | set
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋘"]; new_value=inequality | less-than | mathematics | much | very
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋙"]; new_value=greater-than | inequality | mathematics | much | very
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋮"]; new_value=ellipsis | mathematics | vertical
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋯"]; new_value=ellipsis | horizontal | midline
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋰"]; new_value=diagonal | ellipsis | mathematics | right | up
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋱"]; new_value=diagonal | down | ellipsis | mathematics | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="■"]; new_value=filled | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="□"]; new_value=hollow | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▢"]; new_value=corners | hollow | rounded | square | with
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▣"]; new_value=containing | filled | hollow | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▤"]; new_value=fill | horizontal | square | with
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▥"]; new_value=fill | square | vertical | with
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▦"]; new_value=crosshatch | fill | orthogonal | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▧"]; new_value=fill | left | lower | right | square | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▨"]; new_value=fill | left | lower | right | square | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▩"]; new_value=crosshatch | diagonal | fill | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▬"]; new_value=filled | rectangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▭"]; new_value=hollow | rectangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▮"]; new_value=filled | rectangle | vertical
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▰"]; new_value=filled | parallelogram
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▲"]; new_value=arrow | filled | triangle | up | up-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="△"]; new_value=hollow | triangle | up-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▴"]; new_value=filled | small | triangle | up-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▵"]; new_value=hollow | small | triangle | up-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▷"]; new_value=hollow | right-pointing | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▸"]; new_value=filled | right-pointing | small | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▹"]; new_value=hollow | right-pointing | small | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="►"]; new_value=filled | pointer | right-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▻"]; new_value=hollow | pointer | right-pointing
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▼"]; new_value=arrow | down | down-pointing | filled | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▽"]; new_value=down-pointing | hollow | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▾"]; new_value=down-pointing | filled | small | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▿"]; new_value=down-pointing | hollow | small | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◁"]; new_value=hollow | left-pointing | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◂"]; new_value=filled | left-pointing | small | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◃"]; new_value=hollow | left-pointing | small | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◄"]; new_value=filled | left-pointing | pointer
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◅"]; new_value=hollow | left-pointing | pointer
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◆"]; new_value=diamond | filled
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◇"]; new_value=diamond | hollow
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◈"]; new_value=containing | diamond | filled | hollow
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◉"]; new_value=cicles | circle | circled | concentric | containing | dot | filled | fisheye | hollow | ward
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="○"]; new_value=circle | hollow | ring
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◌"]; new_value=circle | dotted
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◍"]; new_value=circle | fill | vertical | with
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◎"]; new_value=circle | circles | concentric | double | target
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="●"]; new_value=circle | filled
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◐"]; new_value=circle | filled | half | left
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◑"]; new_value=circle | filled | half | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◒"]; new_value=circle | filled | half | lower
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◓"]; new_value=circle | filled | half | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◔"]; new_value=circle | filled | quadrant | right | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◕"]; new_value=all | but | circle | filled | left | quadrant | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◖"]; new_value=circle | filled | half | left
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◗"]; new_value=circle | filled | half | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◘"]; new_value=bullet | inverse
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◙"]; new_value=circle | containing | filled | hollow | inverse | square
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◜"]; new_value=arc | circular | left | quadrant | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◝"]; new_value=arc | circular | quadrant | right | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◞"]; new_value=arc | circular | lower | quadrant | right
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◟"]; new_value=arc | circular | left | lower | quadrant
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◠"]; new_value=circle | half | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◡"]; new_value=circle | half | lower
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◢"]; new_value=filled | lower | right | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◣"]; new_value=filled | left | lower | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◤"]; new_value=filled | left | triangle | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◥"]; new_value=filled | right | triangle | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◦"]; new_value=bullet | hollow
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◯"]; new_value=circle | hollow | large | ring
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◳"]; new_value=hollow | quadrant | right | square | upper
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◷"]; new_value=circle | hollow | quadrant | right | upper | with
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◿"]; new_value=lower | right | triangle
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⨧"]; new_value=plus | subscript | two
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⨯"]; new_value=cross | product | vector
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⨼"]; new_value=interior | product
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⩣"]; new_value=double | logical | or | underbar
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⩽"]; new_value=equal | less-than | slanted
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⪍"]; new_value=above | equal | less-than | similar
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⪚"]; new_value=double-line | equal | greater-than | inequality | mathematics
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⪺"]; new_value=above | almost | equal | not | succeeds
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↮"]; new_value=arrow | left | right | stroke
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₣"]; new_value=currency | franc | french
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₰"]; new_value=currency | german | penny | pfennig
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₶"]; new_value=currency | livre | tournois
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₹"]; new_value=currency | indian | rupee
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="µ"]; new_value=measure | micro | sign
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♯"]; new_value=dièse | diesis | music | note | sharp
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="$"]; new_value=dollar | money | peso | USD
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="£"]; new_value=currency | EGP | GBP | pound
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¥"]; new_value=CNY | currency | JPY | yen | yuan
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="€"]; new_value=currency | EUR | euro
+locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₿"]; new_value=bitcoin | BTC

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -222,7 +222,7 @@ public class TestAnnotations extends TestFmwkPlus {
             Annotations annotations = s.getValue();
             String name = Emoji.getName(emoji);
             String annotationName = annotations.getShortName();
-            if (!symbols.contains(emoji) && !emoji.contains("👲")) {
+            if (!symbols.contains(emoji) && !emoji.contains("👲") && !emoji.contains("🧑")) {
                 assertEquals(emoji + " (en.xml vs. emoji-test.txt)", name, annotationName);
             }
         }


### PR DESCRIPTION
CLDR-17582

- This cleans up the English annotations according to the directions given to vetters.
- The multiword search keys are split up.
- Duplicates (or near duplicates), synonyms, and low-value terms are removed.
    - or at least reduced, with a focus on items that had a very large number of annotations.
- Reduce the maximum number of search terms on items.
- Other misc. cleanup.

When reviewing, note that breaking up keywords and then alphabetizing means that phrases are distributed. Example:
- cp="😄"
- **old:** awesome | face | grin | grinning face with big eyes | happy | mouth | open | smile | smiling | smiling face with open mouth | teeth | yay
- **new:** awesome | big | eyes | face | grin | grinning | happy | mouth | open | smile | smiling | teeth | yay

We can't expect a line-by-line review, so please just spot-check looking for anything that is terrible: We can tweak the English later on before release; the goal here is to adhere more to the guidelines to lessen the chances vetters will be misled (though we caution them that they need to look at the associations in their languages, not English!)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
