### PR TITLE
CLDR-17977 Update _redirects

### DIFF
--- a/docs/site/_redirects
+++ b/docs/site/_redirects
@@ -7,3 +7,6 @@
 
 # redirect old download pages [CLDR-17977]
 /index/downloads/* /downloads/:splat
+
+# pages that were renamed [CLDR-17977]
+/index/cldr-spec/unicode-transliteration-guidelines* /index/cldr-spec/transliteration-guidelines


### PR DESCRIPTION
CLDR-17977

> It appears that [https://cldr.unicode.org/index/cldr-spec/unicode-transliteration-guidelines](https://cldr.unicode.org/index/cldr-spec/unicode-transliteration-guidelines#h.wh84w0csexl6) is another link that used to work but doesn’t any more.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

## Testing:

- https://6a4424c6.cldr.pages.dev/index/cldr-spec/unicode-transliteration-guidelines#h.wh84w0csexl6
- 
ALLOW_MANY_COMMITS=true
