### PR TITLE
CLDR-17673 update plural forms for Sicilian (scn)

### DIFF
--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -5426,8 +5426,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range" draft="unconfirmed">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="one" draft="unconfirmed">{0} jornu</pluralMinimalPairs>
-			<pluralMinimalPairs count="other" draft="unconfirmed">{0} jorna</pluralMinimalPairs>
+			<pluralMinimalPairs count="one">{0} jornu</pluralMinimalPairs>
+			<pluralMinimalPairs count="many">{0} di jorna</pluralMinimalPairs>
+			<pluralMinimalPairs count="other">{0} jorna</pluralMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/supplemental/pluralRanges.xml
+++ b/common/supplemental/pluralRanges.xml
@@ -28,7 +28,7 @@
 			<pluralRange start="other" end="one"   result="other"/>
 			<pluralRange start="other" end="other" result="other"/>
 		</pluralRanges>
-		<pluralRanges locales="az de el gl gsw hu kk ky lij ml mn ne nl sc scn sq sw ta te tk tr ug uz">
+		<pluralRanges locales="az de el gl gsw hu kk ky lij ml mn ne nl sc sq sw ta te tk tr ug uz">
 			<pluralRange start="one"   end="other" result="other"/>
 			<pluralRange start="other" end="one"   result="one"/>
 			<pluralRange start="other" end="other" result="other"/>
@@ -114,7 +114,7 @@
 			<pluralRange start="one"   end="other" result="other"/>
 			<pluralRange start="other" end="other" result="other"/>
 		</pluralRanges>
-		<pluralRanges locales="it">
+		<pluralRanges locales="it scn">
 			<pluralRange start="one"   end="other" result="other"/>
 			<pluralRange start="other" end="one"   result="one"/>
 			<pluralRange start="other" end="other" result="other"/>

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -27,7 +27,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
             <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="ast de en et fi fy gl ia io ji lij nl sc scn sv sw ur yi">
+        <pluralRules locales="ast de en et fi fy gl ia io ji lij nl sc sv sw ur yi">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
@@ -130,7 +130,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
             <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="ca it lld pt_PT vec">
+        <pluralRules locales="ca it lld pt_PT scn vec">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
             <pluralRule count="many">e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …</pluralRule>


### PR DESCRIPTION
CLDR-17673

- [x] This PR completes the ticket.

Command to regenerate pluralRanges.xml: `java -jar tools/cldr-code/target/cldr-code.jar GeneratePluralRanges`

ALLOW_MANY_COMMITS=true
