### PR TITLE
CLDR-17560 skip invalid report ids

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReportsDB.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ReportsDB.java
@@ -91,10 +91,16 @@ public class ReportsDB extends VoterReportStatus<Integer> implements ReportStatu
                                 locale.getBaseName());
                 ResultSet rs = ps.executeQuery(); ) {
             while (rs.next()) {
-                final String report = rs.getString("report");
+                final String reportStr = rs.getString("report");
+                ReportId report = null;
+                try {
+                    report = ReportId.valueOf(reportStr);
+                } catch (IllegalArgumentException iae) {
+                    continue; // skip illegal enum values. may be a 'retired' enum
+                }
                 final Boolean completed = rs.getBoolean("completed");
                 final Boolean acceptable = rs.getBoolean("acceptable");
-                status.mark(ReportId.valueOf(report), completed, acceptable);
+                status.mark(report, completed, acceptable);
             }
         } catch (SQLException e) {
             SurveyLog.logException(e, "fetching reportStatus for " + user + ":" + locale);


### PR DESCRIPTION
- in #3743,  ReportId.supplemental was retired, but it occurs in some user rows
- skip over invalid rows

CLDR-17560

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
