### PR TITLE
CLDR-8823 Don't use Jan, Feb, for non-gregorian calendar systems

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -20,7 +20,11 @@
 %L = (long|short|narrow)
 %M = (Alaska_Hawaii|Bering|Dominican|Goose_Bay|Greenland_Central|Dutch_Guiana|Africa_FarWestern|Liberia|British|Irish|Kuybyshev|Sverdlovsk|Baku|Tbilisi|Turkey|Yerevan|Aktyubinsk|Ashkhabad|Dushanbe|Frunze|Kizilorda|Oral|Samarkand|Shevchenko|Tashkent|Uralsk|Urumqi|Dacca|Karachi|Borneo|Malaya|Kwajalein)
 %N = (gregorian|generic|buddhist|chinese|coptic|dangi|ethiopic|hebrew|indian|islamic|japanese|persian|roc)
-%O = (gregorian|chinese|coptic|dangi|ethiopic|hebrew|indian|islamic|persian)
+# calendar systems that should use Gregorian months (just Gregorian)
+# We don't list roc, etc here because their months are hidden.
+%G = (gregorian)
+# all others use M## form months.
+%O = (coptic|dangi|ethiopic|hebrew|indian|islamic|persian)
 %P = (future|past)
 %R = (gregorian|buddhist|coptic|ethiopic|ethiopic-amete-alem|hebrew|indian|islamic|japanese|persian|roc)
 %S = ([^/]*+)
@@ -82,10 +86,14 @@
 //ldml/dates/calendars/calendar[@type="gregorian"]/quarters/quarterContext[@type="%A"]/quarterWidth[@type="%A"]/quarter[@type="%A"]    ; DateTime ; &calendar(gregorian) ; &calField(Quarters:$2:$1) ; $3
 //ldml/dates/calendars/calendar[@type="%A"]/quarters/quarterContext[@type="%A"]/quarterWidth[@type="%A"]/quarter[@type="%A"]    ; Special  ; Suppress ; &calendar($1) ; &calField(Quarters:$3:$2)-$4 ; HIDE
 
-//ldml/dates/calendars/calendar[@type="%O"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"][@yeartype="%A"]  ; DateTime ; &calendar($1) ; &calField(Months:$3:$2) ; &month($4) (leap)
-//ldml/dates/calendars/calendar[@type="%O"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"]            ; DateTime ; &calendar($1) ; &calField(Months:$3:$2) ; &month($4)
-//ldml/dates/calendars/calendar[@type="%A"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"][@yeartype="%A"]  ; Special  ; Suppress ;  &calendar($1) ; &calField(Months:$3:$2)-&month($4) (leap) ; HIDE
-//ldml/dates/calendars/calendar[@type="%A"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"]            ; Special  ; Suppress ;  &calendar($1) ; &calField(Months:$3:$2)-&month($4) ; HIDE
+# months that follow Gregorian - %G
+//ldml/dates/calendars/calendar[@type="%G"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"][@yeartype="%A"]  ; DateTime ; &calendar($1) ; &calField(Months:$3:$2) ; &month($4) (leap)
+//ldml/dates/calendars/calendar[@type="%G"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"]            ; DateTime ; &calendar($1) ; &calField(Months:$3:$2) ; &month($4)
+# All others just use "M#" form
+//ldml/dates/calendars/calendar[@type="%O"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"][@yeartype="%A"]  ; DateTime ; &calendar($1) ; &calField(Months:$3:$2) ; M$4 (leap)
+//ldml/dates/calendars/calendar[@type="%O"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"]            ; DateTime ; &calendar($1) ; &calField(Months:$3:$2) ; M$4
+//ldml/dates/calendars/calendar[@type="%A"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"][@yeartype="%A"]  ; Special  ; Suppress ;  &calendar($1) ; &calField(Months:$3:$2)-M$4 (leap) ; HIDE
+//ldml/dates/calendars/calendar[@type="%A"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"]            ; Special  ; Suppress ;  &calendar($1) ; &calField(Months:$3:$2)-M$4 ; HIDE
 
 //ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="%A"]/dayWidth[@type="%A"]/day[@type="%A"]                    ; DateTime ; &calendar(gregorian) ; &calField(Days:$2:$1) ; &day($3)
 //ldml/dates/calendars/calendar[@type="%A"]/days/dayContext[@type="%A"]/dayWidth[@type="%A"]/day[@type="%A"]                    ; Special  ; Suppress ; &calendar($1) ; &calField(Days:$3:$2)-&day($4) ; HIDE

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -24,7 +24,7 @@
 # We don't list roc, etc here because their months are hidden.
 %G = (gregorian)
 # all others use M## form months.
