### PR TITLE
CLDR-18122 Update MessageFormat test data

### DIFF
--- a/common/testData/messageFormat/README.md
+++ b/common/testData/messageFormat/README.md
@@ -1,7 +1,3 @@
-# Test Data for CLDR MessageFormat 2.0 Tech Preview
-
-For information about MessageFormat 2.0, see [Unicode Locale Data Markup Language (LDML): Part 9: Message Format](../../../docs/ldml/tr35-messageFormat.md)
-
 The tests in the `./tests/` directory were originally copied from the [messageformat project](https://github.com/messageformat/messageformat/tree/11c95dab2b25db8454e49ff4daadb817e1d5b770/packages/mf2-messageformat/src/__fixtures)
 and are here relicensed by their original author (Eemeli Aro) under the Unicode License.
 
@@ -14,6 +10,8 @@ These test files are intended to be useful for testing multiple different messag
 - `data-model-errors.json` - Strings that should produce a Data Model Error when processed.
   Error names are defined in ["MessageFormat 2.0 Errors"](../spec/errors.md) in the spec.
 
+- `u-options.json` — Test cases for the `u:` options, using built-in functions.
+
 - `functions/` — Test cases that correspond to built-in functions.
   The behaviour of the built-in formatters is implementation-specific so the `exp` field is often
   omitted and assertions are made on error cases.
@@ -25,6 +23,7 @@ Some examples of test harnesses using these tests, from the source repository:
 - [Formatting tests](https://github.com/messageformat/messageformat/blob/11c95dab2b25db8454e49ff4daadb817e1d5b770/packages/mf2-messageformat/src/messageformat.test.ts)
 
 A [JSON schema](./schemas/) is included for the test files in this repository.
+
 ## Error Codes
 
 The following table relates the error names used in the [JSON schema](./schemas/)
@@ -88,8 +87,8 @@ its `Input`, `DecimalPlaces`, `FailsFormat`, and `FailsSelect` values are determ
 1. Let `DecimalPlaces` be 0.
 1. Let `FailsFormat` be `false`.
 1. Let `FailsSelect` be `false`.
-1. Let `arg` be the resolved value of the _expression_ _operand_.
-1. If `arg` is the resolved value of an _expression_
+1. Let `arg` be the _resolved value_ of the _expression_ _operand_.
+1. If `arg` is the _resolved value_ of an _expression_
    with a `:test:function`, `:test:select`, or `:test:format` _annotation_
    for which resolution has succeeded, then
    1. Let `Input` be the `Input` value of `arg`.
@@ -101,7 +100,7 @@ its `Input`, `DecimalPlaces`, `FailsFormat`, and `FailsSelect` values are determ
    1. Let `Input` be the numerical value of `arg`.
 1. Else,
    1. Emit "bad-input" _Resolution Error_.
-   1. Use a _fallback value_ as the resolved value of the _expression_.
+   1. Use a _fallback value_ as the _resolved value_ of the _expression_.
       Further steps of this algorithm are not followed.
 1. If the `decimalPlaces` _option_ is set, then
    1. If its value resolves to a numerical integer value 0 or 1
@@ -109,7 +108,7 @@ its `Input`, `DecimalPlaces`, `FailsFormat`, and `FailsSelect` values are determ
       1. Set `DecimalPlaces` to be the numerical value of the _option_.
    1. Else if its value is not an unresolved value set by _option resolution_,
       1. Emit "bad-option" _Resolution Error_.
-      1. Use a _fallback value_ as the resolved value of the _expression_.
+      1. Use a _fallback value_ as the _resolved value_ of the _expression_.
 1. If the `fails` _option_ is set, then
    1. If its value resolves to the string `'always'`, then
       1. Set `FailsFormat` to be `true`.
@@ -137,7 +136,7 @@ depends on its `Input`, `DecimalPlaces` and `FailsSelect` values.
 
 When an _expression_ with a `:test:function` _annotation_ is assigned to a _variable_ by a _declaration_
 and that _variable_ is used as an _option_ value,
-its resolved value is the `Input` value.
+its _resolved value_ is the `Input` value.
 
 When `:test:function` is used as a _formatter_,
 a _placeholder_ resolving to a value with a `:test:function` _expression_

--- a/common/testData/messageFormat/schemas/v0/tests.schema.json
+++ b/common/testData/messageFormat/schemas/v0/tests.schema.json
@@ -118,6 +118,9 @@
         "src": {
           "$ref": "#/$defs/src"
         },
+        "bidiIsolation": {
+          "$ref": "#/$defs/bidiIsolation"
+        },
         "params": {
           "$ref": "#/$defs/params"
         },
@@ -146,6 +149,9 @@
         "src": {
           "$ref": "#/$defs/src"
         },
+        "bidiIsolation": {
+          "$ref": "#/$defs/bidiIsolation"
+        },
         "params": {
           "$ref": "#/$defs/params"
         },
@@ -171,6 +177,10 @@
     "src": {
       "description": "The MF2 syntax source.",
       "type": "string"
+    },
+    "bidiIsolation": {
+      "description": "The bidi isolation strategy.",
+      "enum": ["default", "none"]
     },
     "params": {
       "description": "Parameters to pass in to the formatter for resolving external variables.",
@@ -244,6 +254,23 @@
             }
           },
           {
+            "description": "Bidi isolation part.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "const": "bidiIsolation"
+              },
+              "value": {
+                "enum": ["\u2066", "\u2067", "\u2068", "\u2069"]
+              }
+            }
+          },
+          {
             "description": "Message markup part.",
             "type": "object",
             "additionalProperties": false,
@@ -267,6 +294,9 @@
                 "type": "string"
               },
               "name": {
+                "type": "string"
+              },
+              "id": {
                 "type": "string"
               },
               "options": {

--- a/common/testData/messageFormat/tests/bidi.json
+++ b/common/testData/messageFormat/tests/bidi.json
@@ -1,0 +1,146 @@
+{
+  "scenario": "Bidi support",
+  "description": "Tests for correct parsing of messages with bidirectional marks and isolates",
+  "defaultTestProperties": {
+    "bidiIsolation": "default",
+    "locale": "en-US"
+  },
+  "tests": [
+    {
+        "description": "simple-message    = o [simple-start pattern]",
+        "src": "  \u061C Hello world!",
+        "exp": "  \u061C Hello world!"
+    },
+    {
+        "description": "complex-message   = o *(declaration o) complex-body o",
+        "src": "\u200E .local $x = {1} {{ {$x}}}",
+        "exp": " \u20681\u2069"
+    },
+    {
+        "description": "complex-message   = o *(declaration o) complex-body o",
+        "src": ".local $x = {1} \u200F {{ {$x}}}",
+        "exp": " \u20681\u2069"
+    },
+    {
+        "description": "complex-message   = o *(declaration o) complex-body o",
+        "src": ".local $x = {1} {{ {$x}}} \u2066",
+        "exp": " \u20681\u2069"
+    },
+    {
+        "description": "input-declaration = input o variable-expression",
+        "src": ".input \u2067 {$x :number} {{hello}}",
+        "params": [{"name": "x", "value": "1"}],
+        "exp": "hello"
+    },
+    {
+        "description": "local s variable o \"=\" o expression",
+        "src": ".local $x \u2068 = \u2069 {1} {{hello}}",
+        "exp": "hello"
+    },
+    {
+        "description": "local s variable o \"=\" o expression",
+        "src": ".local \u2067 $x = {1} {{hello}}",
+        "exp": "hello"
+    },
+    {
+        "description": "local s variable o \"=\" o expression",
+        "src": ".local\u2067 $x = {1} {{hello}}",
+        "exp": "hello"
+    },
+    {
+        "description": "o \"{{\" pattern \"}}\"",
+        "src": "\u2067 {{hello}}",
+        "exp": "hello"
+    },
+    {
+        "description": "match-statement s variant *(o variant)",
+        "src": ".local $x = {1 :number}\n.match $x\n1 {{one}}\n\u061C * {{other}}",
+        "exp": "one"
+    },
+    {
+        "description": "match-statement s variant *(o variant)",
+        "src": ".local $x = {1 :number}.match $x \u061c1 {{one}}* {{other}}",
+        "exp": "one"
+    },
+    {
+        "description": "match-statement s variant *(o variant)",
+        "src": ".local $x = {1 :number}.match $x\u061c1 {{one}}* {{other}}",
+        "expErrors": [{"type": "syntax-error"}]
+    },
+    {
+        "description": "variant = key *(s key) quoted-pattern",
+        "src": ".local $x = {1 :number} .local $y = {$x :number}.match $x $y\n1 \u200E 1 {{one}}* * {{other}}",
+        "exp": "one"
+    },
+    {
+        "description": "variant = key *(s key) quoted-pattern",
+        "src": ".local $x = {1 :number} .local $y = {$x :number}.match $x $y\n1\u200E 1 {{one}}* * {{other}}",
+        "exp": "one"
+    },
+    {
+        "description": "literal-expression  = \"{\" o literal [s function] *(s attribute) o \"}\"",
+        "src": "{\u200E hello \u200F}",
+        "exp": "\u2068hello\u2069"
+    },
+    {
+        "description": "variable-expression = \"{\" o variable [s function] *(s attribute) o \"}\"",
+        "src": ".local $x = {1} {{ {\u200E $x \u200F} }}",
+        "exp": " \u20681\u2069 "
+    },
+    {
+        "description": "function-expression = \"{\" o function *(s attribute) o \"}\"",
+        "src": "{1 \u200E :number \u200F}",
+        "exp": "1"
+    },
+    {
+        "description": "markup = \"{\" o \"#\" identifier *(s option) *(s attribute) o [\"/\"] \"}\"",
+        "src": "{\u200F #b \u200E }",
+        "exp": ""
+    },
+    {
+        "description": "markup = \"{\" o \"/\" identifier *(s option) *(s attribute) o \"}\"",
+        "src": "{\u200F /b \u200E }",
+        "exp": ""
+    },
+    {
+        "description": "option = identifier o \"=\" o (literal / variable)",
+        "src": "{1 :number minimumFractionDigits\u200F=\u200E1 }",
+        "exp": "1.0"
+    },
+    {
+        "description": "attribute      = \"@\" identifier [o \"=\" o (literal / variable)]",
+        "src": "{1 :number @locale\u200F=\u200Een }",
+        "exp": "1"
+    },
+    {
+        "description":  " name... excludes U+FFFD and U+061C -- this pases as name -> [bidi] name-start *name-char",
+        "src": ".local $\u061Cfoo = {1} {{ {$\u061Cfoo} }}",
+        "exp": " \u20681\u2069 "
+    },
+    {
+        "description":  " name matches https://www.w3.org/TR/REC-xml-names/#NT-NCName but excludes U+FFFD and U+061C",
+        "src": ".local $foo\u061Cbar = {2} {{ }}",
+        "expErrors": [{"type": "syntax-error"}]
+    },
+    {
+        "description":  "name       = [bidi] name-start *name-char [bidi]",
+        "src": ".local $\u200Efoo\u200F = {3} {{{$\u200Efoo\u200F}}}",
+        "exp": "\u20683\u2069"
+    },
+    {
+        "description":  "name       = [bidi] name-start *name-char [bidi]",
+        "src": ".local $foo = {4} {{{$\u200Efoo\u200F}}}",
+        "exp": "\u20684\u2069"
+    },
+    {
+        "description":  "name       = [bidi] name-start *name-char [bidi]",
+        "src": ".local $\u200Efoo\u200F = {5} {{{$foo}}}",
+        "exp": "\u20685\u2069"
+    },
+    {
+        "description":  "name       = [bidi] name-start *name-char [bidi]",
+        "src": ".local $foo\u200Ebar = {5} {{{$foo\u200Ebar}}}",
+        "expErrors": [{"type": "syntax-error"}]
+    }
+  ]
+}

--- a/common/testData/messageFormat/tests/fallback.json
+++ b/common/testData/messageFormat/tests/fallback.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "scenario": "Fallback",
+  "description": "Test cases for fallback behaviour.",
+  "defaultTestProperties": {
+    "bidiIsolation": "none",
+    "locale": "en-US",
+    "expErrors": true
+  },
+  "tests": [
+    {
+      "description": "function with unquoted literal operand",
+      "src": "{42 :test:function fails=format}",
+      "exp": "{|42|}"
+    },
+    {
+      "description": "function with quoted literal operand",
+      "src": "{|C:\\\\| :test:function fails=format}",
+      "exp": "{|C:\\\\|}"
+    },
+    {
+      "description": "unannotated implicit input variable",
+      "src": "{$var}",
+      "exp": "{$var}"
+    },
+    {
+      "description": "annotated implicit input variable",
+      "src": "{$var :number}",
+      "exp": "{$var}"
+    },
+    {
+      "description": "local variable with unknown function in declaration",
+      "src": ".local $var = {|val| :test:undefined} {{{$var}}}",
+      "exp": "{$var}"
+    },
+    {
+      "description": "function with local variable operand with unknown function in declaration",
+      "src": ".local $var = {|val| :test:undefined} {{{$var :test:function}}}",
+      "exp": "{$var}"
+    },
+    {
+      "description": "local variable with unknown function in placeholder",
+      "src": ".local $var = {|val|} {{{$var :test:undefined}}}",
+      "exp": "{$var}"
+    },
+    {
+      "description": "function with no operand",
+      "src": "{:test:undefined}",
+      "exp": "{:test:undefined}"
+    }
+  ]
+}

