### PR TITLE
CLDR-17835 Fix light-speed problems

### DIFF
--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -5856,8 +5856,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-year">
 				<displayName>mfeɛ</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
+				<unitPattern count="one">mfeɛ {0}</unitPattern>
+				<unitPattern count="other">mfeɛ {0}</unitPattern>
 				<perUnitPattern>mfeɛ biara {0}</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -10639,16 +10639,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>feminine</gender>
-				<displayName>سرعة الضوء</displayName>
-				<unitPattern count="zero">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="one">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="two">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="few">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="many">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="other">سرعة الضوء {0}</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>masculine</gender>
 				<displayName>جزء بالمليار</displayName>
@@ -12482,15 +12472,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} ربع غالون إمبراطوري</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>سرعة الضوء</displayName>
-				<unitPattern count="zero">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="one">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="two">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="few">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="many">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="other">سرعة الضوء {0}</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>جزء/مليار</displayName>
 				<unitPattern count="zero">{0} جزء/مليار</unitPattern>
@@ -14321,15 +14302,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>سرعة الضوء</displayName>
-				<unitPattern count="zero">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="one">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="two">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="few">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="many">سرعة الضوء {0}</unitPattern>
-				<unitPattern count="other">سرعة الضوء {0}</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>جزء/مليار</displayName>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -8112,13 +8112,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>хуткасць святла</displayName>
-				<unitPattern count="one">{0} хуткасць святла</unitPattern>
-				<unitPattern count="few">{0} хуткасці святла</unitPattern>
-				<unitPattern count="many">{0} хуткасцей святла</unitPattern>
-				<unitPattern count="other">{0} хуткасці святла</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>частак на мільярд</displayName>
 				<unitPattern count="one">{0} частка на мільярд</unitPattern>
@@ -9574,13 +9567,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} брыт. кварт</unitPattern>
 				<unitPattern count="other">{0} брыт. кварты</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>хутк. св.</displayName>
-				<unitPattern count="one">{0} хутк. св.</unitPattern>
-				<unitPattern count="few">{0} хутк. св.</unitPattern>
-				<unitPattern count="many">{0} хутк. св.</unitPattern>
-				<unitPattern count="other">{0} хутк. св.</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>частак/мільярд</displayName>
 				<unitPattern count="one">{0} ч/млрд</unitPattern>
@@ -11035,13 +11021,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>хутк. св.</displayName>
-				<unitPattern count="one">{0} хутк. св.</unitPattern>
-				<unitPattern count="few">{0} хутк. св.</unitPattern>
-				<unitPattern count="many">{0} хутк. св.</unitPattern>
-				<unitPattern count="other">{0} хутк. св.</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>ч/млрд</displayName>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -8793,11 +8793,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Imp. quart</unitPattern>
 				<unitPattern count="other">{0} Imp. quart</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>আঃবঃ</displayName>
-				<unitPattern count="one">{0} আঃবঃ</unitPattern>
-				<unitPattern count="other">{0} আঃবঃ</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>পার্ট প্রতি বিলিয়ন</displayName>
 				<unitPattern count="one">{0} পার্ট প্রতি বিলিয়ন</unitPattern>
@@ -9877,11 +9872,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>আঃবঃ</displayName>
-				<unitPattern count="one">{0} আঃবঃ</unitPattern>
-				<unitPattern count="other">{0} আঃবঃ</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>পার্ট/ বিলিয়ন</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -10960,11 +10950,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>আঃবঃ</displayName>
-				<unitPattern count="one">{0} আঃবঃ</unitPattern>
-				<unitPattern count="other">{0} আঃবঃ</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -17088,12 +17088,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} imperijalna kvarca</unitPattern>
 				<unitPattern count="other">{0} imperijalnih kvarca</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>brzina svjetlosti</displayName>
-				<unitPattern count="one">{0} brzina svjetlosti</unitPattern>
-				<unitPattern count="few">{0} brzine svjetlosti</unitPattern>
-				<unitPattern count="other">{0} brzina svjetlosti</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -18361,12 +18355,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0} imp. kvarta</unitPattern>
 				<unitPattern count="other">{0} imp. kvarata</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>brz. svjetlosti</displayName>
-				<unitPattern count="one">{0} brz. svjetlosti</unitPattern>
-				<unitPattern count="few">{0} brz. svjetlosti</unitPattern>
-				<unitPattern count="other">{0} brz. svjetlosti</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -19633,12 +19621,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} imp. kvart</unitPattern>
 				<unitPattern count="few">{0} imp. kvarta</unitPattern>
 				<unitPattern count="other">{0} imp. kvarata</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>brz. svjetlosti</displayName>
-				<unitPattern count="one">{0} brz. svjetlosti</unitPattern>
-				<unitPattern count="few">{0} brz. svjetlosti</unitPattern>
-				<unitPattern count="other">{0} brz. svjetlosti</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -16999,7 +16999,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -7392,7 +7392,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="common" case="genitive">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0} gange {1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>common</gender>
@@ -8725,14 +8725,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} britisk quart</unitPattern>
 				<unitPattern count="other">{0} britiske quarts</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>common</gender>
-				<displayName>lysets hastighed</displayName>
-				<unitPattern count="one">{0} gang lysets hastighed</unitPattern>
-				<unitPattern count="one" case="genitive">{0} gang lysets hastigheds</unitPattern>
-				<unitPattern count="other">{0} gange lysets hastighed</unitPattern>
-				<unitPattern count="other" case="genitive">{0} gange lysets hastigheds</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>common</gender>
 				<displayName>milliardtedele</displayName>
@@ -8869,7 +8861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0} ⋅ {1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G-kraft</displayName>
@@ -9818,11 +9810,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} britisk qt</unitPattern>
 				<unitPattern count="other">{0} britiske qt</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>lyshastigheden</displayName>
-				<unitPattern count="one">{0} gang lyshastigheden</unitPattern>
-				<unitPattern count="other">{0} gange lyshastigheden</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>dele/milliard</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -9953,7 +9940,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0}⋅{1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>
@@ -10901,11 +10888,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} br. qt.</unitPattern>
 				<unitPattern count="other">{0} br. qt.</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>lyset</displayName>
-				<unitPattern count="one">{0} gang lyset</unitPattern>
-				<unitPattern count="other">{0} gange lyset</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -10674,18 +10674,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="dative">↑↑↑</unitPattern>
 				<unitPattern count="other" case="genitive">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>feminine</gender>
-				<displayName>Lichtgeschwindigkeit</displayName>
-				<unitPattern count="one">{0} Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="one" case="accusative">{0} Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="one" case="dative">{0} Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="one" case="genitive">{0} Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="other">{0}-fache Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="other" case="accusative">{0}-fache Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="other" case="dative">{0}-facher Lichtgeschwindigkeit</unitPattern>
-				<unitPattern count="other" case="genitive">{0}-facher Lichtgeschwindigkeit</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>neuter</gender>
 				<displayName>Milliardstel</displayName>
@@ -11779,11 +11767,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} Imp.qt.</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>Lichtgeschw.</displayName>
-				<unitPattern count="one">{0} Lichtgeschw.</unitPattern>
-				<unitPattern count="other">{0}-fache Lichtg.</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>Milliardstel</displayName>
 				<unitPattern count="one">{0} Milliardstel</unitPattern>
@@ -12862,11 +12845,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>Imp.qt</displayName>
 				<unitPattern count="one">{0} Imp.qt</unitPattern>
 				<unitPattern count="other">{0} Imp.qt</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} c</unitPattern>
-				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -8138,11 +8138,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} inglise kvart</unitPattern>
 				<unitPattern count="other">{0} inglise kvarti</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>valguskiirus</displayName>
