### PR TITLE
CLDR-11018 currency decimal place isn't accurate in the examples

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -75,6 +75,7 @@ import org.unicode.cldr.util.Rational.FormatStyle;
 import org.unicode.cldr.util.ScriptToExemplars;
 import org.unicode.cldr.util.SimpleUnicodeSetFormatter;
 import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.SupplementalDataInfo.CurrencyNumberInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
@@ -2684,6 +2685,14 @@ public class ExampleGenerator {
         DecimalFormat df =
                 icuServiceBuilder.getCurrencyFormat(currency, currencySymbol, numberSystem);
         df.applyPattern(value);
+
+        // getCurrencyFormat sets digits, but applyPattern seems to overwrite it, so fix it again
+        // here
+        SupplementalDataInfo supplementalData = CONFIG.getSupplementalDataInfo();
+        CurrencyNumberInfo info = supplementalData.getCurrencyNumberInfo(currency);
+        int digits = info.getDigits();
+        df.setMinimumFractionDigits(digits);
+        df.setMaximumFractionDigits(digits);
 
         String countValue = parts.getAttributeValue(-1, "count");
         if (countValue != null) {


### PR DESCRIPTION
CLDR-11018

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Before:
<img width="153" alt="image" src="https://github.com/user-attachments/assets/bc71bc11-d092-4e4f-9657-e8a0dd82b03b">

After:
<img width="153" alt="image" src="https://github.com/user-attachments/assets/e20fbad6-8b2f-4249-a0c8-0802c91e1f7d">