### PR TITLE
CLDR-16844 Remember whether the user wants the Info Panel

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -24,7 +24,20 @@ let neighborId = null;
 let buttonClass = null;
 
 let panelInitialized = false;
+
+/**
+ * Is the Info Panel currently displayed?
+ */
 let panelVisible = false;
+
+/**
+ * Does the user want the Info Panel to be displayed when appropriate?
+ * The panel is hidden automatically when there is a "special" view for which
+ * the panel is inappropriate. When returning to the non-special vetting view,
+ * the panel should be displayed again, unless the user has indicated, by clicking
+ * its close box, that they don't want to see it.
+ */
+let panelWanted = true;
 
 let unShow = null;
 
@@ -113,16 +126,26 @@ function appendDiv(el, id) {
   el.appendChild(div);
 }
 
+/**
+ * Open the Info Panel
+ */
 function openPanel() {
   if (!panelVisible) {
-    panelVisible = true;
+    panelVisible = panelWanted = true;
     openOrClosePanel();
   }
 }
 
-function closePanel() {
+/**
+ * Close the Info Panel
+ *
+ * @param {Boolean} userWantsHidden true if closing because user clicked close box (or equivalent),
+ *       false if closing because switching to a "special" view where the Info Panel doesn't belong
+ */
+function closePanel(userWantsHidden) {
   if (panelVisible) {
     panelVisible = false;
+    panelWanted = !userWantsHidden;
     openOrClosePanel();
   }
 }
@@ -192,7 +215,7 @@ function panelShouldBeShown() {
     // Leave panelVisible = false until openPanel makes it true.
     return true;
   }
-  return panelVisible;
+  return panelWanted && !cldrStatus.getCurrentSpecial();
 }
 
 /**


### PR DESCRIPTION
-New boolean panelWanted records user preference

-New boolean parameter for closePanel distinguishes manually clicking close box from automatically closing when switching to special view where panel does not belong

-Revise panelShouldBeShown to check panelWanted and getCurrentSpecial

CLDR-16844

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
