### PR TITLE
CLDR-17839 Further fixes for Hebrew units

### DIFF
--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -9513,24 +9513,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="graphics-dot-per-centimeter">
 				<displayName>נקודות לסנטימטר</displayName>
-				<unitPattern count="one">נקודה {0} לסנטימטר</unitPattern>
-				<unitPattern count="two">{0} נקודות לסנטימטר</unitPattern>
-				<unitPattern count="many">{0} נקודות לסנטימטר</unitPattern>
-				<unitPattern count="other">{0} נקודות לסנטימטר</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot-per-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">נקודה לאינץ׳</unitPattern>
-				<unitPattern count="two">{0} נקודות לאינץ׳</unitPattern>
-				<unitPattern count="many">{0} נקודות לאינץ׳</unitPattern>
-				<unitPattern count="other">{0} נקודות לאינץ׳</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="graphics-dot">
 				<displayName>נקודות קטנות</displayName>
-				<unitPattern count="one">{0} נקודה</unitPattern>
-				<unitPattern count="two">שתי נקודות קטנות</unitPattern>
-				<unitPattern count="many">{0} נקודות קטנות</unitPattern>
-				<unitPattern count="other">{0} נקודות קטנות</unitPattern>
+				<unitPattern count="one">↑↑↑</unitPattern>
+				<unitPattern count="two">↑↑↑</unitPattern>
+				<unitPattern count="many">↑↑↑</unitPattern>
+				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="length-earth-radius">
 				<displayName>רדיוס כדור-הארץ</displayName>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -8920,7 +8920,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="angle-arc-minute">
 				<gender>feminine</gender>
 				<displayName>דקות קשת</displayName>
-				<unitPattern count="one">דקת קשת {0}</unitPattern>
+				<unitPattern count="one">{0} דקת קשת</unitPattern>
 				<unitPattern count="two">{0} דקות קשת</unitPattern>
 				<unitPattern count="many">{0} דקות קשת</unitPattern>
 				<unitPattern count="other">{0} דקות קשת</unitPattern>
@@ -8928,7 +8928,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="angle-arc-second">
 				<gender>feminine</gender>
 				<displayName>שניות קשת</displayName>
-				<unitPattern count="one">שניית קשת {0}</unitPattern>
+				<unitPattern count="one">{0} שניית קשת</unitPattern>
 				<unitPattern count="two">{0} שניות קשת</unitPattern>
 				<unitPattern count="many">{0} שניות קשת</unitPattern>
 				<unitPattern count="other">{0} שניות קשת</unitPattern>
@@ -8936,7 +8936,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-kilometer">
 				<gender>masculine</gender>
 				<displayName>קילומטר רבוע</displayName>
-				<unitPattern count="one">קילומטר רבוע {0}</unitPattern>
+				<unitPattern count="one">{0} קילומטר רבוע</unitPattern>
 				<unitPattern count="two">{0} קילומטר רבוע</unitPattern>
 				<unitPattern count="many">{0} קילומטר רבוע</unitPattern>
 				<unitPattern count="other">{0} קילומטר רבוע</unitPattern>
@@ -8945,7 +8945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-hectare">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">הקטאר {0}</unitPattern>
+				<unitPattern count="one">{0} הקטאר</unitPattern>
 				<unitPattern count="two">{0} הקטאר</unitPattern>
 				<unitPattern count="many">{0} הקטאר</unitPattern>
 				<unitPattern count="other">{0} הקטאר</unitPattern>
@@ -8953,7 +8953,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-meter">
 				<gender>masculine</gender>
 				<displayName>מטר רבוע</displayName>
-				<unitPattern count="one">מטר רבוע {0}</unitPattern>
+				<unitPattern count="one">{0} מטר רבוע</unitPattern>
 				<unitPattern count="two">{0} מטר רבוע</unitPattern>
 				<unitPattern count="many">{0} מטר רבוע</unitPattern>
 				<unitPattern count="other">{0} מטר רבוע</unitPattern>
@@ -8962,7 +8962,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="area-square-centimeter">
 				<gender>masculine</gender>
 				<displayName>סנטימטר רבוע</displayName>
-				<unitPattern count="one">סנטימטר רבוע {0}</unitPattern>
+				<unitPattern count="one">{0} סנטימטר רבוע</unitPattern>
 				<unitPattern count="two">{0} סנטימטר רבוע</unitPattern>
 				<unitPattern count="many">{0} סנטימטר רבוע</unitPattern>
 				<unitPattern count="other">{0} סנטימטר רבוע</unitPattern>
@@ -8970,7 +8970,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-square-mile">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">מייל רבוע {0}</unitPattern>
+				<unitPattern count="one">{0} מייל רבוע</unitPattern>
 				<unitPattern count="two">{0} מייל רבוע</unitPattern>
 				<unitPattern count="many">{0} מייל רבוע</unitPattern>
 				<unitPattern count="other">{0} מייל רבוע</unitPattern>
@@ -8978,28 +8978,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="area-acre">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">אקר {0}</unitPattern>
+				<unitPattern count="one">{0} אקר</unitPattern>
 				<unitPattern count="two">{0} אקר</unitPattern>
 				<unitPattern count="many">{0} אקר</unitPattern>
 				<unitPattern count="other">{0} אקר</unitPattern>
 			</unit>
 			<unit type="area-square-yard">
 				<displayName>יארד רבוע</displayName>
-				<unitPattern count="one">יארד רבוע {0}</unitPattern>
+				<unitPattern count="one">{0} יארד רבוע</unitPattern>
 				<unitPattern count="two">{0} יארד רבוע</unitPattern>
 				<unitPattern count="many">{0} יארד רבוע</unitPattern>
 				<unitPattern count="other">{0} יארד רבוע</unitPattern>
 			</unit>
 			<unit type="area-square-foot">
 				<displayName>רגל רבועה</displayName>
-				<unitPattern count="one">רגל רבועה {0}</unitPattern>
+				<unitPattern count="one">{0} רגל רבועה</unitPattern>
 				<unitPattern count="two">{0} רגל רבועה</unitPattern>
 				<unitPattern count="many">{0} רגל רבועה</unitPattern>
 				<unitPattern count="other">{0} רגל רבועה</unitPattern>
 			</unit>
 			<unit type="area-square-inch">
 				<displayName>אינץ׳ רבוע</displayName>
-				<unitPattern count="one">אינץ׳ רבוע {0}</unitPattern>
+				<unitPattern count="one">{0} אינץ׳ רבוע</unitPattern>
 				<unitPattern count="two">{0} אינץ׳ רבוע</unitPattern>
 				<unitPattern count="many">{0} אינץ׳ רבוע</unitPattern>
 				<unitPattern count="other">{0} אינץ׳ רבוע</unitPattern>
@@ -9071,7 +9071,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="concentr-permyriad">
 				<gender>feminine</gender>
 				<displayName>רבבית</displayName>
-				<unitPattern count="one">רבבית {0}</unitPattern>
+				<unitPattern count="one">{0} רבבית</unitPattern>
 				<unitPattern count="two">{0} רבביות</unitPattern>
 				<unitPattern count="many">{0} רבביות</unitPattern>
 				<unitPattern count="other">{0} רבביות</unitPattern>
@@ -9125,10 +9125,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="digital-terabyte">
 				<gender>masculine</gender>
 				<displayName>טרה-בייט</displayName>
-				<unitPattern count="one">טרה-בייט {0}</unitPattern>
-				<unitPattern count="two">טרה-בייט {0}</unitPattern>
-				<unitPattern count="many">טרה-בייט {0}</unitPattern>
-				<unitPattern count="other">טרה-בייט {0}</unitPattern>
+				<unitPattern count="one">{0} טרה-בייט</unitPattern>
+				<unitPattern count="two">{0} טרה-בייט</unitPattern>
+				<unitPattern count="many">{0} טרה-בייט</unitPattern>
+				<unitPattern count="other">{0} טרה-בייט</unitPattern>
 			</unit>
 			<unit type="digital-terabit">
 				<gender>masculine</gender>
@@ -9296,7 +9296,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="duration-millisecond">
 				<gender>feminine</gender>
 				<displayName>אלפיות השניה</displayName>
-				<unitPattern count="one">אלפית שנייה {0}</unitPattern>
+				<unitPattern count="one">{0} אלפית שנייה</unitPattern>
 				<unitPattern count="two">{0} אלפיות שנייה</unitPattern>
 				<unitPattern count="many">{0} אלפיות שנייה</unitPattern>
 				<unitPattern count="other">{0} אלפיות שנייה</unitPattern>
@@ -9320,7 +9320,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="electric-ampere">
 				<gender>masculine</gender>
 				<displayName>אמפר</displayName>
-				<unitPattern count="one">אמפר {0}</unitPattern>
+				<unitPattern count="one">{0} אמפר</unitPattern>
 				<unitPattern count="two">{0} אמפר</unitPattern>
 				<unitPattern count="many">{0} אמפר</unitPattern>
 				<unitPattern count="other">{0} אמפר</unitPattern>
@@ -9328,7 +9328,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="electric-milliampere">
 				<gender>masculine</gender>
 				<displayName>מיליאמפר</displayName>
-				<unitPattern count="one">מיליאמפר {0}</unitPattern>
+				<unitPattern count="one">{0} מיליאמפר</unitPattern>
 				<unitPattern count="two">{0} מיליאמפר</unitPattern>
 				<unitPattern count="many">{0} מיליאמפר</unitPattern>
 				<unitPattern count="other">{0} מיליאמפר</unitPattern>
@@ -9344,7 +9344,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="electric-volt">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">וולט {0}</unitPattern>
+				<unitPattern count="one">{0} וולט</unitPattern>
 				<unitPattern count="two">{0} וולט</unitPattern>
 				<unitPattern count="many">{0} וולט</unitPattern>
 				<unitPattern count="other">{0} וולט</unitPattern>
@@ -9352,7 +9352,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-kilocalorie">
 				<gender>feminine</gender>
 				<displayName>קילו קלוריות</displayName>
