### PR TITLE
CLDR-18022 fix spec links

### DIFF
--- a/docs/ldml/tr35-collation.md
+++ b/docs/ldml/tr35-collation.md
@@ -538,7 +538,7 @@ A collation type name that starts with "private-", for example, "private-kana", 
 
 > 👉 **Note**: There is an on-line demonstration of collation at [[LocaleExplorer](tr35.md#LocaleExplorer)] that uses the same rule syntax. (Pick the locale and scroll to "Collation Rules", near the end.)
 
-> 👉 **Note**: In CLDR 23 and before, LDML collation files used an XML format. Starting with CLDR 24, the XML collation syntax is deprecated and no longer used. See the _[CLDR 23 version of this document](https://www.unicode.org/reports/tr35/tr35-31/tr35-collation.html#Collation_Tailorings)_ for details about the XML collation syntax.
+> 👉 **Note**: In CLDR 23 and before, LDML collation files used an XML format. Starting with CLDR 24, the XML collation syntax is deprecated and no longer used. See the _[CLDR 23 version of this document](tr35-collation.html#Collation_Tailorings)_ for details about the XML collation syntax.
 
 #### <a name="Collation_Type_Fallback" href="#Collation_Type_Fallback">Collation Type Fallback</a>
 

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -1345,7 +1345,7 @@ The dayPeriodRule may span two days, such as where **night1** is [21:00, 06:00).
 
 If rounding is done—including the rounding done by the time format—then it needs to be done before the dayperiod is computed, so that the correct format is shown.
 
-For examples, see [Day Periods Chart](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/day_periods.html).
+For examples, see [Day Periods Chart](https://www.unicode.org/cldr/charts/46/supplemental/day_periods.html).
 
 ## <a name="Time_Zone_Names" href="#Time_Zone_Names">Time Zone Names</a>
 

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -1477,7 +1477,7 @@ nostr "no:n"
 The generated yesexpr and noexpr would be:
 
 ```
-yesexpr "^([yY]​([eE][sS])?)"
+yesexpr "^([yY]([eE][sS])?)"
 ```
 
 This would match y,Y,yes,yeS,yEs,yES,Yes,YeS,YEs,YES.

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -592,11 +592,11 @@ The ordering of the characters in the set is irrelevant, but for readability in 
 
 ### ~~<a name="Character_Mapping" href="#Character_Mapping">Mapping</a>~~
 
-**This element has been deprecated.** For information on its structure and how it was intended to specify locale-specific preferred encodings for various purposes (e-mail, web), see the [Mapping](https://www.unicode.org/reports/tr35/tr35-39/tr35-general.html#Character_Mapping) section from the CLDR 27 version of the LDML Specification.
+**This element has been deprecated.** For information on its structure and how it was intended to specify locale-specific preferred encodings for various purposes (e-mail, web), see the [Mapping](tr35-general.html#Character_Mapping) section from the CLDR 27 version of the LDML Specification.
 
 ### ~~<a name="IndexLabels" href="#IndexLabels">Index Labels</a>~~
 
-**This element and its subelements have been deprecated.** For information on its structure and how it was intended to provide data for a compressed display of index exemplar characters where space is limited, see the [Index Labels](https://www.unicode.org/reports/tr35/tr35-39/tr35-general.html#IndexLabels) section from the CLDR 27 version of the LDML Specification.
+**This element and its subelements have been deprecated.** For information on its structure and how it was intended to provide data for a compressed display of index exemplar characters where space is limited, see the [Index Labels](tr35-general.html#IndexLabels) section from the CLDR 27 version of the LDML Specification.
 
 ```xml
 <!ELEMENT indexLabels (indexSeparator*, compressedIndexSeparator*, indexRangePattern*, indexLabelBefore*, indexLabelAfter*, indexLabel*) >
@@ -911,12 +911,12 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
 <!-- HTML: no header -->
 
 <table><tbody>
-<tr><td><a name='unit_identifier' href='unit_identifier'>unit_identifier</a></td><td>:=</td>
+<tr><td><a name='unit_identifier' href='#unit_identifier'>unit_identifier</a></td><td>:=</td>
     <td>core_unit_identifier<br/>
         | mixed_unit_identifier<br/>
         | long_unit_identifier</td></tr>
 
-<tr><td><a name='core_unit_identifier' href='core_unit_identifier'>core_unit_identifier</a></td><td>:=</td>
+<tr><td><a name='core_unit_identifier' href='#core_unit_identifier'>core_unit_identifier</a></td><td>:=</td>
     <td>product_unit ("-" per "-" product_unit)*<br/>
         | per "-" product_unit ("-" per "-" product_unit)*
         <ul><li><em>Examples:</em>
@@ -932,25 +932,25 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
 			<li><em>Constraint:</em> The token 'per' is the single value in &lt;unitIdComponent type="per"&gt;</li>
 		</ul></td></tr>
 
-<tr><td><a name='product_unit' href='product_unit'>product_unit</a></td><td>:=</td>
+<tr><td><a name='product_unit' href='#product_unit'>product_unit</a></td><td>:=</td>
         <td>single_unit ("-" single_unit)* ("-" pu_single_unit)*<br/>
             | pu_single_unit ("-" pu_single_unit)*
             <ul><li><em>Example:</em> foot-pound-force</li>
                 <li><em>Constraint:</em> No pu_single_unit may precede a single unit</li>
             </ul></td></tr>
 
-<tr><td><a name='single_unit' href='single_unit'>single_unit</a></td><td>:=</td>
+<tr><td><a name='single_unit' href='#single_unit'>single_unit</a></td><td>:=</td>
     <td>dimensionality_prefix? simple_unit | unit_constant
         <ul><li><em>Examples: </em>square-kilometer, or 100</li></ul></td></tr>
 
-<tr><td>pu_single_unit</td><td>:=</td>
+<tr><td><a name='pu_single_unit' href='#pu_single_unit'>pu_single_unit</a></td><td>:=</td>
     <td>"xxx-" single_unit | "x-" single_unit
     <ul><li><em>Example:</em> xxx-square-knuts (a Harry Potter unit)</li>
         <li><em>Note:</em> "x-" is only for backwards compatibility</li>
         <li>See <a href="#Private_Use_Units">Private-Use Units</a></li>
     </ul></td></tr>
 
-<tr><td><a name='unit_constant' href='unit_constant'>unit_constant</a></td><td>:=</td>
+<tr><td><a name='unit_constant' href='#unit_constant'>unit_constant</a></td><td>:=</td>
     <td>[1-9][0-9]* ("e" [1-9][0-9]*)?
         <ul><li><em>Examples:</em>
             <ul><li>kilowatt-hour-per-100-kilometer</li>
@@ -964,7 +964,7 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
             <li><em>Note:</em> When constructing identifiers, exponents should be greater than 3 and multiples of 3, even though parsers must accept the wider range.</li>
         </ul></td></tr>
 
-<tr><td><a name='dimensionality_prefix' href='dimensionality_prefix'>dimensionality_prefix</a></td><td>:=</td>
+<tr><td><a name='dimensionality_prefix' href='#dimensionality_prefix'>dimensionality_prefix</a></td><td>:=</td>
     <td>"square-"<p>| "cubic-"<p>| "pow" ([2-9]|1[0-5]) "-"
         <ul>
 			<li><em>Constraint:</em> must be value in: &lt;unitIdComponent type="power"&gt;.</li>
@@ -972,7 +972,7 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
 			<li><em>Note:</em> These are values in &lt;unitIdComponent type="power"&gt;</li>
 		</ul></td></tr>
 
-<tr><td><a name='simple_unit' href='simple_unit'>simple_unit</a></td><td>:=</td>
+<tr><td><a name='simple_unit' href='#simple_unit'>simple_unit</a></td><td>:=</td>
     <td>(prefix_component "-")* (prefixed_unit | base_component) ("-" suffix_component)*<br/>
 		|  currency_unit<br/>
 		| "em" | "g" | "us" | "hg" | "of"
@@ -982,27 +982,27 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
 			We will likely deprecate those and add conformant aliases in the future: the "hg" and "of" are already only in deprecated simple_units.</li>
         </ul></td></tr>
 
-<tr><td>prefixed_unit</td><td></td>
+<tr><td><a name='prefixed_unit' href='#prefixed_unit'>prefixed_unit</a></td><td></td>
     <td>prefix base_component<ul><li><em>Example: </em>kilometer</li></ul></td></tr>
 
-<tr><td><a name='prefix' href='prefix'>prefix</a></td><td></td>
+<tr><td><a name='prefix' href='#prefix'>prefix</a></td><td></td>
     <td>si_prefix | binary_prefix</td></tr>
 
-<tr><td>si_prefix</td><td>:=</td>
+<tr><td><a name='si_prefix' href='#si_prefix'>si_prefix</a></td><td>:=</td>
     <td>"deka" | "hecto" | "kilo", …
         <ul><li><em>Constraint:</em> Must be an attribute value of the <code>type</code> in: &lt;unitPrefix type='…' … power10='…'&gt;. 
 			See also <a href="https://www.nist.gov/pml/special-publication-811">NIST special publication 811</a></li></ul></td></tr>
 
-<tr><td>binary_prefix</td><td>:=</td>
+<tr><td><a name='binary_prefix' href='#binary_prefix'>binary_prefix</a></td><td>:=</td>
     <td>"kibi", "mebi", …
         <ul><li><em>Constraint:</em> Must be an attribute value of the <code>type</code> in: &lt;unitPrefix type='…' … power2='…'&gt;. 
 			See also <a href="https://physics.nist.gov/cuu/Units/binary.html">Prefixes for binary multiples</a></li></ul></td></tr>
 
-<tr><td>prefix_component</td><td>:=</td>
+<tr><td><a name='prefix_component' href='#prefix_component'>prefix_component</a></td><td>:=</td>
     <td>[a-z]{3,∞}
         <ul><li><em>Constraint:</em> must be value in: &lt;unitIdComponent type="prefix"&gt;.</li></ul></td></tr>
 
-<tr><td>base_component</td><td>:=</td>
+<tr><td><a name='base_component' href='#base_component'>base_component</a></td><td>:=</td>
     <td>[a-z]{3,∞}
         <ul><li><em>Constraint:</em> must not be a value in any of the following:<br>
 			&lt;unitIdComponent type="prefix"&gt;<br>
@@ -1018,13 +1018,13 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
 		</ul>
 	</td></tr>
 
-<tr><td>suffix_component</td><td>:=</td>
+<tr><td><a name='suffix_component' href='#suffix_component'>suffix_component</a></td><td>:=</td>
     <td>[a-z]{3,∞}
         <ul>
 			<li><em>Constraint:</em> must be value in: &lt;unitIdComponent type="suffix"&gt;</li>
 		</ul></td></tr>
 
-<tr><td><a name='mixed_unit_identifier' href='mixed_unit_identifier'></a></td><td>:=</td>
+<tr><td><a name='mixed_unit_identifier' href='#mixed_unit_identifier'></a></td><td>:=</td>
     <td>(single_unit | pu_single_unit) ("-" and "-" (single_unit | pu_single_unit ))*
         <ul><li><em>Example: foot-and-inch</em></li>
 		</ul></td></tr>
@@ -1035,13 +1035,13 @@ Some of the constraints reference data from the unitIdComponents in [Unit_Conver
 			<li><em>Constraint:</em> The token 'and' is the single value in &lt;unitIdComponent type="and"&gt;</li>
 		</ul></td></tr>
 
-<tr><td>long_unit_identifier</td><td>:=</td>
+<tr><td><a name='long_unit_identifier' href='#long_unit_identifier'>long_unit_identifier</a></td><td>:=</td>
     <td>grouping "-" core_unit_identifier</td></tr>
 
 <tr><td>grouping</td><td>:=</td>
     <td>[a-z]{3,∞}</td></tr>
 
-<tr><td><a name='currency_unit' href='currency_unit'>currency_unit</a></td><td>:=</td>
+<tr><td><a name='currency_unit' href='#currency_unit'>currency_unit</a></td><td>:=</td>
     <td>"curr-" [a-z]{3}
         <ul>
 			<li><em>Constraint:</em> The first part of the currency_unit is a standard prefix; the second part of the currency unit must be a valid <a href="tr35.md#UnicodeCurrencyIdentifier">Unicode currency identifier</a>.</li>
@@ -1477,7 +1477,7 @@ nostr "no:n"
 The generated yesexpr and noexpr would be:
 
 ```
-yesexpr "^([yY]([eE][sS])?)"
+yesexpr "^([yY] ([eE][sS])?)"
 ```
 
 This would match y,Y,yes,yeS,yEs,yES,Yes,YeS,YEs,YES.
@@ -2689,7 +2689,7 @@ All such characters should be removed before looking up any short names and keyw
 
 ### <a name="SynthesizingNames" href="#SynthesizingNames">Synthesizing Sequence Names</a>
 
-Many emoji are represented by sequences of characters. When there are no `annotation` elements for that string, the short name can be synthesized as follows. **Note:** The process details may change after the release of this specification, and may further change in the future if other sequences are added. Please see the [Known Issues](https://cldr.unicode.org/index/downloads/cldr-41#h.qa3jolg7zi2s) section of the CLDR download page for any updates.
+Many emoji are represented by sequences of characters. When there are no `annotation` elements for that string, the short name can be synthesized as follows. **Note:** The process details may change after the release of this specification, and may further change in the future if other sequences are added.
 
 1.  If **sequence** is an **emoji flag sequence**, look up the territory name in CLDR for the corresponding ASCII characters and return as the short name. For example, the regional indicator symbols P+F would map to “Französisch-Polynesien” in German.
 2.  If **sequence** is an **emoji tag sequence**, look up the subdivision name in CLDR for the corresponding ASCII characters and return as the short name. For example, the TAG characters gbsct would map to “Schottland” in German.

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -1477,7 +1477,7 @@ nostr "no:n"
 The generated yesexpr and noexpr would be:
 
 ```
-yesexpr "^([yY] ([eE][sS])?)"
+yesexpr "^([yY]​([eE][sS])?)"
 ```
 
 This would match y,Y,yes,yeS,yEs,yES,Yes,YeS,YEs,YES.

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -107,7 +107,7 @@ The LDML specification is divided into the following parts:
 
 ## Introduction <a name="Supplemental_Data" href="#Supplemental_Data">Supplemental Data</a>
 
-The following represents the format for additional supplemental information. This is information that is important for internationalization and proper use of CLDR, but is not contained in the locale hierarchy. It is not localizable, nor is it overridden by locale data. The current CLDR data can be viewed in the [Supplemental Charts](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/index.html).
+The following represents the format for additional supplemental information. This is information that is important for internationalization and proper use of CLDR, but is not contained in the locale hierarchy. It is not localizable, nor is it overridden by locale data. The current CLDR data can be viewed in the [Supplemental Charts](https://www.unicode.org/cldr/charts/46/supplemental/index.html).
 
 ```xml
 <!ELEMENT supplementalData (version, generation?, cldrVersion?, currencyData?, territoryContainment?, subdivisionContainment?, languageData?, territoryInfo?, postalCodeData?, calendarData?, calendarPreferenceData?, weekData?, timeData?, measurementData?, unitPreferenceData?, timezoneData?, characters?, transforms?, metadata?, codeMappings?, parentLocales?, likelySubtags?, metazoneInfo?, plurals?, telephoneCodeData?, numberingSystems?, bcp47KeywordMappings?, gender?, references?, languageMatching?, dayPeriodRuleSet*, metaZones?, primaryZones?, windowsZones?, coverageLevels?, idValidity?, rgScope?) >
@@ -142,7 +142,7 @@ Excluding groupings, in this tree:
 *   All non-overlapping regions form a strict tree rooted at World.
 *   All leaf-nodes (country) are always at depth 4. Some of these “country” regions are actually parts of other countries, such as Hong Kong (part of China). Such relationships are not part of the containment data.
 
-For a chart showing the relationships (plus the included timezones), see the [Territory Containment Chart](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_containment_un_m_49.html). The XML structure has the following form.
+For a chart showing the relationships (plus the included timezones), see the [Territory Containment Chart](https://www.unicode.org/cldr/charts/46/supplemental/territory_containment_un_m_49.html). The XML structure has the following form.
 
 ```xml
 <territoryContainment>
@@ -223,7 +223,7 @@ Note: Formerly (in CLDR 28 through 30):
 <!ATTLIST languagePopulation officialStatus (de_facto_official | official | official_regional | official_minority) #IMPLIED >
 ```
 
-This data provides testing information for language and territory populations. The main goal is to provide approximate figures for the literate, functional population for each language in each territory: that is, the population that is able to read and write each language, and is comfortable enough to use it with computers. For a chart of this data, see [Territory-Language Information](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_language_information.html).
+This data provides testing information for language and territory populations. The main goal is to provide approximate figures for the literate, functional population for each language in each territory: that is, the population that is able to read and write each language, and is comfortable enough to use it with computers. For a chart of this data, see [Territory-Language Information](https://www.unicode.org/cldr/charts/46/supplemental/territory_language_information.html).
 
 _Example_
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2229,7 +2229,7 @@ _Attribute:_ `from` (required)
 
 - **Nested capturing groups**
 
-    `(?:[abc]​([def]))|(?:[ghi])`
+    `(?:[abc]([def]))|(?:[ghi])`
 
     Capture groups may be nested, however only the innermost group is allowed to be a capture group. The outer group must be a non-capturing group.
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2229,7 +2229,7 @@ _Attribute:_ `from` (required)
 
 - **Nested capturing groups**
 
-    `(?:[abc] ([def]))|(?:[ghi])`
+    `(?:[abc]​([def]))|(?:[ghi])`
 
     Capture groups may be nested, however only the innermost group is allowed to be a capture group. The outer group must be a non-capturing group.
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2229,7 +2229,7 @@ _Attribute:_ `from` (required)
 
 - **Nested capturing groups**
 
-    `(?:[abc]([def]))|(?:[ghi])`
+    `(?:[abc] ([def]))|(?:[ghi])`
 
     Capture groups may be nested, however only the innermost group is allowed to be a capture group. The outer group must be a non-capturing group.
 

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -1039,7 +1039,7 @@ This happens even if nouns are invariant; even if all English nouns were invaria
 1. 1 sheep **is** here. Do you want to buy **it**?
 2. 2 sheep **are** here. Do you want to buy **them**?
 
-For more information, see [Determining-Plural-Categories](https://cldr.unicode.org/index/cldr-spec/plural-rules#h.44ozdx564iez).
+For more information, see [Determining-Plural-Categories](https://cldr.unicode.org/index/cldr-spec/plural-rules#determining-plural-categories).
 
 English does not have a separate plural category for “zero”, because it does not require a different message for “0”. For example, the same message can be used below, with just the numeric placeholder changing.
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -721,7 +721,7 @@ If a language subtag matches the `type` attribute of a `languageAlias` element, 
 
 The private use codes listed as **excluded** in _[Private Use Codes](#Private_Use_Codes)_ will never be given specific semantics in Unicode identifiers, and are thus safe for use for other purposes by other applications.
 
-The CLDR provides data for normalizing language/locale codes, including mapping overlong codes like "eng-840" or "eng-USA" to the correct code "en-US"; see the **[Aliases](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/aliases.html)** Chart.
+The CLDR provides data for normalizing language/locale codes, including mapping overlong codes like "eng-840" or "eng-USA" to the correct code "en-US"; see the **[Aliases](https://www.unicode.org/cldr/charts/46/supplemental/aliases.html)** Chart.
 
 The following are special language subtags:
 
@@ -794,7 +794,7 @@ Unicode identifiers give specific semantics to the following subtags.
 
 | alpha2 | alpha3 | num | Name                         | Comment | ISO 3166-1 status |
 | ------ | ------ | --- | ---------------------------- | ------- | ----------------- |
-| `QO`   | `QOO`  | 961 | Outlying Oceania             | countries in Oceania [009] that do not have a [subcontinent](https://unicode-org.github.io/cldr-staging/charts/38/supplemental/territory_containment_un_m_49.html). | private use |
+| `QO`   | `QOO`  | 961 | Outlying Oceania             | countries in Oceania [009] that do not have a [subcontinent](https://www.unicode.org/cldr/charts/46/supplemental/territory_containment_un_m_49.html). | private use |
 | `QU`   | `QUU`  | 967 | European Union               | **deprecated**: the _canonicalized_ form is EU | private use |
 | `UK`   | -      | -   | United Kingdom               | **deprecated**: the _canonicalized_ form is GB | exceptionally reserved |
 | `XA`   | `XAA`  | 973 | Pseudo-Accents               | special code indicating derived testing locale with English + added accents and lengthened | private use |
@@ -3732,7 +3732,7 @@ The choice of locales to include depends very much upon particular implementatio
 Some information that might be useful for determining the choice is found in the
  [Supplemental Territory Information](tr35-info.md#Supplemental_Territory_Information),
 which provides information on the use of languages in different countries/regions.
-(For a human-readable chart, see [Territory-Language Information](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/territory_language_information.html).)
+(For a human-readable chart, see [Territory-Language Information](https://www.unicode.org/cldr/charts/46/supplemental/territory_language_information.html).)
 
 It is important to note that if a particular locale is in a vertical slice, then all of its parents should be as well, because of inheritance.
 This is not a factor if the data is fully resolved, as in the JSON format data.
@@ -3778,7 +3778,7 @@ The [DTD Annotations](#DTD_Annotations) in are used to determine whether DTD ite
 
 Though such deprecated items are still valid LDML, they are strongly discouraged, and are no longer used in CLDR.
 
-The CLDR [DTD Deltas](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/dtd_deltas.html) chart shows which DTD items have been deprecated in which version of CLDR.
+The CLDR [DTD Deltas](https://www.unicode.org/cldr/charts/46/supplemental/dtd_deltas.html) chart shows which DTD items have been deprecated in which version of CLDR.
 
 The remainder of this section describes selected cases of deprecated structure, and what (if any) should be used instead.
 
@@ -4252,7 +4252,7 @@ The above algorithm is a logical statement of the process, but would obviously n
 | General                                                  | _The following are general references from the text:_ |
 | [<a name="ByType" href="#ByType">ByType</a>]             | CLDR Comparison Charts<br/>[https://cldr.unicode.org/index/charts](https://cldr.unicode.org/index/charts) |
 | [<a name="Calendars" href="#Calendars">Calendars</a>]    | Calendrical Calculations: The Millennium Edition by Edward M. Reingold, Nachum Dershowitz; Cambridge University Press; Book and CD-ROM edition (July 1, 2001); ISBN: 0521777526. Note that the algorithms given in this book are copyrighted. |
-| [<a name="Comparisons" href="#Comparisons">Comparisons</a>]             | Comparisons between locale data from different sources<br/>[https://unicode-org.github.io/cldr-staging/charts/latest/by_type/index.html](https://unicode-org.github.io/cldr-staging/charts/latest/by_type/index.html) |
+| [<a name="Comparisons" href="#Comparisons">Comparisons</a>]             | Comparisons between locale data from different sources<br/>[https://www.unicode.org/cldr/charts/46/by_type/index.html](https://www.unicode.org/cldr/charts/46/by_type/index.html) |
 | [<a name="CurrencyInfo" href="#CurrencyInfo">CurrencyInfo</a>]          | UNECE Currency Data<br/>[https://www.iso.org/iso-4217-currency-codes.html](https://www.iso.org/iso-4217-currency-codes.html) |
 | [<a name="DataFormats" href="#DataFormats">DataFormats</a>]             | CLDR Translation Guidelines<br/>[https://cldr.unicode.org/translation](https://cldr.unicode.org/translation) |
 | [<a name="LDML" href="#LDML">Example</a>]                               | A sample in Locale Data Markup Language<br/>[https://www.unicode.org/cldr/dtd/1.1/ldml-example.xml](https://www.unicode.org/cldr/dtd/1.1/ldml-example.xml) |


### PR DESCRIPTION
CLDR-18022

- Fixed links as per ticket, except for message-format.md (will be done separately)
- Also added some missing links to the EBNF for units.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
