### PR TITLE
CLDR-17726 make TestTransform.TestLocales less obscure

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.tool.LikelySubtags;
 import org.unicode.cldr.util.CLDRConfig;
@@ -860,6 +861,8 @@ public class TestTransforms extends TestFmwkPlus {
             CLDRTransforms.getInstance().registerModified();
         }
 
+        Set<Pair<String, String>> badLocaleScript = new TreeSet<>();
+
         for (String locale : modernCldr) {
             if (special.contains(locale)) {
                 continue;
@@ -900,6 +903,7 @@ public class TestTransforms extends TestFmwkPlus {
                                 + " code points:\n"
                                 + badPlusSample);
                 allMissing.addAll(badPlusSample);
+                badLocaleScript.add(Pair.of(locale, script));
             }
         }
         if (!allMissing.isEmpty()) {
@@ -924,6 +928,11 @@ public class TestTransforms extends TestFmwkPlus {
                             + allMissing.dataSet.keySet());
             for (String script : allMissing.scriptMissing.values()) {
                 UnicodeSet missingFoScript = allMissing.scriptMissing.getKeys(script);
+                String localeForScript =
+                        badLocaleScript.stream()
+                                .filter(p -> p.getSecond().equals((script)))
+                                .map(p -> p.getFirst())
+                                .collect(Collectors.joining(","));
                 errln(
                         "Transliterator for\t"
                                 + script
@@ -932,7 +941,9 @@ public class TestTransforms extends TestFmwkPlus {
                                 + ":\t"
                                 + missingFoScript.toPattern(false)
                                 + "="
-                                + missingFoScript);
+                                + missingFoScript
+                                + " - needed for locales: "
+                                + localeForScript);
             }
         }
     }


### PR DESCRIPTION
- this test is sensitive to the current CLDR locales at modern.
- change the test so that it reports *which* locales are causing the need for chars in the transforms.

CLDR-17726

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
