### PR TITLE
CLDR-11570 Update Ancient Greek writing systems

### DIFF
--- a/common/properties/scriptMetadata.txt
+++ b/common/properties/scriptMetadata.txt
@@ -123,13 +123,13 @@ Dupl; 33; 1BC20; FR; 1; EXCLUSION; NO; NO; NO; YES; NO
 Egyp; 33; 13153; EG; 3; EXCLUSION; NO; NO; YES; YES; NO
 Elba; 33; 10500; AL; 1; EXCLUSION; NO; NO; NO; NO; NO
 Elym; 33; 10FF1; IR; 1; EXCLUSION; YES; NO; NO; NO; NO
-Gara; 33; 10D5D; SN; 1; EXCLUSION; YES; NO; YES; NO; YES  # provisional data for future Unicode 16.0 script
+Gara; 33; 10D5D; SN; 1; EXCLUSION; YES; NO; YES; NO; YES
 Glag; 33; 2C00; BG; 1; EXCLUSION; NO; NO; NO; NO; YES
 Gong; 33; 11D71; IN; 1; LIMITED_USE; NO; NO; YES; NO; NO
 Gonm; 33; 11D10; IN; 1; EXCLUSION; NO; NO; YES; NO; NO
 Goth; 33; 10330; UA; 1; EXCLUSION; NO; NO; NO; NO; NO
 Gran; 33; 11315; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
-Gukh; 33; 1611C; NP; 1; EXCLUSION; NO; NO; YES; NO; NO  # provisional data for future Unicode 16.0 script
+Gukh; 33; 1611C; NP; 1; EXCLUSION; NO; NO; YES; NO; NO
 Hano; 33; 1723; PH; 1; EXCLUSION; NO; NO; YES; NO; NO
 Hatr; 33; 108F4; IQ; 1; EXCLUSION; YES; NO; NO; NO; NO
 Hluw; 33; 14400; TR; 1; EXCLUSION; NO; NO; NO; YES; NO
@@ -143,7 +143,7 @@ Kawi; 33; 11F1B; ID; 1; EXCLUSION; NO; YES; YES; NO; NO
 Khar; 33; 10A00; PK; 1; EXCLUSION; YES; NO; YES; NO; NO
 Khoj; 33; 11208; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
 Kits; 33; 18C65; CN; 2; EXCLUSION; NO; YES; NO; YES; NO
-Krai; 33; 16D45; IN; 1; EXCLUSION; NO; NO; NO; NO; NO  # provisional data for future Unicode 16.0 script
+Krai; 33; 16D45; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
 Kthi; 33; 11083; IN; 1; EXCLUSION; NO; NO; MIN; NO; NO
 Lana; 33; 1A20; TH; 1; LIMITED_USE; NO; YES; YES; NO; NO
 Lepc; 33; 1C00; IN; 1; LIMITED_USE; NO; NO; YES; NO; NO
@@ -176,7 +176,7 @@ Nkoo; 33; 07CA; GN; 1; LIMITED_USE; YES; NO; YES; NO; NO
 Nshu; 33; 1B1C4; CN; 2; EXCLUSION; NO; YES; NO; YES; NO
 Ogam; 33; 168F; IE; 1; EXCLUSION; NO; NO; NO; NO; NO
 Olck; 33; 1C5A; IN; 1; LIMITED_USE; NO; NO; NO; NO; NO
-Onao; 33; 1E5D0; IN; 1; EXCLUSION; NO; NO; MIN; NO; NO  # provisional data for future Unicode 16.0 script
+Onao; 33; 1E5D0; IN; 1; EXCLUSION; NO; NO; MIN; NO; NO
 Orkh; 33; 10C00; MN; 1; EXCLUSION; YES; NO; NO; NO; NO
 Osge; 33; 104B5; US; 1; LIMITED_USE; NO; NO; NO; NO; YES
 Osma; 33; 10480; SO; 1; EXCLUSION; NO; NO; NO; NO; NO
