### PR TITLE
CLDR-15948 Add additional well-formedness clauses

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -516,21 +516,21 @@ A _Unicode locale identifier_ is composed of a Unicode language identifier plus 
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------- |
 | <a name="unicode_locale_id" href="#unicode_locale_id">`unicode_locale_id`</a>                         | `= unicode_language_id`<br/>  `extensions*`<br/>  `pu_extensions? ;` |
 | <a name="extensions" href="#extensions">`extensions`</a>                                              | `= unicode_locale_extensions`<br/>`\| transformed_extensions`<br/>` \| other_extensions ;` |
-| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>  `((sep keyword)+`<br/>  `\|(sep attribute)+ (sep keyword)*) ;` |
+| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>  `((sep keyword)+`<br/>  `\|(sep attribute)+ (sep ufield)*) ;` |
 | <a name="transformed_extensions" href="#transformed_extensions">`transformed_extensions`</a>          | `= sep [tT]`<br/>  `((sep tlang (sep tfield)*)`<br/>  `\| (sep tfield)+) ;` |
 | <a name="pu_extensions" href="#pu_extensions">`pu_extensions`</a>                                     | `= sep [xX]`<br/>`  (sep alphanum{1,8})+ ;` |
 | <a name="other_extensions" href="#other_extensions">`other_extensions`</a>                            | `= sep [alphanum-[tTuUxX]]`<br/>`  (sep alphanum{2,8})+ ;` |
-| `keyword`<br/>(Also known as `ufield`)                                                                | `= key (sep type)? ;` |
-| `key`<br/>(Also known as `ukey`)                                                                      | `= alphanum alpha ;`<br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with tkey.) | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
-| `type`<br/>(Also known as `uvalue`)                                                                   | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
+| <a name="ufield" href="#ufield">`ufield`</a><br/>(Also known as `keyword`)                            | `= ukey (sep uvalue)? ;` |
+| <a name="ukey" href="#ukey">`ukey`</a><br/>(Also known as `key`)                                      | `= alphanum alpha ;`<br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with tkey.) | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
+| <a name="uvalue" href="#uvalue">`uvalue`</a><br/>(Also known as `type`)                               | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
 | `attribute`                                                                                           | `= alphanum{3,8} ;` |
 | <a name="unicode_subdivision_id" href="#unicode_subdivision_id">`unicode_subdivision_id`</a>          | `= `[`unicode_region_subtag`](#unicode_region_subtag)` unicode_subdivision_suffix ;` | [`validity`](#unicode_subdivision_subtag_validity)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/subdivision.xml) |
 | `unicode_subdivision_suffix`                                                                          | `= alphanum{1,4} ;` |
 | <a name="unicode_measure_unit" href="#unicode_measure_unit">`unicode_measure_unit`</a>                | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Validity_Data)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/validity/unit.xml) |
