### PR TITLE
CLDR-17832 BRSv46 CLDRModify passes before alpha0

### DIFF
--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -720,17 +720,17 @@ annotations.
 		<annotation cp="♯" type="tts">sharp</annotation>
 		<annotation cp="🪉">cupid | harp | instrument | love | music | orchestra</annotation>
 		<annotation cp="🪉" type="tts">harp</annotation>
-		<annotation cp="🪏">dig | hole | scoop | shovel | spade | bury | snow | garden | plant</annotation>
+		<annotation cp="🪏">bury | dig | garden | hole | plant | scoop | shovel | snow | spade</annotation>
 		<annotation cp="🪏" type="tts">shovel</annotation>
-		<annotation cp="🪾">barren | drought | leafless | tree | winter | bare | branches | wood | dead | trunk</annotation>
+		<annotation cp="🪾">bare | barren | branches | dead | drought | leafless | tree | trunk | winter | wood</annotation>
 		<annotation cp="🪾" type="tts">leafless tree</annotation>
-		<annotation cp="🫆">fingerprint | forensics | identity | safety | clue | crime | trace | mystery | detective | print</annotation>
+		<annotation cp="🫆">clue | crime | detective | fingerprint | forensics | identity | mystery | print | safety | trace</annotation>
 		<annotation cp="🫆" type="tts">fingerprint</annotation>
-		<annotation cp="🫜">beet | garden | root | turnip | vegetable | radish | food | salad | vegetarian</annotation>
+		<annotation cp="🫜">beet | food | garden | radish | root | salad | turnip | vegetable | vegetarian</annotation>
 		<annotation cp="🫜" type="tts">root vegetable</annotation>
-		<annotation cp="🫟">holi | paint | spill | splatter | stain | drip | mess | liquid | ink</annotation>
+		<annotation cp="🫟">drip | holi | ink | liquid | mess | paint | spill | splatter | stain</annotation>
 		<annotation cp="🫟" type="tts">splatter</annotation>
-		<annotation cp="🫩">bags | exhausted | eyes | face | sleepy | tired | fatigued | bored | weary | late</annotation>
+		<annotation cp="🫩">bags | bored | exhausted | eyes | face | fatigued | late | sleepy | tired | weary</annotation>
 		<annotation cp="🫩" type="tts">face with bags under eyes</annotation>
 		<annotation cp="😀">cheerful | cheery | face | grin | grinning | happy | laugh | nice | smile | smiling | teeth</annotation>
 		<annotation cp="😀" type="tts">grinning face</annotation>
@@ -806,7 +806,7 @@ annotations.
 		<annotation cp="🫡" type="tts">saluting face</annotation>
 		<annotation cp="🤐">face | keep | mouth | quiet | secret | shut | zip | zipper | zipper-mouth</annotation>
 		<annotation cp="🤐" type="tts">zipper-mouth face</annotation>
-		<annotation cp="🤨">disapproval | disbelief | distrust | emoji | eyebrow | face | hmm | mild | raised | skepticism | skeptic | skeptical | surprise | what</annotation>
+		<annotation cp="🤨">disapproval | disbelief | distrust | emoji | eyebrow | face | hmm | mild | raised | skeptic | skeptical | skepticism | surprise | what</annotation>
 		<annotation cp="🤨" type="tts">face with raised eyebrow</annotation>
 		<annotation cp="😐">awkward | blank | deadpan | expressionless | face | fine | jealous | meh | neutral | oh | shade | straight | unamused | unhappy | unimpressed | whatever</annotation>
 		<annotation cp="😐" type="tts">neutral face</annotation>
@@ -1478,7 +1478,7 @@ annotations.
 		<annotation cp="🧚‍♂" type="tts">man fairy</annotation>
 		<annotation cp="🧚‍♀">fairy | fairytale | fantasy | myth | person | pixie | tale | Titania | wings | woman</annotation>
 		<annotation cp="🧚‍♀" type="tts">woman fairy</annotation>
