### PR TITLE
CLDR-18001 site: fix link in ToC to entire page, fix some titles

### DIFF
--- a/docs/site/assets/css/page.css
+++ b/docs/site/assets/css/page.css
@@ -808,23 +808,21 @@ body.page .subpages a.hasChildren:after {
 }
 
 /* these are the ToC entries in the sidebar, according to what element they came from originally. */
-.pagecontents .headingH1 {
+.pagecontents .headingH1,
+.pagecontents .headingH2 {
   margin-left: 0em;
 }
-.pagecontents .headingH2 {
+.pagecontents .headingH3 {
   margin-left: 1em;
 }
-.pagecontents .headingH3 {
+.pagecontents .headingH4 {
   margin-left: 2em;
 }
-.pagecontents .headingH4 {
+.pagecontents .headingH5 {
   margin-left: 3em;
 }
-.pagecontents .headingH5 {
-  margin-left: 4em;
-}
 .pagecontents .headingH6 {
-  margin-left: 5em;
+  margin-left: 4em;
 }
 
 header {
@@ -906,6 +904,10 @@ div.sitemap {
 
 .submap a {
   padding-left: 0.25em;
+}
+
+.topTitle {
+  display: none;
 }
 
 div.sitemap {
@@ -1008,6 +1010,14 @@ header#atViewHeader {
 
 div > header {
   display: none !important;
+}
+
+section.body h1.title {
+  text-align: center;
+}
+
+section.body h1.redundantTitle {
+  display: none;
 }
 
 section.body h1 {

--- a/docs/site/assets/js/cldrsite.js
+++ b/docs/site/assets/js/cldrsite.js
@@ -441,7 +441,13 @@ if (myPath === "sitemap.html") {
       mounted() {
         const t = this;
         siteDataPromise.then(
-          (d) => (t.tree.value = d),
+          (d) => {
+            t.tree.value = d;
+            // set style on first header if redundant
+            if (this.anchorElements[0]?.textContent === this.ourTitle) {
+              this.anchorElements[0].className = "redundantTitle";
+            }
+          },
           (e) => (t.status = e)
         );
       },
@@ -475,7 +481,7 @@ if (myPath === "sitemap.html") {
         contents() {
           // For now we generate a flat map
           // this
-          const objects = this.anchorElements?.map(
+          let objects = this.anchorElements?.map(
             ({ textContent, id, tagName }) => ({
               title: textContent,
               href: `#${id}`,
@@ -484,6 +490,22 @@ if (myPath === "sitemap.html") {
             })
           );
           if (!objects?.length) return null;
+          if (objects[0].title === this.ourTitle) {
+            // redundant title - change the link to go to the entire page
+            objects[0].style = "headingH1 topTitle";
+            objects[0].href = "";
+          } else {
+            // synthesize a title entry in the ToC
+            objects = [
+              {
+                title: this.ourTitle,
+                href: "",
+                children: null,
+                style: "headingH1 topTitle",
+              },
+              ...objects,
+            ];
+          }
           return objects;
         },
         ourTitle() {

--- a/docs/site/assets/js/cldrsite.js
+++ b/docs/site/assets/js/cldrsite.js
@@ -330,14 +330,7 @@ const app = Vue.createApp(
 
        <AncestorPages :ancestorPages="ancestorPages"/>
 
-       <div v-if="!children || !children.length" class="title"> {{ ourTitle }} </div>
-
-       <div v-else class="title" >
-
-            {{ ourTitle }}
-
-      </div>
-        <a class="showmap" href="/sitemap">Site Map</a>
+       <a class="showmap" href="/sitemap">Site Map</a>
 
     </div>`,
   },
@@ -489,23 +482,10 @@ if (myPath === "sitemap.html") {
               style: `heading${tagName}`,
             })
           );
-          if (!objects?.length) return null;
-          if (objects[0].title === this.ourTitle) {
-            // redundant title - change the link to go to the entire page
-            objects[0].style = "headingH1 topTitle";
-            objects[0].href = "";
-          } else {
-            // synthesize a title entry in the ToC
-            objects = [
-              {
-                title: this.ourTitle,
-                href: "",
-                children: null,
-                style: "headingH1 topTitle",
-              },
-              ...objects,
-            ];
+          if (objects[0]?.title === this.ourTitle) {
+            objects = objects.slice(1);
           }
+          if (!objects?.length) return null;
           return objects;
         },
         ourTitle() {
@@ -521,9 +501,12 @@ if (myPath === "sitemap.html") {
         },
       },
       template: `
+      <div>
       <div class="navBar" v-if="contents || (children.length)">
         <PageContents v-if="contents" :children="contents" />
         <SubPagesPopup v-if="children.length" :children="children"/>
+      </div>
+      <h1 class="title">{{ ourTitle }}</h1>
       </div>`,
     },
     {

--- a/docs/site/cldr-tc.md
+++ b/docs/site/cldr-tc.md
@@ -1,5 +1,5 @@
 ---
-title: CLDR Technical Committee (TC)
+title: "CLDR Technical Committee (TC)"
 ---
 
 # CLDR Technical Committee (TC)

--- a/docs/site/development/development-process.md
+++ b/docs/site/development/development-process.md
@@ -1,5 +1,5 @@
 ---
-title: Handling Tickets (bugs/enhancements)
+title: 'Handling Tickets (bugs/enhancements)'
 ---
 
 # Handling Tickets (bugs/enhancements)

--- a/docs/site/development/development-process/design-proposals/bcp-47-changes-draft.md
+++ b/docs/site/development/development-process/design-proposals/bcp-47-changes-draft.md
@@ -1,5 +1,5 @@
 ---
-title: BCP 47 Changes (DRAFT)
+title: 'BCP 47 Changes (DRAFT)'
 ---
 
 # BCP 47 Changes (DRAFT)

--- a/docs/site/development/development-process/design-proposals/chinese-and-other-calendar-support-intercalary-months-year-cycles.md
+++ b/docs/site/development/development-process/design-proposals/chinese-and-other-calendar-support-intercalary-months-year-cycles.md
@@ -1,5 +1,5 @@
 ---
-title: Chinese (and other) calendar support, intercalary months, year cycles
+title: 'Chinese (and other) calendar support, intercalary months, year cycles'
 ---
 
 # Chinese (and other) calendar support, intercalary months, year cycles

--- a/docs/site/development/development-process/design-proposals/delimiter-quotation-mark-proposal.md
+++ b/docs/site/development/development-process/design-proposals/delimiter-quotation-mark-proposal.md
@@ -1,5 +1,5 @@
 ---
-title: Delimiter (Quotation Mark) Proposal
+title: 'Delimiter (Quotation Mark) Proposal'
 ---
 
 # Delimiter (Quotation Mark) Proposal

--- a/docs/site/development/development-process/design-proposals/json-packaging-approved-by-the-cldr-tc-on-2015-03-25.md
+++ b/docs/site/development/development-process/design-proposals/json-packaging-approved-by-the-cldr-tc-on-2015-03-25.md
@@ -1,5 +1,5 @@
 ---
-title: JSON Packaging (Approved by the CLDR TC on 2015-03-25)
+title: 'JSON Packaging (Approved by the CLDR TC on 2015-03-25)'
 ---
 
 # JSON Packaging (Approved by the CLDR TC on 2015-03-25)

--- a/docs/site/development/updating-codes/un-literacy.md
+++ b/docs/site/development/updating-codes/un-literacy.md
@@ -1,5 +1,5 @@
 ---
-title: UN Literacy Data (CLDR BRS)
+title: 'UN Literacy Data (CLDR BRS)'
 ---
 
 # UN Literacy Data (CLDR BRS)

--- a/docs/site/translation/displaynames/countryregion-territory-names.md
+++ b/docs/site/translation/displaynames/countryregion-territory-names.md
@@ -1,5 +1,5 @@
 ---
-title: Country/Region (Territory) Names
+title: 'Country/Region (Territory) Names'
 ---
 
 # Country/Region (Territory) Names

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -1,5 +1,5 @@
 ---
-title: Locale Option Names (Key)
+title: 'Locale Option Names (Key)'
 ---
 
 # Locale Option Names (Key)


### PR DESCRIPTION
CLDR-18001

- suppress link to title in ToC, hide ToC if empty
- suppress title h1 entirely, add centered title
- shift ToC over to the left one

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

## Review Notes

- check links in ToC on index and subpages
- check the /development page as an example of a page that will not have a 'Content' sidebar in this change


![image](https://github.com/user-attachments/assets/a44e3d7d-a5fa-4e6b-b000-2297919cefa5)


![image](https://github.com/user-attachments/assets/9b813d26-2e14-4357-bb31-2357abe84acc)
