### PR TITLE
CLDR-17572 Move LR marker div below star

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -1031,9 +1031,6 @@ function addVitem(td, tr, theRow, item, newButton) {
   subSpan.className = "subSpan";
   cldrVote.appendItem(subSpan, displayValue, item.pClass);
   choiceField.appendChild(subSpan);
-
-  checkLRmarker(choiceField, item.value);
-
   if (item.isBaselineValue == true) {
     cldrDom.appendIcon(
       choiceField,
@@ -1041,6 +1038,7 @@ function addVitem(td, tr, theRow, item, newButton) {
       cldrText.get("voteInfo_baseline_desc")
     );
   }
+  checkLRmarker(choiceField, item.value);
   if (item.votes && !isWinner) {
     if (
       item.valueHash == theRow.voteVhash &&
@@ -1185,7 +1183,6 @@ function appendExampleIcon(parent, text, loc) {
   return el;
 }
 
-// caution: this is called from other modules as well as by appendExampleIcon
 function appendExample(parent, text, loc) {
   const el = document.createElement("div");
   el.className = "d-example well well-sm";
@@ -1429,7 +1426,6 @@ function resetLastShown() {
 export {
   NO_WINNING_VALUE,
   EMPTY_ELEMENT_VALUE,
-  appendExample,
   getPageUrl,
   getRowApprovalStatusClass,
   getStatusIcon,


### PR DESCRIPTION
-Move the LR marker div below the i-star icon, simply by moving the call to checkLRmarker a few lines lower

-Also remove a comment in the same file about appendExample which is no longer true, and remove the export for appendExample which is no longer needed

CLDR-17572

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
