### PR TITLE
CLDR-17948 kbd: bump version to v46

### DIFF
--- a/.github/workflows/keyboard.yml
+++ b/.github/workflows/keyboard.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-nodekbd-
             nodekbd-
       - name: Install kmc
-        run: npm install -g @keymanapp/kmc@alpha
+        run: npm install -g @keymanapp/kmc@beta
       - name: Compile Keyboards
         run: kmc --error-reporting build keyboards/3.0/*.xml
       - name: Run Kbd Charts

--- a/keyboards/3.0/bn.xml
+++ b/keyboards/3.0/bn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="bn" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="bn" conformsTo="46">
     <!--
         History:
           Based on
@@ -19,8 +19,8 @@
     </displays>
 
     <keys>
-        <import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-        <import base="cldr" path="45/keys-Zyyy-currency.xml" />
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+        <import base="cldr" path="46/keys-Zyyy-currency.xml" />
 
         <key id="1" output="১" />
         <key id="2" output="২" />

--- a/keyboards/3.0/fr-t-k0-test.xml
+++ b/keyboards/3.0/fr-t-k0-test.xml
@@ -2,7 +2,7 @@
 <!--
     See CLDR-12026 for the real new azerty keyboard
 -->
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="fr-t-k0-test" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="fr-t-k0-test" conformsTo="46">
 	<locales>
 		<locale id="br" /> <!-- example of including Breton -->
 	</locales>
@@ -31,8 +31,8 @@
 	</displays>
 
 	<keys>
-		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
 
 		<!-- switch keys -->
 		<key id="shift" layerId="shift" />

--- a/keyboards/3.0/fr.xml
+++ b/keyboards/3.0/fr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" conformsTo="45"
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" conformsTo="46"
 	locale="fr">
 	<version number="1.0.0" />
 
@@ -22,8 +22,8 @@
 	</displays>
 
 	<keys>
-		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
 
 		<!-- deadkeys -->
 		<key id="mark-acute" output="\m{acute}" />

--- a/keyboards/3.0/ja-Hira-t-k0-flicks.xml
+++ b/keyboards/3.0/ja-Hira-t-k0-flicks.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="ja-Hira-t-k0-flicks"
-	conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="ja-Hira-t-k0-flicks"
+	conformsTo="46">
 	<version number="1.0.0" />
 	<info author="Team Keyboard" name="Japanese Hiragana" />
 
 	<keys>
-		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
 
         <key id="h-a" output="あ" flickId="h-a"/>
         <key id="h-i" output="い" />

--- a/keyboards/3.0/ja-Latn.xml
+++ b/keyboards/3.0/ja-Latn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="ja-Latn" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="ja-Latn" conformsTo="46">
 	<locales>
 		<locale id="en" />
 	</locales>
@@ -7,8 +7,8 @@
 	<info name="Romaji (JIS)" />
 
 	<keys>
-		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
 	</keys>
 
 	<layers formId="jis">

--- a/keyboards/3.0/mt-t-k0-47key.xml
+++ b/keyboards/3.0/mt-t-k0-47key.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt-t-k0-47key" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt-t-k0-47key" conformsTo="46">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -9,8 +9,8 @@
 
     <keys>
         <!-- imports -->
-        <import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-        <import base="cldr" path="45/keys-Zyyy-currency.xml" />
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+        <import base="cldr" path="46/keys-Zyyy-currency.xml" />
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/keyboards/3.0/mt.xml
+++ b/keyboards/3.0/mt.xml
@@ -4,7 +4,7 @@ Copyright © 1991-2024 Unicode, Inc.
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt" conformsTo="46">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -14,8 +14,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
     <keys>
         <!-- imports -->
-        <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
-        <import base="cldr" path="45/keys-Zyyy-currency.xml"/>
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml"/>
+        <import base="cldr" path="46/keys-Zyyy-currency.xml"/>
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/keyboards/3.0/pcm.xml
+++ b/keyboards/3.0/pcm.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="pcm" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="pcm" conformsTo="46">
   <version number="1.0.0" />
   <info name="Naijíriá Píjin" />
   <keys>
-    <import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-    <import base="cldr" path="45/keys-Zyyy-currency.xml" />
+    <import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+    <import base="cldr" path="46/keys-Zyyy-currency.xml" />
     <key id="grave" output="\u{300}" />
     <key id="backquote" output="`" />
     <key id="acute" output="\u{301}" />

--- a/keyboards/3.0/pt-t-k0-abnt2.xml
+++ b/keyboards/3.0/pt-t-k0-abnt2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="pt-t-k0-abnt2" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="pt-t-k0-abnt2" conformsTo="46">
 	<locales>
 		<locale id="pt" />
 	</locales>
@@ -14,8 +14,8 @@
 	</displays>
 
 	<keys>
-		<import base="cldr" path="45/keys-Zyyy-punctuation.xml" />
-		<import base="cldr" path="45/keys-Zyyy-currency.xml" />
+		<import base="cldr" path="46/keys-Zyyy-punctuation.xml" />
+		<import base="cldr" path="46/keys-Zyyy-currency.xml" />
 
 		<!-- TODO: using the proposed deadkey format -->
 		<key id="d-acute"  output="\m{acute}"/>

--- a/keyboards/dtd/ldmlKeyboard3.dtd
+++ b/keyboards/dtd/ldmlKeyboard3.dtd
@@ -10,7 +10,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ELEMENT keyboard3 ( import*, locales?, version?, info, settings?, displays?, keys?, flicks?, forms?, layers*, variables?, transforms*, special* ) >
 <!ATTLIST keyboard3 locale CDATA #REQUIRED >
     <!--@MATCH:validity/bcp47-wellformed-->
-<!ATTLIST keyboard3 conformsTo (45) #REQUIRED >
+<!ATTLIST keyboard3 conformsTo (45 | 46) #REQUIRED >
     <!--@MATCH:version-->
     <!--@METADATA-->
 <!ATTLIST keyboard3 xmlns CDATA #IMPLIED >

--- a/keyboards/dtd/ldmlKeyboard3.xsd
+++ b/keyboards/dtd/ldmlKeyboard3.xsd
@@ -35,6 +35,7 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
         <xs:simpleType>
           <xs:restriction base="xs:token">
             <xs:enumeration value="45"/>
+            <xs:enumeration value="46"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CldrVersion.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CldrVersion.java
@@ -131,6 +131,11 @@ public enum CldrVersion {
         return compareTo(other) < 0;
     }
 
+    public boolean isAsOldOrOlderThan(CldrVersion other) {
+        return compareTo(other) <= 0;
+    }
+
+
     private CldrVersion() {
         String oldName = name();
         if (oldName.charAt(0) == 'v') {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CldrVersion.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CldrVersion.java
@@ -135,7 +135,6 @@ public enum CldrVersion {
         return compareTo(other) <= 0;
     }
 
-
     private CldrVersion() {
         String oldName = name();
         if (oldName.charAt(0) == 'v') {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/KeyboardFlatten.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/KeyboardFlatten.java
@@ -83,8 +83,8 @@ public class KeyboardFlatten {
         final String path = getPath(item);
         System.err.println("Import: " + base + ":" + path);
         if (base.equals("cldr")) {
-            if (path.startsWith("45/")) {
-                final String subpath = path.replaceFirst("45/", "");
+            if (path.startsWith("46/")) {
+                final String subpath = path.replaceFirst("46/", "");
                 final File importDir =
                         new File(
                                 CLDRConfig.getInstance().getCldrBaseDirectory(),

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ElementAttributeInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ElementAttributeInfo.java
@@ -103,7 +103,7 @@ public class ElementAttributeInfo {
         addElementAttributeInfo(
                 result,
                 DtdType.keyboard3,
-                canonicalCommonDirectory + "/../keyboards/3.0/fr-t-k0-test.xml");
+                canonicalCommonDirectory + "/../tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/und-t-k0-none.xml");
         addElementAttributeInfo(
                 result,
                 DtdType.keyboardTest3,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ElementAttributeInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ElementAttributeInfo.java
@@ -103,7 +103,8 @@ public class ElementAttributeInfo {
         addElementAttributeInfo(
                 result,
                 DtdType.keyboard3,
-                canonicalCommonDirectory + "/../tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/und-t-k0-none.xml");
+                canonicalCommonDirectory
+                        + "/../tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/und-t-k0-none.xml");
         addElementAttributeInfo(
                 result,
                 DtdType.keyboardTest3,

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/und-t-k0-none.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/und-t-k0-none.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file is here to quell ElementAttributeInfo warnings. It is the only keyboard file which uses a .dtd, which is not recommended. -->
+<!DOCTYPE keyboard3 SYSTEM '../../../../../../../../../../keyboards/dtd/ldmlKeyboard3.dtd'>
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="fr-t-k0-test" conformsTo="46">
+    <info name="Unused Keyboard, for DTD tests" />
+    <!-- not a real keyboard. -->
+</keyboard3>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -1248,7 +1248,8 @@ public class TestBasic extends TestFmwkPlus {
                 continue; // DTD didn't exist in last release
             }
             if (dtd == DtdType.ldmlICU) continue;
-            if (dtd == DtdType.keyboard3 && CldrVersion.LAST_RELEASE_VERSION.isAsOldOrOlderThan(CldrVersion.v45_0)) {
+            if (dtd == DtdType.keyboard3
+                    && CldrVersion.LAST_RELEASE_VERSION.isAsOldOrOlderThan(CldrVersion.v45_0)) {
                 // Sample file did not have a DTD in v45, moved to a new location in v46+
                 continue;
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -192,10 +192,6 @@ public class TestBasic extends TestFmwkPlus {
                 continue;
             } else if (fileName.isDirectory()) {
                 checkDtds(fileName, level + 1, foundAttributes, data);
-            } else if (fileName.getPath().contains("/keyboards/3.0/")
-                    && logKnownIssue(
-                            "CLDR-17574", "With v46, parsing issues for keyboard xml files")) {
-                ; // do nothing, skip test
             } else if (name.endsWith(".xml")) {
                 data.add(check(fileName));
                 if (deepCheck // takes too long to do all the time
@@ -1252,6 +1248,10 @@ public class TestBasic extends TestFmwkPlus {
                 continue; // DTD didn't exist in last release
             }
             if (dtd == DtdType.ldmlICU) continue;
+            if (dtd == DtdType.keyboard3 && CldrVersion.LAST_RELEASE_VERSION.isAsOldOrOlderThan(CldrVersion.v45_0)) {
+                // Sample file did not have a DTD in v45, moved to a new location in v46+
+                continue;
+            }
             try {
                 ElementAttributeInfo oldDtd = ElementAttributeInfo.getInstance(oldCommon, dtd);
                 ElementAttributeInfo newDtd = ElementAttributeInfo.getInstance(dtd);
@@ -1565,11 +1565,6 @@ public class TestBasic extends TestFmwkPlus {
             if (file.getParentFile().getName().equals("import")
                     && file.getParentFile().getParentFile().getName().equals("keyboards")) {
                 return; // skip imports
-            }
-            if (file.getPath().contains("/keyboards/3.0/")
-                    && logKnownIssue(
-                            "CLDR-17574", "With v46, parsing issues for keyboard xml files")) {
-                continue;
             }
             checkDtdComparatorFor(file, null);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -472,12 +472,6 @@ public class TestPaths extends TestFmwkPlus {
                 ) {
                     continue;
                 }
-                if (dir2.getPath().contains("/keyboards/3.0")
-                        && logKnownIssue(
-                                "CLDR-17574", "With v46, parsing issues for keyboard xml files")) {
-                    continue;
-                }
-
                 Set<Pair<String, String>> seen = new HashSet<>();
                 Set<String> seenStarred = new HashSet<>();
                 int count = 0;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestDoctypeXmlStreamWrapper.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestDoctypeXmlStreamWrapper.java
@@ -54,9 +54,6 @@ public class TestDoctypeXmlStreamWrapper {
 
     @Test
     void TestReadKeyboard() throws FileNotFoundException, IOException {
-        if (true /* TODO CLDR-17574 With v46, parsing issues for keyboard xml files */) {
-            return;
-        }
         for (int i = 0; i < COUNT; i++) {
             new XMLFileReader()
                     .setHandler(new XMLFileReader.SimpleHandler())
@@ -67,9 +64,6 @@ public class TestDoctypeXmlStreamWrapper {
     @Test
     void TestReadKeyboardByte() throws IOException, SAXException {
         // verify that reading via InputStream (byte) works as well
-        if (true /* TODO CLDR-17574 With v46, parsing issues for keyboard xml files */) {
-            return;
-        }
         try (InputStream fis = new FileInputStream(KEYBOARDS_MT); ) {
             InputSource is = new InputSource(fis);
             is.setSystemId(KEYBOARDS_MT);
@@ -81,9 +75,6 @@ public class TestDoctypeXmlStreamWrapper {
     @Test
     void TestReadKeyboardChar() throws IOException, SAXException {
         // verify that reading via Reader (char) works as well
-        if (true /* TODO CLDR-17574 With v46, parsing issues for keyboard xml files */) {
-            return;
-        }
         try (InputStream fis = new FileInputStream(KEYBOARDS_MT);
                 InputStreamReader isr = new InputStreamReader(fis); ) {
             InputSource is = new InputSource(isr);

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-missing.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-missing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt" conformsTo="46">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -9,7 +9,7 @@
     <keys>
         <!-- imports -->
         <!-- Error - import does not exist. -->
-        <import base="cldr" path="45/keys-Zyyy-DOESNOTEXIST.xml"/>
+        <import base="cldr" path="46/keys-Zyyy-DOESNOTEXIST.xml"/>
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownbase.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownbase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt" conformsTo="46">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
@@ -9,7 +9,7 @@
     <keys>
         <!-- imports -->
         <!-- Error - unknown version. -->
-        <import base="UNKNOWN" path="45/keys-Zyyy-punctuation.xml"/>
+        <import base="UNKNOWN" path="46/keys-Zyyy-punctuation.xml"/>
 
         <!-- accent grave -->
         <key id="a-grave" output="à" />

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownver.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-unknownver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt" conformsTo="46">
     <locales>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-wrongparent.xml
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/tool/KeyboardFlatten/broken-import-wrongparent.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keyboard3 xmlns="https://schemas.unicode.org/cldr/45/keyboard3" locale="mt" conformsTo="45">
+<keyboard3 xmlns="https://schemas.unicode.org/cldr/46/keyboard3" locale="mt" conformsTo="46">
     <locales>
         <!-- Error - can't import 'keys' into a 'locales' section. -->
-        <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
+        <import base="cldr" path="46/keys-Zyyy-punctuation.xml"/>
         <!-- English is also an official language in Malta.-->
         <locale id="en" />
     </locales>


### PR DESCRIPTION
CLDR-17948

- bump schema to support v45 or v46
- bump test files to v46 - note, these won't compile in keyman until keyman is updated
  - the test mechanism doesn't currently support multiple "old" keyboard versions. In the future, cldr-archive could be leveraged for this.
- change the ElementAttributeInfo logic to use a new 'special' keyboard XML file, with a DTD, so it can be parsed. This results in a 'no sample file' warning when testing against v45 since that file didn't exist in v45.  (But v45 and v46 schemas are identical save for the version number)

This will quell most of the warnings noted in CLDR-17574, CLDR-17745.

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
