### PR TITLE
CLDR-17857 add whole-locale warning for missing English name

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -936,7 +936,8 @@ public abstract class CheckCLDR implements CheckAccessor {
             shortDateFieldInconsistentLength,
             illegalParameterValue,
             illegalAnnotationCode,
-            illegalCharacter;
+            illegalCharacter,
+            missingEnglishName;
 
             @Override
             public String toString() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCoverage.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
+import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.InternalCldrException;
 import org.unicode.cldr.util.LanguageTagParser;
@@ -156,6 +157,25 @@ public class CheckCoverage extends FactoryCheckCLDR {
 
         setSkipTest(false);
         latin = ValuePathStatus.isLatinScriptLocale(cldrFileToCheck);
+
+        // check whether the English name is present. See {@link
+        // LikelySubtagsTest#TestMissingInfoForLanguage}
+        {
+            final CLDRLocale locale = CLDRLocale.getInstance(localeID);
+            String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, locale.getLanguage());
+            // getEnglishFile() returns a resolved file, so just check isHere.
+            boolean englishName = getEnglishFile().isHere(path);
+            if (!englishName) {
+                possibleErrors.add(
+                        new CheckStatus()
+                                .setCause(this)
+                                .setMainType(CheckStatus.warningType)
+                                .setSubtype(Subtype.missingEnglishName)
+                                .setMessage(
+                                        "Missing English translation for " + locale.getLanguage(),
+                                        new Object[] {}));
+            }
+        }
 
         return this;
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -340,12 +340,7 @@ public class LikelySubtagsTest extends TestFmwk {
             if (englishName == null) {
                 Level covLevel = ccl.getEffectiveCoverageLevel(language);
                 if (covLevel == null || !covLevel.isAtLeast(Level.BASIC)) {
-                    // https://unicode-org.atlassian.net/browse/CLDR-15663
-                    if (logKnownIssue(
-                            "CLDR-15663",
-                            "English translation should not be required for sub-basic language name")) {
-                        continue; // skip error
-                    }
+                    continue; // skip error if locale is not at least basic. (null means sub-basic)
                 }
                 errln("Missing English translation for: " + language + " which is at " + covLevel);
             }


### PR DESCRIPTION
- warning, not error, otherwise we'd block builds!
- new subtype missingEnglishName
- also remove LogKnownIssues for CLDR-15663

CLDR-17857

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
