### PR TITLE
CLDR-17897 Make ConvertLanguageData Consistent

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -261,6 +261,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="ha_CM" to="ha_Arab_CM"/>		<!--Hausa‧?‧Cameroon	➡ Hausa‧Arabic‧Cameroon-->
 		<likelySubtag from="ha_SD" to="ha_Arab_SD"/>		<!--Hausa‧?‧Sudan	➡ Hausa‧Arabic‧Sudan-->
 		<likelySubtag from="hak" to="hak_Hans_CN"/>		<!--Hakka Chinese‧?‧?	➡ Hakka Chinese‧Simplified‧China-->
+		<likelySubtag from="hak_TW" to="hak_Hant_TW"/>		<!--Hakka Chinese‧?‧Taiwan	➡ Hakka Chinese‧Traditional‧Taiwan-->
+		<likelySubtag from="hak_Hant" to="hak_Hant_TW"/>		<!--Hakka Chinese‧Traditional‧?	➡ Hakka Chinese‧Traditional‧Taiwan-->
 		<likelySubtag from="haw" to="haw_Latn_US"/>		<!--Hawaiian‧?‧?	➡ Hawaiian‧Latin‧United States-->
 		<likelySubtag from="haz" to="haz_Arab_AF"/>		<!--Hazaragi‧?‧?	➡ Hazaragi‧Arabic‧Afghanistan-->
 		<likelySubtag from="he" to="he_Hebr_IL"/>		<!--Hebrew‧?‧?	➡ Hebrew‧Hebrew‧Israel-->
@@ -434,6 +436,8 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="lwl" to="lwl_Thai_TH"/>		<!--Eastern Lawa‧?‧?	➡ Eastern Lawa‧Thai‧Thailand-->
 		<likelySubtag from="lzh" to="lzh_Hans_CN"/>		<!--Literary Chinese‧?‧?	➡ Literary Chinese‧Simplified‧China-->
 		<likelySubtag from="lzz" to="lzz_Latn_TR"/>		<!--Laz‧?‧?	➡ Laz‧Latin‧Türkiye-->
+		<likelySubtag from="lzz_GE" to="lzz_Geor_GE"/>		<!--Laz‧?‧Georgia	➡ Laz‧Georgian‧Georgia-->
+		<likelySubtag from="lzz_Geor" to="lzz_Geor_GE"/>		<!--Laz‧Georgian‧?	➡ Laz‧Georgian‧Georgia-->
 		<likelySubtag from="mad" to="mad_Latn_ID"/>		<!--Madurese‧?‧?	➡ Madurese‧Latin‧Indonesia-->
 		<likelySubtag from="maf" to="maf_Latn_CM"/>		<!--Mafa‧?‧?	➡ Mafa‧Latin‧Cameroon-->
 		<likelySubtag from="mag" to="mag_Deva_IN"/>		<!--Magahi‧?‧?	➡ Magahi‧Devanagari‧India-->
@@ -497,7 +501,9 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="myz" to="myz_Mand_IR"/>		<!--Classical Mandaic‧?‧?	➡ Classical Mandaic‧Mandaean‧Iran-->
 		<likelySubtag from="mzn" to="mzn_Arab_IR"/>		<!--Mazanderani‧?‧?	➡ Mazanderani‧Arabic‧Iran-->
 		<likelySubtag from="na" to="na_Latn_NR"/>		<!--Nauru‧?‧?	➡ Nauru‧Latin‧Nauru-->
-		<likelySubtag from="nan" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧?‧?	➡ Min Nan Chinese‧Simplified‧China-->
+		<likelySubtag from="nan" to="nan_Hant_TW"/>		<!--Min Nan Chinese‧?‧?	➡ Min Nan Chinese‧Traditional‧Taiwan-->
+		<likelySubtag from="nan_CN" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧?‧China	➡ Min Nan Chinese‧Simplified‧China-->
+		<likelySubtag from="nan_Hans" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧Simplified‧?	➡ Min Nan Chinese‧Simplified‧China-->
 		<likelySubtag from="nap" to="nap_Latn_IT"/>		<!--Neapolitan‧?‧?	➡ Neapolitan‧Latin‧Italy-->
 		<likelySubtag from="naq" to="naq_Latn_NA"/>		<!--Nama‧?‧?	➡ Nama‧Latin‧Namibia-->
 		<likelySubtag from="nb" to="nb_Latn_NO"/>		<!--Norwegian Bokmål‧?‧?	➡ Norwegian Bokmål‧Latin‧Norway-->
@@ -567,6 +573,10 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="pl" to="pl_Latn_PL"/>		<!--Polish‧?‧?	➡ Polish‧Latin‧Poland-->
 		<likelySubtag from="pms" to="pms_Latn_IT"/>		<!--Piedmontese‧?‧?	➡ Piedmontese‧Latin‧Italy-->
 		<likelySubtag from="pnt" to="pnt_Grek_GR"/>		<!--Pontic‧?‧?	➡ Pontic‧Greek‧Greece-->
