### PR TITLE
CLDR-16413 for now, drop the mn_Mong_MN grouping separator

### DIFF
--- a/common/main/mn_Mong_MN.xml
+++ b/common/main/mn_Mong_MN.xml
@@ -535,9 +535,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</timeZoneNames>
 	</dates>
 	<numbers>
-		<symbols numberSystem="latn">
-			<decimal draft="contributed">,</decimal>
-		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">


### PR DESCRIPTION
- it's draft, incorrectly duplicates decimal, and is not a complete logical group.

CLDR-16413

- [ ] This PR completes the ticket. (still to do is fix the tests)

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