-				<unitPattern count="one">{0} valguskiirus</unitPattern>
-				<unitPattern count="other">{0} valguskiirust</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>miljardikosa</displayName>
 				<unitPattern count="one">{0} miljardikosa</unitPattern>
@@ -9222,11 +9217,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ingl kvart</unitPattern>
 				<unitPattern count="other">{0} ingl kvarti</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>valguskiirus</displayName>
-				<unitPattern count="one">{0} valguskiirus</unitPattern>
-				<unitPattern count="other">{0} valguskiirust</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>osakesed/miljard</displayName>
 				<unitPattern count="one">{0} miljardikosa</unitPattern>
@@ -10305,11 +10295,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0} qt Imp.</unitPattern>
 				<unitPattern count="other">{0} qt Imp.</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>valguskiirus</displayName>
-				<unitPattern count="one">{0} valguskiirus</unitPattern>
-				<unitPattern count="other">{0} valguskiirust</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -8846,11 +8846,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>نور</displayName>
-				<unitPattern count="one">{0} نور</unitPattern>
-				<unitPattern count="other">{0} نور</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>بخش در بیلیون</displayName>
 				<unitPattern count="one">{0} بخش در بیلیون</unitPattern>
@@ -9930,11 +9925,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} کوارت انگلیسی</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>نور</displayName>
-				<unitPattern count="one">{0} نور</unitPattern>
-				<unitPattern count="other">{0} نور</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>بخش در بیلیون</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -11013,11 +11003,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>qt Imp</displayName>
 				<unitPattern count="one">{0}qt-Imp.</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>نور</displayName>
-				<unitPattern count="one">{0} نور</unitPattern>
-				<unitPattern count="other">{0} نور</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>بخش در بیلیون</displayName>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -10141,19 +10141,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} br. neljännesgallona</unitPattern>
 				<unitPattern count="other">{0} br. neljännesgallonaa</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>valonnopeudet</displayName>
-				<unitPattern count="one">{0} valonnopeus</unitPattern>
-				<unitPattern count="one" case="elative">{0} valonnopeudesta</unitPattern>
-				<unitPattern count="one" case="genitive">{0} valonnopeuden</unitPattern>
-				<unitPattern count="one" case="illative">{0} valonnopeuteen</unitPattern>
-				<unitPattern count="one" case="partitive">{0} valonnopeutta</unitPattern>
-				<unitPattern count="other">{0} valonnopeutta</unitPattern>
-				<unitPattern count="other" case="elative">{0} valonnopeudesta</unitPattern>
-				<unitPattern count="other" case="genitive">{0} valonnopeuden</unitPattern>
-				<unitPattern count="other" case="illative">{0} valonnopeuteen</unitPattern>
-				<unitPattern count="other" case="partitive">{0} valonnopeutta</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>miljardisosat</displayName>
 				<unitPattern count="one">{0} miljardisosa</unitPattern>
@@ -11249,11 +11236,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} qt br.</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} c</unitPattern>
-				<unitPattern count="other">{0} c</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -12332,11 +12314,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0}qt br.</unitPattern>
 				<unitPattern count="other">{0}qt br.</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} c</unitPattern>
-				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -9215,11 +9215,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Imp. na kuwart</unitPattern>
 				<unitPattern count="other">{0} Imp. na kuwart</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>parts per billion</displayName>
 				<unitPattern count="one">{0} part per billion</unitPattern>
@@ -10296,11 +10291,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="volume-quart-imperial">
 				<displayName>Imp na kuwart</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
@@ -11382,11 +11372,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>qt Imp</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0}qt-Imp.</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -10132,14 +10132,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -11783,14 +11775,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} gcárt impiriúla</unitPattern>
 				<unitPattern count="other">{0} cárt impiriúil</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -13427,14 +13411,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="two">↑↑↑</unitPattern>
-				<unitPattern count="few">↑↑↑</unitPattern>
-				<unitPattern count="many">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="two">↑↑↑</unitPattern>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -7936,19 +7936,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>լույսի արագություն</displayName>
-				<unitPattern count="one">{0} լույսի արագություն</unitPattern>
-				<unitPattern count="one" case="ablative">{0} լույսի արագությունից</unitPattern>
-				<unitPattern count="one" case="dative">{0} լույսի արագությանը</unitPattern>
-				<unitPattern count="one" case="instrumental">{0} լույսի արագությամբ</unitPattern>
-				<unitPattern count="one" case="locative">{0} լույսի արագությունում</unitPattern>
-				<unitPattern count="other">{0} լույսի արագություն</unitPattern>
-				<unitPattern count="other" case="ablative">{0} լույսի արագությունից</unitPattern>
-				<unitPattern count="other" case="dative">{0} լույսի արագությանը</unitPattern>
-				<unitPattern count="other" case="instrumental">{0} լույսի արագությամբ</unitPattern>
-				<unitPattern count="other" case="locative">{0} լույսի արագությունում</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>մաս միլիարդի վրա</displayName>
 				<unitPattern count="one">{0} մաս միլիարդի վրա</unitPattern>
@@ -9044,11 +9031,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} անգլիական քվարտ</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>լույսի արագություն</displayName>
-				<unitPattern count="one">{0} լույսի արագություն</unitPattern>
-				<unitPattern count="other">{0} լույսի արագություն</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>մաս/միլիարդ</displayName>
 				<unitPattern count="one">{0} մմլրդվ</unitPattern>
@@ -10127,11 +10109,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>լույսի արագություն</displayName>
-				<unitPattern count="one">{0}լույսի արագություն</unitPattern>
-				<unitPattern count="other">{0}լույսի արագություն</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>մմլրդվ</displayName>

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -6169,7 +6169,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-year">
 				<displayName>Ọtụtụ Afọ</displayName>
 				<unitPattern count="other">{0} Ọtụtụ Afọ</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>Nkeji Nkeano</displayName>
@@ -7061,11 +7060,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">{0} qtrs</unitPattern>
@@ -7955,11 +7949,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-decade">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -10690,18 +10690,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>masculine</gender>
-				<displayName>ljóshraði</displayName>
-				<unitPattern count="one">{0} ljóshraði</unitPattern>
-				<unitPattern count="one" case="accusative">{0} ljóshraða</unitPattern>
-				<unitPattern count="one" case="dative">{0} ljóshraða</unitPattern>
-				<unitPattern count="one" case="genitive">{0} ljóshraða</unitPattern>
-				<unitPattern count="other">{0} ljóshraðar</unitPattern>
-				<unitPattern count="other" case="accusative">{0} ljóshraða</unitPattern>
-				<unitPattern count="other" case="dative">{0} ljóshröðum</unitPattern>
-				<unitPattern count="other" case="genitive">{0} ljóshraða</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>masculine</gender>
 				<displayName>hlutar á milljarð</displayName>
@@ -11795,11 +11783,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} lagarmál</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>ljóshr.</displayName>
-				<unitPattern count="one">{0} ljóshr.</unitPattern>
-				<unitPattern count="other">{0} ljóshr.</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -12878,11 +12861,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} l.mál</unitPattern>
 				<unitPattern count="other">{0} l.mál</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>ljóshr.</displayName>
-				<unitPattern count="one">{0} ljóshr.</unitPattern>
-				<unitPattern count="other">{0} ljóshr.</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -6980,7 +6980,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other" gender="feminine">{0} cubiche</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0} {1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<gender>feminine</gender>
@@ -8090,7 +8090,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</unit>
 			<unit type="speed-light-speed">
 				<gender draft="contributed">feminine</gender>
-				<displayName>luce</displayName>
 				<unitPattern count="one" draft="contributed">{0} alla velocità della luce</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} alla velocità della luce</unitPattern>
 			</unit>