+		<likelySubtag from="pnt_RU" to="pnt_Cyrl_RU"/>		<!--Pontic‧?‧Russia	➡ Pontic‧Cyrillic‧Russia-->
+		<likelySubtag from="pnt_TR" to="pnt_Latn_TR"/>		<!--Pontic‧?‧Türkiye	➡ Pontic‧Latin‧Türkiye-->
+		<likelySubtag from="pnt_Cyrl" to="pnt_Cyrl_RU"/>		<!--Pontic‧Cyrillic‧?	➡ Pontic‧Cyrillic‧Russia-->
+		<likelySubtag from="pnt_Latn" to="pnt_Latn_TR"/>		<!--Pontic‧Latin‧?	➡ Pontic‧Latin‧Türkiye-->
 		<likelySubtag from="pon" to="pon_Latn_FM"/>		<!--Pohnpeian‧?‧?	➡ Pohnpeian‧Latin‧Micronesia-->
 		<likelySubtag from="pqm" to="pqm_Latn_CA"/>		<!--Maliseet-Passamaquoddy‧?‧?	➡ Maliseet-Passamaquoddy‧Latin‧Canada-->
 		<likelySubtag from="pra" to="pra_Khar_PK"/>		<!--Prakrit languages‧?‧?	➡ Prakrit languages‧Kharoshthi‧Pakistan-->
@@ -1036,6 +1046,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Ahom" to="aho_Ahom_IN"/>		<!--?‧Ahom‧?	➡ Ahom‧Ahom‧India-->
 		<likelySubtag from="und_Arab" to="ar_Arab_EG"/>		<!--?‧Arabic‧?	➡ Arabic‧Arabic‧Egypt-->
 		<likelySubtag from="und_Arab_AF" to="fa_Arab_AF"/>		<!--?‧Arabic‧Afghanistan	➡ Persian‧Arabic‧Afghanistan-->
+		<likelySubtag from="und_Arab_AZ" to="az_Arab_AZ"/>		<!--?‧Arabic‧Azerbaijan	➡ Azerbaijani‧Arabic‧Azerbaijan-->
 		<likelySubtag from="und_Arab_BN" to="ms_Arab_BN"/>		<!--?‧Arabic‧Brunei	➡ Malay‧Arabic‧Brunei-->
 		<likelySubtag from="und_Arab_CC" to="ms_Arab_CC"/>		<!--?‧Arabic‧Cocos (Keeling) Islands	➡ Malay‧Arabic‧Cocos (Keeling) Islands-->
 		<likelySubtag from="und_Arab_CN" to="ug_Arab_CN"/>		<!--?‧Arabic‧China	➡ Uyghur‧Arabic‧China-->

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -501,9 +501,9 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="myz" to="myz_Mand_IR"/>		<!--Classical Mandaic‧?‧?	➡ Classical Mandaic‧Mandaean‧Iran-->
 		<likelySubtag from="mzn" to="mzn_Arab_IR"/>		<!--Mazanderani‧?‧?	➡ Mazanderani‧Arabic‧Iran-->
 		<likelySubtag from="na" to="na_Latn_NR"/>		<!--Nauru‧?‧?	➡ Nauru‧Latin‧Nauru-->
-		<likelySubtag from="nan" to="nan_Hant_TW"/>		<!--Min Nan Chinese‧?‧?	➡ Min Nan Chinese‧Traditional‧Taiwan-->
-		<likelySubtag from="nan_CN" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧?‧China	➡ Min Nan Chinese‧Simplified‧China-->
-		<likelySubtag from="nan_Hans" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧Simplified‧?	➡ Min Nan Chinese‧Simplified‧China-->
+		<likelySubtag from="nan" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧?‧?	➡ Min Nan Chinese‧Simplified‧China-->
+		<likelySubtag from="nan_TW" to="nan_Hant_TW"/>		<!--Min Nan Chinese‧?‧Taiwan	➡ Min Nan Chinese‧Traditional‧Taiwan-->
+		<likelySubtag from="nan_Hant" to="nan_Hant_TW"/>		<!--Min Nan Chinese‧Traditional‧?	➡ Min Nan Chinese‧Traditional‧Taiwan-->
 		<likelySubtag from="nap" to="nap_Latn_IT"/>		<!--Neapolitan‧?‧?	➡ Neapolitan‧Latin‧Italy-->
 		<likelySubtag from="naq" to="naq_Latn_NA"/>		<!--Nama‧?‧?	➡ Nama‧Latin‧Namibia-->
 		<likelySubtag from="nb" to="nb_Latn_NO"/>		<!--Norwegian Bokmål‧?‧?	➡ Norwegian Bokmål‧Latin‧Norway-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1647,7 +1647,7 @@ XXX Code for transations where no currency is involved
 		<language type="ha" scripts="Arab Latn"/>
 		<language type="ha" territories="NE NG" alt="secondary"/>
 		<language type="hai" scripts="Latn"/>
-		<language type="hak" scripts="Hans"/>
+		<language type="hak" scripts="Hans Hant" territories="TW"/>
 		<language type="hak" territories="CN" alt="secondary"/>
 		<language type="haw" scripts="Latn"/>
 		<language type="haw" territories="US" alt="secondary"/>
@@ -1890,7 +1890,8 @@ XXX Code for transations where no currency is involved
 		<language type="lv" scripts="Latn" territories="LV"/>
 		<language type="lwl" scripts="Thai"/>
 		<language type="lzh" scripts="Hans" alt="secondary"/>
