### PR TITLE
CLDR-17111 Deprecate old style zone IDs (e.g. EST5EDT, EET)

### DIFF
--- a/common/bcp47/timezone.xml
+++ b/common/bcp47/timezone.xml
@@ -62,7 +62,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="basjj" description="Sarajevo, Bosnia and Herzegovina" alias="Europe/Sarajevo"/>
             <type name="bbbgi" description="Barbados" alias="America/Barbados"/>
             <type name="bddac" description="Dhaka, Bangladesh" alias="Asia/Dhaka Asia/Dacca"/>
-            <type name="bebru" description="Brussels, Belgium" alias="Europe/Brussels"/>
+            <type name="bebru" description="Brussels, Belgium" alias="Europe/Brussels CET MET"/>
             <type name="bfoua" description="Ouagadougou, Burkina Faso" alias="Africa/Ouagadougou"/>
             <type name="bgsof" description="Sofia, Bulgaria" alias="Europe/Sofia"/>
             <type name="bhbah" description="Bahrain" alias="Asia/Bahrain"/>
@@ -141,7 +141,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="cnurc" description="Ürümqi, China" alias="Asia/Urumqi Asia/Kashgar"/>
             <type name="cobog" description="Bogotá, Colombia" alias="America/Bogota"/>
             <type name="crsjo" description="Costa Rica" alias="America/Costa_Rica"/>
-            <type name="cst6cdt" description="POSIX style time zone for US Central Time" alias="CST6CDT" since="1.8"/>
+            <type name="cst6cdt" description="POSIX style time zone for US Central Time" deprecated="true" preferred="uschi"/>
             <type name="cuhav" description="Havana, Cuba" alias="America/Havana Cuba"/>
             <type name="cvrai" description="Cape Verde" alias="Atlantic/Cape_Verde"/>
             <type name="cxxch" description="Christmas Island" alias="Indian/Christmas"/>
@@ -164,7 +164,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="esceu" description="Ceuta, Spain" alias="Africa/Ceuta"/>
             <type name="eslpa" description="Canary Islands, Spain" alias="Atlantic/Canary"/>
             <type name="esmad" description="Madrid, Spain" alias="Europe/Madrid"/>
-            <type name="est5edt" description="POSIX style time zone for US Eastern Time" alias="EST5EDT" since="1.8"/>
+            <type name="est5edt" description="POSIX style time zone for US Eastern Time" deprecated="true" preferred="usnyc"/>
             <type name="etadd" description="Addis Ababa, Ethiopia" alias="Africa/Addis_Ababa"/>
             <type name="fihel" description="Helsinki, Finland" alias="Europe/Helsinki"/>
             <type name="fimhq" description="Mariehamn, Åland, Finland" alias="Europe/Mariehamn"/>
@@ -196,7 +196,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="gpmsb" description="Marigot, Saint Martin" alias="America/Marigot"/>
             <type name="gpsbh" description="Saint Barthélemy" alias="America/St_Barthelemy"/>
             <type name="gqssg" description="Malabo, Equatorial Guinea" alias="Africa/Malabo"/>
-            <type name="grath" description="Athens, Greece" alias="Europe/Athens"/>
+            <type name="grath" description="Athens, Greece" alias="Europe/Athens EET"/>
             <type name="gsgrv" description="South Georgia and the South Sandwich Islands" alias="Atlantic/South_Georgia"/>
             <type name="gtgua" description="Guatemala" alias="America/Guatemala"/>
             <type name="gugum" description="Guam" alias="Pacific/Guam"/>
@@ -273,7 +273,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="mqfdf" description="Martinique" alias="America/Martinique"/>
             <type name="mrnkc" description="Nouakchott, Mauritania" alias="Africa/Nouakchott"/>
             <type name="msmni" description="Montserrat" alias="America/Montserrat"/>
-            <type name="mst7mdt" description="POSIX style time zone for US Mountain Time" alias="MST7MDT" since="1.8"/>
+            <type name="mst7mdt" description="POSIX style time zone for US Mountain Time" deprecated="true" preferred="usden"/>
             <type name="mtmla" description="Malta" alias="Europe/Malta"/>
             <type name="muplu" description="Mauritius" alias="Indian/Mauritius"/>
             <type name="mvmle" description="Maldives" alias="Indian/Maldives"/>
@@ -308,7 +308,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="nzakl" description="Auckland, New Zealand" alias="Pacific/Auckland Antarctica/South_Pole NZ"/>
             <type name="nzcht" description="Chatham Islands, New Zealand" alias="Pacific/Chatham NZ-CHAT"/>
             <type name="ommct" description="Muscat, Oman" alias="Asia/Muscat"/>
-            <type name="papty" description="Panama" alias="America/Panama"/>
+            <type name="papty" description="Panama" alias="America/Panama EST"/>
             <type name="pelim" description="Lima, Peru" alias="America/Lima"/>
             <type name="pfgmr" description="Gambiera Islands, French Polynesia" alias="Pacific/Gambier"/>
             <type name="pfnhv" description="Marquesas Islands, French Polynesia" alias="Pacific/Marquesas"/>