-				<unitPattern count="one">קילו קלוריה {0}</unitPattern>
+				<unitPattern count="one">{0} קילו קלוריה</unitPattern>
 				<unitPattern count="two">{0} קילו קלוריות</unitPattern>
 				<unitPattern count="many">{0} קילו קלוריות</unitPattern>
 				<unitPattern count="other">{0} קילו קלוריות</unitPattern>
@@ -9360,7 +9360,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-calorie">
 				<gender>feminine</gender>
 				<displayName>קלוריות</displayName>
-				<unitPattern count="one">קלוריה {0}</unitPattern>
+				<unitPattern count="one">{0} קלוריה</unitPattern>
 				<unitPattern count="two">{0} קלוריות</unitPattern>
 				<unitPattern count="many">{0} קלוריות</unitPattern>
 				<unitPattern count="other">{0} קלוריות</unitPattern>
@@ -9375,7 +9375,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-kilojoule">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">קילו ג׳אול {0}</unitPattern>
+				<unitPattern count="one">{0} קילו ג׳אול</unitPattern>
 				<unitPattern count="two">{0} קילו ג׳אול</unitPattern>
 				<unitPattern count="many">{0} קילו ג׳אול</unitPattern>
 				<unitPattern count="other">{0} קילו ג׳אול</unitPattern>
@@ -9391,7 +9391,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="energy-kilowatt-hour">
 				<gender>masculine</gender>
 				<displayName>קילוואט־שעה</displayName>
-				<unitPattern count="one">קילוואט־שעה {0}</unitPattern>
+				<unitPattern count="one">{0} קילוואט־שעה</unitPattern>
 				<unitPattern count="two">{0} קילוואט-שעה</unitPattern>
 				<unitPattern count="many">{0} קילוואט-שעה</unitPattern>
 				<unitPattern count="other">{0} קילוואט-שעה</unitPattern>
@@ -9443,7 +9443,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="frequency-gigahertz">
 				<gender>masculine</gender>
 				<displayName>ג׳יגה-הרץ</displayName>
-				<unitPattern count="one">ג׳יגה-הרץ {0}</unitPattern>
+				<unitPattern count="one">{0} ג׳יגה-הרץ</unitPattern>
 				<unitPattern count="two">{0} ג׳יגה-הרץ</unitPattern>
 				<unitPattern count="many">{0} ג׳יגה-הרץ</unitPattern>
 				<unitPattern count="other">{0} ג׳יגה-הרץ</unitPattern>
@@ -9451,7 +9451,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="frequency-megahertz">
 				<gender>masculine</gender>
 				<displayName>מגה-הרץ</displayName>
-				<unitPattern count="one">מגה-הרץ {0}</unitPattern>
+				<unitPattern count="one">{0} מגה-הרץ</unitPattern>
 				<unitPattern count="two">{0} מגה-הרץ</unitPattern>
 				<unitPattern count="many">{0} מגה-הרץ</unitPattern>
 				<unitPattern count="other">{0} מגה-הרץ</unitPattern>
@@ -9459,7 +9459,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="frequency-kilohertz">
 				<gender>masculine</gender>
 				<displayName>קילו-הרץ</displayName>
-				<unitPattern count="one">קילו-הרץ {0}</unitPattern>
+				<unitPattern count="one">{0} קילו-הרץ</unitPattern>
 				<unitPattern count="two">{0} קילו-הרץ</unitPattern>
 				<unitPattern count="many">{0} קילו-הרץ</unitPattern>
 				<unitPattern count="other">{0} קילו-הרץ</unitPattern>
@@ -9467,7 +9467,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="frequency-hertz">
 				<gender>masculine</gender>
 				<displayName>הרץ</displayName>
-				<unitPattern count="one">הרץ {0}</unitPattern>
+				<unitPattern count="one">{0} הרץ</unitPattern>
 				<unitPattern count="two">{0} הרץ</unitPattern>
 				<unitPattern count="many">{0} הרץ</unitPattern>
 				<unitPattern count="other">{0} הרץ</unitPattern>
@@ -9542,7 +9542,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-kilometer">
 				<gender>masculine</gender>
 				<displayName>קילומטרים</displayName>
-				<unitPattern count="one">קילומטר {0}</unitPattern>
+				<unitPattern count="one">{0} קילומטר</unitPattern>
 				<unitPattern count="two">{0} קילומטרים</unitPattern>
 				<unitPattern count="many">{0} קילומטרים</unitPattern>
 				<unitPattern count="other">{0} קילומטרים</unitPattern>
@@ -9551,7 +9551,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-meter">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">מטר {0}</unitPattern>
+				<unitPattern count="one">{0} מטר</unitPattern>
 				<unitPattern count="two">{0} מטרים</unitPattern>
 				<unitPattern count="many">{0} מטרים</unitPattern>
 				<unitPattern count="other">{0} מטרים</unitPattern>
@@ -9560,7 +9560,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-decimeter">
 				<gender>masculine</gender>
 				<displayName>דצימטר</displayName>
-				<unitPattern count="one">דצימטר {0}</unitPattern>
+				<unitPattern count="one">{0} דצימטר</unitPattern>
 				<unitPattern count="two">{0} דצימטרים</unitPattern>
 				<unitPattern count="many">{0} דצימטרים</unitPattern>
 				<unitPattern count="other">{0} דצימטרים</unitPattern>
@@ -9568,7 +9568,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-centimeter">
 				<gender>masculine</gender>
 				<displayName>סנטימטרים</displayName>
-				<unitPattern count="one">סנטימטר {0}</unitPattern>
+				<unitPattern count="one">{0} סנטימטר</unitPattern>
 				<unitPattern count="two">{0} סנטימטרים</unitPattern>
 				<unitPattern count="many">{0} סנטימטרים</unitPattern>
 				<unitPattern count="other">{0} סנטימטרים</unitPattern>
@@ -9577,7 +9577,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-millimeter">
 				<gender>masculine</gender>
 				<displayName>מילימטרים</displayName>
-				<unitPattern count="one">מילימטר {0}</unitPattern>
+				<unitPattern count="one">{0} מילימטר</unitPattern>
 				<unitPattern count="two">{0} מילימטרים</unitPattern>
 				<unitPattern count="many">{0} מילימטרים</unitPattern>
 				<unitPattern count="other">{0} מילימטרים</unitPattern>
@@ -9585,7 +9585,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-micrometer">
 				<gender>masculine</gender>
 				<displayName>מיקרומטרים</displayName>
-				<unitPattern count="one">מיקרומטר {0}</unitPattern>
+				<unitPattern count="one">{0} מיקרומטר</unitPattern>
 				<unitPattern count="two">{0} מיקרומטרים</unitPattern>
 				<unitPattern count="many">{0} מיקרומטרים</unitPattern>
 				<unitPattern count="other">{0} מיקרומטרים</unitPattern>
@@ -9593,7 +9593,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-nanometer">
 				<gender>masculine</gender>
 				<displayName>ננומטרים</displayName>
-				<unitPattern count="one">ננומטר {0}</unitPattern>
+				<unitPattern count="one">{0} ננומטר</unitPattern>
 				<unitPattern count="two">{0} ננומטרים</unitPattern>
 				<unitPattern count="many">{0} ננומטרים</unitPattern>
 				<unitPattern count="other">{0} ננומטרים</unitPattern>
@@ -9601,7 +9601,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-picometer">
 				<gender>masculine</gender>
 				<displayName>פיקומטרים</displayName>
-				<unitPattern count="one">פיקומטר {0}</unitPattern>
+				<unitPattern count="one">{0} פיקומטר</unitPattern>
 				<unitPattern count="two">{0} פיקומטרים</unitPattern>
 				<unitPattern count="many">{0} פיקומטרים</unitPattern>
 				<unitPattern count="other">{0} פיקומטרים</unitPattern>
@@ -9622,7 +9622,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-foot">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">רגל {0}</unitPattern>
+				<unitPattern count="one">{0} רגל</unitPattern>
 				<unitPattern count="two">{0} רגל</unitPattern>
 				<unitPattern count="many">{0} רגל</unitPattern>
 				<unitPattern count="other">{0} רגל</unitPattern>
@@ -9630,7 +9630,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-inch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">אינץ׳ {0}</unitPattern>
+				<unitPattern count="one">{0} אינץ׳</unitPattern>
 				<unitPattern count="two">{0} אינץ׳</unitPattern>
 				<unitPattern count="many">{0} אינץ׳</unitPattern>
 				<unitPattern count="other">{0} אינץ׳</unitPattern>
@@ -9652,7 +9652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-astronomical-unit">
 				<displayName>יחידות אסטרונומיות</displayName>
-				<unitPattern count="one">יחידה אסטרונומית {0}</unitPattern>
+				<unitPattern count="one">{0} יחידה אסטרונומית</unitPattern>
 				<unitPattern count="two">{0} יחידות אסטרונומיות</unitPattern>
 				<unitPattern count="many">{0} יחידות אסטרונומיות</unitPattern>
 				<unitPattern count="other">{0} יחידות אסטרונומיות</unitPattern>
@@ -9673,7 +9673,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-nautical-mile">
 				<displayName>מייל ימי</displayName>
-				<unitPattern count="one">מייל ימי {0}</unitPattern>
+				<unitPattern count="one">{0} מייל ימי</unitPattern>
 				<unitPattern count="two">{0} מייל ימי</unitPattern>
 				<unitPattern count="many">{0} מייל ימי</unitPattern>
 				<unitPattern count="other">{0} מייל ימי</unitPattern>
@@ -9681,7 +9681,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-mile-scandinavian">
 				<gender>masculine</gender>
 				<displayName>מייל-סקנדינביה</displayName>
-				<unitPattern count="one">מייל-סקנדינביה {0}</unitPattern>
+				<unitPattern count="one">{0} מייל-סקנדינביה</unitPattern>
 				<unitPattern count="two">{0} מייל-סקנדינביה</unitPattern>
 				<unitPattern count="many">{0} מייל-סקנדינביה</unitPattern>
 				<unitPattern count="other">{0} מייל-סקנדינביה</unitPattern>
@@ -9689,7 +9689,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="length-point">
 				<gender>feminine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">נקודה {0}</unitPattern>
+				<unitPattern count="one">{0} נקודה</unitPattern>
 				<unitPattern count="two">{0} נקודות</unitPattern>
 				<unitPattern count="many">{0} נקודות</unitPattern>
 				<unitPattern count="other">{0} נקודות</unitPattern>