-		<language type="lzz" scripts="Latn Geor"/>
+		<language type="lzz" scripts="Latn"/>
+		<language type="lzz" scripts="Geor" alt="secondary"/>
 		<language type="mad" scripts="Latn"/>
 		<language type="mad" territories="ID" alt="secondary"/>
 		<language type="maf" scripts="Latn"/>
@@ -1979,7 +1980,7 @@ XXX Code for transations where no currency is involved
 		<language type="mzn" scripts="Arab"/>
 		<language type="mzn" territories="IR" alt="secondary"/>
 		<language type="na" scripts="Latn" territories="NR"/>
-		<language type="nan" scripts="Hans"/>
+		<language type="nan" scripts="Hans Hant" territories="TW"/>
 		<language type="nan" territories="CN" alt="secondary"/>
 		<language type="nap" scripts="Latn"/>
 		<language type="naq" scripts="Latn"/>
@@ -2070,14 +2071,15 @@ XXX Code for transations where no currency is involved
 		<language type="peo" scripts="Xpeo" alt="secondary"/>
 		<language type="pfl" scripts="Latn"/>
 		<language type="phn" scripts="Phnx" alt="secondary"/>
-		<language type="pi" scripts="Deva Sinh Thai" alt="secondary"/>
+		<language type="pi" scripts="Deva Mymr Sinh Thai" alt="secondary"/>
 		<language type="pis" scripts="Latn"/>
 		<language type="pis" territories="SB" alt="secondary"/>
 		<language type="pko" scripts="Latn"/>
 		<language type="pl" scripts="Latn" territories="PL"/>
 		<language type="pl" territories="GB" alt="secondary"/>
 		<language type="pms" scripts="Latn"/>
-		<language type="pnt" scripts="Grek Cyrl Latn"/>
+		<language type="pnt" scripts="Grek"/>
+		<language type="pnt" scripts="Cyrl Latn" alt="secondary"/>
 		<language type="pon" scripts="Latn"/>
 		<language type="pon" territories="FM" alt="secondary"/>
 		<language type="pqm" scripts="Latn"/>
@@ -2277,11 +2279,12 @@ XXX Code for transations where no currency is involved
 		<language type="tk" scripts="Arab Cyrl Latn" territories="TM"/>
 		<language type="tk" territories="AF IR" alt="secondary"/>
 		<language type="tkl" scripts="Latn" territories="TK"/>
-		<language type="tkr" scripts="Latn Cyrl"/>
+		<language type="tkr" scripts="Latn"/>
+		<language type="tkr" scripts="Cyrl" alt="secondary"/>
 		<language type="tkt" scripts="Deva"/>
 		<language type="tli" scripts="Latn"/>
-		<language type="tly" scripts="Latn Arab Cyrl"/>
-		<language type="tly" territories="AZ" alt="secondary"/>
+		<language type="tly" scripts="Latn"/>
+		<language type="tly" scripts="Arab Cyrl" territories="AZ" alt="secondary"/>
 		<language type="tmh" scripts="Latn"/>
 		<language type="tmh" territories="NE" alt="secondary"/>
 		<language type="tn" scripts="Latn" territories="BW"/>
@@ -2309,8 +2312,8 @@ XXX Code for transations where no currency is involved
 		<language type="ttj" scripts="Latn"/>
 		<language type="tts" scripts="Thai"/>
 		<language type="tts" territories="TH" alt="secondary"/>
-		<language type="ttt" scripts="Latn Cyrl"/>
-		<language type="ttt" scripts="Arab" alt="secondary"/>
+		<language type="ttt" scripts="Latn"/>
+		<language type="ttt" scripts="Arab Cyrl" alt="secondary"/>
 		<language type="tum" scripts="Latn"/>
 		<language type="tum" territories="MW" alt="secondary"/>
 		<language type="tvl" scripts="Latn" territories="TV"/>
@@ -3072,6 +3075,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="ab" populationPercent="2.2" officialStatus="official_regional"/>	<!--Abkhazian-->
 			<languagePopulation type="os" populationPercent="2.2" officialStatus="official_regional"/>	<!--Ossetic-->
 			<languagePopulation type="ku" populationPercent="0.89"/>	<!--Kurdish-->
+			<languagePopulation type="lzz_Geor" populationPercent="0.002" references="R1334"/>	<!--Laz (Georgian)-->
 		</territory>
 		<territory type="GF" gdp="1551000000" literacyPercent="83" population="199509">	<!--French Guiana-->
 			<languagePopulation type="fr" populationPercent="77" officialStatus="official" references="R1019"/>	<!--French-->
@@ -3999,6 +4003,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="krl" populationPercent="0.082"/>	<!--Karelian-->
 			<languagePopulation type="lbe" populationPercent="0.078" officialStatus="official_regional"/>	<!--Lak-->
 			<languagePopulation type="koi" populationPercent="0.045" officialStatus="official_regional"/>	<!--Komi-Permyak-->
+			<languagePopulation type="pnt_Cyrl" populationPercent="0.04" references="R1335"/>	<!--Pontic (Cyrillic)-->
 			<languagePopulation type="mrj" populationPercent="0.021"/>	<!--Western Mari-->
 			<languagePopulation type="alt" populationPercent="0.014"/>	<!--Southern Altai-->
 			<languagePopulation type="fi" populationPercent="0.012"/>	<!--Finnish-->
