### PR TITLE
CLDR-16465 json: drop the -modern tier (by default)

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -261,7 +261,7 @@ public class Ldml2JsonConverter {
                             "Modern",
                             'M',
                             "(true|false)",
-                            "true",
+                            "false",
                             "Whether to include the -modern tier")
                     // Primarily useful for non-Maven build systems where CldrUtility.LICENSE may
                     // not be available as it is put in place by pom.xml
@@ -1528,6 +1528,7 @@ public class Ldml2JsonConverter {
     }
 
     public void writePackageList(String outputDir) throws IOException {
+        final boolean includeModern = Boolean.parseBoolean(options.get("Modern").getValue());
         PrintWriter outf =
                 FileUtilities.openUTF8Writer(outputDir + "/cldr-core", "cldr-packages.json");
         System.out.println(
@@ -1582,7 +1583,7 @@ public class Ldml2JsonConverter {
                             packageEntry.get("name").getAsString(),
                             packageEntry.get("description").getAsString());
                 }
-                {
+                if (includeModern) {
                     JsonObject packageEntry = new JsonObject();
                     packageEntry.addProperty("description", e.getValue() + " modern (deprecated)");
                     packageEntry.addProperty("tier", "modern");


### PR DESCRIPTION
- The -M (Modern) option now defaults to false, but the user can set it to true
- also, fix a bug where the modern tier was emitted to PACKAGES.md and the cldr-packages.json file even if -M was false.

CLDR-16465

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