-| `tlang`                                                                                               | `= unicode_language_subtag`<br/>`  (sep unicode_script_subtag)?`<br/>`  (sep unicode_region_subtag)?`<br/>`  (sep unicode_variant_subtag)* ;` | same as in unicode_language_id |
-| `tfield`                                                                                              | `= tkey tvalue;` | [`validity`](#BCP47_T_Extension)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
-| `tkey`                                                                                                | `= alpha digit ;` |
-| `tvalue`                                                                                              | `= (sep alphanum{3,8})+ ;` |
+| <a name="tlang" href="#tlang">`tlang`</a>                                                             | `= unicode_language_subtag`<br/>`  (sep unicode_script_subtag)?`<br/>`  (sep unicode_region_subtag)?`<br/>`  (sep unicode_variant_subtag)* ;` | same as in unicode_language_id |
+| <a name="tfield" href="#tfield">`tfield`</a>                                                          | `= tkey tvalue;` | [`validity`](#BCP47_T_Extension)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47) |
+| <a name="tkey" href="#tkey">`tkey`</a>                                                                | `= alpha digit ;` |
+| <a name="tvalue" href="#tvalue">`tvalue`</a>                                                          | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})+ ;` |
 
 The following are additional well-formedness constraints:
   1. [ wfc: There cannot be more than one extension with the same singleton. For example, en-u-ca-buddhist-u-cf-standard is ill-formed.]
@@ -973,61 +973,69 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
 <tr><th>key<br>(old key name)</th><th>key description</th><th>example type<br>(old type name)</th><th>type description</th></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeCalendarIdentifier" id="UnicodeCalendarIdentifier" href="#UnicodeCalendarIdentifier">Unicode Calendar Identifier</a>
-        defines a type of calendar. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="ca"
+        defines a type of calendar. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>. 
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="ca"
         in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/calendar.xml" target="_blank">calendar.xml</a></b>.<br>
         This selects calendar-specific data within a locale used for formatting and parsing, such as date/time symbols and patterns; it also selects supplemental
         calendarData used for calendrical calculations.
 		The value can affect the computation of the first day of the week: see <a href='tr35-dates.md#first-day-overrides'>First Day Overrides</a>.
         </td></tr>
-<tr><td rowspan="10">"ca"<br>(calendar)</td>
+<tr><td rowspan="10"><code>ca</code><br>(calendar)</td>
     <td rowspan="10">Calendar algorithm<br><br><i>(For information on the calendar algorithms associated with the data used with these, see [<a href="#Calendars">Calendars</a>].)</i></td>
-            <td>"buddhist"</td>
+            <td><code>buddhist</code></td>
             <td>Thai Buddhist calendar (same as Gregorian except for the year)</td></tr>
-        <tr><td>"chinese"</td>
+        <tr><td><code>chinese</code></td>
             <td>Traditional Chinese calendar</td></tr>
         <tr><td colspan="2">…</td></tr>
-        <tr><td>"gregory"<br>(gregorian)</td>
+        <tr><td><code>gregory</code></td>
             <td>Gregorian calendar</td></tr>
         <tr><td colspan="2">…</td></tr>
-        <tr><td>"islamic"</td>
+        <tr><td><code>islamic</code></td>
             <td>Islamic calendar</td></tr>
-        <tr><td>"islamic-civil"</td>
+        <tr><td><code>islamic-civil</code></td>
             <td>Islamic calendar, tabular (intercalary years [2,5,7,10,13,16,18,21,24,26,29] - civil epoch)</td></tr>
-        <tr><td>"islamic-umalqura"</td>
+        <tr><td><code>islamic-umalqura</code></td>
             <td>Islamic calendar, Umm al-Qura</td></tr>
         <tr><td colspan="2">…</td></tr>
         <tr><td colspan="2"><b>Note:</b> <i>Some calendar types are represented by two subtags. In such cases, the first subtag specifies a generic calendar type and the second subtag specifies a calendar algorithm variant. The CLDR uses generic calendar types (single subtag types) for tagging data when calendar algorithm variations within a generic calendar type are irrelevant. For example, type "islamic" is used for specifying Islamic calendar formatting data for all Islamic calendar types, including "islamic-civil" and "islamic-umalqura".</i></td></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeCurrencyFormatIdentifier" id="UnicodeCurrencyFormatIdentifier" href="#UnicodeCurrencyFormatIdentifier">Unicode Currency Format Identifier</a>
-        defines a style for currency formatting. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="cf" in
+        defines a style for currency formatting. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>. 
+        The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="cf" in
         bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/currency.xml" target="_blank">currency.xml</a></b>.<br>
         This selects the specific type of currency formatting pattern within a locale.
         </td></tr>
-<tr><td rowspan="2">"cf"</td>
+<tr><td rowspan="2"><code>cf</code></td>
     <td rowspan="2">Currency Format style</td>
-        <td>"standard"</td><td>Negative numbers use the minusSign symbol (the default).</td></tr>
-        <tr><td>"account"</td><td>Negative numbers use parentheses or equivalent.</td></tr>
+        <td><code>standard</code></td><td>Negative numbers use the minusSign symbol (the default).</td></tr>
+        <tr><td><code>account</code></td><td>Negative numbers use parentheses or equivalent.</td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeCollationIdentifier" id="UnicodeCollationIdentifier" href="#UnicodeCollationIdentifier">Unicode Collation Identifier</a> defines a type of collation (sort order). The valid values are those <i>name</i> attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/collation.xml" target="_blank">collation.xml</a></b>.</td></tr>
+<tr><td colspan="4"><b>A <a name="UnicodeCollationIdentifier" id="UnicodeCollationIdentifier" href="#UnicodeCollationIdentifier">Unicode Collation Identifier</a> defines a type of collation (sort order). 
+         Well-formed values match <a href="#uvalue"><code>uvalue</code></a>. 
+         The valid values are those <i>name</i> attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/collation.xml" target="_blank">collation.xml</a></b>.</td></tr>
 <tr><td colspan="4"><i>For information on each collation setting parameter, from <b>ka</b> to <b>vt</b>, see <a href="tr35-collation.md#Setting_Options">Setting Options</a></i></td></tr>
-<tr><td rowspan="8">"co"<br>(collation)</td>
+<tr><td rowspan="8"><code>co</code><br>(collation)</td>
     <td rowspan="8">Collation type</td>
-            <td>"standard"</td>
+            <td><code>standard</code></td>
             <td>The default ordering for each language. For root it is based on the [<a href="#DUCET">DUCET</a>] (Default Unicode Collation Element Table): see <i><a href="tr35-collation.md#Root_Collation">Root Collation</a></i>. Each other locale is based on that, except for appropriate modifications to certain characters for that language.</td></tr>
-        <tr><td>"search"</td>
+        <tr><td><code>search</code></td>
             <td>A special collation type dedicated for string search—it is not used to determine the relative order of two strings, but only to determine whether they should be considered equivalent for the specified strength, using the string search matching rules appropriate for the language. Compared to the normal collator for the language, this may add or remove primary equivalences, may make additional characters ignorable or change secondary equivalences, and may modify contractions to allow matching within them, depending on the desired behavior. For example, in Czech, the distinction between ‘a’ and ‘á’ is secondary for normal collation, but primary for search; a search for ‘a’ should never match ‘á’ and vice versa. A search collator is normally used with strength set to PRIMARY or SECONDARY (should be SECONDARY if using “asymmetric” search as described in the [<a href="https://www.unicode.org/reports/tr41/#UTS10">UCA</a>] section Asymmetric Search). The search collator in root supplies matching rules that are appropriate for most languages (and which are different than the root collation behavior); language-specific search collators may be provided to override the matching rules for a given language as necessary.</td></tr>
         <tr><td colspan="2"><p>Other keywords provide additional choices for certain locales; <i>they only have effect in certain locales.</i></p></td></tr>
         <tr><td colspan="2">…</td></tr>
-        <tr><td>"phonetic"</td>
+        <tr><td><code>phonetic</code></td>
             <td>Requests a phonetic variant if available, where text is sorted based on pronunciation. It may interleave different scripts, if multiple scripts are in common use.</td></tr>
-        <tr><td>"pinyin"</td>
+        <tr><td><code>pinyin</code></td>
             <td>Pinyin ordering for Latin and for CJK characters; that is, an ordering for CJK characters based on a character-by-character transliteration into a pinyin. (used in Chinese)</td></tr>
-        <tr><td>"searchjl"</td>
+        <tr><td><code>searchjl</code></td>
             <td>Special collation type for a modified string search in which a pattern consisting of a sequence of Hangul initial consonants (jamo lead consonants) will match a sequence of Hangul syllable characters whose initial consonants match the pattern. The jamo lead consonants can be represented using conjoining or compatibility jamo. This search collator is best used at SECONDARY strength with an "asymmetric" search as described in the [<a href="https://www.unicode.org/reports/tr41/#UTS10">UCA</a>] section Asymmetric Search and obtained, for example, using ICU4C's usearch facility with attribute USEARCH_ELEMENT_COMPARISON set to value USEARCH_PATTERN_BASE_WEIGHT_IS_WILDCARD; this ensures that a full Hangul syllable in the search pattern will only match the same syllable in the searched text (instead of matching any syllable with the same initial consonant), while a Hangul initial consonant in the search pattern will match any Hangul syllable in the searched text with the same initial consonant.</td></tr>
         <tr><td colspan="2">…</td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeCurrencyIdentifier" id="UnicodeCurrencyIdentifier" href="#UnicodeCurrencyIdentifier">Unicode Currency Identifier</a> defines a type of currency. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="cu" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/currency.xml" target="_blank">currency.xml</a>.</b></td></tr>
-<tr><td>"cu"<br>(currency)</td>
+<tr><td colspan="4"><b>A <a name="UnicodeCurrencyIdentifier" id="UnicodeCurrencyIdentifier" href="#UnicodeCurrencyIdentifier">Unicode Currency Identifier</a> defines a type of currency. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="cu" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/currency.xml" target="_blank">currency.xml</a>.</b></td></tr>
+<tr><td><code>cu</code><br>(currency)</td>
     <td>Currency type</td>
     <td><i>ISO 4217 code,</i><p><i>plus others in common use</i></p></td>
     <td><p>Well-formed codes are of the form <code>[A-Za-z]{3}</code>, with the canonical format being <code>[A-Z]{3}</code>. 
@@ -1038,11 +1046,13 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
 </tr>
 <tr><td colspan="4"><b>A <a name="UnicodeDictionaryBreakExclusionIdentifier" id="UnicodeDictionaryBreakExclusionIdentifier"
         href="#UnicodeDictionaryBreakExclusionIdentifier">Unicode Dictionary Break Exclusion Identifier</a> specifies scripts to be excluded from dictionary-based text break
-        (for words and lines). The valid values are of one or more items of type SCRIPT_CODE as specified in the <i>name</i> attribute value in the <i>type</i> element of
+        (for words and lines). 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>. 
+	The valid values are of one or more items of type SCRIPT_CODE as specified in the <i>name</i> attribute value in the <i>type</i> element of
         key name="dx" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/segmentation.xml" target="_blank">segmentation.xml</a></b>.<br>
         This affects break iteration regardless of locale.
         </td></tr>
-<tr><td>"dx"</td>
+<tr><td><code>dx</code></td>
     <td>Dictionary break script exclusions</td>
     <td><i><code><a href="#unicode_script_subtag">unicode_script_subtag</a></code> values</i></td>
     <td><ul><li>One or more items of type SCRIPT_CODE (as usual, separated by hyphens), which are valid <code><a href="#unicode_script_subtag">unicode_script_subtag</a></code> values.</li>
@@ -1052,124 +1062,139 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
         <li>The code Zyyy (Common) can be specified to exclude all scripts, if and only if it is the only SCRIPT_CODE value specified. If it is not the only script code, Zyyy has the normal meaning: excluding Script_Extension=Common.</li></ul>
         </td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeEmojiPresentationStyleIdentifier" id="UnicodeEmojiPresentationStyleIdentifier" href="#UnicodeEmojiPresentationStyleIdentifier">Unicode Emoji Presentation Style Identifier</a> specifies a request for the preferred emoji presentation style. This can be used as part of the value for an HTML lang attribute, for example <code>&lt;html lang="sr-Latn-u-em-emoji"&gt;</code>. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="em" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/variant.xml" target="_blank">variant.xml</a></b>.</td></tr>
-<tr><td rowspan="3">"em"</td>
+<tr><td colspan="4"><b>A <a name="UnicodeEmojiPresentationStyleIdentifier" id="UnicodeEmojiPresentationStyleIdentifier" href="#UnicodeEmojiPresentationStyleIdentifier">Unicode Emoji Presentation Style Identifier</a> specifies a request for the preferred emoji presentation style. This can be used as part of the value for an HTML lang attribute, for example <code>&lt;html lang="sr-Latn-u-em-emoji"&gt;</code>. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>. 
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="em" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/variant.xml" target="_blank">variant.xml</a></b>.</td></tr>
+<tr><td rowspan="3"><code>em</code></td>
     <td rowspan="3">Emoji presentation style</td>
-            <td>"emoji"</td>
+            <td><code>emoji</code></td>
             <td>Use an emoji presentation for emoji characters if possible.</td></tr>
-        <tr><td>"text"</td>
+        <tr><td><code>text</code></td>
             <td>Use a text presentation for emoji characters if possible.</td></tr>
-        <tr><td>"default"</td><td>Use the default presentation for emoji characters as specified in UTR #51 <a href="https://www.unicode.org/reports/tr51/#Presentation_Style">Presentation Style</a>.</td></tr>
+        <tr><td><code>default</code></td><td>Use the default presentation for emoji characters as specified in UTR #51 <a href="https://www.unicode.org/reports/tr51/#Presentation_Style">Presentation Style</a>.</td></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeFirstDayIdentifier" id="UnicodeFirstDayIdentifier" href="#UnicodeFirstDayIdentifier">Unicode First Day Identifier</a>
         defines the preferred first day of the week for calendar display. Specifying "fw" in a locale identifier overrides the default value specified by supplemental
         week data for the region (see Part 4 Dates, <a href="tr35-dates.md#Week_Data">Week Data</a>).
-		The valid values are those <i>name</i> attribute values in the <i>type</i> elements
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements
         of key name="fw" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/calendar.xml" target="_blank">calendar.xml</a>.
 		The value can affect the computation of the first day of the week: see <a href='tr35-dates.md#first-day-overrides'>First Day Overrides</a>.
         </td></tr>
-<tr><td rowspan="4">"fw"</td>
+<tr><td rowspan="4"><code>fw</code></td>
     <td rowspan="4">First day of week</td>
-            <td>"sun"</td>
+            <td><code>sun</code></td>
             <td>Sunday</td></tr>
-        <tr><td>"mon"</td>
+        <tr><td><code>mon</code></td>
             <td>Monday</td></tr>
         <tr><td colspan="2">…</td></tr>
-        <tr><td>"sat"</td>
+        <tr><td><code>sat</code></td>
             <td>Saturday</td></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeHourCycleIdentifier" id="UnicodeHourCycleIdentifier" href="#UnicodeHourCycleIdentifier">Unicode Hour Cycle Identifier</a>
         defines the preferred time cycle. Specifying "hc" in a locale identifier overrides the default value specified by supplemental time data for the region
-        (see Part 4 Dates, <a href="tr35-dates.md#Time_Data">Time Data</a>). The valid values are those <i>name</i> attribute values in the <i>type</i> elements of
+        (see Part 4 Dates, <a href="tr35-dates.md#Time_Data">Time Data</a>). 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of
         key name="hc" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/calendar.xml" target="_blank">calendar.xml</a></b>.
         </td></tr>
-<tr><td rowspan="4">"hc"</td>
+<tr><td rowspan="4"><code>hc</code></td>
     <td rowspan="4">Hour cycle</td>
-            <td>"h12"</td>
+            <td><code>h12</code></td>
             <td>Hour system using 1–12; corresponds to 'h' in patterns</td></tr>
-        <tr><td>"h23"</td>
+        <tr><td><code>h23</code></td>
             <td>Hour system using 0–23; corresponds to 'H' in patterns</td></tr>
-        <tr><td>"h11"</td>
+        <tr><td><code>h11</code></td>
             <td>Hour system using 0–11; corresponds to 'K' in patterns</td></tr>
-        <tr><td>"h24"</td>
+        <tr><td><code>h24</code></td>
             <td>Hour system using 1–24; corresponds to 'k' in pattern</td></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeLineBreakStyleIdentifier" id="UnicodeLineBreakStyleIdentifier" href="#UnicodeLineBreakStyleIdentifier">Unicode Line Break Style Identifier</a>
         defines a preferred line break style corresponding to the CSS level 3 <a href="https://drafts.csswg.org/css-text/#line-break-property">line-break option</a>.
-        Specifying "lb" in a locale identifier overrides the locale’s default style (which may correspond to "normal" or "strict"). The valid values are those <i>name</i>
+        Specifying "lb" in a locale identifier overrides the locale’s default style (which may correspond to "normal" or "strict").
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i>
         attribute values in the <i>type</i> elements of key name="lb" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/segmentation.xml" target="_blank">segmentation.xml</a></b>.
         </td></tr>
-<tr><td rowspan="3">"lb"</td>
+<tr><td rowspan="3"><code>lb</code></td>
     <td rowspan="3">Line break style</td>
-            <td>"strict"</td>
+            <td><code>strict</code></td>
             <td>CSS level 3 line-break=strict, e.g. treat CJ as NS</td></tr>
-        <tr><td>"normal"</td>
+        <tr><td><code>normal</code></td>
             <td>CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh</td></tr>
-        <tr><td>"loose"</td>
+        <tr><td><code>loose</code></td>
             <td>CSS lev 3 line-break=loose</td></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeLineBreakWordIdentifier" id="UnicodeLineBreakWordIdentifier" href="#UnicodeLineBreakWordIdentifier">Unicode Line Break Word Identifier</a>
         defines preferred line break word handling behavior corresponding to the CSS level 3 <a href="https://drafts.csswg.org/css-text/#word-break-property">word-break option</a>.
-        Specifying "lw" in a locale identifier overrides the locale’s default style (which may correspond to "normal" or "keepall"). The valid values are those <i>name</i>
+        Specifying "lw" in a locale identifier overrides the locale’s default style (which may correspond to "normal" or "keepall"). 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i>
         attribute values in the <i>type</i> elements of key name="lw" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/segmentation.xml" target="_blank">segmentation.xml</a></b>.
         </td></tr>
-<tr><td rowspan="4">"lw"</td>
+<tr><td rowspan="4"><code>lw</code></td>
     <td rowspan="4">Line break word handling</td>
-            <td>"normal"</td>
+            <td><code>normal</code></td>
             <td>CSS level 3 word-break=normal, normal script/language behavior for midword breaks</td></tr>
-        <tr><td>"breakall"</td>
+        <tr><td><code>breakall</code></td>
             <td>CSS level 3 word-break=break-all, allow midword breaks unless forbidden by lb setting</td></tr>
-        <tr><td>"keepall"</td>
+        <tr><td><code>keepall</code></td>
             <td>CSS level 3 word-break=keep-all, prohibit midword breaks except for dictionary breaks</td></tr>
-	<tr><td>"phrase"</td>
+	<tr><td><code>phrase</code></td>
 	    <td>Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline</td></tr>
 
 <tr><td colspan="4"><b>A <a name="UnicodeMeasurementSystemIdentifier" id="UnicodeMeasurementSystemIdentifier" href="#UnicodeMeasurementSystemIdentifier">Unicode Measurement System Identifier</a>
         defines a preferred measurement system. Specifying "ms" in a locale identifier overrides the default value specified by supplemental measurement system data for the region
-        (see Part 2 General, <a href="tr35-general.md#Measurement_System_Data">Measurement System Data</a>). The valid values are those <i>name</i> attribute values in the
+        (see Part 2 General, <a href="tr35-general.md#Measurement_System_Data">Measurement System Data</a>).
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the
         <i>type</i> elements of key name="ms" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/measure.xml" target="_blank">measure.xml</a></b>.
         The determination of preferred units depends on the locale identifer: the keys ms, mu, rg, the base locale (language, script, region) and the user preferences.
         <i>For information about preferred units and unit conversion, see <a href="tr35-info.md#Unit_Conversion">Unit Conversion</a> and <a href="tr35-info.md#Unit_Preferences">Unit Preferences</a>.</i>
         </td></tr>
-<tr><td rowspan="3">"ms"</td>
+<tr><td rowspan="3"><code>ms</code></td>
     <td rowspan="3">Measurement system</td>
-            <td>"metric"</td>
+            <td><code>metric</code></td>
             <td>Metric System</td></tr>
-        <tr><td>"ussystem"</td>
+        <tr><td><code>ussystem</code></td>
             <td>US System of measurement: feet, pints, etc.; pints are 16oz</td></tr>
-        <tr><td>"uksystem"</td>
+        <tr><td><code>uksystem</code></td>
             <td>UK System of measurement: feet, pints, etc.; pints are 20oz</td></tr>
 
 <tr><td colspan="4"><b>A <a name="MeasurementUnitPreferenceOverride" id="MeasurementUnitPreferenceOverride" href="#MeasurementUnitPreferenceOverride">Measurement Unit Preference Override</a>
-        defines an override for measurement unit preference. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="mu" in
+        defines an override for measurement unit preference. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="mu" in
         bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/measure.xml" target="_blank">measure.xml</a></b>.
         <i>For information about preferred units and unit conversion, see <a href="tr35-info.md#Unit_Conversion">Unit Conversion</a> and <a href="tr35-info.md#Unit_Preferences">Unit Preferences</a>.</i>
         </td></tr>
-<tr><td rowspan="3">"mu"</td>
+<tr><td rowspan="3"><code>mu</code></td>
     <td rowspan="3">Measurement unit override</td>
-            <td>"celsius"</td>
+            <td><code>celsius</code></td>
             <td>Celsius as temperature unit</td></tr>
-        <tr><td>"kelvin"</td>
+        <tr><td><code>kelvin</code></td>
             <td>Kelvin as temperature unit</td></tr>
-        <tr><td>"fahrenhe"</td>
+        <tr><td><code>fahrenhe</code></td>
             <td>Fahrenheit as temperature unit</td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeNumberSystemIdentifier" id="UnicodeNumberSystemIdentifier" href="#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> defines a type of number system. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/number.xml" target="_blank">number.xml</a>.</b></td></tr>
-<tr><td rowspan="7">"nu"<br>(numbers)</td>
+<tr><td colspan="4"><b>A <a name="UnicodeNumberSystemIdentifier" id="UnicodeNumberSystemIdentifier" href="#UnicodeNumberSystemIdentifier">Unicode Number System Identifier</a> defines a type of number system. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/number.xml" target="_blank">number.xml</a>.</b></td></tr>
+<tr><td rowspan="7"><code>nu</code><br>(numbers)</td>
     <td rowspan="7">Numbering system</td>
             <td><i>Unicode script subtag</i></td>
             <td><p>Four-letter types indicating the primary numbering system for the corresponding script represented in Unicode. Unless otherwise specified, it is a decimal numbering system using digits [:GeneralCategory=Nd:]. For example, "latn" refers to the ASCII / Western digits 0-9, while "taml" is an algorithmic (non-decimal) numbering system. (The code "tamldec" is indicates the "modern Tamil decimal digits".)</p>
                 <p class="note">For more information, see <a href="tr35-numbers.md#Numbering_Systems">Numbering Systems</a>.</p></td></tr>
-        <tr><td>"arabext"</td>
+        <tr><td><code>arabext</code></td>
             <td>Extended Arabic-Indic digits ("arab" means the base Arabic-Indic digits)</td></tr>
-        <tr><td>"armnlow"</td>
+        <tr><td><code>armnlow</code></td>
             <td>Armenian lowercase numerals</td></tr>
         <tr><td colspan="2">…</td></tr>
-        <tr><td>"roman"</td>
+        <tr><td><code>roman</code></td>
             <td>Roman numerals</td></tr>
-        <tr><td>"romanlow"</td>
+        <tr><td><code>romanlow</code></td>
             <td>Roman lowercase numerals</td></tr>
-        <tr><td>"tamldec"</td>
+        <tr><td><code>tamldec</code></td>
             <td>Modern Tamil decimal digits</td></tr>
 
 <tr><td colspan="4"><b>A <a name="RegionOverride" id="RegionOverride" href="#RegionOverride">Region Override</a> specifies an alternate region to use for obtaining
@@ -1177,43 +1202,55 @@ The BCP 47 form for keys and types is the canonical form, and recommended. Other
         specified by the <a href="#unicode_region_subtag">unicode_region_subtag</a> in the Unicode Language Identifier (or inferred from the
         <a href="#unicode_language_subtag">unicode_language_subtag</a>)</b>.
         </td></tr>
-<tr><td rowspan="2">"rg"</td>
-    <td rowspan="2">Region Override</td><td>"uszzzz"<br><br></td><td rowspan="2">The value is a <a href="#unicode_subdivision_id">unicode_subdivision_id</a> of type “unknown” or “regular”; this consists of a <a href="#unicode_region_subtag">unicode_region_subtag</a> for a regular region (not a macroregion), suffixed either by “zzzz” (case is not significant) to designate the region as a whole, or by a unicode_subdivision_suffix to provide more specificity. For example, “en-GB-u-rg-uszzzz” represents a locale for British English but with region-specific defaults set to US for items such as default currency, default calendar and week data, default time cycle, and default measurement system and unit preferences.
+<tr><td rowspan="2"><code>rg</code></td>
+    <td rowspan="2">Region Override</td><td><code>uszzzz</code><br><br></td><td rowspan="2">The valid values are a <a href="#unicode_subdivision_id">unicode_subdivision_id</a> of type “unknown” or “regular”; 
+	    this consists of a <a href="#unicode_region_subtag">unicode_region_subtag</a> for a regular region (not a macroregion), 
+	    suffixed either by “zzzz” (case is not significant) to designate the region as a whole, 
+	    or by a unicode_subdivision_suffix to provide more specificity. 
+	    For example, “en-GB-u-rg-uszzzz” represents a locale for British English but with region-specific defaults set to US for items such as default currency, default calendar and week data, default time cycle, and default measurement system and unit preferences.
 	The determination of preferred units depends on the locale identifer: the keys ms, mu, rg, the base locale (language, script, region) and the user preferences.
 	The value can affect the computation of the first day of the week: see <a href='tr35-dates.md#first-day-overrides'>First Day Overrides</a>.
 <i>For information about preferred units and unit conversion, see <a href="tr35-info.md#Unit_Conversion">Unit Conversion</a> and <a href="tr35-info.md#Unit_Preferences">Unit Preferences</a>.</i>
 	</td></tr>
         <tr><td>…</td></tr>
 
-<tr><td colspan="4"><b>A <a name="unicode_subdivision_subtag_validity"></a><a name="UnicodeSubdivisionIdentifier" id="UnicodeSubdivisionIdentifier" href="#UnicodeSubdivisionIdentifier">Unicode Subdivision Identifier</a> defines a regional subdivision used for locales. The valid values are based on the <i>subdivisionContainment</i> element as described in <i>Section <a href="#Unicode_Subdivision_Codes">3.6.5 Subdivision Codes</a></i>.</b></td></tr>
-<tr><td rowspan="2">"sd"</td>
+<tr><td colspan="4"><b>A <a name="unicode_subdivision_subtag_validity"></a><a name="UnicodeSubdivisionIdentifier" id="UnicodeSubdivisionIdentifier" href="#UnicodeSubdivisionIdentifier">Unicode Subdivision Identifier</a> defines a regional subdivision used for locales. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are based on the <i>subdivisionContainment</i> element as described in <i>Section <a href="#Unicode_Subdivision_Codes">3.6.5 Subdivision Codes</a></i>.</b></td></tr>
+<tr><td rowspan="2"><code>sd</code></td>
     <td rowspan="2">Regional Subdivision</td>
-            <td>"gbsct"</td>
+            <td><code>gbsct</code></td>
             <td rowspan="2">A <a href="#unicode_subdivision_id">unicode_subdivision_id</a>, which is a <a href="#unicode_region_subtag">unicode_region_subtag</a> concatenated with a unicode_subdivision_suffix.<br>For example, <i>gbsct</i> is “gb”+“sct” (where sct represents the subdivision code for Scotland). Thus “en-GB-u-sd-gbsct” represents the language variant “English as used in Scotland”. And both “en-u-sd-usca” and “en-US-u-sd-usca” represent “English as used in California”. See <b><i><a href="#Unicode_Subdivision_Codes">3.6.5 Subdivision Codes</a></i></b>.
 			The value can affect the computation of the first day of the week: see <a href='tr35-dates.md#first-day-overrides'>First Day Overrides</a>.
 		</td></tr>
         <tr><td>…</td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeSentenceBreakSuppressionsIdentifier" id="UnicodeSentenceBreakSuppressionsIdentifier" href="#UnicodeSentenceBreakSuppressionsIdentifier">Unicode Sentence Break Suppressions Identifier</a> defines a set of data to be used for suppressing certain sentence breaks that would otherwise be found by UAX #14 rules. The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="ss" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/segmentation.xml" target="_blank">segmentation.xml</a></b>.</td></tr>
-<tr><td rowspan="2">"ss"</td>
+<tr><td colspan="4"><b>A <a name="UnicodeSentenceBreakSuppressionsIdentifier" id="UnicodeSentenceBreakSuppressionsIdentifier" href="#UnicodeSentenceBreakSuppressionsIdentifier">Unicode Sentence Break Suppressions Identifier</a> defines a set of data to be used for suppressing certain sentence breaks that would otherwise be found by UAX #14 rules. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those <i>name</i> attribute values in the <i>type</i> elements of key name="ss" in bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/segmentation.xml" target="_blank">segmentation.xml</a></b>.</td></tr>
+<tr><td rowspan="2"><code>ss</code></td>
     <td rowspan="2">Sentence break suppressions</td>
-            <td>"none"</td>
+            <td><code>none</code></td>
             <td>Don’t use sentence break suppressions data (the default).</td></tr>
-        <tr><td>"standard"</td>
+        <tr><td><code>standard</code></td>
             <td>Use sentence break suppressions data of type "standard"</td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeTimezoneIdentifier" id="UnicodeTimezoneIdentifier" href="#UnicodeTimezoneIdentifier">Unicode Timezone Identifier</a> defines a timezone. The valid values are those name attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/timezone.xml" target="_blank">timezone.xml</a>.</b></td></tr>
-<tr><td>"tz"<br>(timezone)</td>
+<tr><td colspan="4"><b>A <a name="UnicodeTimezoneIdentifier" id="UnicodeTimezoneIdentifier" href="#UnicodeTimezoneIdentifier">Unicode Timezone Identifier</a> defines a timezone. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those name attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/timezone.xml" target="_blank">timezone.xml</a>.</b></td></tr>
+<tr><td><code>tz</code><br>(timezone)</td>
     <td>Time zone</td>
     <td><i>Unicode short time zone IDs</i></td>
     <td><p>Short identifiers defined in terms of a TZ time zone database [<a href="#Olson">Olson</a>] identifier in the common/bcp47/timezone.xml file, plus a few extra values.</p>
         <p>For more information, see <a href="#Time_Zone_Identifiers">Time Zone Identifiers</a>.</p>
         <p>CLDR provides data for normalizing timezone codes.</p></td></tr>
 
-<tr><td colspan="4"><b>A <a name="UnicodeVariantIdentifier" id="UnicodeVariantIdentifier" href="#UnicodeVariantIdentifier">Unicode Variant Identifier</a> defines a special variant used for locales. The valid values are those name attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/variant.xml" target="_blank">variant.xml</a>.</b></td></tr>
-<tr><td>"va"</td>
+<tr><td colspan="4"><b>A <a name="UnicodeVariantIdentifier" id="UnicodeVariantIdentifier" href="#UnicodeVariantIdentifier">Unicode Variant Identifier</a> defines a special variant used for locales. 
+	Well-formed values match <a href="#uvalue"><code>uvalue</code></a>.
+	The valid values are those name attribute values in the <i>type</i> elements of bcp47/<a href="https://github.com/unicode-org/cldr/blob/main/common/bcp47/variant.xml" target="_blank">variant.xml</a>.</b></td></tr>
+<tr><td><code>va</code></td>
     <td>Common variant type</td>
-    <td>"posix"</td>
+    <td><code>posix</code></td>
     <td>POSIX style locale variant. About handling of the "POSIX" variant see <i><a href="#Legacy_Variants">Legacy Variants</a></i>.</td></tr>
 
 </tbody></table>
@@ -1482,9 +1519,10 @@ The Unicode Consortium has registered and is the maintaining authority for two B
 
 These subtags are all in lowercase (that is the canonical casing for these subtags), however, subtags are case-insensitive and casing does not carry any specific meaning. All subtags within the Unicode extensions are alphanumeric characters in length of two to eight that meet the rule `extension` in the [[BCP47](#BCP47)].
 
-The following keys are defined for the -t- extension:
+The following keys are defined for the -t- extension.
+Well-formed values match <a href="#tvalue"><code>tvalue</code></a>.
 
-| Keys   | Description | Values in latest release |
+| Keys   | Description | Valid Values in latest release |
 | ------ | ----------- | ------------------------ |
 | m0     | **Transform extension mechanism:** to reference an authority or rules for a type of transformation | [​transform.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform.xml) |
 | s0, d0 | **Transform source/destination:** for non-languages/scripts, such as fullwidth-halfwidth conversion. | [​transform-destination.xml](https://github.com/unicode-org/cldr/blob/maint/maint-41/common/bcp47/transform-destination.xml) |
@@ -4310,64 +4348,17 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
-**Changes in LDML Version 47 (Differences from Version 46.1)**
-
-(TBD)
-
 **Changes in LDML Version 46.1 (Differences from Version 46)**
 
-### Unit Modifications
+### Well-formed identifiers
+- Added _well-formedness_ clauses before all [`uvalue`](uvalues) and [`tvalue`](tvalues) validity definitions.
+- Added links to [`ukey`](ukey), [`uvalue`](uvalue), [`tkey`](tkey), [`tvalue`](tvalue), etc.
+- Changed the primary terms from keyword, key, type _(leaving them as aliases)_ to ufield, uvalue, tkey.
 - Updated the EBNF in [Unit Syntax](https://cldr-smoke.unicode.org/spec/main/ldml/tr35-general.html#syntax) to:
     - Change the constraints into either well-formedness constraints or validity constraints.
     - Add validity constraints for base-component.
     - Reformat the EBNF to avoid using HTML tables.
 - Updated the [Unit_Preferences](tr35-info.html#Unit_Preferences) to provide well-formedness and validity definitions.
-
-**Changes in LDML Version 46 (Differences from Version 45; temporary reference while editing the above)**
-
-### Conformance Modifications
-
-Updates to [LDML Conformance](#Conformance) including
-- clarification of conformance requirements
-- an expanded list of major sections
-- details about customization
-- a summary of conformance data files
-
-### Locale Identifiers and Inheritance Modifications
-- Clarified definitions of _Unicode BCP 47 locale identifier_ and _Unicode CLDR locale identifier_, moving them to [Unicode CLDR locale identifier](#unicode-locale-identifier)
-- Clarified usage of [Special Script Codes](#special-script-codes).
-- Added definition of [Ordered Elements](#definitions), replacing the obsolete definition of _blocking_ elements.
-- Clarified the usage of the `path` attribute with [aliases](#element-alias).
-
-### Message Format Modifications
-
-Significant updates to [Message Format](tr35-messageFormat.md#Contents) 
-- Removed all of the reserved and private use syntax constructs, simplifying the grammar.
-- Changed the structure of the .match (selector) to require use of local or input declarations. This is a breaking change for existing messages.
-- Added support for bidirectional isolates and marks, and clarified whitespace handling to better enable messages that contains right-to-left identifiers and text.
-
-### Date Modifications
-- Added a tech preview section on [semantic skeletons](tr35-dates.md#Semantic_Skeletons), allowing for less data and faster performance in formatting dates.
-- Clarified that if [dayPeriods](tr35-collation.md#grouping_classes_of_characters) are specified for `noon` and `midnight`, they can often be formatted without also specifying the numeric time
-- In [Element dayPeriods](tr35-dates.md#dayPeriods), added a note on special formatting usable with dayPeriods `noon` and `midnight`.
-
-### Units Modifications
-- Changed the EBNF for [`unit_identifier`](tr35-general.md#Annotations):
-    - Replacing  `number_prefix` by [unit_constant](tr35-general.md#syntax) to generalize expressions like liter-per-100-kilometers, and provide a compact form for longer constants (such as 1e9).
-    - Adding EBNF constraints on `si_prefix` and `binary_prefix`, and adding links to more named components.
-- Clarified the use of -rg for [computing regions](tr35-info.md#compute-regions) in user preferences
-
-### Collation Data Changes
-- Modified [Grouping classes of characters](tr35-collation.md#grouping_classes_of_characters) to reflect two major changes.
-    - The [CLDR root collation](tr35-collation.md#Root_Collation) is a tailoring of the [DUCET](https://www.unicode.org/reports/tr10/#Default_Unicode_Collation_Element_Table).
-Changes have been made to both to align them better:
-        - non-decimal-digit numeric characters now sort after decimal digits
-        - the CLDR root collation no longer tailors any currency symbols (making some of them sort like letter sequences, as in the DUCET). 
-    - Starting with CLDR 46, the CLDR radical-stroke order matches that of the [Unicode Radical-Stroke Index (large PDF)](https://www.unicode.org/Public/UCD/latest/charts/RSIndex.pdf).
-[Its sorting algorithm is defined in UAX #38](https://www.unicode.org/reports/tr38/#SortingAlgorithm).
-
-### Misc. Modifications
-- Clarified the usage model for [emoji search keywords](tr35-general.md#Annotations).
 
 
 Note that small changes such as typos and link fixes are not listed above.


### PR DESCRIPTION
CLDR-15948

We need better well-formedness clauses for identifiers, for references. This doesn't make material changes, since (with some work) someone can derived that the various identifiers have those restrictions. Also added links to some of the EBNF for locale ids, for reference, and reversed the aliasing for keyword, key, type to be the more understandable (and parallel to -t-) terms.

Removed the quotes around the identifiers in the large table, since that was confusing to readers, replacing with `code` style.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