--- a/common/testData/messageFormat/tests/functions/currency.json
+++ b/common/testData/messageFormat/tests/functions/currency.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "scenario": "Currency function",
+  "description": "The built-in formatter and selector for currencies.",
+  "defaultTestProperties": {
+    "bidiIsolation": "none",
+    "locale": "en-US"
+  },
+  "tests": [
+    {
+      "src": "{:currency}",
+      "expErrors": [{ "type": "bad-operand" }]
+    },
+    {
+      "src": "{foo :currency}",
+      "expErrors": [{ "type": "bad-operand" }]
+    },
+    {
+      "src": "{42 :currency}",
+      "expErrors": [{ "type": "bad-operand" }]
+    },
+    {
+      "src": ".local $n = {42 :number} {{{$n :currency}}}",
+      "expErrors": [{ "type": "bad-operand" }]
+    },
+    {
+      "src": "{42 :currency currency=EUR}",
+      "expErrors": false
+    },
+    {
+      "src": ".local $n = {42 :number} {{{$n :currency currency=EUR}}}",
+      "expErrors": false
+    },
+    {
+      "src": ".local $n = {42 :integer} {{{$n :currency currency=EUR}}}",
+      "expErrors": false
+    },
+    {
+      "src": ".local $n = {42 :currency currency=EUR} {{{$n :currency}}}",
+      "expErrors": false
+    },
+    {
+      "src": "{42 :currency currency=EUR fractionDigits=auto}",
+      "expErrors": false
+    },
+    {
+      "src": "{42 :currency currency=EUR fractionDigits=2}",
+      "expErrors": false
+    },
+    {
+      "src": "{$x :currency currency=EUR}",
+      "params": [{ "name": "x", "value": 41 }],
+      "expErrors": false
+    },
+    {
+      "src": ".local $n = {42 :currency currency=EUR} .match $n * {{other}}",
+      "exp": "other",
+      "expErrors": false
+    }
+  ]
+}

