### PR TITLE
CLDR-18108 Give all languages a primary script: trivial cases

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1315,7 +1315,9 @@ XXX Code for transations where no currency is involved
 		<language type="ann" scripts="Latn"/>
 		<language type="anp" scripts="Deva"/>
 		<language type="aoz" scripts="Latn"/>
+		<language type="apc" scripts="Arab"/>
 		<language type="apc" territories="IL JO LB PS SY TR" alt="secondary"/>
+		<language type="apd" scripts="Arab"/>
 		<language type="apd" territories="SD" alt="secondary"/>
 		<language type="ar" scripts="Arab" territories="AE BH DJ DZ EG EH ER IL IQ JO KM KW LB LY MA MR OM PS QA SA SD SO SY TD TN YE"/>
 		<language type="ar" scripts="Syrc" territories="IR SS" alt="secondary"/>
@@ -1397,6 +1399,7 @@ XXX Code for transations where no currency is involved
 		<language type="bjj" territories="IN" alt="secondary"/>
 		<language type="bjn" scripts="Latn"/>
 		<language type="bjn" territories="ID" alt="secondary"/>
+		<language type="bjt" scripts="Latn"/>
 		<language type="bjt" territories="SN" alt="secondary"/>
 		<language type="bkm" scripts="Latn"/>
 		<language type="bku" scripts="Latn"/>
@@ -1422,6 +1425,7 @@ XXX Code for transations where no currency is involved
 		<language type="brx" scripts="Deva"/>
 		<language type="brx" territories="IN" alt="secondary"/>
 		<language type="bs" scripts="Cyrl Latn" territories="BA"/>
+		<language type="bsc" scripts="Latn"/>
 		<language type="bsc" territories="SN" alt="secondary"/>
 		<language type="bss" scripts="Latn"/>
 		<language type="bto" scripts="Latn"/>
@@ -1445,6 +1449,7 @@ XXX Code for transations where no currency is involved
 		<language type="cay" scripts="Latn"/>
 		<language type="cch" scripts="Latn"/>
 		<language type="ccp" scripts="Beng Cakm"/>
+		<language type="ccr" scripts="Latn" alt="secondary"/>
 		<language type="ce" scripts="Cyrl"/>
 		<language type="ce" territories="RU" alt="secondary"/>
 		<language type="ceb" scripts="Latn"/>
@@ -1712,6 +1717,7 @@ XXX Code for transations where no currency is involved
 		<language type="ilo" territories="PH" alt="secondary"/>
 		<language type="inh" scripts="Cyrl"/>
 		<language type="inh" scripts="Arab Latn" territories="RU" alt="secondary"/>
+		<language type="io" scripts="Latn" alt="secondary"/>
 		<language type="is" scripts="Latn" territories="IS"/>
 		<language type="it" scripts="Latn" territories="CH IT SM VA"/>
 		<language type="it" territories="DE FR HR MT US" alt="secondary"/>
@@ -1721,6 +1727,7 @@ XXX Code for transations where no currency is involved
 		<language type="ja" scripts="Jpan" territories="JP"/>
 		<language type="jam" scripts="Latn"/>
 		<language type="jam" territories="JM" alt="secondary"/>
+		<language type="jbo" scripts="Latn" alt="secondary"/>
 		<language type="jgo" scripts="Latn"/>
 		<language type="jmc" scripts="Latn"/>
 		<language type="jml" scripts="Deva"/>
@@ -1749,6 +1756,7 @@ XXX Code for transations where no currency is involved
 		<language type="kdt" scripts="Thai"/>
 		<language type="kea" scripts="Latn"/>
 		<language type="kea" territories="CV" alt="secondary"/>
+		<language type="ken" scripts="Latn"/>
 		<language type="kfo" scripts="Latn"/>
 		<language type="kfr" scripts="Deva"/>
 		<language type="kfr" territories="IN" alt="secondary"/>
@@ -1786,6 +1794,7 @@ XXX Code for transations where no currency is involved
 		<language type="kmb" territories="AO" alt="secondary"/>
 		<language type="kn" scripts="Knda"/>
 		<language type="kn" territories="IN" alt="secondary"/>
+		<language type="knf" scripts="Latn"/>
 		<language type="knf" territories="SN" alt="secondary"/>
 		<language type="knn" scripts="Deva"/>
 		<language type="knn" territories="IN" alt="secondary"/>
@@ -1845,6 +1854,7 @@ XXX Code for transations where no currency is involved
 		<language type="lbe" territories="RU" alt="secondary"/>
 		<language type="lbw" scripts="Latn"/>
 		<language type="lcp" scripts="Thai"/>
+		<language type="len" scripts="Latn" alt="secondary"/>
 		<language type="lep" scripts="Lepc"/>
 		<language type="lez" scripts="Cyrl"/>
 		<language type="lez" scripts="Aghb" territories="RU" alt="secondary"/>
@@ -1925,6 +1935,7 @@ XXX Code for transations where no currency is involved
 		<language type="mfa" territories="TH" alt="secondary"/>
 		<language type="mfe" scripts="Latn"/>
 		<language type="mfe" territories="MU" alt="secondary"/>
+		<language type="mfv" scripts="Latn"/>
 		<language type="mfv" territories="SN" alt="secondary"/>
 		<language type="mg" scripts="Latn" territories="MG"/>
 		<language type="mgh" scripts="Latn"/>
@@ -2088,6 +2099,7 @@ XXX Code for transations where no currency is involved
 		<language type="pnt" scripts="Cyrl Latn" alt="secondary"/>
 		<language type="pon" scripts="Latn"/>
 		<language type="pon" territories="FM" alt="secondary"/>
+		<language type="ppl" scripts="Latn"/>
 		<language type="pqm" scripts="Latn"/>
 		<language type="prd" scripts="Arab"/>
 		<language type="prg" scripts="Latn" alt="secondary"/>
@@ -2208,6 +2220,7 @@ XXX Code for transations where no currency is involved
 		<language type="sms" scripts="Latn"/>
 		<language type="sms" territories="FI" alt="secondary"/>
 		<language type="sn" scripts="Latn" territories="ZW"/>
+		<language type="snf" scripts="Latn"/>
 		<language type="snf" territories="SN" alt="secondary"/>
 		<language type="snk" scripts="Latn"/>
 		<language type="snk" territories="ML" alt="secondary"/>
@@ -2296,6 +2309,7 @@ XXX Code for transations where no currency is involved
 		<language type="tmh" territories="NE" alt="secondary"/>
 		<language type="tn" scripts="Latn" territories="BW"/>
 		<language type="tn" territories="ZA" alt="secondary"/>
+		<language type="tnr" scripts="Latn"/>
 		<language type="tnr" territories="SN" alt="secondary"/>
 		<language type="to" scripts="Latn" territories="TO"/>
 		<language type="tog" scripts="Latn"/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1291,7 +1291,7 @@ XXX Code for transations where no currency is involved
 		<language type="ada" territories="GH" alt="secondary"/>
 		<language type="ady" scripts="Cyrl"/>
 		<language type="ady" territories="RU" alt="secondary"/>
-		<language type="ae" scripts="Avst" alt="secondary"/>
+		<language type="ae" scripts="Avst"/>
 		<language type="aeb" scripts="Arab"/>
 		<language type="aeb" territories="TN" alt="secondary"/>
 		<language type="af" scripts="Latn"/>
@@ -1302,7 +1302,7 @@ XXX Code for transations where no currency is involved
 		<language type="ain" scripts="Kana Latn" alt="secondary"/>
 		<language type="ak" scripts="Latn"/>
 		<language type="ak" territories="GH" alt="secondary"/>
-		<language type="akk" scripts="Xsux" alt="secondary"/>
+		<language type="akk" scripts="Xsux"/>
 		<language type="akz" scripts="Latn"/>
 		<language type="ale" scripts="Latn"/>
 		<language type="aln" scripts="Latn"/>
@@ -1311,7 +1311,7 @@ XXX Code for transations where no currency is involved
 		<language type="am" scripts="Ethi" territories="ET"/>
 		<language type="amo" scripts="Latn"/>
 		<language type="an" scripts="Latn"/>
-		<language type="ang" scripts="Latn" alt="secondary"/>
+		<language type="ang" scripts="Latn"/>
 		<language type="ann" scripts="Latn"/>
 		<language type="anp" scripts="Deva"/>
 		<language type="aoz" scripts="Latn"/>
@@ -1329,7 +1329,7 @@ XXX Code for transations where no currency is involved
 		<language type="arq" territories="DZ" alt="secondary"/>
 		<language type="ars" scripts="Arab"/>
 		<language type="ars" territories="SA" alt="secondary"/>
-		<language type="arw" scripts="Latn" alt="secondary"/>
+		<language type="arw" scripts="Latn"/>
 		<language type="ary" scripts="Arab"/>
 		<language type="ary" territories="MA" alt="secondary"/>
 		<language type="arz" scripts="Arab"/>
@@ -1342,7 +1342,7 @@ XXX Code for transations where no currency is involved
 		<language type="atj" scripts="Latn"/>
 		<language type="av" scripts="Cyrl"/>
 		<language type="av" territories="RU" alt="secondary"/>
