### PR TITLE
CLDR-17560 don't show whole-locale warnings on row

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -463,6 +463,10 @@ function getTestKind(testResults) {
   var theKind = null;
   for (var i = 0; i < testResults.length; i++) {
     var tr = testResults[i];
+    if (tr.entireLocale) {
+      // entire-locale tests don't affect the overall Kind.
+      continue;
+    }
     if (tr.type == "Warning") {
       theKind = tr.type;
     } else if (tr.type == "Error") {


### PR DESCRIPTION
- whole-locale warnings/errs should not affect the kind (color) of a candidate item.

CLDR-17560

- [ ] This PR completes the ticket.


### To Test:

1. go to the 'csw' locale, such as <https://cldr-smoke.unicode.org/cldr-apps/v#/csw/Graphics/>
2. you should NOT  see every locale with a yellowish-tint background.

**Wrong:**

<img width="255" alt="image" src="https://github.com/unicode-org/cldr/assets/855219/c6946199-0c31-4025-b6d4-a7dd52dd293a">


**Correct:**

<img width="295" alt="image" src="https://github.com/unicode-org/cldr/assets/855219/6f3b264e-a406-4d5a-bf77-0a990045d864">

 
<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
4. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
