### PR TITLE
CLDR-15744 partial revert of #3764 user.touch()

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/CookieSession.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/CookieSession.java
@@ -359,9 +359,9 @@ public class CookieSession {
     /** Note a direct user action. */
     public void userDidAction() {
         lastActionMillisSinceEpoch = System.currentTimeMillis();
-        if (user != null) {
-            user.touch(); // explicitly update user last login time
-        }
+        // if (user != null) {
+        //     user.touch(); // explicitly update user last login time
+        // }
     }
 
     /**


### PR DESCRIPTION
 - seems to be creating excessive DB connections

CLDR-15744

partial revert of #3761

for CLDR-17693

I'm not sure that is a root cause or not, but stack traces are pointing to user.touch(),
so reverting to at least mitigate issue.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
