### PR TITLE
CLDR-17859 gaa timeFormats unconfirmed->contributed to pass ICU tests

### DIFF
--- a/common/main/gaa.xml
+++ b/common/main/gaa.xml
@@ -831,26 +831,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<timeFormats>
 					<timeFormatLength type="full">
 						<timeFormat>
-							<pattern draft="unconfirmed">h:mm:ss a zzzz</pattern>
-							<datetimeSkeleton draft="unconfirmed">ahmmsszzzz</datetimeSkeleton>
+							<pattern draft="contributed">h:mm:ss a zzzz</pattern>
+							<datetimeSkeleton draft="contributed">ahmmsszzzz</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="long">
 						<timeFormat>
-							<pattern draft="unconfirmed">h:mm:ss a z</pattern>
-							<datetimeSkeleton draft="unconfirmed">ahmmssz</datetimeSkeleton>
+							<pattern draft="contributed">h:mm:ss a z</pattern>
+							<datetimeSkeleton draft="contributed">ahmmssz</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="medium">
 						<timeFormat>
-							<pattern draft="unconfirmed">h:mm:ss a</pattern>
-							<datetimeSkeleton draft="unconfirmed">ahmmss</datetimeSkeleton>
+							<pattern draft="contributed">h:mm:ss a</pattern>
+							<datetimeSkeleton draft="contributed">ahmmss</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 					<timeFormatLength type="short">
 						<timeFormat>
-							<pattern draft="unconfirmed">h:mm a</pattern>
-							<datetimeSkeleton draft="unconfirmed">ahmm</datetimeSkeleton>
+							<pattern draft="contributed">h:mm a</pattern>
+							<datetimeSkeleton draft="contributed">ahmm</datetimeSkeleton>
 						</timeFormat>
 					</timeFormatLength>
 				</timeFormats>


### PR DESCRIPTION
CLDR-17859

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17859)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Locale data is only converted for ICU if it has draft status of at least contributed, so the `gaa` timeFormats with 'h' were not being picked up and in ICU the `gaa` locale was inheriting timeFormats from root using H. This caused an error in an ICU test that the timeFormats hour cycle matches the region preference. So we promote the `gaa` timeFormats to contributed.

ALLOW_MANY_COMMITS=true