-		<annotation cp="🧛">blood | fangs | halloween | scary | supernatural | teeth | undead | vampire | Dracula</annotation>
+		<annotation cp="🧛">blood | Dracula | fangs | halloween | scary | supernatural | teeth | undead | vampire</annotation>
 		<annotation cp="🧛" type="tts">vampire</annotation>
 		<annotation cp="🧛‍♂">blood | fangs | halloween | man | scary | supernatural | teeth | undead | vampire</annotation>
 		<annotation cp="🧛‍♂" type="tts">man vampire</annotation>
@@ -1708,11 +1708,11 @@ annotations.
 		<annotation cp="👪" type="tts">family</annotation>
 		<annotation cp="🧑‍🧑‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 -->
 		<annotation cp="🧑‍🧑‍🧒" type="tts">family: adult, adult, child</annotation>
-		<annotation cp="🧑‍🧑‍🧒‍🧒">adult | child | child | family</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2 -->
+		<annotation cp="🧑‍🧑‍🧒‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2 -->
 		<annotation cp="🧑‍🧑‍🧒‍🧒" type="tts">family: adult, adult, child, child</annotation>
 		<annotation cp="🧑‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D2 -->
 		<annotation cp="🧑‍🧒" type="tts">family: adult, child</annotation>
-		<annotation cp="🧑‍🧒‍🧒">adult | child | child | family</annotation> <!-- 1F9D1 200D 1F9D2 200D 1F9D2 -->
+		<annotation cp="🧑‍🧒‍🧒">adult | child | family</annotation> <!-- 1F9D1 200D 1F9D2 200D 1F9D2 -->
 		<annotation cp="🧑‍🧒‍🧒" type="tts">family: adult, child, child</annotation>
 		<annotation cp="👣">barefoot | clothing | footprint | footprints | omw | print | walk</annotation>
 		<annotation cp="👣" type="tts">footprints</annotation>
@@ -2166,7 +2166,7 @@ annotations.
 		<annotation cp="🥣" type="tts">bowl with spoon</annotation>
 		<annotation cp="🥗">food | green | salad</annotation>
 		<annotation cp="🥗" type="tts">green salad</annotation>
-		<annotation cp="🍿">movie | popcorn | pop | corn</annotation>
+		<annotation cp="🍿">corn | movie | pop | popcorn</annotation>
 		<annotation cp="🍿" type="tts">popcorn</annotation>
 		<annotation cp="🧈">butter | dairy</annotation>
 		<annotation cp="🧈" type="tts">butter</annotation>
@@ -2724,9 +2724,9 @@ annotations.
 		<annotation cp="⚡" type="tts">high voltage</annotation>
 		<annotation cp="❄">cold | snow | snowflake | weather</annotation>
 		<annotation cp="❄" type="tts">snowflake</annotation>
-		<annotation cp="☃">cold | snow | snowman | man</annotation>
+		<annotation cp="☃">cold | man | snow | snowman</annotation>
 		<annotation cp="☃" type="tts">snowman</annotation>
-		<annotation cp="⛄">cold | snow | snowman | man</annotation>
+		<annotation cp="⛄">cold | man | snow | snowman</annotation>
 		<annotation cp="⛄" type="tts">snowman without snow</annotation>
 		<annotation cp="☄">comet | space</annotation>
 		<annotation cp="☄" type="tts">comet</annotation>
@@ -3128,7 +3128,7 @@ annotations.
 		<annotation cp="🔦" type="tts">flashlight</annotation>
 		<annotation cp="🏮">bar | lantern | light | paper | red | restaurant</annotation>
 		<annotation cp="🏮" type="tts">red paper lantern</annotation>
-		<annotation cp="🪔">diya | lamp | oil | light</annotation>
+		<annotation cp="🪔">diya | lamp | light | oil</annotation>
 		<annotation cp="🪔" type="tts">diya lamp</annotation>
 		<annotation cp="📔">book | cover | decorated | decorative | education | notebook | school | writing</annotation>
 		<annotation cp="📔" type="tts">notebook with decorative cover</annotation>
@@ -3152,7 +3152,7 @@ annotations.
 		<annotation cp="📃" type="tts">page with curl</annotation>
 		<annotation cp="📜">paper | scroll</annotation>
 		<annotation cp="📜" type="tts">scroll</annotation>