-%O = (coptic|dangi|ethiopic|hebrew|indian|islamic|persian)
+%O = (chinese|coptic|dangi|ethiopic|hebrew|indian|islamic|persian)
 %P = (future|past)
 %R = (gregorian|buddhist|coptic|ethiopic|ethiopic-amete-alem|hebrew|indian|islamic|japanese|persian|roc)
 %S = ([^/]*+)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -482,7 +482,9 @@ public class TestPathHeader extends TestFmwkPlus {
             if (hidePathHeader != hideCoverage) {
                 String message = "PathHeader: " + status + ", Coverage: " + level + ": " + path;
                 if (hidePathHeader && !hideCoverage) {
-                    errln(message);
+                    errln(
+                            message
+                                    + " - PathHeader says to HIDE this, but it visible at <comprehensive coverage. Fix PathHeader to show, or fix coverage.");
                 } else if (!hidePathHeader && hideCoverage) {
                     logln(message);
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathHeader.java
@@ -1,0 +1,74 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.util.*;
+
+public class TestPathHeader {
+    static final String GREGORIAN = "gregorian";
+
+    @Test
+    public void TestNonGregorianMonths() {
+        CLDRFile english = CLDRConfig.getInstance().getCldrFactory().make("en", true);
+        PathHeader.Factory phf = PathHeader.getFactory(null);
+        for (final String xpath : english.fullIterable()) {
+            // skip unless a month name
+            if (!xpath.startsWith("//ldml/dates/calendars/calendar")) continue;
+            if (!xpath.contains("/month[")) continue;
+            final PathHeader ph = phf.fromPath(xpath);
+            final String value = english.getStringValue(xpath);
+            // skip any null values.
+            if (value == null) continue;
+            // skip any hidden items
+            final XPathParts xpp = XPathParts.getFrozenInstance(xpath);
+            final String calType = xpp.getAttributes(3).get("type");
+            // we skip Gregorian itself.
+            if (calType.equals(GREGORIAN)) continue;
+            // now, we need Gregorian for comparison.
+            final String gregopath =
+                    xpp.cloneAsThawed().setAttribute("calendar", "type", GREGORIAN).toString();
+            final String gregovalue = english.getStringValue(gregopath);
+            final PathHeader gph = phf.fromPath(gregopath);
+            if (gph.shouldHide()) continue; // hide if the *gregorian* is hidden.
+
+            if (gregovalue != null && value.equals(gregovalue)) {
+                // The month name is the same as the Gregorian. So we assume the codes will be the
+                // same.
+                if (!ph.shouldHide())
+                    assertEquals(
+                            ph.getCode(),
+                            gph.getCode(),
+                            () ->
+                                    "Expected the same PathHeader code"
+                                            + ph
+                                            + " as Gregorian  "
+                                            + gph
+                                            + " for xpath "
+                                            + xpath
+                                            + " because the month "
+                                            + value
+                                            + " was the same as gregorian "
+                                            + gregopath);
+                assertTrue(
+                        ph.shouldHide(),
+                        () ->
+                                "Should be hidden. To fix: remove "
+                                        + calType
+                                        + " from the %G line of PathHeader.txt.");
+            } else {
+                assertNotEquals(
+                        ph.getCode(),
+                        gph.getCode(),
+                        () ->
+                                "Expected a different PathHeader code from Gregorian for xpath "
+                                        + xpath
+                                        + " because the month "
+                                        + value
+                                        + " was the differnet from gregorian "
+                                        + gregovalue
+                                        + ".");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- update PathHeader with a %G, a list of calendars which use the Gregorian month names.

CLDR-8823

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

<img width="525" alt="image" src="https://github.com/unicode-org/cldr/assets/855219/439eb83b-b092-41ab-a0ef-661dc885dfc9">

Includes a test. The test catches some issues.

ALLOW_MANY_COMMITS=true