@@ -9720,7 +9720,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="light-lumen">
 				<gender>masculine</gender>
 				<displayName>לומן</displayName>
-				<unitPattern count="one">לומן {0}</unitPattern>
+				<unitPattern count="one">{0} לומן</unitPattern>
 				<unitPattern count="two">{0} לומן</unitPattern>
 				<unitPattern count="many">{0} לומן</unitPattern>
 				<unitPattern count="other">{0} לומן</unitPattern>
@@ -9743,7 +9743,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-kilogram">
 				<gender>masculine</gender>
 				<displayName>קילוגרם</displayName>
-				<unitPattern count="one">קילוגרם {0}</unitPattern>
+				<unitPattern count="one">{0} קילוגרם</unitPattern>
 				<unitPattern count="two">{0} קילוגרם</unitPattern>
 				<unitPattern count="many">{0} קילוגרם</unitPattern>
 				<unitPattern count="other">{0} קילוגרם</unitPattern>
@@ -9752,7 +9752,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="mass-gram">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">גרם {0}</unitPattern>
+				<unitPattern count="one">{0} גרם</unitPattern>
 				<unitPattern count="two">{0} גרם</unitPattern>
 				<unitPattern count="many">{0} גרם</unitPattern>
 				<unitPattern count="other">{0} גרם</unitPattern>
@@ -9776,7 +9776,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ton">
 				<displayName>טונות</displayName>
-				<unitPattern count="one">טונה {0}</unitPattern>
+				<unitPattern count="one">{0} טונה</unitPattern>
 				<unitPattern count="two">{0} טונות</unitPattern>
 				<unitPattern count="many">{0} טונות</unitPattern>
 				<unitPattern count="other">{0} טונות</unitPattern>
@@ -9798,7 +9798,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce">
 				<displayName>אונקיות</displayName>
-				<unitPattern count="one">אונקיה {0}</unitPattern>
+				<unitPattern count="one">{0} אונקיה</unitPattern>
 				<unitPattern count="two">{0} אונקיות</unitPattern>
 				<unitPattern count="many">{0} אונקיות</unitPattern>
 				<unitPattern count="other">{0} אונקיות</unitPattern>
@@ -9806,7 +9806,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ounce-troy">
 				<displayName>אונקיות טרוי</displayName>
-				<unitPattern count="one">אונקיית טרוי {0}</unitPattern>
+				<unitPattern count="one">{0} אונקיית טרוי</unitPattern>
 				<unitPattern count="two">{0} אונקיות טרוי</unitPattern>
 				<unitPattern count="many">{0} אונקיות טרוי</unitPattern>
 				<unitPattern count="other">{0} אונקיות טרוי</unitPattern>
@@ -9850,7 +9850,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-gigawatt">
 				<gender>masculine</gender>
 				<displayName>ג׳יגה ואט</displayName>
-				<unitPattern count="one">ג׳יגה ואט {0}</unitPattern>
+				<unitPattern count="one">{0} ג׳יגה ואט</unitPattern>
 				<unitPattern count="two">{0} ג׳יגה ואט</unitPattern>
 				<unitPattern count="many">{0} ג׳יגה ואט</unitPattern>
 				<unitPattern count="other">{0} ג׳יגה ואט</unitPattern>
@@ -9858,7 +9858,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-megawatt">
 				<gender>masculine</gender>
 				<displayName>מגה ואט</displayName>
-				<unitPattern count="one">מגה ואט {0}</unitPattern>
+				<unitPattern count="one">{0} מגה ואט</unitPattern>
 				<unitPattern count="two">{0} מגה ואט</unitPattern>
 				<unitPattern count="many">{0} מגה ואט</unitPattern>
 				<unitPattern count="other">{0} מגה ואט</unitPattern>
@@ -9866,7 +9866,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-kilowatt">
 				<gender>masculine</gender>
 				<displayName>קילוואט</displayName>
-				<unitPattern count="one">קילוואט {0}</unitPattern>
+				<unitPattern count="one">{0} קילוואט</unitPattern>
 				<unitPattern count="two">{0} קילוואט</unitPattern>
 				<unitPattern count="many">{0} קילוואט</unitPattern>
 				<unitPattern count="other">{0} קילוואט</unitPattern>
@@ -9874,7 +9874,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-watt">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">ואט {0}</unitPattern>
+				<unitPattern count="one">{0} ואט</unitPattern>
 				<unitPattern count="two">{0} ואט</unitPattern>
 				<unitPattern count="many">{0} ואט</unitPattern>
 				<unitPattern count="other">{0} ואט</unitPattern>
@@ -9882,14 +9882,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="power-milliwatt">
 				<gender>masculine</gender>
 				<displayName>מיליוואט</displayName>
-				<unitPattern count="one">מיליוואט {0}</unitPattern>
+				<unitPattern count="one">{0} מיליוואט</unitPattern>
 				<unitPattern count="two">{0} מיליוואט</unitPattern>
 				<unitPattern count="many">{0} מיליוואט</unitPattern>
 				<unitPattern count="other">{0} מיליוואט</unitPattern>
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>כוח סוס</displayName>
-				<unitPattern count="one">כוח סוס {0}</unitPattern>
+				<unitPattern count="one">{0} כוח סוס</unitPattern>
 				<unitPattern count="two">{0} כוח סוס</unitPattern>
 				<unitPattern count="many">{0} כוח סוס</unitPattern>
 				<unitPattern count="other">{0} כוח סוס</unitPattern>
@@ -9904,14 +9904,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>פאונד לאינץ׳ רבוע</displayName>
-				<unitPattern count="one">פאונד {0} לאינץ׳ רבוע</unitPattern>
+				<unitPattern count="one">{0} פאונדלאינץ׳ רבוע</unitPattern>
 				<unitPattern count="two">{0} פאונד לאינץ׳ רבוע</unitPattern>
 				<unitPattern count="many">{0} פאונד לאינץ׳ רבוע</unitPattern>
 				<unitPattern count="other">{0} פאונד לאינץ׳ רבוע</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
 				<displayName>אינץ׳ כספית</displayName>
-				<unitPattern count="one">אינץ׳ כספית {0}</unitPattern>
+				<unitPattern count="one">{0} אינץ׳ כספית</unitPattern>
 				<unitPattern count="two">{0} אינץ׳ כספית</unitPattern>
 				<unitPattern count="many">{0} אינץ׳ כספית</unitPattern>
 				<unitPattern count="other">{0} אינץ׳ כספית</unitPattern>
@@ -9951,7 +9951,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="pressure-hectopascal">
 				<gender>masculine</gender>
 				<displayName>הקטופסקל</displayName>
-				<unitPattern count="one">הקטופסקל {0}</unitPattern>
+				<unitPattern count="one">{0} הקטופסקל</unitPattern>
 				<unitPattern count="two">{0} הקטופסקל</unitPattern>
 				<unitPattern count="many">{0} הקטופסקל</unitPattern>
 				<unitPattern count="other">{0} הקטופסקל</unitPattern>
@@ -10004,9 +10004,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>בופורט</displayName>
-				<unitPattern count="one">בופורט {0}</unitPattern>
-				<unitPattern count="two">בופורט {0}</unitPattern>
-				<unitPattern count="other">בופורט {0}</unitPattern>
+				<unitPattern count="one">{0} בופורט</unitPattern>
+				<unitPattern count="two">{0} בופורט</unitPattern>
+				<unitPattern count="other">{0} בופורט</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<gender>feminine</gender>
@@ -10019,14 +10019,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="temperature-celsius">
 				<gender>feminine</gender>
 				<displayName>מעלות צלזיוס</displayName>
-				<unitPattern count="one">מעלת צלזיוס {0}</unitPattern>
+				<unitPattern count="one">{0} מעלת צלזיוס</unitPattern>
 				<unitPattern count="two">{0} מעלות צלזיוס</unitPattern>
 				<unitPattern count="many">{0} מעלות צלזיוס</unitPattern>
 				<unitPattern count="other">{0} מעלות צלזיוס</unitPattern>
 			</unit>
 			<unit type="temperature-fahrenheit">
 				<displayName>מעלות פרנהייט</displayName>
-				<unitPattern count="one">מעלת פרנהייט {0}</unitPattern>
+				<unitPattern count="one">{0} מעלת פרנהייט</unitPattern>
 				<unitPattern count="two">{0} מעלות פרנהייט</unitPattern>
 				<unitPattern count="many">{0} מעלות פרנהייט</unitPattern>
 				<unitPattern count="other">{0} מעלות פרנהייט</unitPattern>
@@ -10034,7 +10034,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="temperature-kelvin">
 				<gender>feminine</gender>
 				<displayName>מעלות קלווין</displayName>
-				<unitPattern count="one">קלווין {0}</unitPattern>
+				<unitPattern count="one">{0} קלווין</unitPattern>
 				<unitPattern count="two">{0} קלווין</unitPattern>
 				<unitPattern count="many">{0} קלווין</unitPattern>
 				<unitPattern count="other">{0} קלווין</unitPattern>
@@ -10057,7 +10057,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-cubic-kilometer">
 				<gender>masculine</gender>
 				<displayName>קילומטר מעוקב</displayName>
-				<unitPattern count="one">קילומטר מעוקב {0}</unitPattern>
+				<unitPattern count="one">{0} קילומטר מעוקב</unitPattern>
 				<unitPattern count="two">{0} קילומטר מעוקב</unitPattern>
 				<unitPattern count="many">{0} קילומטר מעוקב</unitPattern>
 				<unitPattern count="other">{0} קילומטר מעוקב</unitPattern>
@@ -10065,7 +10065,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-cubic-meter">
 				<gender>masculine</gender>
 				<displayName>מטר מעוקב</displayName>
-				<unitPattern count="one">מטר מעוקב {0}</unitPattern>
+				<unitPattern count="one">{0} מטר מעוקב</unitPattern>
 				<unitPattern count="two">{0} מטר מעוקב</unitPattern>
 				<unitPattern count="many">{0} מטר מעוקב</unitPattern>
 				<unitPattern count="other">{0} מטר מעוקב</unitPattern>