@@ -9176,7 +9175,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">{0} imp qt</unitPattern>
 			</unit>
 			<unit type="speed-light-speed">
-				<displayName>luce</displayName>
 				<unitPattern count="one" draft="contributed">{0} luce</unitPattern>
 				<unitPattern count="other" draft="contributed">{0} luce</unitPattern>
 			</unit>
@@ -10260,7 +10258,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" draft="contributed">{0}imp qt</unitPattern>
 			</unit>
 			<unit type="speed-light-speed">
-				<displayName>luce</displayName>
 				<unitPattern count="one" draft="contributed">{0}l</unitPattern>
 				<unitPattern count="other" draft="contributed">{0}l</unitPattern>
 			</unit>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -7743,11 +7743,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} ბრიტანული კვარტი</unitPattern>
 				<unitPattern count="other">{0} ბრიტანული კვარტი</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>სინათლის სიჩქარე</displayName>
-				<unitPattern count="one">{0}-მაგი სინათლის სიჩქარე</unitPattern>
-				<unitPattern count="other">{0}-მაგი სინათლის სიჩქარე</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>ნაწილი მილიარდზე</displayName>
 				<unitPattern count="one">{0} ნაწილი მილიარდზე</unitPattern>
@@ -8827,11 +8822,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} ბრიტ. კვარტი</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>სინათლის სიჩქ.</displayName>
-				<unitPattern count="one">{0}-მაგი სინათ. სიჩქ.</unitPattern>
-				<unitPattern count="other">{0}-მაგი სინათ. სიჩქ.</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>ნაწილი/მილიარდზე</displayName>
 				<unitPattern count="one">{0} ნ/მ</unitPattern>
@@ -9332,11 +9322,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0}ლ</unitPattern>
 				<unitPattern count="other">{0}ლ</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} c</unitPattern>
-				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>ნ/მ</displayName>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -8870,10 +8870,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>영국 쿼트</displayName>
 				<unitPattern count="other">{0}영국 쿼트</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>광속</displayName>
-				<unitPattern count="other">{0}광속</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">{0}ppb</unitPattern>
@@ -9765,10 +9761,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">{0}qt Imp.</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>광속</displayName>
-				<unitPattern count="other">{0}광속</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">{0}ppb</unitPattern>
@@ -10659,10 +10651,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>광속</displayName>
-				<unitPattern count="other">{0}광속</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -13604,34 +13604,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} imp. kvortos</unitPattern>
 				<unitPattern count="other">{0} imp. kvortų</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>masculine</gender>
-				<displayName>šviesos greitis</displayName>
-				<unitPattern count="one">{0} šviesos greitis</unitPattern>
-				<unitPattern count="one" case="accusative">{0} šviesos greitį</unitPattern>
-				<unitPattern count="one" case="dative">{0} šviesos greičiui</unitPattern>
-				<unitPattern count="one" case="genitive">{0} šviesos greičio</unitPattern>
-				<unitPattern count="one" case="instrumental">{0} šviesos greičiu</unitPattern>
-				<unitPattern count="one" case="locative">{0} šviesos greityje</unitPattern>
-				<unitPattern count="few">{0} šviesos greičiai</unitPattern>
-				<unitPattern count="few" case="accusative">{0} šviesos greičius</unitPattern>
-				<unitPattern count="few" case="dative">{0} šviesos greičiams</unitPattern>
-				<unitPattern count="few" case="genitive">{0} šviesos greičių</unitPattern>
-				<unitPattern count="few" case="instrumental">{0} šviesos greičiais</unitPattern>
-				<unitPattern count="few" case="locative">{0} šviesos greičiuose</unitPattern>
-				<unitPattern count="many">{0} šviesos greičio</unitPattern>
-				<unitPattern count="many" case="accusative">{0} šviesos greičio</unitPattern>
-				<unitPattern count="many" case="dative">{0} šviesos greičio</unitPattern>
-				<unitPattern count="many" case="genitive">{0} šviesos greičio</unitPattern>
-				<unitPattern count="many" case="instrumental">{0} šviesos greičio</unitPattern>
-				<unitPattern count="many" case="locative">{0} šviesos greičio</unitPattern>
-				<unitPattern count="other">{0} šviesos greičių</unitPattern>
-				<unitPattern count="other" case="accusative">{0} šviesos greičių</unitPattern>
-				<unitPattern count="other" case="dative">{0} šviesos greičių</unitPattern>
-				<unitPattern count="other" case="genitive">{0} šviesos greičių</unitPattern>
-				<unitPattern count="other" case="instrumental">{0} šviesos greičių</unitPattern>
-				<unitPattern count="other" case="locative">{0} šviesos greičių</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>feminine</gender>
 				<displayName>milijoninės dalelytės</displayName>
@@ -15129,13 +15101,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} imp. kv.</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} šv. greit.</unitPattern>
-				<unitPattern count="few">{0} šv. greit.</unitPattern>
-				<unitPattern count="many">{0} šv. greit.</unitPattern>
-				<unitPattern count="other">{0} šv. greit.</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>dalelytė/mln.</displayName>
 				<unitPattern count="one">{0} dalelytė/mln.</unitPattern>
@@ -16590,13 +16555,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} šv. greit.</unitPattern>
-				<unitPattern count="few">{0} šv. greit.</unitPattern>
-				<unitPattern count="many">{0} šv. greit.</unitPattern>
-				<unitPattern count="other">{0} šv. greit.</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>dalelytė/mln.</displayName>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -10041,11 +10041,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>പ്രകാശവേഗം</displayName>
-				<unitPattern count="one">{0} പ്രകാശവേഗം</unitPattern>
-				<unitPattern count="other">{0} പ്രകാശവേഗം</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>പാർട്‌സ്/ബില്ല്യൺ</displayName>
 				<unitPattern count="one">{0} പാർട്ട്/ബില്ല്യൺ</unitPattern>
@@ -11125,11 +11120,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>പ്രകാശവേഗം</displayName>
-				<unitPattern count="one">{0} പ്രകാശവേഗം</unitPattern>
-				<unitPattern count="other">{0} പ്രകാശവേഗം</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>പാർട്‌സ്/ബില്ല്യൺ</displayName>
 				<unitPattern count="one">{0} പി.പി.ബി.</unitPattern>
@@ -12208,11 +12198,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>പ്രകാശവേഗം</displayName>
-				<unitPattern count="one">{0}പ്രകാശവേഗം</unitPattern>
-				<unitPattern count="other">{0}പ്രകാശവേഗം</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>പി.പി.ബി.</displayName>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -9399,11 +9399,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>гэрлийн хурд</displayName>
-				<unitPattern count="one">{0} гэрлийн хурд</unitPattern>
-				<unitPattern count="other">{0} гэрлийн хурд</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>мкг/кг</displayName>
 				<unitPattern count="one">{0} мкг/кг</unitPattern>
@@ -10483,11 +10478,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} том куарт</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>гэрлийн хурд</displayName>
-				<unitPattern count="one">{0} гэрлийн хурд</unitPattern>
-				<unitPattern count="other">{0} гэрлийн хурд</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>мкг/кг</displayName>
 				<unitPattern count="one">{0} мкг/кг</unitPattern>
@@ -11566,11 +11556,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>гэрлийн хурд</displayName>
-				<unitPattern count="one">{0} гэрлийн хурд</unitPattern>
-				<unitPattern count="other">{0} гэрлийн хурд</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>мкг/кг</displayName>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -17076,7 +17076,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>G</displayName>

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -9109,7 +9109,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>↑↑↑</displayName>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -7271,11 +7271,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">{0} Imp. quart</unitPattern>
 				<unitPattern count="other">{0} Imp. quart</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -8355,11 +8350,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>p/b</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -9086,11 +9076,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="volume-quart-imperial">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -13800,34 +13800,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other" case="locative">↑↑↑</unitPattern>
 				<unitPattern count="other" case="vocative">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>feminine</gender>
