### PR TITLE
CLDR-17852 fix characters in ak.xml

### DIFF
--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -21,7 +21,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ak">Akan</language>
 			<language type="am">Amarik</language>
 			<language type="ar">Arabeke</language>
-			<language type="ar_001">Arabeke Kasa Nhyehyԑeԑ Foforͻ</language>
+			<language type="ar_001">Arabeke Kasa Nhyehyɛeɛ Foforɔ</language>
 			<language type="as">Asamese</language>
 			<language type="ast">Asturiani</language>
 			<language type="az">Asabegyanni</language>
@@ -46,16 +46,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="de">Gyaaman</language>
 			<language type="de_AT">Ɔstria Gyaaman</language>
 			<language type="de_CH">Swisalande Gyaaman</language>
-			<language type="doi">Dͻgri</language>
-			<language type="dsb">Sͻͻbia a ԑwͻ fam</language>
+			<language type="doi">Dɔgri</language>
+			<language type="dsb">Sɔɔbia a ɛwɔ fam</language>
 			<language type="el">Greek kasa</language>
 			<language type="en">Borɔfo</language>
 			<language type="en_AU">↑↑↑</language>
 			<language type="en_CA">↑↑↑</language>
-			<language type="en_GB">Ngresi Borͻfo</language>
-			<language type="en_GB" alt="short">Ngresi Borͻfo</language>
-			<language type="en_US">Amԑrika Borͻfo</language>
-			<language type="en_US" alt="short">Amԑrika Borͻfo</language>
+			<language type="en_GB">Ngresi Borɔfo</language>
+			<language type="en_GB" alt="short">Ngresi Borɔfo</language>
+			<language type="en_US">Amɛrika Borɔfo</language>
+			<language type="en_US" alt="short">Amɛrika Borɔfo</language>
 			<language type="eo">Esperanto</language>
 			<language type="es">Spain kasa</language>
 			<language type="es_419">Spain kasa (Laaten Amɛrika)</language>
@@ -69,8 +69,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="fil">Filipin kasa</language>
 			<language type="fo">Farosi</language>
 			<language type="fr">Frɛnkye</language>
-			<language type="fr_CA">Kanada Frԑnkye</language>
-			<language type="fr_CH">Swisalande Frԑnkye</language>
+			<language type="fr_CA">Kanada Frɛnkye</language>
+			<language type="fr_CH">Swisalande Frɛnkye</language>
 			<language type="fy">Atɔeɛ Fam Frihyia Kasa</language>
 			<language type="ga">Aerelande kasa</language>
 			<language type="gd">Skotlandfoɔ Galek Kasa</language>
@@ -79,8 +79,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ha">Hausa</language>
 			<language type="he">Hibri kasa</language>
 			<language type="hi">Hindi</language>
-			<language type="hi_Latn">Laatenfoͻ Hindi</language>
-			<language type="hi_Latn" alt="variant">Hindibrͻfo</language>
+			<language type="hi_Latn">Laatenfoɔ Hindi</language>
+			<language type="hi_Latn" alt="variant">Hindibrɔfo</language>
 			<language type="hr">Kurowehyia kasa</language>
 			<language type="hsb">Atifi fam Sɔɔbia Kasa</language>
 			<language type="hu">Hangri kasa</language>
@@ -93,7 +93,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="it">Italy kasa</language>
 			<language type="ja">Gyapan kasa</language>
 			<language type="jv">Gyabanis kasa</language>
-			<language type="ka">Gyͻͻgyia kasa</language>
+			<language type="ka">Gyɔɔgyia kasa</language>
 			<language type="kea">Kabuvadianu</language>
 			<language type="kgp">Kaingang</language>
 			<language type="kk">kasaki kasa</language>
@@ -101,11 +101,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="kn">Kanada</language>
 			<language type="ko">Korea kasa</language>
 			<language type="kok">Konkani kasa</language>
-			<language type="ks">Kahyimiԑ</language>
-			<language type="ku">Kԑԑde kasa</language>
+			<language type="ks">Kahyimiɛ</language>
+			<language type="ku">Kɛɛde kasa</language>
 			<language type="kxv">Kuvi kasa</language>
-			<language type="ky">Kԑgyese kasa</language>
-			<language type="lb">Lͻsimbͻge kasa</language>
+			<language type="ky">Kɛgyese kasa</language>
+			<language type="lb">Lɔsimbɔge kasa</language>
 			<language type="lij">Liguria kasa</language>
 			<language type="lmo">Lombad kasa</language>
 			<language type="lo">Lawo kasa</language>
@@ -113,33 +113,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="lv">Latvia kasa</language>
 			<language type="mai">Maetili</language>
 			<language type="mi">Mawori</language>
-			<language type="mk">Mԑsidonia kasa</language>
+			<language type="mk">Mɛsidonia kasa</language>
 			<language type="ml">Malayalam kasa</language>
-			<language type="mn">Mongoliafoͻ kasa</language>
+			<language type="mn">Mongoliafoɔ kasa</language>
 			<language type="mni">Manipuri</language>
 			<language type="mr">Marati</language>
 			<language type="ms">Malay kasa</language>
 			<language type="mt">Malta kasa</language>
-			<language type="mul">Kasa ahodoͻ</language>
+			<language type="mul">Kasa ahodoɔ</language>
 			<language type="my">Bɛɛmis kasa</language>
-			<language type="nds">Gyaaman kasa a ԑwͻ fam</language>
+			<language type="nds">Gyaaman kasa a ɛwɔ fam</language>
 			<language type="ne">Nɛpal kasa</language>
 			<language type="nl">Dɛɛkye</language>