@@ -10074,7 +10074,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-cubic-centimeter">
 				<gender>masculine</gender>
 				<displayName>סנטימטר מעוקב</displayName>
-				<unitPattern count="one">סנטימטר מעוקב {0}</unitPattern>
+				<unitPattern count="one">{0} סנטימטר מעוקב</unitPattern>
 				<unitPattern count="two">{0} סנטימטר מעוקב</unitPattern>
 				<unitPattern count="many">{0} סנטימטר מעוקב</unitPattern>
 				<unitPattern count="other">{0} סנטימטר מעוקב</unitPattern>
@@ -10082,7 +10082,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-mile">
 				<displayName>מייל מעוקב</displayName>
-				<unitPattern count="one">מייל מעוקב {0}</unitPattern>
+				<unitPattern count="one">{0} מייל מעוקב</unitPattern>
 				<unitPattern count="two">{0} מייל מעוקב</unitPattern>
 				<unitPattern count="many">{0} מייל מעוקב</unitPattern>
 				<unitPattern count="other">{0} מייל מעוקב</unitPattern>
@@ -10096,14 +10096,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-foot">
 				<displayName>רגל מעוקב</displayName>
-				<unitPattern count="one">רגל מעוקב {0}</unitPattern>
+				<unitPattern count="one">{0} רגל מעוקב</unitPattern>
 				<unitPattern count="two">{0} רגל מעוקב</unitPattern>
 				<unitPattern count="many">{0} רגל מעוקב</unitPattern>
 				<unitPattern count="other">{0} רגל מעוקב</unitPattern>
 			</unit>
 			<unit type="volume-cubic-inch">
 				<displayName>אינץ׳ מעוקב</displayName>
-				<unitPattern count="one">אינץ׳ מעוקב {0}</unitPattern>
+				<unitPattern count="one">{0} אינץ׳ מעוקב</unitPattern>
 				<unitPattern count="two">{0} אינץ׳ מעוקב</unitPattern>
 				<unitPattern count="many">{0} אינץ׳ מעוקב</unitPattern>
 				<unitPattern count="other">{0} אינץ׳ מעוקב</unitPattern>
@@ -10111,7 +10111,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-megaliter">
 				<gender>masculine</gender>
 				<displayName>מגה ליטר</displayName>
-				<unitPattern count="one">מגה ליטר {0}</unitPattern>
+				<unitPattern count="one">{0} מגה ליטר</unitPattern>
 				<unitPattern count="two">{0} מגה ליטר</unitPattern>
 				<unitPattern count="many">{0} מגה ליטר</unitPattern>
 				<unitPattern count="other">{0} מגה ליטר</unitPattern>
@@ -10119,7 +10119,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-hectoliter">
 				<gender>masculine</gender>
 				<displayName>הקטוליטר</displayName>
-				<unitPattern count="one">הקטוליטר {0}</unitPattern>
+				<unitPattern count="one">{0} הקטוליטר</unitPattern>
 				<unitPattern count="two">{0} הקטוליטר</unitPattern>
 				<unitPattern count="many">{0} הקטוליטר</unitPattern>
 				<unitPattern count="other">{0} הקטוליטר</unitPattern>
@@ -10127,7 +10127,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-liter">
 				<gender>masculine</gender>
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">ליטר {0}</unitPattern>
+				<unitPattern count="one">{0} ליטר</unitPattern>
 				<unitPattern count="two">{0} ליטר</unitPattern>
 				<unitPattern count="many">{0} ליטר</unitPattern>
 				<unitPattern count="other">{0} ליטר</unitPattern>
@@ -10136,7 +10136,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-deciliter">
 				<gender>masculine</gender>
 				<displayName>דציליטר</displayName>
-				<unitPattern count="one">דציליטר {0}</unitPattern>
+				<unitPattern count="one">{0} דציליטר</unitPattern>
 				<unitPattern count="two">{0} דציליטר</unitPattern>
 				<unitPattern count="many">{0} דציליטר</unitPattern>
 				<unitPattern count="other">{0} דציליטר</unitPattern>
@@ -10144,7 +10144,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-centiliter">
 				<gender>masculine</gender>
 				<displayName>סנטיליטר</displayName>
-				<unitPattern count="one">סנטיליטר {0}</unitPattern>
+				<unitPattern count="one">{0} סנטיליטר</unitPattern>
 				<unitPattern count="two">{0} סנטיליטר</unitPattern>
 				<unitPattern count="many">{0} סנטיליטר</unitPattern>
 				<unitPattern count="other">{0} סנטיליטר</unitPattern>
@@ -10152,7 +10152,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-milliliter">
 				<gender>masculine</gender>
 				<displayName>מיליליטר</displayName>
-				<unitPattern count="one">מיליליטר {0}</unitPattern>
+				<unitPattern count="one">{0} מיליליטר</unitPattern>
 				<unitPattern count="two">{0} מיליליטר</unitPattern>
 				<unitPattern count="many">{0} מיליליטר</unitPattern>
 				<unitPattern count="other">{0} מיליליטר</unitPattern>
@@ -10160,7 +10160,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-pint-metric">
 				<gender>masculine</gender>
 				<displayName>פינט מטרי</displayName>
-				<unitPattern count="one">פינט מטרי {0}</unitPattern>
+				<unitPattern count="one">{0} פינט מטרי</unitPattern>
 				<unitPattern count="two">{0} פינט מטרי</unitPattern>
 				<unitPattern count="many">{0} פינט מטרי</unitPattern>
 				<unitPattern count="other">{0} פינט מטרי</unitPattern>
@@ -10168,14 +10168,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-cup-metric">
 				<gender>feminine</gender>
 				<displayName>כוס מידה מטרית</displayName>
-				<unitPattern count="one">כוס מידה מטרית {0}</unitPattern>
+				<unitPattern count="one">{0} כוס מידה מטרית</unitPattern>
 				<unitPattern count="two">{0} כ׳ מידה מטרית</unitPattern>
 				<unitPattern count="many">{0} כ׳ מידה מטרית</unitPattern>
 				<unitPattern count="other">{0} כ׳ מידה מטרית</unitPattern>
 			</unit>
 			<unit type="volume-acre-foot">
 				<displayName>אקר-רגל</displayName>
-				<unitPattern count="one">אקר-רגל {0}</unitPattern>
+				<unitPattern count="one">{0} אקר-רגל</unitPattern>
 				<unitPattern count="two">{0} אקר-רגל</unitPattern>
 				<unitPattern count="many">{0} אקר-רגל</unitPattern>
 				<unitPattern count="other">{0} אקר-רגל</unitPattern>
@@ -10189,7 +10189,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-gallon">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">גלון {0}</unitPattern>
+				<unitPattern count="one">{0} גלון</unitPattern>
 				<unitPattern count="two">{0} גלונים</unitPattern>
 				<unitPattern count="many">{0} גלונים</unitPattern>
 				<unitPattern count="other">{0} גלונים</unitPattern>
@@ -10197,7 +10197,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-gallon-imperial">
 				<displayName>גלון אימפריאלי</displayName>
-				<unitPattern count="one">גלון אימפריאלי {0}</unitPattern>
+				<unitPattern count="one">{0} גלון אימפריאלי</unitPattern>
 				<unitPattern count="two">{0} גלון אימפריאלי</unitPattern>
 				<unitPattern count="many">{0} גלון אימפריאלי</unitPattern>
 				<unitPattern count="other">{0} גלון אימפריאלי</unitPattern>
@@ -10205,28 +10205,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart">
 				<displayName>קווארטות</displayName>
-				<unitPattern count="one">קווארטה {0}</unitPattern>
+				<unitPattern count="one">{0} קווארטה</unitPattern>
 				<unitPattern count="two">{0} קווארטות</unitPattern>
 				<unitPattern count="many">{0} קווארטות</unitPattern>
 				<unitPattern count="other">{0} קווארטות</unitPattern>
 			</unit>
 			<unit type="volume-pint">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">פינט {0}</unitPattern>
+				<unitPattern count="one">{0} פינט</unitPattern>
 				<unitPattern count="two">{0} פינט</unitPattern>
 				<unitPattern count="many">{0} פינט</unitPattern>
 				<unitPattern count="other">{0} פינט</unitPattern>
 			</unit>
 			<unit type="volume-cup">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">כוס {0}</unitPattern>
+				<unitPattern count="one">{0} כוס</unitPattern>
 				<unitPattern count="two">{0} כוסות</unitPattern>
 				<unitPattern count="many">{0} כוסות</unitPattern>
 				<unitPattern count="other">{0} כוסות</unitPattern>
 			</unit>
 			<unit type="volume-fluid-ounce">
 				<displayName>אונקיות נוזלים</displayName>
-				<unitPattern count="one">אונקיית נוזלים {0}</unitPattern>
+				<unitPattern count="one">{0} אונקיית נוזלים</unitPattern>
 				<unitPattern count="two">{0} אונקיות נוזלים</unitPattern>
 				<unitPattern count="many">{0} אונקיות נוזלים</unitPattern>
 				<unitPattern count="other">{0} אונקיות נוזלים</unitPattern>
@@ -10247,7 +10247,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-teaspoon">
 				<displayName>כפיות</displayName>
-				<unitPattern count="one">כפית {0}</unitPattern>
+				<unitPattern count="one">{0} כפית</unitPattern>
 				<unitPattern count="two">{0} כפיות</unitPattern>
 				<unitPattern count="many">{0} כפיות</unitPattern>
 				<unitPattern count="other">{0} כפיות</unitPattern>
@@ -10282,28 +10282,28 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-dram">
 				<displayName>דראם אלכוהול</displayName>
-				<unitPattern count="one">דראם אלכוהול {0}</unitPattern>
+				<unitPattern count="one">{0} דראם אלכוהול</unitPattern>
 				<unitPattern count="two">{0} דראם אלכוהול</unitPattern>
 				<unitPattern count="many">{0} דראם אלכוהול</unitPattern>
 				<unitPattern count="other">{0} דראם אלכוהול</unitPattern>
 			</unit>
 			<unit type="volume-jigger">
 				<displayName>ג׳יגר</displayName>
