### PR TITLE
CLDR-17587 Add Haitian Creole

### DIFF
--- a/common/main/ht.xml
+++ b/common/main/ht.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ht"/>
+	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="ht">Kreyòl Ayisyen</language>
+		</languages>
+	</localeDisplayNames>
+	<characters>
+		<exemplarCharacters>[a {an} b {ch} d e è {en} f g h i j k l m n {ng} o ò {on} {ou} {oun} p r s t {ui} v w y z]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[x]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[, ; \: ! ? . … ‘ ' ’ ′ ″ “ &quot; ” ( ) \[ \] / @ \&amp; # § \- %]</exemplarCharacters>
+	</characters>
+	<numbers>
+		<symbols numberSystem="latn">
+			<decimal>,</decimal>
+			<group> </group>
+			<percentSign>%</percentSign>
+			<minusSign>-</minusSign>
+		</symbols>
+	</numbers>
+</ldml>

--- a/common/main/ht.xml
+++ b/common/main/ht.xml
@@ -18,13 +18,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<characters>
 		<exemplarCharacters>[a {an} b {ch} d e è {en} f g h i j k l m n {ng} o ò {on} {ou} {oun} p r s t {ui} v w y z]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[x]</exemplarCharacters>
-		<exemplarCharacters type="numbers">[0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
+		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[, ; \: ! ? . … ‘ ' ’ ′ ″ “ &quot; ” ( ) \[ \] / @ \&amp; # § \- %]</exemplarCharacters>
 	</characters>
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>,</decimal>
-			<group> </group>
+			<group> </group>
 			<percentSign>%</percentSign>
 			<minusSign>-</minusSign>
 		</symbols>

--- a/common/main/ht_HT.xml
+++ b/common/main/ht_HT.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2024 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ht"/>
+		<territory type="HT"/>
+	</identity>
+</ldml>

--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -71,7 +71,7 @@
 				 ebu ee ewo
 				 ff frr fur
 				 gaa gez gn gsw guz gv
-				 haw hnj
+				 haw hnj ht
 				 ii io iu
 				 jbo jgo jmc
 				 kaa kab kaj kam kcg kde ken khq ki kkj kl kln kpe ksb ksf ksh kw

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1887,7 +1887,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			fy_NL
 			ga_IE gaa_GH gd_GB gez_ET gl_ES gn_PY gsw_CH gu_IN guz_KE gv_IM
 			ha_Arab_NG ha_NG haw_US he_IL hi_IN hi_Latn_IN hnj_Hmnp hnj_Hmnp_US hr_HR
-			hsb_DE hu_HU hy_AM
+			hsb_DE ht_HT hu_HU hy_AM
 			ia_001 id_ID ie_EE ife_TG ig_NG ii_CN io_001 is_IS it_IT iu_CA iu_Latn_CA
 			ja_JP jbo_001 jgo_CM jmc_TZ jv_ID
 			ka_GE kaa_Cyrl kaa_Cyrl_UZ kaa_Latn_UZ kab_DZ kaj_NG kam_KE kcg_NG kde_TZ kea_CV ken_CM kgp_BR

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -361,7 +361,10 @@ public class TestInheritance extends TestFmwk {
                             "nn",
                             "nb",
                             // Per CLDR-15276 hi-Latn can have an explicit parent
-                            "hi_Latn"));
+                            "hi_Latn",
+                            // Per CLDR-17587 Haitian Creole is largely influenced by French and is
+                            // best boot-strapped by French
+                            "ht"));
 
     public void TestParentLocaleInvariants() {
         // Testing invariant relationships in parent locales - See


### PR DESCRIPTION
This adds core data for Haitian Creole so that in Fall 2024 / v47 we can fill out the information for this locale.

CLDR-17587

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
