### PR TITLE
CLDR-17865 Fix some bad currencyFormats/unitPattern items

### DIFF
--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -3709,8 +3709,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
-			<unitPattern count="zero">{0} {1}</unitPattern>
-			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="zero">{1} {0}</unitPattern>
+			<unitPattern count="one">{1} {0}</unitPattern>
 			<unitPattern count="other">{1} {0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/es_GT.xml
+++ b/common/main/es_GT.xml
@@ -269,7 +269,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
-			<unitPattern count="other" draft="contributed">{1} {0}</unitPattern>
+			<unitPattern count="other" draft="contributed">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencies>
 			<currency type="GTQ">

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -5076,7 +5076,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="one">{1}{0}</unitPattern>
 			<unitPattern count="other">{1}{0}</unitPattern>
 		</currencyFormats>
 		<currencies>

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -4855,7 +4855,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>
-			<unitPattern count="one">{0} {1}</unitPattern>
+			<unitPattern count="one">{0} {1}</unitPattern>
 			<unitPattern count="other">{0} {1}</unitPattern>
 		</currencyFormats>
 		<currencies>


### PR DESCRIPTION
CLDR-17865

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17865)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Fixed most of the cases mentioned in [CLDR-17865](https://unicode-org.atlassian.net/browse/CLDR-17865) where there are inconsistencies among the currencyFormats/unitPattern items for different plural cases in a locale. Note that the pattern in root for `other` and the patterns in English for `other` and `one` are all "{0} {1}" which produces results like "1 Euro" and "3 Euros". Many of the discrepancies in the ticket were for cases that had "{0} {1}" for the non-`other` cases but "{1} {0}" for the `other` case. The TC discussion was to prefer the `other` case pattern which would produce results whose English equivalent would be something like "Euros 3" (vs "1 Euro" which might be the desired result for `one` in some locales). I checked the Survey Tool votes and discussion (no discussion for any of these cases) to decide what to do.
- blo (Anii) had [(Zero, "{0} {1}"), (One, "{0} {1}"), (Other, "{1} {0}")] but the only vetter votes were for the `other` entry, so I used that for all cases.
- ceb (Cebuano) had [(One, "{0} {1}"), (Other, "{1} {0}")] but the only vetter (from Google) voted explicitly for each of those patterns, so I did not change the data.
- es_GT (Spanish, Guatemala) overrode the inherited value for `other`, replaced with up arrows.
- si (Sinhala) had [(One, "{0} {1}"), (Other, "{1}{0}")]; the `one` pattern only had votes from a Google vetter but the `other` pattern had votes from both Google and Microsoft, so used that for the `one` case as well.
- sw (Swahili) had [(One, "{0} {1}"), (Other, "{1} {0}")] but the only vetter (from Microsoft) voted explicitly for each of those patterns, so I did not change the data.
- vec (Venetian) had [(One, "{0} {1}"), (Other, "{0}\u{202f}{1}")] with NNBSP in the `other` case; the Venetian org voted for each of the cases, but I used the `other` pattern for `one` as well (same ordering, just the addition of NNBSP).

Filed [CLDR-17873](https://unicode-org.atlassian.net/browse/CLDR-17873) to add a test for this.

ALLOW_MANY_COMMITS=true


[CLDR-17865]: https://unicode-org.atlassian.net/browse/CLDR-17865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLDR-17873]: https://unicode-org.atlassian.net/browse/CLDR-17873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