-		<annotation cp="📄">document | facing | page | up | paper</annotation>
+		<annotation cp="📄">document | facing | page | paper | up</annotation>
 		<annotation cp="📄" type="tts">page facing up</annotation>
 		<annotation cp="📰">communication | news | newspaper | paper</annotation>
 		<annotation cp="📰" type="tts">newspaper</annotation>
@@ -3268,7 +3268,7 @@ annotations.
 		<annotation cp="🗃" type="tts">card file box</annotation>
 		<annotation cp="🗄">cabinet | file | filing | paper</annotation>
 		<annotation cp="🗄" type="tts">file cabinet</annotation>
-		<annotation cp="🗑">wastebasket | trash | can | waste | garbage</annotation>
+		<annotation cp="🗑">can | garbage | trash | waste | wastebasket</annotation>
 		<annotation cp="🗑" type="tts">wastebasket</annotation>
 		<annotation cp="🔒">closed | lock | locked | private</annotation>
 		<annotation cp="🔒" type="tts">locked</annotation>
@@ -3514,7 +3514,7 @@ annotations.
 		<annotation cp="⤵" type="tts">right arrow curving down</annotation>
 		<annotation cp="🔃">arrow | arrows | clockwise | refresh | reload | vertical</annotation>
 		<annotation cp="🔃" type="tts">clockwise vertical arrows</annotation>
-		<annotation cp="🔄">again | anticlockwise | arrow | arrows | button | counterclockwise | deja | vu | refresh | rewindershins</annotation>
+		<annotation cp="🔄">again | anticlockwise | arrow | arrows | button | counterclockwise | deja | refresh | rewindershins | vu</annotation>
 		<annotation cp="🔄" type="tts">counterclockwise arrows button</annotation>
 		<annotation cp="🔙">arrow | BACK</annotation>
 		<annotation cp="🔙" type="tts">BACK arrow</annotation>

--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -919,7 +919,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="unconfirmed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="unconfirmed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="unconfirmed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="unconfirmed">↑↑↑</parseLenient>

--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -8923,8 +8923,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality">informal</parameterDefault>
 		<parameterDefault parameter="length">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement>↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement>↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -1334,7 +1334,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<parseLenients scope="general" level="lenient">
 			<parseLenient sample="." draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>
 		</parseLenients>
 		<parseLenients scope="number" level="lenient">

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -1164,7 +1164,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/bal_Latn.xml
+++ b/common/main/bal_Latn.xml
@@ -8644,8 +8644,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement>↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement>↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -2576,16 +2576,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName draft="unconfirmed">↑↑↑</displayName>
 			</field>
 			<!-- <field type="sun">
-				<relative type="-1" draft="unconfirmed">Minggu kemarèn</relative>
-				<relative type="0" draft="unconfirmed">ni Minggu</relative>
-				<relative type="1" draft="unconfirmed">Minggu bèsok</relative>
-				<relativeTime type="future">
-					<relativeTimePattern count="other" draft="unconfirmed">{0} Minggu lagi</relativeTimePattern>
-				</relativeTime>
-				<relativeTime type="past">
-					<relativeTimePattern count="other" draft="unconfirmed">{0} Minggu nyang liwat</relativeTimePattern>
-				</relativeTime>
-			</field> -->
+				 <relative type="-1" draft="unconfirmed">Minggu kemarèn</relative>
+				 <relative type="0" draft="unconfirmed">ni Minggu</relative>
+				 <relative type="1" draft="unconfirmed">Minggu bèsok</relative>
+				 <relativeTime type="future">
+				 <relativeTimePattern count="other" draft="unconfirmed">{0} Minggu lagi</relativeTimePattern>
+				 </relativeTime>
+				 <relativeTime type="past">
+				 <relativeTimePattern count="other" draft="unconfirmed">{0} Minggu nyang liwat</relativeTimePattern>
+				 </relativeTime>
+				 </field>
+			-->
 			<field type="sun-short">
 				<relative type="-1" draft="unconfirmed">Min marèn</relative>
 				<relative type="0" draft="unconfirmed">ni Min</relative>

