### PR TITLE
CLDR-17699 DataDog sourcemap fix for upload to smoketest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -93,7 +93,7 @@ jobs:
       - name: DataDog sourcemap upload
         # only on push to main!
         if: github.repository == 'unicode-org/cldr' && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.inputs.git-ref == ''
-        run: npx --package=@datadog/datadog-ci datadog-ci sourcemaps upload tools/cldr-apps/src/main/webapp/dist/ --minified-path-prefix=/cldr-apps/dist/ --release-version=r${{ github.event.inputs.git-ref }} --service=surveytool
+        run: npx --package=@datadog/datadog-ci datadog-ci sourcemaps upload tools/cldr-apps/src/main/webapp/dist/ --minified-path-prefix=/cldr-apps/dist/ --release-version=r${{ github.sha }} --service=surveytool
         env:
           DATADOG_SITE: ${{ secrets.DATADOG_SITE }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
CLDR-17699

- [ ] This PR completes the ticket.

An update to #3797 - I accidentally calculated the hash wrong for DataDog sourcemap uploads for smoketest.  Production and Staging are fine.  This will have no user visible effect, and I've tested it separately.

ALLOW_MANY_COMMITS=true
