### PR TITLE
CLDR-17402 json: drop _cldrVersion path

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -540,6 +540,7 @@ public class Ldml2JsonConverter {
         Matcher noNumberingSystemMatcher = LdmlConvertRules.NO_NUMBERING_SYSTEM_PATTERN.matcher("");
         Matcher numberingSystemMatcher = LdmlConvertRules.NUMBERING_SYSTEM_PATTERN.matcher("");
         Matcher rootIdentityMatcher = LdmlConvertRules.ROOT_IDENTITY_PATTERN.matcher("");
+        Matcher versionMatcher = LdmlConvertRules.VERSION_PATTERN.matcher("");
         Set<String> activeNumberingSystems = new TreeSet<>();
         activeNumberingSystems.add("latn"); // Always include latin script numbers
         for (String np : LdmlConvertRules.ACTIVE_NUMBERING_SYSTEM_XPATHS) {
@@ -588,8 +589,16 @@ public class Ldml2JsonConverter {
                 continue;
             }
             // Discard root identity element unless the locale is root
+            // TODO: CLDR-17790 this code should not be needed.
             rootIdentityMatcher.reset(fullPath);
             if (rootIdentityMatcher.matches() && !"root".equals(locID)) {
+                continue;
+            }
+
+            // discard version stuff
+            versionMatcher.reset(fullPath);
+            if (versionMatcher.matches()) {
+                // drop //ldml/identity/version entirely.
                 continue;
             }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -422,6 +422,12 @@ class LdmlConvertRules {
     public static final Pattern ROOT_IDENTITY_PATTERN =
             Pattern.compile("//ldml/identity/language\\[@type=\"root\"\\]");
 
+    /**
+     * Version (coming from DTD) should be discarded everywhere. This information is now in
+     * package.json.
+     */
+    public static final Pattern VERSION_PATTERN = Pattern.compile("//ldml/identity/version.*");
+
     /** A simple class to hold the specification of a path transformation. */
     public static class PathTransformSpec {
 


### PR DESCRIPTION
- drop //ldml/identity/version entirely (was producing _cldrVersion in every file)
- also, annotate the code working around CLDR-17790 as a TODO
- As a reminder, this will greatly reduce the diffs every time json is updated.

CLDR-17402

- [X] This PR completes the ticket.

Example output with this change:

```diff
--- a/cldr-json/cldr-units-modern/main/zh/measurementSystemNames.json
+++ b/cldr-json/cldr-units-modern/main/zh/measurementSystemNames.json
@@ -2,9 +2,6 @@
   "main": {
     "zh": {
       "identity": {
-        "version": {
-          "_cldrVersion": "46"
-        },
         "language": "zh"
       },
       "localeDisplayNames": {
```


ALLOW_MANY_COMMITS=true