### PR TITLE
CLDR-17703 Fix NPE in CodePointEscaper

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -154,6 +154,9 @@ public enum CodePointEscaper {
 
     /** Returns a code point from the escaped form <b>of a single code point</b> */
     public static int escapedToCodePoint(String value) {
+        if (value == null || value.isEmpty()) {
+            return 0xFFFD;
+        }
         if (value.codePointAt(0) != CodePointEscaper.ESCAPE_START
                 || value.codePointAt(value.length() - 1) != CodePointEscaper.ESCAPE_END) {
             throw new IllegalArgumentException(
@@ -177,6 +180,9 @@ public enum CodePointEscaper {
 
     /** Returns the escaped form from a string */
     public static String toEscaped(String unescaped, UnicodeSet toEscape) {
+        if (unescaped == null) {
+            return null;
+        }
         StringBuilder result = new StringBuilder();
         unescaped
                 .codePoints()
@@ -191,12 +197,15 @@ public enum CodePointEscaper {
         return result.toString();
     }
     /** Return unescaped string */
-    public static String toUnescaped(String value) {
+    public static String toUnescaped(String escaped) {
+        if (escaped == null) {
+            return null;
+        }
         StringBuilder result = null;
         int donePart = 0;
-        int found = value.indexOf(ESCAPE_START);
+        int found = escaped.indexOf(ESCAPE_START);
         while (found >= 0) {
-            int foundEnd = value.indexOf(ESCAPE_END, found);
+            int foundEnd = escaped.indexOf(ESCAPE_END, found);
             if (foundEnd < 0) {
                 throw new IllegalArgumentException(
                         "Malformed escaped string, missing: " + ESCAPE_END);
@@ -204,12 +213,14 @@ public enum CodePointEscaper {
             if (result == null) {
                 result = new StringBuilder();
             }
-            result.append(value, donePart, found);
+            result.append(escaped, donePart, found);
             donePart = ++foundEnd;
-            result.appendCodePoint(escapedToCodePoint(value.substring(found, foundEnd)));
-            found = value.indexOf(ESCAPE_START, foundEnd);
+            result.appendCodePoint(escapedToCodePoint(escaped.substring(found, foundEnd)));
+            found = escaped.indexOf(ESCAPE_START, foundEnd);
         }
-        return donePart == 0 ? value : result.append(value, donePart, value.length()).toString();
+        return donePart == 0
+                ? escaped
+                : result.append(escaped, donePart, escaped.length()).toString();
     }
 
     private static final String HAS_NAME = " ≡ ";
@@ -232,6 +243,9 @@ public enum CodePointEscaper {
      * brackets</b>
      */
     public static int rawEscapedToCodePoint(CharSequence value) {
+        if (value == null || value.length() == 0) {
+            return 0xFFFD;
+        }
         try {
             return valueOf(value.toString().toUpperCase(Locale.ROOT)).codePoint;
         } catch (Exception e) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
@@ -14,6 +14,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -85,14 +86,18 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
                 "[A Á B C {CS} D {DZ} {DZS} E É F G {GY} H I Í J K L {LY} M N {NY} O Ó Ö Ő P Q R S {SZ} T {TY} U Ú Ü Ű V W X Y Z {ZS}]",
                 "A Á B C CS D DZ DZS E É F G GY H I Í J K L LY M N NY O Ó Ö Ő P Q R S SZ T TY U Ú Ü Ű V W X Y Z ZS"
             },
-            {"[:block=Hangul_Jamo:]", "ᄀ➖ᇿ"},
-            {"[:block=CJK_Unified_Ideographs:]", "一➖鿿"},
-            {"LOCALE", "no"},
-            {"[ĂÅ z]", "Ă z Å"}, // Ensure that order is according to the locale
             {
-                "[ÅÅ]", "Å Å"
-            }, // Ensure it doesn't merge two different characters with same NFC, even though a
-            // collator is used
+                "[:block=Hangul_Jamo:]",
+                "ᄀ ᄁ ᄂ ᄃ ᄄ ᄅ ᄆ ᄇ ᄈ ᄉ ᄊ ᄋ ᄌ ᄍ ᄎ ᄏ ᄐ ᄑ ᄒ ᄓ ᄔ ᄕ ᄖ ᄗ ᄘ ᄙ ᄚ ᄛ ᄜ ᄝ ᄞ ᄟ ᄠ ᄡ ᄢ ᄣ ᄤ ᄥ ᄦ ᄧ ᄨ ᄩ ᄪ ᄫ ᄬ ᄭ ᄮ ᄯ ᄰ ᄱ ᄲ ᄳ ᄴ ᄵ ᄶ ᄷ ᄸ ᄹ ᄺ ᄻ ᄼ ᄽ ᄾ ᄿ ᅀ ᅁ ᅂ ᅃ ᅄ ᅅ ᅆ ᅇ ᅈ ᅉ ᅊ ᅋ ᅌ ᅍ ᅎ ᅏ ᅐ ᅑ ᅒ ᅓ ᅔ ᅕ ᅖ ᅗ ᅘ ᅙ ᅚ ᅛ ᅜ ᅝ ᅞ ❰115F❱ ❰1160❱ ᅡ ᅢ ᅣ ᅤ ᅥ ᅦ ᅧ ᅨ ᅩ ᅪ ᅫ ᅬ ᅭ ᅮ ᅯ ᅰ ᅱ ᅲ ᅳ ᅴ ᅵ ᅶ ᅷ ᅸ ᅹ ᅺ ᅻ ᅼ ᅽ ᅾ ᅿ ᆀ ᆁ ᆂ ᆃ ᆄ ᆅ ᆆ ᆇ ᆈ ᆉ ᆊ ᆋ ᆌ ᆍ ᆎ ᆏ ᆐ ᆑ ᆒ ᆓ ᆔ ᆕ ᆖ ᆗ ᆘ ᆙ ᆚ ᆛ ᆜ ᆝ ᆞ ᆟ ᆠ ᆡ ᆢ ᆣ ᆤ ᆥ ᆦ ᆧ ᆨ ᆩ ᆪ ᆫ ᆬ ᆭ ᆮ ᆯ ᆰ ᆱ ᆲ ᆳ ᆴ ᆵ ᆶ ᆷ ᆸ ᆹ ᆺ ᆻ ᆼ ᆽ ᆾ ᆿ ᇀ ᇁ ᇂ ᇃ ᇄ ᇅ ᇆ ᇇ ᇈ ᇉ ᇊ ᇋ ᇌ ᇍ ᇎ ᇏ ᇐ ᇑ ᇒ ᇓ ᇔ ᇕ ᇖ ᇗ ᇘ ᇙ ᇚ ᇛ ᇜ ᇝ ᇞ ᇟ ᇠ ᇡ ᇢ ᇣ ᇤ ᇥ ᇦ ᇧ ᇨ ᇩ ᇪ ᇫ ᇬ ᇭ ᇮ ᇯ ᇰ ᇱ ᇲ ᇳ ᇴ ᇵ ᇶ ᇷ ᇸ ᇹ ᇺ ᇻ ᇼ ᇽ ᇾ ᇿ"
+            },
+            {"USE_RANGES_ABOVE", "100"},
+            {"[:block=Hangul_Jamo:]", "ᄀ➖ᇿ"},
+            {"USE_RANGES_ABOVE", null},
+            {
+                "[:block=Hangul_Jamo:]",
+                "ᄀ ᄁ ᄂ ᄃ ᄄ ᄅ ᄆ ᄇ ᄈ ᄉ ᄊ ᄋ ᄌ ᄍ ᄎ ᄏ ᄐ ᄑ ᄒ ᄓ ᄔ ᄕ ᄖ ᄗ ᄘ ᄙ ᄚ ᄛ ᄜ ᄝ ᄞ ᄟ ᄠ ᄡ ᄢ ᄣ ᄤ ᄥ ᄦ ᄧ ᄨ ᄩ ᄪ ᄫ ᄬ ᄭ ᄮ ᄯ ᄰ ᄱ ᄲ ᄳ ᄴ ᄵ ᄶ ᄷ ᄸ ᄹ ᄺ ᄻ ᄼ ᄽ ᄾ ᄿ ᅀ ᅁ ᅂ ᅃ ᅄ ᅅ ᅆ ᅇ ᅈ ᅉ ᅊ ᅋ ᅌ ᅍ ᅎ ᅏ ᅐ ᅑ ᅒ ᅓ ᅔ ᅕ ᅖ ᅗ ᅘ ᅙ ᅚ ᅛ ᅜ ᅝ ᅞ ❰115F❱ ❰1160❱ ᅡ ᅢ ᅣ ᅤ ᅥ ᅦ ᅧ ᅨ ᅩ ᅪ ᅫ ᅬ ᅭ ᅮ ᅯ ᅰ ᅱ ᅲ ᅳ ᅴ ᅵ ᅶ ᅷ ᅸ ᅹ ᅺ ᅻ ᅼ ᅽ ᅾ ᅿ ᆀ ᆁ ᆂ ᆃ ᆄ ᆅ ᆆ ᆇ ᆈ ᆉ ᆊ ᆋ ᆌ ᆍ ᆎ ᆏ ᆐ ᆑ ᆒ ᆓ ᆔ ᆕ ᆖ ᆗ ᆘ ᆙ ᆚ ᆛ ᆜ ᆝ ᆞ ᆟ ᆠ ᆡ ᆢ ᆣ ᆤ ᆥ ᆦ ᆧ ᆨ ᆩ ᆪ ᆫ ᆬ ᆭ ᆮ ᆯ ᆰ ᆱ ᆲ ᆳ ᆴ ᆵ ᆶ ᆷ ᆸ ᆹ ᆺ ᆻ ᆼ ᆽ ᆾ ᆿ ᇀ ᇁ ᇂ ᇃ ᇄ ᇅ ᇆ ᇇ ᇈ ᇉ ᇊ ᇋ ᇌ ᇍ ᇎ ᇏ ᇐ ᇑ ᇒ ᇓ ᇔ ᇕ ᇖ ᇗ ᇘ ᇙ ᇚ ᇛ ᇜ ᇝ ᇞ ᇟ ᇠ ᇡ ᇢ ᇣ ᇤ ᇥ ᇦ ᇧ ᇨ ᇩ ᇪ ᇫ ᇬ ᇭ ᇮ ᇯ ᇰ ᇱ ᇲ ᇳ ᇴ ᇵ ᇶ ᇷ ᇸ ᇹ ᇺ ᇻ ᇼ ᇽ ᇾ ᇿ"
+            },
+            {"[:block=CJK_Unified_Ideographs:]", "一➖鿿"},
             {"[\\u001E-!]", "❰1E❱ ❰1F❱ ❰SP❱ !"},
             {"[a\\u0020]", "❰SP❱ a"},
             {"[abcq]", "a b c q"},
@@ -105,14 +110,31 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
             // UnicodeSets
             {"[{\\u0020\u0FFF}]", "❰SP❱❰FFF❱"},
             {"[{a\\u0020b\\u0FFFc}]", "a❰SP❱b❰FFF❱c"},
+            {"[ĂÅ z]", "Ă Å z"}, // Check plain ordering
+            {"LOCALE", "no"},
+            {"[ĂÅ z]", "Ă z Å"}, // Ensure that order is according to the locale
+            {"[ÅÅ]", "Å Å"}, // Ensure it doesn't merge two different characters
+            // with same NFC, even though a collator is used
+            {"LOCALE", null},
+            {"[ĂÅ z]", "Ă Å z"}, // Check plain ordering
         };
 
         SimpleUnicodeSetFormatter susf = new SimpleUnicodeSetFormatter();
 
+        Comparator<String> collator = susf.getComparator();
+        UnicodeSet toEscape = susf.getToEscape();
+        int maxRange = susf.getUseRangesAbove();
+
         int count = 0;
         for (String[] test : unicodeToDisplay) {
             if ("LOCALE".equals(test[0])) {
-                susf = SimpleUnicodeSetFormatter.fromIcuLocale(test[1]);
+                collator = SimpleUnicodeSetFormatter.getComparatorForLocale(test[1]);
+                susf = new SimpleUnicodeSetFormatter(collator, toEscape, maxRange);
+                continue;
+            }
+            if ("USE_RANGES_ABOVE".equals(test[0])) {
+                maxRange = test[1] == null ? -1 : Integer.parseInt(test[1]);
+                susf = new SimpleUnicodeSetFormatter(collator, toEscape, maxRange);
                 continue;
             }
             final UnicodeSet source = new UnicodeSet(test[0]);
@@ -379,6 +401,23 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
         } else {
             warnln("Use -v to see list of escapes");
         }
+    }
+
+    public void TestEdgeCases() {
+        // just make sure none of these throw exceptions
+        assertEquals("null", '\uFFFd', CodePointEscaper.escapedToCodePoint(null));
+        assertEquals("empty", '\uFFFd', CodePointEscaper.escapedToCodePoint(""));
+        assertEquals("null", '\uFFFd', CodePointEscaper.rawEscapedToCodePoint(null));
+        assertEquals("empty", '\uFFFd', CodePointEscaper.rawEscapedToCodePoint(""));
+        assertEquals("null", null, CodePointEscaper.toEscaped(null));
+        assertEquals("empty", "", CodePointEscaper.toEscaped(""));
+        assertEquals("null", null, CodePointEscaper.toEscaped(null, UnicodeSet.EMPTY));
+        assertEquals("empty", "", CodePointEscaper.toEscaped("", UnicodeSet.EMPTY));
+        assertEquals("null", null, CodePointEscaper.toUnescaped(null));
+        assertEquals("empty", "", CodePointEscaper.toUnescaped(""));
+
+        assertEquals(
+                "null", "a\u0001bc", CodePointEscaper.toEscaped("a\u0001bc", UnicodeSet.EMPTY));
     }
 
     public void TestStringEscaper() {


### PR DESCRIPTION
CLDR-17703

- Handle nulls in the CodePointEscaper
- Add tests in UnicodeSetPrettyPrinterTest for edge cases.
    - Also fix the simple test to add more cases (setting locale, and setting the useRangesAbove.
- Clean up SimpleUnicodeSetFormatter.java as well. 
    - There were some test failures that led to cleaning up the handling of the default parameters.
    - Renamed some variables/constants for clarity

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