@@ -206,7 +206,7 @@ Sogo; 33; 10F19; UZ; 1; EXCLUSION; YES; NO; NO; NO; NO
 Sora; 33; 110D0; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
 Soyo; 33; 11A5C; MN; 1; EXCLUSION; NO; NO; YES; NO; NO
 Sund; 33; 1B83; ID; 1; LIMITED_USE; NO; NO; YES; NO; NO
-Sunu; 33; 11BC4; NP; 1; EXCLUSION; NO; NO; NO; NO; NO  # provisional data for future Unicode 16.0 script
+Sunu; 33; 11BC4; NP; 1; EXCLUSION; NO; NO; NO; NO; NO
 Sylo; 33; A800; BD; 1; LIMITED_USE; NO; NO; YES; NO; NO
 Syrc; 33; 0710; SY; 1; LIMITED_USE; YES; NO; YES; NO; NO
 Tagb; 33; 1763; PH; 1; EXCLUSION; NO; NO; NO; NO; NO
@@ -219,9 +219,9 @@ Tfng; 33; 2D30; MA; 1; LIMITED_USE; NO; NO; NO; NO; NO
 Tglg; 33; 1703; PH; 1; EXCLUSION; NO; NO; MIN; NO; NO
 Tirh; 33; 11484; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
 Tnsa; 33; 16ABC; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
-Todr; 33; 105C2; AL; 1; EXCLUSION; NO; NO; NO; NO; NO  # provisional data for future Unicode 16.0 script
+Todr; 33; 105C2; AL; 1; EXCLUSION; NO; NO; NO; NO; NO
 Toto; 33; 1E290; IN; 1; EXCLUSION; NO; NO; NO; NO; NO
-Tutg; 33; 11392; IN; 1; EXCLUSION; NO; NO; YES; NO; NO  # provisional data for future Unicode 16.0 script
+Tutg; 33; 11392; IN; 1; EXCLUSION; NO; NO; YES; NO; NO
 Ugar; 33; 10380; SY; 1; EXCLUSION; NO; NO; NO; NO; NO
 Vaii; 33; A549; LR; 2; LIMITED_USE; NO; NO; NO; YES; NO
 Vith; 33; 10582; AL; 1; EXCLUSION; NO; NO; NO; NO; YES

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -183,6 +183,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="dyu" to="dyu_Latn_BF"/>		<!--Dyula‧?‧?	➡ Dyula‧Latin‧Burkina Faso-->
 		<likelySubtag from="dz" to="dz_Tibt_BT"/>		<!--Dzongkha‧?‧?	➡ Dzongkha‧Tibetan‧Bhutan-->
 		<likelySubtag from="ebu" to="ebu_Latn_KE"/>		<!--Embu‧?‧?	➡ Embu‧Latin‧Kenya-->
+		<likelySubtag from="ecy" to="ecy_Cprt_CY"/>		<!--Eteocypriot‧?‧?	➡ Eteocypriot‧Cypriot‧Cyprus-->
 		<likelySubtag from="ee" to="ee_Latn_GH"/>		<!--Ewe‧?‧?	➡ Ewe‧Latin‧Ghana-->
 		<likelySubtag from="efi" to="efi_Latn_NG"/>		<!--Efik‧?‧?	➡ Efik‧Latin‧Nigeria-->
 		<likelySubtag from="egl" to="egl_Latn_IT"/>		<!--Emilian‧?‧?	➡ Emilian‧Latin‧Italy-->
@@ -241,13 +242,13 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="gju" to="gju_Arab_PK"/>		<!--Gujari‧?‧?	➡ Gujari‧Arabic‧Pakistan-->
 		<likelySubtag from="gl" to="gl_Latn_ES"/>		<!--Galician‧?‧?	➡ Galician‧Latin‧Spain-->
 		<likelySubtag from="glk" to="glk_Arab_IR"/>		<!--Gilaki‧?‧?	➡ Gilaki‧Arabic‧Iran-->
