### PR TITLE
CLDR-17812 v46 vxml: update locale for TestAliases/testCountBase

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAliases.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAliases.java
@@ -60,7 +60,7 @@ public class TestAliases extends TestFmwk {
                 "//ldml/characterLabels/characterLabelPattern[@type=\"strokes\"][@count=\"one\"]",
             },
             {
-                "ak",
+                "wo",
                 "//ldml/characterLabels/characterLabelPattern[@type=\"strokes\"][@count=\"one\"]",
                 "root",
                 "//ldml/characterLabels/characterLabelPattern[@type=\"strokes\"][@count=\"other\"]",


### PR DESCRIPTION
CLDR-17812

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17812)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Since the data in ak was fleshed out, it no longer illustrates an inheritance that was being tested in TestAliases/testCountBase. However `wo` Wolof is now a good example for that.

merge into [#3880](https://github.com/unicode-org/cldr/pull/3880)

ALLOW_MANY_COMMITS=true
