### PR TITLE
CLDR-17827 check that intervalFormats pass DateIntervalInfo.genPatternInfo; fix an,rif,si

### DIFF
--- a/common/main/an.xml
+++ b/common/main/an.xml
@@ -1125,8 +1125,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="yMEd">
 							<greatestDifference id="d" draft="unconfirmed">E, d/M/y – E, d/M/y</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">E, d/M/y</greatestDifference>
-							<greatestDifference id="y" draft="unconfirmed">E, d/M/Y – E, d/M/Y</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E, d/M/y – E, d/M/y</greatestDifference>
+							<greatestDifference id="y" draft="unconfirmed">E, d/M/y – E, d/M/y</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="yMMM">
 							<greatestDifference id="M" draft="unconfirmed">LLL–LLL y</greatestDifference>

--- a/common/main/rif.xml
+++ b/common/main/rif.xml
@@ -1119,7 +1119,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						</intervalFormatItem>
 						<intervalFormatItem id="MEd">
 							<greatestDifference id="d" draft="unconfirmed">E dd/MM – E dd/MM</greatestDifference>
-							<greatestDifference id="M" draft="unconfirmed">E dd/MM</greatestDifference>
+							<greatestDifference id="M" draft="unconfirmed">E dd/MM – E dd/MM</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="MMM">
 							<greatestDifference id="M" draft="unconfirmed">MMM – MMM</greatestDifference>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -1183,7 +1183,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 							<greatestDifference id="m">HH.mm–HH.mm</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="hmv">
-							<greatestDifference id="a">a h.mm – a hhh.mm v</greatestDifference>
+							<greatestDifference id="a">a h.mm – a h.mm v</greatestDifference>
 							<greatestDifference id="h">a h.mm – h.mm v</greatestDifference>
 							<greatestDifference id="m">a h.mm – h.mm v</greatestDifference>
 						</intervalFormatItem>
@@ -1193,7 +1193,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</intervalFormatItem>
 						<intervalFormatItem id="hv">
 							<greatestDifference id="a">a h – a h v</greatestDifference>
-							<greatestDifference id="h">a h – h vv</greatestDifference>
+							<greatestDifference id="h">a h – h v</greatestDifference>
 						</intervalFormatItem>
 						<intervalFormatItem id="Hv">
 							<greatestDifference id="H">↑↑↑</greatestDifference>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -3,6 +3,8 @@ package org.unicode.cldr.test;
 import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.text.DateIntervalInfo;
+import com.ibm.icu.text.DateIntervalInfo.PatternInfo;
 import com.ibm.icu.text.DateTimePatternGenerator;
 import com.ibm.icu.text.DateTimePatternGenerator.VariableField;
 import com.ibm.icu.text.MessageFormat;
@@ -1190,6 +1192,33 @@ public class CheckDates extends FactoryCheckCLDR {
                                     .setMessage(
                                             "Not enough year fields in interval pattern. Must have {0} but only found {1}",
                                             new Object[] {requiredYearFieldCount, yearFieldCount}));
+                }
+            }
+            // check PatternInfo, for CLDR-17827
+            // ICU-22835, DateIntervalInfo.genPatternInfo fails for intervals like LLL - MMM (in fa)
+            if (!(value.contains("LLL") && value.contains("MMM"))) {
+                PatternInfo pattern = DateIntervalInfo.genPatternInfo(value, false);
+                try {
+                    String first = pattern.getFirstPart();
+                    String second = pattern.getSecondPart();
+                    if (first == null || second == null) {
+                        result.add(
+                                new CheckStatus()
+                                        .setCause(this)
+                                        .setMainType(CheckStatus.errorType)
+                                        .setSubtype(Subtype.incorrectDatePattern)
+                                        .setMessage(
+                                                "DateIntervalInfo.PatternInfo returns null for first or second part"));
+                    }
+                } catch (Exception e) {
+                    result.add(
+                            new CheckStatus()
+                                    .setCause(this)
+                                    .setMainType(CheckStatus.errorType)
+                                    .setSubtype(Subtype.incorrectDatePattern)
+                                    .setMessage(
+                                            "DateIntervalInfo.PatternInfo exception {0}",
+                                            new Object[] {e}));
                 }
             }
         }


### PR DESCRIPTION
CLDR-17827

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17827)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Added a check that intervalFormats do not cause problems in DateIntervalInfo.genPatternInfo(), except that there is an ICU bug in DateIntervalInfo.genPatternInfo with intervals in which the repeated field uses two different forms, like LLL - MMM, so skip the test for such patterns (which occur in `fa`); filed [ICU-22835](https://unicode-org.atlassian.net/browse/ICU-22835) about the bug.

Fixed bad intervalFormats in `an`, `rif`,`si`.

ALLOW_MANY_COMMITS=true


[ICU-22835]: https://unicode-org.atlassian.net/browse/ICU-22835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