### PR TITLE
CLDR-18129 Rebuild localeCanonicalization.txt

### DIFF
--- a/common/testData/localeIdentifiers/localeCanonicalization.txt
+++ b/common/testData/localeIdentifiers/localeCanonicalization.txt
@@ -109,6 +109,7 @@ chv	;	cv
 cjr	;	mom
 cka	;	cmr
 cld	;	syr
+cls	;	sa
 cmk	;	xch
 cmn	;	zh
 cnr	;	sr_ME
@@ -307,7 +308,7 @@ nau	;	na
 nav	;	nv
 nbf	;	nru
 nbl	;	nr
-nbx	;	ekc
+nbx	;	gll
 ncp	;	kdz
 nde	;	nd
 ndo	;	ng
@@ -1342,6 +1343,7 @@ chv_Adlm_AC_fonipa	;	cv_Adlm_AC_fonipa
 cjr_Adlm_AC_fonipa	;	mom_Adlm_AC_fonipa
 cka_Adlm_AC_fonipa	;	cmr_Adlm_AC_fonipa
 cld_Adlm_AC_fonipa	;	syr_Adlm_AC_fonipa
+cls_Adlm_AC_fonipa	;	sa_Adlm_AC_fonipa
 cmk_Adlm_AC_fonipa	;	xch_Adlm_AC_fonipa
 cmn_Adlm_AC_fonipa	;	zh_Adlm_AC_fonipa
 cmn_Adlm_AC_fonipa_guoyu	;	zh_Adlm_AC_fonipa
@@ -1571,7 +1573,7 @@ nau_Adlm_AC_fonipa	;	na_Adlm_AC_fonipa
 nav_Adlm_AC_fonipa	;	nv_Adlm_AC_fonipa
 nbf_Adlm_AC_fonipa	;	nru_Adlm_AC_fonipa
 nbl_Adlm_AC_fonipa	;	nr_Adlm_AC_fonipa
-nbx_Adlm_AC_fonipa	;	ekc_Adlm_AC_fonipa
+nbx_Adlm_AC_fonipa	;	gll_Adlm_AC_fonipa
 ncp_Adlm_AC_fonipa	;	kdz_Adlm_AC_fonipa
 nde_Adlm_AC_fonipa	;	nd_Adlm_AC_fonipa
 ndo_Adlm_AC_fonipa	;	ng_Adlm_AC_fonipa


### PR DESCRIPTION
Since invalid locales were corrected in https://github.com/unicode-org/cldr/pull/4215 there are a few canonical mappings that were updated. This PR re-runs the generative scripts to fix the output file localeCanonicalization.txt . See the changes to the supplementalData from that PR that caused these macrolanguage changes: https://github.com/unicode-org/cldr/pull/4215/files#diff-0c0a1db9759811ee6479820227a65f23782f468967e94c162bd45d95aecd470a

Scripts ran:
```
mvn package -DskipTests=true &&  java -jar tools/cldr-code/target/cldr-code.jar ConvertLanguageData &&  java -jar tools/cldr-code/target/cldr-code.jar GenerateLikelySubtags &&  java -jar tools/cldr-code/target/cldr-code.jar GenerateTestData
```

CLDR-18129

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
