### PR TITLE
CLDR-16835 Non-TC locales remain open longer

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrLoad.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.mjs
@@ -1049,10 +1049,30 @@ function getLocaleDir(locale) {
   return localeDir;
 }
 
-function setTheLocaleMap(lm) {
-  locmap = lm;
+/** @returns true if locmap has been loaded from data */
+function localeMapReady() {
+  return !!locmap.locmap;
 }
 
+/** event ID for localeMap changes */
+const LOCALEMAP_EVENT = "localeMapReady";
+
+/**
+ * Calls the callback when the localeMap is ready (with real data).
+ * Calls right away if the localeMap was already loaded.
+ */
+function onLocaleMapReady(callback) {
+  if (localeMapReady()) {
+    callback();
+  } else {
+    cldrStatus.on(LOCALEMAP_EVENT, callback);
+  }
+}
+
+function setTheLocaleMap(lm) {
+  locmap = lm;
+  cldrStatus.dispatchEvent(new Event(LOCALEMAP_EVENT));
+}
 /**
  * Convenience for calling getTheLocaleMap().getLocaleName(loc)
  * @param {String} loc
@@ -1060,6 +1080,10 @@ function setTheLocaleMap(lm) {
  */
 function getLocaleName(loc) {
   return locmap.getLocaleName(loc);
+}
+
+function getLocaleInfo(loc) {
+  return locmap.getLocaleInfo(loc);
 }
 
 /**
@@ -1145,6 +1169,7 @@ export {
   flipToOtherDiv,
   getHash,
   getLocaleDir,
+  getLocaleInfo,
   getLocaleName,
   getTheLocaleMap,
   handleCoverageChanged,
@@ -1152,6 +1177,7 @@ export {
   linkToLocale,
   localeSpecialNote,
   myLoad,
+  onLocaleMapReady,
   parseHashAndUpdate,
   reloadV,
   replaceHash,

--- a/tools/cldr-apps/js/src/esm/cldrStatus.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.mjs
@@ -49,6 +49,10 @@ function on(type, callback) {
   getStatusTarget().addEventListener(type, callback);
 }
 
+/**
+ * Fire off an event manually
+ * @param type the type to dispatch
+ */
 function dispatchEvent(type) {
   return getStatusTarget().dispatchEvent(type);
 }
@@ -477,6 +481,7 @@ function setAutoImportBusy(busy) {
 }
 
 export {
+  dispatchEvent,
   getAutoImportBusy,
   getContextPath,
   getCurrentId,

--- a/tools/cldr-apps/js/src/esm/cldrStatus.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.mjs
@@ -75,6 +75,9 @@ function updateAll(status) {
   if (status.phase) {
     setPhase(status.phase);
   }
+  if (status.ddlPhase) {
+    setDdlPhase(status.ddlPhase);
+  }
   if (status.specialHeader) {
     setSpecialHeader(status.specialHeader);
   }
@@ -296,8 +299,16 @@ function getPhase() {
   return phase;
 }
 
+let ddlPhase = "";
 function setPhase(p) {
   phase = p;
+}
+function getDdlPhase() {
+  return ddlPhase;
+}
+
+function setDdlPhase(p) {
+  ddlPhase = p;
 }
 
 /**
@@ -479,6 +490,7 @@ export {
   getNewVersion,
   getOrganizationName,
   getPermissions,
+  getDdlPhase,
   getPhase,
   getRunningStamp,
   getSessionId,
@@ -507,6 +519,7 @@ export {
   setOrganizationName,
   setPermissions,
   setPhase,
+  setDdlPhase,
   setSessionId,
   setSessionMessage,
   setSpecialHeader,

--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -2,7 +2,11 @@
   <header id="st-header">
     <a-spin v-if="!loaded" :delay="250" />
     <ul>
-      <li>{{ stVersion }} {{ stPhase }}</li>
+      <li>{{ stVersion }} {{ stPhase }}
+        <span class="ddlException" v-if="ddlException" title="Note: As a non-TC DDL locale, this phase has been extended.">
+          (extended)
+        </span>
+      </li>
       <li>
         <a href="#menu///"><span class="main-menu-icon">☰</span></a>
       </li>
@@ -102,6 +106,7 @@ export default {
       stPhase: null,
       stVersion: null,
       tcLocale: true,
+      ddlException: false,
       unreadAnnouncementCount: 0,
       userName: null,
       voteCountMenu: null,
@@ -169,8 +174,14 @@ export default {
       this.tcLocale = cldrLoad?.getLocaleInfo(loc)?.tc;
       if (!loc || this.tcLocale) {
         this.stPhase = cldrStatus.getPhase();
+        this.ddlException = false;
       } else {
         this.stPhase = cldrStatus.getDdlPhase();
+        if (cldrStatus.getDdlPhase() != cldrStatus.getPhase()) {
+          this.ddlException = true;
+        } else {
+          this.ddlException = false;
+        }
       }
       cldrAnnounce.getUnreadCount(this.setUnreadCount);
     },
@@ -273,4 +284,9 @@ label {
 #coverageLevel {
   width: 16ch;
 }
+
+.ddlException {
+  background-color: yellow;
+}
+
 </style>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRConfigImpl.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRConfigImpl.java
@@ -461,6 +461,11 @@ public class CLDRConfigImpl extends CLDRConfig implements JSONString {
     }
 
     @Override
+    public CheckCLDR.Phase getDDLPhase() {
+        return SurveyMain.getDDLPhase().getCPhase();
+    }
+
+    @Override
     public CLDRURLS internalGetUrls() {
         if (contextUrl == null) contextUrl = CLDRURLS.DEFAULT_PATH;
         return new StaticCLDRURLS(this.getProperty(CLDRURLS.CLDR_SURVEY_PATH, contextUrl));

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -988,8 +988,7 @@ public class DataPage {
          */
         public StatusAction getStatusAction(InputMethod inputMethod) {
             // null because this is for display.
-            return SurveyMain.phase()
-                    .getCPhase()
+            return SurveyMain.getCPhase(locale)
                     .getShowRowAction(this, inputMethod, getPathHeader(), userForVotelist);
         }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -1119,7 +1119,7 @@ public class SurveyAjax extends HttpServlet {
             locale.put("highestParent", loc.getHighestNonrootParent());
             locale.put("dcParent", dcParent);
             locale.put("dcChild", dcChild);
-            locale.put("tc", SubmissionLocales.TC_ORG_LOCALES.contains(loc.getBaseName()));
+            locale.put("tc", SubmissionLocales.isTcLocale(loc));
             locale.put(
                     "type",
                     Factory.getSourceTreeType(disk.getSourceDirectoryForLocale(loc.getBaseName())));

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -1092,6 +1092,7 @@ public class SurveyAjax extends HttpServlet {
         // locales will have info about each locale, including name
         JSONObject locales = new JSONObject();
         SupplementalDataInfo sdi = sm.getSupplementalDataInfo();
+        final StandardCodes sc = StandardCodes.make();
 
         Factory disk = sm.getDiskFactory();
 
@@ -1118,6 +1119,7 @@ public class SurveyAjax extends HttpServlet {
             locale.put("highestParent", loc.getHighestNonrootParent());
             locale.put("dcParent", dcParent);
             locale.put("dcChild", dcChild);
+            locale.put("tc", SubmissionLocales.TC_ORG_LOCALES.contains(loc.getBaseName()));
             locale.put(
                     "type",
                     Factory.getSourceTreeType(disk.getSourceDirectoryForLocale(loc.getBaseName())));

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -2658,7 +2658,7 @@ public class SurveyAjax extends HttpServlet {
         final List<CheckCLDR.CheckStatus> checkResult = new ArrayList<>();
         TestCache.TestResultBundle cc = stf.getTestResult(loc, DataPage.getOptions(cs, loc));
         UserRegistry.User u = theirU;
-        CheckCLDR.Phase cPhase = CLDRConfig.getInstance().getPhase();
+        CheckCLDR.Phase cPhase = SurveyMain.getCPhase(loc);
         Set<String> allValidPaths = stf.getPathsForFile(loc);
         CLDRProgressTask progress = sm.openProgress("Bulk:" + loc, all.size());
         CLDRFile cldrUnresolved = cf.getUnresolved();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -209,6 +209,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
 
     // ===== Configuration state
     private static Phase currentPhase = Phase.VETTING;
+    private static Phase currentDdlPhase = Phase.VETTING;
     /** set by CLDR_PHASE property. * */
     private static String oldVersion = "OLDVERSION";
 
@@ -2823,6 +2824,20 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                                     + phaseString);
                 }
                 currentPhase = newPhase;
+                String ddlPhaseString = survprops.getProperty("CLDR_DDL_PHASE", null);
+                Phase ddlPhase = null;
+                try {
+                    if (ddlPhaseString != null) {
+                        ddlPhase = (Phase.valueOf(ddlPhaseString));
+                    }
+                } catch (IllegalArgumentException iae) {
+                    logger.warning("Error trying to parse CLDR_DDL_PHASE: " + iae);
+                }
+                if (ddlPhase == null) {
+                    ddlPhase = newPhase;
+                    logger.warning("CLDR_DDL_PHASE matches main phase " + ddlPhase);
+                }
+                currentDdlPhase = ddlPhase;
             }
             logger.info("Phase: " + phase() + ", cPhase: " + phase().getCPhase());
             progress.update("Setup props..");
@@ -3570,6 +3585,10 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         return currentPhase;
     }
 
+    public static Phase getDDLPhase() {
+        return currentDdlPhase;
+    }
+
     public static String getOldVersion() {
         return oldVersion;
     }
@@ -3642,6 +3661,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
         private final int pages = SurveyMain.pages;
         private Object permissions = null;
         private final Phase phase = phase();
+        private final Phase ddlPhase = getDDLPhase();
         private String sessionId = null;
         private final String specialHeader = getSpecialHeaderText();
         private final long surveyRunningStamp = SurveyMain.surveyRunningStamp.current();
@@ -3675,6 +3695,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                     .put("pages", pages)
                     .put("permissions", permissions)
                     .put("phase", phase)
+                    .put("ddlPhase", ddlPhase)
                     .put("sessionId", sessionId)
                     .put("sessionMessage", sessionMessage)
                     .put("specialHeader", specialHeader)

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -1978,7 +1978,7 @@ public class UserRegistry {
         if (userIsAdmin(u) || userIsTC(u)) return null;
 
         // Otherwise, if closed, deny
-        if (SurveyMain.isPhaseVettingClosed()) return ModifyDenial.DENY_PHASE_CLOSED;
+        if (SurveyMain.isPhaseVettingClosed(locale)) return ModifyDenial.DENY_PHASE_CLOSED;
         if (SurveyMain.isPhaseReadonly()) return ModifyDenial.DENY_PHASE_READONLY;
 
         return null;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Organization;
@@ -247,5 +248,18 @@ public final class SubmissionLocales {
 
     public static Set<ReportId> getReportsAvailableInLimited() {
         return LIMITED_SUBMISSION_REPORTS;
+    }
+
+    public static boolean isTcLocale(CLDRLocale loc) {
+        if (loc == CLDRLocale.ROOT
+                || SubmissionLocales.TC_ORG_LOCALES.contains(loc.getBaseName())) {
+            // root or explicitly listed locale is a TC locale
+            return true;
+        } else if (loc.isParentRoot()) {
+            // any sublocale of root not listed is not a tc locale
+            return false;
+        } else {
+            return isTcLocale(loc.getParent());
+        }
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
@@ -400,6 +400,14 @@ public class CLDRConfig extends Properties {
         return phase;
     }
 
+    /**
+     * @returns the phase for DDL (non-TC) locales. Defaults to same as main phase.
+     */
+    public Phase getDDLPhase() {
+        // by default, same as main phase.
+        return getPhase();
+    }
+
     @Override
     public String getProperty(String key, String d) {
         String result = getProperty(key);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestSubmissionLocales.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.test;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -10,6 +11,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.unicode.cldr.util.CLDRLocale;
 
 public class TestSubmissionLocales {
     @ParameterizedTest
@@ -68,5 +71,23 @@ public class TestSubmissionLocales {
 
     public static final boolean bool(final String s) {
         return Boolean.parseBoolean(s);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // loc, isTc
+        "root, true",
+        "de, true",
+        "de_IT, true",
+        "csw, false",
+        "cho_US, false",
+        "zh, true",
+        "zh_Hant_MO, true",
+    })
+    public void testIsTcLocale(final String loc, final String tf) {
+        final CLDRLocale l = CLDRLocale.getInstance(loc);
+        assertNotNull(l, loc);
+        final Boolean isCldr = Boolean.parseBoolean(tf);
+        assertEquals(isCldr, SubmissionLocales.isTcLocale(l));
     }
 }


### PR DESCRIPTION
CLDR-16835

- [ ] This PR completes the ticket.

- New API `SubmissionLocales.isTcLocale()` and tests:
    - `root` is a TC locale
    - Anything listed in `TC_ORG_LOCALES` is a TC locale, such as, say, `fr`.
    - Any sublocale of a TC locale is a TC locale, such as, say, `fr_CA` or `fr_CM`
    - Anything else is NOT a TC locale, such as `csw`.
- a new config parameter: `CLDR_DDL_PHASE`.  This may NOT be set in main phase READONLY.
    - This new DDL phase only affects locales that are not TC locales.
- Internal API to get this phase, such as SurveyMain.phase() and SurveyMain.getCPhase() taking a CLDRLocale.
- UI where the DDL phase is shown with a notice, ONLY if it is different from the main phase. No UI change for other users or locales.

ALLOW_MANY_COMMITS=true