@@ -4226,7 +4231,6 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="ku" populationPercent="5.5"/>	<!--Kurdish-->
 			<languagePopulation type="apc" populationPercent="5.2" references="R1173"/>	<!--Levantine Arabic-->
 			<languagePopulation type="zza" populationPercent="1.4"/>	<!--Zaza-->
-			<languagePopulation type="kaa" populationPercent="0.1" references="R1199"/>	<!--Kara-Kalpak-->
 			<languagePopulation type="kbd" populationPercent="0.77"/>	<!--Kabardian-->
 			<languagePopulation type="az" populationPercent="0.74"/>	<!--Azerbaijani-->
 			<languagePopulation type="az_Arab" populationPercent="0.65"/>	<!--Azerbaijani (Arabic)-->
@@ -4235,11 +4239,13 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="bg" populationPercent="0.42"/>	<!--Bulgarian-->
 			<languagePopulation type="ady" populationPercent="0.39"/>	<!--Adyghe-->
 			<languagePopulation type="kiu" populationPercent="0.19"/>	<!--Kirmanjki-->
+			<languagePopulation type="kaa" populationPercent="0.1" references="R1199"/>	<!--Kara-Kalpak-->
 			<languagePopulation type="hy" populationPercent="0.056"/>	<!--Armenian-->
 			<languagePopulation type="ka" populationPercent="0.056"/>	<!--Georgian-->
 			<languagePopulation type="sr_Latn" writingPercent="5" populationPercent="0.028" references="R1017"/>	<!--Serbian (Latin)-->
 			<languagePopulation type="lzz" populationPercent="0.028"/>	<!--Laz-->
 			<languagePopulation type="sq" populationPercent="0.021"/>	<!--Albanian-->
+			<languagePopulation type="pnt_Latn" populationPercent="0.0061" references="R1336"/>	<!--Pontic (Latin)-->
 			<languagePopulation type="ab" populationPercent="0.0048" references="R1079"/>	<!--Abkhazian-->
 			<languagePopulation type="el" populationPercent="0.0048"/>	<!--Greek-->
 			<languagePopulation type="tru" populationPercent="0.0036"/>	<!--Turoyo-->
@@ -4257,6 +4263,8 @@ XXX Code for transations where no currency is involved
 		</territory>
 		<territory type="TW" gdp="1143000000000" literacyPercent="96.1" population="23595300">	<!--Taiwan-->
 			<languagePopulation type="zh_Hant" populationPercent="95" officialStatus="official"/>	<!--Chinese (Traditional)-->
+			<languagePopulation type="nan_Hant" populationPercent="57" officialStatus="official" references="R1219"/>	<!--Min Nan Chinese (Traditional)-->
+			<languagePopulation type="hak_Hant" populationPercent="11" officialStatus="official" references="R1333"/>	<!--Hakka Chinese (Traditional)-->
 			<languagePopulation type="trv" populationPercent="0.02"/>	<!--Taroko-->
 		</territory>
 		<territory type="TZ" gdp="234100000000" literacyPercent="67.8" population="67462100">	<!--Tanzania-->
@@ -5692,6 +5700,7 @@ XXX Code for transations where no currency is involved
 		<reference type="R1216">This is base pop for &quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;fub&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot;&quot; lang code; ff shows as a macrolanguage</reference>
 		<reference type="R1217" uri="http://www.ethnologue.com/language/bkm">[missing]</reference>
 		<reference type="R1218" uri="http://en.wikipedia.org/wiki/Vietnamese_language">(could be higher if 2nd lang included; no data yet)</reference>
+		<reference type="R1219" uri="https://en.wikipedia.org/wiki/Taiwanese_Hokkien">[missing]</reference>
 		<reference type="R1220" uri="http://www.ethnologue.com/18/language/knf/">[missing]</reference>
 		<reference type="R1221" uri="https://www.cia.gov/library/publications/the-world-factbook/geos/cc.html">[missing]</reference>
 		<reference type="R1222" uri="http://www.ethnologue.com/show_language.asp?code=dsb">pop 7k. Figure is questionable writing pop artificially set to 5% see also http://en.wikipedia.org/wiki/Lower_Sorbian</reference>
@@ -5805,5 +5814,9 @@ XXX Code for transations where no currency is involved
 		<reference type="R1330" uri="https://en.wikipedia.org/wiki/Languages_of_the_United_Kingdom">Analyzed from 2011 UK census and other sources</reference>
 		<reference type="R1331" uri="https://en.wikipedia.org/wiki/Languages_of_Canada">In total 86.2% of Canadians have working knowledge of English while 29.8% have a working knowledge of French.</reference>
 		<reference type="R1332" uri="https://statisticsmaldives.gov.mv/statistical-release-iii-education">2014 Maldives: 98% literacy in Divehi, 75% in English</reference>
+		<reference type="R1333" uri="https://en.wikipedia.org/wiki/Taiwanese_Hakka">[missing]</reference>
+		<reference type="R1334" uri="https://en.wikipedia.org/wiki/Laz_people#cite_note-ethnologue-1">[missing]</reference>
+		<reference type="R1335" uri="https://en.wikipedia.org/wiki/Greeks_in_Russia_and_Ukraine#cite_ref-15">Greek population in Russia -- most ancestrally used Pontic Greek -- modern usage almost certainly has dropped off but we don't have clear statistics on current usage.</reference>
+		<reference type="R1336" uri="https://joshuaproject.net/people_groups/14444/TU">[missing]</reference>
 	</references>
 </supplementalData>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2801,7 +2801,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="yue_Hans" writingPercent="5" populationPercent="5.2" references="R1328"/>	<!--Cantonese (Simplified)-->
 			<languagePopulation type="hsn" populationPercent="2.9"/>	<!--Xiang Chinese-->
 			<languagePopulation type="hak" populationPercent="2.3"/>	<!--Hakka Chinese-->