@@ -321,9 +321,9 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="pmmqc" description="Saint Pierre and Miquelon" alias="America/Miquelon"/>
             <type name="pnpcn" description="Pitcairn Islands" alias="Pacific/Pitcairn"/>
             <type name="prsju" description="Puerto Rico" alias="America/Puerto_Rico"/>
-            <type name="pst8pdt" description="POSIX style time zone for US Pacific Time" alias="PST8PDT" since="1.8"/>
+            <type name="pst8pdt" description="POSIX style time zone for US Pacific Time" deprecated="true" preferred="uslax"/>
             <type name="ptfnc" description="Madeira, Portugal" alias="Atlantic/Madeira"/>
-            <type name="ptlis" description="Lisbon, Portugal" alias="Europe/Lisbon Portugal"/>
+            <type name="ptlis" description="Lisbon, Portugal" alias="Europe/Lisbon Portugal WET"/>
             <type name="ptpdl" description="Azores, Portugal" alias="Atlantic/Azores"/>
             <type name="pwror" description="Palau" alias="Pacific/Palau"/>
             <type name="pyasu" description="Asunción, Paraguay" alias="America/Asuncion"/>
@@ -403,20 +403,20 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="umawk" description="Wake Island, U.S. Minor Outlying Islands" alias="Pacific/Wake"/>
             <type name="umjon" description="Johnston Atoll, U.S. Minor Outlying Islands" deprecated="true" preferred="ushnl"/>
             <type name="ummdy" description="Midway Islands, U.S. Minor Outlying Islands" alias="Pacific/Midway"/>
-            <type name="unk" description="Unknown time zone" alias="Etc/Unknown"/>
+            <type name="unk" description="Unknown time zone" alias="Etc/Unknown Factory"/>
             <type name="usadk" description="Adak (Alaska), United States" alias="America/Adak America/Atka US/Aleutian"/>
             <type name="usaeg" description="Marengo (Indiana), United States" alias="America/Indiana/Marengo"/>
             <type name="usanc" description="Anchorage, United States" alias="America/Anchorage US/Alaska"/>
             <type name="usboi" description="Boise (Idaho), United States" alias="America/Boise"/>
-            <type name="uschi" description="Chicago, United States" alias="America/Chicago US/Central"/>
-            <type name="usden" description="Denver, United States" alias="America/Denver America/Shiprock Navajo US/Mountain"/>
+            <type name="uschi" description="Chicago, United States" alias="America/Chicago US/Central CST6CDT"/>
+            <type name="usden" description="Denver, United States" alias="America/Denver America/Shiprock Navajo US/Mountain MST7MDT"/>
             <type name="usdet" description="Detroit, United States" alias="America/Detroit US/Michigan"/>
-            <type name="ushnl" description="Honolulu, United States" alias="Pacific/Honolulu US/Hawaii Pacific/Johnston"/>
+            <type name="ushnl" description="Honolulu, United States" alias="Pacific/Honolulu US/Hawaii Pacific/Johnston HST"/>
             <type name="usind" description="Indianapolis, United States" alias="America/Indianapolis America/Fort_Wayne America/Indiana/Indianapolis US/East-Indiana" iana="America/Indiana/Indianapolis"/>
             <type name="usinvev" description="Vevay (Indiana), United States" alias="America/Indiana/Vevay"/>
             <type name="usjnu" description="Juneau (Alaska), United States" alias="America/Juneau"/>
             <type name="usknx" description="Knox (Indiana), United States" alias="America/Indiana/Knox America/Knox_IN US/Indiana-Starke"/>
-            <type name="uslax" description="Los Angeles, United States" alias="America/Los_Angeles US/Pacific US/Pacific-New"/>
+            <type name="uslax" description="Los Angeles, United States" alias="America/Los_Angeles US/Pacific US/Pacific-New PST8PDT"/>
             <type name="uslui" description="Louisville (Kentucky), United States" alias="America/Louisville America/Kentucky/Louisville" iana="America/Kentucky/Louisville"/>
             <type name="usmnm" description="Menominee (Michigan), United States" alias="America/Menominee"/>
             <type name="usmtm" description="Metlakatla (Alaska), United States" alias="America/Metlakatla" since="1.9.1"/>
@@ -424,10 +424,10 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="usnavajo" description="Shiprock (Navajo), United States" deprecated="true" preferred="usden"/>
             <type name="usndcnt" description="Center (North Dakota), United States" alias="America/North_Dakota/Center"/>
             <type name="usndnsl" description="New Salem (North Dakota), United States" alias="America/North_Dakota/New_Salem"/>
-            <type name="usnyc" description="New York, United States" alias="America/New_York US/Eastern"/>
+            <type name="usnyc" description="New York, United States" alias="America/New_York US/Eastern EST5EDT"/>
             <type name="usoea" description="Vincennes (Indiana), United States" alias="America/Indiana/Vincennes"/>
             <type name="usome" description="Nome (Alaska), United States" alias="America/Nome"/>
