### PR TITLE
CLDR-17947 site: pin image width, win fix

### DIFF
--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -180,3 +180,8 @@ header#atViewHeader {
 div > header {
   display: none !important;
 }
+
+img {
+  max-width: 100%;
+  max-height: 90dvh;
+}

--- a/docs/site/assets/js/build.mjs
+++ b/docs/site/assets/js/build.mjs
@@ -31,6 +31,7 @@ const coll = new Intl.Collator(["und"]);
 async function processFile(d, fullPath, out) {
   const f = await fs.readFile(fullPath, "utf-8");
   const m = matter(f);
+  fullPath = fullPath.replace(/\\/g, '/'); // backslash with slash, for win
   if (m && m.data) {
     const { data } = m;
     out.all.push({ ...data, fullPath });


### PR DESCRIPTION
CLDR-17947

- css: pin image width to 100% of the parent (the page), and also pin height to 90% of the viewable area.

also:
- fix builder for windows pathnames

- [ ] This PR completes the ticket.


## Testing
- before: https://cldr.unicode.org/index/language-support-levels
- after: https://b1085791.cldr.pages.dev/index/language-support-levels

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