--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -7995,8 +7995,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length">long</parameterDefault>
-		<nativeSpaceReplacement>↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement>↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">{0}{1}</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -1260,7 +1260,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -1283,7 +1283,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -969,7 +969,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -1182,7 +1182,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -19904,8 +19904,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst" draft="unconfirmed">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality" draft="unconfirmed">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length" draft="unconfirmed">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial" draft="unconfirmed">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence" draft="unconfirmed">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -1452,7 +1452,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -1273,7 +1273,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -1289,7 +1289,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -1562,7 +1562,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -1069,7 +1069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -1121,7 +1121,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -9486,7 +9486,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<personNames>
 		<nameOrderLocales order="givenFirst">und fo</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst">↑↑↑</nameOrderLocales>
-		<nativeSpaceReplacement>↑↑↑</nativeSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<sampleName item="nativeG">
 			<nameField type="given">Mia</nameField>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -1562,7 +1562,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -8292,8 +8292,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst" draft="unconfirmed">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality" draft="unconfirmed">informal</parameterDefault>
 		<parameterDefault parameter="length" draft="unconfirmed">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial" draft="unconfirmed">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence" draft="unconfirmed">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -8361,8 +8361,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst" draft="unconfirmed">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality" draft="unconfirmed">informal</parameterDefault>
 		<parameterDefault parameter="length" draft="unconfirmed">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial" draft="unconfirmed">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence" draft="unconfirmed">{0}{1}</initialPattern>
 		<sampleName item="nativeG">

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -1497,7 +1497,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -1039,7 +1039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -1436,7 +1436,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -1247,7 +1247,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -1327,7 +1327,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -1308,7 +1308,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -1431,7 +1431,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ii.xml
+++ b/common/main/ii.xml
@@ -655,8 +655,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<defaultNumberingSystem draft="contributed">↑↑↑</defaultNumberingSystem>
 		<!-- <otherNumberingSystems>
-			<native draft="contributed">yiii</native>
-		</otherNumberingSystems> -->
+			 <native draft="contributed">yiii</native>
+			 </otherNumberingSystems>
+		-->
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
 			<group>↑↑↑</group>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -1195,7 +1195,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -1423,7 +1423,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -1427,7 +1427,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -971,7 +971,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -1246,7 +1246,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/kk_Arab.xml
+++ b/common/main/kk_Arab.xml
@@ -9937,8 +9937,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst" draft="unconfirmed">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality" draft="unconfirmed">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length" draft="unconfirmed">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial" draft="unconfirmed">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence" draft="unconfirmed">↑↑↑</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -1349,7 +1349,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -987,7 +987,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -1398,7 +1398,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -1201,7 +1201,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -1313,7 +1313,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -1224,7 +1224,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -1324,7 +1324,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -1022,7 +1022,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -437,7 +437,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="unconfirmed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="unconfirmed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="unconfirmed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="unconfirmed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="unconfirmed">↑↑↑</parseLenient>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -1169,7 +1169,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">[₹ ₨ {ଟ.} {ଟଙ୍କା} {Rp} {Rs}]</parseLenient>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -1005,7 +1005,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/pap.xml
+++ b/common/main/pap.xml
@@ -1820,8 +1820,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="givenFirst" draft="unconfirmed">und pap</nameOrderLocales>
 		<nameOrderLocales order="surnameFirst" draft="unconfirmed">↑↑↑</nameOrderLocales>
 		<parameterDefault parameter="formality" draft="unconfirmed">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve" draft="unconfirmed">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial" draft="unconfirmed">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence" draft="unconfirmed">{0}{1}</initialPattern>
 		<personName order="givenFirst" length="long" usage="referring" formality="formal">

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -9265,7 +9265,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<nameOrderLocales order="surnameFirst">ko si ta te vi yue zh</nameOrderLocales>
 		<parameterDefault parameter="formality">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement>↑↑↑</nativeSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
 		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">{0}{1}</initialPattern>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -1399,7 +1399,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -979,7 +979,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -1304,7 +1304,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -1447,7 +1447,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -1370,7 +1370,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -1184,7 +1184,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -1276,7 +1276,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">[₹ ₨ {Rs}]</parseLenient>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -1185,7 +1185,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -1256,7 +1256,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -1244,7 +1244,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -1069,7 +1069,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -522,7 +522,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -1231,7 +1231,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -1429,7 +1429,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -978,7 +978,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -1517,7 +1517,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<parseLenient sample="%" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="‰" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₩" draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -1330,7 +1330,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -8496,8 +8496,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<personNames>
 		<parameterDefault parameter="formality">↑↑↑</parameterDefault>
 		<parameterDefault parameter="length">↑↑↑</parameterDefault>