--- a/common/testData/messageFormat/tests/functions/date.json
+++ b/common/testData/messageFormat/tests/functions/date.json
@@ -3,6 +3,7 @@
   "scenario": "Date function",
   "description": "The built-in formatter for dates.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US",
     "expErrors": false
   },
@@ -35,10 +36,10 @@
       "src": "{|2006-01-02| :date style=long}"
     },
     {
-      "src": ".local $d = {|2006-01-02| :date style=long} {{{$d :date}}}"
+      "src": ".local $d = {|2006-01-02| :date style=long} {{{$d}}}"
     },
     {
-      "src": ".local $t = {|2006-01-02T15:04:06| :time} {{{$t :date}}}"
+      "src": ".local $d = {|2006-01-02| :datetime dateStyle=long timeStyle=long} {{{$d :date}}}"
     }
   ]
 }

--- a/common/testData/messageFormat/tests/functions/datetime.json
+++ b/common/testData/messageFormat/tests/functions/datetime.json
@@ -3,6 +3,7 @@
   "scenario": "Datetime function",
   "description": "The built-in formatter for datetimes.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US",
     "expErrors": false
   },

--- a/common/testData/messageFormat/tests/functions/integer.json
+++ b/common/testData/messageFormat/tests/functions/integer.json
@@ -3,6 +3,7 @@
   "scenario": "Integer function",
   "description": "The built-in formatter for integers.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [
