### PR TITLE
CLDR-18075 timezone names

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -996,6 +996,7 @@ annotations.
 			<territory type="BZ">Belize</territory>
 			<territory type="CA">Canada</territory>
 			<territory type="CC">Cocos (Keeling) Islands</territory>
+			<territory type="CC" alt="short">Cocos Islands</territory>
 			<territory type="CD">Congo - Kinshasa</territory>
 			<territory type="CD" alt="variant">Congo (DRC)</territory>
 			<territory type="CF">Central African Republic</territory>
@@ -1158,6 +1159,7 @@ annotations.
 			<territory type="PL">Poland</territory>
 			<territory type="PM">St. Pierre &amp; Miquelon</territory>
 			<territory type="PN">Pitcairn Islands</territory>
+			<territory type="PN" alt="short">Pitcairn</territory>
 			<territory type="PR">Puerto Rico</territory>
 			<territory type="PS">Palestinian Territories</territory>
 			<territory type="PS" alt="short">Palestine</territory>
@@ -3939,6 +3941,12 @@ annotations.
 			<zone type="Asia/Qostanay">
 				<exemplarCity>Kostanay</exemplarCity>
 			</zone>
+			<zone type="Pacific/Easter">
+				<exemplarCity>Easter Island</exemplarCity>
+			</zone>
+			<zone type="Pacific/Wake">
+				<exemplarCity>Wake Island</exemplarCity>
+			</zone>
 			<zone type="Asia/Saigon">
 				<exemplarCity>Ho Chi Minh City</exemplarCity>
 			</zone>
@@ -4186,7 +4194,7 @@ annotations.
 			</metazone>
 			<metazone type="Brunei">
 				<long>
-					<standard>Brunei Darussalam Time</standard>
+					<standard>Brunei Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Cape_Verde">
@@ -4265,12 +4273,12 @@ annotations.
 			</metazone>
 			<metazone type="DumontDUrville">
 				<long>
-					<standard>Dumont-d’Urville Time</standard>
+					<standard>Dumont d’Urville Time</standard>
 				</long>
 			</metazone>
 			<metazone type="East_Timor">
 				<long>
-					<standard>East Timor Time</standard>
+					<standard>Timor-Leste Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Easter">
@@ -4487,9 +4495,9 @@ annotations.
 			</metazone>
 			<metazone type="Kamchatka">
 				<long>
-					<generic>Petropavlovsk-Kamchatski Time</generic>
-					<standard>Petropavlovsk-Kamchatski Standard Time</standard>
-					<daylight>Petropavlovsk-Kamchatski Summer Time</daylight>
+					<generic>Kamchatka Time</generic>
+					<standard>Kamchatka Standard Time</standard>
+					<daylight>Kamchatka Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kazakhstan">
@@ -4672,7 +4680,7 @@ annotations.
 			</metazone>
 			<metazone type="North_Mariana">
 				<long>
-					<standard>North Mariana Islands Time</standard>
+					<standard>Northern Mariana Islands Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Novosibirsk">
@@ -4746,12 +4754,12 @@ annotations.
 			</metazone>
 			<metazone type="Ponape">
 				<long>
-					<standard>Ponape Time</standard>
+					<standard>Pohnpei Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Pyongyang">
 				<long>
-					<standard>Pyongyang Time</standard>
+					<standard>North Korea Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Qyzylorda">
@@ -4829,9 +4837,9 @@ annotations.
 			</metazone>
 			<metazone type="Taipei">
 				<long>
-					<generic>Taipei Time</generic>
-					<standard>Taipei Standard Time</standard>
-					<daylight>Taipei Daylight Time</daylight>
+					<generic>Taiwan Time</generic>
+					<standard>Taiwan Standard Time</standard>
+					<daylight>Taiwan Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Tajikistan">

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3198,17 +3198,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>UTC</standard>
 				</short>
 			</zone>
-			<zone type="Etc/Unknown">
-				<exemplarCity>Unknown</exemplarCity>
-			</zone>
 			<zone type="Antarctica/DumontDUrville">
-				<exemplarCity>Dumont d’Urville</exemplarCity>
+				<exemplarCity>Dumont-d’Urville</exemplarCity>
 			</zone>
 			<zone type="America/St_Barthelemy">
 				<exemplarCity>St. Barthélemy</exemplarCity>
 			</zone>
 			<zone type="America/Coral_Harbour">
 				<exemplarCity>Atikokan</exemplarCity>
+			</zone>
+			<zone type="America/Noronha">
+				<exemplarCity>Fernando de Noronha</exemplarCity>
 			</zone>
 			<zone type="America/St_Johns">
 				<exemplarCity>St. John’s</exemplarCity>


### PR DESCRIPTION
CLDR-18075

- [x] This PR completes the ticket.

Also CLDR-18076, CLDR-18077, CLDR-18078. 

* Add a short name for territory `CC`, so that `Cocos (Keeling) Islands Time` (location format) becomes `Cocos Islands Time`, matching the non-location format
* Add a short name for territory `PN`, so that `Pitcairn Islands Time` (location format) becomes `Pitcairn Time`, matching the non-location format
* Add exemplar cities for some locations, so that the location format matches the non-location format
  * `Pacific/Easter`, so that `Easter Time` -> `Easter Island Time` (`en.xml`)
  * `Pacific/Wake`, so that `Wake Time` -> `Wake Island Time` (`en.xml`)
  * `America/Noronha`, so that `Noronha Time` -> `Fernando de Noronha Time` (`root.xml`)
* Change some non-location names that use cities when the location names use regions, as they are the only zone in a region (also to align with location format)
  * `Pyongyang Time` -> `North Korea Time`
  * `Taipei Time` -> `Taiwan Time` 
* Change the non-location name `Petropavlovsk-Kamchatski Time` to `Kamchatka Time`, as `Petropavlovsk-Kamchatski` is a city, but the location format uses `Kamchatka`
* Change some metazones names that only barely differ from the location names to match
  * `Brunei Darussalam Time` -> `Brunei Time`
  * `East Timor Time` -> `Timor-Leste Time`
  * `North Mariana Islands Time` -> `Northern Mariana Islands Time`
  * `Ponape Time` -> `Pohnpei Time`

ALLOW_MANY_COMMITS=true