+		<likelySubtag from="gmy" to="gmy_Linb_GR"/>		<!--Mycenaean Greek‧?‧?	➡ Mycenaean Greek‧Linear B‧Greece-->
 		<likelySubtag from="gn" to="gn_Latn_PY"/>		<!--Guarani‧?‧?	➡ Guarani‧Latin‧Paraguay-->
 		<likelySubtag from="gon" to="gon_Deva_IN"/>		<!--Gondi‧?‧?	➡ Gondi‧Devanagari‧India-->
 		<likelySubtag from="gor" to="gor_Latn_ID"/>		<!--Gorontalo‧?‧?	➡ Gorontalo‧Latin‧Indonesia-->
 		<likelySubtag from="gos" to="gos_Latn_NL"/>		<!--Gronings‧?‧?	➡ Gronings‧Latin‧Netherlands-->
 		<likelySubtag from="got" to="got_Goth_UA"/>		<!--Gothic‧?‧?	➡ Gothic‧Gothic‧Ukraine-->
-		<likelySubtag from="grc" to="grc_Cprt_CY"/>		<!--Ancient Greek‧?‧?	➡ Ancient Greek‧Cypriot‧Cyprus-->
-		<likelySubtag from="grc_Linb" to="grc_Linb_GR"/>		<!--Ancient Greek‧Linear B‧?	➡ Ancient Greek‧Linear B‧Greece-->
+		<likelySubtag from="grc" to="grc_Grek_GR"/>		<!--Ancient Greek‧?‧?	➡ Ancient Greek‧Greek‧Greece-->
 		<likelySubtag from="grt" to="grt_Beng_IN"/>		<!--Garo‧?‧?	➡ Garo‧Bangla‧India-->
 		<likelySubtag from="gsw" to="gsw_Latn_CH"/>		<!--Swiss German‧?‧?	➡ Swiss German‧Latin‧Switzerland-->
 		<likelySubtag from="gu" to="gu_Gujr_IN"/>		<!--Gujarati‧?‧?	➡ Gujarati‧Gujarati‧India-->
@@ -1090,7 +1091,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Chrs" to="xco_Chrs_UZ"/>		<!--?‧Chorasmian‧?	➡ Chorasmian‧Chorasmian‧Uzbekistan-->
 		<likelySubtag from="und_Copt" to="cop_Copt_EG"/>		<!--?‧Coptic‧?	➡ Coptic‧Coptic‧Egypt-->
 		<likelySubtag from="und_Cpmn" to="und_Cpmn_CY"/>		<!--?‧Cypro-Minoan‧?	➡ ?‧Cypro-Minoan‧Cyprus-->
-		<likelySubtag from="und_Cprt" to="grc_Cprt_CY"/>		<!--?‧Cypriot‧?	➡ Ancient Greek‧Cypriot‧Cyprus-->
+		<likelySubtag from="und_Cprt" to="ecy_Cprt_CY"/>		<!--?‧Cypriot‧?	➡ Eteocypriot‧Cypriot‧Cyprus-->
 		<likelySubtag from="und_Cyrl" to="ru_Cyrl_RU"/>		<!--?‧Cyrillic‧?	➡ Russian‧Cyrillic‧Russia-->
 		<likelySubtag from="und_Cyrl_AF" to="kaa_Cyrl_AF"/>		<!--?‧Cyrillic‧Afghanistan	➡ Kara-Kalpak‧Cyrillic‧Afghanistan-->
 		<likelySubtag from="und_Cyrl_AL" to="mk_Cyrl_AL"/>		<!--?‧Cyrillic‧Albania	➡ Macedonian‧Cyrillic‧Albania-->
@@ -1221,7 +1222,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Lepc" to="lep_Lepc_IN"/>		<!--?‧Lepcha‧?	➡ Lepcha‧Lepcha‧India-->
 		<likelySubtag from="und_Limb" to="lif_Limb_IN"/>		<!--?‧Limbu‧?	➡ Limbu‧Limbu‧India-->
 		<likelySubtag from="und_Lina" to="lab_Lina_GR"/>		<!--?‧Linear A‧?	➡ Linear A‧Linear A‧Greece-->