@@ -19,14 +20,18 @@
       "exp": "hello 4"
     },
     {
-      "src": ".input {$foo :integer} .match $foo 1 {{one}} * {{other}}",
-      "params": [
-        {
-          "name": "foo",
-          "value": 1.2
-        }
-      ],
-      "exp": "one"
+      "src": ".input {$foo :integer} .match $foo 1 {{=1}} * {{other}}",
+      "params": [{ "name": "foo", "value": 1.2 }],
+      "exp": "=1"
+    },
+    {
+      "src": ".input {$foo :integer} .match $foo 1 {{=1}} one {{one}} * {{other}}",
+      "params": [{ "name": "foo", "value": 1.2 }],
+      "exp": "=1"
+    },
+    {
+      "src": ".local $x = {1.25 :integer} .local $y = {$x :number} {{{$y}}}",
+      "exp": "1"
     }
   ]
 }

--- a/common/testData/messageFormat/tests/functions/math.json
+++ b/common/testData/messageFormat/tests/functions/math.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "scenario": "Math function",
+  "description": "The built-in formatter and selector for addition and subtraction.",
+  "defaultTestProperties": {
+    "bidiIsolation": "none",
+    "locale": "en-US"
+  },
+  "tests": [
+    {
+      "src": "{:math add=13}",
+      "expErrors": [{ "type": "bad-operand" }]
+    },
+    {
+      "src": "{foo :math add=13}",
+      "expErrors": [{ "type": "bad-operand" }]
+    },
+    {
+      "src": "{42 :math}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "{42 :math add=foo}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "{42 :math subtract=foo}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "{42 :math foo=13}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "{42 :math add=13 subtract=13}",
+      "expErrors": [{ "type": "bad-option" }]
+    },
+    {
+      "src": "{41 :math add=1}",
+      "exp": "42"
+    },
+    {
+      "src": "{52 :math subtract=10}",
+      "exp": "42"
+    },
+    {
+      "src": "{41 :math add=1 foo=13}",
+      "exp": "42"
+    },
+    {
+      "src": ".local $x = {41 :integer signDisplay=always} {{{$x :math add=1}}}",
+      "exp": "+42"
+    },
+    {
+      "src": ".local $x = {52 :number signDisplay=always} {{{$x :math subtract=10}}}",
+      "exp": "+42"
+    },
+    {
+      "src": "{$x :math add=1}",
+      "params": [{ "name": "x", "value": 41 }],
+      "exp": "42"
+    },
+    {
+      "src": "{$x :math subtract=10}",
+      "params": [{ "name": "x", "value": 52 }],
+      "exp": "42"
+    },
+    {
+      "src": ".local $x = {1 :math add=1} .match $x 1 {{=1}} 2 {{=2}} * {{other}}",
+      "exp": "=2"
+    },
+    {
+      "src": ".local $x = {10 :integer} .local $y = {$x :math subtract=6} .match $y 10 {{=10}} 4 {{=4}} * {{other}}",
+      "exp": "=4"
+    }
+  ]
+}