-			<language type="nl_BE">Dԑԑkye (Bԑԑgyiͻm</language>
-			<language type="nn">Nͻwefoͻ Ninͻso</language>
-			<language type="no">Nͻwefoͻ kasa</language>
+			<language type="nl_BE">Dɛɛkye (Bɛɛgyiɔm</language>
+			<language type="nn">Nɔwefoɔ Ninɔso</language>
+			<language type="no">Nɔwefoɔ kasa</language>
 			<language type="nqo">Nko</language>
 			<language type="oc">Osita kasa</language>
 			<language type="or">Odia</language>
 			<language type="pa">Pungyabi kasa</language>
-			<language type="pcm">Nigeriafoͻ Pigyin</language>
+			<language type="pcm">Nigeriafoɔ Pigyin</language>
 			<language type="pl">Pɔland kasa</language>
 			<language type="prg">Prusia kasa</language>
 			<language type="ps">Pahyito</language>
 			<language type="pt">Pɔɔtugal kasa</language>
 			<language type="pt_BR">↑↑↑</language>
 			<language type="pt_PT">↑↑↑</language>
-			<language type="qu">Kwԑkya</language>
+			<language type="qu">Kwɛkya</language>
 			<language type="raj">Ragyasitan kasa</language>
 			<language type="rm">Romanhye kasa</language>
 			<language type="ro">Romenia kasa</language>
@@ -155,7 +155,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="sl">Slovɛniafoɔ Kasa</language>
 			<language type="so">Somalia kasa</language>
 			<language type="sq">Aabeniani</language>
-			<language type="sr">Sԑbia Kasa</language>
+			<language type="sr">Sɛbia Kasa</language>
 			<language type="su">Sunda Kasa</language>
 			<language type="sv">Sweden kasa</language>
 			<language type="sw">Swahili</language>
@@ -163,7 +163,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="szl">Silesiafoɔ Kasa</language>
 			<language type="ta">Tamil kasa</language>
 			<language type="te">Telugu</language>
-			<language type="tg">Tԑgyeke kasa</language>
+			<language type="tg">Tɛgyeke kasa</language>
 			<language type="th">Taeland kasa</language>
 			<language type="ti">Tigrinya kasa</language>
 			<language type="tk">Tɛkmɛnistan Kasa</language>
@@ -174,7 +174,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="uk">Ukren kasa</language>
 			<language type="und">kasa a yɛnnim</language>
 			<language type="ur">Urdu kasa</language>
-			<language type="uz">Usbԑkistan Kasa</language>
+			<language type="uz">Usbɛkistan Kasa</language>
 			<language type="vec">Vɛnihyia Kasa</language>
 			<language type="vi">Viɛtnam kasa</language>
 			<language type="vmw">Makuwa</language>
@@ -188,8 +188,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="za">Zuang</language>
 			<language type="zh">Kyaena kasa</language>
 			<language type="zh" alt="menu">Madarin, Kyaena kasa</language>
-			<language type="zh_Hans">Kyaena kasa a emu yԑ mmrԑ</language>
-			<language type="zh_Hans" alt="long">Mandarin Kyaena kasa a emu yԑ mmrԑ</language>
+			<language type="zh_Hans">Kyaena kasa a emu yɛ mmrɛ</language>
+			<language type="zh_Hans" alt="long">Mandarin Kyaena kasa a emu yɛ mmrɛ</language>
 			<language type="zh_Hant">Tete Kyaena kasa</language>
 			<language type="zh_Hant" alt="long">Tete Mandarin Kyaena kasa</language>
 			<language type="zu">Zulu</language>
@@ -202,14 +202,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Armn">Amenia kasa</script>
 			<script type="Beng">Bangala kasa</script>
 			<script type="Bopo">Bopomofo kasa</script>
-			<script type="Brai">Anifrafoͻ kasa</script>
+			<script type="Brai">Anifrafoɔ kasa</script>
 			<script type="Cakm">Kyakma kasa</script>
-			<script type="Cans">Kanadafoͻ Kann Kasa a Wͻakeka Abom</script>
+			<script type="Cans">Kanadafoɔ Kann Kasa a Wɔakeka Abom</script>
 			<script type="Cher">Kɛroki</script>
 			<script type="Cyrl">Kreleke</script>
-			<script type="Deva">Dԑvanagari kasa</script>
+			<script type="Deva">Dɛvanagari kasa</script>
 			<script type="Ethi">Yitiopia kasa</script>
-			<script type="Geor">Dwͻͻgyia kasa</script>
+			<script type="Geor">Dwɔɔgyia kasa</script>
 			<script type="Grek">Griiki kasa</script>
 			<script type="Gujr">Gudwurati kasa</script>
 			<script type="Guru">Gurumuki kasa</script>
@@ -222,9 +222,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Hant" alt="stand-alone">Tete Kyaena Kasa Hanse</script>
 			<script type="Hebr">Hibri kasa</script>
 			<script type="Hira">Hiragana kasa</script>
-			<script type="Hrkt">Gyapanfoͻ selabolo kasa</script>
+			<script type="Hrkt">Gyapanfoɔ selabolo kasa</script>
 			<script type="Jamo">Gyamo kasa</script>
-			<script type="Jpan">Gyapanfoͻ kasa</script>
+			<script type="Jpan">Gyapanfoɔ kasa</script>
 			<script type="Kana">Katakana kasa</script>
 			<script type="Khmr">Kɛma kasa</script>
 			<script type="Knda">Kanada kasa</script>
@@ -232,7 +232,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Laoo">Lawo kasa</script>
 			<script type="Latn">Laatin</script>
 			<script type="Mlym">Malayalam kasa</script>
-			<script type="Mong">Mongoliafoͻ kasa</script>
+			<script type="Mong">Mongoliafoɔ kasa</script>
 			<script type="Mtei">Meeti Mayɛke kasa</script>
 			<script type="Mymr">Mayama kasa</script>
 			<script type="Nkoo">Nko kasa</script>
@@ -246,14 +246,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<script type="Telu">Telugu kasa</script>
 			<script type="Tfng">Tifinafo kasa</script>
 			<script type="Thaa">Taana kasa</script>
-			<script type="Thai">Taelanfoͻ kasa</script>
-			<script type="Tibt">Tibɛtanfoͻ kasa</script>
+			<script type="Thai">Taelanfoɔ kasa</script>
+			<script type="Tibt">Tibɛtanfoɔ kasa</script>
 			<script type="Vaii">Vai kasa</script>
-			<script type="Yiii">Yifoͻ kasa</script>
+			<script type="Yiii">Yifoɔ kasa</script>
 			<script type="Zmth">Nkontabudeɛ</script>
 			<script type="Zsye">Yimogyi</script>
 			<script type="Zsym">Ahyɛnsodeɛ</script>
-			<script type="Zxxx">Deɛ wͻntwerɛeɛ</script>
+			<script type="Zxxx">Deɛ wɔntwerɛeɛ</script>
 			<script type="Zyyy">obiara nim</script>
 			<script type="Zzzz">Deɛ yɛnnim</script>
 		</scripts>
@@ -261,35 +261,35 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="001">wiase</territory>
 			<territory type="002">Abibirem</territory>
 			<territory type="003">Amɛrika Atifi</territory>
-			<territory type="005">Amԑrika Anaafoͻ</territory>
+			<territory type="005">Amɛrika Anaafoɔ</territory>
 			<territory type="009">Osiana</territory>
-			<territory type="011">Abibirem Atͻeɛ Fam</territory>
-			<territory type="013">Amԑrika Mfimfini</territory>
+			<territory type="011">Abibirem Atɔeɛ Fam</territory>
+			<territory type="013">Amɛrika Mfimfini</territory>
 			<territory type="014">Abibirem Apueiɛ Fam</territory>
 			<territory type="015">Abibirem Atifi Fam</territory>
 			<territory type="017">Abibirem Mfimfini</territory>
-			<territory type="018">Abibirem Anaafoͻ Fam</territory>
-			<territory type="019">Amɛrikafoͻ</territory>
+			<territory type="018">Abibirem Anaafoɔ Fam</territory>
+			<territory type="019">Amɛrikafoɔ</territory>
 			<territory type="021">Amɛrika Atifi Fam</territory>
 			<territory type="029">Karibia</territory>
-			<territory type="030">Asia Apueiԑ</territory>
-			<territory type="034">Asia Anaafoͻ</territory>
-			<territory type="035">Asia Anaafoͻ Apuieԑ</territory>
-			<territory type="039">Yuropu Anaafoͻ</territory>
+			<territory type="030">Asia Apueiɛ</territory>
+			<territory type="034">Asia Anaafoɔ</territory>
+			<territory type="035">Asia Anaafoɔ Apuieɛ</territory>
+			<territory type="039">Yuropu Anaafoɔ</territory>
 			<territory type="053">Ɔstrelia ne Asia</territory>
 			<territory type="054">Melanesia</territory>
 			<territory type="057">Micronesia Mantam</territory>
-			<territory type="061">Pͻlenesia</territory>
+			<territory type="061">Pɔlenesia</territory>
 			<territory type="142">Asia</territory>
 			<territory type="143">Asia Mfimfini</territory>
-			<territory type="145">Asia Atͻeԑ</territory>
+			<territory type="145">Asia Atɔeɛ</territory>
 			<territory type="150">Yuropu</territory>
-			<territory type="151">Yuropu Apuieԑ</territory>
+			<territory type="151">Yuropu Apuieɛ</territory>
 			<territory type="154">Yuropu Atifi</territory>
-			<territory type="155">Yuropu Atͻeԑ</territory>
-			<territory type="202">Abibirem Mpaprɛ Anaafoͻ</territory>
+			<territory type="155">Yuropu Atɔeɛ</territory>
+			<territory type="202">Abibirem Mpaprɛ Anaafoɔ</territory>
 			<territory type="419">Laaten Amɛrika</territory>
-			<territory type="AC">Asԑnhyin</territory>
+			<territory type="AC">Asɛnhyin</territory>
 			<territory type="AD">Andora</territory>
 			<territory type="AE">United Arab Emirates</territory>
 			<territory type="AF">Afganistan</territory>
@@ -328,7 +328,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="BY">Bɛlarus</territory>
 			<territory type="BZ">Beliz</territory>
 			<territory type="CA">Kanada</territory>
-			<territory type="CC">Kokoso Supͻ</territory>
+			<territory type="CC">Kokoso Supɔ</territory>
 			<territory type="CD">Kongo Kinhyaahya</territory>
 			<territory type="CD" alt="variant">DR Kongo</territory>
 			<territory type="CF">Afrika Finimfin Man</territory>
@@ -347,22 +347,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="CU">Kuba</territory>
 			<territory type="CV">Kepvɛdfo Islands</territory>
 			<territory type="CW">Kurakaw</territory>
-			<territory type="CX">Buronya Supͻ</territory>
-			<territory type="CY">Saeprͻso</territory>
-			<territory type="CZ">Kyԑk</territory>
-			<territory type="CZ" alt="variant">Kyԑk Man</territory>
+			<territory type="CX">Buronya Supɔ</territory>
+			<territory type="CY">Saeprɔso</territory>
+			<territory type="CZ">Kyɛk</territory>
+			<territory type="CZ" alt="variant">Kyɛk Man</territory>
 			<territory type="DE">Gyaaman</territory>
-			<territory type="DG">Diԑgo Gaasia</territory>
+			<territory type="DG">Diɛgo Gaasia</territory>
 			<territory type="DJ">Gyibuti</territory>
 			<territory type="DK">Dɛnmak</territory>
 			<territory type="DM">Dɔmeneka</territory>
 			<territory type="DO">Dɔmeneka Man</territory>
 			<territory type="DZ">Ɔlgyeria</territory>
 			<territory type="EA">Ceuta ne Melilla</territory>
-			<territory type="EC">Yikuwedͻ</territory>
+			<territory type="EC">Yikuwedɔ</territory>
 			<territory type="EE">Ɛstonia</territory>
 			<territory type="EG">Misrim</territory>
-			<territory type="EH">Sahara Atͻeԑ</territory>
+			<territory type="EH">Sahara Atɔeɛ</territory>
 			<territory type="ER">Ɛritrea</territory>
 			<territory type="ES">Spain</territory>
 			<territory type="ET">Ithiopia</territory>
@@ -370,8 +370,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="EZ">Yuropu Fam</territory>
 			<territory type="FI">Finland</territory>
 			<territory type="FJ">Figyi</territory>
-			<territory type="FK">Fͻkman Aeland</territory>
-			<territory type="FK" alt="variant">Fͻkman Aeland (Islas Maivinas)</territory>
+			<territory type="FK">Fɔkman Aeland</territory>
+			<territory type="FK" alt="variant">Fɔkman Aeland (Islas Maivinas)</territory>
 			<territory type="FM">Maekronehyia</territory>
 			<territory type="FO">Faro Aeland</territory>
 			<territory type="FR">Franse</territory>
@@ -381,7 +381,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="GD">Grenada</territory>
 			<territory type="GE">Gyɔgyea</territory>
 			<territory type="GF">Frɛnkye Gayana</territory>
-			<territory type="GG">Guԑnse</territory>
+			<territory type="GG">Guɛnse</territory>
 			<territory type="GH">Gaana</territory>
 			<territory type="GI">Gyebralta</territory>
 			<territory type="GL">Greenman</territory>
@@ -390,14 +390,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="GP">Guwadelup</territory>
 			<territory type="GQ">Gini Ikuweta</territory>
 			<territory type="GR">Greekman</territory>
-			<territory type="GS">Gyͻͻgyia Anaafoͻ ne Sandwich Aeland Anaafoͻ</territory>
+			<territory type="GS">Gyɔɔgyia Anaafoɔ ne Sandwich Aeland Anaafoɔ</territory>
 			<territory type="GT">Guwatemala</territory>
 			<territory type="GU">Guam</territory>
 			<territory type="GW">Gini Bisaw</territory>
 			<territory type="GY">Gayana</territory>
-			<territory type="HK">Hͻnkͻn Kyaena</territory>
-			<territory type="HK" alt="short">Hͻnkͻn</territory>
-			<territory type="HM">Heard ne McDonald Supͻ</territory>
+			<territory type="HK">Hɔnkɔn Kyaena</territory>
+			<territory type="HK" alt="short">Hɔnkɔn</territory>
+			<territory type="HM">Heard ne McDonald Supɔ</territory>
 			<territory type="HN">Hɔnduras</territory>
 			<territory type="HR">Krowehyia</territory>
 			<territory type="HT">Heiti</territory>
@@ -415,7 +415,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="IR">Iran</territory>
 			<territory type="IS">Aesland</territory>
 			<territory type="IT">Itali</territory>
-			<territory type="JE">Gyԑsi</territory>
+			<territory type="JE">Gyɛsi</territory>
 			<territory type="JM">Gyameka</territory>
 			<territory type="JO">Gyɔdan</territory>
 			<territory type="JP">Gyapan</territory>
@@ -426,7 +426,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="KM">Kɔmɔrɔs</territory>
 			<territory type="KN">Saint Kitts ne Nɛves</territory>
 			<territory type="KP">Korea Atifi</territory>
-			<territory type="KR">Korea Anaafoͻ</territory>
+			<territory type="KR">Korea Anaafoɔ</territory>
 			<territory type="KW">Kuweti</territory>
 			<territory type="KY">Kemanfo Islands</territory>
 			<territory type="KZ">Kazakstan</territory>
@@ -438,7 +438,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="LR">Laeberia</territory>
 			<territory type="LS">Lesoto</territory>
 			<territory type="LT">Lituwenia</territory>
-			<territory type="LU">Lusimbԑg</territory>
+			<territory type="LU">Lusimbɛg</territory>
 			<territory type="LV">Latvia</territory>
 			<territory type="LY">Libya</territory>
 			<territory type="MA">Moroko</territory>
@@ -450,7 +450,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="MH">Mahyaa Aeland</territory>
 			<territory type="MK">Mesidonia Atifi</territory>
 			<territory type="ML">Mali</territory>
-			<territory type="MM">Mayaama (Bԑԑma)</territory>
+			<territory type="MM">Mayaama (Bɛɛma)</territory>
 			<territory type="MN">Mɔngolia</territory>
 			<territory type="MO">Makaw Kyaena</territory>
 			<territory type="MO" alt="short">Makaw</territory>
@@ -468,16 +468,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="NA">Namibia</territory>
 			<territory type="NC">Kaledonia Foforo</territory>
 			<territory type="NE">Nigyɛɛ</territory>
-			<territory type="NF">Norfold Supͻ</territory>
+			<territory type="NF">Norfold Supɔ</territory>
 			<territory type="NG">Naegyeria</territory>
 			<territory type="NI">Nekaraguwa</territory>
 			<territory type="NL">Nɛdɛland</territory>
 			<territory type="NO">Nɔɔwe</territory>
-			<territory type="NP">Nԑpal</territory>
+			<territory type="NP">Nɛpal</territory>
 			<territory type="NR">Naworu</territory>
 			<territory type="NU">Niyu</territory>
 			<territory type="NZ">Ziland Foforo</territory>
-			<territory type="NZ" alt="variant">Ziland Foforɔ a ԑwɔ Awotiarua</territory>
+			<territory type="NZ" alt="variant">Ziland Foforɔ a ɛwɔ Awotiarua</territory>
 			<territory type="OM">Oman</territory>
 			<territory type="PA">Panama</territory>
 			<territory type="PE">Peru</territory>
@@ -498,7 +498,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="QO">Osiana Ano Ano</territory>
 			<territory type="RE">Reyuniɔn</territory>
 			<territory type="RO">Romenia</territory>
-			<territory type="RS">Sԑbia</territory>
+			<territory type="RS">Sɛbia</territory>
 			<territory type="RU">Rɔhyea</territory>
 			<territory type="RW">Rewanda</territory>
 			<territory type="SA">Saudi Arabia</territory>
@@ -511,7 +511,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="SI">Slovinia</territory>
 			<territory type="SJ">Svalbard ne Jan Mayen</territory>
 			<territory type="SK">Slovakia</territory>
-			<territory type="SL">Sɛra Liͻn</territory>
+			<territory type="SL">Sɛra Liɔn</territory>
 			<territory type="SM">San Marino</territory>
 			<territory type="SN">Senegal</territory>
 			<territory type="SO">Somalia</territory>
@@ -532,7 +532,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TJ">Tagyikistan</territory>
 			<territory type="TK">Tokelau</territory>
 			<territory type="TL">Timɔ Boka</territory>
-			<territory type="TL" alt="variant">Timͻ Apueiԑ</territory>
+			<territory type="TL" alt="variant">Timɔ Apueiɛ</territory>
 			<territory type="TM">Tɛkmɛnistan</territory>
 			<territory type="TN">Tunihyia</territory>
 			<territory type="TO">Tonga</territory>
@@ -544,16 +544,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="TZ">Tansania</territory>
 			<territory type="UA">Ukren</territory>
 			<territory type="UG">Yuganda</territory>
-			<territory type="UM">U.S. Nkyԑnnkyԑn Supɔ Ahodoɔ</territory>
+			<territory type="UM">U.S. Nkyɛnnkyɛn Supɔ Ahodoɔ</territory>
 			<territory type="UN">Amansan Nkabomkuo</territory>
 			<territory type="US">Amɛrika</territory>
 			<territory type="US" alt="short">↑↑↑</territory>
 			<territory type="UY">Yurugwae</territory>
-			<territory type="UZ">Usbԑkistan</territory>
+			<territory type="UZ">Usbɛkistan</territory>
 			<territory type="VA">Vatican Man</territory>
 			<territory type="VC">Saint Vincent ne Grenadines</territory>
 			<territory type="VE">Venezuela</territory>
-			<territory type="VG">Ngresifoͻ Virgin Island</territory>
+			<territory type="VG">Ngresifoɔ Virgin Island</territory>
 			<territory type="VI">Amɛrika Virgin Islands</territory>
 			<territory type="VN">Viɛtnam</territory>
 			<territory type="VU">Vanuatu</territory>
@@ -562,93 +562,93 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="XA">Anto Kasa</territory>
 			<territory type="XB">Anto Bidi</territory>
 			<territory type="XK">Kosovo</territory>
-			<territory type="YE">Yԑmԑn</territory>
+			<territory type="YE">Yɛmɛn</territory>
 			<territory type="YT">Mayɔte</territory>
-			<territory type="ZA">Abibirem Anaafoͻ</territory>
+			<territory type="ZA">Abibirem Anaafoɔ</territory>
 			<territory type="ZM">Zambia</territory>
 			<territory type="ZW">Zimbabue</territory>
-			<territory type="ZZ">Mantam a Yԑnnim</territory>
+			<territory type="ZZ">Mantam a Yɛnnim</territory>
 		</territories>
 		<keys>
-			<key type="calendar">Kalԑnna</key>
-			<key type="cf">Sika Fͻmate</key>
+			<key type="calendar">Kalɛnna</key>
+			<key type="cf">Sika Fɔmate</key>
 			<key type="collation">Nyiyie Kwan</key>
 			<key type="currency">Sika</key>
-			<key type="hc">Dͻnhwere Nkͻmmaeԑ (12 anaa 24)</key>
-			<key type="lb">Line Break Nhyehyԑeԑ</key>
-			<key type="ms">Nsusudeԑ Sestԑm</key>
-			<key type="numbers">Nԑma</key>
+			<key type="hc">Dɔnhwere Nkɔmmaeɛ (12 anaa 24)</key>
+			<key type="lb">Line Break Nhyehyɛeɛ</key>
+			<key type="ms">Nsusudeɛ Sestɛm</key>
+			<key type="numbers">Nɛma</key>
 		</keys>
 		<types>
-			<type key="calendar" type="buddhist">Budafoɔ Kalԑnna</type>
-			<type key="calendar" type="chinese">Kyaenafoɔ Kalԑnna</type>
-			<type key="calendar" type="coptic">Kɔtesefoɔ Kalԑnna</type>
-			<type key="calendar" type="dangi">Dangi Kalԑnna</type>
-			<type key="calendar" type="ethiopic">Yitiopia Kalԑnna</type>
-			<type key="calendar" type="ethiopic-amete-alem">Yitiopia Amete Alԑm Kalԑnna</type>
-			<type key="calendar" type="gregorian">Gregorian Kalԑnna</type>
-			<type key="calendar" type="hebrew">Hibri Kalԑnda</type>
-			<type key="calendar" type="islamic">Higyiri Kalԑnda</type>
-			<type key="calendar" type="islamic-civil">Higyiri Kalԑnda (tabula, sivil epokyi</type>
-			<type key="calendar" type="islamic-umalqura">Higyiri Kalԑnda (Ummm al-Kura)</type>
-			<type key="calendar" type="iso8601">ISO-8601 Kalԑnna</type>
-			<type key="calendar" type="japanese">Gyapanfoͻ Kalԑnda</type>
-			<type key="calendar" type="persian">Pԑԑsiafoͻ Kalԑnda</type>
-			<type key="calendar" type="roc">Minguo Kalԑnda</type>
-			<type key="cf" type="account">Sika Nkotabuo Fͻmate</type>
-			<type key="cf" type="standard">Sika Fͻmate Susudua</type>
-			<type key="collation" type="ducet">Koodu Korͻ Nyiyie Kwan a ԑdi Kan</type>
-			<type key="collation" type="search">Daa-Botaeԑ Adehwehwԑ</type>
+			<type key="calendar" type="buddhist">Budafoɔ Kalɛnna</type>
+			<type key="calendar" type="chinese">Kyaenafoɔ Kalɛnna</type>
+			<type key="calendar" type="coptic">Kɔtesefoɔ Kalɛnna</type>
+			<type key="calendar" type="dangi">Dangi Kalɛnna</type>
+			<type key="calendar" type="ethiopic">Yitiopia Kalɛnna</type>
+			<type key="calendar" type="ethiopic-amete-alem">Yitiopia Amete Alɛm Kalɛnna</type>
+			<type key="calendar" type="gregorian">Gregorian Kalɛnna</type>
+			<type key="calendar" type="hebrew">Hibri Kalɛnda</type>
+			<type key="calendar" type="islamic">Higyiri Kalɛnda</type>
+			<type key="calendar" type="islamic-civil">Higyiri Kalɛnda (tabula, sivil epokyi</type>
+			<type key="calendar" type="islamic-umalqura">Higyiri Kalɛnda (Ummm al-Kura)</type>
+			<type key="calendar" type="iso8601">ISO-8601 Kalɛnna</type>
+			<type key="calendar" type="japanese">Gyapanfoɔ Kalɛnda</type>
+			<type key="calendar" type="persian">Pɛɛsiafoɔ Kalɛnda</type>
+			<type key="calendar" type="roc">Minguo Kalɛnda</type>
+			<type key="cf" type="account">Sika Nkotabuo Fɔmate</type>
+			<type key="cf" type="standard">Sika Fɔmate Susudua</type>
+			<type key="collation" type="ducet">Koodu Korɔ Nyiyie Kwan a ɛdi Kan</type>
+			<type key="collation" type="search">Daa-Botaeɛ Adehwehwɛ</type>
 			<type key="collation" type="standard">Nyiyie Kwan Susudua</type>
-			<type key="hc" type="h11">Nnɔnhwere 12 Sestԑm (0–11)</type>
-			<type key="hc" type="h12">Nnɔnhwere 12 Sestԑm (1–12</type>
-			<type key="hc" type="h23">Nnɔnhwere 24 Sestԑm (0–23)</type>
-			<type key="hc" type="h24">Nnɔnhwere 24 Sestԑm (0–24)</type>
-			<type key="lb" type="loose">Line Break Nhyehyԑeԑ a Emu Yԑ Mmrԑ</type>
-			<type key="lb" type="normal">Daa Line Break Nhyehyԑeԑ</type>
-			<type key="lb" type="strict">Line Break Nhyehyԑeԑ Ferenkyemm</type>
-			<type key="ms" type="metric">Mԑtreke Nhyehyԑeԑ</type>
-			<type key="ms" type="uksystem">Imperial Nsusudeԑ Sestԑm</type>
-			<type key="ms" type="ussystem">US Nsusudeԑ Sestԑm</type>
+			<type key="hc" type="h11">Nnɔnhwere 12 Sestɛm (0–11)</type>
+			<type key="hc" type="h12">Nnɔnhwere 12 Sestɛm (1–12</type>
+			<type key="hc" type="h23">Nnɔnhwere 24 Sestɛm (0–23)</type>
+			<type key="hc" type="h24">Nnɔnhwere 24 Sestɛm (0–24)</type>
+			<type key="lb" type="loose">Line Break Nhyehyɛeɛ a Emu Yɛ Mmrɛ</type>
+			<type key="lb" type="normal">Daa Line Break Nhyehyɛeɛ</type>
+			<type key="lb" type="strict">Line Break Nhyehyɛeɛ Ferenkyemm</type>
+			<type key="ms" type="metric">Mɛtreke Nhyehyɛeɛ</type>
+			<type key="ms" type="uksystem">Imperial Nsusudeɛ Sestɛm</type>
+			<type key="ms" type="ussystem">US Nsusudeɛ Sestɛm</type>
 			<type key="numbers" type="arab">Arabeke Digyete</type>
-			<type key="numbers" type="arabext">Arabeke Digyete a Wͻatrԑm</type>
-			<type key="numbers" type="armn">Aamenia Nͻma</type>
-			<type key="numbers" type="armnlow">Aamenia Nͻma Nkumaa</type>
+			<type key="numbers" type="arabext">Arabeke Digyete a Wɔatrɛm</type>
+			<type key="numbers" type="armn">Aamenia Nɔma</type>
+			<type key="numbers" type="armnlow">Aamenia Nɔma Nkumaa</type>
 			<type key="numbers" type="beng">Bangla Gigyete</type>
 			<type key="numbers" type="cakm">Kyakma Digyete</type>
 			<type key="numbers" type="deva">Devanagari Gigyete</type>
-			<type key="numbers" type="ethi">Yitiopia Nͻma</type>
+			<type key="numbers" type="ethi">Yitiopia Nɔma</type>
 			<type key="numbers" type="fullwide">Digyete a Emu Pi</type>
-			<type key="numbers" type="geor">Gyͻgyea Nͻma</type>
-			<type key="numbers" type="grek">Griiki Nͻma</type>
-			<type key="numbers" type="greklow">Griiki Nͻma Nkumaa</type>
+			<type key="numbers" type="geor">Gyɔgyea Nɔma</type>
+			<type key="numbers" type="grek">Griiki Nɔma</type>
+			<type key="numbers" type="greklow">Griiki Nɔma Nkumaa</type>
 			<type key="numbers" type="gujr">Gugyarati Digyete</type>
 			<type key="numbers" type="guru">Gurumuki Digyete</type>
-			<type key="numbers" type="hanidec">Kyaenafoɔ Dԑsima Nͻma</type>
-			<type key="numbers" type="hans">Kyaenafoɔ Dԑsima Nͻma a Emu Yԑ Mmrԑ</type>
-			<type key="numbers" type="hansfin">Kyaenafoɔ Sikasԑm Dԑsima Nͻma a Emu Yԑ Mmrԑ</type>
-			<type key="numbers" type="hant">Kyaenafoɔ Tete Nͻma</type>
-			<type key="numbers" type="hantfin">Tete Kyaena Sikasԑm Nͻma</type>
-			<type key="numbers" type="hebr">Hibri Nͻma</type>
+			<type key="numbers" type="hanidec">Kyaenafoɔ Dɛsima Nɔma</type>
+			<type key="numbers" type="hans">Kyaenafoɔ Dɛsima Nɔma a Emu Yɛ Mmrɛ</type>
+			<type key="numbers" type="hansfin">Kyaenafoɔ Sikasɛm Dɛsima Nɔma a Emu Yɛ Mmrɛ</type>
+			<type key="numbers" type="hant">Kyaenafoɔ Tete Nɔma</type>
+			<type key="numbers" type="hantfin">Tete Kyaena Sikasɛm Nɔma</type>
+			<type key="numbers" type="hebr">Hibri Nɔma</type>
 			<type key="numbers" type="java">Gyavaniisi Digyete</type>
-			<type key="numbers" type="jpan">Gyapanfoͻ Nͻma</type>
-			<type key="numbers" type="jpanfin">Gyapanfoͻ Sikasԑm Nͻma</type>
+			<type key="numbers" type="jpan">Gyapanfoɔ Nɔma</type>
+			<type key="numbers" type="jpanfin">Gyapanfoɔ Sikasɛm Nɔma</type>
 			<type key="numbers" type="khmr">Kima Digyete</type>
 			<type key="numbers" type="knda">Kanada Digyete</type>
 			<type key="numbers" type="laoo">Lawo Digyete</type>
-			<type key="numbers" type="latn">Atͻeԑ Fam Digyete</type>
+			<type key="numbers" type="latn">Atɔeɛ Fam Digyete</type>
 			<type key="numbers" type="mlym">Malayalam Digyete</type>
-			<type key="numbers" type="mtei">Meeti Mayԑke Digyete</type>
+			<type key="numbers" type="mtei">Meeti Mayɛke Digyete</type>
 			<type key="numbers" type="mymr">Mayaama Digyete</type>
 			<type key="numbers" type="olck">Ol Kyiki Digyete</type>
 			<type key="numbers" type="orya">Odia Digyete</type>
-			<type key="numbers" type="roman">Roman Nͻma</type>
-			<type key="numbers" type="romanlow">Romanfoͻ Nͻma Nkumaa</type>
-			<type key="numbers" type="taml">Tamil Tete Nͻma</type>
+			<type key="numbers" type="roman">Roman Nɔma</type>
+			<type key="numbers" type="romanlow">Romanfoɔ Nɔma Nkumaa</type>
+			<type key="numbers" type="taml">Tamil Tete Nɔma</type>
 			<type key="numbers" type="tamldec">Tamil Digyete</type>
 			<type key="numbers" type="telu">Telugu Digyete</type>
-			<type key="numbers" type="thai">Taelanfoͻ Digyete</type>
-			<type key="numbers" type="tibt">Tibԑtan Digyete</type>
+			<type key="numbers" type="thai">Taelanfoɔ Digyete</type>
+			<type key="numbers" type="tibt">Tibɛtan Digyete</type>
 			<type key="numbers" type="vaii">Vai Gigyete</type>
 		</types>
 		<measurementSystemNames>
@@ -664,7 +664,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</localeDisplayNames>
 	<characters>
 		<exemplarCharacters>[a b d e ɛ f g h i k l m n o ɔ p r s t u w y]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[c j q v z]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[c j q v z á ä ã é ë í ó ö ü]</exemplarCharacters>
 		<exemplarCharacters type="index">[A B C D E Ɛ F G H I J K L M N O Ɔ P Q R S T U V W X Y Z]</exemplarCharacters>
 		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="contributed">↑↑↑</exemplarCharacters>
@@ -937,18 +937,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<months>
 					<monthContext type="format">
 						<monthWidth type="abbreviated">
-							<month type="1">Ɔpԑpͻn</month>
-							<month type="2">Ɔgyefoͻ</month>
-							<month type="3">Ɔbԑnem</month>
+							<month type="1">Ɔpɛpɔn</month>
+							<month type="2">Ɔgyefoɔ</month>
+							<month type="3">Ɔbɛnem</month>
 							<month type="4">Oforisuo</month>
-							<month type="5">Kͻtͻnimma</month>
-							<month type="6">Ayԑwohomumu</month>
+							<month type="5">Kɔtɔnimma</month>
+							<month type="6">Ayɛwohomumu</month>
 							<month type="7">Kutawonsa</month>
 							<month type="8">Ɔsanaa</month>
-							<month type="9">Ɛbͻ</month>
+							<month type="9">Ɛbɔ</month>
 							<month type="10">Ahinime</month>
 							<month type="11">Obubuo</month>
-							<month type="12">Ɔpԑnimma</month>
+							<month type="12">Ɔpɛnimma</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">Ɔ</month>
@@ -965,34 +965,34 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Ɔ</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">Ɔpԑpͻn</month>
-							<month type="2">Ɔgyefoͻ</month>
-							<month type="3">Ɔbԑnem</month>
+							<month type="1">Ɔpɛpɔn</month>
+							<month type="2">Ɔgyefoɔ</month>
+							<month type="3">Ɔbɛnem</month>
 							<month type="4">Oforisuo</month>
-							<month type="5">Kͻtͻnimma</month>
-							<month type="6">Ayԑwohomumu</month>
+							<month type="5">Kɔtɔnimma</month>
+							<month type="6">Ayɛwohomumu</month>
 							<month type="7">Kutawonsa</month>
 							<month type="8">Ɔsanaa</month>
-							<month type="9">Ɛbͻ</month>
+							<month type="9">Ɛbɔ</month>
 							<month type="10">Ahinime</month>
 							<month type="11">Obubuo</month>
-							<month type="12">Ɔpԑnimma</month>
+							<month type="12">Ɔpɛnimma</month>
 						</monthWidth>
 					</monthContext>
 					<monthContext type="stand-alone">
 						<monthWidth type="abbreviated">
-							<month type="1">Ɔpԑpͻn</month>
-							<month type="2">Ɔgyefoͻ</month>
-							<month type="3">Ɔbԑnem</month>
+							<month type="1">Ɔpɛpɔn</month>
+							<month type="2">Ɔgyefoɔ</month>
+							<month type="3">Ɔbɛnem</month>
 							<month type="4">Oforisuo</month>
-							<month type="5">Kͻtͻnimma</month>
-							<month type="6">Ayԑwohomumu</month>
+							<month type="5">Kɔtɔnimma</month>
+							<month type="6">Ayɛwohomumu</month>
 							<month type="7">Kutawonsa</month>
 							<month type="8">Ɔsanaa</month>
-							<month type="9">Ɛbͻ</month>
+							<month type="9">Ɛbɔ</month>
 							<month type="10">Ahinime</month>
 							<month type="11">Obubuo</month>
-							<month type="12">Ɔpԑnimma</month>
+							<month type="12">Ɔpɛnimma</month>
 						</monthWidth>
 						<monthWidth type="narrow">
 							<month type="1">Ɔ</month>
@@ -1009,18 +1009,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<month type="12">Ɔ</month>
 						</monthWidth>
 						<monthWidth type="wide">
-							<month type="1">Ɔpԑpͻn</month>
-							<month type="2">Ɔgyefoͻ</month>
-							<month type="3">Ɔbԑnem</month>
+							<month type="1">Ɔpɛpɔn</month>
+							<month type="2">Ɔgyefoɔ</month>
+							<month type="3">Ɔbɛnem</month>
 							<month type="4">Oforisuo</month>
-							<month type="5">Kͻtͻnimma</month>
-							<month type="6">Ayԑwohomumu</month>
+							<month type="5">Kɔtɔnimma</month>
+							<month type="6">Ayɛwohomumu</month>
 							<month type="7">Kutawonsa</month>
 							<month type="8">Ɔsanaa</month>
-							<month type="9">Ɛbͻ</month>
+							<month type="9">Ɛbɔ</month>
 							<month type="10">Ahinime</month>
 							<month type="11">Obubuo</month>
-							<month type="12">Ɔpԑnimma</month>
+							<month type="12">Ɔpɛnimma</month>
 						</monthWidth>
 					</monthContext>
 				</months>
@@ -1105,10 +1105,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<quarters>
 					<quarterContext type="format">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">Kͻta1</quarter>
-							<quarter type="2">Kͻta2</quarter>
-							<quarter type="3">Kͻta3</quarter>
-							<quarter type="4">Kͻta4</quarter>
+							<quarter type="1">Kɔta1</quarter>
+							<quarter type="2">Kɔta2</quarter>
+							<quarter type="3">Kɔta3</quarter>
+							<quarter type="4">Kɔta4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">↑↑↑</quarter>
@@ -1117,18 +1117,18 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">Kͻta a ԑdi kan</quarter>
-							<quarter type="2">kͻta a ԑtͻ so mmienu</quarter>
-							<quarter type="3">Kͻta a ԑtͻ so mmiԑnsa</quarter>
-							<quarter type="4">Kͻta a ԑtͻ so nnan</quarter>
+							<quarter type="1">Kɔta a ɛdi kan</quarter>
+							<quarter type="2">kɔta a ɛtɔ so mmienu</quarter>
+							<quarter type="3">Kɔta a ɛtɔ so mmiɛnsa</quarter>
+							<quarter type="4">Kɔta a ɛtɔ so nnan</quarter>
 						</quarterWidth>
 					</quarterContext>
 					<quarterContext type="stand-alone">
 						<quarterWidth type="abbreviated">
-							<quarter type="1">Kͻta1</quarter>
-							<quarter type="2">Kͻta2</quarter>
-							<quarter type="3">Kͻta3</quarter>
-							<quarter type="4">Kͻta4</quarter>
+							<quarter type="1">Kɔta1</quarter>
+							<quarter type="2">Kɔta2</quarter>
+							<quarter type="3">Kɔta3</quarter>
+							<quarter type="4">Kɔta4</quarter>
 						</quarterWidth>
 						<quarterWidth type="narrow">
 							<quarter type="1">↑↑↑</quarter>
@@ -1137,10 +1137,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<quarter type="4">↑↑↑</quarter>
 						</quarterWidth>
 						<quarterWidth type="wide">
-							<quarter type="1">Kͻta a ԑdi kan</quarter>
-							<quarter type="2">kͻta a ԑtͻ so mmienu</quarter>
-							<quarter type="3">Kͻta a ԑtͻ so mmiԑnsa</quarter>
-							<quarter type="4">Kͻta a ԑtͻ so nnan</quarter>
+							<quarter type="1">Kɔta a ɛdi kan</quarter>
+							<quarter type="2">kɔta a ɛtɔ so mmienu</quarter>
+							<quarter type="3">Kɔta a ɛtɔ so mmiɛnsa</quarter>
+							<quarter type="4">Kɔta a ɛtɔ so nnan</quarter>
 						</quarterWidth>
 					</quarterContext>
 				</quarters>
@@ -1177,9 +1177,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<eras>
 					<eraNames>
 						<era type="0">Ansa Kristo</era>
-						<era type="0" alt="variant">Ansa Daa Berԑ</era>
+						<era type="0" alt="variant">Ansa Daa Berɛ</era>
 						<era type="1">Kristo Akyi</era>
-						<era type="1" alt="variant">Daa Berԑm</era>
+						<era type="1" alt="variant">Daa Berɛm</era>
 					</eraNames>
 					<eraAbbr>
 						<era type="0">AK</era>
@@ -1246,7 +1246,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'w'ͻ {0}</pattern>
+							<pattern>{1} 'w'ɔ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1254,7 +1254,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>{1}, {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'w'ͻ {0}</pattern>
+							<pattern>{1} 'w'ɔ {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1475,90 +1475,90 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</calendars>
 		<fields>
 			<field type="era">
-				<displayName>berԑ</displayName>
+				<displayName>berɛ</displayName>
 			</field>
 			<field type="era-short">
-				<displayName>berԑ</displayName>
+				<displayName>berɛ</displayName>
 			</field>
 			<field type="era-narrow">
-				<displayName>berԑ</displayName>
+				<displayName>berɛ</displayName>
 			</field>
 			<field type="year">
 				<displayName>Afe</displayName>
 				<relative type="-1">afe a atwam</relative>
 				<relative type="0">afe yi</relative>
-				<relative type="1">afe a ԑdi hͻ</relative>
+				<relative type="1">afe a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">afe {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">mfeԑ {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">mfeɛ {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">afe {0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">mfeԑ {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">mfeɛ {0} a atwam</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-short">
 				<displayName>↑↑↑</displayName>
 				<relative type="-1">afe a atwam</relative>
 				<relative type="0">afe yi</relative>
-				<relative type="1">afe a ԑdi hͻ</relative>
+				<relative type="1">afe a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">afe {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">mfeԑ {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">mfeɛ {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">afe {0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">mfeԑ {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">mfeɛ {0} a atwam</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="year-narrow">
 				<displayName>↑↑↑</displayName>
 				<relative type="-1">afe a atwam</relative>
 				<relative type="0">afe yi</relative>
-				<relative type="1">afe a ԑdi hͻ</relative>
+				<relative type="1">afe a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">afe {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">mfeԑ {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">mfeɛ {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">afe {0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">mfeԑ {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">mfeɛ {0} a atwam</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter">
-				<displayName>kͻta</displayName>
-				<relative type="-1">kͻta a atwam</relative>
-				<relative type="0">kͻta yi</relative>
-				<relative type="1">kͻta a ԑdi hͻ</relative>
+				<displayName>kɔta</displayName>
+				<relative type="-1">kɔta a atwam</relative>
+				<relative type="0">kɔta yi</relative>
+				<relative type="1">kɔta a ɛdi hɔ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">kͻta {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">kͻta ahodoͻ {0} mu</relativeTimePattern>
+					<relativeTimePattern count="one">kɔta {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">kɔta ahodoɔ {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">kͻta {0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">kͻta ahodoͻ {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="one">kɔta {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">kɔta ahodoɔ {0} a atwam</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-short">
-				<displayName>kͻta</displayName>
+				<displayName>kɔta</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">kͻta {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">kͻta ahodoͻ {0} mu</relativeTimePattern>
+					<relativeTimePattern count="one">kɔta {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">kɔta ahodoɔ {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">kͻta {0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">kͻta ahodoͻ {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="one">kɔta {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">kɔta ahodoɔ {0} a atwam</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="quarter-narrow">
-				<displayName>kͻta</displayName>
+				<displayName>kɔta</displayName>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">kͻta {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">kͻta {0} mu</relativeTimePattern>
+					<relativeTimePattern count="one">kɔta {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">kɔta {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">kͻta {0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">kͻta {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="one">kɔta {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">kɔta {0} a atwam</relativeTimePattern>
 				</relativeTime>
 			</field>
 			<field type="month">
@@ -1604,58 +1604,58 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="week">
-				<displayName>Nnawͻtwe</displayName>
-				<relative type="-1">nnawͻtwe a atwam</relative>
-				<relative type="0">nnawͻtwe yi</relative>
-				<relative type="1">nnawͻtwe a ɛdi hɔ</relative>
+				<displayName>Nnawɔtwe</displayName>
+				<relative type="-1">nnawɔtwe a atwam</relative>
+				<relative type="0">nnawɔtwe yi</relative>
+				<relative type="1">nnawɔtwe a ɛdi hɔ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">nnawͻtwe {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">nnawͻtwe {0} mu</relativeTimePattern>
+					<relativeTimePattern count="one">nnawɔtwe {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">nnawɔtwe {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">nnawͻtwe{0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">nnawͻtwe{0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="one">nnawɔtwe{0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">nnawɔtwe{0} a atwam</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>nnawͻtwe a ɛtɔ so {0}mu</relativePeriod>
+				<relativePeriod>nnawɔtwe a ɛtɔ so {0}mu</relativePeriod>
 			</field>
 			<field type="week-short">
-				<displayName>Nnawͻtwe</displayName>
-				<relative type="-1">nnawͻtwe a atwam</relative>
-				<relative type="0">nnawͻtwe yi</relative>
-				<relative type="1">nnawͻtwe a ɛdi hɔ</relative>
+				<displayName>Nnawɔtwe</displayName>
+				<relative type="-1">nnawɔtwe a atwam</relative>
+				<relative type="0">nnawɔtwe yi</relative>
+				<relative type="1">nnawɔtwe a ɛdi hɔ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">nnawͻtwe {0} mu</relativeTimePattern>
-					<relativeTimePattern count="other">nnawͻtwe {0} mu</relativeTimePattern>
+					<relativeTimePattern count="one">nnawɔtwe {0} mu</relativeTimePattern>
+					<relativeTimePattern count="other">nnawɔtwe {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">nnawͻtwe{0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">nnawͻtwe{0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="one">nnawɔtwe{0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">nnawɔtwe{0} a atwam</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>nnawͻtwe a ɛtɔ so {0}mu</relativePeriod>
+				<relativePeriod>nnawɔtwe a ɛtɔ so {0}mu</relativePeriod>
 			</field>
 			<field type="week-narrow">
-				<displayName>Nnawͻtwe</displayName>
-				<relative type="-1">nnawͻtwe a atwam</relative>
-				<relative type="0">nnawͻtwe yi</relative>
-				<relative type="1">nnawͻtwe a ɛdi hɔ</relative>
+				<displayName>Nnawɔtwe</displayName>
+				<relative type="-1">nnawɔtwe a atwam</relative>
+				<relative type="0">nnawɔtwe yi</relative>
+				<relative type="1">nnawɔtwe a ɛdi hɔ</relative>
 				<relativeTime type="future">
-					<relativeTimePattern count="one">nnawͻtwe {0} mu.</relativeTimePattern>
-					<relativeTimePattern count="other">nnawͻtwe {0} mu</relativeTimePattern>
+					<relativeTimePattern count="one">nnawɔtwe {0} mu.</relativeTimePattern>
+					<relativeTimePattern count="other">nnawɔtwe {0} mu</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
-					<relativeTimePattern count="one">nnawͻtwe{0} a atwam</relativeTimePattern>
-					<relativeTimePattern count="other">nnawͻtwe {0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="one">nnawɔtwe{0} a atwam</relativeTimePattern>
+					<relativeTimePattern count="other">nnawɔtwe {0} a atwam</relativeTimePattern>
 				</relativeTime>
-				<relativePeriod>nnawͻtwe a ɛtɔ so {0}mu</relativePeriod>
+				<relativePeriod>nnawɔtwe a ɛtɔ so {0}mu</relativePeriod>
 			</field>
 			<field type="weekOfMonth">
-				<displayName>bosome mu nnawͻtwe</displayName>
+				<displayName>bosome mu nnawɔtwe</displayName>
 			</field>
 			<field type="weekOfMonth-short">
-				<displayName>bosome mu nnawͻtwe</displayName>
+				<displayName>bosome mu nnawɔtwe</displayName>
 			</field>
 			<field type="weekOfMonth-narrow">
-				<displayName>bosome mu nnawͻtwe</displayName>
+				<displayName>bosome mu nnawɔtwe</displayName>
 			</field>
 			<field type="day">
 				<displayName>Da</displayName>
@@ -1673,8 +1673,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-short">
 				<displayName>↑↑↑</displayName>
-				<relative type="-1">Ndeda ԑnnora</relative>
-				<relative type="0">Ndɛ ԑnnԑ</relative>
+				<relative type="-1">Ndeda ɛnnora</relative>
+				<relative type="0">Ndɛ ɛnnɛ</relative>
 				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">da {0} mu</relativeTimePattern>
@@ -1687,8 +1687,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</field>
 			<field type="day-narrow">
 				<displayName>↑↑↑</displayName>
-				<relative type="-1">ԑnnora</relative>
-				<relative type="0">ԑnnԑ</relative>
+				<relative type="-1">ɛnnora</relative>
+				<relative type="0">ɛnnɛ</relative>
 				<relative type="1">↑↑↑</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">da {0} mu</relativeTimePattern>
@@ -1709,27 +1709,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>afe mu da</displayName>
 			</field>
 			<field type="weekday">
-				<displayName>nnawͻtwe mu da</displayName>
+				<displayName>nnawɔtwe mu da</displayName>
 			</field>
 			<field type="weekday-short">
-				<displayName>nnawͻtwe mu da</displayName>
+				<displayName>nnawɔtwe mu da</displayName>
 			</field>
 			<field type="weekday-narrow">
-				<displayName>nnawͻtwe mu da</displayName>
+				<displayName>nnawɔtwe mu da</displayName>
 			</field>
 			<field type="weekdayOfMonth">
-				<displayName>nnawͻtwe mu da wͻ bosome mu</displayName>
+				<displayName>nnawɔtwe mu da wɔ bosome mu</displayName>
 			</field>
 			<field type="weekdayOfMonth-short">
-				<displayName>nnawͻtwe mu da wͻ bosome mu</displayName>
+				<displayName>nnawɔtwe mu da wɔ bosome mu</displayName>
 			</field>
 			<field type="weekdayOfMonth-narrow">
-				<displayName>nnawͻtwe mu da wͻ bosome mu</displayName>
+				<displayName>nnawɔtwe mu da wɔ bosome mu</displayName>
 			</field>
 			<field type="sun">
 				<relative type="-1">Kwasiada a atwam</relative>
 				<relative type="0">Kwasiada yi</relative>
-				<relative type="1">Kwasiada a ԑdi hɔ</relative>
+				<relative type="1">Kwasiada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Kwasiada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Kwasiada {0} mu</relativeTimePattern>
@@ -1742,7 +1742,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="sun-short">
 				<relative type="-1">Kwasiada a atwam</relative>
 				<relative type="0">Kwasiada yi</relative>
-				<relative type="1">Kwasiada a ԑdi hɔ</relative>
+				<relative type="1">Kwasiada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Kwasiada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Kwasiada {0} mu</relativeTimePattern>
@@ -1755,7 +1755,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="sun-narrow">
 				<relative type="-1">Kwasiada a atwam</relative>
 				<relative type="0">Kwasiada yi</relative>
-				<relative type="1">Kwasiada a ԑdi hɔ</relative>
+				<relative type="1">Kwasiada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Kwasiada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Kwasiada {0} mu</relativeTimePattern>
@@ -1768,7 +1768,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="mon">
 				<relative type="-1">Dwoada a atwam</relative>
 				<relative type="0">Dwoada yi</relative>
-				<relative type="1">Dwoada a ԑdi hɔ</relative>
+				<relative type="1">Dwoada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Dwoada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Dwoada {0} mu</relativeTimePattern>
@@ -1781,7 +1781,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="mon-short">
 				<relative type="-1">Dwoada a atwam</relative>
 				<relative type="0">Dwoada yi</relative>
-				<relative type="1">Dwoada a ԑdi hɔ</relative>
+				<relative type="1">Dwoada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Dwoada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Dwoada {0} mu</relativeTimePattern>
@@ -1794,7 +1794,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="mon-narrow">
 				<relative type="-1">Dwoada a atwam</relative>
 				<relative type="0">Dwoada yi</relative>
-				<relative type="1">Dwoada a ԑdi hɔ</relative>
+				<relative type="1">Dwoada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Dwoada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Dwoada {0} mu</relativeTimePattern>
@@ -1807,7 +1807,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="tue">
 				<relative type="-1">Benada a atwam</relative>
 				<relative type="0">Benada yi</relative>
-				<relative type="1">Benada a ԑdi hɔ</relative>
+				<relative type="1">Benada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Benada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Benada {0} mu</relativeTimePattern>
@@ -1820,7 +1820,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="tue-short">
 				<relative type="-1">Benada a atwam</relative>
 				<relative type="0">Benada yi</relative>
-				<relative type="1">Benada a ԑdi hɔ</relative>
+				<relative type="1">Benada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Benada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Benada {0} mu</relativeTimePattern>
@@ -1833,7 +1833,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="tue-narrow">
 				<relative type="-1">Benada a atwam</relative>
 				<relative type="0">Benada yi</relative>
-				<relative type="1">Benada a ԑdi hɔ</relative>
+				<relative type="1">Benada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Benada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Benada {0} mu</relativeTimePattern>
@@ -1846,7 +1846,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="wed">
 				<relative type="-1">Wukuada a atwam</relative>
 				<relative type="0">Wukuada yi</relative>
-				<relative type="1">Wukuada a ԑdi hɔ</relative>
+				<relative type="1">Wukuada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Wukuada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Wukuada {0} mu</relativeTimePattern>
@@ -1859,7 +1859,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="wed-short">
 				<relative type="-1">Wukuada a atwam</relative>
 				<relative type="0">Wukuada yi</relative>
-				<relative type="1">Wukuada a ԑdi hɔ</relative>
+				<relative type="1">Wukuada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Wukuada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Wukuada {0} mu</relativeTimePattern>
@@ -1872,7 +1872,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="wed-narrow">
 				<relative type="-1">Wukuada a atwam</relative>
 				<relative type="0">Wukuada yi</relative>
-				<relative type="1">Wukuada a ԑdi hɔ</relative>
+				<relative type="1">Wukuada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Wukuada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Wukuada {0} mu</relativeTimePattern>
@@ -1885,7 +1885,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="thu">
 				<relative type="-1">Yawoada a atwam</relative>
 				<relative type="0">Yawoada yi</relative>
-				<relative type="1">Yawoada a ԑdi hɔ</relative>
+				<relative type="1">Yawoada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Yawoada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Yawoada {0} mu</relativeTimePattern>
@@ -1898,7 +1898,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="thu-short">
 				<relative type="-1">Yawoada a atwam</relative>
 				<relative type="0">Yawoada yi</relative>
-				<relative type="1">Yawoada a ԑdi hɔ</relative>
+				<relative type="1">Yawoada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Yawoada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Yawoada {0} mu</relativeTimePattern>
@@ -1911,7 +1911,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="thu-narrow">
 				<relative type="-1">Yawoada a atwam</relative>
 				<relative type="0">Yawoada yi</relative>
-				<relative type="1">Yawoada a ԑdi hɔ</relative>
+				<relative type="1">Yawoada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Yawoada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Yawoada {0} mu</relativeTimePattern>
@@ -1924,7 +1924,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="fri">
 				<relative type="-1">Fiada a atwam</relative>
 				<relative type="0">Fiada yi</relative>
-				<relative type="1">Fiada a ԑdi hɔ</relative>
+				<relative type="1">Fiada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Fiada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Fiada {0} mu</relativeTimePattern>
@@ -1937,7 +1937,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="fri-short">
 				<relative type="-1">Fiada a atwam</relative>
 				<relative type="0">Fiada yi</relative>
-				<relative type="1">Fiada a ԑdi hɔ</relative>
+				<relative type="1">Fiada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Fiada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Fiada {0} mu</relativeTimePattern>
@@ -1950,7 +1950,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="fri-narrow">
 				<relative type="-1">Fiada a atwam</relative>
 				<relative type="0">Fiada yi</relative>
-				<relative type="1">Fiada a ԑdi hɔ</relative>
+				<relative type="1">Fiada a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Fiada {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Fiada {0} mu</relativeTimePattern>
@@ -1963,7 +1963,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="sat">
 				<relative type="-1">Memeneda a atwam</relative>
 				<relative type="0">Memeneda yi</relative>
-				<relative type="1">Memeneda a ԑdi hɔ</relative>
+				<relative type="1">Memeneda a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Memeneda {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Memeneda {0} mu</relativeTimePattern>
@@ -1976,7 +1976,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="sat-short">
 				<relative type="-1">Memeneda a atwam</relative>
 				<relative type="0">Memeneda yi</relative>
-				<relative type="1">Memeneda a ԑdi hɔ</relative>
+				<relative type="1">Memeneda a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Memeneda {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Memeneda {0} mu</relativeTimePattern>
@@ -1989,7 +1989,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<field type="sat-narrow">
 				<relative type="-1">Memeneda a atwam</relative>
 				<relative type="0">Memeneda yi</relative>
-				<relative type="1">Memeneda a ԑdi hɔ</relative>
+				<relative type="1">Memeneda a ɛdi hɔ</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">Memeneda {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">Memeneda {0} mu</relativeTimePattern>
@@ -2000,16 +2000,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="dayperiod-short">
-				<displayName>anͻpa/anwummerԑ</displayName>
+				<displayName>anɔpa/anwummerɛ</displayName>
 			</field>
 			<field type="dayperiod">
-				<displayName>anͻpa/anwummerԑ</displayName>
+				<displayName>anɔpa/anwummerɛ</displayName>
 			</field>
 			<field type="dayperiod-narrow">
-				<displayName>anͻpa/anwummerԑ</displayName>
+				<displayName>anɔpa/anwummerɛ</displayName>
 			</field>
 			<field type="hour">
-				<displayName>dͻnhwere</displayName>
+				<displayName>dɔnhwere</displayName>
 				<relative type="0">dɔnhwere yi</relative>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">dɔnhwere {0} mu</relativeTimePattern>
@@ -2021,7 +2021,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-short">
-				<displayName>dͻnhwere</displayName>
+				<displayName>dɔnhwere</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">dɔnhwere {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">nnɔnhwere {0} mu</relativeTimePattern>
@@ -2032,7 +2032,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="hour-narrow">
-				<displayName>dͻnhwere</displayName>
+				<displayName>dɔnhwere</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">dɔnhwere {0} mu</relativeTimePattern>
 					<relativeTimePattern count="other">nnɔnhwere {0} mu</relativeTimePattern>
@@ -2111,13 +2111,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</relativeTime>
 			</field>
 			<field type="zone">
-				<displayName>berԑ mu wiase nkyekyԑmu</displayName>
+				<displayName>berɛ mu wiase nkyekyɛmu</displayName>
 			</field>
 			<field type="zone-short">
-				<displayName>nkyekyԑmu</displayName>
+				<displayName>nkyekyɛmu</displayName>
 			</field>
 			<field type="zone-narrow">
-				<displayName>nkyekyԑmu</displayName>
+				<displayName>nkyekyɛmu</displayName>
 			</field>
 		</fields>
 		<timeZoneNames>
@@ -2191,10 +2191,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Argentina/Rio_Gallegos">
-				<exemplarCity>Rio Gallegͻs</exemplarCity>
+				<exemplarCity>Rio Gallegɔs</exemplarCity>
 			</zone>
 			<zone type="America/Mendoza">
-				<exemplarCity>Mɛndͻsa</exemplarCity>
+				<exemplarCity>Mɛndɔsa</exemplarCity>
 			</zone>
 			<zone type="America/Argentina/San_Juan">
 				<exemplarCity>San Dwuan</exemplarCity>
@@ -2221,7 +2221,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Tukuman</exemplarCity>
 			</zone>
 			<zone type="America/Cordoba">
-				<exemplarCity>Kͻͻdͻba</exemplarCity>
+				<exemplarCity>Kɔɔdɔba</exemplarCity>
 			</zone>
 			<zone type="America/Buenos_Aires">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2308,7 +2308,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>St. Baatilemi</exemplarCity>
 			</zone>
 			<zone type="Atlantic/Bermuda">
-				<exemplarCity>Bԑmuda</exemplarCity>
+				<exemplarCity>Bɛmuda</exemplarCity>
 			</zone>
 			<zone type="Asia/Brunei">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2317,7 +2317,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Kralendijk">
-				<exemplarCity>Kralԑngyik</exemplarCity>
+				<exemplarCity>Kralɛngyik</exemplarCity>
 			</zone>
 			<zone type="America/Eirunepe">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2326,7 +2326,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Rio Branko</exemplarCity>
 			</zone>
 			<zone type="America/Porto_Velho">
-				<exemplarCity>Pͻͻto Velho</exemplarCity>
+				<exemplarCity>Pɔɔto Velho</exemplarCity>
 			</zone>
 			<zone type="America/Boa_Vista">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2356,7 +2356,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Fortaleza">
-				<exemplarCity>Fͻͻtalɛsa</exemplarCity>
+				<exemplarCity>Fɔɔtalɛsa</exemplarCity>
 			</zone>
 			<zone type="America/Maceio">
 				<exemplarCity>Makeio</exemplarCity>
@@ -2380,7 +2380,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Belize">
-				<exemplarCity>Bԑlisi</exemplarCity>
+				<exemplarCity>Bɛlisi</exemplarCity>
 			</zone>
 			<zone type="America/Dawson">
 				<exemplarCity>Dɔɔson</exemplarCity>
@@ -2395,13 +2395,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Fort_Nelson">
-				<exemplarCity>Fɔt Nԑlson</exemplarCity>
+				<exemplarCity>Fɔt Nɛlson</exemplarCity>
 			</zone>
 			<zone type="America/Dawson_Creek">
 				<exemplarCity>Dɔɔson Kreek</exemplarCity>
 			</zone>
 			<zone type="America/Creston">
-				<exemplarCity>Krԑston</exemplarCity>
+				<exemplarCity>Krɛston</exemplarCity>
 			</zone>
 			<zone type="America/Edmonton">
 				<exemplarCity>Edmɔnton</exemplarCity>
@@ -2542,7 +2542,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Ɔlgyese</exemplarCity>
 			</zone>
 			<zone type="Pacific/Galapagos">
-				<exemplarCity>Galapagͻs</exemplarCity>
+				<exemplarCity>Galapagɔs</exemplarCity>
 			</zone>
 			<zone type="America/Guayaquil">
 				<exemplarCity>Gayakwuil</exemplarCity>
@@ -2650,7 +2650,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Atene</exemplarCity>
 			</zone>
 			<zone type="Atlantic/South_Georgia">
-				<exemplarCity>Gyͻͻgyia Anaafoͻ</exemplarCity>
+				<exemplarCity>Gyɔɔgyia Anaafoɔ</exemplarCity>
 			</zone>
 			<zone type="America/Guatemala">
 				<exemplarCity>Guwatemala</exemplarCity>
@@ -2896,7 +2896,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Tidwuana</exemplarCity>
 			</zone>
 			<zone type="America/Hermosillo">
-				<exemplarCity>Hԑmɔsilo</exemplarCity>
+				<exemplarCity>Hɛmɔsilo</exemplarCity>
 			</zone>
 			<zone type="America/Ciudad_Juarez">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -2917,7 +2917,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Mɔntirii</exemplarCity>
 			</zone>
 			<zone type="America/Mexico_City">
-				<exemplarCity>Mԑksiko Siti</exemplarCity>
+				<exemplarCity>Mɛksiko Siti</exemplarCity>
 			</zone>
 			<zone type="America/Matamoros">
 				<exemplarCity>Matamɔrɔso</exemplarCity>
@@ -3175,7 +3175,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Paramaribo">
-				<exemplarCity>Paramaribͻ</exemplarCity>
+				<exemplarCity>Paramaribɔ</exemplarCity>
 			</zone>
 			<zone type="Africa/Juba">
 				<exemplarCity>Dwuba</exemplarCity>
@@ -3265,7 +3265,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Anchorage">
-				<exemplarCity>Ankͻragyi</exemplarCity>
+				<exemplarCity>Ankɔragyi</exemplarCity>
 			</zone>
 			<zone type="America/Yakutat">
 				<exemplarCity>↑↑↑</exemplarCity>
@@ -3277,10 +3277,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Metlakatla">
-				<exemplarCity>Mԑtlakatla</exemplarCity>
+				<exemplarCity>Mɛtlakatla</exemplarCity>
 			</zone>
 			<zone type="America/Los_Angeles">
-				<exemplarCity>Lɔs Angyԑlis</exemplarCity>
+				<exemplarCity>Lɔs Angyɛlis</exemplarCity>
 			</zone>
 			<zone type="America/Boise">
 				<exemplarCity>Bɔisi</exemplarCity>
@@ -3289,28 +3289,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>Finisk</exemplarCity>
 			</zone>
 			<zone type="America/Denver">
-				<exemplarCity>Dԑnva</exemplarCity>
+				<exemplarCity>Dɛnva</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/Beulah">
 				<exemplarCity>Beula, Nɔf Dakota</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/New_Salem">
-				<exemplarCity>New Salԑm, Nɔf Dakota</exemplarCity>
+				<exemplarCity>New Salɛm, Nɔf Dakota</exemplarCity>
 			</zone>
 			<zone type="America/North_Dakota/Center">
-				<exemplarCity>Sԑnta, Nɔf Dakota</exemplarCity>
+				<exemplarCity>Sɛnta, Nɔf Dakota</exemplarCity>
 			</zone>
 			<zone type="America/Chicago">
 				<exemplarCity>Kyikago</exemplarCity>
 			</zone>
 			<zone type="America/Menominee">
-				<exemplarCity>Mԑnɔminee</exemplarCity>
+				<exemplarCity>Mɛnɔminee</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Vincennes">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Petersburg">
-				<exemplarCity>Pitԑsbԑgye, Indiana</exemplarCity>
+				<exemplarCity>Pitɛsbɛgye, Indiana</exemplarCity>
 			</zone>
 			<zone type="America/Indiana/Tell_City">
 				<exemplarCity>Tell Siti, Indiana</exemplarCity>
@@ -3334,7 +3334,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="America/Kentucky/Monticello">
-				<exemplarCity>Mɔntisԑlo, Kԑntԑki</exemplarCity>
+				<exemplarCity>Mɔntisɛlo, Kɛntɛki</exemplarCity>
 			</zone>
 			<zone type="America/Detroit">
 				<exemplarCity>Detrɔit</exemplarCity>
@@ -3603,16 +3603,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="China">
 				<long>
-					<generic>Kyaena Berԑ</generic>
-					<standard>Kyaena Susudua Berԑ</standard>
-					<daylight>Kyaena Awia Berԑ</daylight>
+					<generic>Kyaena Berɛ</generic>
+					<standard>Kyaena Susudua Berɛ</standard>
+					<daylight>Kyaena Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Choibalsan">
 				<long>
-					<generic>Kobaasan Berԑ</generic>
-					<standard>Kobaasan Susudua Berԑ</standard>
-					<daylight>Kobaasan Awia Berԑ</daylight>
+					<generic>Kobaasan Berɛ</generic>
+					<standard>Kobaasan Susudua Berɛ</standard>
+					<daylight>Kobaasan Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Christmas">
@@ -3670,7 +3670,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Ecuador">
 				<long>
-					<standard>Yikuwedͻ Berɛ</standard>
+					<standard>Yikuwedɔ Berɛ</standard>
 				</long>
 			</metazone>
 			<metazone type="Europe_Central">
@@ -3701,9 +3701,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Falkland">
 				<long>
-					<generic>Fͻkman Aeland Berɛ</generic>
-					<standard>Fͻkman Aeland Susudua Berɛ</standard>
-					<daylight>Fͻkman Aeland Awia Berɛ</daylight>
+					<generic>Fɔkman Aeland Berɛ</generic>
+					<standard>Fɔkman Aeland Susudua Berɛ</standard>
+					<daylight>Fɔkman Aeland Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Fiji">
@@ -3725,7 +3725,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Galapagos">
 				<long>
-					<standard>Galapagͻs Berɛ</standard>
+					<standard>Galapagɔs Berɛ</standard>
 				</long>
 			</metazone>
 			<metazone type="Gambier">
@@ -3783,16 +3783,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>
-					<generic>Hͻnkͻn Berԑ</generic>
-					<standard>Hͻnkͻn Susudua Berԑ</standard>
-					<daylight>Hͻnkͻn Awia Berԑ</daylight>
+					<generic>Hɔnkɔn Berɛ</generic>
+					<standard>Hɔnkɔn Susudua Berɛ</standard>
+					<daylight>Hɔnkɔn Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Hovd">
 				<long>
-					<generic>Hovd Berԑ</generic>
-					<standard>Hovd Susudua Berԑ</standard>
-					<daylight>Hovd Awia Berԑ</daylight>
+					<generic>Hovd Berɛ</generic>
+					<standard>Hovd Susudua Berɛ</standard>
+					<daylight>Hovd Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="India">
@@ -3848,9 +3848,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Japan">
 				<long>
-					<generic>Gyapan Berԑ</generic>
-					<standard>Gyapan Susudua Berԑ</standard>
-					<daylight>Gyapan Awia Berԑ</daylight>
+					<generic>Gyapan Berɛ</generic>
+					<standard>Gyapan Susudua Berɛ</standard>
+					<daylight>Gyapan Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kazakhstan">
@@ -3870,9 +3870,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Korea">
 				<long>
-					<generic>Korean Berԑ</generic>
-					<standard>Korean Susudua Berԑ</standard>
-					<daylight>Korean Awia Berԑ</daylight>
+					<generic>Korean Berɛ</generic>
+					<standard>Korean Susudua Berɛ</standard>
+					<daylight>Korean Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kosrae">
@@ -3952,9 +3952,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Mongolia">
 				<long>
-					<generic>Yulanbata Berԑ</generic>
-					<standard>Yulanbata Susudua Berԑ</standard>
-					<daylight>Yulanbata Awia Berԑ</daylight>
+					<generic>Yulanbata Berɛ</generic>
+					<standard>Yulanbata Susudua Berɛ</standard>
+					<daylight>Yulanbata Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Moscow">
@@ -3976,7 +3976,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Nepal">
 				<long>
-					<standard>Nԑpal Berɛ</standard>
+					<standard>Nɛpal Berɛ</standard>
 				</long>
 			</metazone>
 			<metazone type="New_Caledonia">
@@ -4095,7 +4095,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Pyongyang">
 				<long>
-					<standard>Pyongyang Berԑ</standard>
+					<standard>Pyongyang Berɛ</standard>
 				</long>
 			</metazone>
 			<metazone type="Reunion">
@@ -4139,7 +4139,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="South_Georgia">
 				<long>
-					<standard>Gyͻͻgyia Anaafoͻ Berɛ</standard>
+					<standard>Gyɔɔgyia Anaafoɔ Berɛ</standard>
 				</long>
 			</metazone>
 			<metazone type="Suriname">
@@ -4159,9 +4159,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Taipei">
 				<long>
-					<generic>Taipei Berԑ</generic>
-					<standard>Taipei Susudua Berԑ</standard>
-					<daylight>Taipei Awia Berԑ</daylight>
+					<generic>Taipei Berɛ</generic>
+					<standard>Taipei Susudua Berɛ</standard>
+					<daylight>Taipei Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Tajikistan">
@@ -4207,9 +4207,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Uzbekistan">
 				<long>
-					<generic>Usbԑkistan Berɛ</generic>
-					<standard>Usbԑkistan Susudua Berɛ</standard>
-					<daylight>Usbԑkistan Awia Berɛ</daylight>
+					<generic>Usbɛkistan Berɛ</generic>
+					<standard>Usbɛkistan Susudua Berɛ</standard>
+					<daylight>Usbɛkistan Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Vanuatu">
@@ -4447,9 +4447,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="AFN">
-				<displayName>Afghanfoͻ Afghani</displayName>
-				<displayName count="one">Afghanfoͻ Afghani</displayName>
-				<displayName count="other">Afghanfoͻ Afghani</displayName>
+				<displayName>Afghanfoɔ Afghani</displayName>
+				<displayName count="one">Afghanfoɔ Afghani</displayName>
+				<displayName count="other">Afghanfoɔ Afghani</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4581,9 +4581,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BTN">
-				<displayName>Butanfoͻ ngutrum</displayName>
-				<displayName count="one">Butanfoͻ ngutrum</displayName>
-				<displayName count="other">Butanfoͻ ngutrum</displayName>
+				<displayName>Butanfoɔ ngutrum</displayName>
+				<displayName count="one">Butanfoɔ ngutrum</displayName>
+				<displayName count="other">Butanfoɔ ngutrum</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="BWP">
@@ -4814,9 +4814,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="HKD">
-				<displayName>Hͻnkͻn Dͻla</displayName>
-				<displayName count="one">Hͻnkͻn Dͻla</displayName>
-				<displayName count="other">Hͻnkͻn Dͻla</displayName>
+				<displayName>Hɔnkɔn Dɔla</displayName>
+				<displayName count="one">Hɔnkɔn Dɔla</displayName>
+				<displayName count="other">Hɔnkɔn Dɔla</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4875,9 +4875,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol draft="contributed">Irak dinaa</symbol>
 			</currency>
 			<currency type="IRR">
-				<displayName>Yiranfoͻ rial</displayName>
-				<displayName count="one">Yiranfoͻ rial</displayName>
-				<displayName count="other">Yiranfoͻ rial</displayName>
+				<displayName>Yiranfoɔ rial</displayName>
+				<displayName count="one">Yiranfoɔ rial</displayName>
+				<displayName count="other">Yiranfoɔ rial</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="ISK">
@@ -4942,9 +4942,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="KRW">
-				<displayName>Korea Anaafoͻ won</displayName>
-				<displayName count="one">Korea Anaafoͻ won</displayName>
-				<displayName count="other">Korea Anaafoͻ won</displayName>
+				<displayName>Korea Anaafoɔ won</displayName>
+				<displayName count="one">Korea Anaafoɔ won</displayName>
+				<displayName count="other">Korea Anaafoɔ won</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -4983,9 +4983,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="LKR">
-				<displayName>Sri Lankafoͻ rupee</displayName>
-				<displayName count="one">Sri Lankafoͻ rupee</displayName>
-				<displayName count="other">Sri Lankafoͻ rupee</displayName>
+				<displayName>Sri Lankafoɔ rupee</displayName>
+				<displayName count="one">Sri Lankafoɔ rupee</displayName>
+				<displayName count="other">Sri Lankafoɔ rupee</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5041,9 +5041,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MNT">
-				<displayName>Mongoliafoͻ tugrike</displayName>
-				<displayName count="one">Mongoliafoͻ tugrike</displayName>
-				<displayName count="other">Mongoliafoͻ tugrike</displayName>
+				<displayName>Mongoliafoɔ tugrike</displayName>
+				<displayName count="one">Mongoliafoɔ tugrike</displayName>
+				<displayName count="other">Mongoliafoɔ tugrike</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5070,9 +5070,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MVR">
-				<displayName>Maldivefoͻ rufiyaa</displayName>
-				<displayName count="one">Maldivefoͻ rufiyaa</displayName>
-				<displayName count="other">Maldivefoͻ rufiyaa</displayName>
+				<displayName>Maldivefoɔ rufiyaa</displayName>
+				<displayName count="one">Maldivefoɔ rufiyaa</displayName>
+				<displayName count="other">Maldivefoɔ rufiyaa</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="MWK">
@@ -5133,9 +5133,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="NPR">
-				<displayName>Nepalfoͻ rupee</displayName>
-				<displayName count="one">Nepalfoͻ rupee</displayName>
-				<displayName count="other">Nepalfoͻ rupee</displayName>
+				<displayName>Nepalfoɔ rupee</displayName>
+				<displayName count="one">Nepalfoɔ rupee</displayName>
+				<displayName count="other">Nepalfoɔ rupee</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5178,9 +5178,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="PKR">
-				<displayName>Pakistanfoͻ rupee</displayName>
-				<displayName count="one">Pakistanfoͻ rupee</displayName>
-				<displayName count="other">Pakistanfoͻ rupee</displayName>
+				<displayName>Pakistanfoɔ rupee</displayName>
+				<displayName count="one">Pakistanfoɔ rupee</displayName>
+				<displayName count="other">Pakistanfoɔ rupee</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5383,9 +5383,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="TWD">
-				<displayName>Taewanfoͻ dͻla foforͻ</displayName>
-				<displayName count="one">Taelanfoͻ dͻla foforͻ</displayName>
-				<displayName count="other">Taewanfoͻ dͻla foforͻ</displayName>
+				<displayName>Taewanfoɔ dɔla foforɔ</displayName>
+				<displayName count="one">Taelanfoɔ dɔla foforɔ</displayName>
+				<displayName count="other">Taewanfoɔ dɔla foforɔ</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5416,9 +5416,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
 			<currency type="UYU">
-				<displayName>Yurugueԑ peso</displayName>
-				<displayName count="one">Yurugueԑ peso</displayName>
-				<displayName count="other">Yurugueԑ peso</displayName>
+				<displayName>Yurugueɛ peso</displayName>
+				<displayName count="one">Yurugueɛ peso</displayName>
+				<displayName count="other">Yurugueɛ peso</displayName>
 				<symbol draft="contributed">↑↑↑</symbol>
 				<symbol alt="narrow" draft="contributed">↑↑↑</symbol>
 			</currency>
@@ -5543,7 +5543,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>piko{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-15">
-				<unitPrefixPattern>fɛmtͻ{0}</unitPrefixPattern>
+				<unitPrefixPattern>fɛmtɔ{0}</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="10p-18">
 				<unitPrefixPattern>atto{0}</unitPrefixPattern>
@@ -5621,7 +5621,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPrefixPattern>↑↑↑</unitPrefixPattern>
 			</compoundUnit>
 			<compoundUnit type="per">
-				<compoundUnitPattern>{0} wͻ {1} biara mu</compoundUnitPattern>
+				<compoundUnitPattern>{0} wɔ {1} biara mu</compoundUnitPattern>
 			</compoundUnit>
 			<compoundUnit type="power2">
 				<compoundUnitPattern1 count="one">sokwɛɛ {0}</compoundUnitPattern1>
@@ -5873,10 +5873,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>bosome biara {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>nnawͻtwe</displayName>
-				<unitPattern count="one">nnawͻtwe {0}</unitPattern>
-				<unitPattern count="other">nnawͻtwe {0}</unitPattern>
-				<perUnitPattern>nnawͻtwe biara {0}</perUnitPattern>
+				<displayName>nnawɔtwe</displayName>
+				<unitPattern count="one">nnawɔtwe {0}</unitPattern>
+				<unitPattern count="other">nnawɔtwe {0}</unitPattern>
+				<perUnitPattern>nnawɔtwe biara {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-day">
 				<displayName>nna</displayName>
@@ -5885,9 +5885,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>dͻnhwere</displayName>
-				<unitPattern count="one">dͻnhwere {0}</unitPattern>
-				<unitPattern count="other">dͻnhwere {0}</unitPattern>
+				<displayName>dɔnhwere</displayName>
+				<unitPattern count="one">dɔnhwere {0}</unitPattern>
+				<unitPattern count="other">dɔnhwere {0}</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-minute">
@@ -6348,8 +6348,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="speed-knot">
 				<displayName>Pɔ</displayName>
-				<unitPattern count="one">Pͻ {0}</unitPattern>
-				<unitPattern count="other">Pͻ {0}</unitPattern>
+				<unitPattern count="one">Pɔ {0}</unitPattern>
+				<unitPattern count="other">Pɔ {0}</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>
@@ -6507,9 +6507,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-tablespoon">
-				<displayName>Atere kԑseԑ</displayName>
-				<unitPattern count="one">Atere kԑseԑ {0}</unitPattern>
-				<unitPattern count="other">Atere kԑseԑ {0}</unitPattern>
+				<displayName>Atere kɛseɛ</displayName>
+				<unitPattern count="one">Atere kɛseɛ {0}</unitPattern>
+				<unitPattern count="other">Atere kɛseɛ {0}</unitPattern>
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName>atere fa</displayName>
@@ -6537,9 +6537,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">koko {0}</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>drͻm</displayName>
-				<unitPattern count="one">drͻm fl {0}</unitPattern>
-				<unitPattern count="other">drͻm fl {0}</unitPattern>
+				<displayName>drɔm</displayName>
+				<unitPattern count="one">drɔm fl {0}</unitPattern>
+				<unitPattern count="other">drɔm fl {0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>gyega</displayName>
@@ -6930,7 +6930,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>nnawͻtwe</displayName>
+				<displayName>nnawɔtwe</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
@@ -6942,7 +6942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>dͻnhwere</displayName>
+				<displayName>dɔnhwere</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
@@ -7594,9 +7594,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">ko {0}</unitPattern>
 			</unit>
 			<unit type="volume-dram">
-				<displayName>drͻm</displayName>
-				<unitPattern count="one">drͻm {0}</unitPattern>
-				<unitPattern count="other">drͻm {0}</unitPattern>
+				<displayName>drɔm</displayName>
+				<unitPattern count="one">drɔm {0}</unitPattern>
+				<unitPattern count="other">drɔm {0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>gyega</displayName>
@@ -7987,7 +7987,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-week">
-				<displayName>nnawͻtwe</displayName>
+				<displayName>nnawɔtwe</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
@@ -7999,7 +7999,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-hour">
-				<displayName>dͻnhwere</displayName>
+				<displayName>dɔnhwere</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 				<perUnitPattern>↑↑↑</perUnitPattern>
@@ -8652,8 +8652,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="volume-dram">
 				<displayName>fl.dr.</displayName>
-				<unitPattern count="one">drͻm fl {0}</unitPattern>
-				<unitPattern count="other">drͻm fl {0}</unitPattern>
+				<unitPattern count="one">drɔm fl {0}</unitPattern>
+				<unitPattern count="other">drɔm fl {0}</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>gyega</displayName>
@@ -8798,7 +8798,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<characterLabel type="dash_connector">dash anaa kɔnɛkta</characterLabel>
 		<characterLabel type="digits">digyite</characterLabel>
 		<characterLabel type="dingbats">↑↑↑</characterLabel>
-		<characterLabel type="divination_symbols">akͻmfosɛm ahyɛnsodeɛ</characterLabel>
+		<characterLabel type="divination_symbols">akɔmfosɛm ahyɛnsodeɛ</characterLabel>
 		<characterLabel type="downwards_arrows">fam aaro</characterLabel>
 		<characterLabel type="downwards_upwards_arrows">fam soro aaro</characterLabel>
 		<characterLabel type="east_asian_scripts">Asia Apueɛ sikripite</characterLabel>
@@ -8873,27 +8873,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<axisName type="ital">italike</axisName>
 		<axisName type="opsz">↑↑↑</axisName>
 		<axisName type="slnt">↑↑↑</axisName>
-		<axisName type="wdth">ntrԑmu</axisName>
+		<axisName type="wdth">ntrɛmu</axisName>
 		<axisName type="wght">emu duru</axisName>
 		<styleName type="ital" subtype="1">↑↑↑</styleName>
-		<styleName type="opsz" subtype="8">dintoͻ</styleName>
-		<styleName type="opsz" subtype="12">atwerԑ</styleName>
-		<styleName type="opsz" subtype="18">atifi asԑm</styleName>
-		<styleName type="opsz" subtype="72">yikyerԑ</styleName>
+		<styleName type="opsz" subtype="8">dintoɔ</styleName>
+		<styleName type="opsz" subtype="12">atwerɛ</styleName>
+		<styleName type="opsz" subtype="18">atifi asɛm</styleName>
+		<styleName type="opsz" subtype="72">yikyerɛ</styleName>
 		<styleName type="opsz" subtype="144">posta</styleName>
-		<styleName type="slnt" subtype="-12">akyire nkyeaeԑ</styleName>
+		<styleName type="slnt" subtype="-12">akyire nkyeaeɛ</styleName>
 		<styleName type="slnt" subtype="0">pintinn</styleName>
-		<styleName type="slnt" subtype="12">nkyeaeԑ</styleName>
-		<styleName type="slnt" subtype="24">nkyeaeԑ pii</styleName>
-		<styleName type="wdth" subtype="50">emu pi mmorosoͻ</styleName>
-		<styleName type="wdth" subtype="62.5">emu pi-mmorosoͻ</styleName>
+		<styleName type="slnt" subtype="12">nkyeaeɛ</styleName>
+		<styleName type="slnt" subtype="24">nkyeaeɛ pii</styleName>
+		<styleName type="wdth" subtype="50">emu pi mmorosoɔ</styleName>
+		<styleName type="wdth" subtype="62.5">emu pi-mmorosoɔ</styleName>
 		<styleName type="wdth" subtype="75">emu pi</styleName>
 		<styleName type="wdth" subtype="87.5">emu pi fa ne fa</styleName>
-		<styleName type="wdth" subtype="100">daasԑm</styleName>
+		<styleName type="wdth" subtype="100">daasɛm</styleName>
 		<styleName type="wdth" subtype="112.5">emu aba da ne fa</styleName>
 		<styleName type="wdth" subtype="125">emu abae</styleName>
-		<styleName type="wdth" subtype="150">emu abae mmorosoͻ</styleName>
-		<styleName type="wdth" subtype="200">emu abae mmorosoͻ koraa</styleName>
+		<styleName type="wdth" subtype="150">emu abae mmorosoɔ</styleName>
+		<styleName type="wdth" subtype="200">emu abae mmorosoɔ koraa</styleName>
 		<styleName type="wght" subtype="100">hweaa</styleName>
 		<styleName type="wght" subtype="200">hweaa koraa</styleName>
 		<styleName type="wght" subtype="300">kanea</styleName>
@@ -8902,21 +8902,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<styleName type="wght" subtype="400">daa</styleName>
 		<styleName type="wght" subtype="500">fa ne fa</styleName>
 		<styleName type="wght" subtype="600">tumm kakra</styleName>
-		<styleName type="wght" subtype="700">akokoͻduru</styleName>
-		<styleName type="wght" subtype="800">akokoͻduru mmorͻsoͻ</styleName>
+		<styleName type="wght" subtype="700">akokoɔduru</styleName>
+		<styleName type="wght" subtype="800">akokoɔduru mmorɔsoɔ</styleName>
 		<styleName type="wght" subtype="900">tuntum</styleName>
 		<styleName type="wght" subtype="950">tuntum a ɛboro so</styleName>
 		<featureName type="afrc">soro-fam frahyen</featureName>
-		<featureName type="cpsp">atwerԑdeԑ akԑseԑ ntetemu</featureName>
-		<featureName type="dlig">ligekya a ԑnyԑ ͻhyԑ</featureName>
+		<featureName type="cpsp">atwerɛdeɛ akɛseɛ ntetemu</featureName>
+		<featureName type="dlig">ligekya a ɛnyɛ ɔhyɛ</featureName>
 		<featureName type="frac">benkum-nifa frahyen</featureName>
-		<featureName type="lnum">nͻma a ԑdeda mu</featureName>
-		<featureName type="onum">tete nͻma deԑ</featureName>
-		<featureName type="ordn">ͻdinaafoͻ</featureName>
-		<featureName type="pnum">prͻpͻͻhyen nͻma</featureName>
-		<featureName type="smcp">atwerԑdeԑ akԑseԑ nkumaa</featureName>
-		<featureName type="tnum">pono so nͻma</featureName>
-		<featureName type="zero">ziro a yԑapae mu</featureName>
+		<featureName type="lnum">nɔma a ɛdeda mu</featureName>
+		<featureName type="onum">tete nɔma deɛ</featureName>
+		<featureName type="ordn">ɔdinaafoɔ</featureName>
+		<featureName type="pnum">prɔpɔɔhyen nɔma</featureName>
+		<featureName type="smcp">atwerɛdeɛ akɛseɛ nkumaa</featureName>
+		<featureName type="tnum">pono so nɔma</featureName>
+		<featureName type="zero">ziro a yɛapae mu</featureName>
 	</typographicNames>
 	<personNames>
 		<nameOrderLocales order="givenFirst">und ak en</nameOrderLocales>


### PR DESCRIPTION
CLDR-17852

- [x] This PR completes the ticket.

As requested in CLDR TC meeting 2024-07-31, this PR changes epsilon and open-o characters to match main exemplar. Specifically:
- epsilon U+0511 (Cyrillic range) changed to U+025B
- open-o U+037B (Greek range) changed to U+0254

Additionally some accented vowels (which occur in the existing data) are added to the auxiliary exemplar.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