-				<displayName>скорость света</displayName>
-				<unitPattern count="one">{0} скорость света</unitPattern>
-				<unitPattern count="one" case="accusative">{0} скорость света</unitPattern>
-				<unitPattern count="one" case="dative">{0} скорости света</unitPattern>
-				<unitPattern count="one" case="genitive">{0} скорости света</unitPattern>
-				<unitPattern count="one" case="instrumental">{0} скоростью света</unitPattern>
-				<unitPattern count="one" case="prepositional">{0} скорости света</unitPattern>
-				<unitPattern count="few">{0} скорости света</unitPattern>
-				<unitPattern count="few" case="accusative">{0} скорости света</unitPattern>
-				<unitPattern count="few" case="dative">{0} скоростям света</unitPattern>
-				<unitPattern count="few" case="genitive">{0} скоростей света</unitPattern>
-				<unitPattern count="few" case="instrumental">{0} скоростями света</unitPattern>
-				<unitPattern count="few" case="prepositional">{0} скоростях света</unitPattern>
-				<unitPattern count="many">{0} скоростей света</unitPattern>
-				<unitPattern count="many" case="accusative">{0} скоростей света</unitPattern>
-				<unitPattern count="many" case="dative">{0} скоростям света</unitPattern>
-				<unitPattern count="many" case="genitive">{0} скоростей света</unitPattern>
-				<unitPattern count="many" case="instrumental">{0} скоростями света</unitPattern>
-				<unitPattern count="many" case="prepositional">{0} скоростях света</unitPattern>
-				<unitPattern count="other">{0} скорости света</unitPattern>
-				<unitPattern count="other" case="accusative">{0} скорости света</unitPattern>
-				<unitPattern count="other" case="dative">{0} скорости света</unitPattern>
-				<unitPattern count="other" case="genitive">{0} скорости света</unitPattern>
-				<unitPattern count="other" case="instrumental">{0} скорости света</unitPattern>
-				<unitPattern count="other" case="prepositional">{0} скорости света</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>feminine</gender>
 				<displayName>миллиардные доли</displayName>
@@ -15325,13 +15297,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} имп. кварт.</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>ск. света</displayName>
-				<unitPattern count="one">{0} ск. света</unitPattern>
-				<unitPattern count="few">{0} ск. света</unitPattern>
-				<unitPattern count="many">{0} ск. света</unitPattern>
-				<unitPattern count="other">{0} ск. света</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -16786,13 +16751,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c</displayName>
-				<unitPattern count="one">{0} c</unitPattern>
-				<unitPattern count="few">{0} c</unitPattern>
-				<unitPattern count="many">{0} c</unitPattern>
-				<unitPattern count="other">{0} c</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -12401,34 +12401,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} britského kvartu</unitPattern>
 				<unitPattern count="other">{0} britských kvartov</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>feminine</gender>
-				<displayName>rýchlosť svetla</displayName>
-				<unitPattern count="one">{0} rýchlosť svetla</unitPattern>
-				<unitPattern count="one" case="accusative">{0} rýchlosť svetla</unitPattern>
-				<unitPattern count="one" case="dative">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="one" case="genitive">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="one" case="instrumental">{0} rýchlosťou svetla</unitPattern>
-				<unitPattern count="one" case="locative">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="few">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="few" case="accusative">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="few" case="dative">{0} rýchlostiam svetla</unitPattern>
-				<unitPattern count="few" case="genitive">{0} rýchlostí svetla</unitPattern>
-				<unitPattern count="few" case="instrumental">{0} rýchlosťami svetla</unitPattern>
-				<unitPattern count="few" case="locative">{0} rýchlostiach svetla</unitPattern>
-				<unitPattern count="many">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="many" case="accusative">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="many" case="dative">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="many" case="genitive">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="many" case="instrumental">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="many" case="locative">{0} rýchlosti svetla</unitPattern>
-				<unitPattern count="other">{0} rýchlostí svetla</unitPattern>
-				<unitPattern count="other" case="accusative">{0} rýchlostí svetla</unitPattern>
-				<unitPattern count="other" case="dative">{0} rýchlostiam svetla</unitPattern>
-				<unitPattern count="other" case="genitive">{0} rýchlostí svetla</unitPattern>
-				<unitPattern count="other" case="instrumental">{0} rýchlosťami svetla</unitPattern>
-				<unitPattern count="other" case="locative">{0} rýchlostiach svetla</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>feminine</gender>
 				<displayName>častice na miliardu</displayName>
@@ -12609,7 +12581,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<compoundUnitPattern1 count="other">↑↑↑</compoundUnitPattern1>
 			</compoundUnit>
 			<compoundUnit type="times">
-				<compoundUnitPattern>{0}{1}</compoundUnitPattern>
+				<compoundUnitPattern>↑↑↑</compoundUnitPattern>
 			</compoundUnit>
 			<unit type="acceleration-g-force">
 				<displayName>jednotka preťaženia</displayName>
@@ -13925,13 +13897,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} qt Imp</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c0</displayName>
-				<unitPattern count="one">{0} c0</unitPattern>
-				<unitPattern count="few">{0} c0</unitPattern>
-				<unitPattern count="many">{0} c0</unitPattern>
-				<unitPattern count="other">{0} c0</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
@@ -15387,13 +15352,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">↑↑↑</unitPattern>
 				<unitPattern count="many">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>c0</displayName>
-				<unitPattern count="one">{0} c0</unitPattern>
-				<unitPattern count="few">{0} c0</unitPattern>
-				<unitPattern count="many">{0} c0</unitPattern>
-				<unitPattern count="other">{0} c0</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -7374,11 +7374,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} çerek imperial</unitPattern>
 				<unitPattern count="other">{0} çerekë imperialë</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>shpejtësi drite</displayName>
-				<unitPattern count="one">{0} shpejtësi drite</unitPattern>
-				<unitPattern count="other">{0} shpejtësi drite</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>pjesë për miliard</displayName>
 				<unitPattern count="one">{0} pjesë për miliard</unitPattern>
@@ -8458,11 +8453,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>shpejtësi drite</displayName>
-				<unitPattern count="one">{0} shpejtësi drite</unitPattern>
-				<unitPattern count="other">{0} shpejtësi drite</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -9541,11 +9531,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>shpejtësi drite</displayName>
-				<unitPattern count="one">{0} shp. dr.</unitPattern>
-				<unitPattern count="other">{0} shp. dr.</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -12115,34 +12115,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} англійських кварт</unitPattern>
 				<unitPattern count="other">{0} англійської кварти</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<gender>feminine</gender>