-            <type name="usphx" description="Phoenix, United States" alias="America/Phoenix US/Arizona"/>
+            <type name="usphx" description="Phoenix, United States" alias="America/Phoenix US/Arizona MST"/>
             <type name="ussit" description="Sitka (Alaska), United States" alias="America/Sitka" since="1.9.1"/>
             <type name="ustel" description="Tell City (Indiana), United States" alias="America/Indiana/Tell_City"/>
             <type name="uswlz" description="Winamac (Indiana), United States" alias="America/Indiana/Winamac"/>
@@ -453,12 +453,12 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="utcw02" description="2 hours behind UTC" alias="Etc/GMT+2"/>
             <type name="utcw03" description="3 hours behind UTC" alias="Etc/GMT+3"/>
             <type name="utcw04" description="4 hours behind UTC" alias="Etc/GMT+4"/>
-            <type name="utcw05" description="5 hours behind UTC" alias="Etc/GMT+5 EST"/>
+            <type name="utcw05" description="5 hours behind UTC" alias="Etc/GMT+5"/>
             <type name="utcw06" description="6 hours behind UTC" alias="Etc/GMT+6"/>
-            <type name="utcw07" description="7 hours behind UTC" alias="Etc/GMT+7 MST"/>
+            <type name="utcw07" description="7 hours behind UTC" alias="Etc/GMT+7"/>
             <type name="utcw08" description="8 hours behind UTC" alias="Etc/GMT+8"/>
             <type name="utcw09" description="9 hours behind UTC" alias="Etc/GMT+9"/>
-            <type name="utcw10" description="10 hours behind UTC" alias="Etc/GMT+10 HST"/>
+            <type name="utcw10" description="10 hours behind UTC" alias="Etc/GMT+10"/>
             <type name="utcw11" description="11 hours behind UTC" alias="Etc/GMT+11"/>
             <type name="utcw12" description="12 hours behind UTC" alias="Etc/GMT+12"/>
             <type name="uymvd" description="Montevideo, Uruguay" alias="America/Montevideo"/>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1794,7 +1794,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <zoneAlias type="SystemV/YST9YDT" replacement="America/Anchorage" reason="deprecated"/>
             <zoneAlias type="SystemV/AST4" replacement="America/Puerto_Rico" reason="deprecated"/>
             <zoneAlias type="SystemV/EST5" replacement="America/Indianapolis" reason="deprecated"/>
-            <zoneAlias type="EST" replacement="America/Indianapolis" reason="deprecated"/>
+            <zoneAlias type="EST" replacement="America/Panama" reason="deprecated"/>
             <zoneAlias type="SystemV/CST6" replacement="America/Regina" reason="deprecated"/>
             <zoneAlias type="SystemV/MST7" replacement="America/Phoenix" reason="deprecated"/>
             <zoneAlias type="MST" replacement="America/Phoenix" reason="deprecated"/>
@@ -1819,6 +1819,10 @@ For terms of use, see http://www.unicode.org/copyright.html
             <zoneAlias type="Europe/Uzhgorod" replacement="Europe/Kiev" reason="deprecated"/>
             <zoneAlias type="Europe/Zaporozhye" replacement="Europe/Kiev" reason="deprecated"/>
             <zoneAlias type="Pacific/Johnston" replacement="Pacific/Honolulu" reason="deprecated"/>
+            <zoneAlias type="EST5EDT" replacement="America/New_York" reason="deprecated"/>
+            <zoneAlias type="CST6CDT" replacement="America/Chicago" reason="deprecated"/>
+            <zoneAlias type="MST7MDT" replacement="America/Denver" reason="deprecated"/>
+            <zoneAlias type="PST8PDT" replacement="America/Los_Angeles" reason="deprecated"/>
         </alias>
 		<defaultContent locales="
 			aa_ET ab_GE af_ZA agq_CM ak_GH am_ET an_ES ann_NG apc_SY ar_001 arn_CL as_IN

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -960,7 +960,7 @@ public class TestLocale extends TestFmwkPlus {
                         LstrType.extension,
                         new AllowedMatch(
                                 "tz",
-                                "aqams|aukns|caffs|camtr|canpg|capnt|cathu|cayzf|cnckg|cnhrb|cnkhg|gaza|mxstis|uaozh|uauzh|umjon|usnavajo"));
+                                "aqams|aukns|caffs|camtr|canpg|capnt|cathu|cayzf|cnckg|cnhrb|cnkhg|gaza|mxstis|uaozh|uauzh|umjon|usnavajo|est5edt|cst6cdt|mst7mdt|pst8pdt"));
 
         for (Entry<String, String> entry :
                 SUPPLEMENTAL_DATA_INFO.getBcp47Extension2Keys().entrySet()) {


### PR DESCRIPTION
CLDR-17111

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true

This PR revises changes from #3736 (cc @yumaoka) to align CLDR's aliases for recently deprecated zones to match IANA's Link=>Zone mappings in the following recent commits:

https://github.com/eggert/tz/commit/782d082623aaa130178d944bdbfbb563d2e1adfa
https://github.com/eggert/tz/commit/a0b09c0230089252acf2eb0f1ba922e99f7f4a03

It also fixes tests broken by these deprecations.