### PR TITLE
CLDR-17759 Highlight cell when vote for a candidate item

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDom.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDom.mjs
@@ -227,6 +227,16 @@ function appendIcon(toElement, className, title) {
   return e;
 }
 
+function parentOfType(tag, obj) {
+  if (!obj) {
+    return null;
+  }
+  if (obj.nodeName === tag) {
+    return obj;
+  }
+  return parentOfType(tag, obj.parentElement);
+}
+
 export {
   addClass,
   appendIcon,
@@ -235,6 +245,7 @@ export {
   createChunk,
   createLinkToFn,
   listenFor,
+  parentOfType,
   removeAllChildNodes,
   removeClass,
   setDisplayed,

--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -203,7 +203,7 @@ function panelShouldBeShown() {
  * @param {String} str the string to show at the top
  * @param {Node} tr the <TR> of the row
  * @param {Object} hideIfLast mysterious parameter, a.k.a. theObj
- * @param {Function} fn the draw function, a.k.a. showFn, sometimes constructed by cldrInfo.showItemInfoFn,
+ * @param {Function} fn the draw function, a.k.a. showFn, sometimes constructed by cldrTable.showItemInfoFn,
  *                      sometimes ourShowFn in cldrVote.showProposedItem
  */
 function show(str, tr, hideIfLast, fn) {
@@ -212,12 +212,7 @@ function show(str, tr, hideIfLast, fn) {
     unShow();
     unShow = null;
   }
-  // Ideally, updateCurrentId and setLastShown should be called from cldrTable, not cldrInfo,
-  // however it's not clear whether they need to be called after openPanel and unShow
-  if (tr?.sethash) {
-    cldrLoad.updateCurrentId(tr.sethash);
-  }
-  cldrTable.setLastShown(hideIfLast);
+  cldrTable.updateSelectedRowAndCell(tr, hideIfLast);
   addDeferredHelp(tr?.theRow); // if !tr.theRow, erase (as when click Next/Previous)
   addPlaceholderHelp(tr?.theRow); // ditto
   addInfoMessage(str);

--- a/tools/cldr-apps/js/src/esm/cldrVote.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVote.mjs
@@ -378,7 +378,7 @@ function showProposedItem(inTd, tr, theRow, value, tests, json) {
     cldrNotify.error("Not submitted", description);
     return;
   } else {
-    setDivClass(ourDiv, testKind);
+    cldrTable.setDivClassSelected(ourDiv, testKind);
   }
 
   if (testKind || !ourItem) {
@@ -428,18 +428,6 @@ function showProposedItem(inTd, tr, theRow, value, tests, json) {
     cldrInfo.showRowObjFunc(tr, ourDiv, ourShowFn);
   }
   return false;
-}
-
-function setDivClass(div, testKind) {
-  if (!testKind) {
-    div.className = "d-item";
-  } else if (testKind == "Warning") {
-    div.className = "d-item-warn";
-  } else if (testKind == "Error") {
-    div.className = "d-item-err";
-  } else {
-    div.className = "d-item";
-  }
 }
 
 /**
@@ -607,7 +595,6 @@ export {
   getTestKind,
   handleWiredClick,
   isBusy,
-  setDivClass,
   setVoteLevelChanged,
   wireUpButton,
   wrapRadio,


### PR DESCRIPTION
-Previously the cell did not get highlighted unless the Info Panel was open

-New function setDivClassSelected calls setLastShown to add thick border after vote

-Refactor: new function setDivClassSelected combines updateCurrentId and setLastShown

-Refactor: move setDivClass from cldrVote to cldrTable

-Refactor: move parentOfType from cldrTable to cldrDom

-Comments

CLDR-17759

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
