### PR TITLE
CLDR-17781 CheckChildren should skip null values

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckChildren.java
@@ -39,6 +39,10 @@ public class CheckChildren<resolvedCldrFileToCheck> extends FactoryCheckCLDR {
             } catch (RuntimeException e) {
                 throw e;
             }
+            if (otherValue == null) {
+                // This child didn't even have a value. Path may be an 'extra path'.
+                continue;
+            }
             if (!otherValue.equals(CldrUtility.NO_INHERITANCE_MARKER)) {
                 tempSet.put(immediateChildren[i].getLocaleID(), otherValue);
             } else {


### PR DESCRIPTION
- if a child's value is null, skip that child. It's clearly not overridden.

CLDR-17781

- [ ] This PR completes the ticket.

- in this case, yo_BJ (which is algorithmic anyway) did not have a value at `//ldml/dates/timeZoneNames/metazone[@type="Kazakhstan"]/long/standard`
- I don't think there's a need to skip algorithmic or other special locales here, it would be a minor speed optimization that wouldn't affect many cases.


ALLOW_MANY_COMMITS=true
