### PR TITLE
CLDR-17918 json: put 8601 calendar under dates

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config.txt
@@ -29,6 +29,7 @@ section=ca-dangi ; path=//cldr/main/[^/]++/dates/calendars/dangi/.* ; package=ca
 section=ca-ethiopic ; path=//cldr/main/[^/]++/dates/calendars/ethiopic/.* ; package=cal-ethiopic ; packageDesc=CLDR data for Ethiopic calendars.
 section=ca-ethiopic-amete-alem ; path=//cldr/main/[^/]++/dates/calendars/ethiopic-amete-alem/.* ; package=cal-ethiopic
 section=ca-generic ; path=//cldr/main/[^/]++/dates/calendars/generic/.* ; package=dates
+section=ca-generic ; path=//cldr/main/[^/]++/dates/calendars/iso8601/.* ; package=dates
 section=ca-gregorian ; path=//cldr/main/[^/]++/dates/calendars/gregorian/.* ; package=dates
 section=ca-hebrew ; path=//cldr/main/[^/]++/dates/calendars/hebrew/.* ; package=cal-hebrew ; packageDesc=CLDR data for Hebrew calendars.
 section=ca-indian ; path=//cldr/main/[^/]++/dates/calendars/indian/.* ; package=cal-indian ; packageDesc=CLDR data for Indian calendars.


### PR DESCRIPTION
- The iso8601 calendar type was added in CLDR-17892
- Add this calendar type under the `cldr-dates-full` package
- TODO: in CLDR-17984 add a test to catch new calendars

CLDR-17918

- [ ] This PR completes the ticket.

(Note: the package mentioned above is where gregorian and generic are already kept.)

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