-		<likelySubtag from="und_Linb" to="grc_Linb_GR"/>		<!--?‧Linear B‧?	➡ Ancient Greek‧Linear B‧Greece-->
+		<likelySubtag from="und_Linb" to="gmy_Linb_GR"/>		<!--?‧Linear B‧?	➡ Mycenaean Greek‧Linear B‧Greece-->
 		<likelySubtag from="und_Lisu" to="lis_Lisu_CN"/>		<!--?‧Fraser‧?	➡ Lisu‧Fraser‧China-->
 		<likelySubtag from="und_Lyci" to="xlc_Lyci_TR"/>		<!--?‧Lycian‧?	➡ Lycian‧Lycian‧Türkiye-->
 		<likelySubtag from="und_Lydi" to="xld_Lydi_TR"/>		<!--?‧Lydian‧?	➡ Lydian‧Lydian‧Türkiye-->
@@ -2813,7 +2814,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="ebo" to="ebo_Latn_CG" origin="sil1"/>		<!--Teke-Ebo‧?‧?	➡ Teke-Ebo‧Latin‧Congo - Brazzaville-->
 		<likelySubtag from="ebr" to="ebr_Latn_CI" origin="sil1"/>		<!--Ebrié‧?‧?	➡ Ebrié‧Latin‧Côte d’Ivoire-->
 		<likelySubtag from="ecr" to="ecr_Grek_GR" origin="sil1"/>		<!--Eteocretan‧?‧?	➡ Eteocretan‧Greek‧Greece-->
-		<likelySubtag from="ecy" to="ecy_Cprt_CY" origin="sil1"/>		<!--Eteocypriot‧?‧?	➡ Eteocypriot‧Cypriot‧Cyprus-->
 		<likelySubtag from="efa" to="efa_Latn_NG" origin="sil1"/>		<!--Efai‧?‧?	➡ Efai‧Latin‧Nigeria-->
 		<likelySubtag from="efe" to="efe_Latn_CD" origin="sil1"/>		<!--Efe‧?‧?	➡ Efe‧Latin‧Congo - Kinshasa-->
 		<likelySubtag from="ega" to="ega_Latn_CI" origin="sil1"/>		<!--Ega‧?‧?	➡ Ega‧Latin‧Côte d’Ivoire-->
@@ -3113,7 +3113,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="gmu" to="gmu_Latn_PG" origin="sil1"/>		<!--Gumalu‧?‧?	➡ Gumalu‧Latin‧Papua New Guinea-->
 		<likelySubtag from="gmv" to="gmv_Ethi_ET" origin="sil1"/>		<!--Gamo‧?‧?	➡ Gamo‧Ethiopic‧Ethiopia-->
 		<likelySubtag from="gmx" to="gmx_Latn_TZ" origin="sil1"/>		<!--Magoma‧?‧?	➡ Magoma‧Latin‧Tanzania-->
-		<likelySubtag from="gmy" to="gmy_Linb_GR" origin="sil1"/>		<!--Mycenaean Greek‧?‧?	➡ Mycenaean Greek‧Linear B‧Greece-->
 		<likelySubtag from="gmz" to="gmz_Latn_NG" origin="sil1"/>		<!--Mgbolizhia‧?‧?	➡ Mgbolizhia‧Latin‧Nigeria-->
 		<likelySubtag from="gna" to="gna_Latn_BF" origin="sil1"/>		<!--Kaansa‧?‧?	➡ Kaansa‧Latin‧Burkina Faso-->
 		<likelySubtag from="gnb" to="gnb_Latn_IN" origin="sil1"/>		<!--Gangte‧?‧?	➡ Gangte‧Latin‧India-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1531,6 +1531,7 @@ XXX Code for transations where no currency is involved
 		<language type="dyu" territories="BF" alt="secondary"/>
 		<language type="dz" scripts="Tibt" territories="BT"/>
 		<language type="ebu" scripts="Latn"/>
+		<language type="ecy" scripts="Cprt" alt="secondary"/>
 		<language type="ee" scripts="Latn"/>
 		<language type="ee" territories="GH TG" alt="secondary"/>
 		<language type="efi" scripts="Latn"/>
@@ -1620,6 +1621,7 @@ XXX Code for transations where no currency is involved
 		<language type="glk" scripts="Arab"/>
 		<language type="glk" territories="IR" alt="secondary"/>
 		<language type="gmh" scripts="Latn" alt="secondary"/>
