### PR TITLE
CLDR-17187 Dutch spell out rule for cardinal 1 needs additional rule

### DIFF
--- a/common/rbnf/nl.xml
+++ b/common/rbnf/nl.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
 <!--
-Copyright © 1991-2013 Unicode, Inc.
-CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+Copyright © 1991-2024 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-DFS-2016
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <ldml>
     <identity>
@@ -89,6 +90,13 @@ For terms of use, see http://www.unicode.org/copyright.html
                 <rbnfrule value="1000000000000">←← biljoen[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000">←← biljard[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-stressed">
+                <rbnfrule value="-x">min →→;</rbnfrule>
+                <rbnfrule value="x.x">=%spellout-cardinal=;</rbnfrule>
+                <rbnfrule value="0">=%spellout-cardinal=;</rbnfrule>
+                <rbnfrule value="1">één;</rbnfrule>
+                <rbnfrule value="2">=%spellout-cardinal=;</rbnfrule>
             </ruleset>
             <ruleset type="ord-ste" access="private">
                 <rbnfrule value="0">ste;</rbnfrule>


### PR DESCRIPTION
CLDR-17187

This adds the alternate spellout-cardinal-stressed RBNF rule for specific Dutch scenarios.  The current cardinal behavior is not incorrect, but sometimes you need to differentiate between the indefinite article and the number. The stressed form shows that it's an actual number and not an indefinite article.

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