-			<languagePopulation type="nan" populationPercent="1.9"/>	<!--Min Nan Chinese-->
+			<languagePopulation type="nan_Hans" populationPercent="1.9"/>	<!--Min Nan Chinese (Simplified)-->
 			<languagePopulation type="gan" populationPercent="1.7"/>	<!--Gan Chinese-->
 			<languagePopulation type="ii" literacyPercent="60" populationPercent="0.6"/>	<!--Sichuan Yi-->
 			<languagePopulation type="ug" populationPercent="0.55" officialStatus="official_regional"/>	<!--Uyghur-->
@@ -4263,7 +4263,7 @@ XXX Code for transations where no currency is involved
 		</territory>
 		<territory type="TW" gdp="1143000000000" literacyPercent="96.1" population="23595300">	<!--Taiwan-->
 			<languagePopulation type="zh_Hant" populationPercent="95" officialStatus="official"/>	<!--Chinese (Traditional)-->
-			<languagePopulation type="nan_Hant" populationPercent="57" officialStatus="official" references="R1219"/>	<!--Min Nan Chinese (Traditional)-->
+			<languagePopulation type="nan" populationPercent="57" officialStatus="official" references="R1219"/>	<!--Min Nan Chinese-->
 			<languagePopulation type="hak_Hant" populationPercent="11" officialStatus="official" references="R1333"/>	<!--Hakka Chinese (Traditional)-->
 			<languagePopulation type="trv" populationPercent="0.02"/>	<!--Taroko-->
 		</territory>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2801,7 +2801,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="yue_Hans" writingPercent="5" populationPercent="5.2" references="R1328"/>	<!--Cantonese (Simplified)-->
 			<languagePopulation type="hsn" populationPercent="2.9"/>	<!--Xiang Chinese-->
 			<languagePopulation type="hak" populationPercent="2.3"/>	<!--Hakka Chinese-->
-			<languagePopulation type="nan_Hans" populationPercent="1.9"/>	<!--Min Nan Chinese (Simplified)-->
+			<languagePopulation type="nan" populationPercent="1.9"/>	<!--Min Nan Chinese-->
 			<languagePopulation type="gan" populationPercent="1.7"/>	<!--Gan Chinese-->
 			<languagePopulation type="ii" literacyPercent="60" populationPercent="0.6"/>	<!--Sichuan Yi-->
 			<languagePopulation type="ug" populationPercent="0.55" officialStatus="official_regional"/>	<!--Uyghur-->
@@ -4263,7 +4263,7 @@ XXX Code for transations where no currency is involved
 		</territory>
 		<territory type="TW" gdp="1143000000000" literacyPercent="96.1" population="23595300">	<!--Taiwan-->
 			<languagePopulation type="zh_Hant" populationPercent="95" officialStatus="official"/>	<!--Chinese (Traditional)-->