-		<nativeSpaceReplacement>↑↑↑</nativeSpaceReplacement>
-		<foreignSpaceReplacement>↑↑↑</foreignSpaceReplacement>
+		<nativeSpaceReplacement xml:space="preserve">↑↑↑</nativeSpaceReplacement>
+		<foreignSpaceReplacement xml:space="preserve">↑↑↑</foreignSpaceReplacement>
 		<initialPattern type="initial">↑↑↑</initialPattern>
 		<initialPattern type="initialSequence">↑↑↑</initialPattern>
 	</personNames>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -1392,7 +1392,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -1243,7 +1243,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<parseLenients scope="general" level="lenient">
 			<parseLenient sample="." draft="contributed">↑↑↑</parseLenient>
 			<parseLenient sample="$" draft="contributed">↑↑↑</parseLenient>
-			<parseLenient sample="£" draft="contributed">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£" draft="contributed">[£￡ ₤]</parseLenient>
 			<parseLenient sample="₹" draft="contributed">↑↑↑</parseLenient>
 		</parseLenients>
 		<parseLenients scope="number" level="lenient">

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -1462,7 +1462,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<parseLenient sample="%">↑↑↑</parseLenient>
 			<parseLenient sample="‰">↑↑↑</parseLenient>
 			<parseLenient sample="$">↑↑↑</parseLenient>
-			<parseLenient sample="£">[£ ￡ ₤]</parseLenient>
+			<parseLenient sample="£">[£￡ ₤]</parseLenient>
 			<parseLenient sample="¥">↑↑↑</parseLenient>
 			<parseLenient sample="₩">↑↑↑</parseLenient>
 			<parseLenient sample="₹">↑↑↑</parseLenient>

--- a/common/main/zh_Latn.xml
+++ b/common/main/zh_Latn.xml
@@ -16,9 +16,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<script type="Latn"/>
 	</identity>
 	<characters>
-		<exemplarCharacters>[a-uw-zàáè-êìíòóùúüāĉēěīńňŋōŝūǎǐǒǔǖǘǚǜǹḿẑếề{m̀}{m̄}{ê̄}{ê̌}]</exemplarCharacters>
+		<exemplarCharacters>[aáàǎā b cĉ d eéèêếề{ê̌}{ê̄}ěē f g h iíìǐī j k l mḿ{m̀}{m̄} nńǹň ŋ oóòǒō p q r sŝ t uúùǔüǘǜǚǖū w x y zẑ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[v]</exemplarCharacters>
-		<exemplarCharacters type="numbers">[0-9]</exemplarCharacters>
-		<exemplarCharacters type="punctuation">[. , \- ' · &quot; ! ?]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[\- ‑ , ! ? . · ' &quot;]</exemplarCharacters>
 	</characters>
 </ldml>


### PR DESCRIPTION
CLDR-17832

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17832)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

The replaces the now-closed earlier PR [#3900](https://github.com/unicode-org/cldr/pull/3900).

CLDRModify passes before alpha0:

1. With no arguments: In personName data, add xml:space="preserve" where necessary.
2. With -fP: In main, reformat parseLenient sets, zh_Latn exemplars; in annotations, reorder en annotations.

Note that the -fQ pass was explicitly skipped per Mark comment on earlier PR: " I don't think we should add the tts names to the keywords, unless the keywords are empty, because it works against the guidance that people should break up the search keywords by word where possible...I suggest that we hold off adding the tts name, and just do the daip (which reorders)".

**Note: This should be merged with a Rebase merge (temporarily enable in Settings), not a Squash merge.**

ALLOW_MANY_COMMITS=true
