### PR TITLE
CLDR-17877 repair country_language_population.tsv columns

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -251,7 +251,7 @@ Chad	TD	"15,833,116"	35%	"28,620,000,000"	official	French	fr	26%			https://www.c
 Chile	CL	"17,925,262"	99%	"452,100,000,000"		English	en	9.5%
 Chile	CL	"17,925,262"	99%	"452,100,000,000"		Mapuche	arn	"272,000"			http://en.wikipedia.org/wiki/Mapuche_language
 Chile	CL	"17,925,262"	99%	"452,100,000,000"	official	Spanish	es	98%			"http://en.wikipedia.org/wiki/Demographics_of_Chile#Languages Spanish ""universal"", set to 98%"
-China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Cantonese (Simplified)	yue_Hans	5.2%		5%	"Mainly in Guangdong Prov, ~70-80 million"
+China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Cantonese (Simplified)	yue_Hans	5.2%	5%		"Mainly in Guangdong Prov, ~70-80 million"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official	Chinese	zh	90%
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		English	en	"62,900"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Gan Chinese	gan	"22,900,000"
@@ -742,7 +742,7 @@ Kosovo	XK	"1,907,592"	92%	"19,600,000,000"		Gheg Albanian	aln	74%			http://www.e
 Kosovo	XK	"1,907,592"	92%	"19,600,000,000"	official	Serbian	sr	5%			Information on the Latin/Cyrillic script percentages for Kosovo not currently found.
 Kosovo	XK	"1,907,592"	92%	"19,600,000,000"	official	Serbian (Latin)	sr_Latn	5%			Information on the Latin/Cyrillic script percentages for Kosovo not currently found.
 Kuwait	KW	"2,916,467"	94%	"289,700,000,000"	official	Arabic	ar	100%
-Kyrgyzstan	KG	"5,849,296"	99%	"23,150,000,000"		Kara-Kalpak kaa	0.02%			https://joshuaproject.net/languages/kaa
+Kyrgyzstan	KG	"5,849,296"	99%	"23,150,000,000"		Kara-Kalpak	kaa	0.02%			https://joshuaproject.net/languages/kaa
 Kyrgyzstan	KG	"5,849,296"	99%	"23,150,000,000"	official	Kyrgyz	ky	48%
 Kyrgyzstan	KG	"5,849,296"	99%	"23,150,000,000"	official	Russian	ru	36%			http://windowoneurasia2.blogspot.com/2013/12/window-on-eurasia-de-russianization.html http://www.stoletie.ru/vzglyad/derusifikacija_nabirajet_oboroty_934.htm
 Laos	LA	"7,234,171"	73%	"49,340,000,000"		Khmu	kjg	5.8%			http://en.wikipedia.org/wiki/Khmu_language


### PR DESCRIPTION
CLDR-17877

- [X] This PR completes the ticket.

Two rows in country_language_population.tsv had misaligned columns. This pull request adjusts the tabs in those rows to realign the column information.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