--- a/common/testData/messageFormat/tests/functions/number.json
+++ b/common/testData/messageFormat/tests/functions/number.json
@@ -3,6 +3,7 @@
   "scenario": "Number function",
   "description": "The built-in formatter for numbers.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [
@@ -131,33 +132,14 @@
     },
     {
       "src": ".local $foo = {$bar :number minimumFractionDigits=foo} {{bar {$foo}}}",
-      "params": [
-        {
-          "name": "bar",
-          "value": 4.2
-        }
-      ],
-      "exp": "bar {$bar}",
-      "expErrors": [
-        {
-          "type": "bad-option"
-        }
-      ]
+      "params": [{ "name": "bar", "value": 4.2 }],
+      "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": ".local $foo = {$bar :number} {{bar {$foo}}}",
-      "params": [
-        {
-          "name": "bar",
-          "value": "foo"
-        }
-      ],
-      "exp": "bar {$bar}",
-      "expErrors": [
-        {
-          "type": "bad-operand"
-        }
-      ]
+      "params": [{ "name": "bar", "value": "foo" }],
+      "exp": "bar {$foo}",
+      "expErrors": [{ "type": "bad-operand" }]
     },
     {
       "src": ".input {$foo :number} {{bar {$foo}}}",
@@ -181,18 +163,8 @@
     },
     {
       "src": ".input {$foo :number minimumFractionDigits=foo} {{bar {$foo}}}",
-      "params": [
-        {
-          "name": "foo",
-          "value": 4.2
-        }
-      ],
-      "exp": "bar {$foo}",
-      "expErrors": [
-        {
-          "type": "bad-option"
-        }
-      ]
+      "params": [{ "name": "foo", "value": 4.2 }],
+      "expErrors": [{ "type": "bad-option" }]
     },
     {
       "src": ".input {$foo :number} {{bar {$foo}}}",

--- a/common/testData/messageFormat/tests/functions/string.json
+++ b/common/testData/messageFormat/tests/functions/string.json
@@ -3,6 +3,7 @@
   "scenario": "String function",
   "description": "The built-in formatter for strings.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [
@@ -44,6 +45,31 @@
           "type": "unresolved-variable"
         }
       ]