-				<displayName>швидкість світла</displayName>
-				<unitPattern count="one">{0} швидкість світла</unitPattern>
-				<unitPattern count="one" case="accusative">{0} швидкість світла</unitPattern>
-				<unitPattern count="one" case="dative">{0} швидкості світла</unitPattern>
-				<unitPattern count="one" case="genitive">{0} швидкості світла</unitPattern>
-				<unitPattern count="one" case="instrumental">{0} швидкістю світла</unitPattern>
-				<unitPattern count="one" case="locative">{0} швидкістю світла</unitPattern>
-				<unitPattern count="few">{0} швидкості світла</unitPattern>
-				<unitPattern count="few" case="accusative">{0} швидкості світла</unitPattern>
-				<unitPattern count="few" case="dative">{0} швидкостям світла</unitPattern>
-				<unitPattern count="few" case="genitive">{0} швидкостей світла</unitPattern>
-				<unitPattern count="few" case="instrumental">{0} швидкостями світла</unitPattern>
-				<unitPattern count="few" case="locative">{0} швидкостях світла</unitPattern>
-				<unitPattern count="many">{0} швидкостей світла</unitPattern>
-				<unitPattern count="many" case="accusative">{0} швидкостей світла</unitPattern>
-				<unitPattern count="many" case="dative">{0} швидкостям світла</unitPattern>
-				<unitPattern count="many" case="genitive">{0} швидкостей світла</unitPattern>
-				<unitPattern count="many" case="instrumental">{0} швидкостями світла</unitPattern>
-				<unitPattern count="many" case="locative">{0} швидкостях світла</unitPattern>
-				<unitPattern count="other">{0} швидкості світла</unitPattern>
-				<unitPattern count="other" case="accusative">{0} швидкості світла</unitPattern>
-				<unitPattern count="other" case="dative">{0} швидкості світла</unitPattern>
-				<unitPattern count="other" case="genitive">{0} швидкості світла</unitPattern>
-				<unitPattern count="other" case="instrumental">{0} швидкості світла</unitPattern>
-				<unitPattern count="other" case="locative">{0} швидкості світла</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<gender>feminine</gender>
 				<displayName>частини на мільярд</displayName>
@@ -13640,13 +13612,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="many">{0} англ. кварт</unitPattern>
 				<unitPattern count="other">{0} англ. кварти</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>шв. св.</displayName>
-				<unitPattern count="one">{0} шв. св.</unitPattern>
-				<unitPattern count="few">{0} шв. св.</unitPattern>
-				<unitPattern count="many">{0} шв. св.</unitPattern>
-				<unitPattern count="other">{0} шв. св.</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>частини/млрд</displayName>
 				<unitPattern count="one">{0} част/млрд</unitPattern>
@@ -15101,13 +15066,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="few">{0}англ.квар.</unitPattern>
 				<unitPattern count="many">{0}англ.квар.</unitPattern>
 				<unitPattern count="other">{0}англ.квар.</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>шв.св.</displayName>
-				<unitPattern count="one">{0}шв.св.</unitPattern>
-				<unitPattern count="few">{0}шв.св.</unitPattern>
-				<unitPattern count="many">{0}шв.св.</unitPattern>
-				<unitPattern count="other">{0}шв.св.</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>ч/млрд</displayName>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -7243,11 +7243,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>yorug‘lik tezligi</displayName>
-				<unitPattern count="one">{0} yorug‘lik tezligi</unitPattern>
-				<unitPattern count="other">{0} yorug‘lik tezligi</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>qism/milliard</displayName>
 				<unitPattern count="one">{0} ta qism/milliard</unitPattern>
@@ -8327,11 +8322,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} imp. kvarta</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>yorug‘lik tezligi</displayName>
-				<unitPattern count="one">{0} yorug‘lik tezligi</unitPattern>
-				<unitPattern count="other">{0} yorug‘lik tezligi</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>qism/milliard</displayName>
 				<unitPattern count="one">{0} ta qism/mlrd</unitPattern>
@@ -9410,11 +9400,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>imp.kvarta</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>yorug‘lik tezligi</displayName>
-				<unitPattern count="one">{0} yorug‘lik tezligi</unitPattern>
-				<unitPattern count="other">{0} yorug‘lik tezligi</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>qism/milliard</displayName>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -10562,10 +10562,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>tốc độ ánh sáng</displayName>
-				<unitPattern count="other">{0} tốc độ ánh sáng</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>phần tỷ</displayName>
 				<unitPattern count="other">{0} phần tỷ</unitPattern>
@@ -11457,10 +11453,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>lít Anh</displayName>
 				<unitPattern count="other">{0} lít Anh</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>tốc độ ánh sáng</displayName>
-				<unitPattern count="other">{0} tốc độ ánh sáng</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>phần tỷ</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
@@ -12351,10 +12343,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>tốc độ ánh sáng</displayName>
-				<unitPattern count="other">{0}tốc độ ánh sáng</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -5814,8 +5814,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</unit>
 			<unit type="duration-year">
 				<displayName>ọ̀dún</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>{0} ọd</perUnitPattern>
+				<unitPattern count="other">{0} ọ̀dún</unitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>idamerin</displayName>
@@ -6710,7 +6709,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<unit type="duration-year">
 				<displayName>ọd</displayName>
 				<unitPattern count="other">{0} ọd</unitPattern>
-				<perUnitPattern>{0}/ọd</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>idame</displayName>
@@ -7603,9 +7601,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="other">↑↑↑</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
+				<displayName>ọd</displayName>
+				<unitPattern count="other">{0} ọd</unitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -15008,10 +15008,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>夜</displayName>
-				<unitPattern count="other">{0} 夜</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>十億分點濃度</displayName>
 				<unitPattern count="other">{0} 十億分點濃度</unitPattern>
@@ -15903,10 +15899,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>英制夸脫</displayName>
 				<unitPattern count="other">{0} 英制夸脫</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>夜</displayName>
-				<unitPattern count="other">{0} 夜</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>濃度/十億</displayName>
 				<unitPattern count="other">↑↑↑</unitPattern>
@@ -16797,10 +16789,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="other">{0}英制夸脫</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>夜</displayName>
-				<unitPattern count="other">{0} 夜</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -6934,12 +6934,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">{0} decades</unitPattern>
 			</unit>
-			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">{0} y</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
-			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -7661,11 +7655,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">{0} Imp. quart</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -8017,12 +8006,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-year">
-				<displayName>y</displayName>
-				<unitPattern count="one">{0} y</unitPattern>
-				<unitPattern count="other">{0} yrs</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
@@ -8745,11 +8728,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
 			<unit type="concentr-portion-per-1e9">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">↑↑↑</unitPattern>
@@ -9101,12 +9079,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0}dec</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="duration-year">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
-				<unitPattern count="other">{0} y</unitPattern>
-				<perUnitPattern>↑↑↑</perUnitPattern>
 			</unit>
 			<unit type="duration-quarter">
 				<displayName>↑↑↑</displayName>
@@ -9827,11 +9799,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<unit type="volume-quart-imperial">
 				<displayName>↑↑↑</displayName>
 				<unitPattern count="one">{0} Imp. quart</unitPattern>
-				<unitPattern count="other">↑↑↑</unitPattern>
-			</unit>
-			<unit type="speed-light-speed">
-				<displayName>↑↑↑</displayName>
-				<unitPattern count="one">↑↑↑</unitPattern>
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="concentr-portion-per-1e9">

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -76,7 +76,6 @@ import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StringId;
 import org.unicode.cldr.util.SupplementalDataInfo;
-// import org.unicode.cldr.util.Log;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 import org.unicode.cldr.util.VoteResolver;
@@ -2324,9 +2323,8 @@ public class CLDRModify {
                                             || newPath == null
                                             || newValue == null) {
                                         throw new IllegalArgumentException(
-                                                "Bad arguments, must have non-null for one of:"
-                                                        + "path, value, new_path, new_value "
-                                                        + ":\n\t"
+                                                action.action
+                                                        + ": must have no path nor value = null AND new_path or new_value:\n\t"
                                                         + entry);
                                     }
                                     String newPathString = newPath.getPath(getResolved());