-				<unitPattern count="one">ג'יגר {0}</unitPattern>
+				<unitPattern count="one">{0} ג׳יגר</unitPattern>
 				<unitPattern count="two">{0} ג'יגר</unitPattern>
 				<unitPattern count="many">{0} ג'יגר</unitPattern>
 				<unitPattern count="other">{0} ג'יגר</unitPattern>
 			</unit>
 			<unit type="volume-pinch">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">פינץ' {0}</unitPattern>
+				<unitPattern count="one">{0} פינץ׳</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>קווארט אימפריאלי</displayName>
-				<unitPattern count="one">קווארט אימפריאלי {0}</unitPattern>
+				<unitPattern count="one">{0} קווארט אימפריאלי</unitPattern>
 				<unitPattern count="two">{0} קווארטות אימפריאליות</unitPattern>
 				<unitPattern count="many">{0} קווארטות אימפריאליות</unitPattern>
 				<unitPattern count="other">{0} קווארטות אימפריאליות</unitPattern>
@@ -10492,14 +10492,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>דק׳ קשת</displayName>
-				<unitPattern count="one">ד׳ קשת {0}</unitPattern>
+				<unitPattern count="one">{0} ד׳ קשת</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} דק׳ קשת</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>שנ׳ קשת</displayName>
-				<unitPattern count="one">שנ׳ קשת {0}</unitPattern>
+				<unitPattern count="one">{0} שנ׳ קשת</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} שנ׳ קשת</unitPattern>
@@ -10602,7 +10602,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="concentr-item">
 				<displayName>פריט</displayName>
-				<unitPattern count="one">פריט {0}</unitPattern>
+				<unitPattern count="one">{0} פריט</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} פריטים</unitPattern>
@@ -10749,21 +10749,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-century">
 				<displayName>מאות</displayName>
-				<unitPattern count="one">מאה {0}</unitPattern>
+				<unitPattern count="one">{0} מאה</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} מאות</unitPattern>
 			</unit>
 			<unit type="duration-decade">
 				<displayName>עשור</displayName>
-				<unitPattern count="one">עשור {0}</unitPattern>
+				<unitPattern count="one">{0} עשור</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} עשורים</unitPattern>
 			</unit>
 			<unit type="duration-year">
 				<displayName>שנים</displayName>
-				<unitPattern count="one">שנה {0}</unitPattern>
+				<unitPattern count="one">{0} שנה</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} שנים</unitPattern>
@@ -10787,7 +10787,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-week">
 				<displayName>שבועות</displayName>
-				<unitPattern count="one">שבוע {0}</unitPattern>
+				<unitPattern count="one">{0} שבוע</unitPattern>
 				<unitPattern count="two">שבועיים</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} שבועות</unitPattern>
@@ -10795,7 +10795,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-day">
 				<displayName>ימים</displayName>
-				<unitPattern count="one">יום {0}</unitPattern>
+				<unitPattern count="one">{0} יום</unitPattern>
 				<unitPattern count="two">יומיים</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} ימ׳</unitPattern>
@@ -11082,7 +11082,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-millimeter">
 				<displayName>מ״מ</displayName>
-				<unitPattern count="one">מ″מ {0}</unitPattern>
+				<unitPattern count="one">{0} מ″מ</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} מ״מ</unitPattern>
@@ -11092,18 +11092,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} μm‎</unitPattern>
+				<unitPattern count="other">{0} μm</unitPattern>
 			</unit>
 			<unit type="length-nanometer">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} nm</unitPattern>
+				<unitPattern count="other">{0} nm</unitPattern>
 			</unit>
 			<unit type="length-picometer">
 				<displayName>פ״מ</displayName>
-				<unitPattern count="one">פ“מ {0}</unitPattern>
+				<unitPattern count="one">{0} פ“מ</unitPattern>
 				<unitPattern count="two">{0} פ״מ</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} פ&quot;מ</unitPattern>
@@ -11117,7 +11117,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-yard">
 				<displayName>יארד</displayName>
-				<unitPattern count="one">יארד {0}</unitPattern>
+				<unitPattern count="one">{0} יארד</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} יארד</unitPattern>
@@ -11127,27 +11127,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} ft</unitPattern>
-				<perUnitPattern>‎{0}/ft</perUnitPattern>
+				<unitPattern count="other">{0} ft</unitPattern>
+				<perUnitPattern>{0} &#x200e;/ft</perUnitPattern>
 			</unit>
 			<unit type="length-inch">
 				<displayName>אינץ׳</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} in</unitPattern>
-				<perUnitPattern>‎{0}/in</perUnitPattern>
+				<unitPattern count="other">{0} in</unitPattern>
+				<perUnitPattern>{0} &#x200e;/in</perUnitPattern>
 			</unit>
 			<unit type="length-parsec">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} pc</unitPattern>
+				<unitPattern count="other">{0} pc</unitPattern>
 			</unit>
 			<unit type="length-light-year">
 				<displayName>שנות אור</displayName>
-				<unitPattern count="one">שנת אור {0}</unitPattern>
+				<unitPattern count="one">{0} שנת אור</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} שנות אור</unitPattern>
@@ -11157,7 +11157,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} au</unitPattern>
+				<unitPattern count="other">{0} au</unitPattern>
 			</unit>
 			<unit type="length-furlong">
 				<displayName>↑↑↑</displayName>
@@ -11189,7 +11189,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="length-point">
 				<displayName>נקודות</displayName>
-				<unitPattern count="one">נק׳ {0}</unitPattern>
+				<unitPattern count="one">{0} נק׳</unitPattern>
 				<unitPattern count="two">{0} נק׳</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} נק'</unitPattern>
@@ -11199,7 +11199,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">‎{0} R☉‎</unitPattern>
+				<unitPattern count="other">{0} R☉&#x200e;</unitPattern>
 			</unit>
 			<unit type="light-lux">
 				<displayName>lux</displayName>
@@ -11238,7 +11238,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-kilogram">
 				<displayName>ק״ג</displayName>
-				<unitPattern count="one">ק״ג {0}</unitPattern>
+				<unitPattern count="one">{0} ק״ג</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} ק״ג</unitPattern>
@@ -11246,7 +11246,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-gram">
 				<displayName>גרם</displayName>
-				<unitPattern count="one">גר׳ {0}</unitPattern>
+				<unitPattern count="one">{0} גר׳</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} גר׳</unitPattern>
@@ -11268,14 +11268,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-ton">
 				<displayName>טונה</displayName>
-				<unitPattern count="one">ט׳ {0}</unitPattern>
+				<unitPattern count="one">{0} ט׳</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} ט׳</unitPattern>
 			</unit>
 			<unit type="mass-stone">
 				<displayName>סטון</displayName>
-				<unitPattern count="one">סטון {0}</unitPattern>
+				<unitPattern count="one">{0} סטון</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} סטון</unitPattern>
@@ -11333,7 +11333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-grain">
 				<displayName>גרעין</displayName>
-				<unitPattern count="one">גרעין {0}</unitPattern>
+				<unitPattern count="one">{0} גרעין</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} גרעינים</unitPattern>
@@ -11375,7 +11375,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="power-horsepower">
 				<displayName>כ״ס</displayName>
-				<unitPattern count="one">כ״ס {0}</unitPattern>
+				<unitPattern count="one">{0} כ״ס</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} כ״ס</unitPattern>
@@ -11528,7 +11528,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cubic-kilometer">
 				<displayName>קמ״ק</displayName>
-				<unitPattern count="one">קמ״ק {0}</unitPattern>
+				<unitPattern count="one">{0} קמ״ק</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} קמ״ק</unitPattern>
@@ -11593,7 +11593,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-liter">
 				<displayName>ליטר</displayName>
-				<unitPattern count="one">ל׳ {0}</unitPattern>
+				<unitPattern count="one">{0} ל׳</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} ל׳</unitPattern>
@@ -11615,7 +11615,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-milliliter">
 				<displayName>מ״ל</displayName>
-				<unitPattern count="one">מ״ל {0}</unitPattern>
+				<unitPattern count="one">{0} מ״ל</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} מ״ל</unitPattern>
@@ -11680,7 +11680,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-cup">
 				<displayName>כוסות</displayName>
-				<unitPattern count="one">כ׳ {0}</unitPattern>
+				<unitPattern count="one">{0} כ׳</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} כ׳</unitPattern>
@@ -11950,21 +11950,21 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="angle-arc-minute">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">דקה {0}</unitPattern>
+				<unitPattern count="one">{0} דקה</unitPattern>
 				<unitPattern count="two">{0} דקות</unitPattern>
 				<unitPattern count="many">{0} דקות</unitPattern>
 				<unitPattern count="other">{0} דקות</unitPattern>
 			</unit>
 			<unit type="angle-arc-second">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">שנ׳ {0}</unitPattern>
+				<unitPattern count="one">{0} שנ׳</unitPattern>
 				<unitPattern count="two">{0} שנ׳</unitPattern>
 				<unitPattern count="many">{0} שנ׳</unitPattern>
 				<unitPattern count="other">{0} שנ׳</unitPattern>
 			</unit>
 			<unit type="area-square-kilometer">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">קמ״ר {0}</unitPattern>
+				<unitPattern count="one">{0} קמ״ר</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
@@ -12221,7 +12221,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-year">
 				<displayName>ש׳</displayName>
-				<unitPattern count="one">ש′ {0}</unitPattern>
+				<unitPattern count="one">{0} ש′</unitPattern>
 				<unitPattern count="two">{0} ש′</unitPattern>
 				<unitPattern count="many">{0} ש′</unitPattern>
 				<unitPattern count="other">{0} ש′</unitPattern>
@@ -12245,7 +12245,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-week">
 				<displayName>שבוע</displayName>
-				<unitPattern count="one">ש′ {0}</unitPattern>
+				<unitPattern count="one">{0} ש′</unitPattern>
 				<unitPattern count="two">{0} ש′</unitPattern>
 				<unitPattern count="many">{0} ש′</unitPattern>
 				<unitPattern count="other">{0} ש′</unitPattern>
@@ -12261,7 +12261,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="duration-hour">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">שע' {0}</unitPattern>
+				<unitPattern count="one">{0} שע׳</unitPattern>
 				<unitPattern count="two">{0} שע׳</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
