### PR TITLE
CLDR-17719 update v46 charts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Chart.java
@@ -38,7 +38,7 @@ public abstract class Chart {
     public static final String CHART_VERSION_DIRECTORY =
             ToolConstants.getBaseDirectory(ToolConstants.CHART_VERSION);
 
-    public static final String GITHUB_ROOT = CLDRURLS.CLDR_REPO_ROOT + "/blob/main/";
+    public static final String GITHUB_ROOT = CLDRURLS.CLDR_REPO_MAIN;
     public static final String LDML_SPEC = "https://unicode.org/reports/tr35/";
 
     public static String dataScrapeMessage(String specPart, String testFile, String... dataFiles) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -367,7 +367,9 @@ public class GenerateTransformCharts {
                         + "These charts do not show the available script and language transliterations that are not to/from Latin. "
                         + "It also does not show other transforms that are available in CLDR, such as the casing transformations, "
                         + "full-width and half-width transformations, and specialized transformations such as IPA-XSampa. "
-                        + "For the latest snapshot of the data files, see <a href='https://github.com/unicode-org/cldr/tree/main/common/transforms'>Transform XML Data</a>. "
+                        + "For the latest snapshot of the data files, see <a href='"
+                        + CLDR_REPO_BASE
+                        + "tree/main/common/transforms'>Transform XML Data</a>. "
                         + "For more information, see below.</blockquote>");
         index.flush();
         index.println("<ul>");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -36,6 +36,7 @@ import org.unicode.cldr.test.TestTransformsSimple;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRTransforms;
 import org.unicode.cldr.util.CLDRTransforms.ParsedTransformID;
+import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.FileCopier;
 import org.unicode.cldr.util.Pair;
@@ -368,7 +369,7 @@ public class GenerateTransformCharts {
                         + "It also does not show other transforms that are available in CLDR, such as the casing transformations, "
                         + "full-width and half-width transformations, and specialized transformations such as IPA-XSampa. "
                         + "For the latest snapshot of the data files, see <a href='"
-                        + CLDR_REPO_BASE
+                        + CLDRURLS.CLDR_REPO_BASE
                         + "tree/main/common/transforms'>Transform XML Data</a>. "
                         + "For more information, see below.</blockquote>");
         index.flush();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -8,7 +8,6 @@ package org.unicode.cldr.tool;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
@@ -1374,10 +1373,8 @@ public class ShowLanguages {
 
         static final Set<Organization> TC_Vendors =
                 Sets.union(
-                        // this is a slightly odd construction, to add airbnb into the sorted items,
-                        // but then end with cldr
-                        ImmutableSortedSet.copyOf(
-                                Sets.union(Organization.getTCOrgs(), Set.of(Organization.airbnb))),
+                        Organization.getTCOrgs(),
+                        // This adds the CLDR org at the end of the list
                         Set.of(Organization.cldr));
 
         private void showCoverageGoals(PrintWriter pw) throws IOException {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1399,7 +1399,9 @@ public class ShowLanguages {
                                 .addColumn(
                                         "Code",
                                         "class='source'",
-                                        "<a href=\"http://www.unicode.org/cldr/data/common/main/{0}.xml\">{0}</a>",
+                                        "<a href=\""
+                                                + CLDRURLS.CLDR_REPO_ROOT
+                                                + "/blob/main/common/main/{0}.xml\">{0}</a>",
                                         "class='source'",
                                         false)
                                 .addColumn(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1378,144 +1378,181 @@ public class ShowLanguages {
                         Set.of(Organization.cldr));
 
         private void showCoverageGoals(PrintWriter pw) throws IOException {
-            PrintWriter pw2 =
-                    new PrintWriter(
-                            new FormattedFileWriter(
-                                    null, "Coverage Goals", null, SUPPLEMENTAL_INDEX_ANCHORS));
+            try (PrintWriter pw2 =
+                            new PrintWriter(
+                                    new FormattedFileWriter(
+                                            null,
+                                            "Coverage Goals",
+                                            null,
+                                            SUPPLEMENTAL_INDEX_ANCHORS));
+                    PrintWriter coverageGoalsTsv =
+                            FileUtilities.openUTF8Writer(
+                                    CLDRPaths.CHART_DIRECTORY + "tsv/", "coverage_goals.tsv"); ) {
 
-            TablePrinter tablePrinter =
-                    new TablePrinter()
-                            // tablePrinter.setSortPriorities(0,4)
-                            .addColumn("Language", "class='source'", null, "class='source'", false)
-                            .setSortPriority(0)
-                            .setBreakSpans(false)
+                TablePrinter tablePrinter =
+                        new TablePrinter()
+                                // tablePrinter.setSortPriorities(0,4)
+                                .addColumn(
+                                        "Language", "class='source'", null, "class='source'", false)
+                                .setSortPriority(0)
+                                .setBreakSpans(false)
+                                .addColumn(
+                                        "Code",
+                                        "class='source'",
+                                        "<a href=\"http://www.unicode.org/cldr/data/common/main/{0}.xml\">{0}</a>",
+                                        "class='source'",
+                                        false)
+                                .addColumn(
+                                        "D. Votes",
+                                        "class='target'",
+                                        null,
+                                        "class='target'",
+                                        false);
+
+                Map<Organization, Map<String, Level>> vendordata = sc.getLocaleTypes();
+                Set<String> locales = new TreeSet<>();
+                Set<Organization> vendors = new LinkedHashSet<>();
+                Set<Organization> smallVendors = new LinkedHashSet<>();
+
+                for (Organization organization : TC_Vendors) {
+                    // if (vendor.equals(Organization.java)) continue;
+                    Map<String, Level> data = vendordata.get(organization);
+                    vendors.add(organization);
+                    tablePrinter
                             .addColumn(
-                                    "Code",
-                                    "class='source'",
-                                    "<a href=\"http://www.unicode.org/cldr/data/common/main/{0}.xml\">{0}</a>",
-                                    "class='source'",
+                                    organization.getDisplayName(),
+                                    "class='target'",
+                                    null,
+                                    "class='target'",
                                     false)
-                            .addColumn("D. Votes", "class='target'", null, "class='target'", false);
-
-            Map<Organization, Map<String, Level>> vendordata = sc.getLocaleTypes();
-            Set<String> locales = new TreeSet<>();
-            Set<Organization> vendors = new LinkedHashSet<>();
-            Set<Organization> smallVendors = new LinkedHashSet<>();
-
-            for (Organization organization : TC_Vendors) {
-                // if (vendor.equals(Organization.java)) continue;
-                Map<String, Level> data = vendordata.get(organization);
-                vendors.add(organization);
-                tablePrinter
-                        .addColumn(
-                                organization.getDisplayName(),
-                                "class='target'",
-                                null,
-                                "class='target'",
-                                false)
-                        .setSpanRows(false);
-                locales.addAll(data.keySet());
-            }
-
-            for (Entry<Organization, Map<String, Level>> vendorData : vendordata.entrySet()) {
-                Organization vendor = vendorData.getKey();
-                if (!TC_Vendors.contains(vendor)) {
-                    smallVendors.add(vendor);
-                    continue;
+                            .setSpanRows(false);
+                    locales.addAll(data.keySet());
+                    showTabbedOrgLevels(coverageGoalsTsv, organization, data);
                 }
-            }
 
-            Collection<Comparable[]> data = new ArrayList<>();
-            List<String> list = new ArrayList<>();
-            LanguageTagParser ltp = new LanguageTagParser();
-            // String alias2 = getAlias("sh_YU");
-
-            pw2.append("<h2>TC Orgs</h2>");
-
-            for (String locale : locales) {
-                list.clear();
-                String localeCode = locale.equals("*") ? "und" : locale;
-                String alias = getAlias(localeCode);
-                if (!alias.equals(localeCode)) {
-                    throw new IllegalArgumentException(
-                            "Should use canonical form: " + locale + " => " + alias);
-                }
-                // String baseLang = ltp.set(localeCode).getLanguage();
-                String baseLangName = getLanguageName(localeCode);
-                list.add("und".equals(localeCode) ? "other" : baseLangName);
-                list.add(locale);
-                int defaultVotes =
-                        supplementalDataInfo.getRequiredVotes(CLDRLocale.getInstance(locale), null);
-                list.add(String.valueOf(defaultVotes));
-                for (Organization vendor : vendors) {
-                    String status = getVendorStatus(locale, vendor, vendordata);
-                    //                    if (!baseLang.equals(locale) && !status.startsWith("<")) {
-                    //                        String langStatus = getVendorStatus(baseLang, vendor,
-                    // vendordata);
-                    //                        if (!langStatus.equals(status)) {
-                    //                            status += "*";
-                    //                        }
-                    //                    }
-                    list.add(status);
-                }
-                data.add(list.toArray(new String[list.size()]));
-            }
-            Comparable[][] flattened = data.toArray(new Comparable[data.size()][]);
-            String value = tablePrinter.addRows(flattened).toTable();
-            pw2.println(value);
-
-            pw2.append("<h2>Others</h2><div align='left'><ul>");
-
-            for (Organization vendor2 : smallVendors) {
-                pw2.append("<li><b>");
-                pw2.append(TransliteratorUtilities.toHTML.transform(vendor2.getDisplayName()))
-                        .append(": </b>");
-                boolean first1 = true;
-                for (Level level : Level.values()) {
-                    boolean first2 = true;
-                    Level other = null;
-                    for (Entry<String, Level> data2 : vendordata.get(vendor2).entrySet()) {
-                        String key = data2.getKey();
-                        Level level2 = data2.getValue();
-                        if (level != level2) {
-                            continue;
-                        }
-                        if (key.equals("*")) {
-                            other = level2;
-                            continue;
-                        }
-                        if (first2) {
-                            if (first1) {
-                                first1 = false;
-                            } else {
-                                pw2.append("; ");
-                            }
-                            pw2.append(level2.toString()).append(": ");
-                            first2 = false;
-                        } else {
-                            pw2.append(", ");
-                        }
-                        pw2.append(TransliteratorUtilities.toHTML.transform(key));
-                    }
-                    if (other != null) {
-                        if (first2) {
-                            if (first1) {
-                                first1 = false;
-                            } else {
-                                pw2.append("; ");
-                            }
-                            pw2.append(level.toString()).append(": ");
-                            first2 = false;
-                        } else {
-                            pw2.append(", ");
-                        }
-                        pw2.append("<i>other</i>");
+                for (Entry<Organization, Map<String, Level>> vendorData : vendordata.entrySet()) {
+                    Organization organization = vendorData.getKey();
+                    if (!TC_Vendors.contains(organization)) {
+                        smallVendors.add(organization);
+                        Map<String, Level> data = vendordata.get(organization);
+                        showTabbedOrgLevels(coverageGoalsTsv, organization, data);
+                        continue;
                     }
                 }
-                pw2.append("</li>");
+
+                Collection<Comparable[]> data = new ArrayList<>();
+                List<String> list = new ArrayList<>();
+                LanguageTagParser ltp = new LanguageTagParser();
+                // String alias2 = getAlias("sh_YU");
+
+                pw2.append("<h2>TC Orgs</h2>");
+
+                for (String locale : locales) {
+                    list.clear();
+                    String localeCode = locale.equals("*") ? "und" : locale;
+                    String alias = getAlias(localeCode);
+                    if (!alias.equals(localeCode)) {
+                        throw new IllegalArgumentException(
+                                "Should use canonical form: " + locale + " => " + alias);
+                    }
+                    // String baseLang = ltp.set(localeCode).getLanguage();
+                    String baseLangName = getLanguageName(localeCode);
+                    list.add("und".equals(localeCode) ? "other" : baseLangName);
+                    list.add(locale);
+                    int defaultVotes =
+                            supplementalDataInfo.getRequiredVotes(
+                                    CLDRLocale.getInstance(locale), null);
+                    list.add(String.valueOf(defaultVotes));
+                    for (Organization vendor : vendors) {
+                        String status = getVendorStatus(locale, vendor, vendordata);
+                        //                    if (!baseLang.equals(locale) &&
+                        // !status.startsWith("<")) {
+                        //                        String langStatus = getVendorStatus(baseLang,
+                        // vendor,
+                        // vendordata);
+                        //                        if (!langStatus.equals(status)) {
+                        //                            status += "*";
+                        //                        }
+                        //                    }
+                        list.add(status);
+                    }
+                    data.add(list.toArray(new String[list.size()]));
+                }
+                Comparable[][] flattened = data.toArray(new Comparable[data.size()][]);
+                String value = tablePrinter.addRows(flattened).toTable();
+                pw2.println(value);
+
+                pw2.append("<h2>Others</h2><div align='left'><ul>");
+
+                for (Organization vendor2 : smallVendors) {
+                    pw2.append("<li><b>");
+                    pw2.append(TransliteratorUtilities.toHTML.transform(vendor2.getDisplayName()))
+                            .append(": </b>");
+                    boolean first1 = true;
+                    for (Level level : Level.values()) {
+                        boolean first2 = true;
+                        Level other = null;
+                        for (Entry<String, Level> data2 : vendordata.get(vendor2).entrySet()) {
+                            String key = data2.getKey();
+                            Level level2 = data2.getValue();
+                            if (level != level2) {
+                                continue;
+                            }
+                            if (key.equals("*")) {
+                                other = level2;
+                                continue;
+                            }
+                            if (first2) {
+                                if (first1) {
+                                    first1 = false;
+                                } else {
+                                    pw2.append("; ");
+                                }
+                                pw2.append(level2.toString()).append(": ");
+                                first2 = false;
+                            } else {
+                                pw2.append(", ");
+                            }
+                            pw2.append(TransliteratorUtilities.toHTML.transform(key));
+                        }
+                        if (other != null) {
+                            if (first2) {
+                                if (first1) {
+                                    first1 = false;
+                                } else {
+                                    pw2.append("; ");
+                                }
+                                pw2.append(level.toString()).append(": ");
+                                first2 = false;
+                            } else {
+                                pw2.append(", ");
+                            }
+                            pw2.append("<i>other</i>");
+                        }
+                    }
+                    pw2.append("</li>");
+                }
+                pw2.append("</ul></div>");
             }
-            pw2.append("</ul></div>");
-            pw2.close();
+        }
+
+        public void showTabbedOrgLevels(
+                PrintWriter coverageGoalsTsv, Organization organization, Map<String, Level> data) {
+            coverageGoalsTsv.println(
+                    String.format(
+                            "\n#%s\t;\t%s\t;\t%s\t;\t%s\n",
+                            "Org", "Locale", "Level", "Locale Name"));
+            for (Entry<String, Level> entry : data.entrySet()) {
+                String locale = entry.getKey();
+                Level level = entry.getValue();
+                final String name =
+                        locale.equals("*")
+                                ? "ALL"
+                                : english.getName(locale, true, CLDRFile.SHORT_ALTS);
+                coverageGoalsTsv.println(
+                        String.format(
+                                "%s\t;\t%s\t;\t%s\t;\t%s", organization, locale, level, name));
+            }
         }
 
         LanguageTagParser lpt2 = new LanguageTagParser();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -8,9 +8,10 @@ package org.unicode.cldr.tool;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row.R2;
@@ -1362,7 +1363,7 @@ public class ShowLanguages {
         }
 
         private String getLanguageName(String languageCode) {
-            String result = english.getName(languageCode);
+            String result = english.getName(languageCode, true, CLDRFile.SHORT_ALTS);
             if (!result.equals(languageCode)) return result;
             Set<String> names = Iso639Data.getNames(languageCode);
             if (names != null && names.size() != 0) {
@@ -1372,37 +1373,18 @@ public class ShowLanguages {
         }
 
         static final Set<Organization> TC_Vendors =
-                ImmutableSet.of(
-                        Organization.apple,
-                        Organization.google,
-                        Organization.microsoft,
-                        Organization.cldr);
+                Sets.union(
+                        // this is a slightly odd construction, to add airbnb into the sorted items,
+                        // but then end with cldr
+                        ImmutableSortedSet.copyOf(
+                                Sets.union(Organization.getTCOrgs(), Set.of(Organization.airbnb))),
+                        Set.of(Organization.cldr));
 
         private void showCoverageGoals(PrintWriter pw) throws IOException {
             PrintWriter pw2 =
                     new PrintWriter(
                             new FormattedFileWriter(
-                                    null,
-                                    "Coverage Goals",
-                                    null
-                                    // "<p>" +
-                                    // "The following show default coverage goals for larger
-                                    // organizations. " +
-                                    // "<i>[n/a]</i> shows where there is no specific value for a
-                                    // given organization, " +
-                                    // "while <i>(...)</i> indicates that the goal is inherited from
-                                    // the parent. " +
-                                    // "A * is added if the goal differs from the parent locale's
-                                    // goal. " +
-                                    // "For information on what these goals mean (comprehensive,
-                                    // modern, moderate,...), see the LDML specification "
-                                    // +
-                                    // "<a
-                                    // href='http://www.unicode.org/reports/tr35/#Coverage_Levels'>Appendix M: Coverage Levels</a>. " +
-                                    // +
-                                    // "</p>"
-                                    ,
-                                    null));
+                                    null, "Coverage Goals", null, SUPPLEMENTAL_INDEX_ANCHORS));
 
             TablePrinter tablePrinter =
                     new TablePrinter()
@@ -1461,8 +1443,8 @@ public class ShowLanguages {
                     throw new IllegalArgumentException(
                             "Should use canonical form: " + locale + " => " + alias);
                 }
-                String baseLang = ltp.set(localeCode).getLanguage();
-                String baseLangName = getLanguageName(baseLang);
+                // String baseLang = ltp.set(localeCode).getLanguage();
+                String baseLangName = getLanguageName(localeCode);
                 list.add("und".equals(localeCode) ? "other" : baseLangName);
                 list.add(locale);
                 int defaultVotes =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -887,7 +887,7 @@ public class ShowLocaleCoverage {
                     tablePrinter
                             .addRow()
                             .addCell(language)
-                            .addCell(ENGLISH.getName(language))
+                            .addCell(ENGLISH.getName(language, true, CLDRFile.SHORT_ALTS))
                             .addCell(file.getName(language))
                             .addCell(script)
                             .addCell(defRegion)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CoreCoverageInfo;
 import org.unicode.cldr.util.CoreCoverageInfo.CoreItems;
@@ -67,7 +68,7 @@ import org.unicode.cldr.util.VettingViewer.MissingStatus;
 public class ShowLocaleCoverage {
 
     private static final String TSV_BASE =
-            CLDR_STAGING_REPO_MAIN
+            CLDRURLS.CLDR_STAGING_REPO_MAIN
                     + "docs/charts/"
                     + ToolConstants.CHART_VI.getVersionString(1, 2)
                     + "/tsv/";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -67,7 +67,8 @@ import org.unicode.cldr.util.VettingViewer.MissingStatus;
 public class ShowLocaleCoverage {
 
     private static final String TSV_BASE =
-            "https://github.com/unicode-org/cldr-staging/blob/main/docs/charts/"
+            CLDR_STAGING_REPO_MAIN
+                    + "docs/charts/"
                     + ToolConstants.CHART_VI.getVersionString(1, 2)
                     + "/tsv/";
     public static final Splitter LF_SPLITTER = Splitter.on('\n');

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -10,9 +10,13 @@ public abstract class CLDRURLS {
     public static final String CLDR_SCHEMA_BASE = "https://schemas.unicode.org/cldr";
     public static final String CLDR_CURVER_BASE = CLDR_SCHEMA_BASE + "/" + CLDRFile.GEN_VERSION;
     /** Base URL for the CLDR repository */
-    public static final String CLDR_REPO_BASE = "https://github.com/unicode-org/cldr";
+    public static final String CLDR_REPO_BASE = "https://github.com/unicode-org/cldr/";
 
-    public static final String DEFAULT_COMMIT_BASE = CLDR_REPO_BASE + "/commit/";
+    public static final String CLDR_REPO_MAIN = CLDR_REPO_BASE + "blob/main/";
+    public static final String CLDR_STAGING_REPO_MAIN =
+            "https://github.com/unicode-org/cldr-staging/blob/main/";
+
+    public static final String DEFAULT_COMMIT_BASE = CLDR_REPO_BASE + "commit/";
     /** Hostname for the Survey Tool */
     public static final String DEFAULT_HOST = "st.unicode.org";
 


### PR DESCRIPTION
CLDR-17719

I found that the coverage_goals.html chart was omitting Meta. I put in a fix so that it would be driven by the Organization.getTCOrgs().

I also generate a .tsv that reformats the Locales.txt data. The reformatted data sorts TC locales first, then others. It does not overwrite Locales.txt, but rather creates the .tsv with the staging charts.

The format looks like:

```
#Organization	;	Locale	;	Level	;	Locale Name

google	;	*	;	moderate	;	ALL
google	;	af	;	modern	;	Afrikaans
google	;	ak	;	moderate	;	Akan
google	;	am	;	modern	;	Amharic
google	;	ar	;	modern	;	Arabic
google	;	as	;	modern	;	Assamese
google	;	az	;	modern	;	Azeri
google	;	be	;	modern	;	Belarusian
google	;	bg	;	modern	;	Bulgarian
```

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
