### PR TITLE
CLDR-17535 Update LikelySubtags tool

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1884,7 +1884,7 @@ XXX Code for transations where no currency is involved
 		<language type="lv" scripts="Latn" territories="LV"/>
 		<language type="lwl" scripts="Thai"/>
 		<language type="lzh" scripts="Hans" alt="secondary"/>
-		<language type="lzz" scripts="Geor Latn"/>
+		<language type="lzz" scripts="Latn Geor"/>
 		<language type="mad" scripts="Latn"/>
 		<language type="mad" territories="ID" alt="secondary"/>
 		<language type="maf" scripts="Latn"/>
@@ -2068,7 +2068,7 @@ XXX Code for transations where no currency is involved
 		<language type="pl" scripts="Latn" territories="PL"/>
 		<language type="pl" territories="GB UA" alt="secondary"/>
 		<language type="pms" scripts="Latn"/>
-		<language type="pnt" scripts="Cyrl Grek Latn"/>
+		<language type="pnt" scripts="Grek Cyrl Latn"/>
 		<language type="pon" scripts="Latn"/>
 		<language type="pon" territories="FM" alt="secondary"/>
 		<language type="pqm" scripts="Latn"/>
@@ -2266,10 +2266,10 @@ XXX Code for transations where no currency is involved
 		<language type="tk" scripts="Arab Cyrl Latn" territories="TM"/>
 		<language type="tk" territories="AF IR" alt="secondary"/>
 		<language type="tkl" scripts="Latn" territories="TK"/>
-		<language type="tkr" scripts="Cyrl Latn"/>
+		<language type="tkr" scripts="Latn Cyrl"/>
 		<language type="tkt" scripts="Deva"/>
 		<language type="tli" scripts="Latn"/>
-		<language type="tly" scripts="Arab Cyrl Latn"/>
+		<language type="tly" scripts="Latn Arab Cyrl"/>
 		<language type="tly" territories="AZ" alt="secondary"/>
 		<language type="tmh" scripts="Latn"/>
 		<language type="tmh" territories="NE" alt="secondary"/>
@@ -2298,7 +2298,7 @@ XXX Code for transations where no currency is involved
 		<language type="ttj" scripts="Latn"/>
 		<language type="tts" scripts="Thai"/>
 		<language type="tts" territories="TH" alt="secondary"/>
-		<language type="ttt" scripts="Cyrl Latn"/>
+		<language type="ttt" scripts="Latn Cyrl"/>
 		<language type="ttt" scripts="Arab" alt="secondary"/>
 		<language type="tum" scripts="Latn"/>
 		<language type="tum" territories="MW" alt="secondary"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -10,10 +10,12 @@ import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Row.R3;
-import com.ibm.icu.impl.Row.R4;
+import com.ibm.icu.impl.locale.XCldrStub.Splitter;
+import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.NumberFormat;
 import java.io.File;
-import java.util.Collection;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,9 +25,14 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.draft.ScriptMetadata;
 import org.unicode.cldr.draft.ScriptMetadata.Info;
 import org.unicode.cldr.tool.GenerateMaximalLocales.LocaleOverride;