+		<language type="gmy" scripts="Linb" alt="secondary"/>
 		<language type="gn" scripts="Latn" territories="PY"/>
 		<language type="goh" scripts="Latn" alt="secondary"/>
 		<language type="gon" scripts="Deva Telu"/>
@@ -1629,7 +1631,7 @@ XXX Code for transations where no currency is involved
 		<language type="gos" scripts="Latn"/>
 		<language type="got" scripts="Goth" alt="secondary"/>
 		<language type="grb" scripts="Latn"/>
-		<language type="grc" scripts="Cprt Grek Linb" alt="secondary"/>
+		<language type="grc" scripts="Grek" alt="secondary"/>
 		<language type="grt" scripts="Beng"/>
 		<language type="gsw" scripts="Latn" territories="CH LI"/>
 		<language type="gsw" territories="DE" alt="secondary"/>
@@ -2861,6 +2863,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="fr" populationPercent="6.6" references="R1132"/>	<!--French-->
 			<languagePopulation type="hy" populationPercent="0.21"/>	<!--Armenian-->
 			<languagePopulation type="ar" populationPercent="0.098"/>	<!--Arabic-->
+			<languagePopulation type="ecy" populationPercent="0.0001"/>	<!--Eteocypriot-->
 		</territory>
 		<territory type="CZ" gdp="519000000000" literacyPercent="99" population="10837900">	<!--Czechia-->
 			<languagePopulation type="cs" populationPercent="98" officialStatus="official"/>	<!--Czech-->
@@ -3147,6 +3150,8 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="bg" populationPercent="0.27"/>	<!--Bulgarian-->
 			<languagePopulation type="sq" populationPercent="0.096"/>	<!--Albanian-->
 			<languagePopulation type="tsd" populationPercent="0.0019"/>	<!--Tsakonian-->