@@ -12689,7 +12689,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="mass-tonne">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">‎t {0}</unitPattern>
+				<unitPattern count="one">{0} t</unitPattern>
 				<unitPattern count="two">{0} t</unitPattern>
 				<unitPattern count="many">{0} t</unitPattern>
 				<unitPattern count="other">{0} t</unitPattern>
@@ -12938,9 +12938,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-beaufort">
 				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">B{0}</unitPattern>
-				<unitPattern count="two">B{0}</unitPattern>
-				<unitPattern count="other">B{0}</unitPattern>
+				<unitPattern count="one">{0} B</unitPattern>
+				<unitPattern count="two">{0} B</unitPattern>
+				<unitPattern count="other">{0} B</unitPattern>
 			</unit>
 			<unit type="temperature-generic">
 				<displayName>↑↑↑</displayName>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -9904,7 +9904,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="pressure-pound-force-per-square-inch">
 				<displayName>פאונד לאינץ׳ רבוע</displayName>
-				<unitPattern count="one">{0} פאונדלאינץ׳ רבוע</unitPattern>
+				<unitPattern count="one">פאונד {0} לאינץ׳ רבוע</unitPattern>
 				<unitPattern count="two">{0} פאונד לאינץ׳ רבוע</unitPattern>
 				<unitPattern count="many">{0} פאונד לאינץ׳ רבוע</unitPattern>
 				<unitPattern count="other">{0} פאונד לאינץ׳ רבוע</unitPattern>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,304 +1,134 @@