+import org.unicode.cldr.tool.GenerateMaximalLocales.LocaleStringComparator;
+import org.unicode.cldr.tool.LangTagsData.LSRSource;
+import org.unicode.cldr.tool.Option.Options;
+import org.unicode.cldr.tool.Option.Params;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
@@ -51,6 +58,7 @@ import org.unicode.cldr.util.Validity.Status;
  * GenerateLikelyAdditions.
  */
 public class GenerateLikelySubtags {
+
     private static final Joiner JOIN_TAB = Joiner.on('\t').useForNull("∅");
 
     private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
@@ -62,19 +70,11 @@ public class GenerateLikelySubtags {
 
     private static final String DEBUG_ADD_KEY = "und_Latn_ZA";
 
-    private static final boolean SHOW_ADD =
-            CldrUtility.getProperty("GenerateLikelySubtags_Debug", false);
-    private static final boolean SUPPRESS_CHANGES =
-            CldrUtility.getProperty("GenerateMaximalLocalesSuppress", false);
-    private static final boolean SHOW_CONTAINERS = false;
-
-    private static final boolean SHOW_ALL_LANGUAGE_CODES = false;
-    private static final boolean SHOW_DETAILED = false;
-    private static final boolean SHOW_INCLUDED_EXCLUDED = false;
-
     private static final double MIN_UNOFFICIAL_LANGUAGE_SIZE = 10000000;
     private static final double MIN_UNOFFICIAL_LANGUAGE_PROPORTION = 0.20;
     private static final double MIN_UNOFFICIAL_CLDR_LANGUAGE_SIZE = 100000;
+
+    /** When a language is not official, scale it down. */
     private static final double UNOFFICIAL_SCALE_DOWN = 0.2;
 
     private static final File list[] = {
@@ -91,13 +91,138 @@ public class GenerateLikelySubtags {
             Relation.of(new HashMap<String, Set<String>>(), HashSet.class);
 
     private static NumberFormat percent = NumberFormat.getPercentInstance();
-    private static NumberFormat number = NumberFormat.getIntegerInstance();
+    private static NumberFormat integer = NumberFormat.getIntegerInstance();
 
-    private static boolean DROP = false;
+    private static boolean DROP_HARDCODED = false;
+
+    private enum MyOptions {
+        minimize(new Params().setHelp("Show minimization actions")),
+        add(new Params().setHelp("Show additions")),
+        population(new Params().setHelp("Show population data used")),
+        order(new Params().setHelp("Show the priority order for langauge data")),
+        debug(new Params().setHelp("Show other debug info")),
+        watch(
+                new Params()
+                        .setHelp(
+                                "Only show info for locales with listed fields ('|' separated), eg -w419|Aghb|AU|bjt will show info for bjt_Latn or und_Laoo_AU")
+                        .setMatch(".*")),
+        ;
+
+        // BOILERPLATE TO COPY
+        final Option option;
+
+        private MyOptions(Params params) {
+            option = new Option(this, params);
+        }
+
+        private static Options myOptions = new Options();
+
+        static {
+            for (MyOptions option : MyOptions.values()) {
+                myOptions.add(option, option.option);
+            }
+        }
+
+        private static Set<String> parse(String[] args) {
+            return myOptions.parse(MyOptions.values()[0], args, true);
+        }
+    }
+
+    private static boolean SHOW_ADD;
+    private static boolean SHOW_MIN;
+    private static boolean SHOW_POP;
+    private static boolean SHOW_ORDER;
+    private static boolean DEBUG;
+    private static Map<String, LstrType> WATCH_PAIRS = null;
+
+    private static final boolean SHOW_OVERRIDES = true;
+
+    static final Map<String, LSRSource> silData = LangTagsData.getJsonData();
+
+    public static void main(String[] args) throws IOException {
+        MyOptions.parse(args);
+        SHOW_ADD = MyOptions.add.option.doesOccur();
+        SHOW_MIN = MyOptions.minimize.option.doesOccur();
+        SHOW_POP = MyOptions.population.option.doesOccur();
+        SHOW_ORDER = MyOptions.order.option.doesOccur();
+        DEBUG = MyOptions.debug.option.doesOccur();
+        String watchValues = MyOptions.watch.option.getValue();
+        if (watchValues != null) {
+            Map<String, LstrType> temp = new TreeMap<>();
+            Splitter.on('|')
+                    .split(watchValues)
+                    .forEach(x -> temp.put(x, getTypeFromCasedSubtag(x)));
+            WATCH_PAIRS = ImmutableMap.copyOf(temp);
+        }
+
+        Map<String, String> old = supplementalData.getLikelySubtags();
+        Map<String, String> oldOrigins = supplementalData.getLikelyOrigins();
+        System.out.println("origins: " + new TreeSet<>(oldOrigins.values()));
+
+        Map<String, String> toMaximized = generatePopulationData(new TreeMap<>(LOCALE_SOURCE));
+
+        Map<String, String> itemsRemoved = new TreeMap<>();
+
+        Map<String, String> result = minimize(toMaximized, itemsRemoved);
+
+        Set<String> newAdditions = new TreeSet();
+        Set<String> newMissing = new TreeSet();
+
+        // Check against last version
+
+        System.out.println(JOIN_TAB.join("Source", "Name", "oldValue", "Name", "newValue", "Name"));
+
+        Set<String> sorted = new TreeSet<>(LOCALE_SOURCE);
+        sorted.addAll(result.keySet());
+        sorted.addAll(old.keySet());
+
+        for (String source : sorted) {
+            String oldValue = old.get(source);
+            String newValue = result.get(source);
+            String removal = itemsRemoved.get(source);
+
+            if (Objects.equal(oldValue, newValue)) {
+                continue;
+            }
+
+            // SKIP the sil values; those will be recreated
+
+            final String origins = oldOrigins.get(source);
+            if (origins != null && origins.contains("sil1")) {
+                continue; // skip for now
+            }
+
+            // skip new values, or oldValues that are specifically removed
+
+            if (oldValue == null || oldValue.equals(removal)) {
+                continue; // skip for now
+            }
+
+            // special cases
+
+            if (getPart(source, LstrType.language).equals("und")
+                    && oldValue.startsWith("en_Latn")) {
+                continue; // skip for now
+            }
+
+            // show the remainder
+
+            System.out.println(
+                    JOIN_TAB.join(
+                            source,
+                            getNameSafe(source),
+                            oldValue,
+                            getNameSafe(oldValue),
+                            newValue,
+                            getNameSafe(newValue)));
+        }
+        System.out.println("new missing\t" + newMissing);
+
+        printLikelySubtags(result);
+    }
 
     static {
-        for (CLDRLocale locale :
-                ToolConfig.getToolInstance().getCldrFactory().getAvailableCLDRLocales()) {
+        for (CLDRLocale locale : mainFactory.getAvailableCLDRLocales()) {
             String region = locale.getCountry();
             if (region == null || region.isEmpty() || Containment.isLeaf(region)) {
                 continue;
@@ -109,17 +234,17 @@ public class GenerateLikelySubtags {
     }
 
     private static final List<String> KEEP_TARGETS =
-            DROP ? List.of() : List.of("und_Arab_PK", "und_Latn_ET", "hi_Latn");
+            DROP_HARDCODED ? List.of() : List.of("und_Arab_PK", "und_Latn_ET", "hi_Latn");
 
     private static final ImmutableSet<String> deprecatedISONotInLST =
-            DROP ? ImmutableSet.of() : ImmutableSet.of("scc", "scr");
+            DROP_HARDCODED ? ImmutableSet.of() : ImmutableSet.of("scc", "scr");
 
     /**
      * This is the simplest way to override, by supplying the max value. It gets a very low weight,
      * so doesn't override any stronger value.
      */
     private static final List<String> MAX_ADDITIONS =
-            DROP
+            DROP_HARDCODED
                     ? List.of()
                     : List.of(
                             "bss_Latn_CM",
@@ -171,7 +296,7 @@ public class GenerateLikelySubtags {
     // Many of the overrides below can be removed once the language/pop/country data is updated.
     private static final Map<String, String> LANGUAGE_OVERRIDES =
             CldrUtility.asMap(
-                    DROP
+                    DROP_HARDCODED
                             ? new String[][] {
                                 {LocaleNames.UND, "en_Latn_US"},
                             }
@@ -337,7 +462,7 @@ public class GenerateLikelySubtags {
         //        {"tet", "Latn"}, // Tetum (East Timor)
         //        {"tk", "Latn"}, // Turkmen (Turkmenistan)
         //        {"ty", "Latn"}, // Tahitian (French Polynesia)
-        {LocaleNames.UND, "Latn"}, // Ultimate fallback
+        // {LocaleNames.UND, "Latn"}, // Ultimate fallback
     };
 
     private static Map<String, String> localeToScriptCache = new TreeMap<>();
@@ -370,47 +495,65 @@ public class GenerateLikelySubtags {
 
     private static int errorCount;
 
-    public static void main(String[] args) {
-        Map<String, String> old = supplementalData.getLikelySubtags();
-        Map<String, String> oldOrigins = supplementalData.getLikelyOrigins();
-        System.out.println("origins: " + new TreeSet<>(oldOrigins.values()));
-
-        Map<String, String> toMaximized = generatePopulationData(new TreeMap<>(LOCALE_SOURCE));
-
-        Map<String, String> result = minimize(toMaximized);
-
-        Set<String> newAdditions = new TreeSet();
-        Set<String> newMissing = new TreeSet();
-
-        System.out.println(JOIN_TAB.join("Source", "Name", "oldValue", "Name", "newValue", "Name"));
-
-        Set<String> sorted = new TreeSet<>(LOCALE_SOURCE);
-        sorted.addAll(result.keySet());
-        sorted.addAll(old.keySet());
-
-        for (String source : sorted) {
-            String oldValue = old.get(source);
-            String newValue = result.get(source);
-            if (Objects.equal(oldValue, newValue)) {
-                continue;
-            }
-            final String origins = oldOrigins.get(source);
-            if (origins != null && origins.contains("sil1")) {
-                continue; // skip for now
-            }
-            if (oldValue == null) {
-                continue; // skip for now
-            }
-            System.out.println(
-                    JOIN_TAB.join(
-                            source,
-                            getNameSafe(source),
-                            oldValue,
-                            getNameSafe(oldValue),
-                            newValue,
-                            getNameSafe(newValue)));
+    /**
+     * Debugging function that returns false if the flag is false, otherwise returns true if the
+     * WATCH is null or the locales don't match the WATCH.
+     *
+     * @param flag
+     * @param locales
+     * @return
+     */
+    static boolean watching(boolean flag, String... locales) {
+        if (!flag) {
+            return false;
         }
-        System.out.println("new missing\t" + newMissing);
+        if (WATCH_PAIRS == null) {
+            return true;
+        }
+        for (String locale : locales) {
+            for (Entry<String, LstrType> entry : WATCH_PAIRS.entrySet()) {
+                if (entry.getKey().equals(getPart(locale, entry.getValue()))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the LstrType from well-formed, properly cased LSTR subtag. Otherwise, returns null from
+     * null, otherwise garbage.
+     */
+    public static LstrType getTypeFromCasedSubtag(String casedSubtag) {
+        if (casedSubtag == null) {
+            return null;
+        }
+        final char cp0 = casedSubtag.charAt(0);
+        final char cp1 = casedSubtag.charAt(1);
+        return cp0 > 'Z'
+                ? LstrType.language // de
+                : cp1 > 'Z'
+                        ? LstrType.script // Latn
+                        : LstrType.region; // US, 001
+    }
+
+    /** Get the part of a locale according to the LstrType */
+    public static String getPart(String locale, LstrType lstrType) {
+        return getPart(CLDRLocale.getInstance(locale), lstrType);
+    }
+
+    /** Get the part of a locale according to the LstrType */
+    public static String getPart(CLDRLocale loc, LstrType type) {
+        switch (type) {
+            case language:
+                return loc.getLanguage();
+            case script:
+                return loc.getScript();
+            case region:
+                return loc.getCountry();
+            default:
+                throw new IllegalArgumentException(type.toString());
+        }
     }
 
     /**
@@ -427,10 +570,10 @@ public class GenerateLikelySubtags {
                     // sort items with 0 components first, then 1, then 2 (there won't be 3)
                     int result =
                             ComparisonChain.start()
-                                    // .compare(getCount(l1), getCount(l2))
-                                    .compare(fixUnd(l1.getLanguage()), fixUnd(l2.getLanguage()))
-                                    .compare(l1.getScript(), l2.getScript())
-                                    .compare(l1.getCountry(), l2.getCountry())
+                                    // .compare(getMask(l1), getMask(l2))
+                                    .compare(getLanguage(l1), getLanguage(l2))
+                                    .compare(getScript(l1), getScript(l2))
+                                    .compare(getRegion(l1), getRegion(l2))
                                     .result();
                     if (result == 0 && !locale1.equals(locale2)) {
                         throw new IllegalArgumentException();
@@ -438,16 +581,20 @@ public class GenerateLikelySubtags {
                     return result;
                 }
 
-                private int getCount(CLDRLocale l1) {
-                    int result =
-                            ("und".equals(l1.getLanguage()) ? 0 : 1)
-                                    + (l1.getScript().isEmpty() ? 0 : 1)
-                                    + (l1.getCountry().isEmpty() ? 0 : 1);
-                    return result;
+                private String getLanguage(CLDRLocale loc) {
+                    return replaceMissing(loc.getLanguage(), "und", "Ω");
                 }
 
-                private String fixUnd(String language) {
-                    return "und".equals(language) ? "" : language;
+                private String getScript(CLDRLocale loc) {
+                    return loc.getScript();
+                }
+
+                private String getRegion(CLDRLocale loc) {
+                    return loc.getCountry();
+                }
+
+                private String replaceMissing(String field, String ifEqual, String replacement) {
+                    return ifEqual.equals(field) ? replacement : field;
                 }
             };
 
@@ -457,11 +604,31 @@ public class GenerateLikelySubtags {
 
     public static String getNameSafe(String oldValue) {
         try {
-            return english.getName(oldValue);
+            if (oldValue != null) {
+                String result = english.getName(oldValue);
+                if (result.startsWith("Unknown language ")) {
+                    result = result.substring("Unknown language ".length());
+                }
+                return result;
+            }
         } catch (Exception e) {
-            return "n/a";
         }
+        return "n/a";
     }
+
+    enum OutputStyle {
+        PLAINTEXT,
+        C,
+        C_ALT,
+        XML
+    }
+
+    private static OutputStyle OUTPUT_STYLE =
+            OutputStyle.valueOf(CldrUtility.getProperty("OutputStyle", "XML", "XML").toUpperCase());
+
+    private static final String TAG_SEPARATOR = OUTPUT_STYLE == OutputStyle.C_ALT ? "-" : "_";
+
+    private static final Joiner JOIN_SPACE = Joiner.on(' ');
 
     private static Map<String, String> generatePopulationData(Map<String, String> toMaximized) {
         // we are going to try a different approach.
@@ -515,20 +682,17 @@ public class GenerateLikelySubtags {
                         // continue;
                     }
                     order *= UNOFFICIAL_SCALE_DOWN;
-                    if (SHOW_ADD)
+                    if (watching(SHOW_POP, writtenLanguage))
                         System.out.println(
-                                "Retaining\t"
-                                        + writtenLanguage
-                                        + "\t"
-                                        + region
-                                        + "\t"
-                                        + getNameSafe(locale)
-                                        + "\t"
-                                        + number.format(literatePopulation)
-                                        + "\t"
-                                        + percent.format(
-                                                literatePopulation / literateTerritoryPopulation)
-                                        + (cldrLocales.contains(locale) ? "\tin-CLDR" : ""));
+                                JOIN_TAB.join(
+                                        "Pop:",
+                                        writtenLanguage,
+                                        region,
+                                        getNameSafe(locale),
+                                        integer.format(literatePopulation),
+                                        percent.format(
+                                                literatePopulation / literateTerritoryPopulation),
+                                        cldrLocales.contains(locale) ? "CLDR Loc" : ""));
                 }
 
                 String script = localeToScriptCache.get(writtenLanguage);
@@ -550,7 +714,22 @@ public class GenerateLikelySubtags {
             }
         }
         if (!noPopulationData.isEmpty()) {
+            System.out.println("script data to add");
+            Set<String> stillBad = new TreeSet<>();
             for (String lang : noPopulationData) {
+                LSRSource silLSR = silData.get(lang);
+                if (silLSR == null) {
+                    stillBad.add(lang);
+                } else {
+                    System.out.println(
+                            "        <language type=\""
+                                    + lang
+                                    + "\" scripts=\""
+                                    + silLSR.data.get1()
+                                    + "\"/>");
+                }
+            }
+            for (String lang : stillBad) {
                 System.out.println(
                         JOIN_TAB.join("No script in pop. data for", lang, getNameSafe(lang)));
             }
@@ -569,18 +748,21 @@ public class GenerateLikelySubtags {
             }
         }
 
-        for (Entry<String, Collection<String>> entry :
-                DeriveScripts.getLanguageToScript().asMap().entrySet()) {
-            String language = entry.getKey();
-            final Collection<String> values = entry.getValue();
-            if (values.size() != 1) {
-                continue; // skip, no either way
-            }
-            Set<R3<Double, String, String>> old = maxData.languages.get(language);
-            if (!maxData.languages.containsKey(language)) {
-                maxData.add(language, values.iterator().next(), TEMP_UNKNOWN_REGION, 1.0);
-            }
-        }
+        // Old code for getting language to script, adding XZ, which converts to ZZ. Replaced by use
+        // of SIL data
+
+        //        for (Entry<String, Collection<String>> entry :
+        //                DeriveScripts.getLanguageToScript().asMap().entrySet()) {
+        //            String language = entry.getKey();
+        //            final Collection<String> values = entry.getValue();
+        //            if (values.size() != 1) {
+        //                continue; // skip, no either way
+        //            }
+        //            Set<R3<Double, String, String>> old = maxData.languages.get(language);
+        //            if (!maxData.languages.containsKey(language)) {
+        //                maxData.add(language, values.iterator().next(), TEMP_UNKNOWN_REGION, 1.0);
+        //            }
+        //        }
 
         // add others, with English default
         for (String region : otherTerritories) {
@@ -642,8 +824,7 @@ public class GenerateLikelySubtags {
                     language + "_" + script + "_" + region,
                     toMaximized,
                     "L->SR",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
         for (String language : maxData.languagesToScripts.keySet()) {
             String script =
@@ -657,8 +838,7 @@ public class GenerateLikelySubtags {
                     language + "_" + script,
                     toMaximized,
                     "L->S",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
         for (String language : maxData.languagesToRegions.keySet()) {
             String region =
@@ -672,21 +852,19 @@ public class GenerateLikelySubtags {
                     language + "_" + region,
                     toMaximized,
                     "L->R",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
 
         for (String script : maxData.scripts.keySet()) {
             R3<Double, String, String> value = maxData.scripts.getAll(script).iterator().next();
-            final Comparable<String> language = value.get1();
-            final Comparable<String> region = value.get2();
+            final String language = value.get1();
+            final String region = value.get2();
             add(
                     "und_" + script,
                     language + "_" + script + "_" + region,
                     toMaximized,
                     "S->LR",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
         for (String script : maxData.scriptsToLanguages.keySet()) {
             String language =
@@ -700,8 +878,7 @@ public class GenerateLikelySubtags {
                     language + "_" + script,
                     toMaximized,
                     "S->L",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
         for (String script : maxData.scriptsToRegions.keySet()) {
             String region =
@@ -715,21 +892,19 @@ public class GenerateLikelySubtags {
                     "und_" + script + "_" + region,
                     toMaximized,
                     "S->R",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
 
         for (String region : maxData.regions.keySet()) {
             R3<Double, String, String> value = maxData.regions.getAll(region).iterator().next();
-            final Comparable<String> language = value.get1();
-            final Comparable<String> script = value.get2();
+            final String language = value.get1();
+            final String script = value.get2();
             add(
                     "und_" + region,
                     language + "_" + script + "_" + region,
                     toMaximized,
                     "R->LS",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
         for (String region : maxData.regionsToLanguages.keySet()) {
             String language =
@@ -743,8 +918,7 @@ public class GenerateLikelySubtags {
                     language + "_" + region,
                     toMaximized,
                     "R->L",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
         for (String region : maxData.regionsToScripts.keySet()) {
             String script =
@@ -758,110 +932,48 @@ public class GenerateLikelySubtags {
                     "und_" + script + "_" + region,
                     toMaximized,
                     "R->S",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
-        }
-
-        for (Entry<String, Counter<R2<String, String>>> containerAndInfo :
-                maxData.containersToLanguage.entrySet()) {
-            String region = containerAndInfo.getKey();
-            if (region.equals("001")) {
-                continue;
-            }
-            Counter<R2<String, String>> data = containerAndInfo.getValue();
-            Set<R2<String, String>> keysetSortedByCount = data.getKeysetSortedByCount(true);
-            if (SHOW_CONTAINERS) { // debug
-                System.out.println(
-                        "Container2L:\t"
-                                + region
-                                + "\t"
-                                + truncateLongString(
-                                        data.getEntrySetSortedByCount(true, null), 127));
-                System.out.println(
-                        "Container2LR:\t"
-                                + region
-                                + "\t"
-                                + maxData.containersToLangRegion.get(region));
-            }
-            R2<String, String> value =
-                    keysetSortedByCount.iterator().next(); // will get most negative
-            final Comparable<String> language = value.get0();
-            final Comparable<String> script = value.get1();
-
-            // fix special cases like es-419, where a locale exists.
-            // for those cases, what we add as output is the container. Otherwise the region.
-            Set<String> skipLanguages = cldrContainerToLanguages.get(region);
-            if (skipLanguages != null && skipLanguages.contains(language)) {
-                add(
-                        "und_" + region,
-                        language + "_" + script + "_" + region,
-                        toMaximized,
-                        "R*->LS",
-                        LocaleOverride.REPLACE_EXISTING,
-                        SHOW_ADD);
-                continue;
-            }
-
-            // we now have the best language and script. Find the best region for that
-            for (R4<Double, String, String, String> e :
-                    maxData.containersToLangRegion.get(region)) {
-                final Comparable<String> language2 = e.get1();
-                final Comparable<String> script2 = e.get2();
-                if (language2.equals(language) && script2.equals(script)) {
-                    add(
-                            "und_" + region,
-                            language + "_" + script + "_" + e.get3(),
-                            toMaximized,
-                            "R*->LS",
-                            LocaleOverride.REPLACE_EXISTING,
-                            SHOW_ADD);
-                    break;
-                }
-            }
+                    LocaleOverride.REPLACE_EXISTING);
         }
 
         for (R2<String, String> languageScript : maxData.languageScripts.keySet()) {
             R2<Double, String> value =
                     maxData.languageScripts.getAll(languageScript).iterator().next();
-            final Comparable<String> language = languageScript.get0();
-            final Comparable<String> script = languageScript.get1();
-            final Comparable<String> region = value.get1();
+            final String language = languageScript.get0();
+            final String script = languageScript.get1();
+            final String region = value.get1();
             add(
                     language + "_" + script,
                     language + "_" + script + "_" + region,
                     toMaximized,
                     "LS->R",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
 
         for (R2<String, String> scriptRegion : maxData.scriptRegions.keySet()) {
             R2<Double, String> value = maxData.scriptRegions.getAll(scriptRegion).iterator().next();
-            final Comparable<String> script = scriptRegion.get0();
-            final Comparable<String> region = scriptRegion.get1();
-            final Comparable<String> language = value.get1();
+            final String script = scriptRegion.get0();
+            final String region = scriptRegion.get1();
+            final String language = value.get1();
             add(
                     "und_" + script + "_" + region,
                     language + "_" + script + "_" + region,
                     toMaximized,
                     "SR->L",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
 
         for (R2<String, String> languageRegion : maxData.languageRegions.keySet()) {
             R2<Double, String> value =
                     maxData.languageRegions.getAll(languageRegion).iterator().next();
-            final Comparable<String> language = languageRegion.get0();
-            final Comparable<String> region = languageRegion.get1();
-            final Comparable<String> script = value.get1();
+            final String language = languageRegion.get0();
+            final String region = languageRegion.get1();
+            final String script = value.get1();
             add(
                     language + "_" + region,
                     language + "_" + script + "_" + region,
                     toMaximized,
                     "LR->S",
-                    LocaleOverride.REPLACE_EXISTING,
-                    SHOW_ADD);
+                    LocaleOverride.REPLACE_EXISTING);
         }
 
         // get the script info from metadata as fallback
@@ -875,31 +987,15 @@ public class GenerateLikelySubtags {
             }
             String originCountry = i.originCountry;
             final String result = likelyLanguage + "_" + script + "_" + originCountry;
-            add(
-                    "und_" + script,
-                    result,
-                    toMaximized,
-                    "S->LR•",
-                    LocaleOverride.KEEP_EXISTING,
-                    SHOW_ADD);
-            add(
-                    likelyLanguage,
-                    result,
-                    toMaximized,
-                    "L->SR•",
-                    LocaleOverride.KEEP_EXISTING,
-                    SHOW_ADD);
+            add("und_" + script, result, toMaximized, "S->LR•", LocaleOverride.KEEP_EXISTING);
+            add(likelyLanguage, result, toMaximized, "L->SR•", LocaleOverride.KEEP_EXISTING);
         }
 
         // add overrides
-        for (String key : LANGUAGE_OVERRIDES.keySet()) {
-            add(
-                    key,
-                    LANGUAGE_OVERRIDES.get(key),
-                    toMaximized,
-                    "OVERRIDE",
-                    LocaleOverride.REPLACE_EXISTING,
-                    true);
+        for (Entry<String, String> entry : LANGUAGE_OVERRIDES.entrySet()) {
+            String source = entry.getKey();
+            String target = entry.getValue();
+            add(source, target, toMaximized, "OVERRIDE", LocaleOverride.REPLACE_EXISTING);
         }
 
         // Make sure that the mapping is Idempotent. If we have A ==> B, we must never have B ==> C
@@ -939,6 +1035,7 @@ public class GenerateLikelySubtags {
         return toMaximized;
     }
 
+    /** Class for maximizing data sources */
     public static class MaxData {
         Relation<String, Row.R3<Double, String, String>> languages =
                 Relation.of(
@@ -957,12 +1054,6 @@ public class GenerateLikelySubtags {
                         new TreeMap<String, Set<Row.R3<Double, String, String>>>(), TreeSet.class);
         Map<String, Counter<String>> regionsToLanguages = new TreeMap<>();
         Map<String, Counter<String>> regionsToScripts = new TreeMap<>();
-
-        Map<String, Counter<Row.R2<String, String>>> containersToLanguage = new TreeMap<>();
-        Relation<String, Row.R4<Double, String, String, String>> containersToLangRegion =
-                Relation.of(
-                        new TreeMap<String, Set<Row.R4<Double, String, String, String>>>(),
-                        TreeSet.class);
 
         Relation<Row.R2<String, String>, Row.R2<Double, String>> languageScripts =
                 Relation.of(
@@ -987,9 +1078,11 @@ public class GenerateLikelySubtags {
          * @param order
          */
         void add(String language, String script, String region, Double order) {
-            if (SHOW_ADD && language.equals(LocaleNames.MIS)) {
-                System.out.println(language + "\t" + script + "\t" + region + "\t" + -order);
-            }
+            if (watching(SHOW_ORDER, language))
+                System.out.println(
+                        JOIN_TAB.join(
+                                "Add Data:", language, script, region, integer.format(order)));
+
             languages.put(language, Row.of(order, script, region));
             // addCounter(languagesToScripts, language, script, order);
             // addCounter(languagesToRegions, language, region, order);
@@ -1005,23 +1098,6 @@ public class GenerateLikelySubtags {
             languageScripts.put(Row.of(language, script), Row.of(order, region));
             scriptRegions.put(Row.of(script, region), Row.of(order, language));
             languageRegions.put(Row.of(language, region), Row.of(order, script));
-
-            Set<String> containerSet = Containment.leafToContainer(region);
-            if (containerSet != null) {
-                for (String container : containerSet) {
-
-                    containersToLangRegion.put(container, Row.of(order, language, script, region));
-                    Counter<R2<String, String>> data = containersToLanguage.get(container);
-                    if (data == null) {
-                        containersToLanguage.put(container, data = new Counter<>());
-                    }
-                    data.add(Row.of(language, script), (long) (double) order);
-                }
-            }
-
-            if (SHOW_ADD)
-                System.out.println(
-                        "Data:\t" + language + "\t" + script + "\t" + region + "\t" + order);
         }
         // private void addCounter(Map<String, Counter<String>> map, String key, String key2, Double
         // count) {
@@ -1041,8 +1117,13 @@ public class GenerateLikelySubtags {
         return (long) popData.getLiteratePopulation();
     }
 
-    private static String getName(String value) {
-        return ConvertLanguageData.getLanguageCodeAndName(value);
+    private static void add(
+            String key,
+            String value,
+            Map<String, String> toAdd,
+            String kind,
+            LocaleOverride override) {
+        add(key, value, toAdd, kind, override, SHOW_ADD);
     }
 
     private static void add(
@@ -1052,39 +1133,42 @@ public class GenerateLikelySubtags {
             String kind,
             LocaleOverride override,
             boolean showAction) {
-        if (SHOW_ADD && key.startsWith(LocaleNames.MIS)) {
-            int debug = 1;
-        }
-        if (key.equals(DEBUG_ADD_KEY)) {
-            System.out.println("*debug*");
-        }
         String oldValue = toAdd.get(key);
         if (oldValue == null) {
-            if (showAction) {
+            if (watching(showAction, key, value)) {
                 System.out.println(
-                        "\tAdding:\t\t"
-                                + getName(key)
-                                + "\t=>\t"
-                                + getName(value)
-                                + "\t\t\t\t"
-                                + kind);
+                        JOIN_TAB.join(
+                                "",
+                                "Adding:",
+                                key,
+                                getNameSafe(key),
+                                "→",
+                                value,
+                                getNameSafe(value),
+                                "",
+                                "",
+                                kind));
             }
         } else if (override == LocaleOverride.KEEP_EXISTING || value.equals(oldValue)) {
             // if (showAction) {
-            // System.out.println("Skipping:\t" + key + "\t=>\t" + value + "\t\t\t\t" + kind);
+            // System.out.println("Skipping:\t" + key + "\t→\t" + value + "\t\t\t\t" + kind);
             // }
             return;
         } else {
-            if (showAction) {
+            if (watching(showAction, key, value)) {
                 System.out.println(
-                        "\tReplacing:\t"
-                                + getName(key)
-                                + "\t=>\t"
-                                + getName(value)
-                                + "\t, was\t"
-                                + getName(oldValue)
-                                + "\t\t"
-                                + kind);
+                        JOIN_TAB.join(
+                                "",
+                                "Replacing:",
+                                key,
+                                getNameSafe(key),
+                                "→",
+                                value,
+                                getNameSafe(value),
+                                ", was",
+                                oldValue,
+                                getNameSafe(oldValue),
+                                kind));
             }
         }
         toAdd.put(key, value);
@@ -1093,54 +1177,41 @@ public class GenerateLikelySubtags {
     public static String truncateLongString(Object data, int maxLen) {
         String info = data.toString();
         if (info.length() > maxLen) {
+            if (UCharacter.codePointAt(info, maxLen - 1) > 0xFFFF) {
+                maxLen--;
+            }
             info = info.substring(0, maxLen) + "…";
-            // TODO, handle supplemental characters.
         }
         return info;
     }
 
-    public static Map<String, String> minimize(Map<String, String> fluffup) {
+    public static Map<String, String> minimize(
+            Map<String, String> fluffup, Map<String, String> itemsRemoved) {
         LanguageTagParser parser = new LanguageTagParser();
         LanguageTagParser targetParser = new LanguageTagParser();
-        Set<String> removals = new TreeSet<>();
-        while (true) {
+        Map<String, String> removals = new TreeMap<>();
+        for (int pass = 0; ; ++pass) {
             removals.clear();
-            for (String locale : fluffup.keySet()) {
-                String target = fluffup.get(locale);
+            for (Entry<String, String> entry : fluffup.entrySet()) {
+                String locale = entry.getKey();
+                String target = entry.getValue();
+
                 if (targetParser.set(target).getRegion().equals(LocaleScriptInfo.UNKNOWN_REGION)) {
-                    removals.add(locale);
-                    if (SHOW_ADD)
-                        System.out.println(
-                                "Removing:\t"
-                                        + getName(locale)
-                                        + "\t=>\t"
-                                        + getName(target)
-                                        + "\t\t - Unknown Region in target");
+                    removals.put(locale, target);
+                    showRemoving(pass, locale, target, "Unknown Region in target");
                     continue;
                 }
                 if (targetParser.getScript().equals(LocaleScriptInfo.UNKNOWN_SCRIPT)) {
-                    removals.add(locale);
-                    if (SHOW_ADD)
-                        System.out.println(
-                                "Removing:\t"
-                                        + getName(locale)
-                                        + "\t=>\t"
-                                        + getName(target)
-                                        + "\t\t - Unknown Script in target");
+                    removals.put(locale, target);
+                    showRemoving(pass, locale, target, "Unknown Script in target");
                     continue;
                 }
 
                 String region = parser.set(locale).getRegion();
                 if (region.length() != 0) {
                     if (region.equals(LocaleScriptInfo.UNKNOWN_REGION)) {
-                        removals.add(locale);
-                        if (SHOW_ADD)
-                            System.out.println(
-                                    "Removing:\t"
-                                            + getName(locale)
-                                            + "\t=>\t"
-                                            + getName(target)
-                                            + "\t\t - Unknown Region in source");
+                        removals.put(locale, target);
+                        showRemoving(pass, locale, target, "Unknown Region in source");
                         continue;
                     }
                     parser.setRegion("");
@@ -1149,15 +1220,8 @@ public class GenerateLikelySubtags {
                     if (newTarget != null) {
                         newTarget = targetParser.set(newTarget).setRegion(region).toString();
                         if (target.equals(newTarget) && !KEEP_TARGETS.contains(locale)) {
-                            removals.add(locale);
-                            if (SHOW_ADD)
-                                System.out.println(
-                                        "Removing:\t"
-                                                + locale
-                                                + "\t=>\t"
-                                                + target
-                                                + "\t\tRedundant with "
-                                                + newLocale);
+                            removals.put(locale, target);
+                            showRemoving(pass, locale, target, "Redundant with\t" + newLocale);
                             continue;
                         }
                     }
@@ -1168,14 +1232,8 @@ public class GenerateLikelySubtags {
                 }
                 if (script.length() != 0) {
                     if (script.equals(LocaleScriptInfo.UNKNOWN_SCRIPT)) {
-                        removals.add(locale);
-                        if (SHOW_ADD)
-                            System.out.println(
-                                    "Removing:\t"
-                                            + locale
-                                            + "\t=>\t"
-                                            + target
-                                            + "\t\t - Unknown Script");
+                        removals.put(locale, target);
+                        showRemoving(pass, locale, target, "Unknown Script");
                         continue;
                     }
                     parser.setScript("");
@@ -1184,15 +1242,8 @@ public class GenerateLikelySubtags {
                     if (newTarget != null) {
                         newTarget = targetParser.set(newTarget).setScript(script).toString();
                         if (target.equals(newTarget) && !KEEP_TARGETS.contains(locale)) {
-                            removals.add(locale);
-                            if (SHOW_ADD)
-                                System.out.println(
-                                        "Removing:\t"
-                                                + locale
-                                                + "\t=>\t"
-                                                + target
-                                                + "\t\tRedundant with "
-                                                + newLocale);
+                            removals.put(locale, target);
+                            showRemoving(pass, locale, target, "Redundant with\t" + newLocale);
                             continue;
                         }
                     }
@@ -1201,10 +1252,152 @@ public class GenerateLikelySubtags {
             if (removals.size() == 0) {
                 break;
             }
-            for (String locale : removals) {
+            itemsRemoved.putAll(removals);
+            for (String locale : removals.keySet()) {
                 fluffup.remove(locale);
             }
         }
         return fluffup;
+    }
+
+    public static void showRemoving(
+            Object pass, String locale, String target, final String reason) {
+        if (watching(SHOW_MIN, target)) {
+            System.out.println(JOIN_TAB.join(pass, "Removing:", locale, "→", target, "", reason));
+        }
+    }
+
+    public static String printingName(String locale, Joiner spacing) {
+        if (locale == null) {
+            return null;
+        }
+        CLDRLocale cLocale = CLDRLocale.getInstance(locale);
+        String lang = cLocale.getLanguage();
+        String script = cLocale.getScript();
+        String region = cLocale.getCountry();
+        return spacing.join(
+                (lang.equals(LocaleNames.UND)
+                        ? "?"
+                        : english.getName(CLDRFile.LANGUAGE_NAME, lang)),
+                (script == null || script.equals("")
+                        ? "?"
+                        : english.getName(CLDRFile.SCRIPT_NAME, script)),
+                (region == null || region.equals("")
+                        ? "?"
+                        : english.getName(CLDRFile.TERRITORY_NAME, region)));
+    }
+
+    private static File printLikelySubtags(Map<String, String> fluffup) throws IOException {
+        final File genDir = new File(CLDRPaths.GEN_DIRECTORY, "supplemental");
+        final File genFile =
+                new File(
+                        genDir,
+                        "likelySubtags" + (OUTPUT_STYLE == OutputStyle.XML ? ".xml" : ".txt"));
+        System.out.println("Writing to " + genFile);
+
+        // set based on above
+        final String SEPARATOR =
+                OUTPUT_STYLE == OutputStyle.C || OUTPUT_STYLE == OutputStyle.C_ALT
+                        ? CldrUtility.LINE_SEPARATOR
+                        : "\t";
+        Joiner spacing =
+                Joiner.on(OUTPUT_STYLE == OutputStyle.PLAINTEXT ? "\t" : " ‧ ").useForNull("∅");
+
+        final String arrow = OUTPUT_STYLE == OutputStyle.PLAINTEXT ? "\t⇒\t" : "\t➡ ";
+
+        try (PrintWriter out = FileUtilities.openUTF8Writer(genFile)) {
+            String header =
+                    OUTPUT_STYLE != OutputStyle.XML
+                            ? "const MapToMaximalSubtags default_subtags[] = {"
+                            : "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "<!DOCTYPE supplementalData SYSTEM \"../../common/dtd/ldmlSupplemental.dtd\">"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "<!--"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + CldrUtility.getCopyrightString()
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "-->"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "<!--"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "Likely subtags data is generated programatically from CLDR's language/territory/population"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "data using the GenerateMaximalLocales tool. Under normal circumstances, this file should"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "not be patched by hand, as any changes made in that fashion may be lost."
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "-->"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "<supplementalData>"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "    <version number=\"$"
+                                    + "Revision$\"/>"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "    <likelySubtags>";
+            String footer =
+                    OUTPUT_STYLE != OutputStyle.XML
+                            ? SEPARATOR + "};"
+                            : "    </likelySubtags>"
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "</supplementalData>";
+            out.println(header);
+            boolean first = true;
+            Set<String> keys = new TreeSet<>(new LocaleStringComparator());
+            keys.addAll(fluffup.keySet());
+            for (String printingLocale : keys) {
+                String printingTarget = fluffup.get(printingLocale);
+                String comment =
+                        printingName(printingLocale, spacing)
+                                + arrow
+                                + printingName(printingTarget, spacing);
+
+                if (OUTPUT_STYLE == OutputStyle.XML) {
+                    out.println(
+                            "\t\t<likelySubtag from=\""
+                                    + printingLocale
+                                    + "\" to=\""
+                                    + printingTarget
+                                    + "\""
+                                    + "/>"
+                                    + "\t\t"
+                                    + "<!--"
+                                    + comment
+                                    + "-->");
+                } else {
+                    if (first) {
+                        first = false;
+                    } else {
+                        out.print(",");
+                    }
+                    if (comment.length() > 70 && SEPARATOR.equals(CldrUtility.LINE_SEPARATOR)) {
+                        comment =
+                                printingName(printingLocale, spacing)
+                                        + SEPARATOR
+                                        + "    // "
+                                        + arrow
+                                        + printingName(printingTarget, spacing);
+                    }
+                    out.print(
+                            "  {"
+                                    + SEPARATOR
+                                    + "    // "
+                                    + comment
+                                    + SEPARATOR
+                                    + "    \""
+                                    + printingLocale
+                                    + "\","
+                                    + SEPARATOR
+                                    + "    \""
+                                    + printingTarget
+                                    + "\""
+                                    + CldrUtility.LINE_SEPARATOR
+                                    + "  }");
+                }
+            }
+            out.println(footer);
+            out.close();
+        }
+        return genFile;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -1,0 +1,1210 @@
+package org.unicode.cldr.tool;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.ibm.icu.impl.Relation;
+import com.ibm.icu.impl.Row;
+import com.ibm.icu.impl.Row.R2;
+import com.ibm.icu.impl.Row.R3;
+import com.ibm.icu.impl.Row.R4;
+import com.ibm.icu.text.NumberFormat;
+import java.io.File;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.unicode.cldr.draft.ScriptMetadata;
+import org.unicode.cldr.draft.ScriptMetadata.Info;
+import org.unicode.cldr.tool.GenerateMaximalLocales.LocaleOverride;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.Containment;
+import org.unicode.cldr.util.Counter;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.LocaleScriptInfo;
+import org.unicode.cldr.util.SimpleFactory;
+import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.StandardCodes.LstrType;
+import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
+import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
+import org.unicode.cldr.util.Validity;
+import org.unicode.cldr.util.Validity.Status;
+
+/**
+ * This class generates likelySubtags.xml, replacing GenerateMaximalSubtags and
+ * GenerateLikelyAdditions.
+ */
+public class GenerateLikelySubtags {
+    private static final Joiner JOIN_TAB = Joiner.on('\t').useForNull("∅");
+
+    private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
+
+    private static final Map<String, Status> LANGUAGE_CODE_TO_STATUS =
+            Validity.getInstance().getCodeToStatus(LstrType.language);
+
+    private static final String TEMP_UNKNOWN_REGION = "XZ";
+
+    private static final String DEBUG_ADD_KEY = "und_Latn_ZA";
+
+    private static final boolean SHOW_ADD =
+            CldrUtility.getProperty("GenerateLikelySubtags_Debug", false);
+    private static final boolean SUPPRESS_CHANGES =
+            CldrUtility.getProperty("GenerateMaximalLocalesSuppress", false);
+    private static final boolean SHOW_CONTAINERS = false;
+
+    private static final boolean SHOW_ALL_LANGUAGE_CODES = false;
+    private static final boolean SHOW_DETAILED = false;
+    private static final boolean SHOW_INCLUDED_EXCLUDED = false;
+
+    private static final double MIN_UNOFFICIAL_LANGUAGE_SIZE = 10000000;
+    private static final double MIN_UNOFFICIAL_LANGUAGE_PROPORTION = 0.20;
+    private static final double MIN_UNOFFICIAL_CLDR_LANGUAGE_SIZE = 100000;
+    private static final double UNOFFICIAL_SCALE_DOWN = 0.2;
+
+    private static final File list[] = {
+        new File(CLDRPaths.MAIN_DIRECTORY), new File(CLDRPaths.EXEMPLARS_DIRECTORY)
+    };
+
+    private static Factory factory = SimpleFactory.make(list, ".*");
+    private static Factory mainFactory = CLDR_CONFIG.getCldrFactory();
+    private static SupplementalDataInfo supplementalData =
+            SupplementalDataInfo.getInstance(CLDRPaths.SUPPLEMENTAL_DIRECTORY);
+    private static StandardCodes standardCodes = StandardCodes.make();
+    private static CLDRFile english = factory.make("en", false);
+    static Relation<String, String> cldrContainerToLanguages =
+            Relation.of(new HashMap<String, Set<String>>(), HashSet.class);
+
+    private static NumberFormat percent = NumberFormat.getPercentInstance();
+    private static NumberFormat number = NumberFormat.getIntegerInstance();
+
+    private static boolean DROP = false;
+
+    static {
+        for (CLDRLocale locale :
+                ToolConfig.getToolInstance().getCldrFactory().getAvailableCLDRLocales()) {
+            String region = locale.getCountry();
+            if (region == null || region.isEmpty() || Containment.isLeaf(region)) {
+                continue;
+            }
+            cldrContainerToLanguages.put(region, locale.getLanguage());
+        }
+        cldrContainerToLanguages.freeze();
+        System.out.println("Keeping macroregions used in cldr " + cldrContainerToLanguages);
+    }
+
+    private static final List<String> KEEP_TARGETS =
+            DROP ? List.of() : List.of("und_Arab_PK", "und_Latn_ET", "hi_Latn");
+
+    private static final ImmutableSet<String> deprecatedISONotInLST =
+            DROP ? ImmutableSet.of() : ImmutableSet.of("scc", "scr");
+
+    /**
+     * This is the simplest way to override, by supplying the max value. It gets a very low weight,
+     * so doesn't override any stronger value.
+     */
+    private static final List<String> MAX_ADDITIONS =
+            DROP
+                    ? List.of()
+                    : List.of(
+                            "bss_Latn_CM",
+                            "gez_Ethi_ET",
+                            "ken_Latn_CM",
+                            "und_Arab_PK",
+                            "wa_Latn_BE",
+                            "fub_Arab_CM",
+                            "fuf_Latn_GN",
+                            "kby_Arab_NE",
+                            "kdh_Latn_TG",
+                            "apd_Arab_TG",
+                            "zlm_Latn_TG",
+                            "cr_Cans_CA",
+                            "hif_Latn_FJ",
+                            "gon_Telu_IN",
+                            "lzz_Latn_TR",
+                            "lif_Deva_NP",
+                            "unx_Beng_IN",
+                            "unr_Beng_IN",
+                            "ttt_Latn_AZ",
+                            "pnt_Grek_GR",
+                            "tly_Latn_AZ",
+                            "tkr_Latn_AZ",
+                            "bsq_Bass_LR",
+                            "ccp_Cakm_BD",
+                            "blt_Tavt_VN",
+                            "rhg_Arab_MM",
+                            "rhg_Rohg_MM",
+                            "clc_Latn_CA",
+                            "crg_Latn_CA",
+                            "hur_Latn_CA",
+                            "kwk_Latn_CA",
+                            "lil_Latn_CA",
+                            "ojs_Cans_CA",
+                            "oka_Latn_CA",
+                            "pqm_Latn_CA",
+                            "hi_Latn_IN",
+                            "no_Latn_NO",
+                            "tok_Latn_001",
+                            "prg_Latn_PL",
+                            "ie_Latn_EE");
+
+    /**
+     * The following overrides do MASH the final values, so they may not result in consistent
+     * results. Safer is to add to MAX_ADDITIONS. However, if you add, add both the language and
+     * language+script mappings.
+     */
+    // Many of the overrides below can be removed once the language/pop/country data is updated.
+    private static final Map<String, String> LANGUAGE_OVERRIDES =
+            CldrUtility.asMap(
+                    DROP
+                            ? new String[][] {
+                                {LocaleNames.UND, "en_Latn_US"},
+                            }
+                            : new String[][] {
+                                {"cic", "cic_Latn_US"},
+                                {"cic_Latn", "cic_Latn_US"},
+                                {"eo", "eo_Latn_001"},
+                                {"eo_Latn", "eo_Latn_001"},
+                                {"es", "es_Latn_ES"},
+                                {"es_Latn", "es_Latn_ES"},
+                                {"ff_BF", "ff_Latn_BF"},
+                                {"ff_GM", "ff_Latn_GM"},
+                                {"ff_GH", "ff_Latn_GH"},
+                                {"ff_GW", "ff_Latn_GW"},
+                                {"ff_LR", "ff_Latn_LR"},
+                                {"ff_NE", "ff_Latn_NE"},
+                                {"ff_NG", "ff_Latn_NG"},
+                                {"ff_SL", "ff_Latn_SL"},
+                                {"ff_Adlm", "ff_Adlm_GN"},
+                                {"ia", "ia_Latn_001"},
+                                {"ia_Latn", "ia_Latn_001"},
+                                {"io", "io_Latn_001"},
+                                {"io_Latn", "io_Latn_001"},
+                                {"jbo", "jbo_Latn_001"},
+                                {"jbo_Latn", "jbo_Latn_001"},
+                                {"ku_Arab", "ku_Arab_IQ"},
+                                {"lrc", "lrc_Arab_IR"},
+                                {"lrc_Arab", "lrc_Arab_IR"},
+                                {"man", "man_Latn_GM"},
+                                {"man_Latn", "man_Latn_GM"},
+                                {"mas", "mas_Latn_KE"},
+                                {"mas_Latn", "mas_Latn_KE"},
+                                {"mn", "mn_Cyrl_MN"},
+                                {"mn_Cyrl", "mn_Cyrl_MN"},
+                                {"mro", "mro_Mroo_BD"},
+                                {"mro_BD", "mro_Mroo_BD"},
+                                {"ms_Arab", "ms_Arab_MY"},
+                                {"pap", "pap_Latn_CW"},
+                                {"pap_Latn", "pap_Latn_CW"},
+                                {
+                                    "rif", "rif_Latn_MA"
+                                }, // https://unicode-org.atlassian.net/browse/CLDR-14962?focusedCommentId=165053
+                                {"rif_Latn", "rif_Latn_MA"},
+                                {"rif_Tfng", "rif_Tfng_MA"},
+                                {"rif_MA", "rif_Latn_MA"}, // Ibid
+                                {"shi", "shi_Tfng_MA"},
+                                {"shi_Tfng", "shi_Tfng_MA"},
+                                {"shi_MA", "shi_Tfng_MA"},
+                                {"sr_Latn", "sr_Latn_RS"},
+                                {"ss", "ss_Latn_ZA"},
+                                {"ss_Latn", "ss_Latn_ZA"},
+                                {"swc", "swc_Latn_CD"},
+                                {"ti", "ti_Ethi_ET"},
+                                {"ti_Ethi", "ti_Ethi_ET"},
+                                {LocaleNames.UND, "en_Latn_US"},
+                                {"und_Adlm", "ff_Adlm_GN"},
+                                {"und_Adlm_GN", "ff_Adlm_GN"},
+                                {"und_Arab", "ar_Arab_EG"},
+                                {"und_Arab_PK", "ur_Arab_PK"},
+                                {"und_Bopo", "zh_Bopo_TW"},
+                                {"und_Deva_FJ", "hif_Deva_FJ"},
+                                {"und_EZ", "de_Latn_EZ"},
+                                {"und_Hani", "zh_Hani_CN"},
+                                {"und_Hani_CN", "zh_Hani_CN"},
+                                {"und_Kana", "ja_Kana_JP"},
+                                {"und_Kana_JP", "ja_Kana_JP"},
+                                {"und_Latn", "en_Latn_US"},
+                                {"und_001", "en_Latn_US"}, // to not be overridden by tok_Latn_001
+                                {
+                                    "und_Latn_001", "en_Latn_US"
+                                }, // to not be overridden by tok_Latn_001
+                                {"und_Latn_ET", "en_Latn_ET"},
+                                {"und_Latn_NE", "ha_Latn_NE"},
+                                {"und_Latn_PH", "fil_Latn_PH"},
+                                {"und_ML", "bm_Latn_ML"},
+                                {"und_Latn_ML", "bm_Latn_ML"},
+                                {"und_MU", "mfe_Latn_MU"},
+                                {"und_NE", "ha_Latn_NE"},
+                                {"und_PH", "fil_Latn_PH"},
+                                {"und_PK", "ur_Arab_PK"},
+                                {"und_SO", "so_Latn_SO"},
+                                {"und_SS", "en_Latn_SS"},
+                                {"und_TK", "tkl_Latn_TK"},
+                                {"und_UN", "en_Latn_UN"},
+                                {"und_005", "pt_Latn_BR"},
+                                {"vo", "vo_Latn_001"},
+                                {"vo_Latn", "vo_Latn_001"},
+                                {"yi", "yi_Hebr_001"},
+                                {"yi_Hebr", "yi_Hebr_001"},
+                                {"yue", "yue_Hant_HK"},
+                                {"yue_Hant", "yue_Hant_HK"},
+                                {"yue_Hans", "yue_Hans_CN"},
+                                {"yue_CN", "yue_Hans_CN"},
+                                {"zh_Hani", "zh_Hani_CN"},
+                                {"zh_Bopo", "zh_Bopo_TW"},
+                                {"ccp", "ccp_Cakm_BD"},
+                                {"ccp_Cakm", "ccp_Cakm_BD"},
+                                {"und_Cakm", "ccp_Cakm_BD"},
+                                {"cu_Glag", "cu_Glag_BG"},
+                                {"sd_Khoj", "sd_Khoj_IN"},
+                                {"lif_Limb", "lif_Limb_IN"},
+                                {"grc_Linb", "grc_Linb_GR"},
+                                {"arc_Nbat", "arc_Nbat_JO"},
+                                {"arc_Palm", "arc_Palm_SY"},
+                                {"pal_Phlp", "pal_Phlp_CN"},
+                                {"en_Shaw", "en_Shaw_GB"},
+                                {"sd_Sind", "sd_Sind_IN"},
+                                {"und_Brai", "fr_Brai_FR"}, // hack
+                                {"und_Hanb", "zh_Hanb_TW"}, // Special script code
+                                {"zh_Hanb", "zh_Hanb_TW"}, // Special script code
+                                {"und_Jamo", "ko_Jamo_KR"}, // Special script code
+
+                                // {"und_Cyrl_PL", "be_Cyrl_PL"},
+
+                                //        {"cr", "cr_Cans_CA"},
+                                //        {"hif", "hif_Latn_FJ"},
+                                //        {"gon", "gon_Telu_IN"},
+                                //        {"lzz", "lzz_Latn_TR"},
+                                //        {"lif", "lif_Deva_NP"},
+                                //        {"unx", "unx_Beng_IN"},
+                                //        {"unr", "unr_Beng_IN"},
+                                //        {"ttt", "ttt_Latn_AZ"},
+                                //        {"pnt", "pnt_Grek_GR"},
+                                //        {"tly", "tly_Latn_AZ"},
+                                //        {"tkr", "tkr_Latn_AZ"},
+                                //        {"bsq", "bsq_Bass_LR"},
+                                //        {"ccp", "ccp_Cakm_BD"},
+                                //        {"blt", "blt_Tavt_VN"},
+                                //        { "mis_Medf", "mis_Medf_NG" },
+
+                                {"ku_Yezi", "ku_Yezi_GE"},
+                                {"und_EU", "en_Latn_IE"},
+                                {"hnj", "hnj_Hmnp_US"}, // preferred lang/script in CLDR
+                                {"hnj_Hmnp", "hnj_Hmnp_US"},
+                                {"und_Hmnp", "hnj_Hmnp_US"},
+                                {"rhg", "rhg_Rohg_MM"}, // preferred lang/script in CLDR
+                                {"rhg_Arab", "rhg_Arab_MM"},
+                                {"und_Arab_MM", "rhg_Arab_MM"},
+                                {"sd_IN", "sd_Deva_IN"}, // preferred in CLDR
+                                // { "sd_Deva", "sd_Deva_IN"},
+                                {"und_Cpmn", "und_Cpmn_CY"},
+                                {"oc_ES", "oc_Latn_ES"},
+                                {"os", "os_Cyrl_GE"},
+                                {"os_Cyrl", "os_Cyrl_GE"},
+                            });
+
+    /**
+     * The following supplements the suppress-script. It overrides info from exemplars and the
+     * locale info.
+     */
+    private static String[][] SpecialScripts = {
+        {"zh", "Hans"}, // Hans (not Hani)
+        {"yue", "Hant"}, // Hant (not Hani)
+        {"ko", "Kore"}, // Korean (North Korea)
+        {"ko_KR", "Kore"}, // Korean (North Korea)
+        {"ja", "Jpan"}, // Special script for japan
+
+        //        {"chk", "Latn"}, // Chuukese (Micronesia)
+        //        {"fil", "Latn"}, // Filipino (Philippines)"
+        //        {"pap", "Latn"}, // Papiamento (Netherlands Antilles)
+        //        {"pau", "Latn"}, // Palauan (Palau)
+        //        {"su", "Latn"}, // Sundanese (Indonesia)
+        //        {"tet", "Latn"}, // Tetum (East Timor)
+        //        {"tk", "Latn"}, // Turkmen (Turkmenistan)
+        //        {"ty", "Latn"}, // Tahitian (French Polynesia)
+        {LocaleNames.UND, "Latn"}, // Ultimate fallback
+    };
+
+    private static Map<String, String> localeToScriptCache = new TreeMap<>();
+
+    static {
+        for (String language : standardCodes.getAvailableCodes("language")) {
+            Map<String, String> info = standardCodes.getLangData("language", language);
+            String script = info.get("Suppress-Script");
+            if (script != null) {
+                localeToScriptCache.put(language, script);
+            }
+        }
+        for (String[] pair : SpecialScripts) { // overriding other elements
+            localeToScriptCache.put(pair[0], pair[1]);
+        }
+    }
+
+    private static Map<String, String> FALLBACK_SCRIPTS;
+
+    static {
+        LanguageTagParser additionLtp = new LanguageTagParser();
+        Map<String, String> _FALLBACK_SCRIPTS = new TreeMap<>();
+        for (String addition : MAX_ADDITIONS) {
+            additionLtp.set(addition);
+            String lan = additionLtp.getLanguage();
+            _FALLBACK_SCRIPTS.put(lan, additionLtp.getScript());
+        }
+        FALLBACK_SCRIPTS = ImmutableMap.copyOf(_FALLBACK_SCRIPTS);
+    }
+
+    private static int errorCount;
+
+    public static void main(String[] args) {
+        Map<String, String> old = supplementalData.getLikelySubtags();
+        Map<String, String> oldOrigins = supplementalData.getLikelyOrigins();
+        System.out.println("origins: " + new TreeSet<>(oldOrigins.values()));
+
+        Map<String, String> toMaximized = generatePopulationData(new TreeMap<>(LOCALE_SOURCE));
+
+        Map<String, String> result = minimize(toMaximized);
+
+        Set<String> newAdditions = new TreeSet();
+        Set<String> newMissing = new TreeSet();
+
+        System.out.println(JOIN_TAB.join("Source", "Name", "oldValue", "Name", "newValue", "Name"));
+
+        Set<String> sorted = new TreeSet<>(LOCALE_SOURCE);
+        sorted.addAll(result.keySet());
+        sorted.addAll(old.keySet());
+
+        for (String source : sorted) {
+            String oldValue = old.get(source);
+            String newValue = result.get(source);
+            if (Objects.equal(oldValue, newValue)) {
+                continue;
+            }
+            final String origins = oldOrigins.get(source);
+            if (origins != null && origins.contains("sil1")) {
+                continue; // skip for now
+            }
+            if (oldValue == null) {
+                continue; // skip for now
+            }
+            System.out.println(
+                    JOIN_TAB.join(
+                            source,
+                            getNameSafe(source),
+                            oldValue,
+                            getNameSafe(oldValue),
+                            newValue,
+                            getNameSafe(newValue)));
+        }
+        System.out.println("new missing\t" + newMissing);
+    }
+
+    /**
+     * Compare locales, first by count of components (handling und), then by language, script, and
+     * finally region
+     */
+    static Comparator<String> LOCALE_SOURCE =
+            new Comparator<>() {
+
+                @Override
+                public int compare(String locale1, String locale2) {
+                    CLDRLocale l1 = CLDRLocale.getInstance(locale1);
+                    CLDRLocale l2 = CLDRLocale.getInstance(locale2);
+                    // sort items with 0 components first, then 1, then 2 (there won't be 3)
+                    int result =
+                            ComparisonChain.start()
+                                    // .compare(getCount(l1), getCount(l2))
+                                    .compare(fixUnd(l1.getLanguage()), fixUnd(l2.getLanguage()))
+                                    .compare(l1.getScript(), l2.getScript())
+                                    .compare(l1.getCountry(), l2.getCountry())
+                                    .result();
+                    if (result == 0 && !locale1.equals(locale2)) {
+                        throw new IllegalArgumentException();
+                    }
+                    return result;
+                }
+
+                private int getCount(CLDRLocale l1) {
+                    int result =
+                            ("und".equals(l1.getLanguage()) ? 0 : 1)
+                                    + (l1.getScript().isEmpty() ? 0 : 1)
+                                    + (l1.getCountry().isEmpty() ? 0 : 1);
+                    return result;
+                }
+
+                private String fixUnd(String language) {
+                    return "und".equals(language) ? "" : language;
+                }
+            };
+
+    static {
+        LOCALE_SOURCE.compare("hnj_MM", "hnj_Laoo");
+    }
+
+    public static String getNameSafe(String oldValue) {
+        try {
+            return english.getName(oldValue);
+        } catch (Exception e) {
+            return "n/a";
+        }
+    }
+
+    private static Map<String, String> generatePopulationData(Map<String, String> toMaximized) {
+        // we are going to try a different approach.
+        // first gather counts for maximized values
+        // Set<Row.R3<String,String,String>,Double> rowsToCounts = new TreeMap();
+        MaxData maxData = new MaxData();
+        Set<String> cldrLocales = factory.getAvailable();
+        Set<String> otherTerritories =
+                new TreeSet<>(standardCodes.getGoodAvailableCodes("territory"));
+
+        // process all the information to get the top values for each triple.
+        // each of the combinations of 1 or 2 components gets to be a key.
+
+        Set<String> noPopulationData = new TreeSet<>();
+
+        for (String region : supplementalData.getTerritoriesWithPopulationData()) {
+            otherTerritories.remove(region);
+            PopulationData regionData = supplementalData.getPopulationDataForTerritory(region);
+            final double literateTerritoryPopulation = regionData.getLiteratePopulation();
+            // we need any unofficial language to meet a certain absolute size requirement and
+            // proportion size
+            // requirement.
+            // so the bar is x percent of the population, reset up to y absolute size.
+            double minimalLiteratePopulation =
+                    literateTerritoryPopulation * MIN_UNOFFICIAL_LANGUAGE_PROPORTION;
+            if (minimalLiteratePopulation < MIN_UNOFFICIAL_LANGUAGE_SIZE) {
+                minimalLiteratePopulation = MIN_UNOFFICIAL_LANGUAGE_SIZE;
+            }
+
+            for (String writtenLanguage :
+                    supplementalData.getLanguagesForTerritoryWithPopulationData(region)) {
+                PopulationData data =
+                        supplementalData.getLanguageAndTerritoryPopulationData(
+                                writtenLanguage, region);
+                final double literatePopulation =
+                        getWritingPopulation(data); // data.getLiteratePopulation();
+                double order = -literatePopulation; // negative so we get the inverse order
+
+                if (data.getOfficialStatus() == OfficialStatus.unknown) {
+                    final String locale = writtenLanguage + "_" + region;
+                    if (literatePopulation >= minimalLiteratePopulation) {
+                        // ok, skip
+                    } else if (literatePopulation >= MIN_UNOFFICIAL_CLDR_LANGUAGE_SIZE
+                            && cldrLocales.contains(locale)) {
+                        // ok, skip
+                    } else {
+                        // if (SHOW_ADD)
+                        // System.out.println("Skipping:\t" + writtenLanguage + "\t" + region + "\t"
+                        // + english.getName(locale)
+                        // + "\t-- too small:\t" + number.format(literatePopulation));
+                        // continue;
+                    }
+                    order *= UNOFFICIAL_SCALE_DOWN;
+                    if (SHOW_ADD)
+                        System.out.println(
+                                "Retaining\t"
+                                        + writtenLanguage
+                                        + "\t"
+                                        + region
+                                        + "\t"
+                                        + getNameSafe(locale)
+                                        + "\t"
+                                        + number.format(literatePopulation)
+                                        + "\t"
+                                        + percent.format(
+                                                literatePopulation / literateTerritoryPopulation)
+                                        + (cldrLocales.contains(locale) ? "\tin-CLDR" : ""));
+                }
+
+                String script = localeToScriptCache.get(writtenLanguage);
+                if (script == null) {
+                    script = LocaleScriptInfo.getScriptFromLocaleOrSupplemental(writtenLanguage);
+                    if (script == null) {
+                        noPopulationData.add(writtenLanguage);
+                        continue;
+                    }
+                    localeToScriptCache.put(writtenLanguage, script);
+                }
+
+                String language = writtenLanguage;
+                final int pos = writtenLanguage.indexOf('_');
+                if (pos > 0) {
+                    language = writtenLanguage.substring(0, pos);
+                }
+                maxData.add(language, script, region, order);
+            }
+        }
+        if (!noPopulationData.isEmpty()) {
+            for (String lang : noPopulationData) {
+                System.out.println(
+                        JOIN_TAB.join("No script in pop. data for", lang, getNameSafe(lang)));
+            }
+        }
+
+        LanguageTagParser additionLtp = new LanguageTagParser();
+
+        for (String addition : MAX_ADDITIONS) {
+            additionLtp.set(addition);
+            String lan = additionLtp.getLanguage();
+            Set<R3<Double, String, String>> key = maxData.languages.get(lan);
+            if (key == null) {
+                maxData.add(lan, additionLtp.getScript(), additionLtp.getRegion(), 1.0);
+            } else {
+                int debug = 0;
+            }
+        }
+
+        for (Entry<String, Collection<String>> entry :
+                DeriveScripts.getLanguageToScript().asMap().entrySet()) {
+            String language = entry.getKey();
+            final Collection<String> values = entry.getValue();
+            if (values.size() != 1) {
+                continue; // skip, no either way
+            }
+            Set<R3<Double, String, String>> old = maxData.languages.get(language);
+            if (!maxData.languages.containsKey(language)) {
+                maxData.add(language, values.iterator().next(), TEMP_UNKNOWN_REGION, 1.0);
+            }
+        }
+
+        // add others, with English default
+        for (String region : otherTerritories) {
+            if (region.length() == 3) continue; // FIX ONCE WE ADD REGIONS
+            maxData.add("en", "Latn", region, 1.0);
+        }
+
+        // get a reverse mapping, so that we can add the aliases
+
+        Map<String, R2<List<String>, String>> languageAliases =
+                SupplementalDataInfo.getInstance().getLocaleAliasInfo().get("language");
+        for (Entry<String, R2<List<String>, String>> str : languageAliases.entrySet()) {
+            String reason = str.getValue().get1();
+            if ("overlong".equals(reason)
+                    || "bibliographic".equals(reason)
+                    || "macrolanguage".equals(reason)) {
+                continue;
+            }
+            List<String> replacements = str.getValue().get0();
+            if (replacements == null) {
+                continue;
+            }
+            String goodLanguage = replacements.get(0);
+
+            String badLanguage = str.getKey();
+            if (badLanguage.contains("_")) {
+                continue;
+            }
+            if (deprecatedISONotInLST.contains(badLanguage)) {
+                continue;
+            }
+            Set<R3<Double, String, String>> goodLanguageData =
+                    maxData.languages.getAll(goodLanguage);
+            if (goodLanguageData == null) {
+                continue;
+            }
+            R3<Double, String, String> value = goodLanguageData.iterator().next();
+            final String script = value.get1();
+            final String region = value.get2();
+            maxData.add(badLanguage, script, region, 1.0);
+            System.out.println(
+                    "Adding aliases: "
+                            + badLanguage
+                            + ", "
+                            + script
+                            + ", "
+                            + region
+                            + ", "
+                            + reason);
+        }
+
+        // now, get the best for each one
+        for (String language : maxData.languages.keySet()) {
+            R3<Double, String, String> value = maxData.languages.getAll(language).iterator().next();
+            final Comparable<String> script = value.get1();
+            final Comparable<String> region = value.get2();
+            add(
+                    language,
+                    language + "_" + script + "_" + region,
+                    toMaximized,
+                    "L->SR",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+        for (String language : maxData.languagesToScripts.keySet()) {
+            String script =
+                    maxData.languagesToScripts
+                            .get(language)
+                            .getKeysetSortedByCount(true)
+                            .iterator()
+                            .next();
+            add(
+                    language,
+                    language + "_" + script,
+                    toMaximized,
+                    "L->S",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+        for (String language : maxData.languagesToRegions.keySet()) {
+            String region =
+                    maxData.languagesToRegions
+                            .get(language)
+                            .getKeysetSortedByCount(true)
+                            .iterator()
+                            .next();
+            add(
+                    language,
+                    language + "_" + region,
+                    toMaximized,
+                    "L->R",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+
+        for (String script : maxData.scripts.keySet()) {
+            R3<Double, String, String> value = maxData.scripts.getAll(script).iterator().next();
+            final Comparable<String> language = value.get1();
+            final Comparable<String> region = value.get2();
+            add(
+                    "und_" + script,
+                    language + "_" + script + "_" + region,
+                    toMaximized,
+                    "S->LR",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+        for (String script : maxData.scriptsToLanguages.keySet()) {
+            String language =
+                    maxData.scriptsToLanguages
+                            .get(script)
+                            .getKeysetSortedByCount(true)
+                            .iterator()
+                            .next();
+            add(
+                    "und_" + script,
+                    language + "_" + script,
+                    toMaximized,
+                    "S->L",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+        for (String script : maxData.scriptsToRegions.keySet()) {
+            String region =
+                    maxData.scriptsToRegions
+                            .get(script)
+                            .getKeysetSortedByCount(true)
+                            .iterator()
+                            .next();
+            add(
+                    "und_" + script,
+                    "und_" + script + "_" + region,
+                    toMaximized,
+                    "S->R",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+
+        for (String region : maxData.regions.keySet()) {
+            R3<Double, String, String> value = maxData.regions.getAll(region).iterator().next();
+            final Comparable<String> language = value.get1();
+            final Comparable<String> script = value.get2();
+            add(
+                    "und_" + region,
+                    language + "_" + script + "_" + region,
+                    toMaximized,
+                    "R->LS",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+        for (String region : maxData.regionsToLanguages.keySet()) {
+            String language =
+                    maxData.regionsToLanguages
+                            .get(region)
+                            .getKeysetSortedByCount(true)
+                            .iterator()
+                            .next();
+            add(
+                    "und_" + region,
+                    language + "_" + region,
+                    toMaximized,
+                    "R->L",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+        for (String region : maxData.regionsToScripts.keySet()) {
+            String script =
+                    maxData.regionsToScripts
+                            .get(region)
+                            .getKeysetSortedByCount(true)
+                            .iterator()
+                            .next();
+            add(
+                    "und_" + region,
+                    "und_" + script + "_" + region,
+                    toMaximized,
+                    "R->S",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+
+        for (Entry<String, Counter<R2<String, String>>> containerAndInfo :
+                maxData.containersToLanguage.entrySet()) {
+            String region = containerAndInfo.getKey();
+            if (region.equals("001")) {
+                continue;
+            }
+            Counter<R2<String, String>> data = containerAndInfo.getValue();
+            Set<R2<String, String>> keysetSortedByCount = data.getKeysetSortedByCount(true);
+            if (SHOW_CONTAINERS) { // debug
+                System.out.println(
+                        "Container2L:\t"
+                                + region
+                                + "\t"
+                                + truncateLongString(
+                                        data.getEntrySetSortedByCount(true, null), 127));
+                System.out.println(
+                        "Container2LR:\t"
+                                + region
+                                + "\t"
+                                + maxData.containersToLangRegion.get(region));
+            }
+            R2<String, String> value =
+                    keysetSortedByCount.iterator().next(); // will get most negative
+            final Comparable<String> language = value.get0();
+            final Comparable<String> script = value.get1();
+
+            // fix special cases like es-419, where a locale exists.
+            // for those cases, what we add as output is the container. Otherwise the region.
+            Set<String> skipLanguages = cldrContainerToLanguages.get(region);
+            if (skipLanguages != null && skipLanguages.contains(language)) {
+                add(
+                        "und_" + region,
+                        language + "_" + script + "_" + region,
+                        toMaximized,
+                        "R*->LS",
+                        LocaleOverride.REPLACE_EXISTING,
+                        SHOW_ADD);
+                continue;
+            }
+
+            // we now have the best language and script. Find the best region for that
+            for (R4<Double, String, String, String> e :
+                    maxData.containersToLangRegion.get(region)) {
+                final Comparable<String> language2 = e.get1();
+                final Comparable<String> script2 = e.get2();
+                if (language2.equals(language) && script2.equals(script)) {
+                    add(
+                            "und_" + region,
+                            language + "_" + script + "_" + e.get3(),
+                            toMaximized,
+                            "R*->LS",
+                            LocaleOverride.REPLACE_EXISTING,
+                            SHOW_ADD);
+                    break;
+                }
+            }
+        }
+
+        for (R2<String, String> languageScript : maxData.languageScripts.keySet()) {
+            R2<Double, String> value =
+                    maxData.languageScripts.getAll(languageScript).iterator().next();
+            final Comparable<String> language = languageScript.get0();
+            final Comparable<String> script = languageScript.get1();
+            final Comparable<String> region = value.get1();
+            add(
+                    language + "_" + script,
+                    language + "_" + script + "_" + region,
+                    toMaximized,
+                    "LS->R",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+
+        for (R2<String, String> scriptRegion : maxData.scriptRegions.keySet()) {
+            R2<Double, String> value = maxData.scriptRegions.getAll(scriptRegion).iterator().next();
+            final Comparable<String> script = scriptRegion.get0();
+            final Comparable<String> region = scriptRegion.get1();
+            final Comparable<String> language = value.get1();
+            add(
+                    "und_" + script + "_" + region,
+                    language + "_" + script + "_" + region,
+                    toMaximized,
+                    "SR->L",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+
+        for (R2<String, String> languageRegion : maxData.languageRegions.keySet()) {
+            R2<Double, String> value =
+                    maxData.languageRegions.getAll(languageRegion).iterator().next();
+            final Comparable<String> language = languageRegion.get0();
+            final Comparable<String> region = languageRegion.get1();
+            final Comparable<String> script = value.get1();
+            add(
+                    language + "_" + region,
+                    language + "_" + script + "_" + region,
+                    toMaximized,
+                    "LR->S",
+                    LocaleOverride.REPLACE_EXISTING,
+                    SHOW_ADD);
+        }
+
+        // get the script info from metadata as fallback
+
+        TreeSet<String> sorted = new TreeSet<>(ScriptMetadata.getScripts());
+        for (String script : sorted) {
+            Info i = ScriptMetadata.getInfo(script);
+            String likelyLanguage = i.likelyLanguage;
+            if (LANGUAGE_CODE_TO_STATUS.get(likelyLanguage) == Status.special) {
+                likelyLanguage = LocaleNames.UND;
+            }
+            String originCountry = i.originCountry;
+            final String result = likelyLanguage + "_" + script + "_" + originCountry;
+            add(
+                    "und_" + script,
+                    result,
+                    toMaximized,
+                    "S->LR•",
+                    LocaleOverride.KEEP_EXISTING,
+                    SHOW_ADD);
+            add(
+                    likelyLanguage,
+                    result,
+                    toMaximized,
+                    "L->SR•",
+                    LocaleOverride.KEEP_EXISTING,
+                    SHOW_ADD);
+        }
+
+        // add overrides
+        for (String key : LANGUAGE_OVERRIDES.keySet()) {
+            add(
+                    key,
+                    LANGUAGE_OVERRIDES.get(key),
+                    toMaximized,
+                    "OVERRIDE",
+                    LocaleOverride.REPLACE_EXISTING,
+                    true);
+        }
+
+        // Make sure that the mapping is Idempotent. If we have A ==> B, we must never have B ==> C
+        // We run this check until we get no problems.
+        Set<List<String>> problems = new HashSet<>();
+
+        while (true) {
+            problems.clear();
+            for (Entry<String, String> entry : toMaximized.entrySet()) {
+                String source = entry.getKey();
+                String target = entry.getValue();
+                if (target.contains("_Zzzz") || target.contains("_ZZ")) { // these are special cases
+                    continue;
+                }
+                String idempotentCandidate = LikelySubtags.maximize(target, toMaximized);
+
+                if (idempotentCandidate == null) {
+                    System.out.println("Can't maximize " + target);
+                } else if (!idempotentCandidate.equals(target)) {
+                    problems.add(ImmutableList.of(source, target, idempotentCandidate));
+                }
+            }
+            if (problems.isEmpty()) {
+                break;
+            }
+            for (List<String> row : problems) {
+                System.out.println(
+                        "Idempotence: dropping mapping "
+                                + row.get(0)
+                                + " to "
+                                + row.get(1)
+                                + " since the target maps further to "
+                                + row.get(2));
+                toMaximized.remove(row.get(0));
+            }
+        }
+        return toMaximized;
+    }
+
+    public static class MaxData {
+        Relation<String, Row.R3<Double, String, String>> languages =
+                Relation.of(
+                        new TreeMap<String, Set<Row.R3<Double, String, String>>>(), TreeSet.class);
+        Map<String, Counter<String>> languagesToScripts = new TreeMap<>();
+        Map<String, Counter<String>> languagesToRegions = new TreeMap<>();
+
+        Relation<String, Row.R3<Double, String, String>> scripts =
+                Relation.of(
+                        new TreeMap<String, Set<Row.R3<Double, String, String>>>(), TreeSet.class);
+        Map<String, Counter<String>> scriptsToLanguages = new TreeMap<>();
+        Map<String, Counter<String>> scriptsToRegions = new TreeMap<>();
+
+        Relation<String, Row.R3<Double, String, String>> regions =
+                Relation.of(
+                        new TreeMap<String, Set<Row.R3<Double, String, String>>>(), TreeSet.class);
+        Map<String, Counter<String>> regionsToLanguages = new TreeMap<>();
+        Map<String, Counter<String>> regionsToScripts = new TreeMap<>();
+
+        Map<String, Counter<Row.R2<String, String>>> containersToLanguage = new TreeMap<>();
+        Relation<String, Row.R4<Double, String, String, String>> containersToLangRegion =
+                Relation.of(
+                        new TreeMap<String, Set<Row.R4<Double, String, String, String>>>(),
+                        TreeSet.class);
+
+        Relation<Row.R2<String, String>, Row.R2<Double, String>> languageScripts =
+                Relation.of(
+                        new TreeMap<Row.R2<String, String>, Set<Row.R2<Double, String>>>(),
+                        TreeSet.class);
+        Relation<Row.R2<String, String>, Row.R2<Double, String>> scriptRegions =
+                Relation.of(
+                        new TreeMap<Row.R2<String, String>, Set<Row.R2<Double, String>>>(),
+                        TreeSet.class);
+        Relation<Row.R2<String, String>, Row.R2<Double, String>> languageRegions =
+                Relation.of(
+                        new TreeMap<Row.R2<String, String>, Set<Row.R2<Double, String>>>(),
+                        TreeSet.class);
+
+        /**
+         * Add population information. "order" is the negative of the population (makes the first be
+         * the highest).
+         *
+         * @param language
+         * @param script
+         * @param region
+         * @param order
+         */
+        void add(String language, String script, String region, Double order) {
+            if (SHOW_ADD && language.equals(LocaleNames.MIS)) {
+                System.out.println(language + "\t" + script + "\t" + region + "\t" + -order);
+            }
+            languages.put(language, Row.of(order, script, region));
+            // addCounter(languagesToScripts, language, script, order);
+            // addCounter(languagesToRegions, language, region, order);
+
+            scripts.put(script, Row.of(order, language, region));
+            // addCounter(scriptsToLanguages, script, language, order);
+            // addCounter(scriptsToRegions, script, region, order);
+
+            regions.put(region, Row.of(order, language, script));
+            // addCounter(regionsToLanguages, region, language, order);
+            // addCounter(regionsToScripts, region, script, order);
+
+            languageScripts.put(Row.of(language, script), Row.of(order, region));
+            scriptRegions.put(Row.of(script, region), Row.of(order, language));
+            languageRegions.put(Row.of(language, region), Row.of(order, script));
+
+            Set<String> containerSet = Containment.leafToContainer(region);
+            if (containerSet != null) {
+                for (String container : containerSet) {
+
+                    containersToLangRegion.put(container, Row.of(order, language, script, region));
+                    Counter<R2<String, String>> data = containersToLanguage.get(container);
+                    if (data == null) {
+                        containersToLanguage.put(container, data = new Counter<>());
+                    }
+                    data.add(Row.of(language, script), (long) (double) order);
+                }
+            }
+
+            if (SHOW_ADD)
+                System.out.println(
+                        "Data:\t" + language + "\t" + script + "\t" + region + "\t" + order);
+        }
+        // private void addCounter(Map<String, Counter<String>> map, String key, String key2, Double
+        // count) {
+        // Counter<String> counter = map.get(key);
+        // if (counter == null) {
+        // map.put(key, counter = new Counter<String>());
+        // }
+        // counter.add(key2, count.longValue());
+        // }
+    }
+
+    private static long getWritingPopulation(PopulationData popData) {
+        final double writingPopulation = popData.getWritingPopulation();
+        if (!Double.isNaN(writingPopulation)) {
+            return (long) writingPopulation;
+        }
+        return (long) popData.getLiteratePopulation();
+    }
+
+    private static String getName(String value) {
+        return ConvertLanguageData.getLanguageCodeAndName(value);
+    }
+
+    private static void add(
+            String key,
+            String value,
+            Map<String, String> toAdd,
+            String kind,
+            LocaleOverride override,
+            boolean showAction) {
+        if (SHOW_ADD && key.startsWith(LocaleNames.MIS)) {
+            int debug = 1;
+        }
+        if (key.equals(DEBUG_ADD_KEY)) {
+            System.out.println("*debug*");
+        }
+        String oldValue = toAdd.get(key);
+        if (oldValue == null) {
+            if (showAction) {
+                System.out.println(
+                        "\tAdding:\t\t"
+                                + getName(key)
+                                + "\t=>\t"
+                                + getName(value)
+                                + "\t\t\t\t"
+                                + kind);
+            }
+        } else if (override == LocaleOverride.KEEP_EXISTING || value.equals(oldValue)) {
+            // if (showAction) {
+            // System.out.println("Skipping:\t" + key + "\t=>\t" + value + "\t\t\t\t" + kind);
+            // }
+            return;
+        } else {
+            if (showAction) {
+                System.out.println(
+                        "\tReplacing:\t"
+                                + getName(key)
+                                + "\t=>\t"
+                                + getName(value)
+                                + "\t, was\t"
+                                + getName(oldValue)
+                                + "\t\t"
+                                + kind);
+            }
+        }
+        toAdd.put(key, value);
+    }
+
+    public static String truncateLongString(Object data, int maxLen) {
+        String info = data.toString();
+        if (info.length() > maxLen) {
+            info = info.substring(0, maxLen) + "…";
+            // TODO, handle supplemental characters.
+        }
+        return info;
+    }
+
+    public static Map<String, String> minimize(Map<String, String> fluffup) {
+        LanguageTagParser parser = new LanguageTagParser();
+        LanguageTagParser targetParser = new LanguageTagParser();
+        Set<String> removals = new TreeSet<>();
+        while (true) {
+            removals.clear();
+            for (String locale : fluffup.keySet()) {
+                String target = fluffup.get(locale);
+                if (targetParser.set(target).getRegion().equals(LocaleScriptInfo.UNKNOWN_REGION)) {
+                    removals.add(locale);
+                    if (SHOW_ADD)
+                        System.out.println(
+                                "Removing:\t"
+                                        + getName(locale)
+                                        + "\t=>\t"
+                                        + getName(target)
+                                        + "\t\t - Unknown Region in target");
+                    continue;
+                }
+                if (targetParser.getScript().equals(LocaleScriptInfo.UNKNOWN_SCRIPT)) {
+                    removals.add(locale);
+                    if (SHOW_ADD)
+                        System.out.println(
+                                "Removing:\t"
+                                        + getName(locale)
+                                        + "\t=>\t"
+                                        + getName(target)
+                                        + "\t\t - Unknown Script in target");
+                    continue;
+                }
+
+                String region = parser.set(locale).getRegion();
+                if (region.length() != 0) {
+                    if (region.equals(LocaleScriptInfo.UNKNOWN_REGION)) {
+                        removals.add(locale);
+                        if (SHOW_ADD)
+                            System.out.println(
+                                    "Removing:\t"
+                                            + getName(locale)
+                                            + "\t=>\t"
+                                            + getName(target)
+                                            + "\t\t - Unknown Region in source");
+                        continue;
+                    }
+                    parser.setRegion("");
+                    String newLocale = parser.toString();
+                    String newTarget = fluffup.get(newLocale);
+                    if (newTarget != null) {
+                        newTarget = targetParser.set(newTarget).setRegion(region).toString();
+                        if (target.equals(newTarget) && !KEEP_TARGETS.contains(locale)) {
+                            removals.add(locale);
+                            if (SHOW_ADD)
+                                System.out.println(
+                                        "Removing:\t"
+                                                + locale
+                                                + "\t=>\t"
+                                                + target
+                                                + "\t\tRedundant with "
+                                                + newLocale);
+                            continue;
+                        }
+                    }
+                }
+                String script = parser.set(locale).getScript();
+                if (locale.equals(DEBUG_ADD_KEY)) {
+                    System.out.println("*debug*");
+                }
+                if (script.length() != 0) {
+                    if (script.equals(LocaleScriptInfo.UNKNOWN_SCRIPT)) {
+                        removals.add(locale);
+                        if (SHOW_ADD)
+                            System.out.println(
+                                    "Removing:\t"
+                                            + locale
+                                            + "\t=>\t"
+                                            + target
+                                            + "\t\t - Unknown Script");
+                        continue;
+                    }
+                    parser.setScript("");
+                    String newLocale = parser.toString();
+                    String newTarget = fluffup.get(newLocale);
+                    if (newTarget != null) {
+                        newTarget = targetParser.set(newTarget).setScript(script).toString();
+                        if (target.equals(newTarget) && !KEEP_TARGETS.contains(locale)) {
+                            removals.add(locale);
+                            if (SHOW_ADD)
+                                System.out.println(
+                                        "Removing:\t"
+                                                + locale
+                                                + "\t=>\t"
+                                                + target
+                                                + "\t\tRedundant with "
+                                                + newLocale);
+                            continue;
+                        }
+                    }
+                }
+            }
+            if (removals.size() == 0) {
+                break;
+            }
+            for (String locale : removals) {
+                fluffup.remove(locale);
+            }
+        }
+        return fluffup;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
@@ -1,0 +1,111 @@
+package org.unicode.cldr.tool;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Comparators;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Set;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRLocale;
+
+public class LSRSource implements Comparable<LSRSource> {
+    private static final Joiner JOIN_SPACE = Joiner.on(' ');
+    private static final Splitter SPLIT_SPACE = Splitter.on(' ').omitEmptyStrings();
+    private final CLDRLocale cldrLocale;
+    private final Set<String> sources;
+
+    LSRSource(String lang, String script, String region, String sources) {
+        cldrLocale = CLDRLocale.getInstance(lang, script, region);
+        this.sources = ImmutableSortedSet.copyOf(SPLIT_SPACE.splitToList(sources));
+    }
+
+    public String getLanguage() {
+        return cldrLocale.getLanguage();
+    }
+
+    public String getScript() {
+        return cldrLocale.getScript();
+    }
+
+    public String getRegion() {
+        return cldrLocale.getRegion();
+    }
+
+    public Set<String> getSources() {
+        return sources;
+    }
+
+    public String getLsrString() {
+        return cldrLocale.toString();
+    }
+
+    @Override
+    public int compareTo(LSRSource other) {
+        return ComparisonChain.start()
+                .compare(cldrLocale, other.cldrLocale)
+                .compare(
+                        sources,
+                        other.sources,
+                        Comparators.lexicographical(Comparator.<String>naturalOrder()))
+                .result();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cldrLocale, sources);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (!(obj instanceof LSRSource)) return false;
+
+        LSRSource other = (LSRSource) obj;
+        return Objects.equals(cldrLocale, other.cldrLocale)
+                && Objects.equals(sources, other.sources);
+    }
+
+    @Override
+    public String toString() {
+        return cldrLocale.toString() + " // " + getSources();
+    }
+
+    public String line(String source) {
+        final CLDRFile english = CLDRConfig.getInstance().getEnglish();
+
+        //      <likelySubtag from="aa" to="aa_Latn_ET"/>
+        // <!--{ Afar; ?; ? } => { Afar; Latin; Ethiopia }-->
+        final String target = cldrLocale.toString();
+        final String result =
+                "<likelySubtag from=\""
+                        + source
+                        + "\" to=\""
+                        + target
+                        + (getSources().isEmpty() ? "" : "\" origin=\"" + getSourceString())
+                        + "\"/>"
+                        + "\t<!-- "
+                        + english.getName(source)
+                        + " ➡︎ "
+                        + english.getName(target)
+                        + " -->";
+        return result;
+    }
+
+    public String getSourceString() {
+        return JOIN_SPACE.join(getSources());
+    }
+
+    public CLDRLocale getCldrLocale() {
+        return cldrLocale;
+    }
+
+    //    public static String combineLSR(String lang, String script, String region) {
+    //        return (lang.isEmpty() ? "und" : lang)
+    //                + (script.isEmpty() ? "" : "_" + script)
+    //                + (region.isEmpty() ? "" : "_" + region);
+    //    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LangTagsData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LangTagsData.java
@@ -1,0 +1,355 @@
+package org.unicode.cldr.tool;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+import com.ibm.icu.impl.Row;
+import com.ibm.icu.util.Output;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.Iso639Data;
+import org.unicode.cldr.util.Iso639Data.Type;
+import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.StandardCodes.LstrType;
+import org.unicode.cldr.util.Validity;
+import org.unicode.cldr.util.Validity.Status;
+
+public class LangTagsData {
+    private final Pattern fullTagMatch = Pattern.compile("\\s*\"(full|tag)\": \"([^\"]+)\",");
+    private final String SIL = "sil1";
+
+    private final Splitter TAB_SPLITTER = Splitter.on('\t');
+    private final Set<String> LIKELY_SPECIALS = ImmutableSet.of("in", "iw", "ji", "jw", "mo");
+    private final Set<String> FIX_VALIDITY = ImmutableSet.of("Zanb");
+    private final Set<String> FIX_COUNTRY = ImmutableSet.of("yi");
+    private final Validity validity = Validity.getInstance();
+
+    private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
+    private static final CLDRFile english = CLDR_CONFIG.getEnglish();
+
+    private static final LangTagsData INSTANCE = new LangTagsData();
+
+    private final Multimap<String, String> wikiData;
+    private final Map<String, LSRSource> jsonData;
+    private final Errors processErrors = new Errors();
+
+    private LangTagsData() {
+        wikiData = readWikidata();
+        jsonData = readJson();
+    }
+
+    public static LangTagsData getInstance() {
+        return INSTANCE;
+    }
+
+    public static Multimap<String, String> getWikiData() {
+        return getInstance().wikiData;
+    }
+
+    public static Map<String, LSRSource> getJsonData() {
+        return getInstance().jsonData;
+    }
+
+    public static Errors getProcessErrors() {
+        return getInstance().processErrors;
+    }
+
+    private Map<String, LSRSource> readJson() {
+
+        final LanguageTagParser ltpFull = new LanguageTagParser();
+        final LanguageTagParser ltpTag = new LanguageTagParser();
+
+        Path path = Paths.get(CLDRPaths.BIRTH_DATA_DIR, "/../external/langtags.json");
+        if (!Files.exists(path)) {
+            throw new IllegalArgumentException(path + " does not exist");
+        }
+
+        Matcher full = fullTagMatch.matcher("");
+        Map<LstrType, Status> errors = new TreeMap<>();
+
+        Output<String> lastFull = new Output<>();
+        Map<String, LSRSource> result = new TreeMap<>();
+        try {
+            Files.lines(path)
+                    .forEach(
+                            x -> {
+                                if (full.reset(x).matches()) {
+                                    final String key = full.group(1);
+                                    final String value = full.group(2).replace("-", "_");
+                                    if (value.startsWith("aai")) {
+                                        int debug = 0;
+                                    }
+                                    switch (key) {
+                                        case "full":
+                                            lastFull.value = value;
+                                            break;
+                                        case "tag":
+                                            try {
+                                                String fullLang =
+                                                        ltpFull.set(lastFull.value).getLanguage();
+                                                if (isIllFormed(lastFull.value, ltpFull)
+                                                        || isIllFormed(value, ltpTag.set(value))) {
+                                                    processErrors.put(
+                                                            Errors.Type.ill_formed_tags,
+                                                            value,
+                                                            lastFull.value,
+                                                            "");
+                                                } else {
+                                                    String reference = SIL;
+                                                    final String fullScript = ltpFull.getScript();
+                                                    String fullRegion = ltpFull.getRegion();
+                                                    if (fullRegion.equals("ZZ")
+                                                            || fullRegion.equals("001")) {
+                                                        Collection<String> tempRegions =
+                                                                wikiData.get(
+                                                                        fullLang); // synthesize
+                                                        if (!tempRegions.isEmpty()) {
+                                                            fullRegion =
+                                                                    tempRegions.iterator().next();
+                                                            reference += " wikidata";
+                                                        }
+                                                    }
+
+                                                    String tagLang = ltpTag.getLanguage();
+                                                    String tagScript = ltpTag.getScript();
+                                                    String tagRegion = ltpTag.getRegion();
+
+                                                    if (!tagLang.equals(fullLang)
+                                                            || (!tagScript.isEmpty()
+                                                                    && !tagScript.equals(
+                                                                            fullScript))
+                                                            || (!tagRegion.isEmpty()
+                                                                    && !tagRegion.equals(
+                                                                            fullRegion))) {
+                                                        processErrors.put(
+                                                                Errors.Type.tag_not_in_full,
+                                                                value,
+                                                                lastFull.value,
+                                                                "");
+                                                    } else {
+                                                        if (isOk(
+                                                                fullLang,
+                                                                fullScript,
+                                                                fullRegion,
+                                                                errors)) {
+                                                            add(
+                                                                    result,
+                                                                    value,
+                                                                    fullLang,
+                                                                    fullScript,
+                                                                    fullRegion,
+                                                                    reference);
+                                                        } else {
+                                                            processErrors.put(
+                                                                    Errors.Type.skipping_scope,
+                                                                    value,
+                                                                    ltpFull.toString(),
+                                                                    errors.toString());
+                                                        }
+                                                    }
+                                                }
+                                            } catch (Exception e) {
+                                                processErrors.put(
+                                                        Errors.Type.exception,
+                                                        value,
+                                                        lastFull.value,
+                                                        e.getMessage());
+                                            }
+                                            break;
+                                        default:
+                                            throw new IllegalArgumentException(); // never happens
+                                    }
+                                }
+                            });
+            return result;
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    private boolean isIllFormed(String source, LanguageTagParser languageTagParser) {
+        return languageTagParser.getLanguage().isEmpty()
+                || !languageTagParser.getVariants().isEmpty()
+                || !languageTagParser.getExtensions().isEmpty()
+                || !languageTagParser.getLocaleExtensions().isEmpty()
+                || source.contains("@");
+    }
+
+    private boolean isOk(String lang, String script, String region, Map<LstrType, Status> errors) {
+        errors.clear();
+        if (!LIKELY_SPECIALS.contains(lang)) {
+            check(LstrType.language, lang, errors);
+        }
+        if (!FIX_VALIDITY.contains(script)) {
+            check(LstrType.script, script, errors);
+        }
+        if (region.equals("001") && Iso639Data.getType(lang) == Type.Constructed) {
+            // ok
+        } else {
+            check(LstrType.region, region, errors);
+        }
+        return errors.isEmpty();
+    }
+
+    private void check(LstrType lstrType, String lang, Map<LstrType, Status> errors) {
+        final Status status = validity.getCodeToStatus(lstrType).get(lang);
+        if (status != Status.regular) {
+            errors.put(lstrType, status);
+        }
+    }
+
+    private Multimap<String, String> readWikidata() {
+        Multimap<String, String> result = TreeMultimap.create();
+        Path path =
+                Paths.get(CLDRPaths.BIRTH_DATA_DIR, "/../external/wididata_lang_region.tsv")
+                        .normalize();
+        if (!Files.exists(path)) {
+            throw new IllegalArgumentException(path + " does not exist");
+        }
+        try {
+            Files.lines(path)
+                    .forEach(
+                            x -> {
+                                if (!x.startsWith("#")) {
+                                    List<String> list = TAB_SPLITTER.splitToList(x);
+                                    String lang = list.get(1);
+                                    String region = list.get(3);
+                                    result.put(lang, region);
+                                }
+                            });
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        return result;
+    }
+
+    private void add(
+            Map<String, LSRSource> result,
+            String source,
+            String lang,
+            final String script,
+            final String region,
+            String reference) {
+        LSRSource old = result.get(source);
+        LSRSource newVersion = new LSRSource(lang, script, region, reference);
+        if (old != null && !old.equals(newVersion)) {
+            throw new IllegalArgumentException(
+                    "Data already exists for " + source + ": old=" + old + ", new: " + newVersion);
+        }
+        result.put(source, newVersion);
+    }
+
+    private static class Errors {
+        public enum Type {
+            ill_formed_tags("Ill-formed tags"),
+            already_CLDR("Language already in CLDR"),
+            tag_not_in_full("tag ⊄ full"),
+            exception("exception"),
+            skipping_scope("Skipping scope, SIL");
+
+            private final String printable;
+
+            private Type(String printable) {
+                this.printable = printable;
+            }
+        }
+
+        public Multimap<Type, String> data = TreeMultimap.create();
+
+        public void put(
+                Type illFormedTags, String tagValue, String fullValue, String errorMessage) {
+            data.put(
+                    illFormedTags,
+                    tagValue
+                            + " ➡ "
+                            + fullValue
+                            + (errorMessage == null || errorMessage.isEmpty()
+                                    ? ""
+                                    : "\t—\t" + errorMessage));
+        }
+
+        public void printAll() {
+            for (Entry<Type, Collection<String>> entry : data.asMap().entrySet()) {
+                Type type = entry.getKey();
+                System.out.println();
+                for (String message : entry.getValue()) {
+                    System.out.println(type + "\t" + message);
+                }
+            }
+        }
+    }
+
+    static class LSRSource implements Comparable<LSRSource> {
+        final Row.R4<String, String, String, String> data;
+
+        LSRSource(String lang, String script, String region, String source) {
+            if (script.contains("Soyo") || region.contains("Soyo")) {
+                int debug = 0;
+            }
+            data = Row.of(lang, script, region, source);
+            data.freeze();
+        }
+
+        @Override
+        public String toString() {
+            return combineLSR(data.get0(), data.get1(), data.get2()) + " // " + data.get3();
+        }
+
+        @Override
+        public int compareTo(LSRSource o) {
+            return data.compareTo(o.data);
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return data.equals(obj);
+        }
+
+        public String line(String source) {
+            // TODO Auto-generated method stub
+            //      <likelySubtag from="aa" to="aa_Latn_ET"/>
+            // <!--{ Afar; ?; ? } => { Afar; Latin; Ethiopia }-->
+            final String target = combineLSR(data.get0(), data.get1(), data.get2());
+            final String origin = data.get3();
+            final String result =
+                    "<likelySubtag from=\""
+                            + source
+                            + "\" to=\""
+                            + target
+                            + (origin.isBlank() ? "" : "\" origin=\"" + origin)
+                            + "\"/>"
+                            + "\t<!-- "
+                            + english.getName(source)
+                            + " ➡︎ "
+                            + english.getName(target)
+                            + " -->";
+            return result;
+        }
+
+        public static String combineLSR(String lang, String script, String region) {
+            return lang
+                    + (script.isEmpty() ? "" : "_" + script)
+                    + (region.isEmpty() ? "" : "_" + region);
+        }
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -672,4 +672,16 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
             return 1 + getParent().getRank();
         }
     }
+
+    // Non-optimized version for now
+    public static CLDRLocale getInstance(String lang, String script, String region) {
+        return getInstance(
+                (lang.isEmpty() || lang.equals("root") ? "und" : lang)
+                        + (script.isEmpty() ? "" : "_" + script)
+                        + (region.isEmpty() ? "" : "_" + region));
+    }
+
+    public String getRegion() {
+        return getCountry();
+    }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageTagCanonicalizer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageTagCanonicalizer.java
@@ -29,24 +29,35 @@ public class LanguageTagCanonicalizer implements StringTransform {
     private final LanguageTagParser ltp1 = new LanguageTagParser();
     private final LanguageTagParser ltp2 = new LanguageTagParser();
 
+    /** Use a parameter to specify LIKELY_FAVOR_SCRIPT or no minimization */
     public LanguageTagCanonicalizer() {
         this(LstrType.script);
     }
 
+    @Deprecated
     public LanguageTagCanonicalizer(boolean favorRegion) {
         this(favorRegion ? LstrType.region : LstrType.script);
     }
 
-    public LanguageTagCanonicalizer(LstrType lstrType) {
-        switch (lstrType) {
-            case region:
-                likely = LIKELY_FAVOR_REGION;
-                break;
-            case script:
-                likely = LIKELY_FAVOR_SCRIPT;
-                break;
-            default:
-                likely = null;
+    /**
+     * Choose the style of minimization, or null for none.
+     *
+     * @param minimizationTypeOrNull
+     */
+    public LanguageTagCanonicalizer(LstrType minimizationTypeOrNull) {
+        if (minimizationTypeOrNull == null) {
+            likely = null; // don't minimize.
+        } else {
+            switch (minimizationTypeOrNull) {
+                case region:
+                    likely = LIKELY_FAVOR_REGION;
+                    break;
+                case script:
+                    likely = LIKELY_FAVOR_SCRIPT;
+                    break;
+                default:
+                    likely = null;
+            }
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleScriptInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleScriptInfo.java
@@ -1,0 +1,152 @@
+package org.unicode.cldr.util;
+
+import com.ibm.icu.lang.UScript;
+import com.ibm.icu.text.UTF16;
+import com.ibm.icu.text.UnicodeSet;
+import com.ibm.icu.text.UnicodeSetIterator;
+import java.util.Map;
+import java.util.Set;
+import org.unicode.cldr.util.CLDRFile.ExemplarType;
+import org.unicode.cldr.util.CLDRFile.WinningChoice;
+import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData;
+import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData.Type;
+
+public class LocaleScriptInfo {
+    private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
+
+    public static String UNKNOWN_SCRIPT = UScript.getShortName(UScript.UNKNOWN);
+    public static String UNKNOWN_REGION = "ZZ";
+
+    private static SupplementalDataInfo supplementalData = CLDR_CONFIG.getSupplementalDataInfo();
+    private static Factory factory = CLDR_CONFIG.getCldrFactory();
+
+    /**
+     * Get the script code (aka short property name, like Latn) from the locale, or if that fails,
+     * from the supplemental languageData.
+     *
+     * @param locale
+     * @return null if fails
+     */
+    public static String getScriptFromLocaleOrSupplemental(String locale) {
+        String script = getScriptFromLocale(locale);
+        if (script == null) {
+            script = getScriptFromSupplementalData(locale);
+        }
+        return script;
+    }
+
+    /**
+     * Get the script code (aka short property name, like Latn) from the locale id, or if that
+     * fails, from the main exemplars.
+     *
+     * @param locale
+     * @return null if fails
+     */
+    public static String getScriptFromLocale(String locale) {
+        // if the script is in the locale ID, return it
+
+        CLDRLocale cLocale = CLDRLocale.getInstance(locale);
+        String script = cLocale.getScript();
+        if (!script.isEmpty()) {
+            return script;
+        }
+
+        // Otherwise, check the main exemplars
+
+        try {
+            CLDRFile cldrFile = factory.make(locale, true);
+            UnicodeSet exemplars =
+                    cldrFile.getExemplarSet(ExemplarType.main, WinningChoice.WINNING);
+            script = getExemplarScriptCode(exemplars);
+            if (!script.equals(UNKNOWN_SCRIPT)) {
+                return script;
+            }
+        } catch (RuntimeException e) {
+            // we failed for some reason
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the script code (aka short property name, like Latn) from the supplemental languageData.
+     *
+     * @param locale
+     * @return null if fails
+     */
+    public static String getScriptFromSupplementalData(String locale) {
+        final Map<Type, BasicLanguageData> basicLanguageData =
+                supplementalData.getBasicLanguageDataMap(locale);
+        if (basicLanguageData != null) {
+            String result = null;
+            for (BasicLanguageData datum : basicLanguageData.values()) {
+                final Set<String> scripts = datum.getScripts();
+                boolean isPrimary = datum.getType() == BasicLanguageData.Type.primary;
+                if (scripts.size() != 1) {
+                    if (scripts.size() > 1 && isPrimary) {
+                        break;
+                    }
+                    continue;
+                }
+                String script = scripts.iterator().next();
+                if (isPrimary) {
+                    return result = script;
+                } else if (result == null) {
+                    result = script;
+                }
+            }
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the first explicit script code from a UnicodeSet, which should be a locale's main
+     * exemplars
+     *
+     * @param unicodeSet
+     * @return Zzzz = Unknown Script if fails.
+     */
+    public static String getExemplarScriptCode(UnicodeSet unicodeSet) {
+        return UScript.getShortName(getExemplarUScriptId(unicodeSet));
+    }
+
+    /**
+     * Get the first explicit script code from a UnicodeSet, which should be a locale's main
+     * exemplars
+     *
+     * @param unicodeSet
+     * @return UScript.UNKNOWN if fails
+     */
+    public static int getExemplarUScriptId(UnicodeSet unicodeSet) {
+        for (UnicodeSetIterator it = new UnicodeSetIterator(unicodeSet); it.next(); ) {
+            if (it.codepoint != UnicodeSetIterator.IS_STRING) {
+                int script = UScript.getScript(it.codepoint);
+                switch (script) {
+                    case UScript.COMMON:
+                    case UScript.INHERITED:
+                    case UScript.UNKNOWN:
+                        continue;
+                    default:
+                        return script;
+                }
+            } else {
+                int cp;
+                for (int i = 0; i < it.string.length(); i += UTF16.getCharCount(cp)) {
+                    int script = UScript.getScript(cp = UTF16.charAt(it.string, i));
+                    switch (script) {
+                        case UScript.COMMON:
+                        case UScript.INHERITED:
+                        case UScript.UNKNOWN:
+                            continue;
+                        default:
+                            return script;
+                    }
+                }
+            }
+        }
+        return UScript.UNKNOWN;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleScriptInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleScriptInfo.java
@@ -70,6 +70,7 @@ public class LocaleScriptInfo {
 
     /**
      * Get the script code (aka short property name, like Latn) from the supplemental languageData.
+     * Take the first one if there are 2.
      *
      * @param locale
      * @return null if fails
@@ -82,10 +83,7 @@ public class LocaleScriptInfo {
             for (BasicLanguageData datum : basicLanguageData.values()) {
                 final Set<String> scripts = datum.getScripts();
                 boolean isPrimary = datum.getType() == BasicLanguageData.Type.primary;
-                if (scripts.size() != 1) {
-                    if (scripts.size() > 1 && isPrimary) {
-                        break;
-                    }
+                if (scripts.isEmpty()) {
                     continue;
                 }
                 String script = scripts.iterator().next();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -451,7 +451,7 @@ public class SupplementalDataInfo {
                 throw new IllegalArgumentException("Illegal Script: " + script);
             }
             if (scripts == Collections.EMPTY_SET) {
-                scripts = new TreeSet<>();
+                scripts = new LinkedHashSet<>(); // retain order
             }
             scripts.add(script);
             return this;


### PR DESCRIPTION
CLDR-17535

The goal is to integrate the SIL data reading into the tool for generating likely subtags. I'm creating a new tool because it needs some major cleanup in order for it to work.

common/supplemental/supplementalData.xml
- fixed a few values for the predominant script

tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
- completely new tool for generating the likely subtag data. It takes code from GenerateMaximalSubtags and breaks it apart into separate files, and cleans up a lot of cruft.
- It now takes regular console options, and the options provide a lot of control over seeing what is happening at each point in the process.
- It incorporates code to directly add the SIL data, after filtering out any data that would be redundant. It does a much better job of filtering the SIL data, allowing for a list of all of the discarded lines, plus the reasons for discarding them.
- It prints a list of items that change from old to new, allowing for double-checking the data without being depending on the file structure.
- The output file has a better ordering; first come the regular locales, then the und_ elements, then the items added for SIL.
- The file listing is cleaned up, so that the comments are on the same line, with an abbreviated format, eg
    - `<likelySubtag from="sr_ME" to="sr_Latn_ME"/> <!--Serbian‧?‧Montenegro ➡ Serbian‧Latin‧Montenegro-->`

tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
- A cleaned up version of a class that contains an LSR locale plus origin attribute values (eg 'sil1')

tools/cldr-code/src/main/java/org/unicode/cldr/tool/LangTagsData.java
- A cleaned up separate class that reads the SIL data, filling in a set of error values for possible later display.

tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
- added a couple of small utilities (there's a separate ticket for more substantive cleanup)

tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageTagCanonicalizer.java
- made it clearer how to get a version that doesn't minimize

tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleScriptInfo.java
- provides a cleaned-up class to get the default script for a locale

tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
- made the script values ordered, so that a predictable result would obtain.

**Changes (disregarding changes due to SIL data)**

1. The explicit new values make sense.
2. The Laoo and hnj values are due to changed data (we hadn't rerun the tool last release); there was a change in the default value for hnj.
3. The und_Latn values were all redundant. For example, because we have und_419 => es_Latn_419, the und_419 => es_Latn_419 is superfluous (code for using the data falls back).


Source | Name | oldValue | Name | newValue | Name
-- | -- | -- | -- | -- | --
und_Aghb | (Caucasian Albanian) | udi_Aghb_RU | Udi (Caucasian Albanian, Russia) | xag_Aghb_AZ | Aghwan (Caucasian Albanian, Azerbaijan)
und_Krai | (Kirat Rai) | bap_Krai_NP | Bantawa (Kirat Rai, Nepal) | bap_Krai_IN | Bantawa (Kirat Rai, India)
hif | Fiji Hindi | hif_Latn_FJ | Fiji Hindi (Latin, Fiji) | hif_Deva_FJ | Fiji Hindi (Devanagari, Fiji)
gon | Gondi | gon_Telu_IN | Gondi (Telugu, India) | gon_Deva_IN | Gondi (Devanagari, India)
und_Hmng | (Pahawh Hmong) | hnj_Hmng_US | Hmong Njua (Pahawh Hmong, United States) | hnj_Hmng_LA | Hmong Njua (Pahawh Hmong, Laos)
kaa | Kara-Kalpak | kaa_Cyrl_UZ | Kara-Kalpak (Cyrillic, Uzbekistan) | kaa_Cyrl_TR | Kara-Kalpak (Cyrillic, Türkiye)
und_Cyrl_TR | (Cyrillic, Türkiye) | kbd_Cyrl_TR | Kabardian (Cyrillic, Türkiye) | kaa_Cyrl_TR | Kara-Kalpak (Cyrillic, Türkiye)
hnj_AU | Hmong Njua (Australia) | hnj_Laoo_AU | Hmong Njua (Lao, Australia) | ∅ | n/a
hnj_CN | Hmong Njua (China) | hnj_Laoo_CN | Hmong Njua (Lao, China) | ∅ | n/a
hnj_FR | Hmong Njua (France) | hnj_Laoo_FR | Hmong Njua (Lao, France) | ∅ | n/a
hnj_GF | Hmong Njua (French Guiana) | hnj_Laoo_GF | Hmong Njua (Lao, French Guiana) | ∅ | n/a
hnj_LA | Hmong Njua (Laos) | hnj_Laoo_LA | Hmong Njua (Lao, Laos) | ∅ | n/a
hnj_MM | Hmong Njua (Myanmar [Burma]) | hnj_Laoo_MM | Hmong Njua (Lao, Myanmar [Burma]) | ∅ | n/a
hnj_SR | Hmong Njua (Suriname) | hnj_Laoo_SR | Hmong Njua (Lao, Suriname) | ∅ | n/a
hnj_TH | Hmong Njua (Thailand) | hnj_Laoo_TH | Hmong Njua (Lao, Thailand) | ∅ | n/a
hnj_VN | Hmong Njua (Vietnam) | hnj_Laoo_VN | Hmong Njua (Lao, Vietnam) | ∅ | n/a
hnj_Laoo | Hmong Njua (Lao) | hnj_Laoo_LA | Hmong Njua (Lao, Laos) | ∅ | n/a
und_Laoo_AU | (Lao, Australia) | hnj_Laoo_AU | Hmong Njua (Lao, Australia) | ∅ | n/a
und_Laoo_CN | (Lao, China) | hnj_Laoo_CN | Hmong Njua (Lao, China) | ∅ | n/a
und_Laoo_FR | (Lao, France) | hnj_Laoo_FR | Hmong Njua (Lao, France) | ∅ | n/a
und_Laoo_GF | (Lao, French Guiana) | hnj_Laoo_GF | Hmong Njua (Lao, French Guiana) | ∅ | n/a
und_Laoo_MM | (Lao, Myanmar [Burma]) | hnj_Laoo_MM | Hmong Njua (Lao, Myanmar [Burma]) | ∅ | n/a
und_Laoo_SR | (Lao, Suriname) | hnj_Laoo_SR | Hmong Njua (Lao, Suriname) | ∅ | n/a
und_Laoo_TH | (Lao, Thailand) | hnj_Laoo_TH | Hmong Njua (Lao, Thailand) | ∅ | n/a
und_Laoo_US | (Lao, United States) | hnj_Laoo_US | Hmong Njua (Lao, United States) | ∅ | n/a
und_Laoo_VN | (Lao, Vietnam) | hnj_Laoo_VN | Hmong Njua (Lao, Vietnam) | ∅ | n/a
und_Latn_419 | (Latin, Latin America) | es_Latn_419 | Latin American Spanish (Latin) | ∅ | n/a
und_Latn_MU | (Latin, Mauritius) | mfe_Latn_MU | Morisyen (Latin, Mauritius) | ∅ | n/a
und_Latn_SL | (Latin, Sierra Leone) | kri_Latn_SL | Krio (Latin, Sierra Leone) | ∅ | n/a
und_Latn_TK | (Latin, Tokelau) | tkl_Latn_TK | Tokelau (Latin, Tokelau) | ∅ | n/a
und_Latn_ZM | (Latin, Zambia) | bem_Latn_ZM | Bemba (Latin, Zambia) | ∅ | n/a

Here are samples of the log when reading the SIL file:

Log Type | Sample | Comment
-- | -- | --
ill_formed_tags | `aae_x_sub84 ➡ aae_Latn_IT_x_sub84` | remove tags that aren't LSR
exception | `apc ➡ apc_Arab_SY` | gets an exception (in this case, an overwrite)
skipping_scope | `abj ➡ abj_Zyyy_IN` | language, script or region has wrong scope, eg {script=special}
tag_is_full | `az_Cyrl_AZ ➡ az_Cyrl_AZ` | tag is completely redundant
language_of_tag_missing | `abq_Cyrl ➡ abq_Cyrl_RU` | we can't have LS or LR without also having a line for L
redundant_mapping | `aa_Arab ➡ aa_Arab_ET` | if we have aa_ET ➡ aa_Arab_ET, then aa_Arab is redundant
canonicalizing | `ajp ➡ ajp_Arab_JO` | applies the regular CLDR canonicalization

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
4. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
5. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