+    },
+    {
+      "description": "NFC: keys are normalized (unquoted)",
+      "src": ".local $x = {\u1E0A\u0323 :string} .match $x \u1E0A\u0323 {{Not normalized}} \u1E0C\u0307 {{Normalized}} * {{Wrong}}",
+      "expErrors": [{"type": "duplicate-variant"}]
+    },
+    {
+      "description": "NFC: keys are normalized (quoted)",
+      "src": ".local $x = {\u1E0A\u0323 :string} .match $x |\u1E0A\u0323| {{Not normalized}} |\u1E0C\u0307| {{Normalized}} * {{Wrong}}",
+      "expErrors": [{"type": "duplicate-variant"}]
+    },
+    {
+      "description": "NFC: keys are normalized (mixed)",
+      "src": ".local $x = {\u1E0A\u0323 :string} .match $x \u1E0A\u0323 {{Not normalized}} |\u1E0C\u0307| {{Normalized}} * {{Wrong}}",
+      "expErrors": [{"type": "duplicate-variant"}]
+    },
+    {
+      "description": "NFC: :string normalizes the comparison value (un-normalized selector, normalized key)",
+      "src": ".local $x = {\u1E0A\u0323 :string} .match $x \u1E0C\u0307 {{Right}} * {{Wrong}}",
+      "exp": "Right"
+    },
+    {
+      "description": "NFC: keys are normalized (normalized selector, un-normalized key)",
+      "src": ".local $x = {\u1E0C\u0307 :string} .match $x \u1E0A\u0323 {{Right}} * {{Wrong}}",
+      "exp": "Right"
     }
   ]
 }

