### PR TITLE
CLDR-18001 site: add Contents to sidebar, fix arrow

### DIFF
--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -789,13 +789,15 @@ body.page header .subpages a:hover {
   border: 1pt solid #99f;
 }
 
-.navBar .subpages {
+.navBar .subpages,
+.navBar .submap {
   list-style: none;
   margin: 0.3em;
   padding: 0;
 }
 
-.navBar .subpages li {
+.navBar .subpages li,
+.pagecontents .submap {
   /* hanging indent if the subpage content wraps */
   padding-left: 1em;
   text-indent: -1em;
@@ -877,10 +879,14 @@ div.sitemap {
   padding: 1em;
 }
 
-div.submap {
+.sitemap div.submap {
   margin-left: 1em;
   border-left: 1px solid gray;
   padding-left: 0.5em;
+}
+
+.submap a {
+  padding-left: 0.25em;
 }
 
 div.sitemap {

--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -803,6 +803,7 @@ body.page header .subpages a:hover {
 
 .subpages .hasChildren {
   float: right;
+  margin-right: -1em;
 }
 
 header {

--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -803,11 +803,6 @@ body.page header .subpages a:hover {
   text-indent: -1em;
 }
 
-.subpages .hasChildren {
-  float: right;
-  margin-right: -1em;
-}
-
 header {
   width: "100%";
   background-color: #5555ff;

--- a/docs/site/assets/js/cldrsite.js
+++ b/docs/site/assets/js/cldrsite.js
@@ -85,13 +85,13 @@ const SubPagesPopup = {
     },
   },
   template: `
-          <div class="subpageList>
+          <div class="subpageList">
           <div class="navHeader">Subpages</div>
           <ul class="subpages" >
               <li v-for="subpage of children" :key="subpage.path">
                   <a v-bind:href="subpage.href">
                       {{ subpage.title }}
-                       <span class="hasChildren" v-if="subpage.children">❱</span>
+                       <span class="hasChildren" v-if="subpage.children">&nbsp;❱</span>
                   </a>
               </li>
           </ul>
@@ -454,7 +454,6 @@ if (myPath === "sitemap.html") {
             children: null,
           }));
           if (!objects?.length) return null;
-          console.dir({ objects });
           return objects;
         },
         ourTitle() {

--- a/docs/site/assets/js/cldrsite.js
+++ b/docs/site/assets/js/cldrsite.js
@@ -1,5 +1,9 @@
 const { ref } = Vue;
 
+// load anchor.js - must be before the sidebar loads. might as well do this
+// first thing.
+anchors.add("h1, h2, h3, h4, h5, h6, caption, dfn");
+
 // site management
 
 let myPath = window.location.pathname.slice(1) || "index.html";
@@ -124,6 +128,22 @@ const SubMap = {
   `,
 };
 
+const SubContents = {
+  name: "SubContents",
+  props: {
+    title: String,
+    href: String,
+    children: Object,
+  },
+  setup() {},
+  template: `
+    <div class="submap">
+      <a v-bind:href="href" v-bind:title="path">{{title}}</a>
+      <SubContents v-if="children && children.length" v-for="child in children" :key="child.href" :title="child.title" :href="child.href" :children="child.children" />
+    </div>
+  `,
+};
+
 const SiteMap = {
   props: {
     tree: {
@@ -149,8 +169,11 @@ const SiteMap = {
 };
 
 const PageContents = {
+  components: {
+    SubContents,
+  },
   props: {
-    tree: {
+    children: {
       type: Object,
       required: true,
     },
@@ -159,6 +182,7 @@ const PageContents = {
   template: `
     <div class="pagecontents">
         <div class="navHeader">Contents</div>
+        <SubContents v-if="children && children.length" v-for="child in children" :key="child.href" :title="child.title" :href="child.href" :children="child.children" />
     </div>
   `,
 };
@@ -381,13 +405,10 @@ if (myPath === "sitemap.html") {
         // is the site map shown?
         const showmap = ref(true);
 
-        const contents = ref(null);
-
         return {
           tree,
           status,
           showmap,
-          contents,
         };
       },
       mounted() {
@@ -399,6 +420,7 @@ if (myPath === "sitemap.html") {
       },
       props: {
         path: String,
+        anchorElements: Object,
       },
       computed: {
         /** base path:  'index' or 'downloads/cldr-33' */
@@ -423,6 +445,18 @@ if (myPath === "sitemap.html") {
             children: (usermap[path].children ?? []).length > 0,
           }));
         },
+        contents() {
+          // For now we generate a flat map
+          // this
+          const objects = this.anchorElements?.map(({ textContent, id }) => ({
+            title: textContent,
+            href: `#${id}`,
+            children: null,
+          }));
+          if (!objects?.length) return null;
+          console.dir({ objects });
+          return objects;
+        },
         ourTitle() {
           if (this.tree?.value) {
             if (this.path === "") return this.rootTitle;
@@ -437,17 +471,15 @@ if (myPath === "sitemap.html") {
       },
       template: `
       <div class="navBar" v-if="contents || (children.length)">
-        <PageContents v-if="contents" />
+        <PageContents v-if="contents" :children="contents" />
         <SubPagesPopup v-if="children.length" :children="children"/>
       </div>`,
     },
     {
       // path of / goes to /index.html
       path: myPath,
+      anchorElements: anchors.elements,
     }
   );
   sapp.mount("#sidebar");
 }
-
-// load anchor.js
-anchors.add("h1, h2, h3, h4, h5, h6, caption, dfn");

--- a/docs/site/assets/js/cldrsite.js
+++ b/docs/site/assets/js/cldrsite.js
@@ -85,7 +85,7 @@ const SubPagesPopup = {
     },
   },
   template: `
-          <div class="subpages">
+          <div class="subpageList>
           <div class="navHeader">Subpages</div>
           <ul class="subpages" >
               <li v-for="subpage of children" :key="subpage.path">


### PR DESCRIPTION
CLDR-18001

- adds Contents section to sidebar, with auto-link headers.  For now, it just has a flat list of headings and doesn't try to sort out the nesting.
- Fix an issue with the "subpage" arrow so it doesn't collide.

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true


## Review Notes

### View the main page and use the Contents to navigate to a link within the page.
![image](https://github.com/user-attachments/assets/48521c37-4ffd-4088-8f78-6b9505746c3f)

### Updated the right-arrow to be an nbsp:
![image](https://github.com/user-attachments/assets/158ec60a-5c6b-4efb-8db1-ad90ebc19c8b)
