### PR TITLE
CLDR-16720 json: trim output files for transforms (v46)

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -896,7 +896,7 @@ public class Ldml2JsonConverter {
                             final String rawTransformFile = filename + TRANSFORM_RAW_SUFFIX;
                             try (PrintWriter outf =
                                     FileUtilities.openUTF8Writer(outputDir, rawTransformFile)) {
-                                outf.println(item.getValue());
+                                outf.println(item.getValue().trim());
                                 // note: not logging the write here- it will be logged when the
                                 // .json file is written.
                             }


### PR DESCRIPTION
CLDR-16720

- no leading or trailing spaces on json transform .txt files

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
