### PR TITLE
CLDR-17620 hide the 'notifications' menu item in production

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -492,7 +492,7 @@ const strings = {
   special_locales: "Locale List",
   special_lock_account: "Lock (Disable) My Account",
   special_lookup: "Look up a code or xpath",
-  special_mail: "Notifications (SMOKETEST ONLY)",
+  special_mail: "Simulate Email Notifications (SMOKETEST ONLY)",
   special_menu: "☰",
   special_oldvotes: "Import Old Votes",
   special_upload: "Upload (Bulk Import)",
@@ -530,6 +530,8 @@ const strings = {
   lock_account_err_reason: "The reason for the request must be filled in.",
   lock_account_success:
     "The account has been locked successfully. Thank you for using the Survey Tool. If you have difficulty still, contact the person who set up your account.",
+
+  mail_noMail: "No simulated notification emails.",
 
   notification_category_abstained:
     "You have abstained, or not yet voted for any value.",

--- a/tools/cldr-apps/js/src/views/MainMenu.vue
+++ b/tools/cldr-apps/js/src/views/MainMenu.vue
@@ -84,9 +84,11 @@
           </li>
         </ul>
       </li>
-      <li>
+      <li v-if="isUnofficial">
         <ul>
-          <li><a href="#mail///">Notifications (SMOKETEST ONLY)</a></li>
+          <li>
+            <a href="#mail///">Simulate Email Notifications (SMOKETEST ONLY)</a>
+          </li>
         </ul>
       </li>
       <li v-if="isAdmin">
@@ -133,6 +135,7 @@ export default {
       canUseVettingSummary: false,
       isAdmin: false,
       isTC: false,
+      isUnofficial: false,
       loggedIn: false,
       org: null,
       recentActivityUrl: null,
@@ -156,6 +159,7 @@ export default {
       // this.canSeeStatistics will be false until there is a new implementation
       this.canUseVettingSummary = perm && perm.userCanUseVettingSummary;
       this.isAdmin = perm && perm.userIsAdmin;
+      this.isUnofficial = cldrStatus.getIsUnofficial();
       this.isTC = perm && perm.userIsTC;
 
       const user = cldrStatus.getSurveyUser();


### PR DESCRIPTION
- this is a testing facility.  Smoketest, etc don't acutally send mail, so there is a test facility. But it should not be visible in production.
- rename notifications to 'sumulate email notifications'.
- clean up ui slightly

CLDR-17620

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
