### PR TITLE
CLDR-17320 check fixes to avoid stack traces

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckExemplars.java
@@ -302,6 +302,16 @@ public class CheckExemplars extends FactoryCheckCLDR {
 
     private void checkParse(
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
+        if (value == null) {
+            CheckStatus message =
+                    new CheckStatus()
+                            .setCause(this)
+                            .setMainType(CheckStatus.errorType)
+                            .setSubtype(Subtype.badParseLenient)
+                            .setMessage("null value");
+            result.add(message);
+            return;
+        }
         try {
             XPathParts oparts = XPathParts.getFrozenInstance(path);
             // only thing we do is make sure that the sample is in the value

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckPlaceHolders.java
@@ -666,6 +666,7 @@ public class CheckPlaceHolders extends CheckCLDR {
         // ldml/listPatterns/listPattern[@type="standard-short"]/listPatternPart[@type="2"]
         if (path.startsWith("//ldml/listPatterns/listPattern")) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
+            if (parts.containsElement("alias")) return; // skip alias XPaths
             // check order, {0} must be before {1}
 
             switch (parts.getAttributeValue(-1, "type")) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -469,26 +469,7 @@ public class TestCheckCLDR extends TestFmwk {
         checkLocale(test, localeID, "?", null);
     }
 
-    /** adjust the logging level of checks */
-    public java.util.logging.Level pushCheckLevel() {
-        java.util.logging.Level oldLevel = null;
-        if (logKnownIssue(
-                "CLDR-17320",
-                "turning off CheckCLDR logging to avoid thousands of log messages, please fix internal stack traces")) {
-            oldLevel = CheckCLDR.setLoggerLevel(java.util.logging.Level.OFF);
-        }
-        return oldLevel;
-    }
-
-    /** undo the effect of a pushCheckLevel */
-    public void popCheckLevel(java.util.logging.Level oldLevel) {
-        if (oldLevel != null) {
-            CheckCLDR.setLoggerLevel(oldLevel);
-        }
-    }
-
     public void TestAllLocales() {
-        java.util.logging.Level oldLevel = pushCheckLevel();
         CheckCLDR test = CheckCLDR.getCheckAll(factory, INDIVIDUAL_TESTS);
         CheckCLDR.setDisplayInformation(english);
         Set<String> unique = new HashSet<>();
@@ -508,18 +489,14 @@ public class TestCheckCLDR extends TestFmwk {
         // (And in fact this test seems faster without it)
         locales.forEach(locale -> checkLocale(test, locale, null, unique));
         logln("Count:\t" + locales.size());
-        popCheckLevel(oldLevel);
     }
 
     public void TestA() {
-        final java.util.logging.Level oldLevel = pushCheckLevel();
-
         CheckCLDR test = CheckCLDR.getCheckAll(factory, INDIVIDUAL_TESTS);
         CheckCLDR.setDisplayInformation(english);
         Set<String> unique = new HashSet<>();
 
         checkLocale(test, "ko", null, unique);
-        popCheckLevel(oldLevel);
     }
 
     public void checkLocale(


### PR DESCRIPTION
- update CheckExemplars parseLenient to error instead of crash on null
- update CheckPlaceHolders to skip aliases instead of crashing
- remove the logknownissue which was to suppress the crash stack traces

CLDR-17320

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
