### PR TITLE
CLDR-17181 add auto author assign

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,15 @@
+# .github/workflows/auto-author-assign.yml
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
- whoever opens the PR, gets assigned to it by default.
- can reassign if needed.

CLDR-17181

- [X] This PR completes the ticket.

Pretty simple, just makes the PR author the assignee.

You can see it running in my fork here https://github.com/srl295/cldr/pull/6

ALLOW_MANY_COMMITS=true
