### PR TITLE
CLDR-17887 Update Meta locale coverage

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -852,8 +852,18 @@ nyiakeng_puachue_hmong ; hnj      ; modern ; Green Hmong (hnj_Hmnp) - default co
 #The following is not in CLDR (yet)
 #nyiakeng_puachue_hmong ; mww_Hmnp ; modern ; White Hmong (mww_Hmnp)
 
+Meta	;	af	;	modern	;	Afrikaans
+Meta	;	am	;	moderate	;	Amharic
 Meta	;	ar	;	modern	;	Arabic
+Meta	;	as	;	modern	;	Assamese
+Meta	;	az	;	modern	;	Azerbaijani
+Meta	;	be	;	modern	;	Belarusian
+Meta	;	bg	;	modern	;	Bulgarian
 Meta	;	bn	;	modern	;	Bengali
+Meta	;	bs	;	modern	;	Bosnian
+Meta	;	ca	;	modern	;	Catalan
+Meta	;	ceb	;	moderate	;	Cebuano
+Meta	;	ckb	;	modern	;	Central Kurdish (Sorani)
 Meta	;	cs	;	modern	;	Czech
 Meta	;	da	;	modern	;	Danish
 Meta	;	de	;	modern	;	German
@@ -862,41 +872,84 @@ Meta	;	en	;	modern	;	American English
 Meta	;	en_GB	;	modern	;	British English
 Meta	;	es	;	modern	;	European Spanish
 Meta	;	es_419	;	modern	;	Latin American Spanish
+Meta	;	et	;	modern	;	Estonian
 Meta	;	fa	;	modern 	;	Persian
 Meta	;	fi	;	modern 	;	Finnish
+Meta	;	fil	;	modern	;	Filipino
 Meta	;	fr	;	modern	;	French
+Meta	;	fur	;	basic	;	Friulian
+Meta	;	gn	;	moderate	;	Guarani
 Meta	;	gu	;	modern	;	Gujarati
+Meta	;	ha	;	moderate	;	Hausa
 Meta	;	he	;	modern	;	Hebrew
 Meta	;	hi	;	modern	;	Hindi
+Meta	;	hr	;	modern	;	Croatian
+Meta	;	ht	;	moderate	;	Haitian Creole
 Meta	;	hu	;	modern	;	Hungarian
+Meta	;	hy	;	modern	;	Armenian
 Meta	;	id	;	modern	;	Indonesian
 Meta	;	it	;	modern	;	Italian
+Meta	;	iu	;	basic	;	Inukitut
 Meta	;	ja	;	modern	;	Japanese
+Meta	;	jv	;	modern	;	Javanese
+Meta	;	ka	;	modern	;	Georgian
+Meta	;	kk	;	modern	;	Kazakh
+Meta	;	km	;	modern	;	Cambodian
 Meta	;	kn	;	modern	;	Kannada
 Meta	;	ko	;	modern	;	Korean
+Meta	;	ku	;	modern	;	Northern Kurdish (Kurmanji)
+Meta	;	ky	;	modern	;	Kyrgyz
+Meta	;	ln	;	moderate	;	Lingala
+Meta	;	lo	;	modern	;	Lao
+Meta	;	lt	;	modern	;	Lithuanian
+Meta	;	lv	;	modern	;	Latvian
+Meta	;	mg	;	moderate	;	Malagasy
+Meta	;	mk	;	modern	;	Macedonian
+Meta	;	ml	;	modern	;	Malayalam
+Meta	;	mn	;	modern	;	Mongolian
 Meta	;	mr	;	modern	;	Marathi
 Meta	;	ms	;	modern	;	Malay
 Meta	;	my	;	modern	;	Burmese (Myanmar)
+Meta	;	ne	;	modern	;	Nepali
 Meta	;	nl	;	modern	;	Dutch
 Meta	;	no	;	modern	;	Norwegian (Bokmål)
+Meta	;	om	;	moderate	;	Oromo
+Meta	;	or	;	moderate	;	Oriya
+Meta	;	pa	;	modern	;	Punjabi
 Meta	;	pl	;	modern	;	Polish
+Meta	;	ps	;	modern	;	Pashto
 Meta	;	pt	;	modern	;	Brazilian Portuguese
 Meta	;	pt_PT	;	modern	;	European Portuguese
+Meta	;	rn	;	moderate	;	Kirundi
 Meta	;	ro	;	modern	;	Romanian
 Meta	;	ru	;	modern	;	Russian
+Meta	;	rw	;	moderate	;	Kinyarwanda
+Meta	;	si	;	modern	;	Sinhalese
 Meta	;	sk	;	modern	;	Slovak
+Meta	;	sl	;	modern	;	Slovenian
+Meta	;	sn	;	moderate	;	Shona
+Meta	;	so	;	modern	;	Somali
+Meta	;	sq	;	modern	;	Albanian
+Meta	;	sr	;	modern	;	Serbian
+Meta	;	ss	;	moderate	;	Swazi
+Meta	;	st	;	moderate	;	Southern Sotho
 Meta	;	sv	;	modern	;	Swedish
 Meta	;	sw	;	modern	;	Swahili
 Meta	;	ta	;	modern	;	Tamil
-Meta  ; te  ; modern  ; Telugu
+Meta	;	te	;	modern	;	Telugu
+Meta	;	tg	;	modern	;	Tajik
 Meta	;	th	;	modern	;	Thai
+Meta	;	tn	;	moderate	;	Tswana
 Meta	;	tr	;	modern	;	Turkish
-Meta	;	ur	;	modern	;	Urdu
 Meta	;	uk	;	modern	;	Ukrainian
+Meta	;	ur	;	modern	;	Urdu
+Meta	;	uz	;	modern	;	Uzbek
 Meta	;	vi	;	modern	;	Vietnamese
+Meta	;	xh	;	moderate	;	Xhosa
 Meta	;	zh	;	modern	;	Simplified Chinese
 Meta	;	zh_Hant	;	modern	;	Traditional Chinese
 Meta	;	zh_Hant_HK	;	modern	;	Traditional Chinese (Hong Kong)
+Meta	;	zu	;	moderate	;	Zulu
 
 Mozilla	;	mul	;	modern
 # ^no votes in 30…40 for this org


### PR DESCRIPTION
Since Locales.txt reflects the languages supported by an organization -- this change adds missing records for locales supported by Meta. This will inform users what locales Meta supports and it will enable Meta linguists to contribute to these languages in the survey tool.

Locales are differentiated by support level by the availability by app.
* Modern: If it is offered on the flapship app Facebook for Android
* Moderate: Only on Meta's emerging markets app Facebook Lite
* Basic supported on their web app -- driven by community input. See announcements for [Inukitut](https://about.fb.com/news/2022/07/inuktitut-official-language-on-facebook-desktop/) and [Friulian](https://about.fb.com/news/2023/02/adding-friulian-as-a-language-setting-on-facebook/)

CLDR-17887

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
