### PR TITLE
CLDR-18062 Update spec version, and status where necessary

### DIFF
--- a/docs/ldml/tr35-collation.md
+++ b/docs/ldml/tr35-collation.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 5: Collation
 
-|Version|46 (draft)      |
+|Version|47 (draft)      |
 |-------|----------------|
 |Editors|Markus Scherer (<a href="mailto:markus.icu@gmail.com">markus.icu@gmail.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
 

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 4: Dates
 
-|Version|46 (draft)        |
+|Version|47 (draft)        |
 |-------|------------------|
 |Editors|Peter Edberg and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
 

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 2: General
 
-|Version|46 (draft)           |
+|Version|47 (draft)           |
 |-------|---------------------|
 |Editors|Yoshito Umaoka (<a href="mailto:yoshito_umaoka@us.ibm.com">yoshito_umaoka@us.ibm.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members|
 

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 6: Supplemental
 
-|Version|46 (draft) |
+|Version|47 (draft) |
 |-------|-----------|
 |Editors|Steven Loomis (<a href="mailto:srloomis@unicode.org">srloomis@unicode.org</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members|
 

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -1,8 +1,8 @@
-## Unicode Technical Standard #35 Tech Preview
+## Unicode Technical Standard #35
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 7: Keyboards
 
-|Version|46 (draft)   |
+|Version|47 (draft)   |
 |-------|-------------|
 |Editors|Steven Loomis (<a href="mailto:srloomis@unicode.org">srloomis@unicode.org</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
 

--- a/docs/ldml/tr35-messageFormat.md
+++ b/docs/ldml/tr35-messageFormat.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 9: Message Format
 
-|Version|46 (draft)              |
+|Version|47 (draft)              |
 |-------|------------------------|
 |Editors|Addison Phillips and [other CLDR committee members](tr35.md#Acknowledgments)|
 

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 3: Numbers
 
-|Version|46 (draft)|
+|Version|47 (draft)|
 |-------|----------|
 |Editors|Shane F. Carr (<a href="mailto:shane@unicode.org">shane@unicode.org</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members|
 

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 8: Person Names
 
-|Version|46 (draft)              |
+|Version|47 (draft)              |
 |-------|------------------------|
 |Editors|Mark Davis, Peter Edberg,  Rich Gillam, Alex Kolisnychenko, Mike McKenna and [other CLDR committee members](tr35.md#Acknowledgments)|
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -2,18 +2,18 @@
 
 # Unicode Locale Data Markup Language (LDML)
 
-|Version|46 (draft)|
+|Version|47 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2024-09-24|
-|This Version|<a href="https://www.unicode.org/reports/tr35/tr35-73/tr35.html">https://www.unicode.org/reports/tr35/tr35-73/tr35.html</a>|
-|Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-72/tr35.html">https://www.unicode.org/reports/tr35/tr35-72/tr35.html</a>|
+|Date|2024-10-25|
+|This Version|<a href="https://www.unicode.org/reports/tr35/tr35-74/tr35.html">https://www.unicode.org/reports/tr35/tr35-74/tr35.html</a>|
+|Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-73/tr35.html">https://www.unicode.org/reports/tr35/tr35-73/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|
 |Corrigenda|<a href="https://cldr.unicode.org/index/corrigenda">https://cldr.unicode.org/index/corrigenda</a>|
 |Latest Proposed Update|<a href="https://www.unicode.org/reports/tr35/proposed.html">https://www.unicode.org/reports/tr35/proposed.html</a></td></tr>
 |Namespace|<a href="https://www.unicode.org/cldr/">https://www.unicode.org/cldr/</a>|
-|DTDs|<a href="https://www.unicode.org/cldr/dtd/46/">https://www.unicode.org/cldr/dtd/46/</a>|
-|Revision|<a href="#Modifications">73</a>|
+|DTDs|<a href="https://www.unicode.org/cldr/dtd/47/">https://www.unicode.org/cldr/dtd/47/</a>|
+|Revision|<a href="#Modifications">74</a>|
 
 ### _Summary_
 
@@ -4306,7 +4306,11 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
-**Differences from LDML Version 45**
+**Differences from LDML Version 46**
+
+TBD
+
+**Differences in LDML Version 45 (temporary reference while editing the above)**
 
 ### Conformance Modifications
 


### PR DESCRIPTION
CLDR-18062

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18062)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Update spec version. The status (draft, proposed update) was mostly already correct on the main branch, except that "Tech Preview" needed to be removed from the Keyboards part as was done on the maint/maint-46 branch as part of PR [#4150](https://github.com/unicode-org/cldr/pull/4150) (but we do not want the rest of that PR's changes in main)

ALLOW_MANY_COMMITS=true