-# Modify non-emoji
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="_"]; new_value=dash | line | low | underdash | underline
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="―"]; new_value=bar | dash | horizontal | line
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="・"]; new_value=dot | dots | interpunct | katakana | middle | middot
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="؛"]; new_value=arabic | semi-colon | semicolon
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="!"]; new_value=bang | exclamation | mark | point
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¡"]; new_value=bang | exclamation | inverted | mark | point
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="?"]; new_value=mark | question
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¿"]; new_value=inverted | mark | question
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="؟"]; new_value=arabic | mark | question
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="."]; new_value=dot | full | period | stop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="。"]; new_value=full | ideographic | period | stop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="'"]; new_value=apostrophe | quote | single | typewriter
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‘"]; new_value=apostrophe | left | quote | single | smart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="’"]; new_value=apostrophe | quote | right | single | smart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‚"]; new_value=apostrophe | low | quote | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="“"]; new_value=double | left | mark | quotation | quote | smart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="”"]; new_value=double | mark | quotation | quote | right | smart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="„"]; new_value=double | low | mark | quotation | quote | right | smart
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="«"]; new_value=angle | brackets | carets | chevron | guillemet | left | quote
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="»"]; new_value=angle | brackets | carets | chevron | guillemet | quote | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp=")"]; new_value=bracket | close | paren | parens | parenthesis | round
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="["]; new_value=bracket | crotchet | open | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="]"]; new_value=bracket | close | crotchet | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="{"]; new_value=brace | bracket | curly | gullwing | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="}"]; new_value=brace | bracket | close | curly | gullwing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〈"]; new_value=angle | bracket | brackets | chevron | diamond | open | pointy | tuple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〉"]; new_value=angle | bracket | brackets | chevron | close | diamond | pointy | tuple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="《"]; new_value=angle | bracket | double | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="》"]; new_value=angle | bracket | close | double
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="「"]; new_value=bracket | corner | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="」"]; new_value=bracket | close | corner
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="『"]; new_value=bracket | corner | hollow | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="』"]; new_value=bracket | close | corner | hollow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="【"]; new_value=black | bracket | lens | lenticular | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="】"]; new_value=black | bracket | close | lens | lenticular
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〔"]; new_value=bracket | open | shell | tortoise
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〕"]; new_value=bracket | close | shell | tortoise
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〖"]; new_value=bracket | hollow | lens | lenticular | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="〗"]; new_value=bracket | close | hollow | lens | lenticular
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¶"]; new_value=alinea | mark | paragraph | paraph | pilcrow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="@"]; new_value=ampersat | arobase | arroba | at | at-sign | commercial | mark | sign | strudel
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="\"]; new_value=backslash | reverse | solidus | whack
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="%"]; new_value=cent | per | per-cent | percent
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‰"]; new_value=mil | mille | per | permil | permille
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="†"]; new_value=dagger | obelisk | obelus | sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‡"]; new_value=dagger | double | obelisk | obelus | sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‧"]; new_value=dash | hyphen | hyphenation | point
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="″"]; new_value=double | prime
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="‴"]; new_value=prime | triple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="※"]; new_value=mark | reference
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="^"]; new_value=accent | caret | chevron | circumflex | control | hat | pointer | power | sign | wedge | xor
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="←"]; new_value=arrow | left | left-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↚"]; new_value=arrow | leftwards | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="→"]; new_value=arrow | right | right-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↛"]; new_value=arrow | rightwards | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↑"]; new_value=arrow | up | up-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↓"]; new_value=arrow | down | down-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↜"]; new_value=arrow | leftwards | wave
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↝"]; new_value=arrow | rightwards | wave
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↞"]; new_value=arrow | headed | leftwards | two
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↟"]; new_value=arrow | headed | two | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↠"]; new_value=arrow | headed | rightwards | two
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↡"]; new_value=arrow | downwards | headed | two
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↢"]; new_value=arrow | leftwards | tail
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↣"]; new_value=arrow | rightwards | tail
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↤"]; new_value=arrow | bar | from | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↥"]; new_value=arrow | bar | from | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↦"]; new_value=arrow | bar | from | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↧"]; new_value=arrow | bar | downwards | from
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↨"]; new_value=arrow | base | down | up | with
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↫"]; new_value=arrow | leftwards | loop
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↬"]; new_value=arrow | loop | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↭"]; new_value=arrow | left | right | wave
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↯"]; new_value=arrow | downwards | zigzag
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↰"]; new_value=arrow | leftwards | tip | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↱"]; new_value=arrow | rightwards | tip | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↲"]; new_value=arrow | downwards | leftwards | tip
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↳"]; new_value=arrow | downwards | rightwards | tip
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↴"]; new_value=arrow | corner | downwards | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↵"]; new_value=arrow | corner | downwards | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↶"]; new_value=anticlockwise | arrow | semicircle | top
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↷"]; new_value=arrow | clockwise | semicircle | top
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↸"]; new_value=arrow | bar | long | north | west
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↹"]; new_value=arrow | bar | bars | leftwards | over | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↺"]; new_value=anticlockwise | arrow | circle | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↻"]; new_value=arrow | circle | clockwise | open
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↼"]; new_value=barb | harpoon | leftwards | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↽"]; new_value=barb | downwards | harpoon | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↾"]; new_value=barb | harpoon | rightwards | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↿"]; new_value=barb | harpoon | leftwards | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇀"]; new_value=barb | harpoon | rightwards | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇁"]; new_value=barb | downwards | harpoon | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇂"]; new_value=barb | downwards | harpoon | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇃"]; new_value=barb | downwards | harpoon | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇄"]; new_value=arrow | leftwards | over | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇅"]; new_value=and | arrow | arrows | down | down-pointing | up | up-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇆"]; new_value=arrow | arrows | left | left-pointing | over | right | right-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇇"]; new_value=arrows | leftwards | paired
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇈"]; new_value=arrows | paired | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇉"]; new_value=arrows | paired | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇊"]; new_value=arrows | downwards | paired
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇋"]; new_value=harpoon | leftwards | over | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇌"]; new_value=harpoon | leftwards | over | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇐"]; new_value=arrow | double | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇍"]; new_value=arrow | double | leftwards | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇑"]; new_value=arrow | double | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇒"]; new_value=arrow | double | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇏"]; new_value=arrow | double | rightwards | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇓"]; new_value=arrow | double | downwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇔"]; new_value=arrow | double | left | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇎"]; new_value=arrow | double | left | right | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇖"]; new_value=arrow | double | north | west
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇗"]; new_value=arrow | double | east | north
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇘"]; new_value=arrow | double | east | south
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇙"]; new_value=arrow | double | south | west
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇚"]; new_value=arrow | leftwards | triple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇛"]; new_value=arrow | rightwards | triple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇜"]; new_value=arrow | leftwards | squiggle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇝"]; new_value=arrow | rightwards | squiggle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇞"]; new_value=arrow | double | stroke | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇟"]; new_value=arrow | double | downwards | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇠"]; new_value=arrow | dashed | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇡"]; new_value=arrow | dashed | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇢"]; new_value=arrow | dashed | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇣"]; new_value=arrow | dashed | downwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇤"]; new_value=arrow | bar | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇥"]; new_value=arrow | bar | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇦"]; new_value=arrow | hollow | leftwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇧"]; new_value=arrow | hollow | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇨"]; new_value=arrow | hollow | rightwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇩"]; new_value=arrow | downwards | hollow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇪"]; new_value=arrow | bar | from | hollow | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⇵"]; new_value=arrow | downwards | leftwards | upwards
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∀"]; new_value=all | any | for | given | universal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∂"]; new_value=differential | partial
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∃"]; new_value=exists | there
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∅"]; new_value=empty | mathematics | operator | set
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∈"]; new_value=contains | element | membership | of | set
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∉"]; new_value=an | element | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∋"]; new_value=as | contains | element | member
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∎"]; new_value=end | halmos | proof | q.e.d. | qed | tombstone
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∏"]; new_value=logic | n-ary | product
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∑"]; new_value=mathematics | n-ary | summation
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="+"]; new_value=add | plus | sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="÷"]; new_value=divide | division | obelus | sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="×"]; new_value=multiplication | multiply | sign | times
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="<"]; new_value=less | less-than | open | tag | than
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≮"]; new_value=inequality | less-than | mathematics | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≠"]; new_value=equal | inequality | inequation | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp=">"]; new_value=close | greater | greater-than | tag | than
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≯"]; new_value=greater-than | inequality | mathematics | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="|"]; new_value=bar | line | pike | pipe | sheffer | stick | stroke | vbar | vertical
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="−"]; new_value=minus | sign | subtract
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∕"]; new_value=division | slash | stroke | virgule
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⁄"]; new_value=fraction | slash | stroke | virgule
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∗"]; new_value=asterisk | operator | star
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∘"]; new_value=composition | operator | ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∙"]; new_value=bullet | operator
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∞"]; new_value=infinity | sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∟"]; new_value=angle | mathematics | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∧"]; new_value=ac | and | atque | logical | wedge
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∬"]; new_value=calculus | double | integral
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∮"]; new_value=contour | integral
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∼"]; new_value=operator | tilde
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∽"]; new_value=reversed | tilde
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="∾"]; new_value=inverted | lazy | s
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≃"]; new_value=asymptote | asymptotically | equal | mathematics
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≅"]; new_value=approximately | congruence | equal | equality | isomorphism | mathematics
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≈"]; new_value=almost | approximate | approximation | equal
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≌"]; new_value=all | equal | equality | mathematics
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≒"]; new_value=approximately | equal | image | the
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≖"]; new_value=equal | equality | in | mathematics | ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≡"]; new_value=exact | identical | to | triple
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≣"]; new_value=equality | equivalent | mathematics | strictly
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≤"]; new_value=equal | equals | inequality | less-than | or
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≥"]; new_value=equal | equals | greater-than | inequality | or
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≦"]; new_value=equal | inequality | less-than | mathematics | over
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≧"]; new_value=equal | greater-than | inequality | mathematics | over
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≪"]; new_value=inequality | less-than | mathematics | much
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≫"]; new_value=greater-than | inequality | mathematics | much
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≳"]; new_value=equivalent | greater-than | inequality | mathematics
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≺"]; new_value=mathematics | operator | precedes | set
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="≻"]; new_value=mathematics | operator | set | succeeds
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊁"]; new_value=does | mathematics | not | operator | set | succeed
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊂"]; new_value=of | set | subset
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊃"]; new_value=mathematics | operator | set | superset
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊆"]; new_value=equal | subset
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊇"]; new_value=equal | equality | mathematics | superset
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊕"]; new_value=circled | plus
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊖"]; new_value=circled | difference | erosion | minus | symmetric
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊗"]; new_value=circled | product | tensor | times
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊘"]; new_value=circled | division | division-like | mathematics | slash
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊙"]; new_value=circled | dot | operator | XNOR
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊚"]; new_value=circled | operator | ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊛"]; new_value=asterisk | circled | operator
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊞"]; new_value=addition-like | mathematics | plus | squared
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊟"]; new_value=mathematics | minus | squared | subtraction-like
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊥"]; new_value=eet | falsum | tack | up
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊮"]; new_value=does | force | not
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊰"]; new_value=mathematics | operator | precedes | relation | set | under
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊱"]; new_value=mathematics | operator | relation | set | succeeds | under
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋭"]; new_value=as | contain | does | equal | group | mathematics | normal | not | subgroup | theory
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊹"]; new_value=conjugate | hermitian | mathematics | matrix | self-adjoint | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⊿"]; new_value=mathematics | right | right-angled | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋁"]; new_value=disjunction | logic | logical | n-ary | or
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋂"]; new_value=intersection | mathematics | n-ary | operator | set
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋃"]; new_value=mathematics | n-ary | operator | set | union
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋅"]; new_value=dot | operator
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋆"]; new_value=operator | star
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋈"]; new_value=binary | bowtie | join | natural | operator
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋒"]; new_value=double | intersection | mathematics | operator | set
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋘"]; new_value=inequality | less-than | mathematics | much | very
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋙"]; new_value=greater-than | inequality | mathematics | much | very
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋮"]; new_value=ellipsis | mathematics | vertical
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋯"]; new_value=ellipsis | horizontal | midline
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋰"]; new_value=diagonal | ellipsis | mathematics | right | up
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⋱"]; new_value=diagonal | down | ellipsis | mathematics | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="■"]; new_value=filled | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="□"]; new_value=hollow | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▢"]; new_value=corners | hollow | rounded | square | with
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▣"]; new_value=containing | filled | hollow | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▤"]; new_value=fill | horizontal | square | with
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▥"]; new_value=fill | square | vertical | with
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▦"]; new_value=crosshatch | fill | orthogonal | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▧"]; new_value=fill | left | lower | right | square | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▨"]; new_value=fill | left | lower | right | square | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▩"]; new_value=crosshatch | diagonal | fill | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▬"]; new_value=filled | rectangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▭"]; new_value=hollow | rectangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▮"]; new_value=filled | rectangle | vertical
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▰"]; new_value=filled | parallelogram
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▲"]; new_value=arrow | filled | triangle | up | up-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="△"]; new_value=hollow | triangle | up-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▴"]; new_value=filled | small | triangle | up-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▵"]; new_value=hollow | small | triangle | up-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▷"]; new_value=hollow | right-pointing | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▸"]; new_value=filled | right-pointing | small | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▹"]; new_value=hollow | right-pointing | small | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="►"]; new_value=filled | pointer | right-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▻"]; new_value=hollow | pointer | right-pointing
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▼"]; new_value=arrow | down | down-pointing | filled | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▽"]; new_value=down-pointing | hollow | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▾"]; new_value=down-pointing | filled | small | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="▿"]; new_value=down-pointing | hollow | small | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◁"]; new_value=hollow | left-pointing | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◂"]; new_value=filled | left-pointing | small | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◃"]; new_value=hollow | left-pointing | small | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◄"]; new_value=filled | left-pointing | pointer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◅"]; new_value=hollow | left-pointing | pointer
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◆"]; new_value=diamond | filled
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◇"]; new_value=diamond | hollow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◈"]; new_value=containing | diamond | filled | hollow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◉"]; new_value=cicles | circle | circled | concentric | containing | dot | filled | fisheye | hollow | ward
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="○"]; new_value=circle | hollow | ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◌"]; new_value=circle | dotted
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◍"]; new_value=circle | fill | vertical | with
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◎"]; new_value=circle | circles | concentric | double | target
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="●"]; new_value=circle | filled
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◐"]; new_value=circle | filled | half | left
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◑"]; new_value=circle | filled | half | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◒"]; new_value=circle | filled | half | lower
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◓"]; new_value=circle | filled | half | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◔"]; new_value=circle | filled | quadrant | right | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◕"]; new_value=all | but | circle | filled | left | quadrant | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◖"]; new_value=circle | filled | half | left
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◗"]; new_value=circle | filled | half | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◘"]; new_value=bullet | inverse
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◙"]; new_value=circle | containing | filled | hollow | inverse | square
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◜"]; new_value=arc | circular | left | quadrant | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◝"]; new_value=arc | circular | quadrant | right | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◞"]; new_value=arc | circular | lower | quadrant | right
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◟"]; new_value=arc | circular | left | lower | quadrant
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◠"]; new_value=circle | half | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◡"]; new_value=circle | half | lower
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◢"]; new_value=filled | lower | right | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◣"]; new_value=filled | left | lower | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◤"]; new_value=filled | left | triangle | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◥"]; new_value=filled | right | triangle | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◦"]; new_value=bullet | hollow
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◯"]; new_value=circle | hollow | large | ring
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◳"]; new_value=hollow | quadrant | right | square | upper
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◷"]; new_value=circle | hollow | quadrant | right | upper | with
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="◿"]; new_value=lower | right | triangle
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⨧"]; new_value=plus | subscript | two
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⨯"]; new_value=cross | product | vector
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⨼"]; new_value=interior | product
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⩣"]; new_value=double | logical | or | underbar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⩽"]; new_value=equal | less-than | slanted
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⪍"]; new_value=above | equal | less-than | similar
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⪚"]; new_value=double-line | equal | greater-than | inequality | mathematics
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="⪺"]; new_value=above | almost | equal | not | succeeds
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="↮"]; new_value=arrow | left | right | stroke
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₣"]; new_value=currency | franc | french
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₰"]; new_value=currency | german | penny | pfennig
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₶"]; new_value=currency | livre | tournois
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₹"]; new_value=currency | indian | rupee
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="µ"]; new_value=measure | micro | sign
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="♯"]; new_value=dièse | diesis | music | note | sharp
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="$"]; new_value=dollar | money | peso | USD
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="£"]; new_value=currency | EGP | GBP | pound
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="¥"]; new_value=CNY | currency | JPY | yen | yuan
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="€"]; new_value=currency | EUR | euro
-locale=en; action=add; new_path=//ldml/annotations/annotation[@cp="₿"]; new_value=bitcoin | BTC
+# Fix hebrew units
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-jigger"]/unitPattern[@count="one"];	new_value={0} ג׳יגר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pinch"]/unitPattern[@count="one"];	new_value={0} פינץ׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-hour"]/unitPattern[@count="one"];	new_value={0} שע׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-solar-radius"]/unitPattern[@count="other"];	new_value={0} R☉\x{200E}
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-foot"]/perUnitPattern;	new_value={0} \x{200E}/ft
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-inch"]/perUnitPattern;	new_value={0} \x{200E}/in
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-micrometer"]/unitPattern[@count="other"];	new_value={0} μm
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-tonne"]/unitPattern[@count="one"];	new_value={0} t
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-revolution"]/unitPattern[@count="one"];	new_value={0} סיבוב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"];	new_value={0} דקת קשת
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"];	new_value={0} שניית קשת
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-kilometer"]/unitPattern[@count="one"];	new_value={0} קילומטר רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-hectare"]/unitPattern[@count="one"];	new_value={0} הקטאר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-meter"]/unitPattern[@count="one"];	new_value={0} מטר רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-centimeter"]/unitPattern[@count="one"];	new_value={0} סנטימטר רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-mile"]/unitPattern[@count="one"];	new_value={0} מייל רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-acre"]/unitPattern[@count="one"];	new_value={0} אקר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-yard"]/unitPattern[@count="one"];	new_value={0} יארד רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-foot"]/unitPattern[@count="one"];	new_value={0} רגל רבועה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-inch"]/unitPattern[@count="one"];	new_value={0} אינץ׳ רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permyriad"]/unitPattern[@count="one"];	new_value={0} רבבית
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="one"];	new_value={0} טרה-בייט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="two"];	new_value={0} טרה-בייט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="many"];	new_value={0} טרה-בייט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="other"];	new_value={0} טרה-בייט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-millisecond"]/unitPattern[@count="one"];	new_value={0} אלפית שנייה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ampere"]/unitPattern[@count="one"];	new_value={0} אמפר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-milliampere"]/unitPattern[@count="one"];	new_value={0} מיליאמפר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-volt"]/unitPattern[@count="one"];	new_value={0} וולט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilocalorie"]/unitPattern[@count="one"];	new_value={0} קילו קלוריה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-calorie"]/unitPattern[@count="one"];	new_value={0} קלוריה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilojoule"]/unitPattern[@count="one"];	new_value={0} קילו ג׳אול
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilowatt-hour"]/unitPattern[@count="one"];	new_value={0} קילוואט־שעה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-gigahertz"]/unitPattern[@count="one"];	new_value={0} ג׳יגה-הרץ
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-megahertz"]/unitPattern[@count="one"];	new_value={0} מגה-הרץ
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-kilohertz"]/unitPattern[@count="one"];	new_value={0} קילו-הרץ
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-hertz"]/unitPattern[@count="one"];	new_value={0} הרץ
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot-per-centimeter"]/unitPattern[@count="one"];	new_value={0} נקודהלסנטימטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-kilometer"]/unitPattern[@count="one"];	new_value={0} קילומטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"];	new_value={0} מטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-decimeter"]/unitPattern[@count="one"];	new_value={0} דצימטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-centimeter"]/unitPattern[@count="one"];	new_value={0} סנטימטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-millimeter"]/unitPattern[@count="one"];	new_value={0} מילימטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-micrometer"]/unitPattern[@count="one"];	new_value={0} מיקרומטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nanometer"]/unitPattern[@count="one"];	new_value={0} ננומטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-picometer"]/unitPattern[@count="one"];	new_value={0} פיקומטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-foot"]/unitPattern[@count="one"];	new_value={0} רגל
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-inch"]/unitPattern[@count="one"];	new_value={0} אינץ׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-astronomical-unit"]/unitPattern[@count="one"];	new_value={0} יחידה אסטרונומית
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nautical-mile"]/unitPattern[@count="one"];	new_value={0} מייל ימי
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"];	new_value={0} מייל-סקנדינביה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-point"]/unitPattern[@count="one"];	new_value={0} נקודה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="one"];	new_value={0} לומן
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"];	new_value={0} קילוגרם
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-gram"]/unitPattern[@count="one"];	new_value={0} גרם
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-ton"]/unitPattern[@count="one"];	new_value={0} טונה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-ounce"]/unitPattern[@count="one"];	new_value={0} אונקיה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-ounce-troy"]/unitPattern[@count="one"];	new_value={0} אונקיית טרוי
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-gigawatt"]/unitPattern[@count="one"];	new_value={0} ג׳יגה ואט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-megawatt"]/unitPattern[@count="one"];	new_value={0} מגה ואט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-kilowatt"]/unitPattern[@count="one"];	new_value={0} קילוואט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-watt"]/unitPattern[@count="one"];	new_value={0} ואט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-milliwatt"]/unitPattern[@count="one"];	new_value={0} מיליוואט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-horsepower"]/unitPattern[@count="one"];	new_value={0} כוח סוס
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-pound-force-per-square-inch"]/unitPattern[@count="one"];	new_value={0} פאונדלאינץ׳ רבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-inch-ofhg"]/unitPattern[@count="one"];	new_value={0} אינץ׳ כספית
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-hectopascal"]/unitPattern[@count="one"];	new_value={0} הקטופסקל
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-beaufort"]/unitPattern[@count="one"];	new_value={0} בופורט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-beaufort"]/unitPattern[@count="two"];	new_value={0} בופורט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-beaufort"]/unitPattern[@count="other"];	new_value={0} בופורט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"];	new_value={0} מעלת צלזיוס
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-fahrenheit"]/unitPattern[@count="one"];	new_value={0} מעלת פרנהייט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="one"];	new_value={0} קלווין
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="one"];	new_value={0} קילומטר מעוקב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="one"];	new_value={0} מטר מעוקב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-centimeter"]/unitPattern[@count="one"];	new_value={0} סנטימטר מעוקב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-mile"]/unitPattern[@count="one"];	new_value={0} מייל מעוקב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-foot"]/unitPattern[@count="one"];	new_value={0} רגל מעוקב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-inch"]/unitPattern[@count="one"];	new_value={0} אינץ׳ מעוקב
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-megaliter"]/unitPattern[@count="one"];	new_value={0} מגה ליטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-hectoliter"]/unitPattern[@count="one"];	new_value={0} הקטוליטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"];	new_value={0} ליטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-deciliter"]/unitPattern[@count="one"];	new_value={0} דציליטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-centiliter"]/unitPattern[@count="one"];	new_value={0} סנטיליטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-milliliter"]/unitPattern[@count="one"];	new_value={0} מיליליטר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"];	new_value={0} פינט מטרי
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup-metric"]/unitPattern[@count="one"];	new_value={0} כוס מידה מטרית
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-acre-foot"]/unitPattern[@count="one"];	new_value={0} אקר-רגל
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon"]/unitPattern[@count="one"];	new_value={0} גלון
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="one"];	new_value={0} גלון אימפריאלי
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart"]/unitPattern[@count="one"];	new_value={0} קווארטה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint"]/unitPattern[@count="one"];	new_value={0} פינט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup"]/unitPattern[@count="one"];	new_value={0} כוס
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="one"];	new_value={0} אונקיית נוזלים
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-teaspoon"]/unitPattern[@count="one"];	new_value={0} כפית
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dram"]/unitPattern[@count="one"];	new_value={0} דראם אלכוהול
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="one"];	new_value={0} קווארט אימפריאלי
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"];	new_value={0} ד׳ קשת
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"];	new_value={0} שנ׳ קשת
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-item"]/unitPattern[@count="one"];	new_value={0} פריט
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-century"]/unitPattern[@count="one"];	new_value={0} מאה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-decade"]/unitPattern[@count="one"];	new_value={0} עשור
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="one"];	new_value={0} שנה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-week"]/unitPattern[@count="one"];	new_value={0} שבוע
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-day"]/unitPattern[@count="one"];	new_value={0} יום
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-millimeter"]/unitPattern[@count="one"];	new_value={0} מ″מ
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-nanometer"]/unitPattern[@count="other"];	new_value={0} nm
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-picometer"]/unitPattern[@count="one"];	new_value={0} פ“מ
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-yard"]/unitPattern[@count="one"];	new_value={0} יארד
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-foot"]/unitPattern[@count="other"];	new_value={0} ft
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-inch"]/unitPattern[@count="other"];	new_value={0} in
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-parsec"]/unitPattern[@count="other"];	new_value={0} pc
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-light-year"]/unitPattern[@count="one"];	new_value={0} שנת אור
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-astronomical-unit"]/unitPattern[@count="other"];	new_value={0} au
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-point"]/unitPattern[@count="one"];	new_value={0} נק׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"];	new_value={0} ק״ג
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-gram"]/unitPattern[@count="one"];	new_value={0} גר׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-ton"]/unitPattern[@count="one"];	new_value={0} ט׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-stone"]/unitPattern[@count="one"];	new_value={0} סטון
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-grain"]/unitPattern[@count="one"];	new_value={0} גרעין
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="power-horsepower"]/unitPattern[@count="one"];	new_value={0} כ״ס
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="one"];	new_value={0} קמ״ק
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-liter"]/unitPattern[@count="one"];	new_value={0} ל׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-milliliter"]/unitPattern[@count="one"];	new_value={0} מ״ל
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cup"]/unitPattern[@count="one"];	new_value={0} כ׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"];	new_value={0} דקה
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"];	new_value={0} שנ׳
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="area-square-kilometer"]/unitPattern[@count="one"];	new_value={0} קמ״ר
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="one"];	new_value={0} ש′
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-week"]/unitPattern[@count="one"];	new_value={0} ש′
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-beaufort"]/unitPattern[@count="one"];	new_value={0} B
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-beaufort"]/unitPattern[@count="two"];	new_value={0} B
+locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-beaufort"]/unitPattern[@count="other"];	new_value={0} B


