### PR TITLE
CLDR-15948 Clean up well-formedness and/or validity constraints

### DIFF
--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -1208,9 +1208,19 @@ Instructions for use are supplied in the header of the file.
 
 Different locales have different preferences for which unit or combination of units is used for a particular usage, such as measuring a person’s height. This is more fine-grained than merely a preference for metric versus US or UK measurement systems. For example, one locale may use meters alone, while another may use centimeters alone or a combination of meters and centimeters; a third may use inches alone, or (informally) a combination of feet and inches.
 
+The determination of preferred units uses the user preference data in [units.xml](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml) together with **input unit**, the **input unit usage**, and the **input locale identifer**.
+  * The _well-formed_ and _valid_ **units** are defined according to [Unit Syntax](tr35-general.html#unit-syntax).
+  * The _well-formed_ **unit usages** are of the form [a-z0-9]{3-8}("-" [a-z0-9]{3-8})*.
+The _valid_ **unit usages** are the union of the set of `NMTOKENS` in the `usage` attribute value for the `unitPreferences` element in [units.xml](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml).
+For example, the following `unitPreferences` elements produce the set {default, floor, geograph, land}.
+    * \<unitPreferences category="area" usage="default">
+    * \<unitPreferences category="area" usage="geograph land">
+    * \<unitPreferences category="area" usage="floor">
+  * There are currently no deprecated **unit usages**.
+Should there be any in the future, for backwards compatibility the above definition would be expanded to include unitUsageAlias elements.
+
 ### <a name="Unit_Preferences_Overrides" href="#Unit_Preferences_Overrides">Unit Preferences Overrides</a>
 
-The determination of preferred units uses the user preference data together with **input unit**, the **input usage**, and the **input locale identifer**.
 Within the locale identifier, the subtags that can affect the result are:
   * the value of the keys mu, ms, and rg
   * the region in the locale identifier (if there is one)

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -419,9 +419,9 @@ For example, the following is from a sample header:
 If an implementation overrides CLDR data, then various lines in the relevant test files may need to be modified correspondingly, or skipped.
 
 ### EBNF
-The BNF syntax used in LDML is a variant of the Extended Backus-Naur Form (EBNF) notation used in [W3C XML Notation](https://www.w3.org/TR/REC-xml/#sec-notation). The main differences are:
+The EBNF syntax used in LDML is a variant of the Extended Backus-Naur Form (EBNF) notation used in [W3C XML Notation](https://www.w3.org/TR/REC-xml/#sec-notation). The main differences are:
 
-1. Bounded repetition following Perl regex syntax is allowed, such as `alphanum{3,8}`.
+1. Bounded repetition following Perl regex syntax is allowed, such as `digit{3}` for 3 digits, `digit{3,5}` for 3 to 5 digits, and `digit{3,}` for 3 or more digits.
 2. Whitespace inside bracketed enumerations and ranges is ignored.
    * eg., `[A-Z a-z]` is the same as `[A-Za-z]`
 3. A backslash may be used to escape a following "x"-prefixed hexadecimal code point or the immediately following character.
@@ -436,7 +436,7 @@ In the text, this is sometimes referred to as "EBNF (Perl-based)".
 
 Before diving into the XML structure, it is helpful to describe the model behind the structure. People do not have to subscribe to this model to use data in LDML, but they do need to understand it so that the data can be correctly translated into whatever model their implementation uses.
 
-The first issue is basic: _what is a locale?_ In this model, a locale is an identifier (id) that refers to a set of user preferences that tend to be shared across significant swaths of the world. Traditionally, the data associated with this id provides support for formatting and parsing of dates, times, numbers, and currencies; for measurement units, for sort-order (collation), plus translated names for time zones, languages, countries, and scripts. The data can also include support for text boundaries (character, word, line, and sentence), text transformations (including transliterations), and other services.
+The first issue is basic: _what is a locale?_ In this model, a locale is an identifier (id) that refers to a set of user preferences that tend to be shared across significant swaths of the world. Traditionally, the data associated with this id provides support for formatting and parsing of dates, times, numbers, and currencies; for measurement units, for sort-order (collation), plus translated names for time zones, languages, countries (regions), and scripts. The data can also include support for text boundaries (character, word, line, and sentence), text transformations (including transliterations), and other services.
 
 Locale data is not cast in stone: the data used on someone's machine generally may reflect the US format, for example, but preferences can typically set to override particular items, such as setting the date format for 2002.03.15, or using metric or Imperial measurement units. In the abstract, locales are simply one of many sets of preferences that, say, a website may want to remember for a particular user. Depending on the application, it may want to also remember the user's time zone, preferred currency, preferred character set, smoker/non-smoker preference, meal preference (vegetarian, kosher, and so on), music preference, religion, party affiliation, favorite charity, and so on.
 
@@ -1030,8 +1030,12 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
 <tr><td>"cu"<br>(currency)</td>
     <td>Currency type</td>
     <td><i>ISO 4217 code,</i><p><i>plus others in common use</i></p></td>
-    <td><p>Codes consisting of 3 ASCII letters that are or have been valid in ISO 4217, plus certain additional codes that are or have been in common use. The list of countries and time periods associated with each currency value is available in <a href="tr35-numbers.md#Supplemental_Currency_Data">Supplemental Currency Data</a>, plus the default number of decimals.</p><p>The XXX code is given a broader interpretation as <i>Unknown or Invalid Currency</i>.</p></td></tr>
-
+    <td><p>Well-formed codes are of the form <code>[A-Za-z]{3}</code>, with the canonical format being <code>[A-Z]{3}</code>. 
+	    The valid codes are ones that are or have been valid in ISO 4217, plus certain additional codes that are or have been in common use. 
+	    <a href="tr35-numbers.md#Supplemental_Currency_Data">Supplemental Currency Data</a> provides the list of countries (regions) and time periods associated with each currency code. 
+	    It also supplies the default number of decimals.</p>
+	    <p>The XXX code is given a broader interpretation than in ISO 4217, as <i>Unknown or Invalid Currency</i>.</p></td>
+</tr>
 <tr><td colspan="4"><b>A <a name="UnicodeDictionaryBreakExclusionIdentifier" id="UnicodeDictionaryBreakExclusionIdentifier"
         href="#UnicodeDictionaryBreakExclusionIdentifier">Unicode Dictionary Break Exclusion Identifier</a> specifies scripts to be excluded from dictionary-based text break
         (for words and lines). The valid values are of one or more items of type SCRIPT_CODE as specified in the <i>name</i> attribute value in the <i>type</i> element of
@@ -1261,7 +1265,7 @@ Not all TZDB links are in CLDR aliases.
 CLDR purposefully does not exactly match the Link structure in the TZDB.
 
 1. The links are maintained in the TZDB, and it would duplicate information that could fall out of sync (especially because the TZDB can be updated many times in a single month).
-2. The TZDB went though a change a few years ago where it dropped the mappings to countries, whereas CLDR still maintains that distinction.
+2. The TZDB went though a change a few years ago where it dropped the mappings to countries (regions), whereas CLDR still maintains that distinction.
 3. Because there are several different timezones that all link together, that would make for a single long alias being an alias for several different short aliases.
 
 CLDR doesn't alias across country boundaries because countries are useful for timezone selection.
@@ -4308,7 +4312,12 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 **Differences from LDML Version 46**
 
-TBD
+### Unit Modifications
+- Updated the EBNF in [Unit Syntax](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-general.html#syntax) to:
+    - Change the constraints into either well-formedness constraints or validity constraints.
+    - Add validity constraints for base-component.
+    - Reformat the EBNF to avoid using HTML tables.
+- Updated the [Unit_Preferences](tr35-info.html#Unit_Preferences) to provide well-formedness and validity definitions.
 
 **Differences in LDML Version 45 (temporary reference while editing the above)**
 


### PR DESCRIPTION
CLDR-15948

docs/ldml/tr35-general.md
- Added a clearer anchor (the old anchor remains valid)
- Having the unit_identifier ABNF in a table is too painful to edit so I converted to markdown.
- The constraints were turned into either well-formedness constraints or validity constraints.
- The substantive change was to add the following to the definition of `base_component`
    - [ vc:  Must be an attribute value of the `source` in: \<convertUnit source='…' …\> or the `type` in \<unitAlias type="…" replacement="…" …\> ]
- Fixed typos from ticket

docs/ldml/tr35-info.md
- moved "The determination of preferred units..." up a section, and fleshed it out to provide a full explanation (with sources) for unit identifiers and unit usage identifiers of their well-formedness and validity.

docs/ldml/tr35.md
- Reword the text for currency identifiers to clarify what the well-formedness and validity are.
- Added notes to the modifications section.
   - There isn't one for currency identifiers; when clarifications or copy-edits are very simple, we typically don't note them. 

We should also provide validity files for these, but this should be sufficient for the immediate future.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
6. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
7. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
