### PR TITLE
CLDR-17759 Clicking cell should select even if Info Panel is hidden

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -189,6 +189,14 @@ function listen(str, tr, theObj, fn) {
   cldrDom.listenFor(theObj, "click", function (e) {
     if (panelShouldBeShown()) {
       show(str, tr, theObj /* hideIfLast */, fn);
+    } else if (tr?.sethash) {
+      // These methods, updateCurrentId and setLastShown may be called from show(), if
+      // panelShouldBeShown() returned true. If the Info Panel is hidden then they still
+      // need to be called. Since they don't involve the Info Panel, the implementation
+      // should be changed to make them independent of the Info Panel and they should be
+      // called from a different module, not cldrInfo.
+      cldrLoad.updateCurrentId(tr.sethash);
+      setLastShown(theObj);
     }
     cldrEvent.stopPropagation(e);
     return false;

--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -1017,7 +1017,6 @@ export {
   closePanel,
   initialize,
   listen,
-  openPanel,
   reset,
   showItemInfoFn,
   showMessage,


### PR DESCRIPTION
-Call updateCurrentId and setLastShown directly from listen if Info Panel is hidden

-This is a work-around; the selection should be independent of Info Panel and cldrInfo as stated in new comment

-Remove unused export for openPanel, called only locally

CLDR-17759

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
