### PR TITLE
CLDR-17532 improve CheckWidths message for annotations

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckWidths.java
@@ -117,7 +117,8 @@ public class CheckWidths extends CheckCLDR {
                             this.subtype = Subtype.valueTooWide;
                             break;
                         case SET_ELEMENTS:
-                            this.message = "Expected no more than {0} items(s), but was {1}.";
+                            this.message =
+                                    "There cannot be more than {3} item(s), and it is recommended to not have more than {0} item(s). Found {1} item(s).";
                             this.subtype = Subtype.tooManyValues;
                             break;
                         default:
@@ -220,7 +221,12 @@ public class CheckWidths extends CheckCLDR {
                             .setCause(cause)
                             .setMainType(errorType)
                             .setSubtype(subtype)
-                            .setMessage(message, warningReference, valueMeasure, percent));
+                            .setMessage(
+                                    message,
+                                    warningReference,
+                                    valueMeasure,
+                                    percent,
+                                    errorReference));
             return true;
         }
     }


### PR DESCRIPTION
- mention both the warning and maximum values, not just the warning value.

CLDR-17532

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true


![image](https://github.com/unicode-org/cldr/assets/855219/ba3a23b2-8914-49a3-9a68-78173d347ad1)

