### PR TITLE
CLDR-17730 Indonesian RBNF is missing a semicolon for spellout-ordinal

### DIFF
--- a/common/rbnf/id.xml
+++ b/common/rbnf/id.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2014 Unicode, Inc.
+Copyright © 1991-2024 Unicode, Inc.
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 For terms of use, see http://www.unicode.org/copyright.html
 -->
@@ -51,7 +51,7 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="-x">negatif →→;</rbnfrule>
                 <rbnfrule value="x.x">=#,##0.#=;</rbnfrule>
                 <rbnfrule value="0">ke=%spellout-cardinal=;</rbnfrule>
-                <rbnfrule value="1">pertama</rbnfrule>
+                <rbnfrule value="1">pertama;</rbnfrule>
                 <rbnfrule value="2">ke=%spellout-cardinal=;</rbnfrule>
             </ruleset>
         </rulesetGrouping>


### PR DESCRIPTION
CLDR-17730

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