-		<language type="avk" scripts="Latn" alt="secondary"/>
+		<language type="avk" scripts="Latn"/>
 		<language type="awa" scripts="Deva"/>
 		<language type="awa" territories="IN" alt="secondary"/>
 		<language type="ay" scripts="Latn" territories="BO"/>
@@ -1449,7 +1449,7 @@ XXX Code for transations where no currency is involved
 		<language type="cay" scripts="Latn"/>
 		<language type="cch" scripts="Latn"/>
 		<language type="ccp" scripts="Beng Cakm"/>
-		<language type="ccr" scripts="Latn" alt="secondary"/>
+		<language type="ccr" scripts="Latn"/>
 		<language type="ce" scripts="Cyrl"/>
 		<language type="ce" territories="RU" alt="secondary"/>
 		<language type="ceb" scripts="Latn"/>
@@ -1460,7 +1460,7 @@ XXX Code for transations where no currency is involved
 		<language type="chk" scripts="Latn"/>
 		<language type="chk" territories="FM" alt="secondary"/>
 		<language type="chm" scripts="Cyrl"/>
-		<language type="chn" scripts="Latn" alt="secondary"/>
+		<language type="chn" scripts="Latn"/>
 		<language type="cho" scripts="Latn"/>
 		<language type="chp" scripts="Latn"/>
 		<language type="chp" scripts="Cans" territories="CA" alt="secondary"/>
@@ -1493,10 +1493,11 @@ XXX Code for transations where no currency is involved
 		<language type="crs" territories="SC" alt="secondary"/>
 		<language type="cs" scripts="Latn" territories="CZ"/>
 		<language type="cs" territories="SK" alt="secondary"/>
-		<language type="csb" scripts="Latn" territories="PL" alt="secondary"/>
+		<language type="csb" scripts="Latn"/>
+		<language type="csb" territories="PL" alt="secondary"/>
 		<language type="csw" scripts="Cans"/>
 		<language type="ctd" scripts="Latn"/>
-		<language type="cu" scripts="Cyrl" alt="secondary"/>
+		<language type="cu" scripts="Cyrl"/>
 		<language type="cv" scripts="Cyrl"/>
 		<language type="cv" territories="RU" alt="secondary"/>
 		<language type="cy" scripts="Latn"/>
@@ -1528,7 +1529,7 @@ XXX Code for transations where no currency is involved
 		<language type="dtp" scripts="Latn"/>
 		<language type="dty" scripts="Deva"/>
 		<language type="dua" scripts="Latn"/>
-		<language type="dum" scripts="Latn" alt="secondary"/>
+		<language type="dum" scripts="Latn"/>
 		<language type="dv" scripts="Thaa" territories="MV"/>
 		<language type="dyo" scripts="Latn"/>
 		<language type="dyo" scripts="Arab" territories="SN" alt="secondary"/>
@@ -1536,19 +1537,19 @@ XXX Code for transations where no currency is involved
 		<language type="dyu" territories="BF" alt="secondary"/>
 		<language type="dz" scripts="Tibt" territories="BT"/>
 		<language type="ebu" scripts="Latn"/>
-		<language type="ecy" scripts="Cprt" alt="secondary"/>
+		<language type="ecy" scripts="Cprt"/>
 		<language type="ee" scripts="Latn"/>
 		<language type="ee" territories="GH TG" alt="secondary"/>
 		<language type="efi" scripts="Latn"/>
 		<language type="efi" territories="NG" alt="secondary"/>
 		<language type="egl" scripts="Latn"/>
-		<language type="egy" scripts="Egyp" alt="secondary"/>
+		<language type="egy" scripts="Egyp"/>
 		<language type="eka" scripts="Latn"/>
 		<language type="eky" scripts="Kali"/>
 		<language type="el" scripts="Grek" territories="CY GR"/>
 		<language type="en" scripts="Latn" territories="AG AI AS AU BB BI BM BS BW BZ CA CC CK CM CQ CX DG DM ER FJ FK FM GB GD GG GH GI GM GS GU GY HK IE IM IN IO JE JM KE KI KN KY LC LR LS MG MH MP MS MT MU MW NA NF NG NR NU NZ PG PH PK PN PR PW RW SB SC SD SG SH SL SS SX SZ TC TK TO TT TV TZ UG UM US VC VG VI VU WS ZA ZM ZW"/>
 		<language type="en" scripts="Dsrt Shaw" territories="AC AE AR AT BA BD BE BG BR CH CL CY CZ DE DK DZ EE EG ES ET FI FR GR HR HU IL IQ IT JO KZ LB LK LT LU LV MA MO MV MX MY NL PL PT RO SE SI SK TA TH TR YE" alt="secondary"/>
-		<language type="enm" scripts="Latn" alt="secondary"/>
+		<language type="enm" scripts="Latn"/>
 		<language type="eo" scripts="Latn"/>
 		<language type="es" scripts="Latn" territories="AR BO CL CO CR CU DO EA EC ES GQ GT HN IC MX NI PA PE PR PY SV UY VE"/>
 		<language type="es" territories="AD BZ CA DE FR GB GI PH PT RO US" alt="secondary"/>
@@ -1582,8 +1583,8 @@ XXX Code for transations where no currency is involved
 		<language type="fr" scripts="Latn" territories="BE BF BI BJ BL CA CD CF CG CH CI CM DJ DZ FR GA GF GN GP GQ HT KM LU MA MC MF MG ML MQ MU NC NE PF PM RE RW SC SN TD TG TN VU WF YT"/>
 		<language type="fr" scripts="Dupl" territories="AT DE GB IT LB NL PT RO ST SY TF US" alt="secondary"/>
 		<language type="frc" scripts="Latn"/>
-		<language type="frm" scripts="Latn" alt="secondary"/>
-		<language type="fro" scripts="Latn" alt="secondary"/>
+		<language type="frm" scripts="Latn"/>
+		<language type="fro" scripts="Latn"/>
 		<language type="frp" scripts="Latn"/>
 		<language type="frr" scripts="Latn"/>
 		<language type="frr" territories="DE" alt="secondary"/>
@@ -1616,7 +1617,7 @@ XXX Code for transations where no currency is involved
 		<language type="gcr" territories="GF" alt="secondary"/>
 		<language type="gd" scripts="Latn"/>
 		<language type="gd" territories="GB" alt="secondary"/>
-		<language type="gez" scripts="Ethi" alt="secondary"/>
+		<language type="gez" scripts="Ethi"/>
 		<language type="gil" scripts="Latn" territories="KI"/>
 		<language type="gjk" scripts="Arab"/>
 		<language type="gju" scripts="Arab"/>
@@ -1625,18 +1626,18 @@ XXX Code for transations where no currency is involved
 		<language type="gld" scripts="Cyrl"/>
 		<language type="glk" scripts="Arab"/>
 		<language type="glk" territories="IR" alt="secondary"/>
-		<language type="gmh" scripts="Latn" alt="secondary"/>
-		<language type="gmy" scripts="Linb" alt="secondary"/>
+		<language type="gmh" scripts="Latn"/>
+		<language type="gmy" scripts="Linb"/>
 		<language type="gn" scripts="Latn" territories="PY"/>
-		<language type="goh" scripts="Latn" alt="secondary"/>
+		<language type="goh" scripts="Latn"/>
 		<language type="gon" scripts="Deva Telu"/>
 		<language type="gon" territories="IN" alt="secondary"/>
 		<language type="gor" scripts="Latn"/>
 		<language type="gor" territories="ID" alt="secondary"/>
 		<language type="gos" scripts="Latn"/>
-		<language type="got" scripts="Goth" alt="secondary"/>
+		<language type="got" scripts="Goth"/>
 		<language type="grb" scripts="Latn"/>
-		<language type="grc" scripts="Grek" alt="secondary"/>
+		<language type="grc" scripts="Grek"/>
 		<language type="grt" scripts="Beng"/>
 		<language type="gsw" scripts="Latn" territories="CH LI"/>
 		<language type="gsw" territories="DE" alt="secondary"/>
@@ -1667,7 +1668,7 @@ XXX Code for transations where no currency is involved
 		<language type="hif" scripts="Deva Latn" territories="FJ"/>
 		<language type="hil" scripts="Latn"/>
 		<language type="hil" territories="PH" alt="secondary"/>
-		<language type="hit" scripts="Xsux" alt="secondary"/>
+		<language type="hit" scripts="Xsux"/>
 		<language type="hmd" scripts="Plrd"/>
 		<language type="hmn" scripts="Latn"/>
 		<language type="hmn" scripts="Hmng" alt="secondary"/>
@@ -1699,13 +1700,13 @@ XXX Code for transations where no currency is involved
 		<language type="hy" scripts="Armn" territories="AM"/>
 		<language type="hy" territories="RU" alt="secondary"/>
 		<language type="hz" scripts="Latn"/>