-			<languagePopulation type="nan" populationPercent="57" officialStatus="official" references="R1219"/>	<!--Min Nan Chinese-->
+			<languagePopulation type="nan_Hant" populationPercent="57" officialStatus="official" references="R1219"/>	<!--Min Nan Chinese (Traditional)-->
 			<languagePopulation type="hak_Hant" populationPercent="11" officialStatus="official" references="R1333"/>	<!--Hakka Chinese (Traditional)-->
 			<languagePopulation type="trv" populationPercent="0.02"/>	<!--Taroko-->
 		</territory>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -392,6 +392,10 @@ public class GenerateLikelySubtags {
                                 {"mro", "mro_Mroo_BD"},
                                 {"mro_BD", "mro_Mroo_BD"},
                                 {"ms_Arab", "ms_Arab_MY"},
+                                {"nan", "nan_Hant_TW"},
+                                {"nan_Hant", "nan_Hant_TW"},
+                                {"nan_Hans", "nan_Hans_CN"},
+                                {"nan_TW", "nan_Hant_TW"},
                                 {"pap", "pap_Latn_CW"},
                                 {"pap_Latn", "pap_Latn_CW"},
                                 {
@@ -514,6 +518,7 @@ public class GenerateLikelySubtags {
                                 {"und_Cyrl_RS", "sr_Cyrl_RS"},
                                 {"und_Cyrl_TJ", "tg_Cyrl_TJ"},
                                 {"und_Cyrl_UA", "uk_Cyrl_UA"},
+                                {"und_Hans_TW", "zh_Hans_TW"},
                                 {"arc_Hatr", "arc_Hatr_IQ"},
                                 {"hnj_Hmng", "hnj_Hmng_LA"},
                                 {"bap_Krai", "bap_Krai_IN"},

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -392,7 +392,7 @@ public class GenerateLikelySubtags {
                                 {"mro", "mro_Mroo_BD"},
                                 {"mro_BD", "mro_Mroo_BD"},
                                 {"ms_Arab", "ms_Arab_MY"},
-                                {"nan", "nan_Hant_TW"},
+                                {"nan", "nan_Hans_CN"},
                                 {"nan_Hant", "nan_Hant_TW"},
                                 {"nan_Hans", "nan_Hans_CN"},
                                 {"nan_TW", "nan_Hant_TW"},

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -469,14 +469,9 @@ public class GenerateLikelySubtags {
                                 //        {"cr", "cr_Cans_CA"},
                                 //        {"hif", "hif_Latn_FJ"},
                                 //        {"gon", "gon_Telu_IN"},
-                                //        {"lzz", "lzz_Latn_TR"},
                                 //        {"lif", "lif_Deva_NP"},
                                 //        {"unx", "unx_Beng_IN"},
                                 //        {"unr", "unr_Beng_IN"},
-                                //        {"ttt", "ttt_Latn_AZ"},
-                                //        {"pnt", "pnt_Grek_GR"},
-                                //        {"tly", "tly_Latn_AZ"},
-                                //        {"tkr", "tkr_Latn_AZ"},
                                 //        {"bsq", "bsq_Bass_LR"},
                                 //        {"ccp", "ccp_Cakm_BD"},
                                 //        {"blt", "blt_Tavt_VN"},
@@ -505,6 +500,7 @@ public class GenerateLikelySubtags {
 
                                 // additions for missing values from LikelySubtagsText
                                 {"und_Arab_AF", "fa_Arab_AF"},
+                                {"und_Arab_AZ", "az_Arab_AZ"},
                                 {"und_Cyrl_BG", "bg_Cyrl_BG"},
                                 {"und_Tibt_BT", "dz_Tibt_BT"},
                                 {"und_Cyrl_BY", "be_Cyrl_BY"},

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -253,17 +253,17 @@ Chile	CL	"17,925,262"	99%	"452,100,000,000"		Mapuche	arn	"272,000"			http://en.w
 Chile	CL	"17,925,262"	99%	"452,100,000,000"	official	Spanish	es	98%			"http://en.wikipedia.org/wiki/Demographics_of_Chile#Languages Spanish ""universal"", set to 98%"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Cantonese (Simplified)	yue_Hans	5.2%	5%		"Mainly in Guangdong Prov, ~70-80 million. Script unspecified so both listed"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Cantonese (Traditional)	yue	5.2%	5%		"Mainly in Guangdong Prov, ~70-80 million. Script unspecified so both listed"
-China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official	Chinese	zh	90%
+China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official	Chinese	zh_Hans	90%
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		English	en	"62,900"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Gan Chinese	gan	"22,900,000"
-China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Hakka Chinese	hak	"31,200,000"
+China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Hakka Chinese	hak_Hans	"31,200,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Kazakh (Arabic)	kk_Arab	"1,180,000"			http://en.wikipedia.org/wiki/Kazakh_language
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official_regional	Korean	ko	"2,040,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Kyrgyz (Arabic)	ky_Arab	"466,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Lisu	lis	"617,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Literary Chinese	lzh	1			No estimate available.
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Lü	khb	"267,000"			"http://www.ethnologue.com/show_language.asp?code=khb (= Tai Lu, Xishuangbanna Dai; New Tai Lue script)"
-China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Min Nan Chinese	nan	"26,800,000"
+China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Min Nan Chinese	nan_Hans	"26,800,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official_regional	Mongolian (Mongolian)	mn_Mong	"3,600,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Naxi	nxq	"329,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Russian	ru	"14,400"
@@ -435,6 +435,7 @@ Georgia	GE	"4,926,087"	100%	"39,850,000,000"		Kurdish	ku	"43,600"
 Georgia	GE	"4,926,087"	100%	"39,850,000,000"		Mingrelian	xmf	11%
 Georgia	GE	"4,926,087"	100%	"39,850,000,000"	official_regional	Ossetic	os	"109,000"
 Georgia	GE	"4,926,087"	100%	"39,850,000,000"		Russian	ru	9%			https://www.cia.gov/cia/publications/factbook/fields/2098.html
+Georgia	GE	"4,926,087"	100%	"39,850,000,000"		Laz	lzz_Geor	100			https://en.wikipedia.org/wiki/Laz_people#cite_note-ethnologue-1
 Germany	DE	"80,457,737"	99%	"4,199,000,000,000"		Bavarian	bar	17%	5%		"https://en.wikipedia.org/wiki/Bavarian_language Widely spoken less written, and most speakers know standard German as well"
 Germany	DE	"80,457,737"	99%	"4,199,000,000,000"		Colognian	ksh	"245,000"			http://www.ethnologue.com/show_language.asp?code=ksh
 Germany	DE	"80,457,737"	99%	"4,199,000,000,000"		Croatian	hr	"635,000"
@@ -1128,6 +1129,7 @@ Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Mari	chm	"522,000"			http://ww
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"	official_regional	Moksha	mdf	"296,000"
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Mongolian	mn	"2,100"
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Ossetic	os	"456,000"			http://www.gks.ru/free_doc/new_site/population/demo/per-itog/tab6.xls census data
+Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Pontic	pnt_Cyrl	"56,168"			https://en.wikipedia.org/wiki/Greeks_in_Russia_and_Ukraine#cite_ref-15 Greek population in Russia -- most ancestrally used Pontic Greek -- modern usage almost certainly has dropped off but we don't have clear statistics on current usage.
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"	official	Russian	ru	94%			http://en.wikipedia.org/wiki/Russian_language (94% of studends in Russia receive primarily Russian-language ed)
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"	official_regional	Sakha	sah	"461,000"			http://en.wikipedia.org/wiki/Sakha_language Also called Sakha.
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Serbian (Latin)	sr_Latn	"5,000"
@@ -1290,8 +1292,8 @@ Syria	SY	"19,454,263"	84%	"50,280,000,000"		Kurdish	ku	8%
 Syria	SY	"19,454,263"	84%	"50,280,000,000"		Syriac	syr	"16,400"	5%		"For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
 Syria	SY	"19,454,263"	84%	"50,280,000,000"		Levantine Arabic	apc	"16,633,300"			https://en.wikipedia.org/wiki/Levantine_Arabic#Speakers_by_country
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Chinese (Traditional)	zh_Hant	95%
-Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hokkien	nan	"13,500,000"			https://en.wikipedia.org/wiki/Taiwanese_Hokkien
-Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hakka	hak	"2,580,000"			https://en.wikipedia.org/wiki/Taiwanese_Hakka
+Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hokkien	nan_Hant	"13,500,000"			https://en.wikipedia.org/wiki/Taiwanese_Hokkien
+Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hakka	hak_Hant	"2,580,000"			https://en.wikipedia.org/wiki/Taiwanese_Hakka
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"		Taroko	trv	"4,750"
 Tajikistan	TJ	"8,604,882"	100%	"28,430,000,000"		Arabic	ar	"1,000"
 Tajikistan	TJ	"8,604,882"	100%	"28,430,000,000"		Persian	fa	"66,900"
@@ -1362,6 +1364,7 @@ Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Kirmanjki	kiu	"158,000"
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Kurdish	ku	5.5%
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Kyrgyz (Latin)	ky_Latn	"1,140"
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Laz	lzz	"22,600"
+Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Pontic	pnt_Latn	"5,100"			https://joshuaproject.net/people_groups/14444/TU
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Serbian (Latin)	sr_Latn	"22,700"	5%		"For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"	official	Turkish	tr	93%			"http://en.wikipedia.org/wiki/Turkish_language#Geographic_distribution http://ec.europa.eu/public_opinion/archives/ebs/ebs_243_en.pdf Europeans and their languages survey, page 7"
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Turoyo	tru	"3,000"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -263,7 +263,7 @@ China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Kyrgyz (Arabic)	ky_Arab	"466,
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Lisu	lis	"617,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Literary Chinese	lzh	1			No estimate available.
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Lü	khb	"267,000"			"http://www.ethnologue.com/show_language.asp?code=khb (= Tai Lu, Xishuangbanna Dai; New Tai Lue script)"
-China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Min Nan Chinese	nan_Hans	"26,800,000"
+China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Min Nan Chinese	nan	"26,800,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official_regional	Mongolian (Mongolian)	mn_Mong	"3,600,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Naxi	nxq	"329,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Russian	ru	"14,400"
@@ -1292,7 +1292,7 @@ Syria	SY	"19,454,263"	84%	"50,280,000,000"		Kurdish	ku	8%
 Syria	SY	"19,454,263"	84%	"50,280,000,000"		Syriac	syr	"16,400"	5%		"For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
 Syria	SY	"19,454,263"	84%	"50,280,000,000"		Levantine Arabic	apc	"16,633,300"			https://en.wikipedia.org/wiki/Levantine_Arabic#Speakers_by_country
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Chinese (Traditional)	zh_Hant	95%
-Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hokkien	nan	"13,500,000"			https://en.wikipedia.org/wiki/Taiwanese_Hokkien
+Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hokkien	nan_Hant	"13,500,000"			https://en.wikipedia.org/wiki/Taiwanese_Hokkien
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hakka	hak_Hant	"2,580,000"			https://en.wikipedia.org/wiki/Taiwanese_Hakka
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"		Taroko	trv	"4,750"
 Tajikistan	TJ	"8,604,882"	100%	"28,430,000,000"		Arabic	ar	"1,000"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -1292,7 +1292,7 @@ Syria	SY	"19,454,263"	84%	"50,280,000,000"		Kurdish	ku	8%
 Syria	SY	"19,454,263"	84%	"50,280,000,000"		Syriac	syr	"16,400"	5%		"For languages not customarily written, the writing population is artificially set to 5% in the absence of better information."
 Syria	SY	"19,454,263"	84%	"50,280,000,000"		Levantine Arabic	apc	"16,633,300"			https://en.wikipedia.org/wiki/Levantine_Arabic#Speakers_by_country
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Chinese (Traditional)	zh_Hant	95%
-Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hokkien	nan_Hant	"13,500,000"			https://en.wikipedia.org/wiki/Taiwanese_Hokkien
+Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hokkien	nan	"13,500,000"			https://en.wikipedia.org/wiki/Taiwanese_Hokkien
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"	official	Hakka	hak_Hant	"2,580,000"			https://en.wikipedia.org/wiki/Taiwanese_Hakka
 Taiwan	TW	"23,545,963"	96%	"1,189,000,000,000"		Taroko	trv	"4,750"
 Tajikistan	TJ	"8,604,882"	100%	"28,430,000,000"		Arabic	ar	"1,000"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -297,6 +297,7 @@ ha	Hausa	primary	Arab	Arabic
 ha	Hausa	primary	Latn	Latin
 hai	Haida	primary	Latn	Latin
 hak	Hakka Chinese	primary	Hans	Simplified
+hak	Hakka Chinese	primary	Hant	Traditional
 haw	Hawaiian	primary	Latn	Latin
 haz	Hazaragi	primary	Arab	Arabic
 he	Hebrew	primary	Hebr	Hebrew
@@ -492,8 +493,8 @@ luz	Southern Luri	primary	Arab	Arabic
 lv	Latvian	primary	Latn	Latin
 lwl	Eastern Lawa	primary	Thai	Thai
 lzh	Literary Chinese	secondary	Hans	Simplified
-lzz	Laz	primary	Geor	Georgian
 lzz	Laz	primary	Latn	Latin
+lzz	Laz	secondary	Geor	Georgian
 mad	Madurese	primary	Latn	Latin
 maf	Mafa	primary	Latn	Latin
 mag	Magahi	primary	Deva	Devanagari
@@ -564,6 +565,7 @@ myz	Classical Mandaic	secondary	Mand	Mandaean
 mzn	Mazanderani	primary	Arab	Arabic
 na	Nauru	primary	Latn	Latin
 nan	Min Nan Chinese	primary	Hans	Simplified
+nan	Min Nan Chinese	primary	Hant	Traditional
 nap	Neapolitan	primary	Latn	Latin
 naq	Nama	primary	Latn	Latin
 nb	Norwegian (Bokmål)	primary	Latn	Latin
@@ -633,6 +635,7 @@ pdt	Plautdietsch	primary	Latn	Latin
 peo	Old Persian	secondary	Xpeo	Old Persian
 pfl	Palatine German	primary	Latn	Latin
 phn	Phoenician	secondary	Phnx	Phoenician
+pi	Pali	primary	Mymr	Myanmar
 pi	Pali	secondary	Deva	Devanagari
 pi	Pali	secondary	Sinh	Sinhala
 pi	Pali	secondary	Thai	Thai
@@ -640,9 +643,9 @@ pis	Pijin	primary	Latn	Latin
 pko	Pökoot	primary	Latn	Latin
 pl	Polish	primary	Latn	Latin
 pms	Piedmontese	primary	Latn	Latin
-pnt	Pontic	primary	Cyrl	Cyrillic
 pnt	Pontic	primary	Grek	Greek
-pnt	Pontic	primary	Latn	Latin
+pnt	Pontic	secondary	Cyrl	Cyrillic
+pnt	Pontic	secondary	Latn	Latin
 pon	Pohnpeian	primary	Latn	Latin
 pqm	Malecite	primary	Latn	Latin
 prd	Parsi-Dari	primary	Arab	Arabic
@@ -815,13 +818,13 @@ tk	Turkmen	primary	Arab	Arabic
 tk	Turkmen	primary	Cyrl	Cyrillic
 tk	Turkmen	primary	Latn	Latin
 tkl	Tokelau	primary	Latn	Latin
-tkr	Tsakhur	primary	Cyrl	Cyrillic
 tkr	Tsakhur	primary	Latn	Latin
+tkr	Tsakhur	secondary	Cyrl	Cyrillic
 tkt	Kathoriya Tharu	primary	Deva	Devanagari
 tli	Tlingit	primary	Latn	Latin
-tly	Talysh	primary	Arab	Arabic
-tly	Talysh	primary	Cyrl	Cyrillic
 tly	Talysh	primary	Latn	Latin
+tly	Talysh	secondary	Arab	Arabic
+tly	Talysh	secondary	Cyrl	Cyrillic
 tmh	Tamashek	primary	Latn	Latin
 tn	Tswana	primary	Latn	Latin
 to	Tongan	primary	Latn	Latin
@@ -842,9 +845,9 @@ tsj	Tshangla	primary	Tibt	Tibetan
 tt	Tatar	primary	Cyrl	Cyrillic
 ttj	Tooro	primary	Latn	Latin
 tts	Northeastern Thai	primary	Thai	Thai
-ttt	Muslim Tat	primary	Cyrl	Cyrillic
 ttt	Muslim Tat	primary	Latn	Latin
 ttt	Muslim Tat	secondary	Arab	Arabic
+ttt	Muslim Tat	secondary	Cyrl	Cyrillic
 tum	Tumbuka	primary	Latn	Latin
 tvl	Tuvalu	primary	Latn	Latin
 twq	Tasawaq	primary	Latn	Latin


### PR DESCRIPTION
If we re-run ConvertLanguageData on unrelated data, it will update the order and values of some other data -- this fixes inconsistencies with the XML outputs to match expectations. The biggest change was updating values in `language_script.tsv` to demote script variations to secondary when they really are not expected. Furthermore I added explicit annotations to `country_language_population.tsv` when the writing system for a country was a variant.

CLDR-17897

- [ ] This PR completes the ticket.
- [x] This PR is pre-work. It fixes the data so its easier to make updates without side effects happening when working on that ticket.

Scripts ran
- [x] mvn package -DskipTests=true
- [x] java -jar tools/cldr-code/target/cldr-code.jar ConvertLanguageData
- [x] java -jar tools/cldr-code/target/cldr-code.jar GenerateLikelySubtags

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