--- a/common/testData/messageFormat/tests/functions/time.json
+++ b/common/testData/messageFormat/tests/functions/time.json
@@ -3,6 +3,7 @@
   "scenario": "Time function",
   "description": "The built-in formatter for times.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US",
     "expErrors": false
   },
@@ -32,10 +33,10 @@
       "src": "{|2006-01-02T15:04:06| :time style=medium}"
     },
     {
-      "src": ".local $t = {|2006-01-02T15:04:06| :time style=medium} {{{$t :time}}}"
+      "src": ".local $t = {|2006-01-02T15:04:06| :time style=medium} {{{$t}}}"
     },
     {
-      "src": ".local $d = {|2006-01-02T15:04:06| :date} {{{$d :time}}}"
+      "src": ".local $t = {|2006-01-02T15:04:06| :datetime dateStyle=long timeStyle=long} {{{$t :time}}}"
     }
   ]
 }

--- a/common/testData/messageFormat/tests/syntax.json
+++ b/common/testData/messageFormat/tests/syntax.json
@@ -3,6 +3,7 @@
   "scenario": "Syntax",
   "description": "Test cases that do not depend on any registry definitions.",
   "defaultTestProperties": {
+    "bidiIsolation": "none",
     "locale": "en-US"
   },
   "tests": [
@@ -697,6 +698,43 @@
     {
       "src": "{{trailing whitespace}} \n",
       "exp": "trailing whitespace"
+    },
+    {
+      "description": "NFC: text is not normalized",
+      "src": "\u1E0A\u0323",
+      "exp": "\u1E0A\u0323"
+    },
+    {
+      "description": "NFC: variables are compared to each other as-if normalized; decl is non-normalized, use is",
+      "src": ".local $\u0044\u0323\u0307 = {foo} {{{$\u1E0c\u0307}}}",
+      "exp": "foo"
+    },
+    {
+      "description": "NFC: variables are compared to each other as-if normalized; decl is normalized, use isn't",
+      "src": ".local $\u1E0c\u0307 = {foo} {{{$\u0044\u0323\u0307}}}",
+      "exp": "foo"
+    },
+    {
+      "description": "NFC: variables are compared to each other as-if normalized; decl is normalized, use isn't",
+      "src": ".input {$\u1E0c\u0307} {{{$\u0044\u0323\u0307}}}",
+      "params": [{"name": "\u1E0c\u0307", "value": "foo"}],
+      "exp": "foo"
+    },
+    {
+      "description": "NFC: variables are compared to each other as-if normalized; decl is non-normalized, use is",
+      "src": ".input {$\u0044\u0323\u0307} {{{$\u1E0c\u0307}}}",
+      "params": [{"name": "\u0044\u0323\u0307", "value": "foo"}],
+      "exp": "foo"
+    },
+    {
+      "description": "NFC: variables are compared to each other as-if normalized; decl is non-normalized, use is; reordering",
+      "src": ".local $\u0044\u0307\u0323 = {foo} {{{$\u1E0c\u0307}}}",
+      "exp": "foo"
+    },
+    {
+      "description": "NFC: variables are compared to each other as-if normalized; decl is non-normalized, use is; special case mapping",
+      "src": ".local $\u0041\u030A\u0301 = {foo} {{{$\u01FA}}}",
+      "exp": "foo"
     }
   ]
 }