-		<language type="ia" scripts="Latn" alt="secondary"/>
+		<language type="ia" scripts="Latn"/>
 		<language type="iba" scripts="Latn"/>
 		<language type="ibb" scripts="Latn"/>
 		<language type="ibb" territories="NG" alt="secondary"/>
 		<language type="id" scripts="Latn" territories="ID"/>
 		<language type="id" scripts="Arab" alt="secondary"/>
-		<language type="ie" scripts="Latn" alt="secondary"/>
+		<language type="ie" scripts="Latn"/>
 		<language type="ife" scripts="Latn"/>
 		<language type="ig" scripts="Latn"/>
 		<language type="ig" territories="NG" alt="secondary"/>
@@ -1717,7 +1718,7 @@ XXX Code for transations where no currency is involved
 		<language type="ilo" territories="PH" alt="secondary"/>
 		<language type="inh" scripts="Cyrl"/>
 		<language type="inh" scripts="Arab Latn" territories="RU" alt="secondary"/>
-		<language type="io" scripts="Latn" alt="secondary"/>
+		<language type="io" scripts="Latn"/>
 		<language type="is" scripts="Latn" territories="IS"/>
 		<language type="it" scripts="Latn" territories="CH IT SM VA"/>
 		<language type="it" territories="DE FR HR MT US" alt="secondary"/>
@@ -1727,13 +1728,13 @@ XXX Code for transations where no currency is involved
 		<language type="ja" scripts="Jpan" territories="JP"/>
 		<language type="jam" scripts="Latn"/>
 		<language type="jam" territories="JM" alt="secondary"/>
-		<language type="jbo" scripts="Latn" alt="secondary"/>
+		<language type="jbo" scripts="Latn"/>
 		<language type="jgo" scripts="Latn"/>
 		<language type="jmc" scripts="Latn"/>
 		<language type="jml" scripts="Deva"/>
 		<language type="jpr" scripts="Hebr"/>
 		<language type="jrb" scripts="Hebr"/>
-		<language type="jut" scripts="Latn" alt="secondary"/>
+		<language type="jut" scripts="Latn"/>
 		<language type="jv" scripts="Latn"/>
 		<language type="jv" scripts="Java" territories="ID" alt="secondary"/>
 		<language type="ka" scripts="Geor" territories="GE"/>
@@ -1745,7 +1746,8 @@ XXX Code for transations where no currency is involved
 		<language type="kam" scripts="Latn"/>
 		<language type="kam" territories="KE" alt="secondary"/>
 		<language type="kao" scripts="Latn"/>
-		<language type="kaw" scripts="Bali Java Kawi" alt="secondary"/>
+		<language type="kaw" scripts="Bali"/>
+		<language type="kaw" scripts="Java Kawi" alt="secondary"/>
 		<language type="kbd" scripts="Cyrl"/>
 		<language type="kbd" territories="RU" alt="secondary"/>
 		<language type="kca" scripts="Cyrl"/>
@@ -1840,8 +1842,9 @@ XXX Code for transations where no currency is involved
 		<language type="kxv" scripts="Deva Orya Telu" alt="secondary"/>
 		<language type="ky" scripts="Arab Cyrl Latn" territories="KG"/>
 		<language type="kyu" scripts="Kali"/>
-		<language type="la" scripts="Latn" territories="VA" alt="secondary"/>
-		<language type="lab" scripts="Lina" alt="secondary"/>
+		<language type="la" scripts="Latn"/>
+		<language type="la" territories="VA" alt="secondary"/>
+		<language type="lab" scripts="Lina"/>
 		<language type="lad" scripts="Hebr"/>
 		<language type="lag" scripts="Latn"/>
 		<language type="lah" scripts="Arab"/>
@@ -1854,7 +1857,7 @@ XXX Code for transations where no currency is involved
 		<language type="lbe" territories="RU" alt="secondary"/>
 		<language type="lbw" scripts="Latn"/>
 		<language type="lcp" scripts="Thai"/>
-		<language type="len" scripts="Latn" alt="secondary"/>
+		<language type="len" scripts="Latn"/>
 		<language type="lep" scripts="Lepc"/>
 		<language type="lez" scripts="Cyrl"/>
 		<language type="lez" scripts="Aghb" territories="RU" alt="secondary"/>
@@ -1866,7 +1869,7 @@ XXX Code for transations where no currency is involved
 		<language type="lij" scripts="Latn"/>
 		<language type="lil" scripts="Latn"/>
 		<language type="lis" scripts="Lisu"/>
-		<language type="liv" scripts="Latn" alt="secondary"/>
+		<language type="liv" scripts="Latn"/>
 		<language type="ljp" scripts="Latn"/>
 		<language type="ljp" territories="ID" alt="secondary"/>
 		<language type="lki" scripts="Arab"/>
@@ -1891,19 +1894,19 @@ XXX Code for transations where no currency is involved
 		<language type="lu" territories="CD" alt="secondary"/>
 		<language type="lua" scripts="Latn"/>
 		<language type="lua" territories="CD" alt="secondary"/>
-		<language type="lui" scripts="Latn" alt="secondary"/>
+		<language type="lui" scripts="Latn"/>
 		<language type="lun" scripts="Latn"/>
 		<language type="luo" scripts="Latn"/>
 		<language type="luo" territories="KE" alt="secondary"/>
 		<language type="lus" scripts="Beng"/>
-		<language type="lut" scripts="Latn" alt="secondary"/>
+		<language type="lut" scripts="Latn"/>
 		<language type="luy" scripts="Latn"/>
 		<language type="luy" territories="KE" alt="secondary"/>
 		<language type="luz" scripts="Arab"/>
 		<language type="luz" territories="IR" alt="secondary"/>
 		<language type="lv" scripts="Latn" territories="LV"/>
 		<language type="lwl" scripts="Thai"/>
-		<language type="lzh" scripts="Hans" alt="secondary"/>
+		<language type="lzh" scripts="Hans"/>
 		<language type="lzz" scripts="Latn"/>
 		<language type="lzz" scripts="Geor" alt="secondary"/>
 		<language type="mad" scripts="Latn"/>
@@ -1955,7 +1958,7 @@ XXX Code for transations where no currency is involved
 		<language type="mls" scripts="Latn"/>
 		<language type="mn" scripts="Cyrl" territories="MN"/>
 		<language type="mn" scripts="Mong Phag" territories="CN" alt="secondary"/>
-		<language type="mnc" scripts="Mong" alt="secondary"/>
+		<language type="mnc" scripts="Mong"/>
 		<language type="mni" scripts="Beng"/>
 		<language type="mni" scripts="Mtei" territories="IN" alt="secondary"/>
 		<language type="mns" scripts="Cyrl"/>
@@ -1991,7 +1994,7 @@ XXX Code for transations where no currency is involved
 		<language type="myv" territories="RU" alt="secondary"/>
 		<language type="myx" scripts="Latn"/>
 		<language type="myx" territories="UG" alt="secondary"/>
-		<language type="myz" scripts="Mand" alt="secondary"/>
+		<language type="myz" scripts="Mand"/>
 		<language type="mzn" scripts="Arab"/>
 		<language type="mzn" territories="IR" alt="secondary"/>
 		<language type="na" scripts="Latn" territories="NR"/>
@@ -2033,8 +2036,8 @@ XXX Code for transations where no currency is involved
 		<language type="noe" scripts="Deva"/>
 		<language type="noe" territories="IN" alt="secondary"/>
 		<language type="nog" scripts="Cyrl"/>
-		<language type="non" scripts="Runr" alt="secondary"/>
-		<language type="nov" scripts="Latn" alt="secondary"/>
+		<language type="non" scripts="Runr"/>
+		<language type="nov" scripts="Latn"/>
 		<language type="nqo" scripts="Nkoo"/>
 		<language type="nr" scripts="Latn"/>
 		<language type="nr" territories="ZA" alt="secondary"/>
@@ -2069,7 +2072,7 @@ XXX Code for transations where no currency is involved
 		<language type="osa" scripts="Osge"/>
 		<language type="osa" scripts="Latn" alt="secondary"/>
 		<language type="osc" scripts="Ital Latn" alt="secondary"/>
-		<language type="otk" scripts="Orkh" alt="secondary"/>
+		<language type="otk" scripts="Orkh"/>
 		<language type="pa" scripts="Arab Guru"/>
 		<language type="pa" territories="CA GB IN PK" alt="secondary"/>
 		<language type="pag" scripts="Latn"/>
@@ -2085,10 +2088,11 @@ XXX Code for transations where no currency is involved
 		<language type="pcm" territories="NG" alt="secondary"/>
 		<language type="pdc" scripts="Latn"/>
 		<language type="pdt" scripts="Latn"/>
-		<language type="peo" scripts="Xpeo" alt="secondary"/>
+		<language type="peo" scripts="Xpeo"/>
 		<language type="pfl" scripts="Latn"/>
-		<language type="phn" scripts="Phnx" alt="secondary"/>
-		<language type="pi" scripts="Deva Mymr Sinh Thai" alt="secondary"/>
+		<language type="phn" scripts="Phnx"/>
+		<language type="pi" scripts="Mymr"/>
+		<language type="pi" scripts="Deva Sinh Thai" alt="secondary"/>
 		<language type="pis" scripts="Latn"/>
 		<language type="pis" territories="SB" alt="secondary"/>
 		<language type="pko" scripts="Latn"/>
