### PR TITLE
CLDR-8081 Add names for traditional Myanmar calendar

### DIFF
--- a/common/bcp47/calendar.xml
+++ b/common/bcp47/calendar.xml
@@ -28,6 +28,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="japanese" description="Japanese Imperial calendar"/>
             <type name="persian" description="Persian calendar"/>
             <type name="roc" description="Republic of China calendar"/>
+            <type name="myanmar" description="Traditional Myanmar calendar"/>
 
             <type name="islamicc" description="Civil (algorithmic) Arabic calendar" deprecated="true" preferred="islamic-civil"  alias="islamic-civil"/>
         </key>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -1968,6 +1968,116 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>
+			<calendar type="myanmar">
+				<months>
+					<monthContext type="format">
+						<monthWidth type="wide">
+							<month type="1">ဦးတန်ခူး</month>
+							<month type="2">ကဆုန်</month>
+							<month type="3">နယုန်</month>
+							<month type="4">ဝါဆို</month>
+							<month type="5">ဒုဝါဆို</month>
+							<month type="6">ဝါခေါင်</month>
+							<month type="7">တော်သလင်း</month>
+							<month type="8">သီတင်းကျွတ်</month>
+							<month type="9">တန်ဆောင်မုန်း</month>
+							<month type="10">နတ်တော်</month>
+							<month type="11">ပြာသို</month>
+							<month type="12">တပို့တွဲ</month>
+							<month type="13">တပေါင်း</month>
+							<month type="14">နှောင်းတန်ခူး</month>
+							<month type="15">နှောင်းကဆုန်</month>
+						</monthWidth>
+						<monthWidth type="abbreviated">
+							<month type="1">↑↑↑</month>
+							<month type="2">↑↑↑</month>
+							<month type="3">↑↑↑</month>
+							<month type="4">↑↑↑</month>
+							<month type="5">↑↑↑</month>
+							<month type="6">↑↑↑</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">↑↑↑</month>
+							<month type="12">↑↑↑</month>
+							<month type="13">↑↑↑</month>
+							<month type="14">↑↑↑</month>
+							<month type="15">↑↑↑</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">↑↑↑</month>
+							<month type="2">↑↑↑</month>
+							<month type="3">↑↑↑</month>
+							<month type="4">↑↑↑</month>
+							<month type="5">↑↑↑</month>
+							<month type="6">↑↑↑</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">↑↑↑</month>
+							<month type="12">↑↑↑</month>
+							<month type="13">↑↑↑</month>
+							<month type="14">↑↑↑</month>
+							<month type="15">↑↑↑</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<month type="1">↑↑↑</month>
+							<month type="2">↑↑↑</month>
+							<month type="3">↑↑↑</month>
+							<month type="4">↑↑↑</month>
+							<month type="5">↑↑↑</month>
+							<month type="6">↑↑↑</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">↑↑↑</month>
+							<month type="12">↑↑↑</month>
+							<month type="13">↑↑↑</month>
+							<month type="14">↑↑↑</month>
+							<month type="15">↑↑↑</month>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">↑↑↑</month>
+							<month type="2">↑↑↑</month>
+							<month type="3">↑↑↑</month>
+							<month type="4">↑↑↑</month>
+							<month type="5">↑↑↑</month>
+							<month type="6">↑↑↑</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">↑↑↑</month>
+							<month type="12">↑↑↑</month>
+							<month type="13">↑↑↑</month>
+							<month type="14">↑↑↑</month>
+							<month type="15">↑↑↑</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">↑↑↑</month>
+							<month type="2">↑↑↑</month>
+							<month type="3">↑↑↑</month>
+							<month type="4">↑↑↑</month>
+							<month type="5">↑↑↑</month>
+							<month type="6">↑↑↑</month>
+							<month type="7">↑↑↑</month>
+							<month type="8">↑↑↑</month>
+							<month type="9">↑↑↑</month>
+							<month type="10">↑↑↑</month>
+							<month type="11">↑↑↑</month>
+							<month type="12">↑↑↑</month>
+							<month type="13">↑↑↑</month>
+							<month type="14">↑↑↑</month>
+							<month type="15">↑↑↑</month>
+						</monthWidth>
+					</monthContext>
+				</months>
+			</calendar>
 		</calendars>
 		<fields>
 			<field type="era">

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -2284,6 +2284,73 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<alias source="locale" path="../../calendar[@type='generic']/dateTimeFormats"/>
 				</dateTimeFormats>
 			</calendar>