+			<languagePopulation type="gmy" populationPercent="0"/>	<!--Mycenaean Greek-->
+			<languagePopulation type="grc" populationPercent="0"/>	<!--Ancient Greek-->
 		</territory>
 		<territory type="GS" gdp="1081000" literacyPercent="99" population="20">	<!--South Georgia & South Sandwich Islands-->
 			<languagePopulation type="en" populationPercent="100" officialStatus="official" references="R1338"/>	<!--English-->

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -458,7 +458,6 @@ public class GenerateLikelySubtags {
                                 {"cu_Glag", "cu_Glag_BG"},
                                 {"sd_Khoj", "sd_Khoj_IN"},
                                 {"lif_Limb", "lif_Limb_IN"},
-                                {"grc_Linb", "grc_Linb_GR"},
                                 {"arc_Nbat", "arc_Nbat_JO"},
                                 {"arc_Palm", "arc_Palm_SY"},
                                 {"pal_Phlp", "pal_Phlp_CN"},

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Script_Metadata.csv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Script_Metadata.csv
@@ -68,7 +68,7 @@ WR,Name,Script_Code,Age,Size,Sample,Sample_Code,Origin Country,~Density,Likely L
 66,Buhid,Buhd,3.2,20,ᝃ,1743,Philippines,1,Buhid,bku,Exclusion,no,no,Yes,no,no
 67,Carian,Cari,5.1,49,𐊷,102A0,Turkey,1,Carian,xcr,Exclusion,no,no,no,no,no
 68,Cuneiform,Xsux,5.0,"1,037",𒀀,12000,Iraq,3,Akkadian,akk,Exclusion,no,no,no,Yes,no
-69,Cypriot,Cprt,4.0,55,𐠀,10800,Cyprus,1,Ancient Greek,grc,Exclusion,Yes,no,no,no,no
+69,Cypriot,Cprt,4.0,55,𐠀,10800,Cyprus,1,Eteocypriot,ecy,Exclusion,Yes,no,no,no,no
 70,Deseret,Dsrt,3.1,80,𐐔,10414,United States,1,English,en,Exclusion,no,no,no,no,Yes
 71,Egyptian_Hieroglyphs,Egyp,5.2,"1,071",𓅓,13153,Egypt,3,Ancient Egyptian,egy,Exclusion,no,no,Yes,Yes,no
 72,Gothic,Goth,3.1,27,𐌰,10330,Ukraine,1,Gothic,got,Exclusion,no,no,no,no,no
@@ -78,7 +78,7 @@ WR,Name,Script_Code,Age,Size,Sample,Sample_Code,Origin Country,~Density,Likely L
 76,Inscriptional_Parthian,Prti,5.2,30,𐭀,10B40,Iran,1,Parthian,xpr,Exclusion,Yes,no,no,no,no
 77,Kaithi,Kthi,5.2,66,𑂃,11083,India,1,Bhojpuri,bho,Exclusion,no,no,min,no,no
 78,Kharoshthi,Khar,4.1,65,𐨀,10A00,Pakistan,1,Gandhari,pra,Exclusion,Yes,no,Yes,no,no
-79,Linear_B,Linb,4.0,211,𐀀,10000,Greece,1,Ancient Greek,grc,Exclusion,no,no,no,Yes,no
+79,Linear_B,Linb,4.0,211,𐀀,10000,Greece,1,Mycenaean Greek,gmy,Exclusion,no,no,no,Yes,no
 80,Lycian,Lyci,5.1,29,𐊀,10280,Turkey,1,Lycian,xlc,Exclusion,no,no,no,no,no
 81,Lydian,Lydi,5.1,27,𐤠,10920,Turkey,1,Lydian,xld,Exclusion,Yes,no,no,no,no
 82,Ogham,Ogam,3.0,29,ᚏ,168F,Ireland,1,Old Irish,sga,Exclusion,no,no,no,no,no

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -321,6 +321,7 @@ Cyprus	CY	"1,237,088"	99%	"31,780,000,000"		English	en	73%
 Cyprus	CY	"1,237,088"	99%	"31,780,000,000"		French	fr	6.6%			https://observatoire.francophonie.org//wp-content/uploads/2022/03/odsef-lfdm-2022.pdf Organisation internationale de la Francophonie Meta-study. Data from 2012 and 2016 Eurostat studies on first and second language usage across Europe
 Cyprus	CY	"1,237,088"	99%	"31,780,000,000"	official	Greek	el	95%
 Cyprus	CY	"1,237,088"	99%	"31,780,000,000"	official	Turkish	tr	23%
+Cyprus	CY	"1,237,088"	99%	"31,780,000,000"		Eteocypriot	ecy	1
 Czechia	CZ	"10,686,269"	99%	"375,900,000,000"	official	Czech	cs	98%
 Czechia	CZ	"10,686,269"	99%	"375,900,000,000"		English	en	27%
 Czechia	CZ	"10,686,269"	99%	"375,900,000,000"		German	de	15%
@@ -489,6 +490,8 @@ Greece	GR	"10,761,523"	97%	"299,300,000,000"		Macedonian	mk	"175,000"
 Greece	GR	"10,761,523"	97%	"299,300,000,000"		Pontic	pnt	3.7%
 Greece	GR	"10,761,523"	97%	"299,300,000,000"		Tsakonian	tsd	200
 Greece	GR	"10,761,523"	97%	"299,300,000,000"		Turkish	tr	"125,000"
+Greece	GR	"10,761,523"	97%	"299,300,000,000"		Ancient Greek	grc	1
+Greece	GR	"10,761,523"	97%	"299,300,000,000"		Mycenaean Greek	gmy	1
 Greenland	GL	"57,691"	100%	"2,413,000,000"		Danish	da	"7,830"
 Greenland	GL	"57,691"	100%	"2,413,000,000"	official	Kalaallisut	kl	84%
 Grenada	GD	"112,207"	96%	"1,634,000,000"	official	English	en	96%			https://www.cia.gov/cia/publications/factbook/geos/gj.html English official; the figure is derived from literacy * lang pop

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -205,6 +205,7 @@ dyo	Jola-Fonyi	secondary	Arab	Arabic
 dyu	Dyula	primary	Latn	Latin
 dz	Dzongkha	primary	Tibt	Tibetan
 ebu	Embu	primary	Latn	Latin
+ecy	Eteocypriot	primary	Cprt	Cypriot Syllabary
 ee	Ewe	primary	Latn	Latin
 efi	Efik	primary	Latn	Latin
 egl	Emilian	primary	Latn	Latin
@@ -272,6 +273,7 @@ gl	Galician	primary	Latn	Latin
 gld	Nanai	primary	Cyrl	Cyrillic
 glk	Gilaki	primary	Arab	Arabic
 gmh	Middle High German	secondary	Latn	Latin
+gmy	Mycenaean Greek	primary	Linb	Linear B
 gn	Guarani	primary	Latn	Latin
 goh	Old High German	secondary	Latn	Latin
 gon	Gondi	primary	Deva	Devanagari
@@ -280,9 +282,7 @@ gor	Gorontalo	primary	Latn	Latin
 gos	Gronings	primary	Latn	Latin
 got	Gothic	secondary	Goth	Gothic
 grb	Grebo	primary	Latn	Latin
-grc	Ancient Greek	secondary	Cprt	Cypriot
-grc	Ancient Greek	secondary	Grek	Greek
-grc	Ancient Greek	secondary	Linb	Linear B
+grc	Ancient Greek	primary	Grek	Greek
 grt	Garo	primary	Beng	Bangla
 gsw	Swiss German	primary	Latn	Latin
 gu	Gujarati	primary	Gujr	Gujarati

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -283,7 +283,6 @@ gos	Gronings	primary	Latn	Latin
 got	Gothic	secondary	Goth	Gothic
 grb	Grebo	primary	Latn	Latin
 grc	Ancient Greek	primary	Grek	Greek
-grc	Ancient Greek	secondary	Cprt	Cypriot Syllabary
 grt	Garo	primary	Beng	Bangla
 gsw	Swiss German	primary	Latn	Latin
 gu	Gujarati	primary	Gujr	Gujarati

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -283,6 +283,7 @@ gos	Gronings	primary	Latn	Latin
 got	Gothic	secondary	Goth	Gothic
 grb	Grebo	primary	Latn	Latin
 grc	Ancient Greek	primary	Grek	Greek
+grc	Ancient Greek	secondary	Cprt	Cypriot Syllabary
 grt	Garo	primary	Beng	Bangla
 gsw	Swiss German	primary	Latn	Latin
 gu	Gujarati	primary	Gujr	Gujarati


### PR DESCRIPTION
CLDR-11570

Ancient Greek is only written in Greek alphabet rather than Linear B or Cypriot Syllabary -- so this change corrects that. In fact, Linear B was never used for Ancient Greek -- rather it was used by its predecessor Mycenaean Greek (ancient greek to the ancient greeks). The Cypriot Syllabary was used primarily for a different language, Eteocypriot -- its not related to Greek or Indo-European. There is some Ancient Greek text (particularly the Arcadocypriot dialect) in the Cypriot Syllabary, and it's even present in the [Idalion Tablet](https://en.wikipedia.org/wiki/Idalion_Tablet) and the [Idalion bilingual](https://en.wikipedia.org/wiki/Idalion_bilingual) but its pretty rare.

Unfortunately I cannot list "Cypriot Syllabary" as secondary without it bumping out the Greek Alphabet because Cprt > Grek alphabetically. Thereby I made a separate Jira ticket to fix ambiguities in the xml https://unicode-org.atlassian.net/browse/CLDR-18087. This ticket just focused on the Ancient Greek fix so we can fix the bug.

- [x] This PR completes the ticket.

Scripts ran:
```
mvn package
java -jar tools/cldr-code/target/cldr-code.jar ConvertLanguageData 
java -jar tools/cldr-code/target/cldr-code.jar GenerateLikelySubtags
java -jar tools/cldr-code/target/cldr-code.jar GenerateTestData
java -jar tools/cldr-code/target/cldr-code.jar GenerateScriptMetadata
java -jar tools/cldr-code/target/cldr-code.jar GenerateValidityXML
```


ALLOW_MANY_COMMITS=true
