### PR TITLE
CLDR-17776 disallow reports if vetting closed

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrReport.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrReport.mjs
@@ -112,7 +112,7 @@ async function getOneLocaleStatus(locale) {
       `getOneLocaleStatus(${locale}) expected an array of one item but got ${obj.locales.length}`
     );
   }
-  return obj.locales[0].reports;
+  return obj.locales[0];
 }
 
 /**
@@ -122,9 +122,9 @@ async function getOneLocaleStatus(locale) {
  * @returns
  */
 async function getOneReportLocaleStatus(locale, onlyReport) {
-  const reports = await getOneLocaleStatus(locale);
-  const myReport = reports.filter(({ report }) => report === onlyReport)[0];
-  return myReport;
+  const { reports, canVote } = await getOneLocaleStatus(locale);
+  const report = reports.filter(({ report }) => report === onlyReport)[0];
+  return { report, canVote };
 }
 
 /**

--- a/tools/cldr-apps/js/src/views/ReportResponse.vue
+++ b/tools/cldr-apps/js/src/views/ReportResponse.vue
@@ -44,6 +44,7 @@
 
 <script>
 import * as cldrClient from "../esm/cldrClient.mjs";
+import * as cldrNotify from "../esm/cldrNotify.mjs";
 import * as cldrReport from "../esm/cldrReport.mjs";
 import * as cldrStatus from "../esm/cldrStatus.mjs";
 import * as cldrTable from "../esm/cldrTable.mjs";
@@ -172,7 +173,12 @@ export default {
         );
         await this.reload(); // will set loaded=true
       } catch (e) {
-        console.error(e);
+        cldrNotify.exception(
+          e,
+          `Trying to vote for report ${
+            this.report
+          } in ${cldrStatus.getCurrentLocale()}`
+        );
         this.error = e;
         this.loaded = true;
       }
@@ -210,7 +216,12 @@ export default {
         this.loaded = true;
         this.error = null;
       } catch (e) {
-        console.error(e);
+        cldrNotify.exception(
+          e,
+          `Trying to load report ${
+            this.report
+          } in ${cldrStatus.getCurrentLocale()}`
+        );
         this.error = e;
         this.loaded = true;
       }

--- a/tools/cldr-apps/js/src/views/ReportResponse.vue
+++ b/tools/cldr-apps/js/src/views/ReportResponse.vue
@@ -10,7 +10,7 @@
       before continuing.
     </p>
 
-    <a-radio-group v-model:value="state" @change="changed">
+    <a-radio-group v-model:value="state" :disabled="!canVote" @change="changed">
       <a-radio :style="radioStyle" value="acceptable">
         I have reviewed the items below, and they are all acceptable</a-radio
       >
@@ -60,6 +60,7 @@ export default {
   ],
   data() {
     return {
+      canVote: false,
       completed: false,
       acceptable: false,
       loaded: false,
@@ -211,9 +212,10 @@ export default {
           completed: this.completed,
           acceptable: this.acceptable,
         });
-        this.reportStatus = await reportLocaleStatusResponse; // { status: approved, acceptability: acceptable }
-        console.dir(await reportLocaleStatusResponse);
+        const { report, canVote } = await reportLocaleStatusResponse;
+        this.reportStatus = report; // { status: approved, acceptability: acceptable }
         this.loaded = true;
+        this.canVote = canVote;
         this.error = null;
       } catch (e) {
         cldrNotify.exception(


### PR DESCRIPTION
Back end side:
- Change CheckCLDR.Phase.getShowRowAction() to allow pathValueInfo and pathHeader to be optional (null)
- add convenience functions on StatusAction
- Report API returns 403 forbidden if NOT in phase where voting is allowed.

CLDR-17776

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
