### PR TITLE
CLDR-18001 site: move sitemap to separate page

### DIFF
--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -2,6 +2,5 @@
 /assets/json
 /assets/vendor
 /sitemap.xml
-/sitemap.md
 
 

--- a/docs/site/_layouts/sitemap.html
+++ b/docs/site/_layouts/sitemap.html
@@ -8,22 +8,26 @@
 	<link rel="stylesheet" href="/assets/css/page.css" />
 </head>
 
-<body class="page">
+<body class="sitemappage">
 	<!-- <h1>{{ page.title }}</h1> -->
-	<header class="pageheader">
+	<header>
 		<div class="navparent">
 			<div id="nav" class="nav">
-				<!-- Vue mount here -->
+				<!-- Vue mount here for normal navigation -->
 			</div>
 		</div>
 		<div class="message"><i>This navigation UI is temporary, just to give access to the pages.</i></div>
+		<!-- <div class="bar"><a href="/sitemap" class="bar">Site Map</a></div> -->
 	</header>
-
-
 
 	<section class="body">
 		{{ content }}
 	</section>
+
+	<div id="sitemap">
+		<!-- sitemap goes here-->
+	</div>
+
 	<footer>
 		© 1991-2024 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries. See <a href="https://www.unicode.org/copyright.html">Terms of Use</a>.
 	</footer>

--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -40,18 +40,15 @@ header .nav a.uplink {
   color: white;
 }
 
