### PR TITLE
CLDR-16799 allow not-logged-in to see dashboard

### DIFF
--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -291,10 +291,6 @@ export default {
     },
 
     fetchData() {
-      if (!cldrStatus.getSurveyUser()) {
-        this.fetchErr = "Please log in to see the Dashboard.";
-        return;
-      }
       this.locale = cldrStatus.getCurrentLocale();
       this.level = cldrCoverage.effectiveName(this.locale);
       if (!this.locale || !this.level) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -1108,6 +1108,10 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
 
         @Override
         public boolean userDidVote(User myUser, String somePath) {
+            if (myUser == null || myUser.id == UserRegistry.NO_USER) {
+                // if there is no user, by definition the user did not vote.
+                return false;
+            }
             PerXPathData xpd = peekXpathData(somePath);
             return (xpd != null && xpd.userDidVote(myUser));
         }


### PR DESCRIPTION
- remove UI front end check for login to dashboard
- use UserRegistry.NO_USER (-1) as a userid, and organization unaffiliated, for such a guest dashboard.
- suppress the Abstain category, since the user can't vote anyway. (Losing is also going to be empty, so it will never show.)

CLDR-16799

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