--- a/common/testData/messageFormat/tests/u-options.json
+++ b/common/testData/messageFormat/tests/u-options.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://raw.githubusercontent.com/unicode-org/message-format-wg/main/test/schemas/v0/tests.schema.json",
+  "scenario": "u: Options",
+  "description": "Common options affecting the function context",
+  "defaultTestProperties": {
+    "bidiIsolation": "default",
+    "locale": "en-US"
+  },
+  "tests": [
+    {
+      "src": "{#tag u:id=x}content{/ns:tag u:id=x}",
+      "exp": "content",
+      "expParts": [
+        {
+          "type": "markup",
+          "kind": "open",
+          "id": "x",
+          "name": "tag"
+        },
+        {
+          "type": "literal",
+          "value": "content"
+        },
+        {
+          "type": "markup",
+          "kind": "close",
+          "id": "x",
+          "name": "ns:tag"
+        }
+      ]
+    },
+    {
+      "src": "{#tag u:dir=rtl u:locale=ar}content{/ns:tag}",
+      "exp": "content",
+      "expErrors": [{ "type": "bad-option" }, { "type": "bad-option" }],
+      "expParts": [
+        {
+          "type": "markup",
+          "kind": "open",
+          "name": "tag"
+        },
+        {
+          "type": "literal",
+          "value": "content"
+        },
+        {
+          "type": "markup",
+          "kind": "close",
+          "name": "ns:tag"
+        }
+      ]
+    },
+    {
+      "src": "hello {4.2 :number u:locale=fr}",
+      "exp": "hello 4,2"
+    },
+    {
+      "src": "hello {world :string u:dir=ltr u:id=foo}",
+      "exp": "hello \u2066world\u2069",
+      "expParts": [
+        {
+          "type": "literal",
+          "value": "hello "
+        },
+        { "type": "bidiIsolation", "value": "\u2066" },
+        {
+          "type": "string",
+          "source": "|world|",
+          "dir": "ltr",
+          "id": "foo",
+          "value": "world"
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
+
+      ]
+    },
+    {
+      "src": "hello {world :string u:dir=rtl}",
+      "exp": "hello \u2067world\u2069",
+      "expParts": [
+        { "type": "literal", "value": "hello " },
+        { "type": "bidiIsolation", "value": "\u2067" },
+        {
+          "type": "string",
+          "source": "|world|",
+          "dir": "rtl",
+          "locale": "en-US",
+          "value": "world"
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
+      ]
+    },
+    {
+      "src": "hello {world :string u:dir=auto}",
+      "exp": "hello \u2068world\u2069",
+      "expParts": [
+        { "type": "literal", "value": "hello " },
+        { "type": "bidiIsolation", "value": "\u2068" },
+        {
+          "type": "string",
+          "source": "|world|",
+          "locale": "en-US",
+          "value": "world"
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
+      ]
+    },
+    {
+      "src": ".local $world = {world :string u:dir=ltr u:id=foo} {{hello {$world}}}",
+      "exp": "hello \u2066world\u2069",
+      "expParts": [
+        {
+          "type": "literal",
+          "value": "hello "
+        },
+        { "type": "bidiIsolation", "value": "\u2066" },
+        {
+          "type": "string",
+          "source": "|world|",
+          "dir": "ltr",
+          "id": "foo",
+          "value": "world"
+        },
+        { "type": "bidiIsolation", "value": "\u2069" }
+      ]
+    },
+    {
+      "locale": "ar",
+      "src": "أهلاً {بالعالم :string u:dir=rtl}",
+      "exp": "أهلاً \u2067بالعالم\u2069"
+    },
+    {
+      "locale": "ar",
+      "src": "أهلاً {بالعالم :string u:dir=auto}",
+      "exp": "أهلاً \u2068بالعالم\u2069"
+    },
+    {
+      "locale": "ar",
+      "src": "أهلاً {world :string u:dir=ltr}",
+      "exp": "أهلاً \u2066world\u2069"
+    },
+    {
+      "locale": "ar",
+      "src": "أهلاً {بالعالم :string}",
+      "exp": "أهلاً \u2068بالعالم\u2069"
+    }
+  ]
+}


### PR DESCRIPTION
Update the MessageFormat test data to reflect the latest state of tests in the MessageFormat WG repo. Currently, MFWG is finalizing the spec for 2.0 that it will submit soon to CLDR-TC for review, on the way to a special CLDR 46.1 point release planned for including the MF 2.0 spec at an off-cycle time point.

cc @catamorphism @mradbourne

CLDR-18122

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18122)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
