### PR TITLE
CLDR-18057 BRS 46 Download page remove beta, fix spec links; announcement; stub 47 page

### DIFF
--- a/docs/site/downloads/cldr-46.md
+++ b/docs/site/downloads/cldr-46.md
@@ -8,12 +8,6 @@ title: CLDR 46 Release Note
 |:---:|:----------:|:---------:|:------:|:--------:|:------------:|:---:|:----------:|:---------:|:---------:|
 |  46 | 2024-10-24 | [v46](/index/downloads/cldr-46) | [CLDR46](https://unicode.org/Public/cldr/46/) | [Charts46](https://unicode.org/cldr/charts/46/) | [LDML46](https://www.unicode.org/reports/tr35/tr35-73/tr35.html) | [Δ46](https://unicode-org.atlassian.net/issues/?jql=project+%3D+CLDR+AND+status+%3D+Done+AND+resolution+%3D+Fixed+AND+fixVersion+%3D+%2246%22+ORDER+BY+priority+DESC) | [release-46](https://github.com/unicode-org/cldr/releases/tag/release-46) | [ΔDtd46](https://www.unicode.org/cldr/charts/46/supplemental/dtd_deltas.html) | [46.0.0](https://github.com/unicode-org/cldr-json/releases/tag/46.0.0) |
 
-<span style="color:red; font-weight: bold;">This is a beta version of CLDR v46.</span>
-
-The data is available at [release-46-beta2](https://github.com/unicode-org/cldr/releases/tag/release-46-beta2),
-and the specification is available at [tr35/proposed.html](https://www.unicode.org/reports/tr35/proposed.html).
-Feedback is welcome via [tickets](/requesting_changes). (The CLDR site is undergoing a migration to Markdown, so the UI for navigation is temporary.)
-
 ## Overview
 
 Unicode CLDR provides key building blocks for software supporting the world's languages.
@@ -57,14 +51,14 @@ For a full listing, see [Coverage Levels](https://unicode.org/cldr/charts/46/sup
 
 The following are the most significant changes to the specification (LDML).
 
-1. [Message Format](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-messageFormat.html#Contents) — see a summary [below](#message-format-specification)
-2. [LDML Conformance](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#Conformance)
-3. [emoji search keywords](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-general.html#Annotations) in tech preview — see a summary [below](#emoji-search-keywords)
-4. [semantic skeletons](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-dates.html#Semantic_Skeletons)
-5. [Grouping classes of characters](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-collation.html#grouping_classes_of_characters) and other collation changes — see a summary [below](#collation-data-changes)
+1. [Message Format](https://www.unicode.org/reports/tr35/tr35-73/tr35-messageFormat.html#Contents) — see a summary [below](#message-format-specification)
+2. [LDML Conformance](https://www.unicode.org/reports/tr35/tr35-73/tr35.html#Conformance)
+3. [emoji search keywords](https://www.unicode.org/reports/tr35/tr35-73/tr35-general.html#Annotations) in tech preview — see a summary [below](#emoji-search-keywords)
+4. [semantic skeletons](https://www.unicode.org/reports/tr35/tr35-73/tr35-dates.html#Semantic_Skeletons)
+5. [Grouping classes of characters](https://www.unicode.org/reports/tr35/tr35-73/tr35-collation.html#grouping_classes_of_characters) and other collation changes — see a summary [below](#collation-data-changes)
 
 There are many more changes that are important to implementations, such as changes to certain identifier syntax and various algorithms.
-See the [Modifications section](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#Modifications) of the specification for details.
+See the [Modifications section](https://www.unicode.org/reports/tr35/tr35-73/tr35.html#Modifications) of the specification for details.
 
 ## Data Changes
 
@@ -93,7 +87,7 @@ The CLDR `iso8601` calendar uses patterns in the order: era, year, month, day, d
 More preference changes are planned for the next release.
 4. Minimization for likelySubtags removes many additional redundant mappings.
     - For example, the mapping `acy_Grek → acy_Grek_CY` is unnecessary, because the mapping `acy → acy_Latn_CY` is sufficient.
-For the reason why, see the algorithm in [Likely Subtags](https://cldr-smoke.unicode.org/spec/main/ldml/tr35.html#likely-subtags).
+For the reason why, see the algorithm in [Likely Subtags](https://www.unicode.org/reports/tr35/tr35-73/tr35.html#likely-subtags).
     - The ordering in the file is more consistent; first the main mappings, then the mapping from region and/or script to likely language, then the data contributed by SIL.
     - The regions have been cleaned up: there are no entries with `ZZ`, and `001` is limited to artifical languages such as Interlingua. The only other macroregion code is in `und_419 → es_Latn_419` (Spanish‧Latin‧Latin America)
 5. Language matching
@@ -141,7 +135,7 @@ Full localization will await the next submission phase for CLDR.
 For a full listing, see [Delta Data](https://unicode.org/cldr/charts/46/delta/index.html)
 
 ### Message Format Specification
-The CLDR Technical Committee decided to continue the tech preview phase for [Message Format](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-messageFormat.html#Contents) in version 46.
+The CLDR Technical Committee decided to continue the tech preview phase for [Message Format](https://www.unicode.org/reports/tr35/tr35-73/tr35-messageFormat.html#Contents) in version 46.
 The plan is to have a final version of the specification in a 46.1 release before the end of 2024.
 
 The most significant changes since v45 were:

--- a/docs/site/downloads/cldr-47.md
+++ b/docs/site/downloads/cldr-47.md
@@ -1,0 +1,123 @@
+---
+title: CLDR 47 Release Note
+---
+
+# CLDR 47 Release Note
+
+| No. |    Date    | Rel. Note |  Data  |  Charts  | Spec |   Delta  | GitHub Tag | Delta DTD | CLDR JSON |
+|:---:|:----------:|:---------:|:------:|:--------:|:------------:|:---:|:----------:|:---------:|:---------:|
+|  47 | 2025-04-~~XX~~ | [v47](/index/downloads/cldr-47) | ~~[CLDR47](https://unicode.org/Public/cldr/47/)~~ | [Charts47](https://unicode.org/cldr/charts/dev) | [LDML47](https://www.unicode.org/reports/tr35/proposed.html) | [Δ47](https://unicode-org.atlassian.net/issues/?jql=project+%3D+CLDR+AND+status+%3D+Done+AND+resolution+%3D+Fixed+AND+fixVersion+%3D+%2247%22+ORDER+BY+priority+DESC) | ~~[release-47]()~~ | [ΔDtd47](https://www.unicode.org/cldr/charts/dev/supplemental/dtd_deltas.html) | ~~[47.0.0]()~~ |
+
+## Overview
+
+Unicode CLDR provides key building blocks for software supporting the world's languages.
+CLDR data is used by all [major software systems](/index#who-uses-cldr)
+(including all mobile phones) for their software internationalization and localization,
+adapting software to the conventions of different languages.
+
+The most significant changes in this release are:
+
+- TBD
+
+For more details, see below.
+
+### Locale Coverage Status
+#### Current Levels
+
+Count | Level | Usage | Examples
+-- | -- | -- | --
+xx | Modern | Suitable for full UI internationalization | …
+xx | Moderate | Suitable for “document content” internationalization, eg. in spreadsheet | …
+xx | Basic | Suitable for locale selection, eg. choice of language on mobile phone | …
+
+#### Changes
+
+| ± | New Level | Locales |
+| -- | -- | -- |
+| 📈 | Modern | … |
+| 📈 | Moderate | … |
+| 📈 | Basic | … |
+| 📉 | Basic* | … |
+
+\* Note: Each release, the number of items needed for Modern and Moderate increases. So locales without active contributors may drop down in coverage level.
+
+For a full listing, see [Coverage Levels](https://unicode.org/cldr/charts/dev/supplemental/locale_coverage.html)
+
+## [Specification Changes](https://www.unicode.org/reports/tr35/proposed.html)
+
+The following are the most significant changes to the specification (LDML).
+
+- TBD
+
+There are many more changes that are important to implementations, such as changes to certain identifier syntax and various algorithms.
+See the [Modifications section](https://www.unicode.org/reports/tr35/proposed.html#Modifications) of the specification for details.
+
+## Data Changes
+
+### DTD Changes
+
+- TBD
+
+For a full listing, see [Delta DTDs](https://unicode.org/cldr/charts/dev/supplemental/dtd_deltas.html).
+
+### Supplemental Data Changes
+
+- TBD
+
+For a full listing, see [¤¤BCP47 Delta](https://unicode.org/cldr/charts/dev/delta/bcp47.html) and [¤¤Supplemental Delta](https://unicode.org/cldr/charts/dev/delta/supplemental-data.html)
+
+### [Locale Changes](https://unicode.org/cldr/charts/dev/delta/index.html)
+
+- TBD
+
+For a full listing, see [Delta Data](https://unicode.org/cldr/charts/dev/delta/index.html)
+
+### Message Format Specification
+
+- TBD
+
+### Emoji Search Keywords
+
+- TBD
+
+### Collation Data Changes
+
+- TBD
+
+### JSON Data Changes
+
+- TBD
+
+### File Changes
+
+- TBD
+
+### Tooling Changes
+
+- TBD
+
+### Keyboard Changes
+
+- TBD
+
+## Migration
+
+- TBD
+
+## Known Issues
+
+1. [CLDR-17095] The region-based firstDay value (see weekData) is currently used for several different purposes. In the future, some of these functions will be separated out:
+    - The day that should be shown as the first day of the week in a calendar view.
+    - The first day of the week (day 1) for weekday numbering.
+    - The first day of the week for week-of-year calendar calculations.
+
+## Acknowledgments
+
+Many people have made significant contributions to CLDR and LDML;
+see the [Acknowledgments](/index/acknowledgments) page for a full listing.
+
+The Unicode [Terms of Use](https://unicode.org/copyright.html) apply to CLDR data;
+in particular, see [Exhibit 1](https://unicode.org/copyright.html#Exhibit1).
+
+For web pages with different views of CLDR data, see [http://cldr.unicode.org/index/charts](/index/charts).
+

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -6,8 +6,7 @@ title: Unicode CLDR Project
 
 ## News
 
-- **2024-09-26 [CLDR 46 Beta](https://blog.unicode.org/2024/09/unicode-cldr-46-beta-available-for.html) available for testing and specification review**
-- **2024-09-05 [CLDR 46 Alpha](https://blog.unicode.org/2024/09/unicode-cldr-v46-alpha-available-for.html)  available for testing**
+- **2024-10-24 [CLDR 46](downloads/cldr-46) released**
 - **2024-04-17 [CLDR 45](downloads/cldr-45) released**
 - **2023-12-13 [CLDR 44.1](downloads/cldr-44#h.nvqx283jwsx) released (an update to CLDR v44)**
 - **2023-10-31 [CLDR 44](downloads/cldr-44) released**

--- a/docs/site/sitemap.tsv
+++ b/docs/site/sitemap.tsv
@@ -17,6 +17,7 @@ index
 		index/cldr-spec/definitions	
 		index/bcp47-extension	
 	index/downloads		
+		downloads/cldr-47	
 		downloads/cldr-46	
 		downloads/cldr-45	
 		downloads/cldr-44	


### PR DESCRIPTION
CLDR-18057

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

- For CLDR 46 release note:
    - Remove beta status note at the top
    - Change spec links using smoketest to use final posted spec
- Add CLDR 47 stub release note
- On homepage, replace announcements of CLDR 46 alpha/beta with announcement of final

ALLOW_MANY_COMMITS=true
