### PR TITLE
CLDR-17699 DataDog in Ansible

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -90,6 +90,11 @@ jobs:
           -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: DataDog sourcemap upload
+        run: npx --package=@datadog/datadog-ci datadog-ci sourcemaps upload tools/cldr-apps/src/main/webapp/dist/ --minified-path-prefix=/cldr-apps/dist/ --release-version=r${{ github.event.inputs.git-ref }} --service=surveytool
+        env:
+          DATADOG_SITE: ${{ secrets.DATADOG_SITE }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       - name: Checkout CLDR archive
         run: >
           mkdir -v ../cldr-archive && java -jar tools/cldr-code/target/cldr-code.jar checkout-archive

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -91,6 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: DataDog sourcemap upload
+        # only on push to main!
+        if: github.repository == 'unicode-org/cldr' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.inputs.git-ref == ''
         run: npx --package=@datadog/datadog-ci datadog-ci sourcemaps upload tools/cldr-apps/src/main/webapp/dist/ --minified-path-prefix=/cldr-apps/dist/ --release-version=r${{ github.event.inputs.git-ref }} --service=surveytool
         env:
           DATADOG_SITE: ${{ secrets.DATADOG_SITE }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -52,6 +52,11 @@ jobs:
           -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: DataDog sourcemap upload
+        run: npx --package=@datadog/datadog-ci datadog-ci sourcemaps upload tools/cldr-apps/src/main/webapp/dist/ --minified-path-prefix=/cldr-apps/dist/ --release-version=r${{ github.event.inputs.git-ref }} --service=surveytool
+        env:
+          DATADOG_SITE: ${{ secrets.DATADOG_SITE }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       - name: Build liberty server
         run: >
           mvn -s .github/workflows/mvn-settings.xml -B  -pl cldr-apps liberty:create liberty:deploy liberty:package -Dinclude=usr --file tools/pom.xml

--- a/tools/scripts/ansible/hosts
+++ b/tools/scripts/ansible/hosts
@@ -3,13 +3,15 @@ cldr-smoke.unicode.org
 cldr-staging.unicode.org
 
 [staging:vars]
-ddenv=staging
+# dd_env is the DataDog environment, staging vs prod
+dd_env=staging
 
 [prod]
 st.unicode.org
 
 [prod:vars]
-ddenv=prod
+# dd_env is the DataDog environment, staging vs prod
+dd_env=prod
 
 # CLDR Commit Checker web hosting here
 [ccc]

--- a/tools/scripts/ansible/hosts
+++ b/tools/scripts/ansible/hosts
@@ -2,8 +2,14 @@
 cldr-smoke.unicode.org
 cldr-staging.unicode.org
 
+[staging:vars]
+ddenv=staging
+
 [prod]
 st.unicode.org
+
+[prod:vars]
+ddenv=prod
 
 # CLDR Commit Checker web hosting here
 [ccc]

--- a/tools/scripts/ansible/monitoring-playbook.yml
+++ b/tools/scripts/ansible/monitoring-playbook.yml
@@ -18,6 +18,6 @@
         block: |
           # enable apm and set the env
               enabled: true
-              env: {{ ddenv }}
+              env: {{ dd_env }}
         marker: '# {mark} ANSIBLE MANAGED BLOCK'
         insertafter: '^apm_config:'

--- a/tools/scripts/ansible/monitoring-playbook.yml
+++ b/tools/scripts/ansible/monitoring-playbook.yml
@@ -1,12 +1,12 @@
-- hosts: cldr-staging.unicode.org
+- hosts:
+    - cldr-staging.unicode.org
+    - st.unicode.org
   become: yes
   vars_files:
     - vars/main.yml
     - local-vars/local.yml
-  tasks:
-    - name: Import the Datadog Agent role from the Datadog collection
-      import_role:
-        name: datadog.dd.agent
+  roles:
+    - { role: datadog.datadog, become: yes }
   vars:
     datadog_api_key: "{{ dd_key }}"
     datadog_site: "{{ dd_site }}"

--- a/tools/scripts/ansible/monitoring-playbook.yml
+++ b/tools/scripts/ansible/monitoring-playbook.yml
@@ -11,4 +11,13 @@
     datadog_api_key: "{{ dd_key }}"
     datadog_site: "{{ dd_site }}"
     datadog_apm_instrumentation_enabled: "host"  # docker not installed else 'all'
-
+  tasks:
+    - name: Update datadog.yaml for apm/env
+      blockinfile:
+        path: /etc/datadog-agent/datadog.yaml
+        block: |
+          # enable apm and set the env
+              enabled: true
+              env: {{ ddenv }}
+        marker: '# {mark} ANSIBLE MANAGED BLOCK'
+        insertafter: '^apm_config:'

--- a/tools/scripts/ansible/requirements.yml
+++ b/tools/scripts/ansible/requirements.yml
@@ -5,7 +5,7 @@
 - src: derjd.journald
   version: 0.0.1
 - src: DataDog.datadog
-  version: 4.20.1
+  version: 4.21.0
 # - src: https://github.com/Naillik13/ansible-role-mysql
 #   version:
 

--- a/tools/scripts/ansible/templates/bootstrap-properties.j2
+++ b/tools/scripts/ansible/templates/bootstrap-properties.j2
@@ -9,7 +9,7 @@ org.unicode.cldr.util.CLDRConfigImpl.cldrHome="{{ cldr_path }}"
 # datadog things
 dd.dynamic.instrumentation.enabled=true
 dd.logs.injection=true
-dd.env={{ ddenv }}
+dd.env={{ dd_env }}
 
 # for DD: use json!
 com.ibm.ws.logging.message.format=json

--- a/tools/scripts/ansible/templates/bootstrap-properties.j2
+++ b/tools/scripts/ansible/templates/bootstrap-properties.j2
@@ -5,3 +5,12 @@
 # the full path to the config dir.
 # It requires a code update in CLDRConfigImpl.
 org.unicode.cldr.util.CLDRConfigImpl.cldrHome="{{ cldr_path }}"
+
+# datadog things
+dd.dynamic.instrumentation.enabled=true
+dd.logs.injection=true
+dd.env={{ ddenv }}
+
+# for DD: use json!
+com.ibm.ws.logging.message.format=json
+com.ibm.ws.logging.message.source=message,trace,accessLog,ffdc,audit


### PR DESCRIPTION
CLDR-17699

- [ ] This PR completes the ticket.

- we were missing sourcemap uploads for production and for smoketest (though smoketest isn't used with datadog currently)
- add ansible rules to enable datadog

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
