### PR TITLE
CLDR-17953 Improve UI and implementation for VXML generation

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VxmlGenerator.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VxmlGenerator.java
@@ -1,40 +1,33 @@
 package org.unicode.cldr.web;
 
-import java.io.Writer;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.unicode.cldr.util.CLDRLocale;
 
 public class VxmlGenerator {
-    public void generate(Set<CLDRLocale> sortSet, Writer out) throws ExecutionException {
-        this.sortSet = sortSet;
+
+    private final Set<CLDRLocale> locales;
+
+    public VxmlGenerator() {
+        this.locales = OutputFileManager.createVxmlLocaleSet();
+    }
+
+    public void generate(VxmlQueue.Results results) throws ExecutionException {
         try {
-            OutputFileManager.generateVxml(this, out);
+            OutputFileManager.generateVxml(this, results);
         } catch (Exception e) {
             throw new ExecutionException(e);
         }
     }
 
-    private Set<CLDRLocale> sortSet = null;
-
-    public Set<CLDRLocale> getSortSet() {
-        return sortSet;
+    public Set<CLDRLocale> getLocales() {
+        return locales;
     }
 
     public enum VerificationStatus {
         SUCCESSFUL,
         FAILED,
         INCOMPLETE
-    }
-
-    private VerificationStatus verificationStatus = VerificationStatus.INCOMPLETE;
-
-    public VerificationStatus getVerificationStatus() {
-        return verificationStatus;
-    }
-
-    public void setVerificationStatus(VerificationStatus status) {
-        verificationStatus = status;
     }
 
     /**


### PR DESCRIPTION
-Request every 5 seconds instead of 10 seconds for better feedback

-Change button from Stop to Cancel, less ambiguous

-Change status label from READY to SUCCEEDED, less ambiguous

-Show the full path of the generated directory, along with a button for copying it to the clipboard

-Do not create a long HTML string on the back end combining various types of information; instead, store individual data items in the http response, enabling the front end to determine their presentation

-Do not show the entire list of locales generated; instead, show the number of locales generated so far as numerator and the total number of locales to be generated as denominator, along with the most recent locale generated

-Bug fix: enable repeated runs with new method QueueEntry.reset

-Rename VxmlQueue.LoadingPolicy to VxmlQueue.RequestType for clarity

-Refactoring for better code organization

-Fix compiler warnings

-Comments

CLDR-17953

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
