### PR TITLE
CLDR-17184 fix some warnings in staging and prod actions

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Calculate Tag Name
         id: tagname
         run: >
-          echo "::set-output name=tag::$(env TZ=UTC date +'production/%Y-%m-%d-%H%Mz')"
+          echo "tag=$(env TZ=UTC date +'production/%Y-%m-%d-%H%Mz')" >> $GITHUB_OUTPUT
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,10 +27,6 @@ jobs:
           ref: ${{ github.event.inputs.git-ref }}
           repository: ${{ github.event.inputs.repo }}
           lfs: false
-      - name: Calculate Tag Name
-        id: tagname
-        run: >
-          echo "::set-output name=tag::$(env TZ=UTC date +'staging/%Y-%m-%d-%H%Mz')"
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
- use the GITHUB_OUTPUT file instead of set-output in production
- drop an unneeded set-output in staging

CLDR-17184

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

We'll need to do a push to production to really test this.