@@ -2102,8 +2106,8 @@ XXX Code for transations where no currency is involved
 		<language type="ppl" scripts="Latn"/>
 		<language type="pqm" scripts="Latn"/>
 		<language type="prd" scripts="Arab"/>
-		<language type="prg" scripts="Latn" alt="secondary"/>
-		<language type="pro" scripts="Latn" alt="secondary"/>
+		<language type="prg" scripts="Latn"/>
+		<language type="pro" scripts="Latn"/>
 		<language type="ps" scripts="Arab" territories="AF"/>
 		<language type="ps" territories="PK" alt="secondary"/>
 		<language type="pt" scripts="Latn" territories="AO BR CV GQ GW MO MZ PT ST TL"/>
@@ -2191,7 +2195,7 @@ XXX Code for transations where no currency is involved
 		<language type="seh" scripts="Latn"/>
 		<language type="seh" territories="MZ" alt="secondary"/>
 		<language type="sei" scripts="Latn"/>
-		<language type="sel" scripts="Cyrl" alt="secondary"/>
+		<language type="sel" scripts="Cyrl"/>
 		<language type="ses" scripts="Latn"/>
 		<language type="sg" scripts="Latn" territories="CF"/>
 		<language type="sga" scripts="Latn Ogam" alt="secondary"/>
@@ -2216,7 +2220,7 @@ XXX Code for transations where no currency is involved
 		<language type="sma" scripts="Latn"/>
 		<language type="smj" scripts="Latn"/>
 		<language type="smn" scripts="Latn"/>
-		<language type="smp" scripts="Samr" alt="secondary"/>
+		<language type="smp" scripts="Samr"/>
 		<language type="sms" scripts="Latn"/>
 		<language type="sms" territories="FI" alt="secondary"/>
 		<language type="sn" scripts="Latn" territories="ZW"/>
@@ -2262,7 +2266,7 @@ XXX Code for transations where no currency is involved
 		<language type="syi" scripts="Latn"/>
 		<language type="syl" scripts="Beng"/>
 		<language type="syl" scripts="Sylo" territories="BD" alt="secondary"/>
-		<language type="syr" scripts="Syrc" alt="secondary"/>
+		<language type="syr" scripts="Syrc"/>
 		<language type="szl" scripts="Latn"/>
 		<language type="ta" scripts="Taml" territories="LK SG"/>
 		<language type="ta" territories="GB IN MY" alt="secondary"/>
@@ -2314,7 +2318,7 @@ XXX Code for transations where no currency is involved
 		<language type="to" scripts="Latn" territories="TO"/>
 		<language type="tog" scripts="Latn"/>
 		<language type="toi" territories="ZM" alt="secondary"/>
-		<language type="tok" scripts="Latn" alt="secondary"/>
+		<language type="tok" scripts="Latn"/>
 		<language type="tpi" scripts="Latn" territories="PG"/>
 		<language type="tr" scripts="Latn" territories="CY TR"/>
 		<language type="tr" scripts="Arab" territories="DE" alt="secondary"/>
@@ -2349,7 +2353,7 @@ XXX Code for transations where no currency is involved
 		<language type="udm" scripts="Latn" territories="RU" alt="secondary"/>
 		<language type="ug" scripts="Arab Cyrl"/>
 		<language type="ug" scripts="Latn" territories="CN" alt="secondary"/>
-		<language type="uga" scripts="Ugar" alt="secondary"/>
+		<language type="uga" scripts="Ugar"/>
 		<language type="uk" scripts="Cyrl" territories="UA"/>
 		<language type="uk" territories="RS" alt="secondary"/>
 		<language type="uli" scripts="Latn"/>
@@ -2378,8 +2382,8 @@ XXX Code for transations where no currency is involved
 		<language type="vmf" territories="DE" alt="secondary"/>
 		<language type="vmw" scripts="Latn"/>
 		<language type="vmw" territories="MZ" alt="secondary"/>
-		<language type="vo" scripts="Latn" alt="secondary"/>
-		<language type="vot" scripts="Latn" alt="secondary"/>
+		<language type="vo" scripts="Latn"/>
+		<language type="vot" scripts="Latn"/>
 		<language type="vro" scripts="Latn"/>
 		<language type="vun" scripts="Latn"/>
 		<language type="wa" scripts="Latn"/>
@@ -2405,21 +2409,21 @@ XXX Code for transations where no currency is involved
 		<language type="wuu" territories="CN" alt="secondary"/>
 		<language type="xal" scripts="Cyrl"/>
 		<language type="xav" scripts="Latn"/>
-		<language type="xcr" scripts="Cari" alt="secondary"/>
+		<language type="xcr" scripts="Cari"/>
 		<language type="xh" scripts="Latn"/>
 		<language type="xh" territories="ZA" alt="secondary"/>
-		<language type="xlc" scripts="Lyci" alt="secondary"/>
-		<language type="xld" scripts="Lydi" alt="secondary"/>
+		<language type="xlc" scripts="Lyci"/>
+		<language type="xld" scripts="Lydi"/>
 		<language type="xmf" scripts="Geor"/>
-		<language type="xmn" scripts="Mani" alt="secondary"/>
-		<language type="xmr" scripts="Merc" alt="secondary"/>
-		<language type="xna" scripts="Narb" alt="secondary"/>
+		<language type="xmn" scripts="Mani"/>
+		<language type="xmr" scripts="Merc"/>
+		<language type="xna" scripts="Narb"/>
 		<language type="xnr" scripts="Deva"/>
 		<language type="xnr" territories="IN" alt="secondary"/>
 		<language type="xog" scripts="Latn"/>
 		<language type="xog" territories="UG" alt="secondary"/>
-		<language type="xpr" scripts="Prti" alt="secondary"/>
-		<language type="xsa" scripts="Sarb" alt="secondary"/>
+		<language type="xpr" scripts="Prti"/>
+		<language type="xsa" scripts="Sarb"/>
 		<language type="xsr" scripts="Deva"/>
 		<language type="xum" scripts="Ital Latn" alt="secondary"/>
 		<language type="yao" scripts="Latn"/>
@@ -2439,7 +2443,7 @@ XXX Code for transations where no currency is involved
 		<language type="zap" scripts="Latn"/>
 		<language type="zdj" scripts="Arab" territories="KM"/>
 		<language type="zea" scripts="Latn"/>
-		<language type="zen" scripts="Tfng" alt="secondary"/>
+		<language type="zen" scripts="Tfng"/>
 		<language type="zgh" scripts="Tfng"/>
 		<language type="zgh" territories="MA" alt="secondary"/>
 		<language type="zh" scripts="Hans Hant" territories="CN HK MO SG TW"/>

