### PR TITLE
CLDR-18129 Investigate and fix (where necessary) invalid codes

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -61,7 +61,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT language ( #PCDATA ) >
 <!ATTLIST language type NMTOKEN #REQUIRED >
-    <!--@MATCH:validity/locale-->
+    <!--@MATCH:validity/nlocale-->
 <!ATTLIST language alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/long, secondary, short, variant, menu, official-->
 <!ATTLIST language draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -702,7 +702,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT languageAlias EMPTY >
 <!ATTLIST languageAlias type NMTOKEN #REQUIRED >
-    <!--@MATCH:or/validity/locale||literal/aa_saaho, aar, abk, afr, aka, alb, amh, ara, arg, arm, art_lojban, asm, ava, ave, aym, aze, bak, bam, baq, bel, ben, bih, bis, bod, bos, bre, bul, bur, cat, ces, cha, che, chi, chu, chv, cor, cos, cre, cym, cze, dan, deu, div, dut, dzo, ell, eng, epo, est, eus, ewe, fao, fas, fij, fin, fra, fre, fry, ful, geo, ger, gla, gle, glg, glv, gre, grn, guj, hat, hau, hbs, heb, her, hin, hmo, hrv, hun, hye, i_ami, i_bnn, i_hak, i_klingon, i_lux, i_navajo, i_pwn, i_tao, i_tay, i_tsu, ibo, ice, ido, iii, iku, ile, ina, ind, ipk, isl, ita, jav, jpn, kal, kan, kas, kat, kau, kaz, khm, kik, kin, kir, kom, kon, kor, kua, kur, lao, lat, lav, lim, lin, lit, ltz, lub, lug, mac, mah, mal, mao, mar, may, mkd, mlg, mlt, mol, mon, mri, msa, mya, nau, nav, nbl, nde, ndo, nep, nld, nno, no_bokmal, no_nynorsk, no_bok, no_nyn, nob, nor, nya, oci, oji, ori, orm, oss, pan, per, pli, pol, por, pus, que, roh, ron, rum, run, rus, sag, san, scc, scr, sgn_BE_FR, sgn_BE_NL, sgn_CH_DE, sin, slk, slo, slv, sme, smo, sna, snd, som, sot, spa, sqi, srd, srp, ssw, sun, swa, swe, tah, tam, tat, tel, tgk, tgl, tha, tib, tir, ton, tsn, tso, tuk, tur, twi, uig, ukr, urd, uzb, ven, vie, vol, wel, wln, wol, xho, yid, yor, zh_guoyu, zh_hakka, zh_min_nan, zh_xiang, zha, zho, zul, cel_gaulish, i_default, i_enochian, i_mingo, und_aaland, und_bokmal, und_hakka, und_lojban, und_nynorsk, und_saaho, und_xiang, zh_min, en_GB_oed, zh_cmn, zh_cmn_Hans, zh_cmn_Hant, zh_gan, zh_wuu, zh_yue-->
+    <!--@MATCH:or/validity/bcp47-wellformed||literal/aa_saaho, art_lojban, cel_gaulish, en_GB_oed, hy_arevmda, i_ami, i_bnn, i_default, i_enochian, i_hak, i_klingon, i_lux, i_mingo, i_navajo, i_pwn, i_tao, i_tay, i_tsu, no_bok, no_bokmal, no_nyn, no_nynorsk, sgn_BE_FR, sgn_BE_NL, sgn_BR, sgn_CH_DE, sgn_CO, sgn_DE, sgn_DK, sgn_ES, sgn_FR, sgn_GB, sgn_GR, sgn_IE, sgn_IT, sgn_JP, sgn_MX, sgn_NI, sgn_NL, sgn_NO, sgn_PT, sgn_SE, sgn_US, sgn_ZA, und_aaland, und_arevela, und_arevmda, und_bokmal, und_hakka, und_hepburn_heploc, und_lojban, und_nynorsk, und_saaho, und_xiang, zh_cmn, zh_cmn_Hans, zh_cmn_Hant, zh_gan, zh_guoyu, zh_hakka, zh_min, zh_min_nan, zh_wuu, zh_xiang, zh_yue-->
 <!ATTLIST languageAlias replacement NMTOKEN #REQUIRED >
     <!--@MATCH:or/validity/locale||literal/en_x_i_default, nan_x_zh_min, see_x_i_mingo, und_x_i_enochian, xtg_x_cel_gaulish-->
     <!--@VALUE-->
@@ -962,9 +962,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT likelySubtag EMPTY >
 <!ATTLIST likelySubtag from NMTOKEN #REQUIRED >
-    <!--@MATCH:validity/locale-->
+    <!--@MATCH:validity/xlocale-->
 <!ATTLIST likelySubtag to NMTOKEN #REQUIRED >
-    <!--@MATCH:validity/locale-->
+    <!--@MATCH:validity/xlocale-->
     <!--@VALUE-->
 <!ATTLIST likelySubtag origin NMTOKENS #IMPLIED >
     <!--@MATCH:set/literal/sil1, wikidata, special-->
@@ -996,7 +996,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT pluralRules ( pluralRule* ) >
 <!ATTLIST pluralRules locales NMTOKENS #REQUIRED >
-    <!--@MATCH:set/validity/locale-->
+    <!--@MATCH:set/or/validity/xlocale||literal/sh-->
 <!ATTLIST pluralRules draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
     <!--@DEPRECATED-->

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -152,7 +152,7 @@ annotations.
 			<language type="csw">Swampy Cree</language>
 			<language type="cu">Church Slavic</language>
 			<language type="cv">Chuvash</language>
-			<language type="cwd">Woods Cree</language>
+			<language type="cr">Cree</language>
 			<language type="cy">Welsh</language>
 			<language type="da">Danish</language>
 			<language type="dak">Dakota</language>
@@ -256,7 +256,7 @@ annotations.
 			<language type="hak">Hakka Chinese</language>
 			<language type="haw">Hawaiian</language>
 			<language type="hax">Southern Haida</language>
-			<language type="hdn">Northern Haida</language>
+			<language type="hai">Haida</language>
 			<language type="he">Hebrew</language>
 			<language type="hi">Hindi</language>
 			<language type="hi_Latn">Hindi (Latin)</language>
@@ -284,7 +284,7 @@ annotations.
 			<language type="ig">Igbo</language>
 			<language type="ii">Sichuan Yi</language>
 			<language type="ik">Inupiaq</language>
-			<language type="ike">Eastern Canadian Inuktitut</language>
+			<language type="iu">Inuktitut</language>
 			<language type="ikt">Western Canadian Inuktitut</language>
 			<language type="ilo">Iloko</language>
 			<language type="inh">Ingush</language>
@@ -474,7 +474,7 @@ annotations.
 			<language type="oj">Ojibwa</language>
 			<language type="ojb">Northwestern Ojibwa</language>
 			<language type="ojc">Central Ojibwa</language>
-			<language type="ojg">Eastern Ojibwa</language>
+			<language type="oj">Ojibwa</language>
 			<language type="ojs">Oji-Cree</language>
 			<language type="ojw">Western Ojibwa</language>
 			<language type="oka">Okanagan</language>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -31,7 +31,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="afh">afrihili</language>
 			<language type="agq">aghem</language>
 			<language type="ain">ainu</language>
-			<language type="ajp">urduni</language>
+			<language type="apc">urduni</language>
 			<language type="ak">akan</language>
 			<language type="akk">akkadi</language>
 			<language type="akz">alabama</language>

--- a/common/main/la.xml
+++ b/common/main/la.xml
@@ -24,7 +24,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="az" draft="provisional">Atropatenica</language>
 			<language type="be" draft="provisional">Ruthenica Alba</language>
 			<language type="bg" draft="provisional">Bulgarica</language>
-			<language type="bh" draft="provisional">Bihari</language>
 			<language type="bn" draft="provisional">Bengalica</language>
 			<language type="bo" draft="provisional">Tibetana</language>
 			<language type="br" draft="provisional">Britonica</language>
@@ -66,12 +65,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<language type="ia" draft="provisional">Interlingua</language>
 			<language type="ie" draft="provisional">Interlingue</language>
 			<language type="ig" draft="provisional">Igbonica</language>
-			<language type="in" draft="provisional">Indonesia</language>
+			<language type="id" draft="provisional">Indonesia</language>
 			<language type="is" draft="provisional">Islandica</language>
 			<language type="it" draft="provisional">Italiana</language>
-			<language type="iw" draft="provisional">Hebraica</language>
+			<language type="he" draft="provisional">Hebraica</language>
 			<language type="ja" draft="provisional">Iaponica</language>
-			<language type="ji" draft="provisional">Iudaeogermanica</language>
+			<language type="yi" draft="provisional">Iudaeogermanica</language>
 			<language type="jv" draft="provisional">Iavensis</language>
 			<language type="ka" draft="provisional">Georgiana</language>
 			<language type="kk" draft="provisional">Cazachica</language>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -31,7 +31,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<language type="afh">Afrihili</language>
 			<language type="agq">Aghem</language>
 			<language type="ain">Aino</language>
-			<language type="ajp" draft="contributed">Zuid-Levantijns-Arabisch</language>
+			<language type="apc" draft="contributed">Levantijns-Arabisch</language>
 			<language type="ak">Akan</language>
 			<language type="akk">Akkadisch</language>
 			<language type="akz">Alabama</language>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -4928,7 +4928,7 @@ XXX Code for transations where no currency is involved
 		<weekOfPreference ordering="weekOfYear weekOfInterval" locales="zu"/>
 		<weekOfPreference ordering="weekOfDate" locales="ca es fr gl"/>
 		<weekOfPreference ordering="weekOfDate weekOfMonth" locales="en bn ja ka"/>
-		<weekOfPreference ordering="weekOfDate weekOfMonth weekOfInterval" locales="bg de iw pt ur zh"/>
+		<weekOfPreference ordering="weekOfDate weekOfMonth weekOfInterval" locales="bg de he pt ur zh"/>
 		<weekOfPreference ordering="weekOfDate weekOfYear weekOfMonth" locales="nl"/>
 		<weekOfPreference ordering="weekOfDate weekOfInterval weekOfMonth" locales="af"/>
 		<weekOfPreference ordering="weekOfMonth" locales="ar fil gu hu hy id kk ko"/>

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -179,7 +179,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="mof" replacement="xnt" reason="deprecated"/>  <!-- Mohegan-Montauk-Narragansett -->
 			<languageAlias type="mwd" replacement="dmw" reason="deprecated"/>  <!-- Mudbura -->
 			<languageAlias type="nbf" replacement="nru" reason="deprecated"/>  <!-- Naxi -->
-			<languageAlias type="nbx" replacement="ekc" reason="deprecated"/>  <!-- Ngura -->
+			<languageAlias type="nbx" replacement="gll" reason="deprecated"/>  <!-- Ngura -->
 			<languageAlias type="nln" replacement="azd" reason="deprecated"/>  <!-- Durango Nahuatl -->
 			<languageAlias type="nlr" replacement="nrk" reason="deprecated"/>  <!-- Ngarla -->
 			<languageAlias type="noo" replacement="dtd" reason="deprecated"/>  <!-- Nootka -->
@@ -306,6 +306,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="him" replacement="srx" reason="macrolanguage"/> <!-- Himachali ⇒ Sirmauri (= Pahari, Himachali) -->
 			<languageAlias type="mnk" replacement="man" reason="macrolanguage"/> <!-- Mandinka ⇒ Mandingo -->
 			<languageAlias type="bh" replacement="bho" reason="macrolanguage"/> <!-- Bihari ⇒ Bhojpuri -->
+			<languageAlias type="cls" replacement="sa" reason="macrolanguage"/> <!-- Classical Sanskrit ⇒ Sanskrit -->
+			<!-- Special case <languageAlias type="nb" replacement="no" reason="macrolanguage"/> <! - - Norwegian Bokmål ⇒ Norwegian -->
+			<!-- Special case <languageAlias type="sr" replacement="sh" reason="macrolanguage"/> <! - - Serbian ⇒ Serbo-Croatian -->
 
 			<languageAlias type="prs" replacement="fa_AF" reason="overlong"/> <!-- Dari ⇒ Farsi (Afganistan) -->
 			<languageAlias type="swc" replacement="sw_CD" reason="overlong"/> <!-- Congo Swahili ⇒ Swahili (Congo - Kinshasa) -->

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -1312,7 +1312,7 @@ public class SupplementalDataInfo {
         if (unitAliases != null) { // don't load unless the information is there (for old releases);
             unitConverter.addAliases(unitAliases);
         }
-        unitConverter.freeze();
+        unitConverter.freeze(new File(directory, "../validity").toString());
         rationalParser.freeze();
         unitPreferences.freeze();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
@@ -168,6 +168,10 @@ public class UnitConverter implements Freezable<UnitConverter> {
 
     @Override
     public UnitConverter freeze() {
+        return freeze(CLDRPaths.VALIDITY_DIRECTORY);
+    }
+
+    public UnitConverter freeze(String validityDirectory) {
         if (!frozen) {
             frozen = true;
             rationalParser.freeze();
@@ -185,7 +189,7 @@ public class UnitConverter implements Freezable<UnitConverter> {
             baseUnits = builder.build();
             targetInfoComparator = new TargetInfoComparator();
 
-            buildMapComparators();
+            buildMapComparators(validityDirectory);
 
             // must be after building comparators
             idToUnitId = ImmutableMap.copyOf(buildIdToUnitId());
@@ -194,14 +198,19 @@ public class UnitConverter implements Freezable<UnitConverter> {
     }
 
     public void buildMapComparators() {
+        buildMapComparators(CLDRPaths.VALIDITY_DIRECTORY);
+    }
+
+    public void buildMapComparators(String validityDirectory) {
         Set<R4<Integer, UnitSystem, Rational, String>> all = new TreeSet<>();
+        final Validity validity = Validity.getInstance(validityDirectory);
         Set<String> baseSeen = new HashSet<>();
+
         if (DEBUG) {
             UnitParser up = new UnitParser(componentTypeData);
             Output<UnitIdComponentType> uict = new Output<>();
 
-            for (String longUnit :
-                    Validity.getInstance().getStatusToCodes(LstrType.unit).get(Status.regular)) {
+            for (String longUnit : validity.getStatusToCodes(LstrType.unit).get(Status.regular)) {
                 String shortUnit = getShortId(longUnit);
                 up.set(shortUnit);
                 List<String> items = new ArrayList<>();
@@ -219,8 +228,7 @@ public class UnitConverter implements Freezable<UnitConverter> {
                 System.out.println(shortUnit + "\t" + Joiner.on('\t').join(items));
             }
         }
-        for (String longUnit :
-                Validity.getInstance().getStatusToCodes(LstrType.unit).get(Status.regular)) {
+        for (String longUnit : validity.getStatusToCodes(LstrType.unit).get(Status.regular)) {
             Output<String> base = new Output<>();
             String shortUnit = getShortId(longUnit);
             ConversionInfo conversionInfo = parseUnitId(shortUnit, base, false);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Validity.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Validity.java
@@ -2,7 +2,9 @@ package org.unicode.cldr.util;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
+import com.ibm.icu.util.ICUUncheckedIOException;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -38,6 +40,11 @@ public class Validity {
     }
 
     public static Validity getInstance(String validityDirectory) {
+        try {
+            validityDirectory = new File(validityDirectory).getCanonicalFile().toString();
+        } catch (IOException e) {
+            throw new ICUUncheckedIOException(e);
+        }
         Validity result = cache.get(validityDirectory);
         if (result == null) {
             final Validity value = new Validity(validityDirectory);
@@ -79,7 +86,7 @@ public class Validity {
                 codeToStatus.put(type, subCodeToStatus = new LinkedHashMap<>());
             }
 
-            XMLFileReader.loadPathValues(basePath + file, lineData, true);
+            XMLFileReader.loadPathValues(new File(basePath, file).toString(), lineData, true);
             for (Pair<String, String> item : lineData) {
                 XPathValue parts = SimpleXPathParts.getFrozenInstance(item.getFirst());
                 if (!"id".equals(parts.getElement(-1))) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -92,7 +92,7 @@ public class TestAttributeValues extends TestFmwk {
                     addXMLFiles(dtdType, mainDirs + stringDir, files);
                     if (isVerbose())
                         synchronized (pathChecker.testLog) {
-                            warnln(mainDirs + stringDir);
+                            logln(mainDirs + stringDir);
                         }
                 }
                 Stream<String> stream = SERIAL ? files.stream() : files.parallelStream();
@@ -102,7 +102,7 @@ public class TestAttributeValues extends TestFmwk {
                 //                    checkFile(pathChecker, file);
                 //                }
             }
-            pathChecker.show(isVerbose(), showStatuses);
+            pathChecker.show(dtdType, isVerbose(), showStatuses);
         }
         //        List<String> localesToTest = Arrays.asList("en", "root"); // , "zh", "hi", "ja",
         // "ru", "cy"
@@ -145,9 +145,9 @@ public class TestAttributeValues extends TestFmwk {
         } else {
             for (String file : dirFile.list()) {
                 String localeID = file.replace(".xml", "");
-                if (StandardCodes.isLocaleAtLeastBasic(localeID)) {
-                    addXMLFiles(dtdType, path + "/" + file, files);
-                }
+                // if (StandardCodes.isLocaleAtLeastBasic(localeID)) {
+                addXMLFiles(dtdType, path + "/" + file, files);
+                // }
             }
         }
     }
@@ -186,7 +186,8 @@ public class TestAttributeValues extends TestFmwk {
                                     ++_attributeCount;
                                     String attribute = r.getAttributeLocalName(i);
                                     String attributeValue = r.getAttributeValue(i);
-                                    pathChecker.checkAttribute(element, attribute, attributeValue);
+                                    pathChecker.checkAttribute(
+                                            fullFile, element, attribute, attributeValue);
                                 }
                                 break;
                         }
@@ -237,7 +238,7 @@ public class TestAttributeValues extends TestFmwk {
             matchValues = ImmutableMap.copyOf(_matchValues);
         }
 
-        private void checkPath(String path) {
+        private void checkPath(String fullFile, String path) {
             if (seen.contains(path)) {
                 return;
             }
@@ -251,19 +252,20 @@ public class TestAttributeValues extends TestFmwk {
                 for (Entry<String, String> entry : parts.getAttributes(elementIndex).entrySet()) {
                     String attribute = entry.getKey();
                     String attrValue = entry.getValue();
-                    checkAttribute(element, attribute, attrValue);
+                    checkAttribute(fullFile, element, attribute, attrValue);
                 }
             }
         }
 
-        public void checkElement(String element, Attributes atts) {
+        public void checkElement(String fullFile, String element, Attributes atts) {
             int length = atts.getLength();
             for (int i = 0; i < length; ++i) {
-                checkAttribute(element, atts.getQName(i), atts.getValue(i));
+                checkAttribute(fullFile, element, atts.getQName(i), atts.getValue(i));
             }
         }
 
-        private void checkAttribute(String element, String attribute, String attrValue) {
+        private void checkAttribute(
+                String fullFile, String element, String attribute, String attrValue) {
             // skip cases we know we don't need to test
             if (!needsTesting.containsEntry(element, attribute)) {
                 return;
@@ -296,16 +298,18 @@ public class TestAttributeValues extends TestFmwk {
                 // Set breakpoint here for debugging (referenced from
                 // http://cldr.unicode.org/development/testattributevalues)
                 dtdData.getValueStatus(element, attribute, attrValue);
+                testLog.warnln(
+                        Joiner.on('\t').join("Invalid", fullFile, element, attribute, attrValue));
             }
             synchronized (valueStatusInfo) {
                 valueStatusInfo.put(valueStatus, element, attribute, attrValue, Boolean.TRUE);
             }
         }
 
-        void show(boolean verbose, ImmutableSet<ValueStatus> retain) {
+        void show(DtdType dtdType, boolean verbose, ImmutableSet<ValueStatus> retain) {
             if (dtdData.dtdType == DtdType.keyboard3
                     && testLog.logKnownIssue("CLDR-14974", "skipping for keyboard")) {
-                testLog.warnln("Skipping for keyboard3");
+                testLog.warnln("keyboard3 is missing validity checks");
             }
             boolean haveProblems = false;
             for (ValueStatus valueStatus : ValueStatus.values()) {
@@ -323,7 +327,9 @@ public class TestAttributeValues extends TestFmwk {
             }
             StringBuilder out = new StringBuilder();
             out.append(
-                    "\nIf the test fails, look at https://cldr.unicode.org/development/cldr-development-site/testattributevalues\n");
+                    "For "
+                            + dtdType.directories
+                            + "\nIf the test fails, use -v for details. Also look at https://cldr.unicode.org/development/updating-codes/testattributevalues for guidance.\n");
 
             out.append("file\tCount:\t" + dtdData.dtdType + "\t" + fileCount + "\n");
             out.append("element\tCount:\t" + dtdData.dtdType + "\t" + elementCount + "\n");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -5,6 +5,8 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
@@ -41,6 +43,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.tool.CldrVersion;
 import org.unicode.cldr.tool.LikelySubtags;
@@ -195,7 +198,7 @@ public class TestBasic extends TestFmwkPlus {
             } else if (fileName.getPath().contains("/keyboards/3.0/")
                     && logKnownIssue(
                             "CLDR-17574", "With v46, parsing issues for keyboard xml files")) {
-                ; // do nothing, skip test
+                // do nothing, skip test
             } else if (name.endsWith(".xml")) {
                 data.add(check(fileName));
                 if (deepCheck // takes too long to do all the time
@@ -1652,5 +1655,42 @@ public class TestBasic extends TestFmwkPlus {
     public void sortPaths(Comparator<String> dc, String... array) {
         Arrays.sort(array, 0, array.length, dc);
     }
+
     // public void TestNewDtdData() moved to TestDtdData
+
+    public void testBcp47Ids() {
+        if (!TestCLDRPaths.canUseArchiveDirectory()) {
+            return;
+        }
+        final File ARCHIVE = new File(CLDRPaths.ARCHIVE_DIRECTORY);
+        Set<Pair<String, String>> seen = new LinkedHashSet<>();
+        TreeSet<File> sorted = new TreeSet<>(Collections.reverseOrder());
+        sorted.addAll(Arrays.asList(ARCHIVE.listFiles()));
+        Set<Pair<String, String>> newKeys = pairs(SUPPLEMENTAL_DATA_INFO.getBcp47Keys());
+
+        for (File file : sorted) {
+            if (!file.getName().startsWith("cldr-")) {
+                continue;
+            }
+            System.out.println(file);
+            File supplementalDir = new File(file, "common/supplemental");
+            SupplementalDataInfo otherSupplementalData =
+                    SupplementalDataInfo.getInstance(supplementalDir);
+            Set<Pair<String, String>> oldKeys = pairs(otherSupplementalData.getBcp47Keys());
+            if (!newKeys.containsAll(oldKeys)) {
+                SetView<Pair<String, String>> oldButNotNew = Sets.difference(oldKeys, newKeys);
+                SetView<Pair<String, String>> oldButNotNewMinusSeen =
+                        Sets.difference(oldButNotNew, seen);
+                if (!assertEquals(file.toString(), Collections.emptySet(), oldButNotNewMinusSeen)) {
+                    seen.addAll(oldButNotNewMinusSeen);
+                }
+            }
+        }
+    }
+
+    private Set<Pair<String, String>> pairs(Relation<String, String> bcp47Keys) {
+        return bcp47Keys.entrySet().stream()
+                .map(x -> Pair.of(x.getKey(), x.getValue()))
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
 }


### PR DESCRIPTION
CLDR-18129

common/dtd/ldml.dtd
- for @MATCH language@type, use nlocale (locales for names)

common/dtd/ldmlSupplemental.dtd
- all @MATCH changes:
- languageAlias@type, use bc47-wellformed (locales for names), and list allowed ill-formed values
- likelySubtag@from&to, use xlocale (which allows for compatibility cases like "iw"
- pluralRules@locales, use xlocale but also allow "sh"

common/main/en.xml
common/main/fi.xml
common/main/la.xml
common/main/nl.xml
common/supplemental/supplementalData.xml
common/supplemental/supplementalMetadata.xml
- Tighten down the test to avoid deprecated / predominant-encompassed languages.
- Add XLocaleMatchValue, NLocaleMatchValue to allow for special cases

tools/cldr-code/src/main/java/org/unicode/cldr/util/MatchValue.java
- tighten up validity/locale to disallow deprecated
- allow for setting the status for each field separately
- provide for subclassing to extend the language check

tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
tools/cldr-code/src/main/java/org/unicode/cldr/util/Validity.java
- Allow for testing validity against past versions

tools/cldr-code/src/main/java/org/unicode/cldr/util/UnitConverter.java
- clean up some code that didn't allow for old versions

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
- Enhance testing to print (warnln) details of which items caused failures.

tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
- Add compatibility test for bcp47 to ensure that identifiers never disappear

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
