### PR TITLE
CLDR-18092 Clarify Venetian language in Mexico

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2349,7 +2349,7 @@ XXX Code for transations where no currency is involved
 		<language type="ve" scripts="Latn"/>
 		<language type="ve" territories="ZA" alt="secondary"/>
 		<language type="vec" scripts="Latn"/>
-		<language type="vec" territories="BR HR IT MX SI" alt="secondary"/>
+		<language type="vec" territories="BR HR IT SI" alt="secondary"/>
 		<language type="vep" scripts="Latn"/>
 		<language type="vi" scripts="Latn" territories="VN"/>
 		<language type="vi" scripts="Hani" territories="US" alt="secondary"/>
@@ -3691,7 +3691,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="nhw" populationPercent="0.39"/>	<!--Western Huasteca Nahuatl-->
 			<languagePopulation type="maz" populationPercent="0.34"/>	<!--Central Mazahua-->
 			<languagePopulation type="nch" populationPercent="0.19"/>	<!--Central Huasteca Nahuatl-->
-			<languagePopulation type="vec" populationPercent="0.0019" officialStatus="official_regional" references="R1136"/>	<!--Venetian-->
+			<languagePopulation type="vec" populationPercent="0.0019" references="R1136"/>	<!--Venetian-->
 			<languagePopulation type="sei" populationPercent="0.0007"/>	<!--Seri-->
 		</territory>
 		<territory type="MY" gdp="1152000000000" literacyPercent="93.1" population="34564800">	<!--Malaysia-->

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -864,7 +864,7 @@ Mexico	MX	"125,959,205"	94%	"2,463,000,000,000"		Seri	sei	900
 Mexico	MX	"125,959,205"	94%	"2,463,000,000,000"	de_facto_official	Spanish	es	83%
 Mexico	MX	"125,959,205"	94%	"2,463,000,000,000"		Western Huasteca Nahuatl	nhw	"485,000"
 Mexico	MX	"125,959,205"	94%	"2,463,000,000,000"		Yucateco	yua	"848,000"
-Mexico	MX	"125,959,205"	94%	"2,463,000,000,000"	official_regional	Venetian	vec	"2,500"			https://en.wikipedia.org/wiki/Chipilo_Venetian_dialect
+Mexico	MX	"125,959,205"	94%	"2,463,000,000,000"		Venetian	vec	"2,500"			https://en.wikipedia.org/wiki/Chipilo_Venetian_dialect
 Micronesia	FM	"103,643"	89%	"348,000,000"		Chuukese	chk	30%
 Micronesia	FM	"103,643"	89%	"348,000,000"	official	English	en	57%
 Micronesia	FM	"103,643"	89%	"348,000,000"		Kosraean	kos	"8,000"


### PR DESCRIPTION
There's a community of Mexicans that speak Venetian - but it is definitely not an offical language for the country, region, or city. This updates the data to remove this error.

CLDR-18092

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
