### PR TITLE
CLDR-7428 Freeze collators; new class CollatorHelper

### DIFF
--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
@@ -7,9 +7,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.ibm.icu.dev.test.TestFmwk.TestGroup;
 import com.ibm.icu.dev.test.TestLog;
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.PrintWriter;
 import java.sql.SQLException;
@@ -17,12 +14,8 @@ import java.util.logging.Logger;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
-import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.web.CLDRProgressIndicator;
 import org.unicode.cldr.web.DBUtils;
 import org.unicode.cldr.web.SurveyLog;
@@ -129,13 +122,6 @@ public class TestAll extends TestGroup {
     public static class WebTestInfo {
         private static WebTestInfo INSTANCE = null;
 
-        private SupplementalDataInfo supplementalDataInfo;
-        private StandardCodes sc;
-        private Factory cldrFactory;
-        private CLDRFile english;
-        private CLDRFile root;
-        private RuleBasedCollator col;
-
         public static WebTestInfo getInstance() {
             synchronized (WebTestInfo.class) {
                 if (INSTANCE == null) {
@@ -146,62 +132,6 @@ public class TestAll extends TestGroup {
         }
 
         private WebTestInfo() {}
-
-        public SupplementalDataInfo getSupplementalDataInfo() {
-            synchronized (this) {
-                if (supplementalDataInfo == null) {
-                    supplementalDataInfo =
-                            SupplementalDataInfo.getInstance(CLDRPaths.SUPPLEMENTAL_DIRECTORY);
-                }
-            }
-            return supplementalDataInfo;
-        }
-
-        public StandardCodes getStandardCodes() {
-            synchronized (this) {
-                if (sc == null) {
-                    sc = StandardCodes.make();
-                }
-            }
-            return sc;
-        }
-
-        public Factory getCldrFactory() {
-            synchronized (this) {
-                if (cldrFactory == null) {
-                    cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
-                }
-            }
-            return cldrFactory;
-        }
-
-        public CLDRFile getEnglish() {
-            synchronized (this) {
-                if (english == null) {
-                    english = getCldrFactory().make("en", true);
-                }
-            }
-            return english;
-        }
-
-        public CLDRFile getRoot() {
-            synchronized (this) {
-                if (root == null) {
-                    root = getCldrFactory().make("root", true);
-                }
-            }
-            return root;
-        }
-
-        public Collator getCollator() {
-            synchronized (this) {
-                if (col == null) {
-                    col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
-                    col.setNumericCollation(true);
-                }
-            }
-            return col;
-        }
     }
 
     static boolean dbSetup = false;

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
@@ -9,12 +9,11 @@ import com.ibm.icu.dev.test.TestFmwk.TestGroup;
 import com.ibm.icu.dev.test.TestLog;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RuleBasedCollator;
+import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.util.logging.Logger;
-
-import com.ibm.icu.util.ULocale;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/unittest/web/TestAll.java
@@ -13,6 +13,8 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.util.logging.Logger;
+
+import com.ibm.icu.util.ULocale;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
@@ -195,7 +197,7 @@ public class TestAll extends TestGroup {
         public Collator getCollator() {
             synchronized (this) {
                 if (col == null) {
-                    col = (RuleBasedCollator) Collator.getInstance();
+                    col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
                     col.setNumericCollation(true);
                 }
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -36,6 +36,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
@@ -321,7 +322,7 @@ public class Misc {
         String[] locales =
                 "en ru nl en-GB fr de it pl pt-BR es tr th ja zh-CN zh-TW ko ar bg sr uk ca hr cs da fil fi hu id lv lt no pt-PT ro sk sl es-419 sv vi el iw fa hi am af et is ms sw zu bn mr ta eu fr-CA gl zh-HK ur gu kn ml te"
                         .split(" ");
-        Set<String> nameAndInfo = new TreeSet<>(info.getCollator());
+        Set<String> nameAndInfo = new TreeSet<>(CollatorHelper.EMOJI_COLLATOR);
         for (String localeCode : locales) {
             String baseLanguage = ltp.set(localeCode).getLanguage();
             R2<List<String>, String> temp = lang2replacement.get(baseLanguage);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -143,6 +143,8 @@ public class Misc {
 
     private static void showSortKey() {
         String[] tests = "a ä A ぁ あ ァ ｧ ア ｱ ㋐".split(" ");
+        // TODO: freeze the Collator; problematic since changed in innermost for loop below
+        // Reference: https://unicode-org.atlassian.net/browse/CLDR-7428
         RuleBasedCollator c = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         c.setStrength(RuleBasedCollator.QUATERNARY);
         c.setCaseLevel(true);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -143,7 +143,7 @@ public class Misc {
 
     private static void showSortKey() {
         String[] tests = "a ä A ぁ あ ァ ｧ ア ｱ ㋐".split(" ");
-        RuleBasedCollator c = (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+        RuleBasedCollator c = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         c.setStrength(RuleBasedCollator.QUATERNARY);
         c.setCaseLevel(true);
         c.setHiraganaQuaternary(true);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ExtractICUData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ExtractICUData.java
@@ -465,7 +465,7 @@ public class ExtractICUData {
             }
             out.println("</table></td></tr>");
         }
-        Collator c = Collator.getInstance(ULocale.ENGLISH);
+        Collator c = Collator.getInstance(ULocale.ROOT);
         ((RuleBasedCollator) c).setNumericCollation(true);
 
         // int enumValue = UCharacter.getIntPropertyValue(codePoint, propEnum);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ExtractICUData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ExtractICUData.java
@@ -12,9 +12,7 @@ import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.Transliterator;
-import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.UResourceBundle;
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,6 +33,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.PathUtilities;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SimpleFactory;
@@ -411,9 +410,7 @@ public class ExtractICUData {
             {UProperty.DOUBLE_START, UProperty.DOUBLE_START},
             {UProperty.STRING_START, UProperty.STRING_LIMIT},
         };
-        Collator col = Collator.getInstance(ULocale.ROOT); // freeze below
-        ((RuleBasedCollator) col).setNumericCollation(true);
-        col = col.freeze();
+        Collator col = CollatorHelper.ROOT_NUMERIC;
         Map<String, Set<String>> alpha = new TreeMap<>(col);
 
         for (int range = 0; range < ranges.length; ++range) {
@@ -466,13 +463,6 @@ public class ExtractICUData {
             }
             out.println("</table></td></tr>");
         }
-        Collator c = Collator.getInstance(ULocale.ROOT); // freeze below
-        ((RuleBasedCollator) c).setNumericCollation(true);
-        c = c.freeze();
-
-        // int enumValue = UCharacter.getIntPropertyValue(codePoint, propEnum);
-        // return UCharacter.getPropertyValueName(propEnum,enumValue, (int)nameChoice);
-
     }
 
     private static String getName(int index, String valueName, String shortValueName) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ExtractICUData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/ExtractICUData.java
@@ -411,8 +411,9 @@ public class ExtractICUData {
             {UProperty.DOUBLE_START, UProperty.DOUBLE_START},
             {UProperty.STRING_START, UProperty.STRING_LIMIT},
         };
-        Collator col = Collator.getInstance(ULocale.ROOT);
+        Collator col = Collator.getInstance(ULocale.ROOT); // freeze below
         ((RuleBasedCollator) col).setNumericCollation(true);
+        col = col.freeze();
         Map<String, Set<String>> alpha = new TreeMap<>(col);
 
         for (int range = 0; range < ranges.length; ++range) {
@@ -465,8 +466,9 @@ public class ExtractICUData {
             }
             out.println("</table></td></tr>");
         }
-        Collator c = Collator.getInstance(ULocale.ROOT);
+        Collator c = Collator.getInstance(ULocale.ROOT); // freeze below
         ((RuleBasedCollator) c).setNumericCollation(true);
+        c = c.freeze();
 
         // int enumValue = UCharacter.getIntPropertyValue(codePoint, propEnum);
         // return UCharacter.getPropertyValueName(propEnum,enumValue, (int)nameChoice);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLComparator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLComparator.java
@@ -115,9 +115,11 @@ public class LDMLComparator {
 
     static Collator getDefaultCollation() {
         // if (DEFAULT_COLLATION != null) return DEFAULT_COLLATION;
-        RuleBasedCollator temp = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        RuleBasedCollator temp =
+                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
         temp.setStrength(Collator.IDENTICAL);
         temp.setNumericCollation(true);
+        temp = (RuleBasedCollator) temp.freeze();
         // DEFAULT_COLLATION = temp;
         return temp;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLComparator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLComparator.java
@@ -115,7 +115,7 @@ public class LDMLComparator {
 
     static Collator getDefaultCollation() {
         // if (DEFAULT_COLLATION != null) return DEFAULT_COLLATION;
-        RuleBasedCollator temp = (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+        RuleBasedCollator temp = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         temp.setStrength(Collator.IDENTICAL);
         temp.setNumericCollation(true);
         // DEFAULT_COLLATION = temp;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLComparator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/icu/LDMLComparator.java
@@ -13,7 +13,6 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.Normalizer;
-import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -28,6 +27,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.Vector;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.LDMLUtilities;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -114,14 +114,7 @@ public class LDMLComparator {
     }
 
     static Collator getDefaultCollation() {
-        // if (DEFAULT_COLLATION != null) return DEFAULT_COLLATION;
-        RuleBasedCollator temp =
-                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-        temp.setStrength(Collator.IDENTICAL);
-        temp.setNumericCollation(true);
-        temp = (RuleBasedCollator) temp.freeze();
-        // DEFAULT_COLLATION = temp;
-        return temp;
+        return CollatorHelper.ROOT_NUMERIC_IDENTICAL;
     }
 
     Hashtable<String, String> optionTable = new Hashtable<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -3309,7 +3309,7 @@ public class CLDRModify {
 
     /** Internal */
     public static void testJavaSemantics() {
-        Collator caseInsensitive = Collator.getInstance(ULocale.ROOT);
+        Collator caseInsensitive = Collator.getInstance(ULocale.ROOT).freeze();
         caseInsensitive.setStrength(Collator.SECONDARY);
         Set<String> setWithCaseInsensitive = new TreeSet<>(caseInsensitive);
         setWithCaseInsensitive.addAll(Arrays.asList(new String[] {"a", "b", "c"}));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -55,6 +55,7 @@ import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CLDRTool;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.DateTimeCanonicalizer;
 import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
 import org.unicode.cldr.util.DowngradePaths;
@@ -3309,9 +3310,7 @@ public class CLDRModify {
 
     /** Internal */
     public static void testJavaSemantics() {
-        Collator caseInsensitive = Collator.getInstance(ULocale.ROOT); // freeze below
-        caseInsensitive.setStrength(Collator.SECONDARY);
-        caseInsensitive = caseInsensitive.freeze();
+        Collator caseInsensitive = CollatorHelper.ROOT_SECONDARY;
         Set<String> setWithCaseInsensitive = new TreeSet<>(caseInsensitive);
         setWithCaseInsensitive.addAll(Arrays.asList(new String[] {"a", "b", "c"}));
         Set<String> plainSet = new TreeSet<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -3309,8 +3309,9 @@ public class CLDRModify {
 
     /** Internal */
     public static void testJavaSemantics() {
-        Collator caseInsensitive = Collator.getInstance(ULocale.ROOT).freeze();
+        Collator caseInsensitive = Collator.getInstance(ULocale.ROOT); // freeze below
         caseInsensitive.setStrength(Collator.SECONDARY);
+        caseInsensitive = caseInsensitive.freeze();
         Set<String> setWithCaseInsensitive = new TreeSet<>(caseInsensitive);
         setWithCaseInsensitive.addAll(Arrays.asList(new String[] {"a", "b", "c"}));
         Set<String> plainSet = new TreeSet<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -258,7 +258,7 @@ public class ChartCollation extends Chart {
         dataItem.collator = col;
     }
 
-    // RuleBasedCollator ROOT = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+    // RuleBasedCollator ROOT = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
 
     private class Subchart extends Chart {
         private static final String HIGH_COLLATION_PRIMARY = "\uFFFF";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -258,8 +258,6 @@ public class ChartCollation extends Chart {
         dataItem.collator = col;
     }
 
-    // RuleBasedCollator ROOT = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
-
     private class Subchart extends Chart {
         private static final String HIGH_COLLATION_PRIMARY = "\uFFFF";
         String title;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -76,7 +76,7 @@ public class ChartLanguageGroups extends Chart {
                 + "The data doesn't completely match wikipedia’s; there are some patches for CLDR languages.</p>\n";
     }
 
-    Collator ENGLISH_ORDER = Collator.getInstance(ULocale.ROOT);
+    Collator ENGLISH_ORDER = Collator.getInstance(ULocale.ROOT).freeze();
 
     @Override
     public void writeContents(FormattedFileWriter pw) throws IOException {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -3,8 +3,6 @@ package org.unicode.cldr.tool;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.collect.Multimap;
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.util.ULocale;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Comparator;
@@ -76,8 +74,6 @@ public class ChartLanguageGroups extends Chart {
                 + "The data doesn't completely match wikipedia’s; there are some patches for CLDR languages.</p>\n";
     }
 
-    Collator ENGLISH_ORDER = Collator.getInstance(ULocale.ROOT).freeze();
-
     @Override
     public void writeContents(FormattedFileWriter pw) throws IOException {
 
@@ -112,7 +108,9 @@ public class ChartLanguageGroups extends Chart {
                         new Comparator<Pair<String, String>>() {
                             @Override
                             public int compare(Pair<String, String> o1, Pair<String, String> o2) {
-                                int diff = ENGLISH_ORDER.compare(o1.getFirst(), o2.getFirst());
+                                int diff =
+                                        CollatorHelper.ROOT_ORDER.compare(
+                                                o1.getFirst(), o2.getFirst());
                                 if (diff != 0) {
                                     return diff;
                                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -109,7 +109,7 @@ public class ChartLanguageGroups extends Chart {
                             @Override
                             public int compare(Pair<String, String> o1, Pair<String, String> o2) {
                                 int diff =
-                                        CollatorHelper.ROOT_ORDER.compare(
+                                        CollatorHelper.ROOT_COLLATOR.compare(
                                                 o1.getFirst(), o2.getFirst());
                                 if (diff != 0) {
                                     return diff;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -76,7 +76,7 @@ public class ChartLanguageGroups extends Chart {
                 + "The data doesn't completely match wikipedia’s; there are some patches for CLDR languages.</p>\n";
     }
 
-    Collator ENGLISH_ORDER = Collator.getInstance(ULocale.ENGLISH);
+    Collator ENGLISH_ORDER = Collator.getInstance(ULocale.ROOT);
 
     @Override
     public void writeContents(FormattedFileWriter pw) throws IOException {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckAnnotations.java
@@ -4,14 +4,12 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.util.Annotations;
 import org.unicode.cldr.util.Annotations.AnnotationSet;
-import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CollatorHelper;
 
 public class CheckAnnotations {
     public static void main(String[] args) {
         AnnotationSet data = Annotations.getDataSet("en");
-        CLDRConfig config = CLDRConfig.getInstance();
-        // UnicodeMap<Annotations> data2 = Annotations.getData("de");
-        Set<String> sorted = new TreeSet<>(config.getCollator());
+        Set<String> sorted = new TreeSet<>(CollatorHelper.EMOJI_COLLATOR);
 
         int i = 0;
         boolean needMore = true;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareData.java
@@ -1,9 +1,6 @@
 package org.unicode.cldr.tool;
 
 import com.ibm.icu.dev.util.UOption;
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.util.ULocale;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -29,14 +26,6 @@ public class CompareData {
     };
 
     String[] directoryList = {"main", "collation", "segmentations"};
-
-    static RuleBasedCollator uca =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-
-    {
-        uca.setNumericCollation(true);
-        uca = (RuleBasedCollator) uca.freeze();
-    }
 
     static PrettyPath prettyPathMaker = new PrettyPath();
     static CLDRFile english;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareData.java
@@ -30,10 +30,12 @@ public class CompareData {
 
     String[] directoryList = {"main", "collation", "segmentations"};
 
-    static RuleBasedCollator uca = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+    static RuleBasedCollator uca =
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
 
     {
         uca.setNumericCollation(true);
+        uca = (RuleBasedCollator) uca.freeze();
     }
 
     static PrettyPath prettyPathMaker = new PrettyPath();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareEmoji.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareEmoji.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.ibm.icu.text.Collator;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +15,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Emoji;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.SimpleFactory;
@@ -29,11 +29,12 @@ public class CompareEmoji {
     static final Factory FACTORY_DERIVED = SimpleFactory.make(paths, ".*");
 
     private static final Joiner BAR_JOINER = Joiner.on(" | ");
-    private static final Collator collator = CLDRConfig.getInstance().getCollator();
+
     private static final String base =
             "/Users/markdavis/github/private/DATA/cldr-private/emoji_diff/";
     private static final Set<String> sorted =
-            ImmutableSet.copyOf(Emoji.getAllRgi().addAllTo(new TreeSet<>(collator)));
+            ImmutableSet.copyOf(
+                    Emoji.getAllRgi().addAllTo(new TreeSet<>(CollatorHelper.EMOJI_COLLATOR)));
 
     enum Status {
         regular,
@@ -155,7 +156,7 @@ public class CompareEmoji {
                     continue;
                 }
                 String key = split[0];
-                Set<String> values = new TreeSet<>(collator);
+                Set<String> values = new TreeSet<>(CollatorHelper.EMOJI_COLLATOR);
                 for (int i = 1; i < split.length; ++i) {
                     values.add(split[i]);
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -1924,7 +1924,8 @@ public class ConvertLanguageData {
 
     public static class GeneralCollator implements Comparator<String> {
         static UTF16.StringComparator cpCompare = new UTF16.StringComparator(true, false, 0);
-        static RuleBasedCollator UCA = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        static RuleBasedCollator UCA =
+                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
 
         static {
             UCA.setNumericCollation(true);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -6,9 +6,7 @@ import com.google.common.math.DoubleMath;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R2;
-import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.NumberFormat;
-import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.util.ULocale;
 import java.io.BufferedReader;
@@ -42,6 +40,7 @@ import org.unicode.cldr.util.Builder;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.Iso639Data.Scope;
@@ -1924,12 +1923,6 @@ public class ConvertLanguageData {
 
     public static class GeneralCollator implements Comparator<String> {
         static UTF16.StringComparator cpCompare = new UTF16.StringComparator(true, false, 0);
-        static RuleBasedCollator UCA =
-                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
-
-        static {
-            UCA.setNumericCollation(true);
-        }
 
         @Override
         public int compare(String s1, String s2) {
@@ -1938,7 +1931,7 @@ public class ConvertLanguageData {
             } else if (s2 == null) {
                 return 1;
             }
-            int result = UCA.compare(s1, s2);
+            int result = CollatorHelper.ROOT_NUMERIC.compare(s1, s2);
             if (result != 0) return result;
             return cpCompare.compare(s1, s2);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -67,7 +67,7 @@ import org.unicode.cldr.util.props.ICUPropertyFactory;
 public class CountItems {
 
     private static final Collator ROOT_PRIMARY_COLLATOR =
-            Collator.getInstance(ULocale.ROOT).setStrength2(Collator.PRIMARY);
+            Collator.getInstance(ULocale.ROOT).setStrength2(Collator.PRIMARY).freeze();
 
     static final String needsTranslationString =
             "America/Buenos_Aires " // America/Rio_Branco
@@ -318,7 +318,7 @@ public class CountItems {
     }
 
     public static void genSupplementalZoneData(boolean skipUnaliased) throws IOException {
-        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
         col.setNumericCollation(true);
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_country = sc.getZoneToCounty();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -45,6 +45,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.IsoCurrencyParser;
@@ -318,8 +319,7 @@ public class CountItems {
     }
 
     public static void genSupplementalZoneData(boolean skipUnaliased) throws IOException {
-        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
-        col.setNumericCollation(true);
+        RuleBasedCollator col = (RuleBasedCollator) CollatorHelper.ROOT_NUMERIC;
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_country = sc.getZoneToCounty();
         Map<String, Set<String>> country_zone = sc.getCountryToZoneSet();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -318,7 +318,7 @@ public class CountItems {
     }
 
     public static void genSupplementalZoneData(boolean skipUnaliased) throws IOException {
-        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance();
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         col.setNumericCollation(true);
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_country = sc.getZoneToCounty();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -19,7 +19,6 @@ import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.Transform;
 import com.ibm.icu.text.UnicodeSet;
-import com.ibm.icu.util.ULocale;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -67,8 +66,7 @@ import org.unicode.cldr.util.props.ICUPropertyFactory;
 /** Simple program to count the amount of data in CLDR. Internal Use. */
 public class CountItems {
 
-    private static final Collator ROOT_PRIMARY_COLLATOR =
-            Collator.getInstance(ULocale.ROOT).setStrength2(Collator.PRIMARY).freeze();
+    private static final Collator ROOT_PRIMARY_COLLATOR = CollatorHelper.ROOT_PRIMARY;
 
     static final String needsTranslationString =
             "America/Buenos_Aires " // America/Rio_Branco
@@ -319,7 +317,7 @@ public class CountItems {
     }
 
     public static void genSupplementalZoneData(boolean skipUnaliased) throws IOException {
-        RuleBasedCollator col = (RuleBasedCollator) CollatorHelper.ROOT_NUMERIC;
+        RuleBasedCollator col = CollatorHelper.ROOT_NUMERIC;
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_country = sc.getZoneToCounty();
         Map<String, Set<String>> country_zone = sc.getCountryToZoneSet();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -205,10 +205,11 @@ class ExtractMessages {
         }
     }
 
-    public static Collator col = Collator.getInstance(ULocale.ROOT);
+    public static Collator col = Collator.getInstance(ULocale.ROOT); // freeze below
 
     static {
         col.setStrength(Collator.SECONDARY);
+        col = col.freeze();
     }
 
     private static OtherHandler otherHandler = new OtherHandler();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -205,7 +205,7 @@ class ExtractMessages {
         }
     }
 
-    public static Collator col = Collator.getInstance(ULocale.ENGLISH);
+    public static Collator col = Collator.getInstance(ULocale.ROOT);
 
     static {
         col.setStrength(Collator.SECONDARY);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
@@ -2,7 +2,6 @@ package org.unicode.cldr.tool;
 
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.ICUUncheckedIOException;
-import com.ibm.icu.util.ULocale;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -16,11 +15,11 @@ import org.unicode.cldr.test.HelpMessages;
 import org.unicode.cldr.util.ArrayComparator;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 
 public class FormattedFileWriter extends java.io.Writer {
     public static final String CHART_TARGET_DIR = CLDRPaths.CHART_DIRECTORY + "/supplemental/";
-    public static final Collator COL =
-            Collator.getInstance(ULocale.ROOT).setStrength2(Collator.IDENTICAL).freeze();
+    public static final Collator COL = CollatorHelper.ROOT_IDENTICAL;
     // public static final PairComparator<String,String> PC = new PairComparator(COL, null);
     public static final ArrayComparator PC = new ArrayComparator(COL);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FormattedFileWriter.java
@@ -20,7 +20,7 @@ import org.unicode.cldr.util.CldrUtility;
 public class FormattedFileWriter extends java.io.Writer {
     public static final String CHART_TARGET_DIR = CLDRPaths.CHART_DIRECTORY + "/supplemental/";
     public static final Collator COL =
-            Collator.getInstance(ULocale.ROOT).setStrength2(Collator.IDENTICAL);
+            Collator.getInstance(ULocale.ROOT).setStrength2(Collator.IDENTICAL).freeze();
     // public static final PairComparator<String,String> PC = new PairComparator(COL, null);
     public static final ArrayComparator PC = new ArrayComparator(COL);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -5,7 +5,6 @@ import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.UTF16;
-import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -18,6 +17,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.EscapingUtilities;
 import org.unicode.cldr.util.Factory;
@@ -30,7 +30,7 @@ public class GenerateComparison {
 
     private static PrettyPath prettyPathMaker;
 
-    private static Collator collator = Collator.getInstance(ULocale.ROOT).freeze();
+    private static Collator collator = CollatorHelper.ROOT_ORDER;
 
     static class EnglishRowComparator implements Comparator<R2<String, String>> {
         private static Comparator<String> unicode = new UTF16.StringComparator(true, false, 0);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -5,6 +5,7 @@ import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.UTF16;
+import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -12,8 +13,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
-
-import com.ibm.icu.util.ULocale;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
@@ -31,7 +30,7 @@ public class GenerateComparison {
 
     private static PrettyPath prettyPathMaker;
 
-    private static Collator collator = Collator.getInstance(ULocale.ROOT);
+    private static Collator collator = Collator.getInstance(ULocale.ROOT).freeze();
 
     static class EnglishRowComparator implements Comparator<R2<String, String>> {
         private static Comparator<String> unicode = new UTF16.StringComparator(true, false, 0);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -30,7 +30,7 @@ public class GenerateComparison {
 
     private static PrettyPath prettyPathMaker;
 
-    private static Collator collator = CollatorHelper.ROOT_ORDER;
+    private static Collator collator = CollatorHelper.ROOT_COLLATOR;
 
     static class EnglishRowComparator implements Comparator<R2<String, String>> {
         private static Comparator<String> unicode = new UTF16.StringComparator(true, false, 0);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -12,6 +12,8 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
+
+import com.ibm.icu.util.ULocale;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
@@ -29,7 +31,7 @@ public class GenerateComparison {
 
     private static PrettyPath prettyPathMaker;
 
-    private static Collator collator = Collator.getInstance();
+    private static Collator collator = Collator.getInstance(ULocale.ROOT);
 
     static class EnglishRowComparator implements Comparator<R2<String, String>> {
         private static Comparator<String> unicode = new UTF16.StringComparator(true, false, 0);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -153,7 +153,7 @@ public class GenerateSidewaysView {
     private static long startTime = System.currentTimeMillis();
 
     static RuleBasedCollator standardCollation =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
 
     static {
         standardCollation.setStrength(Collator.IDENTICAL);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -17,7 +17,6 @@ import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.BreakIterator;
-import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.RuleBasedNumberFormat;
@@ -48,6 +47,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.Status;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdData.Attribute;
 import org.unicode.cldr.util.DtdData.AttributeStatus;
@@ -141,27 +141,16 @@ public class GenerateSidewaysView {
     static Comparator<Object> UCA;
 
     static {
-        RuleBasedCollator UCA2 =
-                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-        UCA2.setNumericCollation(true);
-        UCA2.setStrength(Collator.IDENTICAL);
-        UCA2 = (RuleBasedCollator) UCA2.freeze();
         UCA =
                 new org.unicode.cldr.util.MultiComparator(
-                        UCA2, new UTF16.StringComparator(true, false, 0));
+                        CollatorHelper.ROOT_NUMERIC_IDENTICAL,
+                        new UTF16.StringComparator(true, false, 0));
     }
 
     private static Map<PathHeader, Map<String, Set<String>>> path_value_locales = new TreeMap<>();
     private static long startTime = System.currentTimeMillis();
 
-    static RuleBasedCollator standardCollation =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-
-    static {
-        standardCollation.setStrength(Collator.IDENTICAL);
-        standardCollation.setNumericCollation(true);
-        standardCollation = (RuleBasedCollator) standardCollation.freeze();
-    }
+    static RuleBasedCollator standardCollation = CollatorHelper.ROOT_NUMERIC_IDENTICAL;
 
     private static CLDRFile english;
     // private static DataShower dataShower = new DataShower();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -141,9 +141,11 @@ public class GenerateSidewaysView {
     static Comparator<Object> UCA;
 
     static {
-        RuleBasedCollator UCA2 = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        RuleBasedCollator UCA2 =
+                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
         UCA2.setNumericCollation(true);
         UCA2.setStrength(Collator.IDENTICAL);
+        UCA2 = (RuleBasedCollator) UCA2.freeze();
         UCA =
                 new org.unicode.cldr.util.MultiComparator(
                         UCA2, new UTF16.StringComparator(true, false, 0));
@@ -153,11 +155,12 @@ public class GenerateSidewaysView {
     private static long startTime = System.currentTimeMillis();
 
     static RuleBasedCollator standardCollation =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
 
     static {
         standardCollation.setStrength(Collator.IDENTICAL);
         standardCollation.setNumericCollation(true);
+        standardCollation = (RuleBasedCollator) standardCollation.freeze();
     }
 
     private static CLDRFile english;
@@ -678,7 +681,7 @@ public class GenerateSidewaysView {
     // .setCompressRanges(true)
     // .setToQuote(ALL_CHARS)
     // .setQuoter(MyTransform)
-    // .format(lastChars);
+    // .format(lastChars).freeze();
     // exemplarsWithoutBrackets = exemplarsWithoutBrackets.substring(1,
     // exemplarsWithoutBrackets.length() - 1);
     // return exemplarsWithoutBrackets;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -40,7 +40,7 @@ class GenerateStatistics {
     static CLDRFile english;
     static Factory factory;
     static LanguageTagParser ltp = new LanguageTagParser();
-    static Collator col = Collator.getInstance(ULocale.ROOT);
+    static Collator col = Collator.getInstance(ULocale.ROOT).freeze();
     static boolean notitlecase = true;
 
     public static void generateSize(
@@ -344,7 +344,7 @@ class GenerateStatistics {
 
     private static class LanguageList implements Comparable<Object> {
         Object[] contents;
-        static Collator col = Collator.getInstance(ULocale.ROOT);
+        static Collator col = Collator.getInstance(ULocale.ROOT).freeze();
         static Comparator<Object[]> comp = new ArrayComparator(new Collator[] {col, col, null});
 
         LanguageList(String locale, String englishName, String localName) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -26,6 +26,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.ArrayComparator;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Log;
@@ -40,7 +41,7 @@ class GenerateStatistics {
     static CLDRFile english;
     static Factory factory;
     static LanguageTagParser ltp = new LanguageTagParser();
-    static Collator col = Collator.getInstance(ULocale.ROOT).freeze();
+    static Collator col = CollatorHelper.ROOT_ORDER;
     static boolean notitlecase = true;
 
     public static void generateSize(
@@ -344,7 +345,7 @@ class GenerateStatistics {
 
     private static class LanguageList implements Comparable<Object> {
         Object[] contents;
-        static Collator col = Collator.getInstance(ULocale.ROOT).freeze();
+        static Collator col = CollatorHelper.ROOT_ORDER;
         static Comparator<Object[]> comp = new ArrayComparator(new Collator[] {col, col, null});
 
         LanguageList(String locale, String englishName, String localName) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -40,7 +40,7 @@ class GenerateStatistics {
     static CLDRFile english;
     static Factory factory;
     static LanguageTagParser ltp = new LanguageTagParser();
-    static Collator col = Collator.getInstance(ULocale.ENGLISH);
+    static Collator col = Collator.getInstance(ULocale.ROOT);
     static boolean notitlecase = true;
 
     public static void generateSize(
@@ -344,7 +344,7 @@ class GenerateStatistics {
 
     private static class LanguageList implements Comparable<Object> {
         Object[] contents;
-        static Collator col = Collator.getInstance(ULocale.ENGLISH);
+        static Collator col = Collator.getInstance(ULocale.ROOT);
         static Comparator<Object[]> comp = new ArrayComparator(new Collator[] {col, col, null});
 
         LanguageList(String locale, String englishName, String localName) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -41,7 +41,7 @@ class GenerateStatistics {
     static CLDRFile english;
     static Factory factory;
     static LanguageTagParser ltp = new LanguageTagParser();
-    static Collator col = CollatorHelper.ROOT_ORDER;
+    static Collator col = CollatorHelper.ROOT_COLLATOR;
     static boolean notitlecase = true;
 
     public static void generateSize(
@@ -345,7 +345,7 @@ class GenerateStatistics {
 
     private static class LanguageList implements Comparable<Object> {
         Object[] contents;
-        static Collator col = CollatorHelper.ROOT_ORDER;
+        static Collator col = CollatorHelper.ROOT_COLLATOR;
         static Comparator<Object[]> comp = new ArrayComparator(new Collator[] {col, col, null});
 
         LanguageList(String locale, String englishName, String localName) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -515,9 +515,11 @@ public class GenerateTransformCharts {
     static Comparator<String> UCA;
 
     static {
-        RuleBasedCollator UCA2 = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
+        RuleBasedCollator UCA2 =
+                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
         UCA2.setNumericCollation(true);
         UCA2.setStrength(Collator.IDENTICAL);
+        UCA2 = (RuleBasedCollator) UCA2.freeze();
         UCA =
                 new org.unicode.cldr.util.MultiComparator(
                         UCA2, new UTF16.StringComparator(true, false, 0));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -119,7 +119,7 @@ public class GenerateTransformCharts {
     // Transliterator anyToLatin = Transliterator.getInstance("any-latin");
     //
     // UnicodeSet failNorm = new UnicodeSet();
-    // // Collator sc = Collator.getInstance(ULocale.ROOT);
+    // // Collator sc = Collator.getInstance(ULocale.ROOT).freeze();
     // // sc.setStrength(Collator.IDENTICAL);
     // Comparator sc = new UTF16.StringComparator(true, false, 0);
     // Set latinFail = new TreeSet(new ArrayComparator(new Comparator[] { sc, sc, sc }));
@@ -515,7 +515,7 @@ public class GenerateTransformCharts {
     static Comparator<String> UCA;
 
     static {
-        RuleBasedCollator UCA2 = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        RuleBasedCollator UCA2 = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
         UCA2.setNumericCollation(true);
         UCA2.setStrength(Collator.IDENTICAL);
         UCA =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -10,14 +10,11 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UScript;
-import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.Normalizer;
-import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
-import com.ibm.icu.util.ULocale;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -38,6 +35,7 @@ import org.unicode.cldr.util.CLDRTransforms;
 import org.unicode.cldr.util.CLDRTransforms.ParsedTransformID;
 import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.FileCopier;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.TransliteratorUtilities;
@@ -515,14 +513,10 @@ public class GenerateTransformCharts {
     static Comparator<String> UCA;
 
     static {
-        RuleBasedCollator UCA2 =
-                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-        UCA2.setNumericCollation(true);
-        UCA2.setStrength(Collator.IDENTICAL);
-        UCA2 = (RuleBasedCollator) UCA2.freeze();
         UCA =
                 new org.unicode.cldr.util.MultiComparator(
-                        UCA2, new UTF16.StringComparator(true, false, 0));
+                        CollatorHelper.ROOT_NUMERIC_IDENTICAL,
+                        new UTF16.StringComparator(true, false, 0));
     }
 
     private static void showLatin(Pair<String, String> scriptChoice, Set<String> targetVariant)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTransformCharts.java
@@ -119,7 +119,7 @@ public class GenerateTransformCharts {
     // Transliterator anyToLatin = Transliterator.getInstance("any-latin");
     //
     // UnicodeSet failNorm = new UnicodeSet();
-    // // Collator sc = Collator.getInstance(ULocale.ENGLISH);
+    // // Collator sc = Collator.getInstance(ULocale.ROOT);
     // // sc.setStrength(Collator.IDENTICAL);
     // Comparator sc = new UTF16.StringComparator(true, false, 0);
     // Set latinFail = new TreeSet(new ArrayComparator(new Comparator[] { sc, sc, sc }));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/MakeTransliterator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/MakeTransliterator.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Pair;
 
 /**
@@ -49,7 +50,7 @@ public class MakeTransliterator {
 
     static NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH);
 
-    static Collator col = Collator.getInstance(ULocale.ROOT).freeze();
+    static Collator col = CollatorHelper.ROOT_ORDER;
 
     static String cldrDataDir =
             "C:\\cvsdata\\unicode\\cldr\\tools\\java\\org\\unicode\\cldr\\util\\data\\transforms\\";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/MakeTransliterator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/MakeTransliterator.java
@@ -50,7 +50,7 @@ public class MakeTransliterator {
 
     static NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH);
 
-    static Collator col = CollatorHelper.ROOT_ORDER;
+    static Collator col = CollatorHelper.ROOT_COLLATOR;
 
     static String cldrDataDir =
             "C:\\cvsdata\\unicode\\cldr\\tools\\java\\org\\unicode\\cldr\\util\\data\\transforms\\";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/MakeTransliterator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/MakeTransliterator.java
@@ -49,7 +49,7 @@ public class MakeTransliterator {
 
     static NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH);
 
-    static Collator col = Collator.getInstance(ULocale.ROOT);
+    static Collator col = Collator.getInstance(ULocale.ROOT).freeze();
 
     static String cldrDataDir =
             "C:\\cvsdata\\unicode\\cldr\\tools\\java\\org\\unicode\\cldr\\util\\data\\transforms\\";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -467,7 +467,7 @@ public class Misc {
     }
 
     static void printZoneAliases() {
-        RuleBasedCollator col = (RuleBasedCollator) CollatorHelper.ROOT_NUMERIC;
+        RuleBasedCollator col = CollatorHelper.ROOT_NUMERIC;
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_countries = sc.getZoneToCounty();
         Map<String, String> old_new = sc.getZoneLinkold_new();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -466,7 +466,7 @@ public class Misc {
     }
 
     static void printZoneAliases() {
-        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
         col.setNumericCollation(true);
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_countries = sc.getZoneToCounty();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -39,6 +39,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso3166Data;
 import org.unicode.cldr.util.LanguageTagParser;
@@ -466,8 +467,7 @@ public class Misc {
     }
 
     static void printZoneAliases() {
-        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
-        col.setNumericCollation(true);
+        RuleBasedCollator col = (RuleBasedCollator) CollatorHelper.ROOT_NUMERIC;
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_countries = sc.getZoneToCounty();
         Map<String, String> old_new = sc.getZoneLinkold_new();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -466,7 +466,7 @@ public class Misc {
     }
 
     static void printZoneAliases() {
-        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         col.setNumericCollation(true);
         StandardCodes sc = StandardCodes.make();
         Map<String, String> zone_countries = sc.getZoneToCounty();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -10,12 +10,9 @@ import com.google.common.base.Joiner;
 import com.ibm.icu.dev.util.UOption;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.lang.UScript;
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
-import com.ibm.icu.util.ULocale;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -77,14 +74,6 @@ public class ShowData {
                 + CldrUtility.isoFormatDateOnly(new java.util.Date())
                 + "</p>"
                 + System.lineSeparator();
-    }
-
-    static RuleBasedCollator uca =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-
-    {
-        uca.setNumericCollation(true);
-        uca = (RuleBasedCollator) uca.freeze();
     }
 
     static PathHeader.Factory prettyPathMaker =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -79,10 +79,12 @@ public class ShowData {
                 + System.lineSeparator();
     }
 
-    static RuleBasedCollator uca = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+    static RuleBasedCollator uca =
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
 
     {
         uca.setNumericCollation(true);
+        uca = (RuleBasedCollator) uca.freeze();
     }
 
     static PathHeader.Factory prettyPathMaker =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
@@ -276,7 +276,7 @@ public class TablePrinter {
     static class ColumnSorter<T extends Comparable> implements Comparator<T[]> {
         private int[] sortPriorities = new int[0];
         private BitSet ascending = new BitSet();
-        Collator englishCollator = Collator.getInstance(ULocale.ROOT);
+        Collator englishCollator = Collator.getInstance(ULocale.ROOT).freeze();
 
         @Override
         @SuppressWarnings("unchecked")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
@@ -277,7 +277,7 @@ public class TablePrinter {
     static class ColumnSorter<T extends Comparable> implements Comparator<T[]> {
         private int[] sortPriorities = new int[0];
         private BitSet ascending = new BitSet();
-        Collator englishCollator = CollatorHelper.ROOT_ORDER;
+        Collator englishCollator = CollatorHelper.ROOT_COLLATOR;
 
         @Override
         @SuppressWarnings("unchecked")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
@@ -11,6 +11,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import org.unicode.cldr.util.CollatorHelper;
 
 public class TablePrinter {
 
@@ -276,7 +277,7 @@ public class TablePrinter {
     static class ColumnSorter<T extends Comparable> implements Comparator<T[]> {
         private int[] sortPriorities = new int[0];
         private BitSet ascending = new BitSet();
-        Collator englishCollator = Collator.getInstance(ULocale.ROOT).freeze();
+        Collator englishCollator = CollatorHelper.ROOT_ORDER;
 
         @Override
         @SuppressWarnings("unchecked")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/TablePrinter.java
@@ -276,7 +276,7 @@ public class TablePrinter {
     static class ColumnSorter<T extends Comparable> implements Comparator<T[]> {
         private int[] sortPriorities = new int[0];
         private BitSet ascending = new BitSet();
-        Collator englishCollator = Collator.getInstance(ULocale.ENGLISH);
+        Collator englishCollator = Collator.getInstance(ULocale.ROOT);
 
         @Override
         @SuppressWarnings("unchecked")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
@@ -375,7 +375,7 @@ public class CLDRConfig extends Properties {
         static final Collator ROOT_NUMERIC = makeRootNumeric();
 
         private static final Collator makeRootNumeric() {
-            RuleBasedCollator _ROOT_COL = (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+            RuleBasedCollator _ROOT_COL = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
             _ROOT_COL.setNumericCollation(true);
             _ROOT_COL.freeze();
             return _ROOT_COL;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
@@ -339,8 +339,7 @@ public class CLDRConfig extends Properties {
             try {
                 colRoot = new RuleBasedCollator(rules);
             } catch (Exception e) {
-                colRoot = (RuleBasedCollator) getInstance().getCollator();
-                return colRoot;
+                return CollatorHelper.EMOJI_COLLATOR;
             }
             colRoot.setStrength(Collator.IDENTICAL);
             colRoot.setNumericCollation(true);
@@ -356,14 +355,6 @@ public class CLDRConfig extends Properties {
     @SuppressWarnings("unchecked")
     public final Comparator<String> getComparatorRoot() {
         return (Comparator) (getCollatorRoot());
-    }
-
-    public Collator getCollator() {
-        return CollatorHelper.EMOJI_COLLATOR;
-    }
-
-    public Collator getRootNumeric() {
-        return CollatorHelper.ROOT_NUMERIC;
     }
 
     public synchronized Phase getPhase() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
@@ -8,7 +8,6 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.dev.test.TestLog;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -357,30 +356,6 @@ public class CLDRConfig extends Properties {
     @SuppressWarnings("unchecked")
     public final Comparator<String> getComparatorRoot() {
         return (Comparator) (getCollatorRoot());
-    }
-
-    private static final class CollatorHelper {
-        static final Collator EMOJI_COLLATOR = makeEmojiCollator();
-
-        private static final Collator makeEmojiCollator() {
-            final RuleBasedCollator col =
-                    (RuleBasedCollator)
-                            Collator.getInstance(ULocale.forLanguageTag("en-u-co-emoji"));
-            col.setStrength(Collator.IDENTICAL);
-            col.setNumericCollation(true);
-            col.freeze();
-            return col;
-        }
-
-        static final Collator ROOT_NUMERIC = makeRootNumeric();
-
-        private static final Collator makeRootNumeric() {
-            RuleBasedCollator _ROOT_COL =
-                    (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-            _ROOT_COL.setNumericCollation(true);
-            _ROOT_COL.freeze();
-            return _ROOT_COL;
-        }
     }
 
     public Collator getCollator() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRConfig.java
@@ -375,7 +375,8 @@ public class CLDRConfig extends Properties {
         static final Collator ROOT_NUMERIC = makeRootNumeric();
 
         private static final Collator makeRootNumeric() {
-            RuleBasedCollator _ROOT_COL = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+            RuleBasedCollator _ROOT_COL =
+                    (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
             _ROOT_COL.setNumericCollation(true);
             _ROOT_COL.freeze();
             return _ROOT_COL;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollationMapMaker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollationMapMaker.java
@@ -199,7 +199,8 @@ public class CollationMapMaker {
     }
 
     static final boolean showDetails = false;
-    static final RuleBasedCollator uca = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+    static final RuleBasedCollator uca =
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
     static final UnicodeSet filteredChars =
             new UnicodeSet(
                             "[{ss}[^[:Co:][:Cf:][:Cc:][:Cn:][:Cs:][:script=Han:][:script=Hangul:]-[:nfkcquickcheck=no:]]]")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollationMapMaker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollationMapMaker.java
@@ -20,7 +20,6 @@ import com.ibm.icu.text.Transliterator;
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
-import com.ibm.icu.util.ULocale;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -199,8 +198,7 @@ public class CollationMapMaker {
     }
 
     static final boolean showDetails = false;
-    static final RuleBasedCollator uca =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
+    static final RuleBasedCollator uca = (RuleBasedCollator) CollatorHelper.ROOT_ORDER;
     static final UnicodeSet filteredChars =
             new UnicodeSet(
                             "[{ss}[^[:Co:][:Cf:][:Cc:][:Cn:][:Cs:][:script=Han:][:script=Hangul:]-[:nfkcquickcheck=no:]]]")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollationMapMaker.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollationMapMaker.java
@@ -198,7 +198,7 @@ public class CollationMapMaker {
     }
 
     static final boolean showDetails = false;
-    static final RuleBasedCollator uca = (RuleBasedCollator) CollatorHelper.ROOT_ORDER;
+    static final RuleBasedCollator uca = CollatorHelper.ROOT_COLLATOR;
     static final UnicodeSet filteredChars =
             new UnicodeSet(
                             "[{ss}[^[:Co:][:Cf:][:Cc:][:Cn:][:Cs:][:script=Han:][:script=Hangul:]-[:nfkcquickcheck=no:]]]")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollatorHelper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollatorHelper.java
@@ -5,28 +5,63 @@ import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.util.ULocale;
 
 public final class CollatorHelper {
-    public static final Collator ROOT_ORDER = makeRootOrder();
-    public static final Collator ROOT_NUMERIC = makeRootNumeric();
-    public static final Collator EMOJI_COLLATOR = makeEmojiCollator();
+    public static final RuleBasedCollator EMOJI_COLLATOR = makeEmojiCollator();
+    public static final RuleBasedCollator ROOT_COLLATOR = makeRootCollator();
+    public static final RuleBasedCollator ROOT_IDENTICAL = makeRootIdentical();
+    public static final RuleBasedCollator ROOT_NUMERIC = makeRootNumeric();
+    public static final RuleBasedCollator ROOT_NUMERIC_IDENTICAL = makeRootNumericIdentical();
+    public static final RuleBasedCollator ROOT_PRIMARY = makeRootPrimary();
+    public static final RuleBasedCollator ROOT_PRIMARY_SHIFTED = makeRootPrimaryShifted();
+    public static final RuleBasedCollator ROOT_SECONDARY = makeRootSecondary();
 
-    private static Collator makeRootOrder() {
-        return Collator.getInstance(ULocale.ROOT).freeze();
-    }
-
-    private static Collator makeRootNumeric() {
-        RuleBasedCollator col =
-                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
+    private static RuleBasedCollator makeEmojiCollator() {
+        ULocale uLocale = ULocale.forLanguageTag("en-u-co-emoji");
+        RuleBasedCollator col = (RuleBasedCollator) RuleBasedCollator.getInstance(uLocale);
+        col.setStrength(RuleBasedCollator.IDENTICAL);
         col.setNumericCollation(true);
-        col.freeze();
-        return col;
+        return (RuleBasedCollator) col.freeze();
     }
 
-    private static Collator makeEmojiCollator() {
-        final RuleBasedCollator col =
-                (RuleBasedCollator) Collator.getInstance(ULocale.forLanguageTag("en-u-co-emoji"));
+    private static RuleBasedCollator makeRootCollator() {
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        return (RuleBasedCollator) col.freeze();
+    }
+
+    private static RuleBasedCollator makeRootIdentical() {
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        col.setStrength(Collator.IDENTICAL);
+        return (RuleBasedCollator) col.freeze();
+    }
+
+    private static RuleBasedCollator makeRootNumeric() {
+        RuleBasedCollator col = (RuleBasedCollator) RuleBasedCollator.getInstance(ULocale.ROOT);
+        col.setNumericCollation(true);
+        return (RuleBasedCollator) col.freeze();
+    }
+
+    private static RuleBasedCollator makeRootNumericIdentical() {
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         col.setStrength(Collator.IDENTICAL);
         col.setNumericCollation(true);
-        col.freeze();
-        return col;
+        return (RuleBasedCollator) col.freeze();
+    }
+
+    private static RuleBasedCollator makeRootPrimary() {
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        col.setStrength(Collator.PRIMARY);
+        return (RuleBasedCollator) col.freeze();
+    }
+
+    private static RuleBasedCollator makeRootPrimaryShifted() {
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        col.setStrength(Collator.PRIMARY);
+        col.setAlternateHandlingShifted(true);
+        return (RuleBasedCollator) col.freeze();
+    }
+
+    private static RuleBasedCollator makeRootSecondary() {
+        RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        col.setStrength(Collator.SECONDARY);
+        return (RuleBasedCollator) col.freeze();
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollatorHelper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CollatorHelper.java
@@ -1,0 +1,32 @@
+package org.unicode.cldr.util;
+
+import com.ibm.icu.text.Collator;
+import com.ibm.icu.text.RuleBasedCollator;
+import com.ibm.icu.util.ULocale;
+
+public final class CollatorHelper {
+    public static final Collator ROOT_ORDER = makeRootOrder();
+    public static final Collator ROOT_NUMERIC = makeRootNumeric();
+    public static final Collator EMOJI_COLLATOR = makeEmojiCollator();
+
+    private static Collator makeRootOrder() {
+        return Collator.getInstance(ULocale.ROOT).freeze();
+    }
+
+    private static Collator makeRootNumeric() {
+        RuleBasedCollator col =
+                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
+        col.setNumericCollation(true);
+        col.freeze();
+        return col;
+    }
+
+    private static Collator makeEmojiCollator() {
+        final RuleBasedCollator col =
+                (RuleBasedCollator) Collator.getInstance(ULocale.forLanguageTag("en-u-co-emoji"));
+        col.setStrength(Collator.IDENTICAL);
+        col.setNumericCollation(true);
+        col.freeze();
+        return col;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdData.java
@@ -1886,7 +1886,7 @@ public class DtdData extends XMLFileReader.SimpleHandler {
             new MapComparator<String>().add("standard", "accounting").freeze();
     static Comparator<String> zoneOrder = StandardCodes.make().getTZIDComparator();
 
-    static final Comparator<String> COMP = (Comparator) CLDRConfig.getInstance().getCollator();
+    static final Comparator<String> COMP = (Comparator) CollatorHelper.EMOJI_COLLATOR;
 
     // Hack for US
     static final Comparator<String> UNICODE_SET_COMPARATOR =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Emoji.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Emoji.java
@@ -33,7 +33,7 @@ import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.PathHeader.PageId;
 
 public class Emoji {
-    public static final Collator COLLATOR = CLDRConfig.getInstance().getCollator();
+    public static final Collator COLLATOR = CollatorHelper.EMOJI_COLLATOR;
     public static final String EMOJI_VARIANT = "\uFE0F";
     public static final char JOINER = '\u200D';
     public static final String JOINER_STR = "\u200D";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MapComparator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MapComparator.java
@@ -33,7 +33,8 @@ public class MapComparator<K> implements Comparator<K>, Freezable<MapComparator<
          * @return
          */
         private static Collator getUCA() {
-            final RuleBasedCollator newUca = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+            final RuleBasedCollator newUca =
+                    (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
             newUca.setNumericCollation(true);
             return newUca.freeze();
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/MapComparator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/MapComparator.java
@@ -8,11 +8,8 @@
  */
 package org.unicode.cldr.util;
 
-import com.ibm.icu.text.Collator;
-import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Freezable;
-import com.ibm.icu.util.ULocale;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,21 +21,6 @@ import java.util.TreeMap;
 import java.util.function.Function;
 
 public class MapComparator<K> implements Comparator<K>, Freezable<MapComparator<K>> {
-    private static final class CollatorHelper {
-        public static final Collator UCA = getUCA();
-
-        /**
-         * This does not change, so we can create one and freeze it.
-         *
-         * @return
-         */
-        private static Collator getUCA() {
-            final RuleBasedCollator newUca =
-                    (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-            newUca.setNumericCollation(true);
-            return newUca.freeze();
-        }
-    }
 
     // initialize this once
     private Map<K, Integer> ordering = new TreeMap<>(); // maps from name to rank
@@ -201,7 +183,7 @@ public class MapComparator<K> implements Comparator<K>, Freezable<MapComparator<
 
         if (a instanceof CharSequence) {
             if (b instanceof CharSequence) {
-                int result = CollatorHelper.UCA.compare(a.toString(), b.toString());
+                int result = CollatorHelper.ROOT_NUMERIC.compare(a.toString(), b.toString());
                 if (result != 0) {
                     return result;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReferenceStringSearch.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReferenceStringSearch.java
@@ -28,7 +28,8 @@ import java.util.ArrayList;
 public class ReferenceStringSearch {
     private static final int PADDING = 3;
 
-    private RuleBasedCollator collator = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+    private RuleBasedCollator collator =
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
 
     private BreakIterator breaker;
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReferenceStringSearch.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReferenceStringSearch.java
@@ -11,7 +11,6 @@ import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.CollationElementIterator;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RuleBasedCollator;
-import com.ibm.icu.util.ULocale;
 import java.util.ArrayList;
 
 /**
@@ -28,8 +27,7 @@ import java.util.ArrayList;
 public class ReferenceStringSearch {
     private static final int PADDING = 3;
 
-    private RuleBasedCollator collator =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT).freeze();
+    private RuleBasedCollator collator = (RuleBasedCollator) CollatorHelper.ROOT_ORDER;
 
     private BreakIterator breaker;
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReferenceStringSearch.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ReferenceStringSearch.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 public class ReferenceStringSearch {
     private static final int PADDING = 3;
 
-    private RuleBasedCollator collator = (RuleBasedCollator) CollatorHelper.ROOT_ORDER;
+    private RuleBasedCollator collator = CollatorHelper.ROOT_COLLATOR;
 
     private BreakIterator breaker;
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SimpleUnicodeSetFormatter.java
@@ -40,7 +40,7 @@ public class SimpleUnicodeSetFormatter implements FormatterParser<UnicodeSet> {
     public static Normalizer2 nfc = Normalizer2.getNFCInstance();
 
     public static final Comparator<String> BASIC_COLLATOR =
-            (Comparator) CLDRConfig.getInstance().getCollator();
+            (Comparator) CollatorHelper.EMOJI_COLLATOR;
 
     public static final int DEFAULT_RANGES_ABOVE = 1024;
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -233,9 +233,10 @@ public class TestUtilities {
             if (maxNumeric < numeric) maxNumeric = numeric;
         }
         // get the differences (and sort them)
-        RuleBasedCollator eng = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+        RuleBasedCollator eng =
+                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
         eng.setNumericCollation(true);
-
+        eng = (RuleBasedCollator) eng.freeze();
         Set<String> extra = new TreeSet<>(eng);
         extra.addAll(map_timezone_integer.keySet());
         extra.removeAll(timezones);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -233,15 +233,11 @@ public class TestUtilities {
             if (maxNumeric < numeric) maxNumeric = numeric;
         }
         // get the differences (and sort them)
-        RuleBasedCollator eng =
-                (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-        eng.setNumericCollation(true);
-        eng = (RuleBasedCollator) eng.freeze();
-        Set<String> extra = new TreeSet<>(eng);
+        Set<String> extra = new TreeSet<>(CollatorHelper.ROOT_NUMERIC);
         extra.addAll(map_timezone_integer.keySet());
         extra.removeAll(timezones);
         System.out.println("Extra: " + extra);
-        Set<String> needed = new TreeSet<>(eng);
+        Set<String> needed = new TreeSet<>(CollatorHelper.ROOT_NUMERIC);
         needed.addAll(timezones);
         needed.removeAll(map_timezone_integer.keySet());
         System.out.println("Needed: " + needed);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -233,7 +233,7 @@ public class TestUtilities {
             if (maxNumeric < numeric) maxNumeric = numeric;
         }
         // get the differences (and sort them)
-        RuleBasedCollator eng = (RuleBasedCollator) Collator.getInstance();
+        RuleBasedCollator eng = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         eng.setNumericCollation(true);
 
         Set<String> extra = new TreeSet<>(eng);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
@@ -15,7 +15,6 @@ import com.ibm.icu.text.UTF16.StringComparator;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.util.ICUUncheckedIOException;
-import com.ibm.icu.util.ULocale;
 import java.io.IOException;
 import java.text.FieldPosition;
 import java.util.Comparator;
@@ -52,11 +51,8 @@ public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
     /** Make from root collator obtained from ICU */
     public static final UnicodeSetPrettyPrinter ROOT_ICU =
             from(
-                    (Comparator) Collator.getInstance(ULocale.ROOT).freeze(),
-                    (Comparator)
-                            Collator.getInstance(ULocale.ROOT)
-                                    .setStrength2(Collator.PRIMARY)
-                                    .freeze());
+                    (Comparator) CollatorHelper.ROOT_COLLATOR,
+                    (Comparator) CollatorHelper.ROOT_PRIMARY);
 
     /** Make from ICU Locale */
     public static UnicodeSetPrettyPrinter fromIcuLocale(String localeId) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -100,7 +100,7 @@ public class VerifyCompactNumbers {
         DateTimeFormats.writeCss(DIR);
         final CLDRFile english = CLDR_CONFIG.getEnglish();
 
-        Map<String, String> indexMap = new TreeMap<>(CLDR_CONFIG.getCollator());
+        Map<String, String> indexMap = new TreeMap<>(CollatorHelper.EMOJI_COLLATOR);
 
         for (String locale : availableLanguages) {
             if (defaultContentLocales.contains(locale)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -263,7 +263,7 @@ public class VerifyZones {
         DateTimeFormats.writeCss(DIR);
         final CLDRFile english = CLDR_CONFIG.getEnglish();
 
-        Map<String, String> indexMap = new TreeMap<>(CLDR_CONFIG.getCollator());
+        Map<String, String> indexMap = new TreeMap<>(CollatorHelper.EMOJI_COLLATOR);
 
         for (String localeID : factory2.getAvailableLanguages()) {
             Level level = StandardCodes.make().getLocaleCoverageLevel(organization, localeID);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1083,7 +1083,7 @@ public class VettingViewer<T> {
     }
 
     private Map<String, String> getSortedNames(Organization org, Level desiredLevel) {
-        Map<String, String> sortedNames = new TreeMap<>(CLDRConfig.getInstance().getCollator());
+        Map<String, String> sortedNames = new TreeMap<>(CollatorHelper.EMOJI_COLLATOR);
 
         // A user in the Unaffiliated organization can access a list with all non-TC locales.
         if (org == Organization.unaffiliated && desiredLevel == Level.BASIC) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -4,7 +4,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.Output;
-import com.ibm.icu.util.ULocale;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.Map.Entry;
@@ -926,7 +925,7 @@ public class VoteResolver<T> {
     private CLDRLocale locale;
     private PathHeader pathHeader;
 
-    private static final Collator englishCollator = Collator.getInstance(ULocale.ROOT).freeze();
+    private static final Collator englishCollator = CollatorHelper.ROOT_ORDER;
 
     /** Used for comparing objects of type T */
     private final Comparator<T> objectCollator =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -925,7 +925,7 @@ public class VoteResolver<T> {
     private CLDRLocale locale;
     private PathHeader pathHeader;
 
-    private static final Collator englishCollator = CollatorHelper.ROOT_ORDER;
+    private static final Collator englishCollator = CollatorHelper.ROOT_COLLATOR;
 
     /** Used for comparing objects of type T */
     private final Comparator<T> objectCollator =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -926,7 +926,7 @@ public class VoteResolver<T> {
     private CLDRLocale locale;
     private PathHeader pathHeader;
 
-    private static final Collator englishCollator = Collator.getInstance(ULocale.ENGLISH).freeze();
+    private static final Collator englishCollator = Collator.getInstance(ULocale.ROOT).freeze();
 
     /** Used for comparing objects of type T */
     private final Comparator<T> objectCollator =
@@ -1335,7 +1335,7 @@ public class VoteResolver<T> {
      * be symmetrical in its handling of hard and soft votes.
      *
      * <p>Note: now that "↑↑↑" is permitted to participate directly in voting resolution, it becomes
-     * significant that with Collator.getInstance(ULocale.ENGLISH), "↑↑↑" sorts before "AAA" just as
+     * significant that with Collator.getInstance(ULocale.ROOT), "↑↑↑" sorts before "AAA" just as
      * "AAA" sorts before "BBB".
      *
      * @param sortedValues the set of sorted values, possibly to be modified

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollationStringByteConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollationStringByteConverter.java
@@ -335,7 +335,7 @@ public class TestCollationStringByteConverter {
     }
 
     public static void check() throws Exception {
-        final RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+        final RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
         col.setStrength(Collator.PRIMARY);
         col.setAlternateHandlingShifted(true);
         CollationStringByteConverter converter =

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollationStringByteConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollationStringByteConverter.java
@@ -8,7 +8,6 @@
 package org.unicode.cldr.unittest;
 
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.SimpleDateFormat;
@@ -21,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.TreeMap;
 import org.unicode.cldr.util.CollationStringByteConverter;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Dictionary;
 import org.unicode.cldr.util.Dictionary.DictionaryBuilder;
 import org.unicode.cldr.util.Dictionary.DictionaryCharList;
@@ -335,9 +335,7 @@ public class TestCollationStringByteConverter {
     }
 
     public static void check() throws Exception {
-        final RuleBasedCollator col = (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
-        col.setStrength(Collator.PRIMARY);
-        col.setAlternateHandlingShifted(true);
+        final RuleBasedCollator col = CollatorHelper.ROOT_PRIMARY_SHIFTED;
         CollationStringByteConverter converter =
                 new CollationStringByteConverter(col, new Utf8StringByteConverter()); // new
         // ByteString(true)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestHelper.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestHelper.java
@@ -7,9 +7,7 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
-import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.UnicodeSet;
-import com.ibm.icu.util.ULocale;
 import java.io.StringWriter;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -211,11 +209,9 @@ public class TestHelper extends TestFmwkPlus {
         Counter<String> counter = new Counter<>(true);
         Comparator<String> uca =
                 new Comparator<>() {
-                    Collator col = Collator.getInstance(ULocale.ROOT);
-
                     @Override
                     public int compare(String o1, String o2) {
-                        return col.compare(o1, o2);
+                        return CollatorHelper.ROOT_ORDER.compare(o1, o2);
                     }
                 };
         InverseComparator ucaDown = new InverseComparator(uca);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestHelper.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestHelper.java
@@ -211,7 +211,7 @@ public class TestHelper extends TestFmwkPlus {
                 new Comparator<>() {
                     @Override
                     public int compare(String o1, String o2) {
-                        return CollatorHelper.ROOT_ORDER.compare(o1, o2);
+                        return CollatorHelper.ROOT_COLLATOR.compare(o1, o2);
                     }
                 };
         InverseComparator ucaDown = new InverseComparator(uca);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestHelper.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestHelper.java
@@ -211,7 +211,7 @@ public class TestHelper extends TestFmwkPlus {
         Counter<String> counter = new Counter<>(true);
         Comparator<String> uca =
                 new Comparator<>() {
-                    Collator col = Collator.getInstance(ULocale.ENGLISH);
+                    Collator col = Collator.getInstance(ULocale.ROOT);
 
                     @Override
                     public int compare(String o1, String o2) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestReferenceStringSearch.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestReferenceStringSearch.java
@@ -37,7 +37,7 @@ public class TestReferenceStringSearch {
     }
 
     static final RuleBasedCollator TEST_COLLATOR =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ENGLISH);
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
 
     static {
         TEST_COLLATOR.setStrength(Collator.PRIMARY);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestReferenceStringSearch.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestReferenceStringSearch.java
@@ -37,11 +37,12 @@ public class TestReferenceStringSearch {
     }
 
     static final RuleBasedCollator TEST_COLLATOR =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT);
+            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
 
     static {
         TEST_COLLATOR.setStrength(Collator.PRIMARY);
         TEST_COLLATOR.setAlternateHandlingShifted(true); // ignore puncuation
+        TEST_COLLATOR.freeze();
     }
 
     static final BreakIterator TEST_BREAKER = BreakIterator.getCharacterInstance();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestReferenceStringSearch.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestReferenceStringSearch.java
@@ -2,17 +2,16 @@ package org.unicode.cldr.unittest;
 
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.BreakIterator;
-import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.text.SearchIterator;
 import com.ibm.icu.text.StringCharacterIterator;
 import com.ibm.icu.text.StringSearch;
-import com.ibm.icu.util.ULocale;
 import java.text.CharacterIterator;
 import java.util.Map;
 import java.util.TreeMap;
 import org.unicode.cldr.util.CollationMapMaker;
+import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Dictionary;
 import org.unicode.cldr.util.Dictionary.DictionaryCharList;
 import org.unicode.cldr.util.ReferenceStringSearch;
@@ -37,13 +36,7 @@ public class TestReferenceStringSearch {
     }
 
     static final RuleBasedCollator TEST_COLLATOR =
-            (RuleBasedCollator) Collator.getInstance(ULocale.ROOT); // freeze below
-
-    static {
-        TEST_COLLATOR.setStrength(Collator.PRIMARY);
-        TEST_COLLATOR.setAlternateHandlingShifted(true); // ignore puncuation
-        TEST_COLLATOR.freeze();
-    }
+            CollatorHelper.ROOT_PRIMARY_SHIFTED; // ignore puncuation
 
     static final BreakIterator TEST_BREAKER = BreakIterator.getCharacterInstance();
 


### PR DESCRIPTION
-Change all calls to Collator.getInstance() without parameter to Collator.getInstance(ULocale.ROOT)

-Change all calls to Collator.getInstance(ULocale.ENGLISH) to Collator.getInstance(ULocale.ROOT)

-Public CollatorHelper replaces old private versions in CLDRConfig and MapComparator

-CollatorHelper has EMOJI_COLLATOR, ROOT_COLLATOR, ROOT_IDENTICAL, ROOT_NUMERIC, ROOT_NUMERIC_IDENTICAL, ROOT_PRIMARY, ROOT_PRIMARY_SHIFTED, ROOT_SECONDARY

-Use those collators everywhere possible instead of recreating

-Call freeze() for all (but one) Collator.getInstance(ULocale.ROOT)

-TODO comment for one problematic call in Misc.java loop

-Replace all CLDRConfig.getInstance().getCollator() with CollatorHelper.EMOJI_COLLATOR

-Avoid deprecated setStrength2

-Remove dead code

CLDR-7428

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