+			<calendar type="myanmar">
+				<months>
+					<monthContext type="format">
+						<monthWidth type="abbreviated">
+							<alias source="locale" path="../monthWidth[@type='wide']"/>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<alias source="locale" path="../../monthContext[@type='stand-alone']/monthWidth[@type='narrow']"/>
+						</monthWidth>
+						<monthWidth type="wide">
+							<month type="1">Tagu</month>
+							<month type="2">Kason</month>
+							<month type="3">Nayon</month>
+							<month type="4">Waso</month>
+							<month type="5">Second Waso</month>
+							<month type="6">Wagaung</month>
+							<month type="7">Tawthalin</month>
+							<month type="8">Thadingyut</month>
+							<month type="9">Tazaungmon</month>
+							<month type="10">Nadaw</month>
+							<month type="11">Pyatho</month>
+							<month type="12">Tabodwe</month>
+							<month type="13">Tabaung</month>
+							<month type="14">Late Tagu</month>
+							<month type="15">Late Kason</month>
+						</monthWidth>
+					</monthContext>
+					<monthContext type="stand-alone">
+						<monthWidth type="abbreviated">
+							<alias source="locale" path="../../monthContext[@type='format']/monthWidth[@type='abbreviated']"/>
+						</monthWidth>
+						<monthWidth type="narrow">
+							<month type="1">1</month>
+							<month type="2">2</month>
+							<month type="3">3</month>
+							<month type="4">4</month>
+							<month type="5">5</month>
+							<month type="6">6</month>
+							<month type="7">7</month>
+							<month type="8">8</month>
+							<month type="9">9</month>
+							<month type="10">10</month>
+							<month type="11">11</month>
+							<month type="12">12</month>
+							<month type="13">13</month>
+							<month type="14">14</month>
+							<month type="15">15</month>
+						</monthWidth>
+						<monthWidth type="wide">
+							<alias source="locale" path="../../monthContext[@type='format']/monthWidth[@type='wide']"/>
+						</monthWidth>
+					</monthContext>
+				</months>
+				<eras>
+					<eraNames>
+						<alias source="locale" path="../eraAbbr"/>
+					</eraNames>
+					<eraAbbr>
+						<era type="0">ME</era>
+						<era type="1">ME</era>
+						<era type="2">ME</era>
+					</eraAbbr>
+					<eraNarrow>
+						<alias source="locale" path="../eraAbbr"/>
+					</eraNarrow>
+				</eras>
+			</calendar>
 			<calendar type="persian">
 				<months>
 					<monthContext type="format">


### PR DESCRIPTION
CLDR-8081

This PR helps fulfill the ICU / ICU4C calendar request ( https://github.com/unicode-org/icu/pull/630 ). It's necessary to add a name for the calendar to BCP47, and names for the months to CLDR.

On a project in Myanmar in 2015, I observed that people may offer the lunar calendar date for their birthday. Our team used reference books to go between the Gregorian calendar and the traditional system.
Online references: https://en.wikipedia.org/wiki/Burmese_calendar#Month ; https://saraniya.com/myanmar/myanmar-calendar/ ; https://archive.org/details/burmesearakanese00irwiiala/page/8/mode/2up
Interactive: https://yan9a.github.io/mmcal/

Understanding the name: the ICU ticket refers to the Myanmar calendar, and dates should match the calendar maintained by the Myanmar Calendar Advisory Board.

Understanding eras: following mmcal's example to use eras to represent pre-colonial, colonial, and post-independence calendar systems (years are continuous and have the same abbreviation, ME).

Understanding 15 months:
- There are 12 standard months, the first is Tagu and the last is Tabaung
- During "little watat" years, Waso is followed by a 30-day leap month named Second Waso
- The Burmese New Year often occurs in the middle of Tagu, meaning that "Tagu 1350" could refer to the beginning or end of that year. To avoid confusion the name Late Tagu / Hnaung Tagu can be used at the end of the year. Late Tagu and Late Kason (another possible split month) bring the total to 15 month names.


I'm unable to complete the tests on my machine:

[ERROR] Failed to execute goal on project cldr-code: Could not resolve dependencies for project org.unicode.cldr:cldr-code:jar:46.0-SNAPSHOT: Failed to collect dependencies at com.ibm.icu:icu4j:jar:76.0.1-SNAPSHOT: Failed to read artifact descriptor for com.ibm.icu:icu4j:jar:76.0.1-SNAPSHOT: Could not transfer artifact com.ibm.icu:icu4j:pom:76.0.1-SNAPSHOT from/to githubicu (https://maven.pkg.github.com/unicode-org/icu): authentication failed for https://maven.pkg.github.com/unicode-org/icu/com/ibm/icu/icu4j/76.0.1-SNAPSHOT/icu4j-76.0.1-SNAPSHOT.pom, status: 401 Unauthorized -> [Help 1]