--- a/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
+++ b/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
@@ -13,4 +13,4 @@ The [`language\_script.tsv`](https://github.com/unicode-org/cldr/blob/main/tools
 
 Languages with multiple ambiguous scripts should have that reflected in their CLDR structure (eg. `sr_Cyrl_RS`), with aliases for the language\-region combinations.
 
-In order to re-generate the XML data use ConvertLanguageData as written about in [the article about updating the language scripts](.../update-language-script-info.md).
+In order to re-generate the XML data use ConvertLanguageData as written about in [the article about updating the language scripts](/development/update-language-script-info.md).

--- a/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
+++ b/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
@@ -7,7 +7,7 @@ title: Language Script Description
 The [`language\_script.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv) data file should list all of the language / script combinations that are in common use. Usage by country is indicated in the [`country\_language\_population.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv) spreadsheet.
 
 1. Every language should have 1 script considered the **primary** script.
-    1. This data is used to determine [the most Likely language and region](/development/updating-codes/likelysubtags-and-default-content) so there needs to be at least 1 primary value.
+    1. This data is currently used to determine [the likely script for a language](/development/updating-codes/likelysubtags-and-default-content) so there needs to be at least 1 primary value. Because it is the default, it determines the script of locales without language codes in the `<territoryInfo>`. 
     2. __Changed in v47__ Include a primary script for historical languages (eg. Ancient Greek, Coptic). The primary script should reflect where the majority of the written corpus originates from.
 2. Other scripts used for a language should be marked **secondary**.
 

--- a/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
+++ b/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
@@ -4,19 +4,16 @@ title: Language Script Description
 
 # Language Script Description
 
-The language\_script spreadsheet should list all of the language / script combinations that are in common modern use. The countries are not important, since their function has been overtaken by the country\_language\_population spreadsheet.
+The [`language\_script.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv) data file should list all of the language / script combinations that are in common use. Usage by country is indicated in the [`country\_language\_population.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv) spreadsheet.
 
-1. If the language and script are both modern, and the script is a major way to write the language in some country, then we should see that line marked as **primary**.
-2. Otherwise it should be marked **secondary**.
-
-Every language that is in official use in any country according to country\_language\_population  should have at least one primary script in the language\_script spreadsheet.
+1. Every language needs at least 1 script considered the **primary** script.
+    1. This data is used to determine [the most Likely language and region](likelysubtags-and-default-content) so there needs to be at least 1 primary value.
+    2. [Changed in v47] Include a primary script for historical languages (eg. Ancient Greek, Coptic). The primary script should reflect where the majority of the written corpus originates from.
+2. Languages written by significant populations with different scritps in different countries can have multiple **primary** scripts. The [likely subtags](https://www.unicode.org/cldr/charts/latest/supplemental/likely_subtags.html) patterns will use population counts to disambiguate the default script for each locale.
+3. Other scripts used for a language should be marked **secondary**.
 
 If a language has multiple primary scripts, then it should not appear without the script tag in the country\_language\_population.tsv. For example, we should not see "az", but rather "az\_Cyrl", "az\_Latn", and so on. For each country where the language is used, we should see figures on the script\-specific values. The values may overlap, that is, we may see az\_Cyrl at 60% and az\_Latn at 55%. However, the combination with the predominantly used script **must** have a larger figure than the others.
 
 This is also reflected in CLDR main: languages with multiple scripts will have that reflected in their structure (eg sr\-Cyrl\-RS), with aliases for the language\-region combinations.
 
-Files in https://github.com/unicode-org/cldr/tree/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data
-
-1. country\_language\_population.tsv
-2. language\_script.tsv
-
+In order to re-generate the XML data use ConvertLanguageData as written about in [the article about updating the language scripts](.../update-language-script-info.md).

--- a/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
+++ b/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
@@ -7,7 +7,7 @@ title: Language Script Description
 The [`language\_script.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv) data file should list all of the language / script combinations that are in common use. Usage by country is indicated in the [`country\_language\_population.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv) spreadsheet.
 
 1. Every language should have 1 script considered the **primary** script.
-    1. This data is used to determine [the most Likely language and region](likelysubtags-and-default-content) so there needs to be at least 1 primary value.
+    1. This data is used to determine [the most Likely language and region](/development/updating-codes/likelysubtags-and-default-content) so there needs to be at least 1 primary value.
     2. __Changed in v47__ Include a primary script for historical languages (eg. Ancient Greek, Coptic). The primary script should reflect where the majority of the written corpus originates from.
 2. Other scripts used for a language should be marked **secondary**.
 

--- a/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
+++ b/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
@@ -6,14 +6,11 @@ title: Language Script Description
 
 The [`language\_script.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv) data file should list all of the language / script combinations that are in common use. Usage by country is indicated in the [`country\_language\_population.tsv`](https://github.com/unicode-org/cldr/blob/main/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv) spreadsheet.
 
-1. Every language needs at least 1 script considered the **primary** script.
+1. Every language should have 1 script considered the **primary** script.
     1. This data is used to determine [the most Likely language and region](likelysubtags-and-default-content) so there needs to be at least 1 primary value.
-    2. [Changed in v47] Include a primary script for historical languages (eg. Ancient Greek, Coptic). The primary script should reflect where the majority of the written corpus originates from.
-2. Languages written by significant populations with different scritps in different countries can have multiple **primary** scripts. The [likely subtags](https://www.unicode.org/cldr/charts/latest/supplemental/likely_subtags.html) patterns will use population counts to disambiguate the default script for each locale.
-3. Other scripts used for a language should be marked **secondary**.
+    2. __Changed in v47__ Include a primary script for historical languages (eg. Ancient Greek, Coptic). The primary script should reflect where the majority of the written corpus originates from.
+2. Other scripts used for a language should be marked **secondary**.
 
-If a language has multiple primary scripts, then it should not appear without the script tag in the country\_language\_population.tsv. For example, we should not see "az", but rather "az\_Cyrl", "az\_Latn", and so on. For each country where the language is used, we should see figures on the script\-specific values. The values may overlap, that is, we may see az\_Cyrl at 60% and az\_Latn at 55%. However, the combination with the predominantly used script **must** have a larger figure than the others.
-
-This is also reflected in CLDR main: languages with multiple scripts will have that reflected in their structure (eg sr\-Cyrl\-RS), with aliases for the language\-region combinations.
+Languages with multiple ambiguous scripts should have that reflected in their CLDR structure (eg. `sr_Cyrl_RS`), with aliases for the language\-region combinations.
 
 In order to re-generate the XML data use ConvertLanguageData as written about in [the article about updating the language scripts](.../update-language-script-info.md).

--- a/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
+++ b/docs/site/development/updating-codes/update-language-script-info/language-script-description.md
@@ -13,4 +13,4 @@ The [`language\_script.tsv`](https://github.com/unicode-org/cldr/blob/main/tools
 
 Languages with multiple ambiguous scripts should have that reflected in their CLDR structure (eg. `sr_Cyrl_RS`), with aliases for the language\-region combinations.
 
-In order to re-generate the XML data use ConvertLanguageData as written about in [the article about updating the language scripts](/development/update-language-script-info.md).
+In order to re-generate the XML data use ConvertLanguageData as written about in [the article about updating the language scripts](/development/updating-codes/update-language-script-info).

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -34,7 +34,6 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.draft.ScriptMetadata;
-import org.unicode.cldr.draft.ScriptMetadata.IdUsage;
 import org.unicode.cldr.draft.ScriptMetadata.Info;
 import org.unicode.cldr.util.Builder;
 import org.unicode.cldr.util.CLDRFile;
@@ -2049,7 +2048,7 @@ public class ConvertLanguageData {
                                 row);
                         continue;
                     }
-                    
+
                     addLanguage2Script(language, status, script);
                     if (row.size() > 5) {
                         String reference = row.get(5);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -2026,7 +2026,8 @@ public class ConvertLanguageData {
                 if (!checkCode(LstrType.language, language, row)) continue;
                 for (String script : scripts.split("\\s+")) {
                     if (!checkCode(LstrType.script, script, row)) continue;
-                    // if the script is not modern, demote
+
+                    // Make sure the script has information
                     Info scriptInfo = ScriptMetadata.getInfo(script);
                     if (scriptInfo == null) {
                         BadItem.ERROR.toString(
@@ -2035,24 +2036,8 @@ public class ConvertLanguageData {
                                 row);
                         continue;
                     }
-                    IdUsage idUsage = scriptInfo.idUsage;
-                    if (status == BasicLanguageData.Type.primary
-                            && idUsage != IdUsage.RECOMMENDED) {
-                        if (idUsage == IdUsage.ASPIRATIONAL || idUsage == IdUsage.LIMITED_USE) {
-                            BadItem.WARNING.toString(
-                                    "Script has unexpected usage; make secondary if a Recommended script is used widely for the langauge",
-                                    idUsage + ", " + script + "=" + getULocaleScriptName(script),
-                                    row);
-                        } else {
-                            BadItem.ERROR.toString(
-                                    "Script is not modern; make secondary",
-                                    idUsage + ", " + script + "=" + getULocaleScriptName(script),
-                                    row);
-                            status = BasicLanguageData.Type.secondary;
-                        }
-                    }
 
-                    // if the language is not modern, demote
+                    // Make sure the language code is valid
                     if (LOCALE_ALIAS_INFO.get("language").containsKey(language)) {
                         BadItem.ERROR.toString(
                                 "Remove/Change deprecated language",
@@ -2064,15 +2049,7 @@ public class ConvertLanguageData {
                                 row);
                         continue;
                     }
-                    if (status == BasicLanguageData.Type.primary
-                            && !sc.isModernLanguage(language)) {
-                        BadItem.ERROR.toString(
-                                "Should be secondary, language is not modern",
-                                language + " " + getLanguageName(language),
-                                row);
-                        status = BasicLanguageData.Type.secondary;
-                    }
-
+                    
                     addLanguage2Script(language, status, script);
                     if (row.size() > 5) {
                         String reference = row.get(5);

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -886,7 +886,6 @@ uga	Ugaritic	primary	Ugar	Ugaritic
 uk	Ukrainian	primary	Cyrl	Cyrillic
 uli	Ulithian	primary	Latn	Latin
 umb	Umbundu	primary	Latn	Latin
-und	Unknown	primary	Latn	Latin
 unr	Mundari	primary	Beng	Bangla
 unr	Mundari	primary	Deva	Devanagari
 unx	Munda	primary	Beng	Bangla

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -10,7 +10,7 @@ ace	Achinese	primary	Latn	Latin
 ach	Acoli	primary	Latn	Latin
 ada	Adangme	primary	Latn	Latin
 ady	Adyghe	primary	Cyrl	Cyrillic
-ae	Avestan	secondary	Avst	Avestan
+ae	Avestan	primary	Avst	Avestan
 aeb	Tunisian Arabic	primary	Arab	Arabic
 af	Afrikaans	primary	Latn	Latin
 agq	Aghem	primary	Latn	Latin
@@ -19,7 +19,7 @@ aii	Assyrian Neo-Aramaic	secondary	Syrc	Syriac
 ain	Ainu	secondary	Kana	Katakana
 ain	Ainu	secondary	Latn	Latin
 ak	Akan	primary	Latn	Latin
-akk	Akkadian	secondary	Xsux	Sumero-Akkadian Cuneiform
+akk	Akkadian	primary	Xsux	Sumero-Akkadian Cuneiform
 akz	Alabama	primary	Latn	Latin
 ale	Aleut	primary	Latn	Latin
 aln	Gheg Albanian	primary	Latn	Latin
@@ -27,10 +27,12 @@ alt	Southern Altai	primary	Cyrl	Cyrillic
 am	Amharic	primary	Ethi	Ethiopic
 amo	Amo	primary	Latn	Latin
 an	Aragonese	primary	Latn	Latin
-ang	Old English	secondary	Latn	Latin
+ang	Old English	primary	Latn	Latin
 ann	Obolo	primary	Latn	Latin
 anp	Angika	primary	Deva	Devanagari
 aoz	Uab Meto	primary	Latn	Latin
+apc	Levantine Arabic	primary	Arab	Arabic
+apd	Sudanese Arabic	primary	Arab	Arabic
 ar	Arabic	primary	Arab	Arabic
 ar	Arabic	secondary	Syrc	Syriac
 arc	Aramaic	secondary	Armi	Imperial Aramaic
@@ -41,7 +43,7 @@ aro	Araona	primary	Latn	Latin
 arp	Arapaho	primary	Latn	Latin
 arq	Algerian Arabic	primary	Arab	Arabic
 ars	Najdi Arabic	primary	Arab	Arabic
-arw	Arawak	secondary	Latn	Latin
+arw	Arawak	primary	Latn	Latin
 ary	Moroccan Arabic	primary	Arab	Arabic
 arz	Egyptian Arabic	primary	Arab	Arabic
 as	Assamese	primary	Beng	Bangla
@@ -49,7 +51,7 @@ asa	Asu	primary	Latn	Latin
 ast	Asturian	primary	Latn	Latin
 atj	Atikamekw	primary	Latn	Latin
 av	Avaric	primary	Cyrl	Cyrillic
-avk	Kotava	secondary	Latn	Latin
+avk	Kotava	primary	Latn	Latin
 awa	Awadhi	primary	Deva	Devanagari
 ay	Aymara	primary	Latn	Latin
 az	Azerbaijani	primary	Arab	Arabic
@@ -84,12 +86,14 @@ bgn	Western Balochi	primary	Arab	Arabic
 bgx	Balkan Gagauz Turkish	primary	Grek	Greek
 bhb	Bhili	primary	Deva	Devanagari
 bhi	Bhilali	primary	Deva	Devanagari
+bhk	Albay Bicolano	primary	Latn	Latin
 bho	Bhojpuri	primary	Deva	Devanagari
 bi	Bislama	primary	Latn	Latin
 bik	Bikol	primary	Latn	Latin
 bin	Bini	primary	Latn	Latin
 bjj	Kanauji	primary	Deva	Devanagari
 bjn	Banjar	primary	Latn	Latin
+bjt	Balanta-Ganja	primary	Latn	Latin
 bkm	Kom	primary	Latn	Latin
 bku	Buhid	primary	Latn	Latin
 bku	Buhid	secondary	Buhd	Buhid
@@ -111,6 +115,7 @@ brh	Brahui	secondary	Latn	Latin
 brx	Bodo	primary	Deva	Devanagari
 bs	Bosnian	primary	Cyrl	Cyrillic
 bs	Bosnian	primary	Latn	Latin
+bsc	Bassari	primary	Latn	Latin
 bss	Akoose	primary	Latn	Latin
 bto	Rinconada Bikol	primary	Latn	Latin
 btv	Bateri	primary	Deva	Devanagari
@@ -131,13 +136,14 @@ cay	Cayuga	primary	Latn	Latin
 cch	Atsam	primary	Latn	Latin
 ccp	Chakma	primary	Beng	Bangla
 ccp	Chakma	primary	Cakm	Chakma
+ccr	Cacaopera	primary	Latn	Latin
 ce	Chechen	primary	Cyrl	Cyrillic
 ceb	Cebuano	primary	Latn	Latin
 cgg	Chiga	primary	Latn	Latin
 ch	Chamorro	primary	Latn	Latin
 chk	Chuukese	primary	Latn	Latin
 chm	Mari	primary	Cyrl	Cyrillic
-chn	Chinook Jargon	secondary	Latn	Latin
+chn	Chinook Jargon	primary	Latn	Latin
 cho	Choctaw	primary	Latn	Latin
 chp	Chipewyan	primary	Latn	Latin
 chp	Chipewyan	secondary	Cans	Unified Canadian Aboriginal Syllabics
@@ -169,12 +175,12 @@ crl	Northern East Cree	secondary	Latn	Latin
 crm	Moose Cree	primary	Cans	Unified Canadian Aboriginal Syllabics
 crs	Seselwa Creole French	primary	Latn	Latin
 cs	Czech	primary	Latn	Latin
-csb	Kashubian	secondary	Latn	Latin
+csb	Kashubian	primary	Latn	Latin
 csw	Swampy Cree	primary	Cans	Unified Canadian Aboriginal Syllabics
 ctd	Tedim Chin	primary	Latn	Latin
 cwd	Woods Cree	primary	Cans	Unified Canadian Aboriginal Syllabics
 cwd	Woods Cree	secondary	Latn	Latin
-cu	Church Slavic	secondary	Cyrl	Cyrillic
+cu	Church Slavic	primary	Cyrl	Cyrillic
 cv	Chuvash	primary	Cyrl	Cyrillic
 cy	Welsh	primary	Latn	Latin
 da	Danish	primary	Latn	Latin
@@ -200,7 +206,7 @@ dtm	Tomo Kan Dogon	primary	Latn	Latin
 dtp	Central Dusun	primary	Latn	Latin
 dty	Dotyali	primary	Deva	Devanagari
 dua	Duala	primary	Latn	Latin
-dum	Middle Dutch	secondary	Latn	Latin
+dum	Middle Dutch	primary	Latn	Latin
 dv	Divehi	primary	Thaa	Thaana
 dyo	Jola-Fonyi	primary	Latn	Latin
 dyo	Jola-Fonyi	secondary	Arab	Arabic
@@ -211,14 +217,14 @@ ecy	Eteocypriot	primary	Cprt	Cypriot Syllabary
 ee	Ewe	primary	Latn	Latin
 efi	Efik	primary	Latn	Latin
 egl	Emilian	primary	Latn	Latin
-egy	Ancient Egyptian	secondary	Egyp	Egyptian hieroglyphs
+egy	Ancient Egyptian	primary	Egyp	Egyptian hieroglyphs
 eka	Ekajuk	primary	Latn	Latin
 eky	Eastern Kayah	primary	Kali	Kayah Li
 el	Greek	primary	Grek	Greek
 en	English	primary	Latn	Latin
 en	English	secondary	Dsrt	Deseret
 en	English	secondary	Shaw	Shavian
-enm	Middle English	secondary	Latn	Latin
+enm	Middle English	primary	Latn	Latin
 eo	Esperanto	primary	Latn	Latin
 es	Spanish	primary	Latn	Latin
 esu	Central Yupik	primary	Latn	Latin
@@ -245,8 +251,8 @@ fon	Fon	primary	Latn	Latin
 fr	French	primary	Latn	Latin
 fr	French	secondary	Dupl	Duployan shorthand
 frc	Cajun French	primary	Latn	Latin
-frm	Middle French	secondary	Latn	Latin
-fro	Old French	secondary	Latn	Latin
+frm	Middle French	primary	Latn	Latin
+fro	Old French	primary	Latn	Latin
 frp	Arpitan	primary	Latn	Latin
 frr	Northern Frisian	primary	Latn	Latin
 frs	Eastern Frisian	primary	Latn	Latin
@@ -267,22 +273,22 @@ gbm	Garhwali	primary	Deva	Devanagari
 gbz	Zoroastrian Dari	primary	Arab	Arabic
 gcr	Guianese Creole French	primary	Latn	Latin
 gd	Scottish Gaelic	primary	Latn	Latin
-gez	Geez	secondary	Ethi	Ethiopic
+gez	Geez	primary	Ethi	Ethiopic
 gil	Gilbertese	primary	Latn	Latin
 gjk	Kachi Koli	primary	Arab	Arabic
 gju	Gujari	primary	Arab	Arabic
 gl	Galician	primary	Latn	Latin
 gld	Nanai	primary	Cyrl	Cyrillic
 glk	Gilaki	primary	Arab	Arabic
-gmh	Middle High German	secondary	Latn	Latin
+gmh	Middle High German	primary	Latn	Latin
 gmy	Mycenaean Greek	primary	Linb	Linear B
 gn	Guarani	primary	Latn	Latin
-goh	Old High German	secondary	Latn	Latin
+goh	Old High German	primary	Latn	Latin
 gon	Gondi	primary	Deva	Devanagari
 gon	Gondi	primary	Telu	Telugu
 gor	Gorontalo	primary	Latn	Latin
 gos	Gronings	primary	Latn	Latin
-got	Gothic	secondary	Goth	Gothic
+got	Gothic	primary	Goth	Gothic
 grb	Grebo	primary	Latn	Latin
 grc	Ancient Greek	primary	Grek	Greek
 grt	Garo	primary	Beng	Bangla
@@ -309,7 +315,7 @@ hi	Hindi	secondary	Mahj	Mahajani
 hif	Fiji Hindi	primary	Deva	Devanagari
 hif	Fiji Hindi	primary	Latn	Latin
 hil	Hiligaynon	primary	Latn	Latin
-hit	Hittite	secondary	Xsux	Sumero-Akkadian Cuneiform
+hit	Hittite	primary	Xsux	Sumero-Akkadian Cuneiform
 hmd	Large Flowery Miao	primary	Plrd	Pollard Phonetic
 hmn	Hmong	primary	Latn	Latin
 hmn	Hmong	secondary	Hmng	Pahawh Hmong
@@ -333,12 +339,12 @@ hup	Hupa	primary	Latn	Latin
 hur	Halkomelem	primary	Latn	Latin
 hy	Armenian	primary	Armn	Armenian
 hz	Herero	primary	Latn	Latin
-ia	Interlingua	secondary	Latn	Latin
+ia	Interlingua	primary	Latn	Latin
 iba	Iban	primary	Latn	Latin
 ibb	Ibibio	primary	Latn	Latin
 id	Indonesian	primary	Latn	Latin
 id	Indonesian	secondary	Arab	Arabic
-ie	Interlingue	secondary	Latn	Latin
+ie	Interlingue	primary	Latn	Latin
 ife	Ifè	primary	Latn	Latin
 ig	Igbo	primary	Latn	Latin
 ii	Sichuan Yi	primary	Yiii	Yi
@@ -349,6 +355,7 @@ ilo	Iloko	primary	Latn	Latin
 inh	Ingush	primary	Cyrl	Cyrillic
 inh	Ingush	secondary	Arab	Arabic
 inh	Ingush	secondary	Latn	Latin
+io	Ido	primary	Latn	Latin
 is	Icelandic	primary	Latn	Latin
 it	Italian	primary	Latn	Latin
 iu	Inuktitut	primary	Cans	Unified Canadian Aboriginal Syllabics
@@ -356,12 +363,13 @@ iu	Inuktitut	primary	Latn	Latin
 izh	Ingrian	primary	Latn	Latin
 ja	Japanese	primary	Jpan	Japanese
 jam	Jamaican Creole English	primary	Latn	Latin
+jbo	Lojban	primary	Latn	Latin
 jgo	Ngomba	primary	Latn	Latin
 jmc	Machame	primary	Latn	Latin
 jml	Jumli	primary	Deva	Devanagari
 jpr	Judeo-Persian	primary	Hebr	Hebrew
 jrb	Judeo-Arabic	primary	Hebr	Hebrew
-jut	Jutish	secondary	Latn	Latin
+jut	Jutish	primary	Latn	Latin
 jv	Javanese	primary	Latn	Latin
 jv	Javanese	secondary	Java	Javanese
 ka	Georgian	primary	Geor	Georgian
@@ -382,6 +390,7 @@ kck	Kalanga	primary	Latn	Latin
 kde	Makonde	primary	Latn	Latin
 kdt	Kuy	primary	Thai	Thai
 kea	Kabuverdianu	primary	Latn	Latin
+ken	Kenyang	primary	Latn	Latin
 kfo	Koro	primary	Latn	Latin
 kfr	Kachhi	primary	Deva	Devanagari
 kfy	Kumaoni	primary	Deva	Devanagari
@@ -409,6 +418,7 @@ kln	Kalenjin	primary	Latn	Latin
 km	Khmer	primary	Khmr	Khmer
 kmb	Kimbundu	primary	Latn	Latin
 kn	Kannada	primary	Knda	Kannada
+knf	Mankanya	primary	Latn	Latin
 knn	Konkani	primary	Deva	Devanagari
 ko	Korean	primary	Kore	Korean
 koi	Komi-Permyak	primary	Cyrl	Cyrillic
@@ -449,8 +459,8 @@ ky	Kyrgyz	primary	Arab	Arabic
 ky	Kyrgyz	primary	Cyrl	Cyrillic
 ky	Kyrgyz	primary	Latn	Latin
 kyu	Western Kayah	primary	Kali	Kayah Li
-la	Latin	secondary	Latn	Latin
-lab	Linear A	secondary	Lina	Linear A
+la	Latin	primary	Latn	Latin
+lab	Linear A	primary	Lina	Linear A
 lad	Ladino	primary	Hebr	Hebrew
 lag	Langi	primary	Latn	Latin
 lah	Lahnda	primary	Arab	Arabic
@@ -460,6 +470,7 @@ lb	Luxembourgish	primary	Latn	Latin
 lbe	Lak	primary	Cyrl	Cyrillic
 lbw	Tolaki	primary	Latn	Latin
 lcp	Western Lawa	primary	Thai	Thai
+len	Lenca	primary	Latn	Latin
 lep	Lepcha	primary	Lepc	Lepcha
 lez	Lezghian	primary	Cyrl	Cyrillic
 lez	Lezghian	secondary	Aghb	Caucasian Albanian
@@ -472,7 +483,7 @@ lif	Limbu	primary	Limb	Limbu
 lij	Ligurian	primary	Latn	Latin
 lil	Lillooet	primary	Latn	Latin
 lis	Lisu	primary	Lisu	Fraser
-liv	Livonian	secondary	Latn	Latin
+liv	Livonian	primary	Latn	Latin
 ljp	Lampung Api	primary	Latn	Latin
 lki	Laki	primary	Arab	Arabic
 lkt	Lakota	primary	Latn	Latin
@@ -488,16 +499,16 @@ lt	Lithuanian	primary	Latn	Latin
 ltg	Latgalian	primary	Latn	Latin
 lu	Luba-Katanga	primary	Latn	Latin
 lua	Luba-Lulua	primary	Latn	Latin
-lui	Luiseno	secondary	Latn	Latin
+lui	Luiseno	primary	Latn	Latin
 lun	Lunda	primary	Latn	Latin
 luo	Luo	primary	Latn	Latin
 lus	Mizo	primary	Beng	Bangla
-lut	Lushootseed	secondary	Latn	Latin
+lut	Lushootseed	primary	Latn	Latin
 luy	Luyia	primary	Latn	Latin
 luz	Southern Luri	primary	Arab	Arabic
 lv	Latvian	primary	Latn	Latin
 lwl	Eastern Lawa	primary	Thai	Thai
-lzh	Literary Chinese	secondary	Hans	Simplified
+lzh	Literary Chinese	primary	Hans	Simplified
 lzz	Laz	primary	Latn	Latin
 lzz	Laz	secondary	Geor	Georgian
 mad	Madurese	primary	Latn	Latin
@@ -521,6 +532,7 @@ men	Mende	secondary	Mend	Mende
 mer	Meru	primary	Latn	Latin
 mfa	Pattani Malay	primary	Arab	Arabic
 mfe	Morisyen	primary	Latn	Latin
+mfv	Mandjak	primary	Latn	Latin
 mg	Malagasy	primary	Latn	Latin
 mgh	Makhuwa-Meetto	primary	Latn	Latin
 mgo	Metaʼ	primary	Latn	Latin
@@ -537,7 +549,7 @@ mls	Masalit	primary	Latn	Latin
 mn	Mongolian	primary	Cyrl	Cyrillic
 mn	Mongolian	secondary	Mong	Mongolian
 mn	Mongolian	secondary	Phag	Phags-pa
-mnc	Manchu	secondary	Mong	Mongolian
+mnc	Manchu	primary	Mong	Mongolian
 mni	Manipuri	primary	Beng	Bangla
 mni	Manipuri	secondary	Mtei	Meitei Mayek
 mns	Mansi	primary	Cyrl	Cyrillic
@@ -566,7 +578,7 @@ mxc	Manyika	primary	Latn	Latin
 my	Burmese	primary	Mymr	Myanmar
 myv	Erzya	primary	Cyrl	Cyrillic
 myx	Masaaba	primary	Latn	Latin
-myz	Classical Mandaic	secondary	Mand	Mandaean
+myz	Classical Mandaic	primary	Mand	Mandaean
 mzn	Mazanderani	primary	Arab	Arabic
 na	Nauru	primary	Latn	Latin
 nan	Min Nan Chinese	primary	Hans	Simplified
@@ -596,8 +608,8 @@ no	Norwegian	primary	Latn	Latin
 nod	Northern Thai	primary	Lana	Lanna
 noe	Nimadi	primary	Deva	Devanagari
 nog	Nogai	primary	Cyrl	Cyrillic
-non	Old Norse	secondary	Runr	Runic
-nov	Novial	secondary	Latn	Latin
+non	Old Norse	primary	Runr	Runic
+nov	Novial	primary	Latn	Latin
 nqo	N’Ko	primary	Nkoo	N’Ko
 nr	South Ndebele	primary	Latn	Latin
 nsk	Naskapi	primary	Cans	Unified Canadian Aboriginal Syllabics
@@ -625,7 +637,7 @@ osa	Osage	primary	Osge	Osage
 osa	Osage	secondary	Latn	Latin
 osc	Oscan	secondary	Ital	Old Italic
 osc	Oscan	secondary	Latn	Latin
-otk	Old Turkish	secondary	Orkh	Orkhon
+otk	Old Turkish	primary	Orkh	Orkhon
 pa	Punjabi	primary	Arab	Arabic
 pa	Punjabi	primary	Guru	Gurmukhi
 pag	Pangasinan	primary	Latn	Latin
@@ -638,9 +650,9 @@ pcd	Picard	primary	Latn	Latin
 pcm	Nigerian Pidgin	primary	Latn	Latin
 pdc	Pennsylvania German	primary	Latn	Latin
 pdt	Plautdietsch	primary	Latn	Latin
-peo	Old Persian	secondary	Xpeo	Old Persian
+peo	Old Persian	primary	Xpeo	Old Persian
 pfl	Palatine German	primary	Latn	Latin
-phn	Phoenician	secondary	Phnx	Phoenician
+phn	Phoenician	primary	Phnx	Phoenician
 pi	Pali	primary	Mymr	Myanmar
 pi	Pali	secondary	Deva	Devanagari
 pi	Pali	secondary	Sinh	Sinhala
@@ -653,10 +665,11 @@ pnt	Pontic	primary	Grek	Greek
 pnt	Pontic	secondary	Cyrl	Cyrillic
 pnt	Pontic	secondary	Latn	Latin
 pon	Pohnpeian	primary	Latn	Latin
+ppl	Nahaut Pipil	primary	Latn	Latin
 pqm	Malecite	primary	Latn	Latin
 prd	Parsi-Dari	primary	Arab	Arabic
-prg	Prussian	secondary	Latn	Latin
-pro	Old Provençal	secondary	Latn	Latin
+prg	Prussian	primary	Latn	Latin
+pro	Old Provençal	primary	Latn	Latin
 ps	Pashto	primary	Arab	Arabic
 pt	Portuguese	primary	Latn	Latin
 puu	Punu	primary	Latn	Latin
@@ -735,7 +748,7 @@ see	Seneca	primary	Latn	Latin
 sef	Cebaara Senoufo	primary	Latn	Latin
 seh	Sena	primary	Latn	Latin
 sei	Seri	primary	Latn	Latin
-sel	Selkup	secondary	Cyrl	Cyrillic
+sel	Selkup	primary	Cyrl	Cyrillic
 ses	Koyraboro Senni	primary	Latn	Latin
 sg	Sango	primary	Latn	Latin
 sga	Old Irish	secondary	Latn	Latin
@@ -756,9 +769,10 @@ sm	Samoan	primary	Latn	Latin
 sma	Southern Sami	primary	Latn	Latin
 smj	Lule Sami	primary	Latn	Latin
 smn	Inari Sami	primary	Latn	Latin
-smp	Samaritan	secondary	Samr	Samaritan
+smp	Samaritan	primary	Samr	Samaritan
 sms	Skolt Sami	primary	Latn	Latin
 sn	Shona	primary	Latn	Latin
+snf	Noon	primary	Latn	Latin
 snk	Soninke	primary	Latn	Latin
 so	Somali	primary	Latn	Latin
 so	Somali	secondary	Arab	Arabic
@@ -792,7 +806,7 @@ sxn	Sangir	primary	Latn	Latin
 syi	Seki	primary	Latn	Latin
 syl	Sylheti	primary	Beng	Bangla
 syl	Sylheti	secondary	Sylo	Syloti Nagri
-syr	Syriac	secondary	Syrc	Syriac
+syr	Syriac	primary	Syrc	Syriac
 szl	Silesian	primary	Latn	Latin
 ta	Tamil	primary	Taml	Tamil
 tab	Tabassaran	primary	Cyrl	Cyrillic
@@ -833,6 +847,7 @@ tly	Talysh	secondary	Arab	Arabic
 tly	Talysh	secondary	Cyrl	Cyrillic
 tmh	Tamashek	primary	Latn	Latin
 tn	Tswana	primary	Latn	Latin
+tnr	Ménik	primary	Latn	Latin
 to	Tongan	primary	Latn	Latin
 tog	Nyasa Tonga	primary	Latn	Latin
 tok	Toki Pona	primary	Latn	Latin
@@ -867,10 +882,11 @@ udm	Udmurt	secondary	Latn	Latin
 ug	Uyghur	primary	Arab	Arabic
 ug	Uyghur	primary	Cyrl	Cyrillic
 ug	Uyghur	secondary	Latn	Latin
-uga	Ugaritic	secondary	Ugar	Ugaritic
+uga	Ugaritic	primary	Ugar	Ugaritic
 uk	Ukrainian	primary	Cyrl	Cyrillic
 uli	Ulithian	primary	Latn	Latin
 umb	Umbundu	primary	Latn	Latin
+und	Unknown	primary	Latn	Latin
 unr	Mundari	primary	Beng	Bangla
 unr	Mundari	primary	Deva	Devanagari
 unx	Munda	primary	Beng	Bangla
@@ -890,8 +906,8 @@ vic	Virgin Islands Creole English	primary	Latn	Latin
 vls	West Flemish	primary	Latn	Latin
 vmf	Main-Franconian	primary	Latn	Latin
 vmw	Makhuwa	primary	Latn	Latin
-vo	Volapük	secondary	Latn	Latin
-vot	Votic	secondary	Latn	Latin
+vo	Volapük	primary	Latn	Latin
+vot	Votic	primary	Latn	Latin
 vro	Võro	primary	Latn	Latin
 vun	Vunjo	primary	Latn	Latin
 wa	Walloon	primary	Latn	Latin
@@ -910,18 +926,18 @@ wtm	Mewati	primary	Deva	Devanagari
 wuu	Wu Chinese	primary	Hans	Simplified
 xal	Kalmyk	primary	Cyrl	Cyrillic
 xav	Xavánte	primary	Latn	Latin
-xcr	Carian	secondary	Cari	Carian
+xcr	Carian	primary	Cari	Carian
 xh	Xhosa	primary	Latn	Latin
-xlc	Lycian	secondary	Lyci	Lycian
-xld	Lydian	secondary	Lydi	Lydian
+xlc	Lycian	primary	Lyci	Lycian
+xld	Lydian	primary	Lydi	Lydian
 xmf	Mingrelian	primary	Geor	Georgian
-xmn	Manichaean Middle Persian	secondary	Mani	Manichaean
-xmr	Meroitic	secondary	Merc	Meroitic Cursive
-xna	Ancient North Arabian	secondary	Narb	Old North Arabian
+xmn	Manichaean Middle Persian	primary	Mani	Manichaean
+xmr	Meroitic	primary	Merc	Meroitic Cursive
+xna	Ancient North Arabian	primary	Narb	Old North Arabian
 xnr	Kangri	primary	Deva	Devanagari
 xog	Soga	primary	Latn	Latin
-xpr	Parthian	secondary	Prti	Inscriptional Parthian
-xsa	Sabaean	secondary	Sarb	Old South Arabian
+xpr	Parthian	primary	Prti	Inscriptional Parthian
+xsa	Sabaean	primary	Sarb	Old South Arabian
 xsr	Sherpa	primary	Deva	Devanagari
 xum	Umbrian	secondary	Ital	Old Italic
 xum	Umbrian	secondary	Latn	Latin
@@ -942,7 +958,7 @@ zag	Zaghawa	primary	Latn	Latin
 zap	Zapotec	primary	Latn	Latin
 zdj	Ngazidja Comorian	primary	Arab	Arabic
 zea	Zeelandic	primary	Latn	Latin
-zen	Zenaga	secondary	Tfng	Tifinagh
+zen	Zenaga	primary	Tfng	Tifinagh
 zgh	Standard Moroccan Tamazight	primary	Tfng	Tifinagh
 zh	Chinese	primary	Hans	Simplified
 zh	Chinese	primary	Hant	Traditional

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -820,7 +820,7 @@ public class TestInheritance extends TestFmwk {
                                 + ","
                                 + " but "
                                 + language
-                                + " is missing in language_script.txt");
+                                + " is missing in language_script.tsv");
                 continue;
             }
             for (BasicLanguageData entry : data.values()) {
@@ -839,7 +839,7 @@ public class TestInheritance extends TestFmwk {
                             + language
                             + " doesn't have "
                             + script
-                            + " in language_script.txt");
+                            + " in language_script.tsv");
         }
     }
 


### PR DESCRIPTION
This change adds "primary" scripts to many languages in language_script.tsv.

This won't change likely subtags, rather this just future-proofs our data by recognizing a singular primary script, avoiding issues where ambiguities served customers the wrong script.

I also added scripts for languages in country_language_population.tsv that were missing.

CLDR-18108

- [x] This PR completes the ticket.


There are many more tasks, especially more complicated ones, in the parent ticket https://unicode-org.atlassian.net/browse/CLDR-18102

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
