### PR TITLE
CLDR-17160 Update Kawi default Script

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -325,7 +325,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="kaj" to="kaj_Latn_NG"/>		<!--Jju‧?‧?	➡ Jju‧Latin‧Nigeria-->
 		<likelySubtag from="kam" to="kam_Latn_KE"/>		<!--Kamba‧?‧?	➡ Kamba‧Latin‧Kenya-->
 		<likelySubtag from="kao" to="kao_Latn_ML"/>		<!--Xaasongaxango‧?‧?	➡ Xaasongaxango‧Latin‧Mali-->
-		<likelySubtag from="kaw" to="kaw_Kawi_ID"/>		<!--Kawi‧?‧?	➡ Kawi‧Kawi‧Indonesia-->
+		<likelySubtag from="kaw" to="kaw_Bali_ID"/>		<!--Kawi‧?‧?	➡ Kawi‧Balinese‧Indonesia-->
 		<likelySubtag from="kbd" to="kbd_Cyrl_RU"/>		<!--Kabardian‧?‧?	➡ Kabardian‧Cyrillic‧Russia-->
 		<likelySubtag from="kby" to="kby_Arab_NE"/>		<!--Manga Kanuri‧?‧?	➡ Manga Kanuri‧Arabic‧Niger-->
 		<likelySubtag from="kcg" to="kcg_Latn_NG"/>		<!--Tyap‧?‧?	➡ Tyap‧Latin‧Nigeria-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1738,6 +1738,7 @@ XXX Code for transations where no currency is involved
 		<language type="kam" scripts="Latn"/>
 		<language type="kam" territories="KE" alt="secondary"/>
 		<language type="kao" scripts="Latn"/>
+		<language type="kaw" scripts="Bali Java Kawi" alt="secondary"/>
 		<language type="kbd" scripts="Cyrl"/>
 		<language type="kbd" territories="RU" alt="secondary"/>
 		<language type="kca" scripts="Cyrl"/>
@@ -3241,6 +3242,8 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="sxn" populationPercent="0.092"/>	<!--Sangir-->
 			<languagePopulation type="sly" populationPercent="0.054"/>	<!--Selayar-->
 			<languagePopulation type="mwv" populationPercent="0.024"/>	<!--Mentawai-->
+			<languagePopulation type="ban_Bali" populationPercent="0" references="R1002"/>	<!--Balinese (Balinese)-->
+			<languagePopulation type="kaw" populationPercent="0" references="R1006"/>	<!--Kawi-->
 		</territory>
 		<territory type="IE" gdp="608500000000" literacyPercent="99" population="5233460">	<!--Ireland-->
 			<languagePopulation type="en" populationPercent="98" officialStatus="official" references="R1202"/>	<!--English-->
@@ -5497,9 +5500,11 @@ XXX Code for transations where no currency is involved
 	<references>
 		<reference type="R1000" uri="https://www.cia.gov/cia/publications/factbook/geos/aa.html">Dutch official</reference>
 		<reference type="R1001" uri="http://www.migrationinformation.org/Feature/display.cfm?ID=72">At most 6% are not fluent in English</reference>
+		<reference type="R1002">Precise data not available, added so Balinese script defaults to Balinese</reference>
 		<reference type="R1003">While Cyrillic is customary, the vast majority of the population can read both.For languages not customarily written, the writing populiation is artificially set to 5% in the absence of better information.</reference>
 		<reference type="R1004" uri="http://www.ethnologue.com/show_country.asp?name=NL">The figure includes 'Vlaams' population from Ethnologue</reference>
 		<reference type="R1005" uri="http://www.orbilat.com/Languages/Walloon/Walloon.htm">It is estimated that Walloon is used actively by 10-20% of the total population of Wallonia or between 300,000 and 600,000 people. For languages not customarily written, the writing population is artificially set to 5% in the absence of better information.</reference>
+		<reference type="R1006">Precise data not available</reference>
 		<reference type="R1007" uri="http://www.ethnologue.com/show_country.asp?name=Bahrain">Arabic official, the figure is derived from literacy * lang pop</reference>
 		<reference type="R1008" uri="http://lanic.utexas.edu/project/tilan/reports/rtf359/bolivia1.html">Spanish is the official language, only about 60-70% of the population speaks it at all ;</reference>
 		<reference type="R1009" uri="https://www.cia.gov/cia/publications/factbook/geos/bc.html">English official, 81% literacy; the figure is derived from literacy * lang pop</reference>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -614,6 +614,7 @@ India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Waddar	wbq	"2,320,000"
 India	IN	"1,296,834,042"	63%	"9,474,000,000,000"		Wagdi	wbr	"1,940,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Achinese	ace	"3,620,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Balinese	ban	"4,700,000"	10%		http://yamiproject.cs.pu.edu.tw/yami/conference/paper/015.pdf http://www.statemaster.com/encyclopedia/Balinese-language widely used; taught in school as a main lang
+Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Balinese	ban_Bali	2			Precise data not available, added so Balinese script defaults to Balinese
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Banjar	bjn	"3,870,000"	10%
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Batak Toba	bbc	"2,410,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Betawi	bew	"5,540,000"
@@ -623,6 +624,7 @@ Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Gayo	gay	"311,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Gorontalo	gor	"1,090,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"	official	Indonesian	id	64%
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Javanese	jv	34%	10%		Indonesia high literacy; low written use of local languages
+Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Kawi	kaw	1			Precise data not available
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Kerinci	kvr	"362,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Komering	kge	"844,000"
 Indonesia	ID	"262,787,403"	93%	"3,250,000,000,000"		Lampung Api	ljp	"1,810,000"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -370,6 +370,9 @@ kac	Kachin	primary	Latn	Latin
 kaj	Jju	primary	Latn	Latin
 kam	Kamba	primary	Latn	Latin
 kao	Xaasongaxango	primary	Latn	Latin
+kaw	Kawi	primary	Bali	Balinese
+kaw	Kawi	secondary	Kawi	Kawi
+kaw	Kawi	secondary	Java	Javanese
 kbd	Kabardian	primary	Cyrl	Cyrillic
 kca	Khanty	primary	Cyrl	Cyrillic
 kcg	Tyap	primary	Latn	Latin


### PR DESCRIPTION
Kawi, also known as Old Javanese, is undergoing a bit of a revival. It has been written in Javanese, Balinese, and the original Kawi writing system. In modern usage the revival seems to favor the Balinese script. This was recommended by the Jira Ticket [CLDR-17160](https://unicode-org.atlassian.net/browse/CLDR-17160) and will match SIL langtags entry.

```
{
        "full": "kaw-Bali-MY",
        "iana": [ "Kawi" ],
        "iso639_3": "kaw",
        "name": "Kawi",
        "region": "MY",
        "regionname": "Malaysia",
        "script": "Bali",
        "sldr": false,
        "tag": "kaw",
        "tags": [ "kaw-Bali", "kaw-MY" ],
        "windows": "kaw-Bali"
    },
```

CLDR-17160

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true


[CLDR-17160]: https://unicode-org.atlassian.net/browse/CLDR-17160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