-body.page .showmap a,
-body.page .showmap a:visited {
+body.page a.showmap {
   color: white;
-  text-decoration-color: white;
-  text-decoration-style: none;
+  text-decoration: none;
 }
 
-body.sitemappage .showmap a,
-body.sitemappage .showmap a:visited {
-  color: gray;
-  text-decoration-color: gray;
-  font-weight: bold;
+body.sitemappage a.showmap,
+body.sitemappage a.showmap:visited {
+  color: lightgray;
+  text-decoration: none;
 }
 
 .showmap {
@@ -59,7 +56,7 @@ body.sitemappage .showmap a:visited {
   right: 1em;
 }
 
-.showmap:hover {
+body.page a.showmap:hover {
   text-decoration: underline;
   color: white;
 }

--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -1,6 +1,22 @@
 /* mirror of div.body */
-section.body {
+body.page section.body {
   margin: 3em;
+}
+
+/* If there is any content on the sitemap.md page, left indent it to fit with the rest,
+but don't create a big space for it.  */
+body.sitemappage section.body {
+  margin-left: 3em;
+}
+
+body.page header .subpages a:link {
+  text-decoration: none;
+}
+body.page header .subpages a:visited {
+  text-decoration: none;
+}
+body.page header .subpages a:hover {
+  text-decoration: underline;
 }
 
 header {
@@ -80,10 +96,6 @@ div.submap {
   padding-left: 0.5em;
 }
 
-div.sitemap .hamburger {
-  display: none;
-}
-
 div.subpages > .hamburger {
   position: absolute;
   right: 1em;
@@ -102,6 +114,7 @@ div.sitemap > div.submap {
 
 .subpages .hamburger:hover {
   color: gray;
+  text-shadow: 1px 1px 3px gray;
 }
 
 header .nav ul b {

--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -40,19 +40,31 @@ header .nav a.uplink {
   color: white;
 }
 
-div.showmap {
-  position: absolute;
-  right: 1em;
+body.page .showmap a,
+body.page .showmap a:visited {
   color: white;
+  text-decoration-color: white;
+  text-decoration-style: none;
 }
 
-div.showmap:hover {
+body.sitemappage .showmap a,
+body.sitemappage .showmap a:visited {
+  color: gray;
+  text-decoration-color: gray;
+  font-weight: bold;
+}
+
+.showmap {
+  position: absolute;
+  right: 1em;
+}
+
+.showmap:hover {
   text-decoration: underline;
   color: white;
 }
 
-header .nav div.subpages,
-div.sitemap {
+header .nav div.subpages {
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   z-index: 1;
   background-color: white;
@@ -61,14 +73,21 @@ div.sitemap {
   padding: 0.5em;
 }
 
+div.sitemap {
+  padding: 1em;
+}
+
 div.submap {
   margin-left: 1em;
   border-left: 1px solid gray;
   padding-left: 0.5em;
 }
 
-div.subpages > .hamburger,
 div.sitemap .hamburger {
+  display: none;
+}
+
+div.subpages > .hamburger {
   position: absolute;
   right: 1em;
   top: 1em;

--- a/docs/site/assets/css/reports-v2.css
+++ b/docs/site/assets/css/reports-v2.css
@@ -1,21 +1,21 @@
 /*
-	Style sheet for web-based Unicode Standard Annexes, Technical Standards and Technical Reports 
+	Style sheet for web-based Unicode Standard Annexes, Technical Standards and Technical Reports
 	M.Davis and A.Freytag
-	
+
 	Last edited: 2015-04-06 AF, 2015-04-15 KW
 	removed all "-web" and "-book" suffixes
-	
-	To use, in <head>... 
+
+	To use, in <head>...
 	insert:<link REL="stylesheet" HREF="../reports-v2.css" TYPE="text/css">
  */
 
 
 /* conditional display */
 body		{ margin: 0; font-family:  Arial, Geneva, sans-serif;
-				color: black; background-color: white; background-repeat:repeat; 
+				color: black; background-color: white; background-repeat:repeat;
 				background-attachment: scroll; background-position: 0%; }
 div.body	{ margin: 3em; } 	/* margin for body only */
-						 
+
 blockquote	{ margin: 20px; }
 /* for quoting from the standard */
 blockquote.tus	{ font-size: 11pt; font-family: Times New Roman, serif; }
@@ -37,19 +37,19 @@ li 			{margin-top: 0.25em; margin-bottom: 0.25em; }
 .lightgray    { background-color: #E4E4E4 !important; }  /*not sure we need this one */
 .vlightgray   { background-color: #F8F8F8 !important; }
 .sandstone   { background-color: #ECE8E0 !important; }
- 
+
 span.codepoint   { font-family: monospace; }
 span.charSample { font-size: 200%; }
-span.name 	{ text-transform: lowercase; 
+span.name 	{ text-transform: lowercase;
 			font-variant: small-caps; font-size: 75%; }
 
 span.section { font-style: italic; }
 span.secno { font-style: italic; }
 
 p.caption	 { page-break-after: avoid; font-weight: bold; text-align: center; }
-p.rule		 { font-style:italic; background-color: #ECE8E0; }	
+p.rule		 { font-style:italic; background-color: #ECE8E0; }
 td.rule, th.rule	 { font-style:italic;  font-weight: 400 !important; padding: 3px !important; margin:2px !important; }
-td.rule, th.rule	{ background-color: #ECE8E0 !important; border: 1px solid #F2F2F2 !important; }	
+td.rule, th.rule	{ background-color: #ECE8E0 !important; border: 1px solid #F2F2F2 !important; }
 
 
 /* from UAX#29 */
@@ -74,7 +74,7 @@ td.icon 	{ border-style: none; border-width: 0; padding: 2px; margin: 0;
 			background-color: #5555FF; color: white;
 			font-size: 100%; text-align: left;
 			font-weight: bold; font-family: Arial, Geneva, sans-serif; }
-				
+
 td.gray 	{ border-style: none; border-width: 0; padding: 0px; margin: 0;
 			background-color: #EEEEFE; color: white;
 			font-size: 6pt; }
@@ -94,10 +94,10 @@ table.border th, table.border td	{ border-style: solid !important; border-width:
 
 
 /* Tables should inherit from body, but do not seem to in NN */
-a:link		{ color: #3030FF; text-decoration:none; }
-a:active	{ color: #3030FF; }
-a:visited	{ color: #3030FF; text-decoration:none; }
-a:hover 	{ text-decoration:underline; }
+section.body a:link		{ color: #3030FF; text-decoration:none; }
+section.body a:active	{ color: #3030FF; }
+section.body a:visited	{ color: #3030FF; text-decoration:none; }
+section.body a:hover 	{ text-decoration:underline; }
 
 /* HEADERS and RELATED STYLES */
 h1, h2, h3, h4, h5, h6 { font-weight: bold; margin-top: 8px; }
@@ -113,11 +113,11 @@ h6			{ font-size: small; font-style: italic; }
 /* don't color links on headers and captions, unless hovering */
 h2 a:link, h3 a:link, h4 a:link, h5 a:link, p.caption a:link, caption a:link,
 h2 a:visited, h3 a:visited, h4 a:visited, h5 a:visited, p.caption a:visited, caption a:visited {
-    color:black; 
+    color:black;
     text-decoration:none;
     }
 h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, p.caption a:hover, caption a:hover {
-    color: #3030FF; 
+    color: #3030FF;
     text-decoration:underline;
     }
 
@@ -141,13 +141,13 @@ h3.summary { margin-top: 1em; }
 h4.contents {}
 h4.status {}
 
- 
+
 /* link style for character class */
 a.charclass { font-weight:bold; text-decoration: none; color: #808080 }
 
- 
+
 /* syntax coloring for C source code samples */
- 
+
 .CKeyword		{color: rgb(0,0,255); }
 .CComment		{color: rgb(0,128,0); }
 .CCommand		{ font-weight:bold; color: rgb(255,0,0); }
@@ -164,20 +164,20 @@ span.removedspan	{ text-decoration: line-through; background-color: #FFFF00; bor
 .reviewnote 	{ background-color: #FFFF80; color: #CC0000; border-style: dashed;
 			border-width: 1px; }
 
- 
- 
+
+
 /* table w/o a grid, except for lines in first and last row like in TR#25 */
- 
+
 table.gray	 { border-collapse: collapse; border-style: none; border-width: medium; }
- 
-th.grayfirst, td.grayfirst { border-left-style: none; border-left-width: medium; border-right-style: none; 
+
+th.grayfirst, td.grayfirst { border-left-style: none; border-left-width: medium; border-right-style: none;
 				border-right-width: medium; border-top: 1.5pt solid gray;
 				border-bottom: .75pt solid gray; padding-left: 5.4pt;
 				padding-right: 5.4pt; padding-top: 0in; padding-bottom: 0in }
-th.graymiddle, td.graymiddle { border-style: none; border-width: medium; padding-left: 5.4pt; 
+th.graymiddle, td.graymiddle { border-style: none; border-width: medium; padding-left: 5.4pt;
 				padding-right:5.4pt; padding-top: 0in; padding-bottom: 0in; }
 
-th.graylast, td.graylast { border-left-style: none; border-left-width: medium; border-right-style: none; 
+th.graylast, td.graylast { border-left-style: none; border-left-width: medium; border-right-style: none;
 				border-right-width: medium; border-top-style: none;
 				border-top-width: medium; border-bottom: 1.5pt solid gray;
 				padding-left: 5.4pt; padding-right: 5.4pt; padding-top: 0in;
@@ -187,12 +187,12 @@ th.graylast, td.graylast { border-left-style: none; border-left-width: medium; b
 /* list styles that work well in table of contents */
 ul.toc		{ list-style-position: outside; list-style-type: none; margin-left: 1em; margin-bottom: 0pt;
 				margin-top: 0pt; line-height: 90%; }
- 
+
 ol.toc		{ list-style-type: decimal; margin-bottom: 0pt; }
- 
+
 ol ul.toc	{ list-style-position: outside; list-style-type: none; margin-left: 0em; margin-bottom: 0pt;
 					margin-top: 0pt; line-height: 90%; }
- 
+
 ul ul.toc	{ list-style-position: outside; list-style-type: none; margin-left: 1.3em; margin-bottom: 0pt;
 					margin-top: 0pt; line-height: 90%; }
 ul.toc li 		{ margin-left: 0; }
@@ -202,7 +202,7 @@ ol ul 		{ list-style-type: disc; }
 ul.nobullet		{ list-style-type: none; }
 
 /* is the preceding needed for web ? */
-			
+
 .right       { text-align: right; }
 .left        { text-align: Left; }
 .center      { text-align: center; }
@@ -210,7 +210,7 @@ ul.nobullet		{ list-style-type: none; }
 
 /* UAX#14 specific styles, duplicated here in case they are applicable elsehwere */
 table.pair		{ border:1px solid; font-size:8pt; }
-table.pair th	{ text-align:center; font-size:8pt; }	
+table.pair th	{ text-align:center; font-size:8pt; }
 table.pair th.pairItem { background-color:#800080; }
 .nb-la			{ width:7em; border-style: none; border-width: 0; padding-left: 0.2em; background-color:#ECE8E0; }
 .nb-lb			{ border-style: none; border-width: 0; padding-left: 0.2em; background-color:#F0F0F0; }
@@ -230,42 +230,42 @@ span.symbol { font-size: 90%; font-family: Arial, Geneva, sans-serif } /* same a
 /* the -nb variants are the same but w/o borders */
 
 table.simple { border-width:1px; border-style:solid; border-color:#A0A0A0;
-                border-collapse:collapse; padding:0.2em; font-size:1em} 
+                border-collapse:collapse; padding:0.2em; font-size:1em}
 		table.simple th { border-width:1px; border-style:solid; border-color:#A0A0A0;
-                font-weight:bold; padding:5px; text-align: left; } 
+                font-weight:bold; padding:5px; text-align: left; }
 		table.simple td {border-width:1px; border-style:solid; border-color:#A0A0A0;
                 padding:5px; text-align: left;  }
 
 
 table.subtle { border-width:1px; border-style:solid; border-color:#A0A0A0;
-                border-collapse:collapse; padding:0.2em; font-size:1em} 
+                border-collapse:collapse; padding:0.2em; font-size:1em}
 		table.subtle th { border-width:1px; border-style:solid; border-color:#A0A0A0;
-                font-weight:bold; padding:5px; text-align: left; } 
+                font-weight:bold; padding:5px; text-align: left; }
 		table.subtle td {border-width:1px; border-style:solid; border-color:#A0A0A0;
                 padding:5px; text-align: left;  }
 
 
-table.subtle-nb { border-style:none; border-width:0; border-collapse:collapse; } 
-		table.subtle-nb th { border:solid 1px #F2F2F2;  font-weight:bold; padding:5px; text-align:left; } 
+table.subtle-nb { border-style:none; border-width:0; border-collapse:collapse; }
+		table.subtle-nb th { border:solid 1px #F2F2F2;  font-weight:bold; padding:5px; text-align:left; }
 		table.subtle-nb td { border-style:none;  border-width: 0; font-weight:normal; padding:5px; text-align:left; }
 
-table.subtle-nb table.subtle th { border-width:1px; border-style:solid; border-color:#A0A0A0;  } 
-table.subtle-nb table.subtle td { border-width:1px; border-style:solid; border-color:#A0A0A0;  } 
+table.subtle-nb table.subtle th { border-width:1px; border-style:solid; border-color:#A0A0A0;  }
+table.subtle-nb table.subtle td { border-width:1px; border-style:solid; border-color:#A0A0A0;  }
 table.subtle-nb table.simple th { color: #000000; background-color: #FFFFFF; /* was: #FFFFFF; */
-	border-width:1px; border-style:solid; 
+	border-width:1px; border-style:solid;
 	border-color:#A0A0A0; }
 table.subtle-nb table.simple td { border-width:1px; border-style:solid; border-color:#A0A0A0; }
 table.subtle table.simple th { color: #000000; background-color:#FFFFFF; } /*was #FFFFFF */
-		
-table.subtle th         { color: #606060; background-color:#ECE8E0;} 
-table.subtle-nb th      { color: #606060; background-color:#ECE8E0;} 
-		
-table.subtle th p       { color: #606060; background-color:#ECE8E0; } 
-table.subtle-nb tr th p { color: #606060; background-color:#ECE8E0; } 
 
-table.simple th p       { margin:0; } 
-table.subtle th p       { margin:0; } 
-table.subtle-nb th p    { margin:0; } 
+table.subtle th         { color: #606060; background-color:#ECE8E0;}
+table.subtle-nb th      { color: #606060; background-color:#ECE8E0;}
+
+table.subtle th p       { color: #606060; background-color:#ECE8E0; }
+table.subtle-nb tr th p { color: #606060; background-color:#ECE8E0; }
+
+table.simple th p       { margin:0; }
+table.subtle th p       { margin:0; }
+table.subtle-nb th p    { margin:0; }
 
 
 /* first-child selector only works in IE if DOCTYPE has a URL (standards mode) */
@@ -275,10 +275,10 @@ table.simple td>p:first-child { margin: 0; }
 table.simple td>p             { margin-top: 1.5em; }
 
 table.subtle td>p:first-child  { margin:0; }
-table.subtle td>p              { margin-top:1.5em; } 
+table.subtle td>p              { margin-top:1.5em; }
 
 table.subtle-nb td>p:first-child { margin:0;  }
-table.subtle-nb td>p             { margin-top:1.5em; } 
+table.subtle-nb td>p             { margin-top:1.5em; }
 
 table.simple td>ul:first-child { margin-top:0; margin-bottom:0; }
 table.simple td>ol:first-child { margin-top:0; margin-bottom:0; }
@@ -297,7 +297,7 @@ table.subtle-nb td>ol             { margin-top:1.5em; margin-bottom:0.5em; }
 
 /* override the default padding use with table style "simple" */
 table.nopad { padding: 0; }
-table.nopad th, table.nopad td { padding:0;} 
+table.nopad th, table.nopad td { padding:0;}
 
 table.loose th, table.loose td { padding-top: 8px; padding-bottom: 8px; }
 

--- a/docs/site/assets/js/build.mjs
+++ b/docs/site/assets/js/build.mjs
@@ -11,7 +11,7 @@ import { Dirent } from "node:fs";
 // utilities and constants
 
 // files to skip
-const SKIP_THESE = /(node_modules|\.jekyll-cache|^sitemap.*)/;
+const SKIP_THESE = /(node_modules|\.jekyll-cache|^sitemap.tsv)/;
 
 // final URL of site
 const SITE = "https://cldr.unicode.org";
@@ -31,7 +31,7 @@ const coll = new Intl.Collator(["und"]);
 async function processFile(d, fullPath, out) {
   const f = await fs.readFile(fullPath, "utf-8");
   const m = matter(f);
-  fullPath = fullPath.replace(/\\/g, '/'); // backslash with slash, for win
+  fullPath = fullPath.replace(/\\/g, "/"); // backslash with slash, for win
   if (m && m.data) {
     const { data } = m;
     out.all.push({ ...data, fullPath });

--- a/docs/site/assets/js/cldrsite.js
+++ b/docs/site/assets/js/cldrsite.js
@@ -77,6 +77,7 @@ const SubPagesPopup = {
   },
   template: `
           <div class="subpages">
+          <span class="hamburger" @click="hide()">✕</span>
           <ul class="subpages" >
               <li v-for="subpage of children" :key="subpage.path">
                   <a v-bind:href="subpage.href">
@@ -137,8 +138,6 @@ const SiteMap = {
   },
   template: `
     <div class="sitemap">
-          <span class="hamburger" @click="hide()">✕</span>
-          <b>Site Map</b><hr/>
           <SubMap :usermap="tree.value.usermap" path="index"/>
     </div>
   `,

--- a/docs/site/sitemap.md
+++ b/docs/site/sitemap.md
@@ -1,0 +1,6 @@
+---
+layout: sitemap
+title: "CLDR Site Map"
+---
+
+<!-- no content needed, the site map will follow this section. -->

--- a/docs/site/sitemap.tsv
+++ b/docs/site/sitemap.tsv
@@ -5,23 +5,23 @@
 # Every page must be listed.   index/charts means index/charts.md for example.
 # If an item has 'sub items' it becomes a directory parent.
 # You can comment out lines, but an error will be given at build time if a page is missing.
-index			
-	index/cldr-spec		
-		index/cldr-spec/core-data-for-new-locales	
-		index/cldr-spec/coverage-levels	
-		index/cldr-spec/collation-guidelines	
-		index/cldr-spec/currency-process	
-		index/cldr-spec/picking-the-right-language-code	
-		index/cldr-spec/plural-rules	
-		index/cldr-spec/transliteration-guidelines	
-		index/cldr-spec/definitions	
-	index/downloads		
-		downloads/cldr-46	
-		downloads/cldr-45	
-		downloads/cldr-44	
-		downloads/cldr-43	
-		index/json-format-data	
-		downloads/previous-releases	
+index
+	index/cldr-spec
+		index/cldr-spec/core-data-for-new-locales
+		index/cldr-spec/coverage-levels
+		index/cldr-spec/collation-guidelines
+		index/cldr-spec/currency-process
+		index/cldr-spec/picking-the-right-language-code
+		index/cldr-spec/plural-rules
+		index/cldr-spec/transliteration-guidelines
+		index/cldr-spec/definitions
+	index/downloads
+		downloads/cldr-46
+		downloads/cldr-45
+		downloads/cldr-44
+		downloads/cldr-43
+		index/json-format-data
+		downloads/previous-releases
 			downloads/cldr-42
 			downloads/cldr-41
 			downloads/cldr-40
@@ -35,30 +35,30 @@ index
 			downloads/cldr-33
 			downloads/cldr-32
 			downloads/cldr-31
-	index/charts		
-	index/draft-schedule		
+	index/charts
+	index/draft-schedule
 	requesting_changes
-	index/bcp47-extension		
-	cldr-tc		
-		cldr-tc/design-wg	
-		cldr-tc/message-format-wg	
-		cldr-tc/person-name-wg	
-		cldr-tc/infrastructure-wg	
-		index/keyboard-workgroup	
-		ddl	
-	general-information		
-		index/language-support-levels	
-		index/locale-coverage	
-		index/process	
-		index/process/cldr-data-retention-policy	
-		index/requesting-additionsupdates-to-cldr-languagepopulation-data	
-		stable-links-info	
-		covered-by-other-projects	
-		index/cldr-presentations	
-		index/corrigenda	
-		index/acknowledgments	
-	translation		
-		translation/getting-started	
+	index/bcp47-extension
+	cldr-tc
+		cldr-tc/design-wg
+		cldr-tc/message-format-wg
+		cldr-tc/person-name-wg
+		cldr-tc/infrastructure-wg
+		index/keyboard-workgroup
+		ddl
+	general-information
+		index/language-support-levels
+		index/locale-coverage
+		index/process
+		index/process/cldr-data-retention-policy
+		index/requesting-additionsupdates-to-cldr-languagepopulation-data
+		stable-links-info
+		covered-by-other-projects
+		index/cldr-presentations
+		index/corrigenda
+		index/acknowledgments
+	translation
+		translation/getting-started
 			translation/getting-started/data-stability
 			translation/getting-started/empty-cache
 			translation/getting-started/errors-and-warnings
@@ -76,59 +76,59 @@ index
 			translation/translation-guide-general/references
 			translation/unique-translations
 			translation/getting-started/fixing-errors
-		index/survey-tool	
+		index/survey-tool
 			index/survey-tool/bulk-data-upload
 			index/survey-tool/coverage
 			index/survey-tool/faq-and-known-bugs
 			index/survey-tool/managing-users
 			index/survey-tool/survey-tool-accounts
-		translation/displaynames	
+		translation/displaynames
 			translation/displaynames/countryregion-territory-names
 			translation/displaynames/languagelocale-name-patterns
 			translation/displaynames/languagelocale-names
 			translation/displaynames/locale-option-names-key
 			translation/displaynames/script-names
-		translation/characters	
+		translation/characters
 			translation/characters/character-labels
 			translation/characters/short-names-and-keywords
 			translation/characters/typographic-names
-		translation/core-data	
+		translation/core-data
 			translation/core-data/characters
 			translation/core-data/exemplars
 			translation/core-data/numbering-systems
-		translation/currency-names-and-symbols	
+		translation/currency-names-and-symbols
 			translation/currency-names-and-symbols/currency-names
 			translation/currency-names-and-symbols/special-cases
 			translation/number-currency-formats
 			translation/number-currency-formats/number-and-currency-patterns
 			translation/number-currency-formats/number-symbols
 			translation/number-currency-formats/other-patterns
-		translation/date-time	
+		translation/date-time
 			translation/date-time/date-time-names
 			translation/date-time/date-time-patterns
 			translation/date-time/date-time-symbols
 			translation/date-time/date-times-terminology
 			translation/time-zones-and-city-names
-		translation/language-specific	
+		translation/language-specific
 			translation/language-specific/lakota
 			translation/language-specific/odia
 			translation/language-specific/persian
-		translation/miscellaneous	
+		translation/miscellaneous
 			translation/miscellaneous-displaying-lists
 			translation/miscellaneous-person-name-formats
 			translation/transforms
 			translation/units
 			translation/units/measurement-systems
 			translation/units/unit-names-and-patterns
-	development		
-		development/getting-started	
+	development
+		development/getting-started
 			development/cldr-development-site
 			development/development-process
 			development/new-cldr-developers
 			development/guidance-on-direct-modifications-to-cldr-data
 			development/maven
 			development/creating-the-archive
-		development/tests-and-tools	
+		development/tests-and-tools
 			development/running-tests
 			development/running-tools
 			development/cldr-development-site/running-cldr-tools
@@ -136,20 +136,20 @@ index
 			development/coding-cldr-tools/documenting-cldr-tools
 			development/coding-cldr-tools/cldr-file
 			development/GenerateTestData
-		development/cldr-big-red-switch	
+		development/cldr-big-red-switch
 			development/cldr-big-red-switch/generating-charts
 			downloads/brs-copy-en_gb-to-en_001
 			development/cldr-big-red-switch/cldrmodify-passes
 			development/cldr-big-red-switch/cldrmodify-using-config-file
 			development/cldr-big-red-switch/brs-post-items
-		development/updating	
+		development/updating
 			development/updating-dtds
 			development/cldr-development-site/updating-englishroot
 			development/adding-locales
 			development/updating-codes/adding-new-territory
 			development/updating-codes/adding-transforms-transliterators
 			development/updating-codes/testattributevalues
-		development/updating-codes	
+		development/updating-codes
 			development/updating-codes/external-version-metadata
 			development/updating-codes/likelysubtags-and-default-content
 			development/updating-codes/update-currency-codes
@@ -166,7 +166,7 @@ index
 			development/updating-codes/updating-language-groups
 			development/updating-codes/generate-emoji-paths
 			development/updating-codes/un-literacy
-		development/development-process/design-proposals	
+		development/development-process/design-proposals
 			development/development-process/design-proposals/alternate-time-formats
 			development/development-process/design-proposals/bcp-47-changes-draft
 			development/development-process/design-proposals/bcp47-syntax-mapping
@@ -220,3 +220,4 @@ index
 			development/development-process/design-proposals/uts-35-splitting
 			development/development-process/design-proposals/voting
 			development/development-process/design-proposals/xmb
+	sitemap


### PR DESCRIPTION
CLDR-18001

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

lot of copy and paste here, to cleanup (modularize) in the future.

ALLOW_MANY_COMMITS=true

- `sitemap.md` is empty but could have instructions or notes which appear above the sitemap. 

## To review

- go to the cloudflare site linked below
- notice that the sitemap is a separate page, accessible by header and as a normal subpage of index

