### PR TITLE
CLDR-17844 Modify the date report

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/BidiUtils.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/BidiUtils.java
@@ -1,0 +1,162 @@
+package org.unicode.cldr.util;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import com.ibm.icu.text.Bidi;
+import com.ibm.icu.text.UnicodeSet;
+import com.ibm.icu.text.UnicodeSet.SpanCondition;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * A set of utilities for handling BIDI, especially in charts and examples but not restricted to
+ * that.
+ */
+public class BidiUtils {
+    public static final String ALERT = "⚠️";
+    static final String LRM = CodePointEscaper.LRM.getString();
+
+    // These are intended to be classes of characters that "stick together in order"
+    // The initial focus is dates, so this will probably need to be expanded for numbers; might need
+    // more syntax
+
+    private enum SpanClass {
+        NUMBERS("\\p{N}"),
+        LETTERS_MARKS("[\\p{L}\\p{M}]"),
+        DATE_PUNCT("[+]"),
+        SPACES("\\p{Z}"),
+        OTHERS("\\p{any}") // must be last, to pick up remainder.
+    ;
+        final UnicodeSet uset;
+
+        private SpanClass(String unicodeSetSource) {
+            uset = new UnicodeSet(unicodeSetSource);
+        }
+
+        static {
+            // clean up by removing previous values
+            UnicodeSet soFar = new UnicodeSet();
+            for (SpanClass sc : SpanClass.values()) {
+                sc.uset.removeAll(soFar).freeze();
+                soFar.addAll(sc.uset);
+            }
+        }
+    }
+    /**
+     * Checks the ordering of the example, under the specified bidiDirectionOptions;
+     *
+     * @param example Source text, not HTMLified
+     * @param outputReorderedResults One string for each specified bidiDirectionOption
+     * @param bidiDirectionOptions an array of BIDI directions from com.ibm.icu.text.Bidi. if there
+     *     are no items, the default is DIRECTION_DEFAULT_LEFT_TO_RIGHT (dir="auto"),
+     *     DIRECTION_RIGHT_TO_LEFT (dir="rtl").
+     * @return true unless two or more of the resulting strings are different.
+     */
+    public static boolean isOrderingUnchanged(
+            String example, List<String> outputReorderedResults, int... bidiDirectionOptions) {
+        boolean hasList = outputReorderedResults != null;
+        if (!hasList) {
+            outputReorderedResults = new ArrayList<>();
+        } else {
+            outputReorderedResults.clear();
+        }
+        boolean result = true;
+        for (int count = 0; count < bidiDirectionOptions.length; ++count) {
+            String reordered = new Bidi(example, bidiDirectionOptions[count]).writeReordered(0);
+            outputReorderedResults.add(reordered);
+            if (result && count != 0 && !reordered.equals(outputReorderedResults.get(0))) {
+                result = false;
+                if (!hasList) {
+                    break; // if the output results are not needed, then stop.
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Return a list of the , where each span is a sequence of:
+     *
+     * @param orderedLTR
+     * @return
+     */
+    /**
+     * Gets the 'fields' in a formatted string, used to test whether bidi reordering causes the
+     * original fields to merge when reordered. Each field is the longest contiguous span of
+     * characters with the same properties: *
+     *
+     * <ul>
+     *   <li>numbers (\p{N})
+     *   <li>letters & marks ([\p{L}\p{M}
+     *   <li>Other
+     * </ul>
+     *
+     * @param ordered
+     * @return a set of fields, in the same order as found in the text but duplicates removed (ike
+     *     LinkedHashSeet).
+     */
+    public static Set<String> getFields(String reordred, Set<String> result) {
+        int start = 0;
+        while (start < reordred.length()) {
+            for (SpanClass sc : SpanClass.values()) {
+                int end = sc.uset.span(reordred, start, SpanCondition.CONTAINED);
+                if (end != start) {
+                    result.add(reordred.substring(start, end));
+                    start = end;
+                    break;
+                }
+            }
+        }
+        return ImmutableSet.copyOf(result);
+    }
+
+    /**
+     * Show when the fields in strings are different
+     *
+     * @param bidiReordereds
+     * @return
+     */
+    public static String getAlert(List<String> bidiReordereds) {
+        Set<Set<String>> results = new LinkedHashSet<>();
+        for (String bidiReordered : bidiReordereds) {
+            Set<String> fieldsLTR = BidiUtils.getFields(bidiReordered, new TreeSet<>());
+            results.add(fieldsLTR);
+        }
+        if (results.size() < 2) {
+            return "";
+        }
+        // there can still be differences within a field of OTHERS, that we  ignore.
+        // EG ⚠️ 20,28,2B; 2B,28,20 " (+" vs " (+"
+
+        // show just the difference in the first 2, for now.
+        Iterator<Set<String>> it = results.iterator();
+        Set<String> first = it.next();
+        Set<String> second = it.next();
+        SetView<String> uniqueFirst = Sets.difference(first, second);
+        SetView<String> uniqueSecond = Sets.difference(second, first);
+        return ALERT + " " + escape(uniqueFirst) + "; " + escape(uniqueSecond);
+    }
+
+    public static String escape(Set<String> uniqueFirst) {
+        return uniqueFirst.stream()
+                .map(x -> CodePointEscaper.toEscaped(x))
+                .collect(Collectors.joining(LRM + ", " + LRM, LRM, LRM));
+    }
+
+    public static String alphagram(String string) {
+        return string.codePoints()
+                .sorted()
+                .collect(
+                        StringBuilder::new, // Supplier<R> supplier
+                        StringBuilder::appendCodePoint, // ObjIntConsumer<R> accumulator
+                        StringBuilder::append // BiConsumer<R,​R> combiner
+                        )
+                .toString();
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -2,6 +2,7 @@ package org.unicode.cldr.util;
 
 import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.lang.UCharacter;
+import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import java.util.Locale;
 
@@ -19,10 +20,13 @@ public enum CodePointEscaper {
     LF(0xA, "line feed"),
     CR(0xD, "carriage return"),
     SP(0x20, "space", "ASCII space"),
-    NSP(0x2009, "narrow/thin space", "Also known as ‘thin space’"),
+    TSP(0x2009, "thin space", "Aka ‘narrow space’"),
     NBSP(0xA0, "no-break space", "Same as space, but doesn’t line wrap."),
 
-    NNBSP(0x202F, "narrow/thin no-break space", "Same as narrow space, but doesn’t line wrap."),
+    NBTSP(
+            0x202F,
+            "no-break thin space",
+            "Same as thin space, but doesn’t line wrap. Aka 'narrow no-break space'"),
 
     WNJ(
             0x200B,
@@ -147,6 +151,11 @@ public enum CodePointEscaper {
         return codePoint;
     }
 
+    /** Return the string form of the code point for this character. */
+    public String getString() {
+        return UTF16.valueOf(codePoint);
+    }
+
     /** Returns the escaped form from the code point for this enum */
     public String codePointToEscaped() {
         return ESCAPE_START + rawCodePointToEscaped(codePoint) + ESCAPE_END;
@@ -196,6 +205,15 @@ public enum CodePointEscaper {
                         });
         return result.toString();
     }
+
+    public static String getEscaped(int cp, UnicodeSet toEscape) {
+        if (!toEscape.contains(cp)) {
+            return UTF16.valueOf(cp);
+        } else {
+            return codePointToEscaped(cp);
+        }
+    }
+
     /** Return unescaped string */
     public static String toUnescaped(String escaped) {
         if (escaped == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -90,13 +90,14 @@ public class DateTimeFormats {
     private static final UnicodeSet BIDI_MARKS = new UnicodeSet("[:Bidi_Control:]").freeze();
 
     private static final String ltrBackground = "background-color:#EEE;";
-    private static final String tableBackground = " background-color:#DDF;";
+    private static final String tableBackground = "background-color:#DDF; border: 1px solid blue;";
 
     private static final String rtlStart = "<div dir='rtl'>";
-    private static final String ltrStart = "<div dir='ltr' style='" + ltrBackground + "'>";
+    private static final String autoLtrStart = "<div dir='auto' style='" + ltrBackground + "'>";
+    private static final String autoStart = "<div dir='auto'>";
     private static final String divEnd = "</div>";
     private static final String tableStyle =
-            "style='border-collapse: collapse;" + tableBackground + " margin: auto'";
+            "style='border-collapse: collapse;" + tableBackground + " margin: auto'"; //
 
     private static final String ltrSpan = "<span style='" + ltrBackground + "'>";
     private static final String tableSpan = "<span style='" + tableBackground + "'>";
@@ -522,8 +523,8 @@ public class DateTimeFormats {
                                     ? ""
                                     : "However, two examples are provided if the locale is right-to-left, like Arabic or Hebrew, "
                                             + "<i>and</i> the paragraph direction can cause a different display. "
-                                            + "The first has a RTL paragraph direction, "
-                                            + "while the second has a LTR paragraph direction "
+                                            + "The first has a <b>RTL</b> paragraph direction, "
+                                            + "while the second has a <b>auto</b> paragraph direction (LTR unless the first 'strong' character is RTL) "
                                             + ltrSpan
                                             + "<i>and</i> a different background"
                                             + spanEnd
@@ -663,18 +664,21 @@ public class DateTimeFormats {
         }
         String transformedExample = TransliteratorUtilities.toHTML.transform(example);
         if ((isRTL || BIDI_MARKS.containsSome(example)) && !example.contains(MISSING_PART)) {
-            Bidi bidiLTR = new Bidi(example, Bidi.DIRECTION_LEFT_TO_RIGHT);
+            Bidi bidiLTR = new Bidi(example, Bidi.DIRECTION_DEFAULT_LEFT_TO_RIGHT);
             String orderedLTR = bidiLTR.writeReordered(0);
             Bidi bidiRTL = new Bidi(example, Bidi.DIRECTION_RIGHT_TO_LEFT);
             String orderedRTL = bidiRTL.writeReordered(0);
             if (!orderedLTR.equals(orderedRTL)) {
                 // since this is RTL, we put it first
-                String rtlVersion = rtlStart + transformedExample + divEnd;
-                String ltrVersion = ltrStart + transformedExample + divEnd; // colored
+                String rtlVersion = rtlStart + transformedExample + divEnd; // not colored
+                String autoVersion = autoLtrStart + transformedExample + divEnd; // colored
                 Set<String> fieldsLTR = getFields(orderedLTR);
                 Set<String> fieldsRTL = getFields(orderedRTL);
                 String alert = fieldsLTR.equals(fieldsRTL) ? "" : " ⚠️ ";
-                transformedExample = rtlVersion + ltrVersion + alert;
+                transformedExample = rtlVersion + autoVersion + alert;
+            } else {
+                String autoVersion = autoStart + transformedExample + divEnd; // not colored
+                transformedExample = autoVersion;
             }
         }
 


### PR DESCRIPTION
CLDR-17844

Modify the date report to help figure out what is happening with the date formats, and present the user with more and clearer information.

- Added BidiUtils with utilities for display of examples/reports
- Small changes to CodePointEscaper, plus support for printing a table of escape IDs in a report.
- DateTypeFormats
    - General cleanup
    - Add a paragraph of text underneath **Patterns** to explain the format. Clarify that this is for the default number system, and explain more about the format
    - In an RTL language there may be two examples, the top one is the dir=<locale-direction>, and second is dir=auto with a distinct background. This allows vetters to see the contrast, and correct if important.
    - Add a line showing the escaped text
    - Add a warning when the reordering causes numbers or words to collide (all items currently pass)
    - If there are any escaped characters in any cell, print a Key at the end for those characters.
    - In the options for running manually, if there is a filter, then it is used; otherwise the locales are filtered to just the availableLanguages (for the charts).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
