### PR TITLE
CLDR-18042 Replace `Any-ASCII` reference by `Latin-ASCII`

### DIFF
--- a/common/transforms/de-ASCII.xml
+++ b/common/transforms/de-ASCII.xml
@@ -26,7 +26,7 @@ $AE → AE;
 $OE → OE;
 $UE → UE;
 
-::Any-ASCII;
+::Latin-ASCII;
 			</tRule>
 		</transform>
 	</transforms>


### PR DESCRIPTION
CLDR-18042

- [x] This PR completes the ticket.

Latin-ASCII actually exists.

ALLOW_MANY_COMMITS=true
