### PR TITLE
CLDR-17761 Update en.xml -- add variant Mvskoke to Muscogee (mus)

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -63,7 +63,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST language type NMTOKEN #REQUIRED >
     <!--@MATCH:validity/locale-->
 <!ATTLIST language alt NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/long, secondary, short, variant, menu-->
+    <!--@MATCH:literal/long, secondary, short, variant, menu, official-->
 <!ATTLIST language draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED:true, false-->

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -426,6 +426,7 @@ annotations.
 			<language type="mua">Mundang</language>
 			<language type="mul">Multiple languages</language>
 			<language type="mus">Muscogee</language>
+			<language type="mus" alt="variant">Mvskoke</language>
 			<language type="mwl">Mirandese</language>
 			<language type="mwr">Marwari</language>
 			<language type="mwv">Mentawai</language>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -426,7 +426,8 @@ annotations.
 			<language type="mua">Mundang</language>
 			<language type="mul">Multiple languages</language>
 			<language type="mus">Muscogee</language>
-			<language type="mus" alt="variant">Mvskoke</language>
+			<language type="mus" alt="variant">Muscogee</language>
+			<language type="mus" alt="official">Mvskoke</language>
 			<language type="mwl">Mirandese</language>
 			<language type="mwr">Marwari</language>
 			<language type="mwv">Mentawai</language>


### PR DESCRIPTION
This starts the ball rolling in adding recognition for the name Mvskoke -- an endonym for Muscogee. Initially we just want to add it as a variant. In the future we may want to swap the official & variant options if the Mvskoke/Muscogee linguistic authority prefers it.

[CLDR-17761](https://unicode-org.atlassian.net/browse/CLDR-17761)

- [ ] ~~This PR completes the ticket.~~
- [x] This PR addresses short-term issues with the ticket, pending long-term followup.


ALLOW_MANY_COMMITS=true


[CLDR-17761]: https://unicode-org.atlassian.net/browse/CLDR-17761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