@@ -2345,8 +2343,8 @@ public class CLDRModify {
                                     if ((pathMatch == null && valueMatch == null)
                                             || (newPath == null && newValue == null)) {
                                         throw new IllegalArgumentException(
-                                                "Bad arguments, must have "
-                                                        + "(path!=null OR value=null) AND (new_path!=null OR new_value!=null):\n\t"
+                                                action.action
+                                                        + ": must have (path or value) AND (new_path or new_value):\n\t"
                                                         + entry);
                                     }
                                     break;
@@ -2354,8 +2352,8 @@ public class CLDRModify {
                                 case delete:
                                     if (newPath != null || newValue != null) {
                                         throw new IllegalArgumentException(
-                                                "Bad arguments, must have "
-                                                        + "newPath=null, newValue=null"
+                                                action.action
+                                                        + ": must have no new_path nor new_value:\n\t"
                                                         + entry);
                                     }
                                     break;

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,134 +1,487 @@
-# Fix hebrew units
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-jigger"]/unitPattern[@count="one"];	new_value={0} ג׳יגר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pinch"]/unitPattern[@count="one"];	new_value={0} פינץ׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-hour"]/unitPattern[@count="one"];	new_value={0} שע׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-solar-radius"]/unitPattern[@count="other"];	new_value={0} R☉\x{200E}
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-foot"]/perUnitPattern;	new_value={0} \x{200E}/ft
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-inch"]/perUnitPattern;	new_value={0} \x{200E}/in
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-micrometer"]/unitPattern[@count="other"];	new_value={0} μm
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="mass-tonne"]/unitPattern[@count="one"];	new_value={0} t
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-revolution"]/unitPattern[@count="one"];	new_value={0} סיבוב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"];	new_value={0} דקת קשת
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"];	new_value={0} שניית קשת
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-kilometer"]/unitPattern[@count="one"];	new_value={0} קילומטר רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-hectare"]/unitPattern[@count="one"];	new_value={0} הקטאר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-meter"]/unitPattern[@count="one"];	new_value={0} מטר רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-centimeter"]/unitPattern[@count="one"];	new_value={0} סנטימטר רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-mile"]/unitPattern[@count="one"];	new_value={0} מייל רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-acre"]/unitPattern[@count="one"];	new_value={0} אקר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-yard"]/unitPattern[@count="one"];	new_value={0} יארד רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-foot"]/unitPattern[@count="one"];	new_value={0} רגל רבועה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="area-square-inch"]/unitPattern[@count="one"];	new_value={0} אינץ׳ רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="concentr-permyriad"]/unitPattern[@count="one"];	new_value={0} רבבית
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="one"];	new_value={0} טרה-בייט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="two"];	new_value={0} טרה-בייט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="many"];	new_value={0} טרה-בייט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="digital-terabyte"]/unitPattern[@count="other"];	new_value={0} טרה-בייט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-millisecond"]/unitPattern[@count="one"];	new_value={0} אלפית שנייה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-ampere"]/unitPattern[@count="one"];	new_value={0} אמפר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-milliampere"]/unitPattern[@count="one"];	new_value={0} מיליאמפר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="electric-volt"]/unitPattern[@count="one"];	new_value={0} וולט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilocalorie"]/unitPattern[@count="one"];	new_value={0} קילו קלוריה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-calorie"]/unitPattern[@count="one"];	new_value={0} קלוריה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilojoule"]/unitPattern[@count="one"];	new_value={0} קילו ג׳אול
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="energy-kilowatt-hour"]/unitPattern[@count="one"];	new_value={0} קילוואט־שעה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-gigahertz"]/unitPattern[@count="one"];	new_value={0} ג׳יגה-הרץ
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-megahertz"]/unitPattern[@count="one"];	new_value={0} מגה-הרץ
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-kilohertz"]/unitPattern[@count="one"];	new_value={0} קילו-הרץ
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="frequency-hertz"]/unitPattern[@count="one"];	new_value={0} הרץ
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="graphics-dot-per-centimeter"]/unitPattern[@count="one"];	new_value={0} נקודהלסנטימטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-kilometer"]/unitPattern[@count="one"];	new_value={0} קילומטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-meter"]/unitPattern[@count="one"];	new_value={0} מטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-decimeter"]/unitPattern[@count="one"];	new_value={0} דצימטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-centimeter"]/unitPattern[@count="one"];	new_value={0} סנטימטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-millimeter"]/unitPattern[@count="one"];	new_value={0} מילימטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-micrometer"]/unitPattern[@count="one"];	new_value={0} מיקרומטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nanometer"]/unitPattern[@count="one"];	new_value={0} ננומטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-picometer"]/unitPattern[@count="one"];	new_value={0} פיקומטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-foot"]/unitPattern[@count="one"];	new_value={0} רגל
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-inch"]/unitPattern[@count="one"];	new_value={0} אינץ׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-astronomical-unit"]/unitPattern[@count="one"];	new_value={0} יחידה אסטרונומית
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-nautical-mile"]/unitPattern[@count="one"];	new_value={0} מייל ימי
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-mile-scandinavian"]/unitPattern[@count="one"];	new_value={0} מייל-סקנדינביה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="length-point"]/unitPattern[@count="one"];	new_value={0} נקודה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="light-lumen"]/unitPattern[@count="one"];	new_value={0} לומן
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"];	new_value={0} קילוגרם
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-gram"]/unitPattern[@count="one"];	new_value={0} גרם
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-ton"]/unitPattern[@count="one"];	new_value={0} טונה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-ounce"]/unitPattern[@count="one"];	new_value={0} אונקיה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="mass-ounce-troy"]/unitPattern[@count="one"];	new_value={0} אונקיית טרוי
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-gigawatt"]/unitPattern[@count="one"];	new_value={0} ג׳יגה ואט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-megawatt"]/unitPattern[@count="one"];	new_value={0} מגה ואט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-kilowatt"]/unitPattern[@count="one"];	new_value={0} קילוואט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-watt"]/unitPattern[@count="one"];	new_value={0} ואט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-milliwatt"]/unitPattern[@count="one"];	new_value={0} מיליוואט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="power-horsepower"]/unitPattern[@count="one"];	new_value={0} כוח סוס
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-pound-force-per-square-inch"]/unitPattern[@count="one"];	new_value={0} פאונדלאינץ׳ רבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-inch-ofhg"]/unitPattern[@count="one"];	new_value={0} אינץ׳ כספית
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="pressure-hectopascal"]/unitPattern[@count="one"];	new_value={0} הקטופסקל
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-beaufort"]/unitPattern[@count="one"];	new_value={0} בופורט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-beaufort"]/unitPattern[@count="two"];	new_value={0} בופורט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-beaufort"]/unitPattern[@count="other"];	new_value={0} בופורט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-celsius"]/unitPattern[@count="one"];	new_value={0} מעלת צלזיוס
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-fahrenheit"]/unitPattern[@count="one"];	new_value={0} מעלת פרנהייט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="temperature-kelvin"]/unitPattern[@count="one"];	new_value={0} קלווין
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="one"];	new_value={0} קילומטר מעוקב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="one"];	new_value={0} מטר מעוקב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-centimeter"]/unitPattern[@count="one"];	new_value={0} סנטימטר מעוקב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-mile"]/unitPattern[@count="one"];	new_value={0} מייל מעוקב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-foot"]/unitPattern[@count="one"];	new_value={0} רגל מעוקב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-inch"]/unitPattern[@count="one"];	new_value={0} אינץ׳ מעוקב
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-megaliter"]/unitPattern[@count="one"];	new_value={0} מגה ליטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-hectoliter"]/unitPattern[@count="one"];	new_value={0} הקטוליטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-liter"]/unitPattern[@count="one"];	new_value={0} ליטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-deciliter"]/unitPattern[@count="one"];	new_value={0} דציליטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-centiliter"]/unitPattern[@count="one"];	new_value={0} סנטיליטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-milliliter"]/unitPattern[@count="one"];	new_value={0} מיליליטר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint-metric"]/unitPattern[@count="one"];	new_value={0} פינט מטרי
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup-metric"]/unitPattern[@count="one"];	new_value={0} כוס מידה מטרית
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-acre-foot"]/unitPattern[@count="one"];	new_value={0} אקר-רגל
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon"]/unitPattern[@count="one"];	new_value={0} גלון
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-gallon-imperial"]/unitPattern[@count="one"];	new_value={0} גלון אימפריאלי
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart"]/unitPattern[@count="one"];	new_value={0} קווארטה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-pint"]/unitPattern[@count="one"];	new_value={0} פינט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-cup"]/unitPattern[@count="one"];	new_value={0} כוס
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce"]/unitPattern[@count="one"];	new_value={0} אונקיית נוזלים
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-teaspoon"]/unitPattern[@count="one"];	new_value={0} כפית
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-dram"]/unitPattern[@count="one"];	new_value={0} דראם אלכוהול
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="volume-quart-imperial"]/unitPattern[@count="one"];	new_value={0} קווארט אימפריאלי
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"];	new_value={0} ד׳ קשת
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"];	new_value={0} שנ׳ קשת
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="concentr-item"]/unitPattern[@count="one"];	new_value={0} פריט
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-century"]/unitPattern[@count="one"];	new_value={0} מאה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-decade"]/unitPattern[@count="one"];	new_value={0} עשור
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="one"];	new_value={0} שנה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-week"]/unitPattern[@count="one"];	new_value={0} שבוע
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-day"]/unitPattern[@count="one"];	new_value={0} יום
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-millimeter"]/unitPattern[@count="one"];	new_value={0} מ″מ
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-nanometer"]/unitPattern[@count="other"];	new_value={0} nm
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-picometer"]/unitPattern[@count="one"];	new_value={0} פ“מ
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-yard"]/unitPattern[@count="one"];	new_value={0} יארד
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-foot"]/unitPattern[@count="other"];	new_value={0} ft
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-inch"]/unitPattern[@count="other"];	new_value={0} in
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-parsec"]/unitPattern[@count="other"];	new_value={0} pc
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-light-year"]/unitPattern[@count="one"];	new_value={0} שנת אור
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-astronomical-unit"]/unitPattern[@count="other"];	new_value={0} au
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="length-point"]/unitPattern[@count="one"];	new_value={0} נק׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-kilogram"]/unitPattern[@count="one"];	new_value={0} ק״ג
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-gram"]/unitPattern[@count="one"];	new_value={0} גר׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-ton"]/unitPattern[@count="one"];	new_value={0} ט׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-stone"]/unitPattern[@count="one"];	new_value={0} סטון
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="mass-grain"]/unitPattern[@count="one"];	new_value={0} גרעין
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="power-horsepower"]/unitPattern[@count="one"];	new_value={0} כ״ס
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cubic-kilometer"]/unitPattern[@count="one"];	new_value={0} קמ״ק
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-liter"]/unitPattern[@count="one"];	new_value={0} ל׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-milliliter"]/unitPattern[@count="one"];	new_value={0} מ״ל
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="volume-cup"]/unitPattern[@count="one"];	new_value={0} כ׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="angle-arc-minute"]/unitPattern[@count="one"];	new_value={0} דקה
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="angle-arc-second"]/unitPattern[@count="one"];	new_value={0} שנ׳
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="area-square-kilometer"]/unitPattern[@count="one"];	new_value={0} קמ״ר
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="one"];	new_value={0} ש′
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-week"]/unitPattern[@count="one"];	new_value={0} ש′
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-beaufort"]/unitPattern[@count="one"];	new_value={0} B
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-beaufort"]/unitPattern[@count="two"];	new_value={0} B
-locale=he;	action=add;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-beaufort"]/unitPattern[@count="other"];	new_value={0} B
+#Locale	Action=add;	Path	Value
+#Locale	Action=add;	Value	Path
+locale=ak;	action=add;	new_value=mfeɛ {0};	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=ak;	action=add;	new_value=mfeɛ {0};	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=cs;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="short"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=da;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="long"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=da;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=da;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="short"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=ig;	action=add;	new_value=Ọtụtụ Afọ;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/displayName
+locale=ig;	action=add;	new_value={0} Ọtụtụ Afọ;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=it;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="long"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=nl;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="short"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=nn;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="short"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=sk;	action=add;	new_value=↑↑↑;	new_path=//ldml/units/unitLength[@type="short"]/compoundUnit[@type="times"]/compoundUnitPattern
+locale=ti;	action=add;	new_value=ዓመታት;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/displayName
+locale=ti;	action=add;	new_value={0}/ዓመታት;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/perUnitPattern
+locale=ti;	action=add;	new_value={0} ዓመት;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=ti;	action=add;	new_value={0} ዓመታት;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=ti;	action=add;	new_value=ዓመታት;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/displayName
+locale=ti;	action=add;	new_value={0}/ዓመት;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/perUnitPattern
+locale=ti;	action=add;	new_value={0} ዓመት;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=ti;	action=add;	new_value={0}ዓመት;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=ti;	action=add;	new_value=ዓመታት;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/displayName
+locale=ti;	action=add;	new_value={0}/ዓመት;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/perUnitPattern
+locale=ti;	action=add;	new_value={0} ዓመት;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=ti;	action=add;	new_value={0} ዓመታት;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=yo;	action=add;	new_value=ọ̀dún;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/displayName
+locale=yo;	action=add;	new_value={0} ọ̀dún;	new_path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=yo;	action=add;	new_value=ọd;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/displayName
+locale=yo;	action=add;	new_value={0} ọd;	new_path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=yo;	action=add;	new_value=ọd;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/displayName
+locale=yo;	action=add;	new_value={0} ọd;	new_path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="two"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="zero"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="two"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="zero"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="two"]
+locale=ar;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="zero"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=be;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=bn;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=bs;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=da;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=de;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=et;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fa;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="elative"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="illative"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="partitive"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="elative"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="illative"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="partitive"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fi;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=fil;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="two"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="two"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ga;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="two"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName[@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="instrumental"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="terminative"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="translative"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="instrumental"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="terminative"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="translative"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName[@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName[@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@draft="contributed"]
+locale=hu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@draft="contributed"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="ablative"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="instrumental"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="locative"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="ablative"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="instrumental"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="locative"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=hy;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/perUnitPattern
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/displayName
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/perUnitPattern
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/displayName
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/perUnitPattern
+locale=ig;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=is;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender[@draft="contributed"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@draft="contributed"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@draft="contributed"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@draft="contributed"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@draft="contributed"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@draft="contributed"]
+locale=it;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@draft="contributed"]
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ka;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ko;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ko;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ko;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ko;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ko;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ko;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="accusative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="dative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="genitive"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="instrumental"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="locative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="accusative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="dative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="genitive"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="instrumental"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="locative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="instrumental"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="locative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="instrumental"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="locative"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=lt;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ml;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=mn;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ps;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="accusative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="dative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="genitive"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="instrumental"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="prepositional"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="accusative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="dative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="genitive"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="instrumental"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="prepositional"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="instrumental"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="prepositional"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="instrumental"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="prepositional"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=ru;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="accusative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="dative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="genitive"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="instrumental"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="locative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="accusative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="dative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="genitive"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="instrumental"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="locative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="instrumental"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="locative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="instrumental"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="locative"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=sk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=sq;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/gender
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="accusative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="dative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="genitive"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="instrumental"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="locative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="accusative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="dative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="genitive"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="instrumental"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="locative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="dative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="instrumental"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="locative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="dative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="instrumental"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="locative"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=uk;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=uz;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=vi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=vi;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=vi;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=vi;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=vi;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=vi;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=yo;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/perUnitPattern
+locale=yo;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/perUnitPattern
+locale=yo;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/perUnitPattern
+locale=zh_Hant;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=zh_Hant;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=zh_Hant;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=zh_Hant;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=zh_Hant;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=zh_Hant;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/displayName
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/perUnitPattern
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/displayName
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/perUnitPattern
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/displayName
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="narrow"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/displayName
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/perUnitPattern
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="one"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="duration-year"]/unitPattern[@count="other"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+locale=zu;	action=delete;		path=//ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -912,7 +912,7 @@ public class TestCLDRFile extends TestFmwk {
                 continue;
             }
             String value = swissHighGerman.getStringValue(xpath);
-            if (value.indexOf('ß') >= 0) {
+            if (value != null && value.indexOf('ß') >= 0) {
                 warnln("«" + value + "» contains ß at " + xpath);
             }
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -29,6 +29,7 @@ import com.ibm.icu.number.NumberFormatter;
 import com.ibm.icu.number.NumberFormatter.UnitWidth;
 import com.ibm.icu.number.Precision;
 import com.ibm.icu.number.UnlocalizedNumberFormatter;
+import com.ibm.icu.text.MessageFormat;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ICUUncheckedIOException;
@@ -88,6 +89,7 @@ import org.unicode.cldr.util.GrammarInfo;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalFeature;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
+import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleStringProvider;
 import org.unicode.cldr.util.MapComparator;
 import org.unicode.cldr.util.Organization;
@@ -124,6 +126,8 @@ import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 
 public class TestUnits extends TestFmwk {
+    private static final Joiner JOIN_TAB = Joiner.on('\t').useForNull("∅");
+    private static final StandardCodes STANDARD_CODES = StandardCodes.make();
     private static final boolean DEBUG = System.getProperty("TestUnits:DEBUG") != null;
     private static final boolean TEST_ICU = System.getProperty("TestUnits:TEST_ICU") != null;
 
@@ -2694,7 +2698,7 @@ public class TestUnits extends TestFmwk {
 
         // first gather all the  examples
         Set<String> skippedUnits = new LinkedHashSet<>();
-        Set<String> testSet = StandardCodes.make().getLocaleCoverageLocales(Organization.cldr);
+        Set<String> testSet = STANDARD_CODES.getLocaleCoverageLocales(Organization.cldr);
         Counter<String> localeToErrorCount = new Counter<>();
         main:
         for (String localeId : testSet) {
@@ -3313,7 +3317,7 @@ public class TestUnits extends TestFmwk {
                 if (pluralForm == null) {
                     errln("Have display name but no plural: " + pluralFormPath);
                 } else {
-                    String cleaned = pluralForm.replace("{0}", "").trim();
+                    String cleaned = clean(pluralForm);
                     assertEquals(
                             "Unit display name should correspond to plural in English "
                                     + width
@@ -4490,5 +4494,57 @@ public class TestUnits extends TestFmwk {
             {"light-speed-week", "meter-second-per-second", "299792458*604800"},
         };
         checkConversionToBase(tests);
+
+        Factory factory = CLDR_CONFIG.getFullCldrFactory();
+        Set<String> available = factory.getAvailableLanguages();
+        Set<String> TC =
+                Sets.intersection(
+                        available,
+                        Sets.difference(
+                                STANDARD_CODES.getLocaleCoverageLocales(Organization.cldr),
+                                STANDARD_CODES.getLocaleCoverageLocales(Organization.special)));
+        // UnitId id = converter.createUnitId("light-speed-second");
+        // String lightSeconds1 = id.toString(cldrFile,"long", "other", "nominative", null, true);
+        if (isVerbose()) {
+            System.out.println(
+                    "\nlocale, times, light, years, lightYears, lightYearsC".replace(", ", "\t"));
+        }
+        Set<Level> neededCoverageLevel = Set.of(Level.MODERATE, Level.MODERN, Level.COMPREHENSIVE);
+        for (String locale : TC) {
+            Level coverage = STANDARD_CODES.getLocaleCoverageLevel(Organization.cldr, locale);
+            if (!neededCoverageLevel.contains(coverage)) {
+                continue;
+            }
+            CLDRFile cldrFile = factory.make(locale, true);
+            String lightYears =
+                    clean(
+                            cldrFile.getStringValue(
+                                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"length-light-year\"]/unitPattern[@count=\"other\"]"));
+            String years =
+                    clean(
+                            cldrFile.getStringValue(
+                                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-year\"]/unitPattern[@count=\"other\"]"));
+            String light =
+                    clean(
+                            cldrFile.getStringValue(
+                                    "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"speed-light-speed\"]/unitPattern[@count=\"one\"]"));
+            String times =
+                    cldrFile.getStringValue(
+                            "//ldml/units/unitLength[@type=\"long\"]/compoundUnit[@type=\"times\"]/compoundUnitPattern");
+            String lightYearsC = MessageFormat.format(times, light, clean(years));
+            // String seconds =
+            // clean(cldrFile.getStringValue("//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"duration-second\"]/unitPattern[@count=\"other\"]"));
+            // String lightSecondsC = MessageFormat.format(times, light, clean(seconds));
+
+            times = clean(times);
+            if (isVerbose()) {
+                System.out.println(
+                        JOIN_TAB.join(locale, times, light, years, lightYears, lightYearsC));
+            }
+        }
+    }
+
+    public String clean(String unitPattern) {
+        return unitPattern.replace("{0}", "").replace("{1}", "").trim();
     }
 }


### PR DESCRIPTION
CLDR-17835

The goal for type="speed-light-speed" is to be able to generate names for light-second, light-minute, and so on. In this cycle, that information was generated as a trial, allowing use to compare what the synthesized name for light-year would be against the extant names for light year. 

Much of the data looks pretty good, but some was sufficiently bad that it needed deletion. There are also cases where the data for type="speed-light-speed" looks ok, but some additional structure needs to be added before it can be deployed in synthesized names. In particular:
- In some locales, the order of the components needs to be different, eg the equivalent of "year-light" (see https://it.wikipedia.org/wiki/Anno_luce)
- In some locales, the separator needs to be changed to space or removed.

This could be done changing the type="times" values, which provide the separator and order. But it appears that it needs to be refined, because 'light-" behaves a bit differently. For example French reverses the order for light-year (https://fr.wikipedia.org/wiki/Année-lumière), but does not for kilowatt-hour (https://fr.wikipedia.org/wiki/Kilowatt-heure) 

We should be able to add some additional structure for those in the next cycle, but we are too close to release to do it in this cycle.

Locale file changes
- Most data changes were removals of type="speed-light-speed" that were clearly problematic
- Some were deletions of problematic type="duration-year", type="times", type="duration-light-year".
- Some were 'rescues', where it was clear from other items in the locale what the values should have been
    -example, common/main/ak.xml

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
- Add tooling to show information about light-speed, light, year, light-year, and times patterns (in verbose mode)
- Use that information (see https://docs.google.com/spreadsheets/d/1LxzAysbtYQtbW1hIqlx0TpqMyv7PLv1vm_pB_sdpWM8/edit?gid=2062266520#gid=2062266520 to come up with a set of changes that fix the problematic cases.
- Use SearchXML to find the paths for all the the units in locales that have the issues.
    - For example, the following options were used to get the items that had problems with some paths for duration-year
    - -f^(tg|tt|xh|zu|ig|ti|yo)$
    - -p\\Q@type=\"duration-year\"\\E
    - Note the use of \\Q...\\E to get a non-regex match, and the use of \" to keep the console from removing the literal " marks
- In another sheet of the spreadsheet, refine the search results as input for modify_config
    - Change most fields from add to delete (This will cause them to inherit from root, and then be open for translation next time.
    - Delete some of the lines that were ok to keep
    - For add, look over the results to see where it was clear what could be retained.
 - Run CLDRModify -fk to make the changes in the files.
 - Review again, and create this PR.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
