### PR TITLE
CLDR-17812 v46 vxml: Add {0} for de speed-light-speed one, fix error wording in TestCheckCLDR/TestPlaceholders

### DIFF
--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -10677,10 +10677,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="speed-light-speed">
 				<gender>feminine</gender>
 				<displayName>Lichtgeschwindigkeit</displayName>
-				<unitPattern count="one">Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="one" case="accusative">Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="one" case="dative">Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="one" case="genitive">Lichtgeschwindigkeit</unitPattern>
+				<unitPattern count="one">{0} Lichtgeschwindigkeit</unitPattern>
+				<unitPattern count="one" case="accusative">{0} Lichtgeschwindigkeit</unitPattern>
+				<unitPattern count="one" case="dative">{0} Lichtgeschwindigkeit</unitPattern>
+				<unitPattern count="one" case="genitive">{0} Lichtgeschwindigkeit</unitPattern>
 				<unitPattern count="other">{0}-fache Lichtgeschwindigkeit</unitPattern>
 				<unitPattern count="other" case="accusative">{0}-fache Lichtgeschwindigkeit</unitPattern>
 				<unitPattern count="other" case="dative">{0}-facher Lichtgeschwindigkeit</unitPattern>
@@ -11781,7 +11781,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-light-speed">
 				<displayName>Lichtgeschw.</displayName>
-				<unitPattern count="one">Lichtgeschw.</unitPattern>
+				<unitPattern count="one">{0} Lichtgeschw.</unitPattern>
 				<unitPattern count="other">{0}-fache Lichtg.</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -424,11 +424,13 @@ public class TestCheckCLDR extends TestFmwk {
                 }
             } else { // not disallowed
                 if (!containsMessagePattern) {
+                    // The following error seems wrong if placeholderStatus is LOCALE_DEPENDENT
+                    // in which case some entries might not have placeholders; see CLDR-17820
                     errln(
                             cldrFileToTest.getLocaleID()
                                     + " Value ("
                                     + value
-                                    + ") contains placeholder, but placeholder info = «"
+                                    + ") does not contain placeholder, but placeholder info = «"
                                     + placeholderStatus
                                     + "»\t"
                                     + path);


### PR DESCRIPTION
CLDR-17812

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17812)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

merge into [#3880](https://github.com/unicode-org/cldr/pull/3880)

`de` added unit data for speed-light-speed in which the "one" case has no placeholder; per discussion that reflects a misunderstanding of how this data is intended to be used, so add a placeholder so tests pass (the data will be deleted soon anyway). Also fix the wording of an error message in TestCheckCLDR/TestPlaceholders.

ALLOW_MANY_COMMITS=true