### PR DESCRIPTION
CLDR-17839

Working off of https://docs.google.com/spreadsheets/d/1dRVt9xb4Ffsf86DrxbPIaj26qVz0GB7DL7yyE9N5pfI/edit?gid=2136703940#gid=2136703940 , which has units that contained {, but didn’t start with {0}. 

In particular:

- fixed patterns have {0} uniformly at the start, if it wasn't already. 
    - there were 2 exceptions, with a medial {0} that I left alone. 
- fixed a few places where the unit started or ended with a neutral (by protecting with LRM or LRM)
- fixed some others that had excess LRM/RLM
    - the remaining LRMs — for clarity in review — are all in xml format (&#x200e;), which will be converted back to the regular character during cldr modify passes.
- fixed places where apostrophe was used instead of  ‎׳‎ U+05F3 HEBREW PUNCTUATION GERESH

For the future, I think we should provide warnings for problems for vetters.

Important for review!

- The text in an XML editor will often show up in a way hides the internal structure. In particular, the {0} may appear to be at the start, but actually be at the end. To make it more confusion, both the form at the start and the form at the end will appear identical! 
- If you want to check, there are two ways.
    - Go to https://util.unicode.org/UnicodeJsps/bidi.jsp and pasted in the values into Sample. Hit Show Bidi button, and look at the memory positions.
    - Use CLDR Staging to look at some of the changed items, including the examples. 

For example the first changed line shows (old/new):
```
<unitPattern count="one">דקת קשת {0}</unitPattern>
<unitPattern count="one">{0} דקת קשת</unitPattern>
```

These look identical when using an English browser to see the Files Changed, but when you paste them into the following and compare the two Memory Position rows, you'll see that the first Memory Position has {0} at the end (pos 33-35) and the second Memory Position has it at the start (pos 25-26)
https://util.unicode.org/UnicodeJsps/bidi.jsp?a=%3CunitPattern+count%3D%22one%22%3E%D7%93%D7%A7%D7%AA+%D7%A7%D7%A9%D7%AA+%7B0%7D%3C%2FunitPattern%3E%0D%0A%3CunitPattern+count%3D%22one%22%3E%7B0%7D+%D7%93%D7%A7%D7%AA+%D7%A7%D7%A9%D7%AA%3C%2FunitPattern%3E&p=Auto

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
