### PR TITLE
CLDR-17675 Revert change in en_ZA

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -2042,7 +2042,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT decimal ( #PCDATA ) >
 <!ATTLIST decimal alt NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/variant-->
+    <!--@MATCH:literal/variant, us, official-->
 <!ATTLIST decimal draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED:true, false-->
@@ -2053,7 +2053,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT group ( #PCDATA ) >
 <!ATTLIST group alt NMTOKENS #IMPLIED >
-    <!--@MATCH:literal/variant-->
+    <!--@MATCH:literal/variant, us, official-->
 <!ATTLIST group draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED:true, false-->

--- a/common/main/en_ZA.xml
+++ b/common/main/en_ZA.xml
@@ -238,9 +238,20 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</dates>
 	<numbers>
 		<symbols numberSystem="latn">
-			<decimal>↑↑↑</decimal>
-			<group>↑↑↑</group>
+			<decimal>,</decimal> 
+			<decimal alt="official">,</decimal>
+			<decimal alt="us">.</decimal>
+			<group> </group>
+			<group alt="official"> </group>
+			<group alt="us">,</group>
 		</symbols>
+		<currencyFormats numberSystem="latn">
+			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">¤#,##0.00</pattern>
+				</currencyFormat>
+			</currencyFormatLength>
+		</currencyFormats>
 		<currencies>
 			<currency type="ZAR">
 				<symbol>R</symbol>


### PR DESCRIPTION
New PR, replacing https://github.com/unicode-org/cldr/pull/3908
----
[CLDR-17675](https://unicode-org.atlassian.net/browse/CLDR-17675)

Revert the decimal/grouping change, but add alts to allow implementations to choose between official and us variant.

From the discussion in the Design meeting, we agreed on 2 variants, plus the default, as the normal pattern. That allows implementations to pick among the two choices by name — without having to know which was the default — or pick the default. People are also in favor of using semantic alt names, rather than just 'variant'.

Still draft because I want to pass this by the TC; there were a couple of things I wanted to get feedback on.

I think the decision was to go with the official syntax (12,34) for the default, but wanted feedback.
For the US style, I used alt="us", as probably the most recognizable term. But other suggestions are welcome. (Perhaps alt="period"?)

The ticket also mentioned R5,87 as the standard currency format, eg no space between currency alphabetics and the digits. That is in place also.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true


[CLDR-17675]: https://unicode-org.atlassian.net/browse/CLDR-17675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