### PR TITLE
CLDR-17792 Don't strip ZWSP for value compare, allow currency symbol collision for it

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -491,6 +491,15 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
             if (path.contains("/decimal") || path.contains("/group")) {
                 return this;
             }
+            // Currency symbol value \u200B (ZWSP) is allowed to match other paths; when it is used,
+            // the actual currency symbol must be in a decimal element for the specific currency.
+            if (path.contains("/symbol") && value.equals("\\u200B")) {
+                String decimalPath = path.replace("/symbol", "/decimal");
+                String decimalValue = getResolvedCldrFileToCheck().getWinningValue(decimalPath);
+                if (decimalValue != null && decimalValue.length() > 0) {
+                    return this;
+                }
+            }
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String currency = parts.getAttributeValue(-2, "type");
             Iterator<String> iterator = paths.iterator();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleXMLSource.java
@@ -170,10 +170,12 @@ public class SimpleXMLSource extends XMLSource {
     static final Normalizer2 NFKC = Normalizer2.getNFKCInstance();
 
     // The following includes letters, marks, numbers, currencies, and *selected*
-    // symbols/punctuation
+    // symbols/punctuation.
+    // Also \u200B ZWSP which has a special function, should not strip it when
+    // normalizing values for comparison.
     static final UnicodeSet NON_ALPHANUM =
             new UnicodeSet(
-                            "[^[:L:][:M:][:N:][:Sc:][\\u202F\uFFFF _ ¡ « ( ) \\- \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]")
+                            "[^[:L:][:M:][:N:][:Sc:][\\u200B\\u202F\uFFFF _ ¡ « ( ) \\- \\[ \\] \\{ \\} § / \\\\ % ٪ ‰ ؉ ‱-″ ` \\^ ¯ ¨ ° + ¬ | ¦ ~ − ⊕ ⍰ ☉ © ®]]")
                     .freeze();
 
     public static String normalize(String valueToMatch) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
@@ -275,6 +275,19 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
         checkDisplayCollisions("fil", filPathValuePairs, filFactory);
     }
 
+    public void checkCurrencySymbolCollisions() {
+        // CLDR-17792
+        Map<String, String> pt_PTPathValuePairs =
+                ImmutableMap.of(
+                        "ldml/numbers/currencies/currency[@type=\"EUR\"]/symbol", "€",
+                        "ldml/numbers/currencies/currency[@type=\"GBP\"]/symbol", "£",
+                        "ldml/numbers/currencies/currency[@type=\"PTE\"]/symbol", "\u200B",
+                        "ldml/numbers/currencies/currency[@type=\"PTE\"]/decimal", "$",
+                        "ldml/numbers/currencies/currency[@type=\"USD\"]/symbol", "US$");
+        TestFactory pt_PTFactory = makeFakeCldrFile("pt_PT", pt_PTPathValuePairs);
+        checkDisplayCollisions("pt_PT", pt_PTPathValuePairs, pt_PTFactory);
+    }
+
     public void checkDisplayCollisions(
             String locale, Map<String, String> pathValuePairs, TestFactory factory) {
         CheckDisplayCollisions cdc = new CheckDisplayCollisions(factory);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -600,6 +600,13 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
                 // PathSpaceData("//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dayPeriods/dayPeriodContext[@type=\"format\"]/dayPeriodWidth[@type=\"narrow\"]/dayPeriod[@type=\"am\"]",
                 //    " pizza \u00A0\u202F cardboard ", "pizza\u202Fcardboard",
                 //    PathSpaceType.allowNNbsp),
+
+                // Verify that ZWSP u200B as symbol for PTE (in e.g. pt_PT) is not altered
+                new PathSpaceData(
+                        "//ldml/numbers/currencies/currency[@type=\"PTE\"]/symbol",
+                        "\u200B",
+                        "\u200B",
+                        PathSpaceType.allowSpOrNbsp),
             };
             return a;
         }


### PR DESCRIPTION
CLDR-17792

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17792)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Currently Survey Tools is reporting a display collision for \u200B (ZWSP) used as currency symbol for PTE in pt_PT, even though this is the value that has been there for several releases, and is the correct value to use since for this particular currency in pt_PT the symbol is actually in the decimal separator element; see https://st.unicode.org/cldr-apps/v#/pt_PT/C_SEEurope/7f78787c0e4c5be3 (best to view this with coverage set to Comprehensive to see the associated fields).

The error does not appear in offline unit tests or Console Check, so the fix here is somewhat speculative:
- Update SimpleXMLSource.NON_ALPHANUM so \u200B does not get stripped when comparing values across paths
- Update CheckDisplayCollisions to specifically allow a collision for  \u200B as a currency symbol if there is an explicit decimal separator for the same currency.
- Add a test for the above, and also a test to verify that DAIP is not altering the \u200B as a currency symbol.

ALLOW_MANY_COMMITS=true
