### PR TITLE
CLDR-15830 Refactor getName: new class NameGetter

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -90,7 +90,8 @@ public class GenerateLanguageData {
                 //                );
                 for (String territory : territories) {
                     PopulationData terrData = info.getPopulationDataForTerritory(territory);
-                    String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                    String territoryName =
+                            english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
 
                     PopulationData data =
                             info.getLanguageAndTerritoryPopulationData(languageCode, territory);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -15,6 +15,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Counter2;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
@@ -44,8 +45,9 @@ public class GenerateLanguageData {
             // Counter2<String> langToGDP = new Counter2<String>();
             LanguageTagParser ltp = new LanguageTagParser();
             Map<String, String> languageNameToCode = new TreeMap<>();
+            NameGetter nameGetter = english.nameGetter();
             for (String languageCode : info.getLanguages()) {
-                languageNameToCode.put(english.nameGetter().getNameFromLocaleOrTZID(languageCode), languageCode);
+                languageNameToCode.put(nameGetter.getNameFromBCP47(languageCode), languageCode);
             }
             out.println("\n@sheet:CLDR County Data");
             out.println("code\tgdp\tlit-pop\tpopulation\tliteracy");
@@ -71,7 +73,7 @@ public class GenerateLanguageData {
             Map<String, Counter2<String>> langToCountriesOfficial = new TreeMap<>();
 
             for (String languageCode : info.getLanguages()) {
-                String languageName = english.nameGetter().getNameFromLocaleOrTZID(languageCode);
+                String languageName = nameGetter.getNameFromBCP47(languageCode);
 
                 String baseLanguage = languageCode;
                 ltp.set(languageCode);
@@ -91,7 +93,7 @@ public class GenerateLanguageData {
                 for (String territory : territories) {
                     PopulationData terrData = info.getPopulationDataForTerritory(territory);
                     String territoryName =
-                            english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                            nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
 
                     PopulationData data =
                             info.getLanguageAndTerritoryPopulationData(languageCode, territory);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -45,7 +45,7 @@ public class GenerateLanguageData {
             LanguageTagParser ltp = new LanguageTagParser();
             Map<String, String> languageNameToCode = new TreeMap<>();
             for (String languageCode : info.getLanguages()) {
-                languageNameToCode.put(english.getName(languageCode), languageCode);
+                languageNameToCode.put(english.nameGetter().getName(languageCode), languageCode);
             }
             out.println("\n@sheet:CLDR County Data");
             out.println("code\tgdp\tlit-pop\tpopulation\tliteracy");
@@ -71,7 +71,7 @@ public class GenerateLanguageData {
             Map<String, Counter2<String>> langToCountriesOfficial = new TreeMap<>();
 
             for (String languageCode : info.getLanguages()) {
-                String languageName = english.getName(languageCode);
+                String languageName = english.nameGetter().getName(languageCode);
 
                 String baseLanguage = languageCode;
                 ltp.set(languageCode);
@@ -90,7 +90,7 @@ public class GenerateLanguageData {
                 //                );
                 for (String territory : territories) {
                     PopulationData terrData = info.getPopulationDataForTerritory(territory);
-                    String territoryName = english.getName(CLDRFile.TERRITORY_NAME, territory);
+                    String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
 
                     PopulationData data =
                             info.getLanguageAndTerritoryPopulationData(languageCode, territory);
@@ -156,7 +156,7 @@ public class GenerateLanguageData {
             }
             // for (String language :langToPopulation.keySet()) {
             // out.println(
-            // english.getName(language)
+            // english.nameGetter().getName(language)
             // + "\t" + language
             // + "\t" + langToPopulation.getCount(language)
             // + "\t" + langToGDP.getCount(language)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -45,7 +45,7 @@ public class GenerateLanguageData {
             LanguageTagParser ltp = new LanguageTagParser();
             Map<String, String> languageNameToCode = new TreeMap<>();
             for (String languageCode : info.getLanguages()) {
-                languageNameToCode.put(english.nameGetter().getName(languageCode), languageCode);
+                languageNameToCode.put(english.nameGetter().getNameFromLocaleOrTZID(languageCode), languageCode);
             }
             out.println("\n@sheet:CLDR County Data");
             out.println("code\tgdp\tlit-pop\tpopulation\tliteracy");
@@ -71,7 +71,7 @@ public class GenerateLanguageData {
             Map<String, Counter2<String>> langToCountriesOfficial = new TreeMap<>();
 
             for (String languageCode : info.getLanguages()) {
-                String languageName = english.nameGetter().getName(languageCode);
+                String languageName = english.nameGetter().getNameFromLocaleOrTZID(languageCode);
 
                 String baseLanguage = languageCode;
                 ltp.set(languageCode);
@@ -91,7 +91,7 @@ public class GenerateLanguageData {
                 for (String territory : territories) {
                     PopulationData terrData = info.getPopulationDataForTerritory(territory);
                     String territoryName =
-                            english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                            english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
 
                     PopulationData data =
                             info.getLanguageAndTerritoryPopulationData(languageCode, territory);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -138,7 +138,7 @@ public class Misc {
                     break;
                 }
             }
-            System.out.println(string + "\t" + defCon + "\t" + english.getName(defCon));
+            System.out.println(string + "\t" + defCon + "\t" + english.nameGetter().getName(defCon));
         }
     }
 
@@ -328,7 +328,7 @@ public class Misc {
             if (temp != null) {
                 baseLanguage = temp.get0().get(0);
             }
-            String englishName = english.getName(baseLanguage);
+            String englishName = english.nameGetter().getName(baseLanguage);
             CLDRFile cldrFile = factory.make(baseLanguage, false);
             UnicodeSet set = cldrFile.getExemplarSet("", WinningChoice.WINNING);
             int script = -1;
@@ -339,7 +339,7 @@ public class Misc {
                     break;
                 }
             }
-            String nativeName = cldrFile.getName(baseLanguage);
+            String nativeName = cldrFile.nameGetter().getName(baseLanguage);
             nameAndInfo.add(
                     englishName
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -138,7 +138,8 @@ public class Misc {
                     break;
                 }
             }
-            System.out.println(string + "\t" + defCon + "\t" + english.nameGetter().getName(defCon));
+            System.out.println(
+                    string + "\t" + defCon + "\t" + english.nameGetter().getName(defCon));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -139,7 +139,7 @@ public class Misc {
                 }
             }
             System.out.println(
-                    string + "\t" + defCon + "\t" + english.nameGetter().getName(defCon));
+                    string + "\t" + defCon + "\t" + english.nameGetter().getNameFromLocaleOrTZID(defCon));
         }
     }
 
@@ -329,7 +329,7 @@ public class Misc {
             if (temp != null) {
                 baseLanguage = temp.get0().get(0);
             }
-            String englishName = english.nameGetter().getName(baseLanguage);
+            String englishName = english.nameGetter().getNameFromLocaleOrTZID(baseLanguage);
             CLDRFile cldrFile = factory.make(baseLanguage, false);
             UnicodeSet set = cldrFile.getExemplarSet("", WinningChoice.WINNING);
             int script = -1;
@@ -340,7 +340,7 @@ public class Misc {
                     break;
                 }
             }
-            String nativeName = cldrFile.nameGetter().getName(baseLanguage);
+            String nativeName = cldrFile.nameGetter().getNameFromLocaleOrTZID(baseLanguage);
             nameAndInfo.add(
                     englishName
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -139,7 +139,7 @@ public class Misc {
                 }
             }
             System.out.println(
-                    string + "\t" + defCon + "\t" + english.nameGetter().getNameFromLocaleOrTZID(defCon));
+                    string + "\t" + defCon + "\t" + english.nameGetter().getNameFromBCP47(defCon));
         }
     }
 
@@ -329,7 +329,7 @@ public class Misc {
             if (temp != null) {
                 baseLanguage = temp.get0().get(0);
             }
-            String englishName = english.nameGetter().getNameFromLocaleOrTZID(baseLanguage);
+            String englishName = english.nameGetter().getNameFromBCP47(baseLanguage);
             CLDRFile cldrFile = factory.make(baseLanguage, false);
             UnicodeSet set = cldrFile.getExemplarSet("", WinningChoice.WINNING);
             int script = -1;
@@ -340,7 +340,7 @@ public class Misc {
                     break;
                 }
             }
-            String nativeName = cldrFile.nameGetter().getNameFromLocaleOrTZID(baseLanguage);
+            String nativeName = cldrFile.nameGetter().getNameFromBCP47(baseLanguage);
             nameAndInfo.add(
                     englishName
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -969,14 +969,14 @@ public class XLocaleDistance {
                 if (region.equals("*") || region.startsWith("$")) {
                     result.append(region);
                 } else {
-                    result.append(english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
+                    result.append(english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
                 }
             case 2:
                 String script = alt.get(1);
                 if (script.equals("*")) {
                     result.insert(0, script);
                 } else {
-                    result.insert(0, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, script));
+                    result.insert(0, english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, script));
                 }
             case 1:
                 String language = alt.get(0);
@@ -984,7 +984,7 @@ public class XLocaleDistance {
                     result.insert(0, language);
                 } else {
                     result.insert(
-                            0, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, language));
+                            0, english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, language));
                 }
         }
         return Joiner.on("; ").join(alt);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -969,14 +969,19 @@ public class XLocaleDistance {
                 if (region.equals("*") || region.startsWith("$")) {
                     result.append(region);
                 } else {
-                    result.append(english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
+                    result.append(
+                            english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
                 }
             case 2:
                 String script = alt.get(1);
                 if (script.equals("*")) {
                     result.insert(0, script);
                 } else {
-                    result.insert(0, english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, script));
+                    result.insert(
+                            0,
+                            english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, script));
                 }
             case 1:
                 String language = alt.get(0);
@@ -984,7 +989,9 @@ public class XLocaleDistance {
                     result.insert(0, language);
                 } else {
                     result.insert(
-                            0, english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, language));
+                            0,
+                            english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, language));
                 }
         }
         return Joiner.on("; ").join(alt);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -969,21 +969,21 @@ public class XLocaleDistance {
                 if (region.equals("*") || region.startsWith("$")) {
                     result.append(region);
                 } else {
-                    result.append(english.getName(CLDRFile.TERRITORY_NAME, region));
+                    result.append(english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
                 }
             case 2:
                 String script = alt.get(1);
                 if (script.equals("*")) {
                     result.insert(0, script);
                 } else {
-                    result.insert(0, english.getName(CLDRFile.TERRITORY_NAME, script));
+                    result.insert(0, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, script));
                 }
             case 1:
                 String language = alt.get(0);
                 if (language.equals("*")) {
                     result.insert(0, language);
                 } else {
-                    result.insert(0, english.getName(CLDRFile.TERRITORY_NAME, language));
+                    result.insert(0, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, language));
                 }
         }
         return Joiner.on("; ").join(alt);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -983,7 +983,8 @@ public class XLocaleDistance {
                 if (language.equals("*")) {
                     result.insert(0, language);
                 } else {
-                    result.insert(0, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, language));
+                    result.insert(
+                            0, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, language));
                 }
         }
         return Joiner.on("; ").join(alt);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -413,7 +413,7 @@ public class CLDRTest extends TestFmwk {
         String name = localeNameCache.get(locale);
         if (name != null) return name;
         if (english == null) english = cldrFactory.make("en", true);
-        String result = english.nameGetter().getNameFromLocaleOrTZID(locale);
+        String result = english.nameGetter().getNameFromBCP47(locale);
         /*
          * Collection c = Utility.splitList(locale, '_', false, null);
          * String[] pieces = new String[c.size()];
@@ -1047,7 +1047,8 @@ public class CLDRTest extends TestFmwk {
                 @Override
                 public Object transform(Object source) {
                     if (english == null) english = cldrFactory.make("en", true);
-                    return english.nameGetter().getNameFromTypestrCode("currency", source.toString())
+                    return english.nameGetter()
+                                    .getNameFromTypestrCode("currency", source.toString())
                             + " ("
                             + source
                             + ")";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -413,7 +413,7 @@ public class CLDRTest extends TestFmwk {
         String name = localeNameCache.get(locale);
         if (name != null) return name;
         if (english == null) english = cldrFactory.make("en", true);
-        String result = english.getName(locale);
+        String result = english.nameGetter().getName(locale);
         /*
          * Collection c = Utility.splitList(locale, '_', false, null);
          * String[] pieces = new String[c.size()];
@@ -1047,7 +1047,10 @@ public class CLDRTest extends TestFmwk {
                 @Override
                 public Object transform(Object source) {
                     if (english == null) english = cldrFactory.make("en", true);
-                    return english.getName("currency", source.toString()) + " (" + source + ")";
+                    return english.nameGetter().getName("currency", source.toString())
+                            + " ("
+                            + source
+                            + ")";
                 }
             };
 
@@ -1189,7 +1192,7 @@ public class CLDRTest extends TestFmwk {
         logln("Missing English currency names");
         for (Iterator<String> it = legalCurrencies.iterator(); it.hasNext(); ) {
             String currency = it.next();
-            String name = english.getName("currency", currency);
+            String name = english.nameGetter().getName("currency", currency);
             if (name == null) {
                 String standardName = sc.getFullData("currency", currency).get(0);
                 logln("\t\t\t<currency type=\"" + currency + "\">");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -413,7 +413,7 @@ public class CLDRTest extends TestFmwk {
         String name = localeNameCache.get(locale);
         if (name != null) return name;
         if (english == null) english = cldrFactory.make("en", true);
-        String result = english.nameGetter().getName(locale);
+        String result = english.nameGetter().getNameFromLocaleOrTZID(locale);
         /*
          * Collection c = Utility.splitList(locale, '_', false, null);
          * String[] pieces = new String[c.size()];
@@ -1047,7 +1047,7 @@ public class CLDRTest extends TestFmwk {
                 @Override
                 public Object transform(Object source) {
                     if (english == null) english = cldrFactory.make("en", true);
-                    return english.nameGetter().getName("currency", source.toString())
+                    return english.nameGetter().getNameFromTypestrCode("currency", source.toString())
                             + " ("
                             + source
                             + ")";
@@ -1192,7 +1192,7 @@ public class CLDRTest extends TestFmwk {
         logln("Missing English currency names");
         for (Iterator<String> it = legalCurrencies.iterator(); it.hasNext(); ) {
             String currency = it.next();
-            String name = english.nameGetter().getName("currency", currency);
+            String name = english.nameGetter().getNameFromTypestrCode("currency", currency);
             if (name == null) {
                 String standardName = sc.getFullData("currency", currency).get(0);
                 logln("\t\t\t<currency type=\"" + currency + "\">");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -1985,7 +1985,7 @@ public class ConsoleCheckCLDR {
      * @return
      */
     private static String getLocaleAndName(String locale) {
-        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getName(locale);
+        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getNameFromLocaleOrTZID(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return locale + " [" + localizedName + "]";
     }
@@ -1998,7 +1998,7 @@ public class ConsoleCheckCLDR {
      * @return
      */
     private static String getNameAndLocale(String locale, boolean linkToXml) {
-        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getName(locale);
+        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getNameFromLocaleOrTZID(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         if (linkToXml) {
             locale =
@@ -2012,7 +2012,7 @@ public class ConsoleCheckCLDR {
     }
 
     private static String getLocaleName(String locale) {
-        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getName(locale);
+        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getNameFromLocaleOrTZID(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return localizedName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -1985,7 +1985,8 @@ public class ConsoleCheckCLDR {
      * @return
      */
     private static String getLocaleAndName(String locale) {
-        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getNameFromLocaleOrTZID(locale);
+        String localizedName =
+                CheckCLDR.getDisplayInformation().nameGetter().getNameFromBCP47(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return locale + " [" + localizedName + "]";
     }
@@ -1998,7 +1999,8 @@ public class ConsoleCheckCLDR {
      * @return
      */
     private static String getNameAndLocale(String locale, boolean linkToXml) {
-        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getNameFromLocaleOrTZID(locale);
+        String localizedName =
+                CheckCLDR.getDisplayInformation().nameGetter().getNameFromBCP47(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         if (linkToXml) {
             locale =
@@ -2012,7 +2014,8 @@ public class ConsoleCheckCLDR {
     }
 
     private static String getLocaleName(String locale) {
-        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getNameFromLocaleOrTZID(locale);
+        String localizedName =
+                CheckCLDR.getDisplayInformation().nameGetter().getNameFromBCP47(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return localizedName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -1985,7 +1985,7 @@ public class ConsoleCheckCLDR {
      * @return
      */
     private static String getLocaleAndName(String locale) {
-        String localizedName = CheckCLDR.getDisplayInformation().getName(locale);
+        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getName(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return locale + " [" + localizedName + "]";
     }
@@ -1998,7 +1998,7 @@ public class ConsoleCheckCLDR {
      * @return
      */
     private static String getNameAndLocale(String locale, boolean linkToXml) {
-        String localizedName = CheckCLDR.getDisplayInformation().getName(locale);
+        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getName(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         if (linkToXml) {
             locale =
@@ -2012,7 +2012,7 @@ public class ConsoleCheckCLDR {
     }
 
     private static String getLocaleName(String locale) {
-        String localizedName = CheckCLDR.getDisplayInformation().getName(locale);
+        String localizedName = CheckCLDR.getDisplayInformation().nameGetter().getName(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return localizedName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
@@ -144,7 +144,7 @@ public class EmojiSubdivisionNames {
                                     + "\t"
                                     + rank
                                     + "\t"
-                                    + english.nameGetter().getName(locale)
+                                    + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                     + "\t"
                                     + locale);
                     for (String sd : SUBDIVISIONS) {
@@ -171,7 +171,7 @@ public class EmojiSubdivisionNames {
                             + "\t"
                             + rank
                             + "\t"
-                            + english.nameGetter().getName(locale)
+                            + english.nameGetter().getNameFromLocaleOrTZID(locale)
                             + "\t"
                             + locale);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
@@ -140,7 +140,7 @@ public class EmojiSubdivisionNames {
                     LanguageGroup group = LanguageGroup.get(ulocale);
                     int rank = LanguageGroup.rankInGroup(ulocale);
                     System.out.print(
-                            group + "\t" + rank + "\t" + english.getName(locale) + "\t" + locale);
+                            group + "\t" + rank + "\t" + english.nameGetter().getName(locale) + "\t" + locale);
                     for (String sd : SUBDIVISIONS) {
                         System.out.print('\t');
                         System.out.print(map.get(sd));
@@ -161,7 +161,7 @@ public class EmojiSubdivisionNames {
             LanguageGroup group = LanguageGroup.get(ulocale);
             int rank = LanguageGroup.rankInGroup(ulocale);
             System.out.println(
-                    group + "\t" + rank + "\t" + english.getName(locale) + "\t" + locale);
+                    group + "\t" + rank + "\t" + english.nameGetter().getName(locale) + "\t" + locale);
         }
 
         //        System.out.println(getSubdivisionIdToName("fr"));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
@@ -21,6 +21,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.EmojiConstants;
 import org.unicode.cldr.util.LanguageGroup;
 import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 
@@ -130,6 +131,7 @@ public class EmojiSubdivisionNames {
         System.out.println();
         CLDRFile english = CLDRConfig.getInstance().getEnglish();
         Set<String> locales = new HashSet<>();
+        NameGetter nameGetter = english.nameGetter();
         for (String filename : SUBDIVISION_FILE_NAMES) {
             if (filename.endsWith(".xml")) {
                 String locale = filename.substring(0, filename.length() - 4);
@@ -144,7 +146,7 @@ public class EmojiSubdivisionNames {
                                     + "\t"
                                     + rank
                                     + "\t"
-                                    + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                    + nameGetter.getNameFromBCP47(locale)
                                     + "\t"
                                     + locale);
                     for (String sd : SUBDIVISIONS) {
@@ -171,7 +173,7 @@ public class EmojiSubdivisionNames {
                             + "\t"
                             + rank
                             + "\t"
-                            + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                            + english.nameGetter().getNameFromBCP47(locale)
                             + "\t"
                             + locale);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
@@ -140,7 +140,13 @@ public class EmojiSubdivisionNames {
                     LanguageGroup group = LanguageGroup.get(ulocale);
                     int rank = LanguageGroup.rankInGroup(ulocale);
                     System.out.print(
-                            group + "\t" + rank + "\t" + english.nameGetter().getName(locale) + "\t" + locale);
+                            group
+                                    + "\t"
+                                    + rank
+                                    + "\t"
+                                    + english.nameGetter().getName(locale)
+                                    + "\t"
+                                    + locale);
                     for (String sd : SUBDIVISIONS) {
                         System.out.print('\t');
                         System.out.print(map.get(sd));
@@ -161,7 +167,13 @@ public class EmojiSubdivisionNames {
             LanguageGroup group = LanguageGroup.get(ulocale);
             int rank = LanguageGroup.rankInGroup(ulocale);
             System.out.println(
-                    group + "\t" + rank + "\t" + english.nameGetter().getName(locale) + "\t" + locale);
+                    group
+                            + "\t"
+                            + rank
+                            + "\t"
+                            + english.nameGetter().getName(locale)
+                            + "\t"
+                            + locale);
         }
 
         //        System.out.println(getSubdivisionIdToName("fr"));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -756,7 +756,7 @@ public class ExampleGenerator {
                         final String name =
                                 localeId.equals("und")
                                         ? "«any other»"
-                                        : cldrFile2.nameGetter().getName(localeId);
+                                        : cldrFile2.nameGetter().getNameFromLocaleOrTZID(localeId);
                         examples.add(localeId + " = " + name);
                     }
                     break;
@@ -2411,7 +2411,7 @@ public class ExampleGenerator {
                 result =
                         setBackground(
                                 cldrFile.nameGetter()
-                                        .getName(CLDRFile.TERRITORY_NAME, countryCode));
+                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode));
             }
         } else if (parts.contains("zone")) { // {0} Time
             result = value; // trivial -- is this beneficial?
@@ -2420,7 +2420,7 @@ public class ExampleGenerator {
                     format(
                             value,
                             setBackground(
-                                    cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, "JP")));
+                                    cldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, "JP")));
             result =
                     addExampleResult(
                             format(
@@ -3112,7 +3112,7 @@ public class ExampleGenerator {
                 examples.add(
                         invertBackground(
                                 cldrFile.nameGetter()
-                                        .getName(
+                                        .getNameFromLocaleOrTZBoolEtc(
                                                 locales.get(i),
                                                 false,
                                                 localeKeyTypePattern,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -756,7 +756,7 @@ public class ExampleGenerator {
                         final String name =
                                 localeId.equals("und")
                                         ? "«any other»"
-                                        : cldrFile2.getName(localeId);
+                                        : cldrFile2.nameGetter().getName(localeId);
                         examples.add(localeId + " = " + name);
                     }
                     break;
@@ -2408,12 +2408,12 @@ public class ExampleGenerator {
                     return; // fail, skip
                 }
             } else {
-                result = setBackground(cldrFile.getName(CLDRFile.TERRITORY_NAME, countryCode));
+                result = setBackground(cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode));
             }
         } else if (parts.contains("zone")) { // {0} Time
             result = value; // trivial -- is this beneficial?
         } else if (parts.contains("regionFormat")) { // {0} Time
-            result = format(value, setBackground(cldrFile.getName(CLDRFile.TERRITORY_NAME, "JP")));
+            result = format(value, setBackground(cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, "JP")));
             result =
                     addExampleResult(
                             format(
@@ -3104,7 +3104,7 @@ public class ExampleGenerator {
             for (int i = 0; i < locales.size(); i++) {
                 examples.add(
                         invertBackground(
-                                cldrFile.getName(
+                                cldrFile.nameGetter().getName(
                                         locales.get(i),
                                         false,
                                         localeKeyTypePattern,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2408,12 +2408,19 @@ public class ExampleGenerator {
                     return; // fail, skip
                 }
             } else {
-                result = setBackground(cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode));
+                result =
+                        setBackground(
+                                cldrFile.nameGetter()
+                                        .getName(CLDRFile.TERRITORY_NAME, countryCode));
             }
         } else if (parts.contains("zone")) { // {0} Time
             result = value; // trivial -- is this beneficial?
         } else if (parts.contains("regionFormat")) { // {0} Time
-            result = format(value, setBackground(cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, "JP")));
+            result =
+                    format(
+                            value,
+                            setBackground(
+                                    cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, "JP")));
             result =
                     addExampleResult(
                             format(
@@ -3104,12 +3111,13 @@ public class ExampleGenerator {
             for (int i = 0; i < locales.size(); i++) {
                 examples.add(
                         invertBackground(
-                                cldrFile.nameGetter().getName(
-                                        locales.get(i),
-                                        false,
-                                        localeKeyTypePattern,
-                                        localePattern,
-                                        localeSeparator)));
+                                cldrFile.nameGetter()
+                                        .getName(
+                                                locales.get(i),
+                                                false,
+                                                localeKeyTypePattern,
+                                                localePattern,
+                                                localeSeparator)));
             }
             return;
         } else if (parts.contains("languages")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -68,6 +68,7 @@ import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
 import org.unicode.cldr.util.ICUServiceBuilder;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.PathDescription;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PluralSamples;
@@ -752,11 +753,12 @@ public class ExampleGenerator {
             final CLDRFile cldrFile2 = getCldrFile();
             switch (parts.getElement(2)) {
                 case "nameOrderLocales":
+                    NameGetter nameGetter2 = cldrFile2.nameGetter();
                     for (String localeId : PersonNameFormatter.SPLIT_SPACE.split(value)) {
                         final String name =
                                 localeId.equals("und")
                                         ? "«any other»"
-                                        : cldrFile2.nameGetter().getNameFromLocaleOrTZID(localeId);
+                                        : nameGetter2.getNameFromBCP47(localeId);
                         examples.add(localeId + " = " + name);
                     }
                     break;
@@ -2411,7 +2413,8 @@ public class ExampleGenerator {
                 result =
                         setBackground(
                                 cldrFile.nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode));
+                                        .getNameFromTypenumCode(
+                                                CLDRFile.TERRITORY_NAME, countryCode));
             }
         } else if (parts.contains("zone")) { // {0} Time
             result = value; // trivial -- is this beneficial?
@@ -2420,7 +2423,9 @@ public class ExampleGenerator {
                     format(
                             value,
                             setBackground(
-                                    cldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, "JP")));
+                                    cldrFile.nameGetter()
+                                            .getNameFromTypenumCode(
+                                                    CLDRFile.TERRITORY_NAME, "JP")));
             result =
                     addExampleResult(
                             format(
@@ -3108,16 +3113,16 @@ public class ExampleGenerator {
                     element.equals("localeKeyTypePattern") ? "uz-Arab-u-tz-etadd" : "uz-Arab-AF");
             locales.add("uz-Arab-AF-u-tz-etadd-nu-arab");
             // String[] examples = new String[locales.size()];
+            NameGetter nameGetter = cldrFile.nameGetter();
             for (int i = 0; i < locales.size(); i++) {
                 examples.add(
                         invertBackground(
-                                cldrFile.nameGetter()
-                                        .getNameFromLocaleOrTZBoolEtc(
-                                                locales.get(i),
-                                                false,
-                                                localeKeyTypePattern,
-                                                localePattern,
-                                                localeSeparator)));
+                                nameGetter.getNameFromBCP47Etc(
+                                        locales.get(i),
+                                        false,
+                                        localeKeyTypePattern,
+                                        localePattern,
+                                        localeSeparator)));
             }
             return;
         } else if (parts.contains("languages")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
@@ -208,7 +208,7 @@ public class QuickCheck {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            System.out.println(locale + "\t-\t" + english.nameGetter().getName(locale));
+            System.out.println(locale + "\t-\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
             DtdType dtdType = null;
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
@@ -208,7 +208,7 @@ public class QuickCheck {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            System.out.println(locale + "\t-\t" + english.getName(locale));
+            System.out.println(locale + "\t-\t" + english.nameGetter().getName(locale));
             DtdType dtdType = null;
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
@@ -208,7 +208,7 @@ public class QuickCheck {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            System.out.println(locale + "\t-\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            System.out.println(locale + "\t-\t" + english.nameGetter().getNameFromBCP47(locale));
             DtdType dtdType = null;
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
@@ -38,6 +38,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.Iso639Data.Scope;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SimpleFactory;
@@ -236,8 +237,9 @@ public class TestMisc {
             int vote = Level.getDefaultWeight("google", desiredLocale);
             rel.add(new Pair<>(vote, desiredLocale));
         }
+        NameGetter nameGetter = english.nameGetter();
         for (Pair<Integer, String> p : rel) {
-            System.out.println(p + "\t" + english.nameGetter().getNameFromLocaleOrTZID(p.getSecond()));
+            System.out.println(p + "\t" + nameGetter.getNameFromBCP47(p.getSecond()));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
@@ -237,7 +237,7 @@ public class TestMisc {
             rel.add(new Pair<>(vote, desiredLocale));
         }
         for (Pair<Integer, String> p : rel) {
-            System.out.println(p + "\t" + english.getName(p.getSecond()));
+            System.out.println(p + "\t" + english.nameGetter().getName(p.getSecond()));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
@@ -237,7 +237,7 @@ public class TestMisc {
             rel.add(new Pair<>(vote, desiredLocale));
         }
         for (Pair<Integer, String> p : rel) {
-            System.out.println(p + "\t" + english.nameGetter().getName(p.getSecond()));
+            System.out.println(p + "\t" + english.nameGetter().getNameFromLocaleOrTZID(p.getSecond()));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
@@ -161,10 +161,10 @@ public class TestSupplementalData {
                 languagesLeftover.removeAll(otherLanguages);
                 Set<String> otherLanguagesLeftover = new TreeSet<>(otherLanguages);
                 otherLanguagesLeftover.removeAll(languages);
-                String territoryString = english.getName(CLDRFile.TERRITORY_NAME, territory);
+                String territoryString = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
                 if (otherLanguagesLeftover.size() != 0) {
                     for (String other : otherLanguagesLeftover) {
-                        String name = english.getName(other);
+                        String name = english.nameGetter().getName(other);
                         System.out.println(
                                 territoryString + "\t" + territory + "\t" + name + "\t" + other);
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
@@ -161,7 +161,8 @@ public class TestSupplementalData {
                 languagesLeftover.removeAll(otherLanguages);
                 Set<String> otherLanguagesLeftover = new TreeSet<>(otherLanguages);
                 otherLanguagesLeftover.removeAll(languages);
-                String territoryString = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                String territoryString =
+                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
                 if (otherLanguagesLeftover.size() != 0) {
                     for (String other : otherLanguagesLeftover) {
                         String name = english.nameGetter().getName(other);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
@@ -16,6 +16,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.StandardCodes;
@@ -152,6 +153,7 @@ public class TestSupplementalData {
             }
         }
         // compare them, listing differences
+        NameGetter nameGetter = english.nameGetter();
         for (String territory : sc.getGoodAvailableCodes("territory")) {
             Set<String> languages = supplementalData.getTerritoryToLanguages(territory);
             Set<String> otherLanguages = otherTerritoryToLanguages.getAll(territory);
@@ -162,10 +164,10 @@ public class TestSupplementalData {
                 Set<String> otherLanguagesLeftover = new TreeSet<>(otherLanguages);
                 otherLanguagesLeftover.removeAll(languages);
                 String territoryString =
-                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                        nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
                 if (otherLanguagesLeftover.size() != 0) {
                     for (String other : otherLanguagesLeftover) {
-                        String name = english.nameGetter().getNameFromLocaleOrTZID(other);
+                        String name = nameGetter.getNameFromBCP47(other);
                         System.out.println(
                                 territoryString + "\t" + territory + "\t" + name + "\t" + other);
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
@@ -162,10 +162,10 @@ public class TestSupplementalData {
                 Set<String> otherLanguagesLeftover = new TreeSet<>(otherLanguages);
                 otherLanguagesLeftover.removeAll(languages);
                 String territoryString =
-                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
                 if (otherLanguagesLeftover.size() != 0) {
                     for (String other : otherLanguagesLeftover) {
-                        String name = english.nameGetter().getName(other);
+                        String name = english.nameGetter().getNameFromLocaleOrTZID(other);
                         System.out.println(
                                 territoryString + "\t" + territory + "\t" + name + "\t" + other);
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -32,6 +32,7 @@ import org.unicode.cldr.util.FileCopier;
 import org.unicode.cldr.util.LanguageGroup;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.NameGetter;
 
 public class ChartAnnotations extends Chart {
 
@@ -159,6 +160,7 @@ public class ChartAnnotations extends Chart {
         Multimap<String, String> localeToSub = TreeMultimap.create();
         LanguageTagParser ltp = new LanguageTagParser();
 
+        NameGetter nameGetter = ENGLISH.nameGetter();
         for (String locale : locales) {
             ltp.set(locale);
             if (locale.equals("root")) {
@@ -176,7 +178,7 @@ public class ChartAnnotations extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.nameGetter().getNameFromLocaleOrTZBool(locale, true);
+            String name = nameGetter.getNameFromBCP47Bool(locale, true);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -187,7 +189,7 @@ public class ChartAnnotations extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.nameGetter().getNameFromLocaleOrTZBool("en", true);
+            String ename = nameGetter.getNameFromBCP47Bool("en", true);
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -176,7 +176,7 @@ public class ChartAnnotations extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.getName(locale, true);
+            String name = ENGLISH.nameGetter().getName(locale, true);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -187,7 +187,7 @@ public class ChartAnnotations extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.getName("en", true);
+            String ename = ENGLISH.nameGetter().getName("en", true);
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 
@@ -300,7 +300,7 @@ public class ChartAnnotations extends Chart {
     //        int ri1 = getRegionalIndicator(cp.codePointAt(0));
     //        if (ri1 >= 0) {
     //            int ri2 = getRegionalIndicator(cp.codePointAt(2));
-    //            return ENGLISH.getName(CLDRFile.TERRITORY_NAME, String.valueOf((char) ri1) +
+    //            return ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, String.valueOf((char) ri1) +
     // String.valueOf((char) ri2));
     //        }
     //        String result = NAMES80.get(cp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -300,7 +300,8 @@ public class ChartAnnotations extends Chart {
     //        int ri1 = getRegionalIndicator(cp.codePointAt(0));
     //        if (ri1 >= 0) {
     //            int ri2 = getRegionalIndicator(cp.codePointAt(2));
-    //            return ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, String.valueOf((char) ri1) +
+    //            return ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, String.valueOf((char)
+    // ri1) +
     // String.valueOf((char) ri2));
     //        }
     //        String result = NAMES80.get(cp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -176,7 +176,7 @@ public class ChartAnnotations extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.nameGetter().getName(locale, true);
+            String name = ENGLISH.nameGetter().getNameFromLocaleOrTZBool(locale, true);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -187,7 +187,7 @@ public class ChartAnnotations extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.nameGetter().getName("en", true);
+            String ename = ENGLISH.nameGetter().getNameFromLocaleOrTZBool("en", true);
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -228,7 +228,10 @@ public class ChartCollation extends Chart {
             if (!data.containsKey("standard")) {
                 addCollator(data, "standard", (RuleBasedCollator) null);
             }
-            new Subchart(ENGLISH.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS), locale, data)
+            new Subchart(
+                            ENGLISH.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS),
+                            locale,
+                            data)
                     .writeChart(anchors);
         }
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -229,7 +229,8 @@ public class ChartCollation extends Chart {
                 addCollator(data, "standard", (RuleBasedCollator) null);
             }
             new Subchart(
-                            ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, CLDRFile.SHORT_ALTS),
+                            ENGLISH.nameGetter()
+                                    .getNameFromBCP47BoolAlt(locale, true, CLDRFile.SHORT_ALTS),
                             locale,
                             data)
                     .writeChart(anchors);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -229,7 +229,7 @@ public class ChartCollation extends Chart {
                 addCollator(data, "standard", (RuleBasedCollator) null);
             }
             new Subchart(
-                            ENGLISH.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS),
+                            ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, CLDRFile.SHORT_ALTS),
                             locale,
                             data)
                     .writeChart(anchors);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -228,7 +228,7 @@ public class ChartCollation extends Chart {
             if (!data.containsKey("standard")) {
                 addCollator(data, "standard", (RuleBasedCollator) null);
             }
-            new Subchart(ENGLISH.getName(locale, true, CLDRFile.SHORT_ALTS), locale, data)
+            new Subchart(ENGLISH.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS), locale, data)
                     .writeChart(anchors);
         }
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
@@ -92,7 +92,7 @@ public class ChartDayPeriods extends Chart {
                     tablePrinter
                             .addRow()
                             .addCell(group)
-                            .addCell(ENGLISH.nameGetter().getName(locale))
+                            .addCell(ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale))
                             .addCell(locale)
                             // .addCell(type)
                             .addCell(df.format(time))

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
@@ -92,7 +92,7 @@ public class ChartDayPeriods extends Chart {
                     tablePrinter
                             .addRow()
                             .addCell(group)
-                            .addCell(ENGLISH.getName(locale))
+                            .addCell(ENGLISH.nameGetter().getName(locale))
                             .addCell(locale)
                             // .addCell(type)
                             .addCell(df.format(time))

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
@@ -92,7 +92,7 @@ public class ChartDayPeriods extends Chart {
                     tablePrinter
                             .addRow()
                             .addCell(group)
-                            .addCell(ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale))
+                            .addCell(ENGLISH.nameGetter().getNameFromBCP47(locale))
                             .addCell(locale)
                             // .addCell(type)
                             .addCell(df.format(time))

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -1011,7 +1011,7 @@ public class ChartDelta extends Chart {
                     .addCell(coverageLevel)
                     .finishRow();
         }
-        String title = ENGLISH.nameGetter().getName(file) + " " + chartNameCap;
+        String title = ENGLISH.nameGetter().getNameFromLocaleOrTZID(file) + " " + chartNameCap;
         writeTable(anchors, file, tablePrinter, title, tsvFile);
 
         diff.clear();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -1011,7 +1011,7 @@ public class ChartDelta extends Chart {
                     .addCell(coverageLevel)
                     .finishRow();
         }
-        String title = ENGLISH.getName(file) + " " + chartNameCap;
+        String title = ENGLISH.nameGetter().getName(file) + " " + chartNameCap;
         writeTable(anchors, file, tablePrinter, title, tsvFile);
 
         diff.clear();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -1011,7 +1011,7 @@ public class ChartDelta extends Chart {
                     .addCell(coverageLevel)
                     .finishRow();
         }
-        String title = ENGLISH.nameGetter().getNameFromLocaleOrTZID(file) + " " + chartNameCap;
+        String title = ENGLISH.nameGetter().getNameFromBCP47(file) + " " + chartNameCap;
         writeTable(anchors, file, tablePrinter, title, tsvFile);
 
         diff.clear();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
@@ -166,7 +166,7 @@ public class ChartGrammaticalForms extends Chart {
             }
             Set<String> failures = new LinkedHashSet<>();
             GrammarInfo grammarInfo = SDI.getGrammarInfo(localeId, false);
-            String localeName = CONFIG.getEnglish().getName(localeId);
+            String localeName = CONFIG.getEnglish().nameGetter().getName(localeId);
             for (GrammaticalFeature feature : GrammaticalFeature.values()) {
                 Map<GrammaticalScope, Set<String>> scopeToValues =
                         grammarInfo.get(GrammaticalTarget.nominal, feature);
@@ -905,7 +905,7 @@ public class ChartGrammaticalForms extends Chart {
                             powerTable));
 
             if (!info.isEmpty()) {
-                String name = ENGLISH.getName(locale);
+                String name = ENGLISH.nameGetter().getName(locale);
                 new Subchart(name + ": Unit Grammar Info", locale, info).writeChart(anchors);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
@@ -166,7 +166,7 @@ public class ChartGrammaticalForms extends Chart {
             }
             Set<String> failures = new LinkedHashSet<>();
             GrammarInfo grammarInfo = SDI.getGrammarInfo(localeId, false);
-            String localeName = CONFIG.getEnglish().nameGetter().getNameFromLocaleOrTZID(localeId);
+            String localeName = CONFIG.getEnglish().nameGetter().getNameFromBCP47(localeId);
             for (GrammaticalFeature feature : GrammaticalFeature.values()) {
                 Map<GrammaticalScope, Set<String>> scopeToValues =
                         grammarInfo.get(GrammaticalTarget.nominal, feature);
@@ -905,7 +905,7 @@ public class ChartGrammaticalForms extends Chart {
                             powerTable));
 
             if (!info.isEmpty()) {
-                String name = ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale);
+                String name = ENGLISH.nameGetter().getNameFromBCP47(locale);
                 new Subchart(name + ": Unit Grammar Info", locale, info).writeChart(anchors);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
@@ -166,7 +166,7 @@ public class ChartGrammaticalForms extends Chart {
             }
             Set<String> failures = new LinkedHashSet<>();
             GrammarInfo grammarInfo = SDI.getGrammarInfo(localeId, false);
-            String localeName = CONFIG.getEnglish().nameGetter().getName(localeId);
+            String localeName = CONFIG.getEnglish().nameGetter().getNameFromLocaleOrTZID(localeId);
             for (GrammaticalFeature feature : GrammaticalFeature.values()) {
                 Map<GrammaticalScope, Set<String>> scopeToValues =
                         grammarInfo.get(GrammaticalTarget.nominal, feature);
@@ -905,7 +905,7 @@ public class ChartGrammaticalForms extends Chart {
                             powerTable));
 
             if (!info.isEmpty()) {
-                String name = ENGLISH.nameGetter().getName(locale);
+                String name = ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale);
                 new Subchart(name + ": Unit Grammar Info", locale, info).writeChart(anchors);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -181,7 +181,7 @@ public class ChartLanguageGroups extends Chart {
                 ? "All"
                 : langCode.equals("zh")
                         ? "Mandarin Chinese"
-                        : ENGLISH.getName(CLDRFile.LANGUAGE_NAME, langCode)
+                        : ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, langCode)
                                 .replace(" (Other)", "")
                                 .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -181,7 +181,8 @@ public class ChartLanguageGroups extends Chart {
                 ? "All"
                 : langCode.equals("zh")
                         ? "Mandarin Chinese"
-                        : ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, langCode)
+                        : ENGLISH.nameGetter()
+                                .getName(CLDRFile.LANGUAGE_NAME, langCode)
                                 .replace(" (Other)", "")
                                 .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -182,7 +182,7 @@ public class ChartLanguageGroups extends Chart {
                 : langCode.equals("zh")
                         ? "Mandarin Chinese"
                         : ENGLISH.nameGetter()
-                                .getName(CLDRFile.LANGUAGE_NAME, langCode)
+                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, langCode)
                                 .replace(" (Other)", "")
                                 .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
@@ -79,7 +79,8 @@ public class ChartLanguageMatching extends Chart {
 
     private String getName(String codeWithStars, boolean user) {
         if (!codeWithStars.contains("*") && !codeWithStars.contains("$")) {
-            return ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(codeWithStars, true, CLDRFile.SHORT_ALTS);
+            return ENGLISH.nameGetter()
+                    .getNameFromBCP47BoolAlt(codeWithStars, true, CLDRFile.SHORT_ALTS);
         }
         String[] parts = codeWithStars.split("_");
         if (parts[0].equals("*")) {
@@ -98,7 +99,9 @@ public class ChartLanguageMatching extends Chart {
             }
         }
         String result =
-                ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
+                ENGLISH.nameGetter()
+                        .getNameFromBCP47BoolAlt(
+                                String.join("_", parts), true, CLDRFile.SHORT_ALTS);
         if (user) {
             result =
                     result.replace("Xxxx", "any-script")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
@@ -63,7 +63,7 @@ public class ChartLanguageMatching extends Chart {
 
                 tablePrinter
                         .addRow()
-                        // .addCell(ENGLISH.getName(locale))
+                        // .addCell(ENGLISH.nameGetter().getName(locale))
                         .addCell(getName(row.get0(), true))
                         .addCell(getName(row.get1(), false))
                         .addCell(row.get0())
@@ -79,7 +79,7 @@ public class ChartLanguageMatching extends Chart {
 
     private String getName(String codeWithStars, boolean user) {
         if (!codeWithStars.contains("*") && !codeWithStars.contains("$")) {
-            return ENGLISH.getName(codeWithStars, true, CLDRFile.SHORT_ALTS);
+            return ENGLISH.nameGetter().getName(codeWithStars, true, CLDRFile.SHORT_ALTS);
         }
         String[] parts = codeWithStars.split("_");
         if (parts[0].equals("*")) {
@@ -97,7 +97,7 @@ public class ChartLanguageMatching extends Chart {
                 parts[2] = "XY";
             }
         }
-        String result = ENGLISH.getName(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
+        String result = ENGLISH.nameGetter().getName(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
         if (user) {
             result =
                     result.replace("Xxxx", "any-script")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
@@ -97,7 +97,8 @@ public class ChartLanguageMatching extends Chart {
                 parts[2] = "XY";
             }
         }
-        String result = ENGLISH.nameGetter().getName(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
+        String result =
+                ENGLISH.nameGetter().getName(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
         if (user) {
             result =
                     result.replace("Xxxx", "any-script")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
@@ -79,7 +79,7 @@ public class ChartLanguageMatching extends Chart {
 
     private String getName(String codeWithStars, boolean user) {
         if (!codeWithStars.contains("*") && !codeWithStars.contains("$")) {
-            return ENGLISH.nameGetter().getName(codeWithStars, true, CLDRFile.SHORT_ALTS);
+            return ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(codeWithStars, true, CLDRFile.SHORT_ALTS);
         }
         String[] parts = codeWithStars.split("_");
         if (parts[0].equals("*")) {
@@ -98,7 +98,7 @@ public class ChartLanguageMatching extends Chart {
             }
         }
         String result =
-                ENGLISH.nameGetter().getName(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
+                ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(String.join("_", parts), true, CLDRFile.SHORT_ALTS);
         if (user) {
             result =
                     result.replace("Xxxx", "any-script")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
@@ -34,7 +34,7 @@ public class ChartPersonName extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.nameGetter().getName(locale) + ": Person Names";
+        return ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale) + ": Person Names";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
@@ -34,7 +34,7 @@ public class ChartPersonName extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale) + ": Person Names";
+        return ENGLISH.nameGetter().getNameFromBCP47(locale) + ": Person Names";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
@@ -34,7 +34,7 @@ public class ChartPersonName extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.getName(locale) + ": Person Names";
+        return ENGLISH.nameGetter().getName(locale) + ": Person Names";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -101,7 +101,7 @@ public class ChartSubdivisionNames extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.nameGetter().getNameFromLocaleOrTZBool(locale, true);
+            String name = ENGLISH.nameGetter().getNameFromBCP47Bool(locale, true);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -112,7 +112,7 @@ public class ChartSubdivisionNames extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.nameGetter().getNameFromLocaleOrTZBool("en", true);
+            String ename = ENGLISH.nameGetter().getNameFromBCP47Bool("en", true);
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -165,9 +165,10 @@ public class ChartSubdivisionNames extends Chart {
                 tablePrinter
                         .addRow()
                         .addCell(
-                                english.nameGetter().getName(
-                                        CLDRFile.TERRITORY_NAME,
-                                        code.substring(0, 2).toUpperCase(Locale.ENGLISH)))
+                                english.nameGetter()
+                                        .getName(
+                                                CLDRFile.TERRITORY_NAME,
+                                                code.substring(0, 2).toUpperCase(Locale.ENGLISH)))
                         .addCell(code);
                 for (Entry<String, String> nameAndLocale : nameToCode.entrySet()) {
                     String name = nameAndLocale.getKey();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -101,7 +101,7 @@ public class ChartSubdivisionNames extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.nameGetter().getName(locale, true);
+            String name = ENGLISH.nameGetter().getNameFromLocaleOrTZBool(locale, true);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -112,7 +112,7 @@ public class ChartSubdivisionNames extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.nameGetter().getName("en", true);
+            String ename = ENGLISH.nameGetter().getNameFromLocaleOrTZBool("en", true);
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 
@@ -166,7 +166,7 @@ public class ChartSubdivisionNames extends Chart {
                         .addRow()
                         .addCell(
                                 english.nameGetter()
-                                        .getName(
+                                        .getNameFromTypenumCode(
                                                 CLDRFile.TERRITORY_NAME,
                                                 code.substring(0, 2).toUpperCase(Locale.ENGLISH)))
                         .addCell(code);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -101,7 +101,7 @@ public class ChartSubdivisionNames extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.getName(locale, true);
+            String name = ENGLISH.nameGetter().getName(locale, true);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -112,7 +112,7 @@ public class ChartSubdivisionNames extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.getName("en", true);
+            String ename = ENGLISH.nameGetter().getName("en", true);
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 
@@ -165,7 +165,7 @@ public class ChartSubdivisionNames extends Chart {
                 tablePrinter
                         .addRow()
                         .addCell(
-                                english.getName(
+                                english.nameGetter().getName(
                                         CLDRFile.TERRITORY_NAME,
                                         code.substring(0, 2).toUpperCase(Locale.ENGLISH)))
                         .addCell(code);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
@@ -124,7 +124,7 @@ public class ChartSubdivisions extends Chart {
                 }
                 tablePrinter
                         .addRow()
-                        .addCell(ENGLISH.getName(CLDRFile.TERRITORY_NAME, region))
+                        .addCell(ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, region))
                         .addCell(region)
                         .addCell(name1)
                         // .addCell(type)
@@ -139,7 +139,7 @@ public class ChartSubdivisions extends Chart {
             Set<String> regionAliases = inverseAliases.get(region);
             tablePrinter
                     .addRow()
-                    .addCell(ENGLISH.getName(CLDRFile.TERRITORY_NAME, region))
+                    .addCell(ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, region))
                     .addCell(region)
                     .addCell(
                             regionAliases == null

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
@@ -124,7 +124,9 @@ public class ChartSubdivisions extends Chart {
                 }
                 tablePrinter
                         .addRow()
-                        .addCell(ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
+                        .addCell(
+                                ENGLISH.nameGetter()
+                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
                         .addCell(region)
                         .addCell(name1)
                         // .addCell(type)
@@ -139,7 +141,9 @@ public class ChartSubdivisions extends Chart {
             Set<String> regionAliases = inverseAliases.get(region);
             tablePrinter
                     .addRow()
-                    .addCell(ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
+                    .addCell(
+                            ENGLISH.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
                     .addCell(region)
                     .addCell(
                             regionAliases == null

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
@@ -124,7 +124,7 @@ public class ChartSubdivisions extends Chart {
                 }
                 tablePrinter
                         .addRow()
-                        .addCell(ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, region))
+                        .addCell(ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
                         .addCell(region)
                         .addCell(name1)
                         // .addCell(type)
@@ -139,7 +139,7 @@ public class ChartSubdivisions extends Chart {
             Set<String> regionAliases = inverseAliases.get(region);
             tablePrinter
                     .addRow()
-                    .addCell(ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, region))
+                    .addCell(ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
                     .addCell(region)
                     .addCell(
                             regionAliases == null

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
@@ -34,7 +34,7 @@ public class ChartSupplemental extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale) + ": Overall Errors";
+        return ENGLISH.nameGetter().getNameFromBCP47(locale) + ": Overall Errors";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
@@ -34,7 +34,7 @@ public class ChartSupplemental extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.nameGetter().getName(locale) + ": Overall Errors";
+        return ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale) + ": Overall Errors";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
@@ -34,7 +34,7 @@ public class ChartSupplemental extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.getName(locale) + ": Overall Errors";
+        return ENGLISH.nameGetter().getName(locale) + ": Overall Errors";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
@@ -64,7 +64,7 @@ public class CheckEnglishCurrencyNames {
         System.out.println("Modern Codes: " + modernCurrencyCodes2territory);
         for (String currency : modernCurrencyCodes2territory.keySet()) {
             final String name =
-                    english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+                    english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
@@ -72,7 +72,7 @@ public class CheckEnglishCurrencyNames {
         System.out.println("Non-Modern Codes (with dates): " + currencyCodesWithDates);
         for (String currency : currencyCodesWithDates.keySet()) {
             final String name =
-                    english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+                    english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
@@ -135,20 +135,20 @@ public class CheckEnglishCurrencyNames {
                                     ? "N/A"
                                     : nativeLanguage
                                             .nameGetter()
-                                            .getName(CLDRFile.CURRENCY_SYMBOL, currency);
+                                            .getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, currency);
                     System.out.println(
                             currency
                                     + "\t"
-                                    + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency)
+                                    + english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
                                     + "\t"
                                     + territory
                                     + "\t"
                                     + english.nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, territory)
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                                     + "\t"
                                     + language
                                     + "\t"
-                                    + english.nameGetter().getName(language)
+                                    + english.nameGetter().getNameFromLocaleOrTZID(language)
                                     + "\t"
                                     + symbol);
                     // TODO add script
@@ -173,7 +173,7 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     territory
                             + "\t"
-                            + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory));
+                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory));
         }
         System.out.format("Collected usage data\n");
         for (Entry<String, Set<String>> currencyAndSymbols : currency2symbols.keyValuesSet()) {
@@ -182,7 +182,7 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     currency
                             + "\t"
-                            + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency)
+                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
                             + "\t"
                             + symbols.size()
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
@@ -63,14 +63,16 @@ public class CheckEnglishCurrencyNames {
         }
         System.out.println("Modern Codes: " + modernCurrencyCodes2territory);
         for (String currency : modernCurrencyCodes2territory.keySet()) {
-            final String name = english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+            final String name =
+                    english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
         }
         System.out.println("Non-Modern Codes (with dates): " + currencyCodesWithDates);
         for (String currency : currencyCodesWithDates.keySet()) {
-            final String name = english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+            final String name =
+                    english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
@@ -131,7 +133,9 @@ public class CheckEnglishCurrencyNames {
                     String symbol =
                             nativeLanguage == null
                                     ? "N/A"
-                                    : nativeLanguage.nameGetter().getName(CLDRFile.CURRENCY_SYMBOL, currency);
+                                    : nativeLanguage
+                                            .nameGetter()
+                                            .getName(CLDRFile.CURRENCY_SYMBOL, currency);
                     System.out.println(
                             currency
                                     + "\t"
@@ -139,7 +143,8 @@ public class CheckEnglishCurrencyNames {
                                     + "\t"
                                     + territory
                                     + "\t"
-                                    + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
+                                    + english.nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, territory)
                                     + "\t"
                                     + language
                                     + "\t"
@@ -166,7 +171,9 @@ public class CheckEnglishCurrencyNames {
         System.out.format("No official languages\n");
         for (String territory : noOfficialLanguages) {
             System.out.println(
-                    territory + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory));
+                    territory
+                            + "\t"
+                            + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory));
         }
         System.out.format("Collected usage data\n");
         for (Entry<String, Set<String>> currencyAndSymbols : currency2symbols.keyValuesSet()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
@@ -63,14 +63,14 @@ public class CheckEnglishCurrencyNames {
         }
         System.out.println("Modern Codes: " + modernCurrencyCodes2territory);
         for (String currency : modernCurrencyCodes2territory.keySet()) {
-            final String name = english.getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+            final String name = english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
         }
         System.out.println("Non-Modern Codes (with dates): " + currencyCodesWithDates);
         for (String currency : currencyCodesWithDates.keySet()) {
-            final String name = english.getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+            final String name = english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
@@ -131,19 +131,19 @@ public class CheckEnglishCurrencyNames {
                     String symbol =
                             nativeLanguage == null
                                     ? "N/A"
-                                    : nativeLanguage.getName(CLDRFile.CURRENCY_SYMBOL, currency);
+                                    : nativeLanguage.nameGetter().getName(CLDRFile.CURRENCY_SYMBOL, currency);
                     System.out.println(
                             currency
                                     + "\t"
-                                    + english.getName(CLDRFile.CURRENCY_NAME, currency)
+                                    + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency)
                                     + "\t"
                                     + territory
                                     + "\t"
-                                    + english.getName(CLDRFile.TERRITORY_NAME, territory)
+                                    + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
                                     + "\t"
                                     + language
                                     + "\t"
-                                    + english.getName(language)
+                                    + english.nameGetter().getName(language)
                                     + "\t"
                                     + symbol);
                     // TODO add script
@@ -166,7 +166,7 @@ public class CheckEnglishCurrencyNames {
         System.out.format("No official languages\n");
         for (String territory : noOfficialLanguages) {
             System.out.println(
-                    territory + "\t" + english.getName(CLDRFile.TERRITORY_NAME, territory));
+                    territory + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory));
         }
         System.out.format("Collected usage data\n");
         for (Entry<String, Set<String>> currencyAndSymbols : currency2symbols.keyValuesSet()) {
@@ -175,7 +175,7 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     currency
                             + "\t"
-                            + english.getName(CLDRFile.CURRENCY_NAME, currency)
+                            + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, currency)
                             + "\t"
                             + symbols.size()
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
@@ -10,6 +10,7 @@ import java.util.TreeSet;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.CurrencyDateInfo;
@@ -22,6 +23,7 @@ public class CheckEnglishCurrencyNames {
     static StandardCodes sc = StandardCodes.make();
     static Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
     static CLDRFile english = cldrFactory.make("en", true);
+    static NameGetter englishNameGetter = english.nameGetter();
 
     public static void main(String[] args) {
         Date now = new Date();
@@ -64,7 +66,9 @@ public class CheckEnglishCurrencyNames {
         System.out.println("Modern Codes: " + modernCurrencyCodes2territory);
         for (String currency : modernCurrencyCodes2territory.keySet()) {
             final String name =
-                    english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+                    englishNameGetter
+                            .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
+                            .toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
@@ -72,7 +76,9 @@ public class CheckEnglishCurrencyNames {
         System.out.println("Non-Modern Codes (with dates): " + currencyCodesWithDates);
         for (String currency : currencyCodesWithDates.keySet()) {
             final String name =
-                    english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency).toLowerCase();
+                    englishNameGetter
+                            .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
+                            .toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
             }
@@ -135,20 +141,22 @@ public class CheckEnglishCurrencyNames {
                                     ? "N/A"
                                     : nativeLanguage
                                             .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, currency);
+                                            .getNameFromTypenumCode(
+                                                    CLDRFile.CURRENCY_SYMBOL, currency);
                     System.out.println(
                             currency
                                     + "\t"
-                                    + english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
+                                    + englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.CURRENCY_NAME, currency)
                                     + "\t"
                                     + territory
                                     + "\t"
-                                    + english.nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                                    + englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, territory)
                                     + "\t"
                                     + language
                                     + "\t"
-                                    + english.nameGetter().getNameFromLocaleOrTZID(language)
+                                    + englishNameGetter.getNameFromBCP47(language)
                                     + "\t"
                                     + symbol);
                     // TODO add script
@@ -173,7 +181,8 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     territory
                             + "\t"
-                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory));
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.TERRITORY_NAME, territory));
         }
         System.out.format("Collected usage data\n");
         for (Entry<String, Set<String>> currencyAndSymbols : currency2symbols.keyValuesSet()) {
@@ -182,7 +191,8 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     currency
                             + "\t"
-                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.CURRENCY_NAME, currency)
                             + "\t"
                             + symbols.size()
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
@@ -37,7 +37,11 @@ public class CheckLanguageNameCoverage {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);
             Level level = coverages.getLevel(path);
             System.out.println(
-                    langCode + "\t" + level + "\t" + config.getEnglish().nameGetter().getName(langCode));
+                    langCode
+                            + "\t"
+                            + level
+                            + "\t"
+                            + config.getEnglish().nameGetter().getName(langCode));
         }
         for (String langCode : map.keySet()) {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
@@ -37,7 +37,7 @@ public class CheckLanguageNameCoverage {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);
             Level level = coverages.getLevel(path);
             System.out.println(
-                    langCode + "\t" + level + "\t" + config.getEnglish().getName(langCode));
+                    langCode + "\t" + level + "\t" + config.getEnglish().nameGetter().getName(langCode));
         }
         for (String langCode : map.keySet()) {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
@@ -41,7 +41,7 @@ public class CheckLanguageNameCoverage {
                             + "\t"
                             + level
                             + "\t"
-                            + config.getEnglish().nameGetter().getName(langCode));
+                            + config.getEnglish().nameGetter().getNameFromLocaleOrTZID(langCode));
         }
         for (String langCode : map.keySet()) {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
@@ -41,7 +41,7 @@ public class CheckLanguageNameCoverage {
                             + "\t"
                             + level
                             + "\t"
-                            + config.getEnglish().nameGetter().getNameFromLocaleOrTZID(langCode));
+                            + config.getEnglish().nameGetter().getNameFromBCP47(langCode));
         }
         for (String langCode : map.keySet()) {
             String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
@@ -23,7 +23,7 @@ public class CompareOyster {
                             + "\t"
                             + itemRegion
                             + "\t"
-                            + file.getName(CLDRFile.TERRITORY_NAME, itemRegion));
+                            + file.nameGetter().getName(CLDRFile.TERRITORY_NAME, itemRegion));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
@@ -23,7 +23,7 @@ public class CompareOyster {
                             + "\t"
                             + itemRegion
                             + "\t"
-                            + file.nameGetter().getName(CLDRFile.TERRITORY_NAME, itemRegion));
+                            + file.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, itemRegion));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
@@ -23,7 +23,8 @@ public class CompareOyster {
                             + "\t"
                             + itemRegion
                             + "\t"
-                            + file.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, itemRegion));
+                            + file.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, itemRegion));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -107,10 +107,10 @@ public class CompareSuppress {
     }
 
     public static String langAndName(CLDRFile english, String base) {
-        return base + "\t" + english.getName(base);
+        return base + "\t" + english.nameGetter().getName(base);
     }
 
     public static String scriptAndName(CLDRFile english, String suppressScript) {
-        return suppressScript + "\t" + english.getName(CLDRFile.SCRIPT_NAME, suppressScript);
+        return suppressScript + "\t" + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, suppressScript);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -107,12 +107,12 @@ public class CompareSuppress {
     }
 
     public static String langAndName(CLDRFile english, String base) {
-        return base + "\t" + english.nameGetter().getName(base);
+        return base + "\t" + english.nameGetter().getNameFromLocaleOrTZID(base);
     }
 
     public static String scriptAndName(CLDRFile english, String suppressScript) {
         return suppressScript
                 + "\t"
-                + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, suppressScript);
+                + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, suppressScript);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -111,6 +111,8 @@ public class CompareSuppress {
     }
 
     public static String scriptAndName(CLDRFile english, String suppressScript) {
-        return suppressScript + "\t" + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, suppressScript);
+        return suppressScript
+                + "\t"
+                + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, suppressScript);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -107,7 +107,7 @@ public class CompareSuppress {
     }
 
     public static String langAndName(CLDRFile english, String base) {
-        return base + "\t" + english.nameGetter().getNameFromLocaleOrTZID(base);
+        return base + "\t" + english.nameGetter().getNameFromBCP47(base);
     }
 
     public static String scriptAndName(CLDRFile english, String suppressScript) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -50,6 +50,7 @@ import org.unicode.cldr.util.LanguageTagCanonicalizer;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleIDParser.Level;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SpreadSheet;
@@ -119,6 +120,7 @@ public class ConvertLanguageData {
 
     static Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
     static CLDRFile english = cldrFactory.make("en", true);
+    static final NameGetter englishNameGetter = english.nameGetter();
 
     static SupplementalDataInfo supplementalData =
             SupplementalDataInfo.getInstance(CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY);
@@ -260,7 +262,7 @@ public class ConvertLanguageData {
 
     public static String getLanguageCodeAndName(String code) {
         if (code == null) return null;
-        return english.nameGetter().getNameFromLocaleOrTZID(code) + " [" + code + "]";
+        return englishNameGetter.getNameFromBCP47(code) + " [" + code + "]";
     }
 
     private static String getReplacement(String oldDefault, Set<String> defaultLocaleContent) {
@@ -382,7 +384,7 @@ public class ConvertLanguageData {
                                     "changing <languageData>",
                                     languageSubtag
                                             + "\t"
-                                            + english.nameGetter().getNameFromLocaleOrTZID(languageSubtag),
+                                            + englishNameGetter.getNameFromBCP47(languageSubtag),
                                     problem));
                 }
             }
@@ -442,8 +444,8 @@ public class ConvertLanguageData {
                         .append(s)
                         .append(":")
                         .append(
-                                english.nameGetter()
-                                        .getNameFromTypestrCode(s.length() == 4 ? "script" : "region", s))
+                                englishNameGetter.getNameFromTypestrCode(
+                                        s.length() == 4 ? "script" : "region", s))
                         .append("] ");
                 if (oldValue == null) {
                     temp.append(" added as ").append(newValue);
@@ -992,7 +994,8 @@ public class ConvertLanguageData {
         static Map<String, String> oldToFixed = new HashMap<>();
 
         public String getLanguageName() {
-            String cldrResult = getExcelQuote(english.nameGetter().getNameFromLocaleOrTZBool(languageCode, true));
+            String cldrResult =
+                    getExcelQuote(englishNameGetter.getNameFromBCP47Bool(languageCode, true));
             //            String result = getLanguageName2();
             //            if (!result.equalsIgnoreCase(cldrResult)) {
             //                if (null == oldToFixed.put(result, cldrResult)) {
@@ -1066,7 +1069,10 @@ public class ConvertLanguageData {
 
     public static String getCountryCodeAndName(String code) {
         if (code == null) return null;
-        return english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code) + " [" + code + "]";
+        return englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code)
+                + " ["
+                + code
+                + "]";
     }
 
     static class RowComparator implements Comparator<RowData> {
@@ -2580,17 +2586,17 @@ public class ConvertLanguageData {
     }
 
     private static String getULocaleLocaleName(String languageCode) {
-        return english.nameGetter().getNameFromLocaleOrTZBool(languageCode, true);
+        return englishNameGetter.getNameFromBCP47Bool(languageCode, true);
         // return new ULocale(languageCode).getDisplayName();
     }
 
     private static String getULocaleScriptName(String scriptCode) {
-        return english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, scriptCode);
+        return englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, scriptCode);
         // return ULocale.getDisplayScript("und_" + scriptCode, ULocale.ENGLISH);
     }
 
     private static String getULocaleCountryName(String countryCode) {
-        return english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
+        return englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
         // return ULocale.getDisplayCountry("und_" + countryCode, ULocale.ENGLISH);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -260,7 +260,7 @@ public class ConvertLanguageData {
 
     public static String getLanguageCodeAndName(String code) {
         if (code == null) return null;
-        return english.getName(code) + " [" + code + "]";
+        return english.nameGetter().getName(code) + " [" + code + "]";
     }
 
     private static String getReplacement(String oldDefault, Set<String> defaultLocaleContent) {
@@ -380,7 +380,7 @@ public class ConvertLanguageData {
                     warnings.add(
                             BadItem.DETAIL.toString(
                                     "changing <languageData>",
-                                    languageSubtag + "\t" + english.getName(languageSubtag),
+                                    languageSubtag + "\t" + english.nameGetter().getName(languageSubtag),
                                     problem));
                 }
             }
@@ -439,7 +439,7 @@ public class ConvertLanguageData {
                 temp.append("[")
                         .append(s)
                         .append(":")
-                        .append(english.getName(s.length() == 4 ? "script" : "region", s))
+                        .append(english.nameGetter().getName(s.length() == 4 ? "script" : "region", s))
                         .append("] ");
                 if (oldValue == null) {
                     temp.append(" added as ").append(newValue);
@@ -988,7 +988,7 @@ public class ConvertLanguageData {
         static Map<String, String> oldToFixed = new HashMap<>();
 
         public String getLanguageName() {
-            String cldrResult = getExcelQuote(english.getName(languageCode, true));
+            String cldrResult = getExcelQuote(english.nameGetter().getName(languageCode, true));
             //            String result = getLanguageName2();
             //            if (!result.equalsIgnoreCase(cldrResult)) {
             //                if (null == oldToFixed.put(result, cldrResult)) {
@@ -1062,7 +1062,7 @@ public class ConvertLanguageData {
 
     public static String getCountryCodeAndName(String code) {
         if (code == null) return null;
-        return english.getName(CLDRFile.TERRITORY_NAME, code) + " [" + code + "]";
+        return english.nameGetter().getName(CLDRFile.TERRITORY_NAME, code) + " [" + code + "]";
     }
 
     static class RowComparator implements Comparator<RowData> {
@@ -2576,17 +2576,17 @@ public class ConvertLanguageData {
     }
 
     private static String getULocaleLocaleName(String languageCode) {
-        return english.getName(languageCode, true);
+        return english.nameGetter().getName(languageCode, true);
         // return new ULocale(languageCode).getDisplayName();
     }
 
     private static String getULocaleScriptName(String scriptCode) {
-        return english.getName(CLDRFile.SCRIPT_NAME, scriptCode);
+        return english.nameGetter().getName(CLDRFile.SCRIPT_NAME, scriptCode);
         // return ULocale.getDisplayScript("und_" + scriptCode, ULocale.ENGLISH);
     }
 
     private static String getULocaleCountryName(String countryCode) {
-        return english.getName(CLDRFile.TERRITORY_NAME, countryCode);
+        return english.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode);
         // return ULocale.getDisplayCountry("und_" + countryCode, ULocale.ENGLISH);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -380,7 +380,9 @@ public class ConvertLanguageData {
                     warnings.add(
                             BadItem.DETAIL.toString(
                                     "changing <languageData>",
-                                    languageSubtag + "\t" + english.nameGetter().getName(languageSubtag),
+                                    languageSubtag
+                                            + "\t"
+                                            + english.nameGetter().getName(languageSubtag),
                                     problem));
                 }
             }
@@ -439,7 +441,9 @@ public class ConvertLanguageData {
                 temp.append("[")
                         .append(s)
                         .append(":")
-                        .append(english.nameGetter().getName(s.length() == 4 ? "script" : "region", s))
+                        .append(
+                                english.nameGetter()
+                                        .getName(s.length() == 4 ? "script" : "region", s))
                         .append("] ");
                 if (oldValue == null) {
                     temp.append(" added as ").append(newValue);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -260,7 +260,7 @@ public class ConvertLanguageData {
 
     public static String getLanguageCodeAndName(String code) {
         if (code == null) return null;
-        return english.nameGetter().getName(code) + " [" + code + "]";
+        return english.nameGetter().getNameFromLocaleOrTZID(code) + " [" + code + "]";
     }
 
     private static String getReplacement(String oldDefault, Set<String> defaultLocaleContent) {
@@ -382,7 +382,7 @@ public class ConvertLanguageData {
                                     "changing <languageData>",
                                     languageSubtag
                                             + "\t"
-                                            + english.nameGetter().getName(languageSubtag),
+                                            + english.nameGetter().getNameFromLocaleOrTZID(languageSubtag),
                                     problem));
                 }
             }
@@ -443,7 +443,7 @@ public class ConvertLanguageData {
                         .append(":")
                         .append(
                                 english.nameGetter()
-                                        .getName(s.length() == 4 ? "script" : "region", s))
+                                        .getNameFromTypestrCode(s.length() == 4 ? "script" : "region", s))
                         .append("] ");
                 if (oldValue == null) {
                     temp.append(" added as ").append(newValue);
@@ -992,7 +992,7 @@ public class ConvertLanguageData {
         static Map<String, String> oldToFixed = new HashMap<>();
 
         public String getLanguageName() {
-            String cldrResult = getExcelQuote(english.nameGetter().getName(languageCode, true));
+            String cldrResult = getExcelQuote(english.nameGetter().getNameFromLocaleOrTZBool(languageCode, true));
             //            String result = getLanguageName2();
             //            if (!result.equalsIgnoreCase(cldrResult)) {
             //                if (null == oldToFixed.put(result, cldrResult)) {
@@ -1066,7 +1066,7 @@ public class ConvertLanguageData {
 
     public static String getCountryCodeAndName(String code) {
         if (code == null) return null;
-        return english.nameGetter().getName(CLDRFile.TERRITORY_NAME, code) + " [" + code + "]";
+        return english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code) + " [" + code + "]";
     }
 
     static class RowComparator implements Comparator<RowData> {
@@ -2580,17 +2580,17 @@ public class ConvertLanguageData {
     }
 
     private static String getULocaleLocaleName(String languageCode) {
-        return english.nameGetter().getName(languageCode, true);
+        return english.nameGetter().getNameFromLocaleOrTZBool(languageCode, true);
         // return new ULocale(languageCode).getDisplayName();
     }
 
     private static String getULocaleScriptName(String scriptCode) {
-        return english.nameGetter().getName(CLDRFile.SCRIPT_NAME, scriptCode);
+        return english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, scriptCode);
         // return ULocale.getDisplayScript("und_" + scriptCode, ULocale.ENGLISH);
     }
 
     private static String getULocaleCountryName(String countryCode) {
-        return english.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode);
+        return english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
         // return ULocale.getDisplayCountry("und_" + countryCode, ULocale.ENGLISH);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -52,6 +52,7 @@ import org.unicode.cldr.util.IsoCurrencyParser.Data;
 import org.unicode.cldr.util.IsoRegionData;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Log;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
@@ -478,6 +479,7 @@ public class CountItems {
         }
         // convert to map
         Map<String, String> results = new TreeMap<>();
+        NameGetter nameGetter = english.nameGetter();
         for (String item : countryToContinent.keySet()) {
             final Set<String> containees = countryToContinent.getAll(item);
             if (containees.size() != 1) {
@@ -485,8 +487,8 @@ public class CountItems {
             }
             results.put(
                     item,
-                    english.nameGetter()
-                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
+                    nameGetter.getNameFromTypenumCode(
+                            CLDRFile.TERRITORY_NAME, containees.iterator().next()));
         }
         return results;
     }
@@ -498,6 +500,7 @@ public class CountItems {
         Set<String> masked = new HashSet<>();
         Map<String, String> zoneNew_Old = new TreeMap<>(col);
         String lastZone = "XXX";
+        NameGetter nameGetter = english.nameGetter();
         for (String zone : new TreeSet<>(zone_country.keySet())) {
             String[] parts = zone.split("/");
             String newPrefix =
@@ -559,7 +562,7 @@ public class CountItems {
                             "# "
                                     + newCountry
                                     + "\t"
-                                    + english.nameGetter().getNameFromTypestrCode("territory", newCountry));
+                                    + nameGetter.getNameFromTypestrCode("territory", newCountry));
                     lastCountry = newCountry;
                 }
                 Log.println("\t'" + oldName + "'\t>\t'" + newName + "';");
@@ -986,6 +989,7 @@ public class CountItems {
         Set<String> missingRegions = new TreeSet<>();
         Set<String> exceptionSet = new HashSet<>(Arrays.asList(exceptions));
         List<String> duplicateDestroyer = new ArrayList<>();
+        NameGetter nameGetter = english.nameGetter();
         for (String region : availableCodes) {
 
             if (exceptionSet.contains(region)) continue;
@@ -1002,7 +1006,7 @@ public class CountItems {
             } else {
                 result = region;
             }
-            String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, result);
+            String name = nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, result);
             if (!(duplicateDestroyer.contains(alpha3 + result + name))) {
                 duplicateDestroyer.add(alpha3 + result + name);
                 System.out.println(
@@ -1016,7 +1020,7 @@ public class CountItems {
             }
         }
         for (String region : missingRegions) {
-            String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
+            String name = nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
             System.err.println("ERROR: Missing " + codeType + " code for " + region + "\t" + name);
         }
     }
@@ -1093,12 +1097,13 @@ public class CountItems {
         Map<String, Level> onlyLocales = platform_locale_status.get(Organization.ibm);
         Set<String> locales = onlyLocales.keySet();
         CLDRFile english = cldrFactory.make("en", true);
+        NameGetter nameGetter = english.nameGetter();
         for (Iterator<String> it = locales.iterator(); it.hasNext(); ) {
             String locale = it.next();
             System.out.println(
                     locale
                             + "\t"
-                            + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                            + nameGetter.getNameFromBCP47(locale)
                             + "\t"
                             + onlyLocales.get(locale));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -484,7 +484,9 @@ public class CountItems {
                 throw new IllegalArgumentException(item + "\t" + containees);
             }
             results.put(
-                    item, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
+                    item,
+                    english.nameGetter()
+                            .getName(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
         }
         return results;
     }
@@ -499,7 +501,8 @@ public class CountItems {
         for (String zone : new TreeSet<>(zone_country.keySet())) {
             String[] parts = zone.split("/");
             String newPrefix =
-                    zone_country.get(zone); // english.nameGetter().getName("tzid", zone_country.get(zone),
+                    zone_country.get(
+                            zone); // english.nameGetter().getName("tzid", zone_country.get(zone),
             // false).replace(' ', '_');
             if (newPrefix.equals("001")) {
                 newPrefix = "ZZ";
@@ -553,7 +556,10 @@ public class CountItems {
                 String newCountry = newName.split("/")[0];
                 if (!newCountry.equals(lastCountry)) {
                     Log.println(
-                            "# " + newCountry + "\t" + english.nameGetter().getName("territory", newCountry));
+                            "# "
+                                    + newCountry
+                                    + "\t"
+                                    + english.nameGetter().getName("territory", newCountry));
                     lastCountry = newCountry;
                 }
                 Log.println("\t'" + oldName + "'\t>\t'" + newName + "';");
@@ -821,7 +827,10 @@ public class CountItems {
             String tech = row.get0();
             String bib = row.get1();
             String lang = row.get2();
-            String name = Iso639Data.getNames(lang).iterator().next(); // english.nameGetter().getName(lang);
+            String name =
+                    Iso639Data.getNames(lang)
+                            .iterator()
+                            .next(); // english.nameGetter().getName(lang);
             if ((bib != null && !lang.equals(bib)) || (tech != null && !lang.equals(tech))) {
                 System.out.println(
                         "  { \"" + bib + "\", \"" + tech + "\", \"" + lang + "\" },  // " + name);
@@ -1087,7 +1096,11 @@ public class CountItems {
         for (Iterator<String> it = locales.iterator(); it.hasNext(); ) {
             String locale = it.next();
             System.out.println(
-                    locale + "\t" + english.nameGetter().getName(locale) + "\t" + onlyLocales.get(locale));
+                    locale
+                            + "\t"
+                            + english.nameGetter().getName(locale)
+                            + "\t"
+                            + onlyLocales.get(locale));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -484,7 +484,7 @@ public class CountItems {
                 throw new IllegalArgumentException(item + "\t" + containees);
             }
             results.put(
-                    item, english.getName(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
+                    item, english.nameGetter().getName(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
         }
         return results;
     }
@@ -499,7 +499,7 @@ public class CountItems {
         for (String zone : new TreeSet<>(zone_country.keySet())) {
             String[] parts = zone.split("/");
             String newPrefix =
-                    zone_country.get(zone); // english.getName("tzid", zone_country.get(zone),
+                    zone_country.get(zone); // english.nameGetter().getName("tzid", zone_country.get(zone),
             // false).replace(' ', '_');
             if (newPrefix.equals("001")) {
                 newPrefix = "ZZ";
@@ -553,7 +553,7 @@ public class CountItems {
                 String newCountry = newName.split("/")[0];
                 if (!newCountry.equals(lastCountry)) {
                     Log.println(
-                            "# " + newCountry + "\t" + english.getName("territory", newCountry));
+                            "# " + newCountry + "\t" + english.nameGetter().getName("territory", newCountry));
                     lastCountry = newCountry;
                 }
                 Log.println("\t'" + oldName + "'\t>\t'" + newName + "';");
@@ -821,7 +821,7 @@ public class CountItems {
             String tech = row.get0();
             String bib = row.get1();
             String lang = row.get2();
-            String name = Iso639Data.getNames(lang).iterator().next(); // english.getName(lang);
+            String name = Iso639Data.getNames(lang).iterator().next(); // english.nameGetter().getName(lang);
             if ((bib != null && !lang.equals(bib)) || (tech != null && !lang.equals(tech))) {
                 System.out.println(
                         "  { \"" + bib + "\", \"" + tech + "\", \"" + lang + "\" },  // " + name);
@@ -993,7 +993,7 @@ public class CountItems {
             } else {
                 result = region;
             }
-            String name = english.getName(CLDRFile.TERRITORY_NAME, result);
+            String name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, result);
             if (!(duplicateDestroyer.contains(alpha3 + result + name))) {
                 duplicateDestroyer.add(alpha3 + result + name);
                 System.out.println(
@@ -1007,7 +1007,7 @@ public class CountItems {
             }
         }
         for (String region : missingRegions) {
-            String name = english.getName(CLDRFile.TERRITORY_NAME, region);
+            String name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region);
             System.err.println("ERROR: Missing " + codeType + " code for " + region + "\t" + name);
         }
     }
@@ -1087,7 +1087,7 @@ public class CountItems {
         for (Iterator<String> it = locales.iterator(); it.hasNext(); ) {
             String locale = it.next();
             System.out.println(
-                    locale + "\t" + english.getName(locale) + "\t" + onlyLocales.get(locale));
+                    locale + "\t" + english.nameGetter().getName(locale) + "\t" + onlyLocales.get(locale));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -486,7 +486,7 @@ public class CountItems {
             results.put(
                     item,
                     english.nameGetter()
-                            .getName(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
+                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, containees.iterator().next()));
         }
         return results;
     }
@@ -559,7 +559,7 @@ public class CountItems {
                             "# "
                                     + newCountry
                                     + "\t"
-                                    + english.nameGetter().getName("territory", newCountry));
+                                    + english.nameGetter().getNameFromTypestrCode("territory", newCountry));
                     lastCountry = newCountry;
                 }
                 Log.println("\t'" + oldName + "'\t>\t'" + newName + "';");
@@ -1002,7 +1002,7 @@ public class CountItems {
             } else {
                 result = region;
             }
-            String name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, result);
+            String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, result);
             if (!(duplicateDestroyer.contains(alpha3 + result + name))) {
                 duplicateDestroyer.add(alpha3 + result + name);
                 System.out.println(
@@ -1016,7 +1016,7 @@ public class CountItems {
             }
         }
         for (String region : missingRegions) {
-            String name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region);
+            String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
             System.err.println("ERROR: Missing " + codeType + " code for " + region + "\t" + name);
         }
     }
@@ -1098,7 +1098,7 @@ public class CountItems {
             System.out.println(
                     locale
                             + "\t"
-                            + english.nameGetter().getName(locale)
+                            + english.nameGetter().getNameFromLocaleOrTZID(locale)
                             + "\t"
                             + onlyLocales.get(locale));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
@@ -150,7 +150,7 @@ public class DeriveScripts {
                         + ";\t"
                         + scriptField
                         + "\t# "
-                        + english.getName(CLDRFile.LANGUAGE_NAME, language)
+                        + english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language)
                         + ";\t"
                         + status
                         + ";\t"
@@ -205,13 +205,13 @@ public class DeriveScripts {
                                 + "\t"
                                 + lang
                                 + "\t"
-                                + english.getName(lang)
+                                + english.nameGetter().getName(lang)
                                 + "\t"
                                 + scripts
                                 + "\t"
                                 + likelyScript
                         //                + "\t" + script + "\t" +
-                        // english.getName(CLDRFile.SCRIPT_NAME, script)
+                        // english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
                         );
             }
             System.out.println("#total:\t" + i);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
@@ -150,7 +150,7 @@ public class DeriveScripts {
                         + ";\t"
                         + scriptField
                         + "\t# "
-                        + english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language)
+                        + english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
                         + ";\t"
                         + status
                         + ";\t"
@@ -205,7 +205,7 @@ public class DeriveScripts {
                                 + "\t"
                                 + lang
                                 + "\t"
-                                + english.nameGetter().getName(lang)
+                                + english.nameGetter().getNameFromLocaleOrTZID(lang)
                                 + "\t"
                                 + scripts
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
@@ -150,7 +150,8 @@ public class DeriveScripts {
                         + ";\t"
                         + scriptField
                         + "\t# "
-                        + english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
+                        + english.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
                         + ";\t"
                         + status
                         + ";\t"
@@ -205,7 +206,7 @@ public class DeriveScripts {
                                 + "\t"
                                 + lang
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(lang)
+                                + english.nameGetter().getNameFromBCP47(lang)
                                 + "\t"
                                 + scripts
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
@@ -35,7 +35,7 @@ public class DiffWithParent {
             PrettyPath pp = new PrettyPath();
             for (String locale : cldrFactory.getAvailable()) {
                 if (fileMatcher.reset(locale).matches()) {
-                    System.out.println(locale + "\t" + english.getName(locale));
+                    System.out.println(locale + "\t" + english.nameGetter().getName(locale));
                     CLDRFile file = cldrFactory.make(locale, false);
                     String parentLocale = LocaleIDParser.getParent(locale);
                     CLDRFile parent = cldrFactory.make(parentLocale, true); // use
@@ -74,7 +74,7 @@ public class DiffWithParent {
                     PrintWriter out =
                             FileUtilities.openUTF8Writer(
                                     CLDRPaths.GEN_DIRECTORY, locale + "_diff.html");
-                    String title = locale + " " + english.getName(locale) + " Diff with Parent";
+                    String title = locale + " " + english.nameGetter().getName(locale) + " Diff with Parent";
                     out.println(
                             "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>"
                                     + title

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
@@ -35,7 +35,7 @@ public class DiffWithParent {
             PrettyPath pp = new PrettyPath();
             for (String locale : cldrFactory.getAvailable()) {
                 if (fileMatcher.reset(locale).matches()) {
-                    System.out.println(locale + "\t" + english.nameGetter().getName(locale));
+                    System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
                     CLDRFile file = cldrFactory.make(locale, false);
                     String parentLocale = LocaleIDParser.getParent(locale);
                     CLDRFile parent = cldrFactory.make(parentLocale, true); // use
@@ -77,7 +77,7 @@ public class DiffWithParent {
                     String title =
                             locale
                                     + " "
-                                    + english.nameGetter().getName(locale)
+                                    + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                     + " Diff with Parent";
                     out.println(
                             "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
@@ -74,7 +74,11 @@ public class DiffWithParent {
                     PrintWriter out =
                             FileUtilities.openUTF8Writer(
                                     CLDRPaths.GEN_DIRECTORY, locale + "_diff.html");
-                    String title = locale + " " + english.nameGetter().getName(locale) + " Diff with Parent";
+                    String title =
+                            locale
+                                    + " "
+                                    + english.nameGetter().getName(locale)
+                                    + " Diff with Parent";
                     out.println(
                             "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>"
                                     + title

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
@@ -35,7 +35,8 @@ public class DiffWithParent {
             PrettyPath pp = new PrettyPath();
             for (String locale : cldrFactory.getAvailable()) {
                 if (fileMatcher.reset(locale).matches()) {
-                    System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+                    System.out.println(
+                            locale + "\t" + english.nameGetter().getNameFromBCP47(locale));
                     CLDRFile file = cldrFactory.make(locale, false);
                     String parentLocale = LocaleIDParser.getParent(locale);
                     CLDRFile parent = cldrFactory.make(parentLocale, true); // use
@@ -77,7 +78,7 @@ public class DiffWithParent {
                     String title =
                             locale
                                     + " "
-                                    + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                    + english.nameGetter().getNameFromBCP47(locale)
                                     + " Diff with Parent";
                     out.println(
                             "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -90,7 +90,7 @@ class ExtractMessages {
                             "Skipping, no CLDR locale file: "
                                     + name
                                     + "\t"
-                                    + english.getName(name)
+                                    + english.nameGetter().getName(name)
                                     + "\t"
                                     + e1.getClass().getName()
                                     + "\t"
@@ -158,7 +158,7 @@ class ExtractMessages {
 
             for (String name : skipped) {
                 System.out.println(
-                        "\tSkipping, no CLDR locale file: " + name + "\t" + english.getName(name));
+                        "\tSkipping, no CLDR locale file: " + name + "\t" + english.nameGetter().getName(name));
             }
             double deltaTime = System.currentTimeMillis() - startTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");
@@ -448,7 +448,7 @@ class ExtractMessages {
             switch (type) {
                 case LANGUAGE:
                     for (String code : sc.getAvailableCodes("language")) {
-                        String name = english.getName("language", code);
+                        String name = english.nameGetter().getName("language", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -489,7 +489,7 @@ class ExtractMessages {
                     break;
                 case REGION:
                     for (String code : sc.getAvailableCodes("territory")) {
-                        String name = english.getName("territory", code);
+                        String name = english.nameGetter().getName("territory", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -528,7 +528,7 @@ class ExtractMessages {
                     break;
                 case CURRENCY:
                     for (String code : sc.getAvailableCodes("currency")) {
-                        String name = english.getName("currency", code);
+                        String name = english.nameGetter().getName("currency", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -670,7 +670,7 @@ class ExtractMessages {
 
         public String getCldrValue(CLDRFile cldrFile, String id) {
             String result = cldrFile.getStringValue(getPath(id));
-            // cldrFile.getName(CLDRFile.LANGUAGE_NAME, id, false);
+            // cldrFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, id, false);
             if (result == null && type == Type.TIMEZONE) {
                 String[] parts = id.split("/");
                 result = parts[parts.length - 1].replace("_", " ");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -90,7 +90,7 @@ class ExtractMessages {
                             "Skipping, no CLDR locale file: "
                                     + name
                                     + "\t"
-                                    + english.nameGetter().getNameFromLocaleOrTZID(name)
+                                    + english.nameGetter().getNameFromBCP47(name)
                                     + "\t"
                                     + e1.getClass().getName()
                                     + "\t"
@@ -161,7 +161,7 @@ class ExtractMessages {
                         "\tSkipping, no CLDR locale file: "
                                 + name
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(name));
+                                + english.nameGetter().getNameFromBCP47(name));
             }
             double deltaTime = System.currentTimeMillis() - startTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");
@@ -492,7 +492,8 @@ class ExtractMessages {
                     break;
                 case REGION:
                     for (String code : sc.getAvailableCodes("territory")) {
-                        String name = english.nameGetter().getNameFromTypestrCode("territory", code);
+                        String name =
+                                english.nameGetter().getNameFromTypestrCode("territory", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -158,7 +158,10 @@ class ExtractMessages {
 
             for (String name : skipped) {
                 System.out.println(
-                        "\tSkipping, no CLDR locale file: " + name + "\t" + english.nameGetter().getName(name));
+                        "\tSkipping, no CLDR locale file: "
+                                + name
+                                + "\t"
+                                + english.nameGetter().getName(name));
             }
             double deltaTime = System.currentTimeMillis() - startTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -90,7 +90,7 @@ class ExtractMessages {
                             "Skipping, no CLDR locale file: "
                                     + name
                                     + "\t"
-                                    + english.nameGetter().getName(name)
+                                    + english.nameGetter().getNameFromLocaleOrTZID(name)
                                     + "\t"
                                     + e1.getClass().getName()
                                     + "\t"
@@ -161,7 +161,7 @@ class ExtractMessages {
                         "\tSkipping, no CLDR locale file: "
                                 + name
                                 + "\t"
-                                + english.nameGetter().getName(name));
+                                + english.nameGetter().getNameFromLocaleOrTZID(name));
             }
             double deltaTime = System.currentTimeMillis() - startTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");
@@ -451,7 +451,7 @@ class ExtractMessages {
             switch (type) {
                 case LANGUAGE:
                     for (String code : sc.getAvailableCodes("language")) {
-                        String name = english.nameGetter().getName("language", code);
+                        String name = english.nameGetter().getNameFromTypestrCode("language", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -492,7 +492,7 @@ class ExtractMessages {
                     break;
                 case REGION:
                     for (String code : sc.getAvailableCodes("territory")) {
-                        String name = english.nameGetter().getName("territory", code);
+                        String name = english.nameGetter().getNameFromTypestrCode("territory", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -531,7 +531,7 @@ class ExtractMessages {
                     break;
                 case CURRENCY:
                     for (String code : sc.getAvailableCodes("currency")) {
-                        String name = english.nameGetter().getName("currency", code);
+                        String name = english.nameGetter().getNameFromTypestrCode("currency", code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindHardInheritance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindHardInheritance.java
@@ -82,7 +82,7 @@ public class FindHardInheritance {
 
     public static void main(String[] args) {
         //        for (String localeId : CLDRConfig.getInstance().getCldrFactory().getAvailable()) {
-        //            String name = CLDRConfig.getInstance().getEnglish().getName(localeId);
+        //            String name = CLDRConfig.getInstance().getEnglish().nameGetter().getName(localeId);
         //            System.out.println(localeId + "\t" + name);
         //        }
         //        if (true) return;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindHardInheritance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindHardInheritance.java
@@ -82,7 +82,8 @@ public class FindHardInheritance {
 
     public static void main(String[] args) {
         //        for (String localeId : CLDRConfig.getInstance().getCldrFactory().getAvailable()) {
-        //            String name = CLDRConfig.getInstance().getEnglish().nameGetter().getName(localeId);
+        //            String name =
+        // CLDRConfig.getInstance().getEnglish().nameGetter().getName(localeId);
         //            System.out.println(localeId + "\t" + name);
         //        }
         //        if (true) return;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
@@ -134,7 +134,7 @@ public class FindPluralDifferences {
                                     + "➞"
                                     + newVersion
                                     + "\t"
-                                    + ToolConfig.getToolInstance().getEnglish().getName(locale)
+                                    + ToolConfig.getToolInstance().getEnglish().nameGetter().getName(locale)
                                     + "\t"
                                     + locale
                                     + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
@@ -137,7 +137,7 @@ public class FindPluralDifferences {
                                     + ToolConfig.getToolInstance()
                                             .getEnglish()
                                             .nameGetter()
-                                            .getNameFromLocaleOrTZID(locale)
+                                            .getNameFromBCP47(locale)
                                     + "\t"
                                     + locale
                                     + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
@@ -137,7 +137,7 @@ public class FindPluralDifferences {
                                     + ToolConfig.getToolInstance()
                                             .getEnglish()
                                             .nameGetter()
-                                            .getName(locale)
+                                            .getNameFromLocaleOrTZID(locale)
                                     + "\t"
                                     + locale
                                     + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
@@ -134,7 +134,10 @@ public class FindPluralDifferences {
                                     + "➞"
                                     + newVersion
                                     + "\t"
-                                    + ToolConfig.getToolInstance().getEnglish().nameGetter().getName(locale)
+                                    + ToolConfig.getToolInstance()
+                                            .getEnglish()
+                                            .nameGetter()
+                                            .getName(locale)
                                     + "\t"
                                     + locale
                                     + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -237,7 +237,7 @@ public class FindPreferredHours {
                 // else {
                 // if (!haveFirst) {
                 // System.out.print("*** Conflict in\t" + region + "\t" +
-                // ENGLISH.getName("territory", region) +
+                // ENGLISH.nameGetter().getName("territory", region) +
                 // "\twith\t");
                 // System.out.println(preferred + "\t" + locales);
                 // haveFirst = true;
@@ -267,15 +267,15 @@ public class FindPreferredHours {
                             + "\t"
                             + region
                             + "\t"
-                            + ENGLISH.getName("territory", region)
+                            + ENGLISH.nameGetter().getName("territory", region)
                             + "\t"
                             + subcontinent
                             + "\t"
-                            + ENGLISH.getName("territory", subcontinent)
+                            + ENGLISH.nameGetter().getName("territory", subcontinent)
                             + "\t"
                             + continent
                             + "\t"
-                            + ENGLISH.getName("territory", continent)
+                            + ENGLISH.nameGetter().getName("territory", continent)
                             + "\t"
                             + showInfo(preferredSet));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -267,15 +267,15 @@ public class FindPreferredHours {
                             + "\t"
                             + region
                             + "\t"
-                            + ENGLISH.nameGetter().getName("territory", region)
+                            + ENGLISH.nameGetter().getNameFromTypestrCode("territory", region)
                             + "\t"
                             + subcontinent
                             + "\t"
-                            + ENGLISH.nameGetter().getName("territory", subcontinent)
+                            + ENGLISH.nameGetter().getNameFromTypestrCode("territory", subcontinent)
                             + "\t"
                             + continent
                             + "\t"
-                            + ENGLISH.nameGetter().getName("territory", continent)
+                            + ENGLISH.nameGetter().getNameFromTypestrCode("territory", continent)
                             + "\t"
                             + showInfo(preferredSet));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
@@ -41,7 +41,7 @@ public class FixTransformNames {
     private void run(String[] args) {
         CLDRFile file = testInfo.getEnglish();
         for (String lang : StandardCodes.make().getAvailableCodes(CodeType.language)) {
-            String name = file.nameGetter().getNameFromLocaleOrTZID(lang);
+            String name = file.nameGetter().getNameFromBCP47(lang);
             if (!name.equals(lang)) {
                 fieldToCode.put(name, lang);
                 languageCodes.add(lang);
@@ -251,7 +251,7 @@ public class FixTransformNames {
             }
             return result;
         }
-        return english.nameGetter().getNameFromLocaleOrTZID(target.replace('-', '_'));
+        return english.nameGetter().getNameFromBCP47(target.replace('-', '_'));
     }
 
     private String add(String result, int type, String code) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
@@ -41,7 +41,7 @@ public class FixTransformNames {
     private void run(String[] args) {
         CLDRFile file = testInfo.getEnglish();
         for (String lang : StandardCodes.make().getAvailableCodes(CodeType.language)) {
-            String name = file.nameGetter().getName(lang);
+            String name = file.nameGetter().getNameFromLocaleOrTZID(lang);
             if (!name.equals(lang)) {
                 fieldToCode.put(name, lang);
                 languageCodes.add(lang);
@@ -251,7 +251,7 @@ public class FixTransformNames {
             }
             return result;
         }
-        return english.nameGetter().getName(target.replace('-', '_'));
+        return english.nameGetter().getNameFromLocaleOrTZID(target.replace('-', '_'));
     }
 
     private String add(String result, int type, String code) {
@@ -261,7 +261,7 @@ public class FixTransformNames {
         if (result.length() != 0) {
             result += ", ";
         }
-        String temp = english.nameGetter().getName(type, code);
+        String temp = english.nameGetter().getNameFromTypenumCode(type, code);
         if (type == CLDRFile.SCRIPT_NAME && fieldToCode.containsKey(temp)) {
             temp += "*";
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
@@ -41,7 +41,7 @@ public class FixTransformNames {
     private void run(String[] args) {
         CLDRFile file = testInfo.getEnglish();
         for (String lang : StandardCodes.make().getAvailableCodes(CodeType.language)) {
-            String name = file.getName(lang);
+            String name = file.nameGetter().getName(lang);
             if (!name.equals(lang)) {
                 fieldToCode.put(name, lang);
                 languageCodes.add(lang);
@@ -251,7 +251,7 @@ public class FixTransformNames {
             }
             return result;
         }
-        return english.getName(target.replace('-', '_'));
+        return english.nameGetter().getName(target.replace('-', '_'));
     }
 
     private String add(String result, int type, String code) {
@@ -261,7 +261,7 @@ public class FixTransformNames {
         if (result.length() != 0) {
             result += ", ";
         }
-        String temp = english.getName(type, code);
+        String temp = english.nameGetter().getName(type, code);
         if (type == CLDRFile.SCRIPT_NAME && fieldToCode.containsKey(temp)) {
             temp += "*";
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -105,7 +105,11 @@ public class GenerateChangeChart {
                     counter.add(ph.getSectionId(), 1);
                 }
                 final String summaryLine =
-                        locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + counter;
+                        locale
+                                + "\t"
+                                + ENGLISH.nameGetter().getNameFromBCP47(locale)
+                                + "\t"
+                                + counter;
                 System.out.println(summaryLine);
                 out.println(summaryLine);
             }
@@ -226,7 +230,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale.toString());
+            final String name = ENGLISH.nameGetter().getNameFromBCP47(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();
@@ -297,7 +301,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale.toString());
+            final String name = ENGLISH.nameGetter().getNameFromBCP47(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -104,7 +104,7 @@ public class GenerateChangeChart {
                     data.add(key);
                     counter.add(ph.getSectionId(), 1);
                 }
-                final String summaryLine = locale + "\t" + ENGLISH.getName(locale) + "\t" + counter;
+                final String summaryLine = locale + "\t" + ENGLISH.nameGetter().getName(locale) + "\t" + counter;
                 System.out.println(summaryLine);
                 out.println(summaryLine);
             }
@@ -225,7 +225,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.getName(locale.toString());
+            final String name = ENGLISH.nameGetter().getName(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();
@@ -296,7 +296,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.getName(locale.toString());
+            final String name = ENGLISH.nameGetter().getName(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -105,7 +105,7 @@ public class GenerateChangeChart {
                     counter.add(ph.getSectionId(), 1);
                 }
                 final String summaryLine =
-                        locale + "\t" + ENGLISH.nameGetter().getName(locale) + "\t" + counter;
+                        locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + counter;
                 System.out.println(summaryLine);
                 out.println(summaryLine);
             }
@@ -226,7 +226,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.nameGetter().getName(locale.toString());
+            final String name = ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();
@@ -297,7 +297,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.nameGetter().getName(locale.toString());
+            final String name = ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -104,7 +104,8 @@ public class GenerateChangeChart {
                     data.add(key);
                     counter.add(ph.getSectionId(), 1);
                 }
-                final String summaryLine = locale + "\t" + ENGLISH.nameGetter().getName(locale) + "\t" + counter;
+                final String summaryLine =
+                        locale + "\t" + ENGLISH.nameGetter().getName(locale) + "\t" + counter;
                 System.out.println(summaryLine);
                 out.println(summaryLine);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -106,7 +106,7 @@ public class GenerateComparison {
         unifiedList.addAll(newList);
         Set<R2<String, String>> pairs = new TreeSet<>();
         for (String code : unifiedList) {
-            pairs.add(Row.of(english.getName(code), code));
+            pairs.add(Row.of(english.nameGetter().getName(code), code));
         }
 
         prettyPathMaker = new PrettyPath();
@@ -197,7 +197,7 @@ public class GenerateComparison {
             // TODO Sort by the pretty form
             // Set<R2<String,String>> pathPairs = new TreeSet();
             // for (String code : unifiedList) {
-            // pairs.add(Row.make(code, english.getName(code)));
+            // pairs.add(Row.make(code, english.nameGetter().getName(code)));
             // }
 
             // Initialize sets
@@ -205,7 +205,7 @@ public class GenerateComparison {
             // href='likely_subtags.html#und_{0}'>{0}</a>",
             // "class='source'", true)
 
-            final String localeDisplayName = english.getName(locale);
+            final String localeDisplayName = english.nameGetter().getName(locale);
             TablePrinter table =
                     new TablePrinter()
                             .setCaption("Changes in " + localeDisplayName + " (" + locale + ")")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -106,7 +106,7 @@ public class GenerateComparison {
         unifiedList.addAll(newList);
         Set<R2<String, String>> pairs = new TreeSet<>();
         for (String code : unifiedList) {
-            pairs.add(Row.of(english.nameGetter().getNameFromLocaleOrTZID(code), code));
+            pairs.add(Row.of(english.nameGetter().getNameFromBCP47(code), code));
         }
 
         prettyPathMaker = new PrettyPath();
@@ -205,7 +205,7 @@ public class GenerateComparison {
             // href='likely_subtags.html#und_{0}'>{0}</a>",
             // "class='source'", true)
 
-            final String localeDisplayName = english.nameGetter().getNameFromLocaleOrTZID(locale);
+            final String localeDisplayName = english.nameGetter().getNameFromBCP47(locale);
             TablePrinter table =
                     new TablePrinter()
                             .setCaption("Changes in " + localeDisplayName + " (" + locale + ")")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -106,7 +106,7 @@ public class GenerateComparison {
         unifiedList.addAll(newList);
         Set<R2<String, String>> pairs = new TreeSet<>();
         for (String code : unifiedList) {
-            pairs.add(Row.of(english.nameGetter().getName(code), code));
+            pairs.add(Row.of(english.nameGetter().getNameFromLocaleOrTZID(code), code));
         }
 
         prettyPathMaker = new PrettyPath();
@@ -205,7 +205,7 @@ public class GenerateComparison {
             // href='likely_subtags.html#und_{0}'>{0}</a>",
             // "class='source'", true)
 
-            final String localeDisplayName = english.nameGetter().getName(locale);
+            final String localeDisplayName = english.nameGetter().getNameFromLocaleOrTZID(locale);
             TablePrinter table =
                     new TablePrinter()
                             .setCaption("Changes in " + localeDisplayName + " (" + locale + ")")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -492,7 +492,8 @@ public class GenerateCoverageLevels {
                             + "\t"
                             + percent.format(foundCount / (foundCount + missingCount));
             samples2.println(summaryLine);
-            summary.println(locale + "\t" + english.nameGetter().getName(locale) + "\t" + summaryLine2);
+            summary.println(
+                    locale + "\t" + english.nameGetter().getName(locale) + "\t" + summaryLine2);
             if (header != null) {
                 counts.println(header);
                 header = null;
@@ -552,7 +553,12 @@ public class GenerateCoverageLevels {
                 mapLevelData.get(locale).found.add(level, weight);
             } else {
                 System.out.println(
-                        locale + "\t" + english.nameGetter().getName(locale) + "\t" + "missing " + title);
+                        locale
+                                + "\t"
+                                + english.nameGetter().getName(locale)
+                                + "\t"
+                                + "missing "
+                                + title);
                 mapLevelData.get(locale).missing.add(level, weight);
                 mapLevelData.get(locale).samples.put(level, samples);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -340,7 +340,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : rbnfFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + english.getName(locale));
+            System.out.println(locale + "\t" + english.nameGetter().getName(locale));
             getRBNFData(locale, rbnfFactory.make(locale, true), ordinals, spellout, localesFound);
         }
         markData(
@@ -378,7 +378,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : collationFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + english.getName(locale));
+            System.out.println(locale + "\t" + english.nameGetter().getName(locale));
             getCollationData(locale, collationFactory.make(locale, true), localesFound);
         }
         markData(
@@ -392,7 +392,7 @@ public class GenerateCoverageLevels {
 
         System.out.println("gathering main data");
         for (String locale : mainAvailable) {
-            System.out.println(locale + "\t" + english.getName(locale));
+            System.out.println(locale + "\t" + english.nameGetter().getName(locale));
             LevelData levelData = mapLevelData.get(locale);
             getMainData(locale, levelData, cldrFactory.make(locale, true));
         }
@@ -418,17 +418,17 @@ public class GenerateCoverageLevels {
                     new StringBuilder(
                             script
                                     + "\t"
-                                    + english.getName(CLDRFile.SCRIPT_NAME, script)
+                                    + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
                                     + "\t"
                                     + lang
                                     + "\t"
-                                    + english.getName(CLDRFile.LANGUAGE_NAME, lang));
+                                    + english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang));
             if (header != null) {
                 header.append("Code\tScript\tCode\tLocale");
             }
             // Now print the information
             samples2.println();
-            samples2.println(locale + "\t" + english.getName(locale));
+            samples2.println(locale + "\t" + english.nameGetter().getName(locale));
             double weightedFound = 0;
             double weightedMissing = 0;
             long missingCountTotal = 0;
@@ -492,7 +492,7 @@ public class GenerateCoverageLevels {
                             + "\t"
                             + percent.format(foundCount / (foundCount + missingCount));
             samples2.println(summaryLine);
-            summary.println(locale + "\t" + english.getName(locale) + "\t" + summaryLine2);
+            summary.println(locale + "\t" + english.nameGetter().getName(locale) + "\t" + summaryLine2);
             if (header != null) {
                 counts.println(header);
                 header = null;
@@ -552,7 +552,7 @@ public class GenerateCoverageLevels {
                 mapLevelData.get(locale).found.add(level, weight);
             } else {
                 System.out.println(
-                        locale + "\t" + english.getName(locale) + "\t" + "missing " + title);
+                        locale + "\t" + english.nameGetter().getName(locale) + "\t" + "missing " + title);
                 mapLevelData.get(locale).missing.add(level, weight);
                 mapLevelData.get(locale).samples.put(level, samples);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -340,7 +340,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : rbnfFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + english.nameGetter().getName(locale));
+            System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
             getRBNFData(locale, rbnfFactory.make(locale, true), ordinals, spellout, localesFound);
         }
         markData(
@@ -378,7 +378,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : collationFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + english.nameGetter().getName(locale));
+            System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
             getCollationData(locale, collationFactory.make(locale, true), localesFound);
         }
         markData(
@@ -392,7 +392,7 @@ public class GenerateCoverageLevels {
 
         System.out.println("gathering main data");
         for (String locale : mainAvailable) {
-            System.out.println(locale + "\t" + english.nameGetter().getName(locale));
+            System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
             LevelData levelData = mapLevelData.get(locale);
             getMainData(locale, levelData, cldrFactory.make(locale, true));
         }
@@ -418,17 +418,17 @@ public class GenerateCoverageLevels {
                     new StringBuilder(
                             script
                                     + "\t"
-                                    + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
+                                    + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
                                     + "\t"
                                     + lang
                                     + "\t"
-                                    + english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang));
+                                    + english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang));
             if (header != null) {
                 header.append("Code\tScript\tCode\tLocale");
             }
             // Now print the information
             samples2.println();
-            samples2.println(locale + "\t" + english.nameGetter().getName(locale));
+            samples2.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
             double weightedFound = 0;
             double weightedMissing = 0;
             long missingCountTotal = 0;
@@ -493,7 +493,7 @@ public class GenerateCoverageLevels {
                             + percent.format(foundCount / (foundCount + missingCount));
             samples2.println(summaryLine);
             summary.println(
-                    locale + "\t" + english.nameGetter().getName(locale) + "\t" + summaryLine2);
+                    locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + summaryLine2);
             if (header != null) {
                 counts.println(header);
                 header = null;
@@ -555,7 +555,7 @@ public class GenerateCoverageLevels {
                 System.out.println(
                         locale
                                 + "\t"
-                                + english.nameGetter().getName(locale)
+                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                 + "\t"
                                 + "missing "
                                 + title);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -33,6 +33,7 @@ import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 import org.unicode.cldr.util.XPathParts;
@@ -56,6 +57,7 @@ public class GenerateCoverageLevels {
     private static final Factory cldrFactory = Factory.make(MAIN_DIRECTORY, FILES);
     private static final Comparator<String> attributeComparator = CLDRFile.getAttributeOrdering();
     private static final CLDRFile english = cldrFactory.make("en", true);
+    private static final NameGetter englishNameGetter = english.nameGetter();
     private static SupplementalDataInfo supplementalData =
             CLDRConfig.getInstance().getSupplementalDataInfo();
     // SupplementalDataInfo.getInstance(english.getSupplementalDirectory());
@@ -340,7 +342,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : rbnfFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            System.out.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
             getRBNFData(locale, rbnfFactory.make(locale, true), ordinals, spellout, localesFound);
         }
         markData(
@@ -378,7 +380,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : collationFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            System.out.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
             getCollationData(locale, collationFactory.make(locale, true), localesFound);
         }
         markData(
@@ -392,7 +394,7 @@ public class GenerateCoverageLevels {
 
         System.out.println("gathering main data");
         for (String locale : mainAvailable) {
-            System.out.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            System.out.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
             LevelData levelData = mapLevelData.get(locale);
             getMainData(locale, levelData, cldrFactory.make(locale, true));
         }
@@ -418,17 +420,19 @@ public class GenerateCoverageLevels {
                     new StringBuilder(
                             script
                                     + "\t"
-                                    + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
+                                    + englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.SCRIPT_NAME, script)
                                     + "\t"
                                     + lang
                                     + "\t"
-                                    + english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang));
+                                    + englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.LANGUAGE_NAME, lang));
             if (header != null) {
                 header.append("Code\tScript\tCode\tLocale");
             }
             // Now print the information
             samples2.println();
-            samples2.println(locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            samples2.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
             double weightedFound = 0;
             double weightedMissing = 0;
             long missingCountTotal = 0;
@@ -493,7 +497,11 @@ public class GenerateCoverageLevels {
                             + percent.format(foundCount / (foundCount + missingCount));
             samples2.println(summaryLine);
             summary.println(
-                    locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + summaryLine2);
+                    locale
+                            + "\t"
+                            + englishNameGetter.getNameFromBCP47(locale)
+                            + "\t"
+                            + summaryLine2);
             if (header != null) {
                 counts.println(header);
                 header = null;
@@ -555,7 +563,7 @@ public class GenerateCoverageLevels {
                 System.out.println(
                         locale
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                + englishNameGetter.getNameFromBCP47(locale)
                                 + "\t"
                                 + "missing "
                                 + title);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
@@ -103,7 +103,8 @@ public class GenerateDayPeriodChart {
 
             for (String locale : dayPeriodLocales) { // SC.getLocaleCoverageLocales("cldr",
                 // EnumSet.of(Level.MODERN))) {
-                System.out.print(type + "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
+                System.out.print(
+                        type + "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
                 DayPeriodInfo dayPeriod = getFixedDayPeriodInfo(type, locale);
                 doRow(dayPeriod);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
@@ -104,7 +104,7 @@ public class GenerateDayPeriodChart {
             for (String locale : dayPeriodLocales) { // SC.getLocaleCoverageLocales("cldr",
                 // EnumSet.of(Level.MODERN))) {
                 System.out.print(
-                        type + "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
+                        type + "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
                 DayPeriodInfo dayPeriod = getFixedDayPeriodInfo(type, locale);
                 doRow(dayPeriod);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
@@ -103,7 +103,7 @@ public class GenerateDayPeriodChart {
 
             for (String locale : dayPeriodLocales) { // SC.getLocaleCoverageLocales("cldr",
                 // EnumSet.of(Level.MODERN))) {
-                System.out.print(type + "\t" + locale + "\t" + ENGLISH.getName(locale));
+                System.out.print(type + "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
                 DayPeriodInfo dayPeriod = getFixedDayPeriodInfo(type, locale);
                 doRow(dayPeriod);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
@@ -104,7 +104,11 @@ public class GenerateDayPeriodChart {
             for (String locale : dayPeriodLocales) { // SC.getLocaleCoverageLocales("cldr",
                 // EnumSet.of(Level.MODERN))) {
                 System.out.print(
-                        type + "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
+                        type
+                                + "\t"
+                                + locale
+                                + "\t"
+                                + ENGLISH.nameGetter().getNameFromBCP47(locale));
                 DayPeriodInfo dayPeriod = getFixedDayPeriodInfo(type, locale);
                 doRow(dayPeriod);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -176,7 +176,10 @@ public class GenerateDerivedAnnotations {
                         if (main == null) {
                             main = cldrFactory.make(locale, true);
                         }
-                        shortName = main.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currencyCode);
+                        shortName =
+                                main.nameGetter()
+                                        .getNameFromTypenumCode(
+                                                CLDRFile.CURRENCY_NAME, currencyCode);
                         if (shortName.contentEquals(currencyCode)) {
                             shortName = null; // don't want fallback raw code
                         }
@@ -216,7 +219,7 @@ public class GenerateDerivedAnnotations {
                                 + "\t"
                                 + level
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                + english.nameGetter().getNameFromBCP47(locale)
                                 + "\t"
                                 + failures.size()
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -176,7 +176,7 @@ public class GenerateDerivedAnnotations {
                         if (main == null) {
                             main = cldrFactory.make(locale, true);
                         }
-                        shortName = main.getName(CLDRFile.CURRENCY_NAME, currencyCode);
+                        shortName = main.nameGetter().getName(CLDRFile.CURRENCY_NAME, currencyCode);
                         if (shortName.contentEquals(currencyCode)) {
                             shortName = null; // don't want fallback raw code
                         }
@@ -216,7 +216,7 @@ public class GenerateDerivedAnnotations {
                                 + "\t"
                                 + level
                                 + "\t"
-                                + english.getName(locale)
+                                + english.nameGetter().getName(locale)
                                 + "\t"
                                 + failures.size()
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -176,7 +176,7 @@ public class GenerateDerivedAnnotations {
                         if (main == null) {
                             main = cldrFactory.make(locale, true);
                         }
-                        shortName = main.nameGetter().getName(CLDRFile.CURRENCY_NAME, currencyCode);
+                        shortName = main.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currencyCode);
                         if (shortName.contentEquals(currencyCode)) {
                             shortName = null; // don't want fallback raw code
                         }
@@ -216,7 +216,7 @@ public class GenerateDerivedAnnotations {
                                 + "\t"
                                 + level
                                 + "\t"
-                                + english.nameGetter().getName(locale)
+                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                 + "\t"
                                 + failures.size()
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -733,7 +733,8 @@ public class GenerateEnums {
             // dumb
             // octal
             // syntax
-            System.out.println(un + "\t" + region + "\t" + english.nameGetter().getName("territory", region));
+            System.out.println(
+                    un + "\t" + region + "\t" + english.nameGetter().getName("territory", region));
         }
 
         showGeneratedCommentEnd(DATA_INDENT);
@@ -873,7 +874,8 @@ public class GenerateEnums {
                                 ? getEnglishName(codeName)
                                 : type.equals("currency")
                                         ? getName(codeName)
-                                        : english.nameGetter().getName(CLDRFile.SCRIPT_NAME, codeName);
+                                        : english.nameGetter()
+                                                .getName(CLDRFile.SCRIPT_NAME, codeName);
         resolvedEnglishName = doFallbacks.transliterate(resolvedEnglishName);
 
         String prefix = CODE_INDENT + "/** " + resolvedEnglishName; // + " - " +

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -135,7 +135,7 @@ public class GenerateEnums {
     }
 
     private String getName(String code) {
-        String result = english.nameGetter().getName(CLDRFile.CURRENCY_NAME, code);
+        String result = english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, code);
         if (result == null) {
             result = code;
             System.out.println("Failed to find: " + code);
@@ -174,7 +174,7 @@ public class GenerateEnums {
         int len = "  /** Arabic */                                        Arab,".length();
         for (Iterator<String> it = scripts.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, code);
+            String englishName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code);
             if (englishName == null) continue;
             printRow(Log.getLog(), code, null, "script", code_replacements, len);
             // Log.println(" /**" + englishName + "*/ " + code + ",");
@@ -222,7 +222,7 @@ public class GenerateEnums {
 
         for (Iterator<String> it = languages.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, code);
+            String englishName = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code);
             if (englishName == null) continue;
             System.out.println("     /**" + englishName + "*/    " + code + ",");
         }
@@ -640,7 +640,7 @@ public class GenerateEnums {
                     format(popData.getPopulation()),
                     format(popData.getLiteratePopulation() / popData.getPopulation()),
                     format(popData.getGdp()),
-                    english.nameGetter().getName("territory", territory));
+                    english.nameGetter().getNameFromTypestrCode("territory", territory));
             // remove all the ISO 639-3 until they are part of BCP 47
             // we need to remove in earlier pass so we have the count
             Set<String> languages = new TreeSet<>();
@@ -671,7 +671,7 @@ public class GenerateEnums {
                         format(popData.getPopulation()),
                         format(popData.getLiteratePopulation() / popData.getPopulation()),
                         (count == 0 ? ";" : ""),
-                        english.nameGetter().getName(language));
+                        english.nameGetter().getNameFromLocaleOrTZID(language));
             }
         }
         Log.close();
@@ -734,7 +734,7 @@ public class GenerateEnums {
             // octal
             // syntax
             System.out.println(
-                    un + "\t" + region + "\t" + english.nameGetter().getName("territory", region));
+                    un + "\t" + region + "\t" + english.nameGetter().getNameFromTypestrCode("territory", region));
         }
 
         showGeneratedCommentEnd(DATA_INDENT);
@@ -875,7 +875,7 @@ public class GenerateEnums {
                                 : type.equals("currency")
                                         ? getName(codeName)
                                         : english.nameGetter()
-                                                .getName(CLDRFile.SCRIPT_NAME, codeName);
+                                                .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, codeName);
         resolvedEnglishName = doFallbacks.transliterate(resolvedEnglishName);
 
         String prefix = CODE_INDENT + "/** " + resolvedEnglishName; // + " - " +
@@ -912,7 +912,7 @@ public class GenerateEnums {
         if (codeName.length() > 3) codeName = codeName.substring(2); // fix UN name
         String name = extraNames.get(codeName);
         if (name != null) return name;
-        name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, codeName);
+        name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, codeName);
         if (name != null) return name;
         return codeName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -34,6 +34,7 @@ import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.Iso639Data.Scope;
 import org.unicode.cldr.util.Iso639Data.Type;
 import org.unicode.cldr.util.Log;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo;
@@ -68,6 +69,7 @@ public class GenerateEnums {
     // private Map enum_TLD = new TreeMap();
 
     private CLDRFile english = factory.make("en", false);
+    private final NameGetter englishNameGetter = english.nameGetter();
 
     private CLDRFile supplementalMetadata = factory.make("supplementalMetadata", false);
 
@@ -135,7 +137,7 @@ public class GenerateEnums {
     }
 
     private String getName(String code) {
-        String result = english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, code);
+        String result = englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, code);
         if (result == null) {
             result = code;
             System.out.println("Failed to find: " + code);
@@ -174,7 +176,8 @@ public class GenerateEnums {
         int len = "  /** Arabic */                                        Arab,".length();
         for (Iterator<String> it = scripts.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code);
+            String englishName =
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code);
             if (englishName == null) continue;
             printRow(Log.getLog(), code, null, "script", code_replacements, len);
             // Log.println(" /**" + englishName + "*/ " + code + ",");
@@ -222,7 +225,8 @@ public class GenerateEnums {
 
         for (Iterator<String> it = languages.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code);
+            String englishName =
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code);
             if (englishName == null) continue;
             System.out.println("     /**" + englishName + "*/    " + code + ",");
         }
@@ -640,7 +644,7 @@ public class GenerateEnums {
                     format(popData.getPopulation()),
                     format(popData.getLiteratePopulation() / popData.getPopulation()),
                     format(popData.getGdp()),
-                    english.nameGetter().getNameFromTypestrCode("territory", territory));
+                    englishNameGetter.getNameFromTypestrCode("territory", territory));
             // remove all the ISO 639-3 until they are part of BCP 47
             // we need to remove in earlier pass so we have the count
             Set<String> languages = new TreeSet<>();
@@ -671,7 +675,7 @@ public class GenerateEnums {
                         format(popData.getPopulation()),
                         format(popData.getLiteratePopulation() / popData.getPopulation()),
                         (count == 0 ? ";" : ""),
-                        english.nameGetter().getNameFromLocaleOrTZID(language));
+                        englishNameGetter.getNameFromBCP47(language));
             }
         }
         Log.close();
@@ -734,7 +738,11 @@ public class GenerateEnums {
             // octal
             // syntax
             System.out.println(
-                    un + "\t" + region + "\t" + english.nameGetter().getNameFromTypestrCode("territory", region));
+                    un
+                            + "\t"
+                            + region
+                            + "\t"
+                            + englishNameGetter.getNameFromTypestrCode("territory", region));
         }
 
         showGeneratedCommentEnd(DATA_INDENT);
@@ -874,8 +882,8 @@ public class GenerateEnums {
                                 ? getEnglishName(codeName)
                                 : type.equals("currency")
                                         ? getName(codeName)
-                                        : english.nameGetter()
-                                                .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, codeName);
+                                        : englishNameGetter.getNameFromTypenumCode(
+                                                CLDRFile.SCRIPT_NAME, codeName);
         resolvedEnglishName = doFallbacks.transliterate(resolvedEnglishName);
 
         String prefix = CODE_INDENT + "/** " + resolvedEnglishName; // + " - " +
@@ -912,7 +920,7 @@ public class GenerateEnums {
         if (codeName.length() > 3) codeName = codeName.substring(2); // fix UN name
         String name = extraNames.get(codeName);
         if (name != null) return name;
-        name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, codeName);
+        name = englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, codeName);
         if (name != null) return name;
         return codeName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -135,7 +135,7 @@ public class GenerateEnums {
     }
 
     private String getName(String code) {
-        String result = english.getName(CLDRFile.CURRENCY_NAME, code);
+        String result = english.nameGetter().getName(CLDRFile.CURRENCY_NAME, code);
         if (result == null) {
             result = code;
             System.out.println("Failed to find: " + code);
@@ -174,7 +174,7 @@ public class GenerateEnums {
         int len = "  /** Arabic */                                        Arab,".length();
         for (Iterator<String> it = scripts.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName = english.getName(CLDRFile.SCRIPT_NAME, code);
+            String englishName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, code);
             if (englishName == null) continue;
             printRow(Log.getLog(), code, null, "script", code_replacements, len);
             // Log.println(" /**" + englishName + "*/ " + code + ",");
@@ -222,7 +222,7 @@ public class GenerateEnums {
 
         for (Iterator<String> it = languages.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName = english.getName(CLDRFile.LANGUAGE_NAME, code);
+            String englishName = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, code);
             if (englishName == null) continue;
             System.out.println("     /**" + englishName + "*/    " + code + ",");
         }
@@ -640,7 +640,7 @@ public class GenerateEnums {
                     format(popData.getPopulation()),
                     format(popData.getLiteratePopulation() / popData.getPopulation()),
                     format(popData.getGdp()),
-                    english.getName("territory", territory));
+                    english.nameGetter().getName("territory", territory));
             // remove all the ISO 639-3 until they are part of BCP 47
             // we need to remove in earlier pass so we have the count
             Set<String> languages = new TreeSet<>();
@@ -671,7 +671,7 @@ public class GenerateEnums {
                         format(popData.getPopulation()),
                         format(popData.getLiteratePopulation() / popData.getPopulation()),
                         (count == 0 ? ";" : ""),
-                        english.getName(language));
+                        english.nameGetter().getName(language));
             }
         }
         Log.close();
@@ -733,7 +733,7 @@ public class GenerateEnums {
             // dumb
             // octal
             // syntax
-            System.out.println(un + "\t" + region + "\t" + english.getName("territory", region));
+            System.out.println(un + "\t" + region + "\t" + english.nameGetter().getName("territory", region));
         }
 
         showGeneratedCommentEnd(DATA_INDENT);
@@ -873,7 +873,7 @@ public class GenerateEnums {
                                 ? getEnglishName(codeName)
                                 : type.equals("currency")
                                         ? getName(codeName)
-                                        : english.getName(CLDRFile.SCRIPT_NAME, codeName);
+                                        : english.nameGetter().getName(CLDRFile.SCRIPT_NAME, codeName);
         resolvedEnglishName = doFallbacks.transliterate(resolvedEnglishName);
 
         String prefix = CODE_INDENT + "/** " + resolvedEnglishName; // + " - " +
@@ -910,7 +910,7 @@ public class GenerateEnums {
         if (codeName.length() > 3) codeName = codeName.substring(2); // fix UN name
         String name = extraNames.get(codeName);
         if (name != null) return name;
-        name = english.getName(CLDRFile.TERRITORY_NAME, codeName);
+        name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, codeName);
         if (name != null) return name;
         return codeName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -219,7 +219,7 @@ public class GenerateG2xG2 {
                 String territory = it.next();
                 if (territory.charAt(0) < 'A') continue;
                 String locale = "haw-" + territory;
-                System.out.print(locale + ": " + english.nameGetter().getName(locale) + ", ");
+                System.out.print(locale + ": " + english.nameGetter().getNameFromLocaleOrTZID(locale) + ", ");
             }
             if (true) return true;
         }
@@ -234,7 +234,7 @@ public class GenerateG2xG2 {
                 System.out.println(
                         country
                                 + "\t"
-                                + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, country));
+                                + english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, country));
             }
             return true;
         } else if (choice == 0) { // get available
@@ -337,9 +337,9 @@ public class GenerateG2xG2 {
                                 + "\t"
                                 + sourceLocale
                                 + "\t("
-                                + english.nameGetter().getName(sourceLocale)
+                                + english.nameGetter().getNameFromLocaleOrTZID(sourceLocale)
                                 + ": "
-                                + sourceData.nameGetter().getName(sourceLocale)
+                                + sourceData.nameGetter().getNameFromLocaleOrTZID(sourceLocale)
                                 + ")"
                                 + "\t"
                                 + priorityMap.get(item)
@@ -387,9 +387,9 @@ public class GenerateG2xG2 {
     private static String getItemName(CLDRFile data, int type, String item) {
         String result;
         if (type == CLDRFile.LANGUAGE_NAME) {
-            result = data.nameGetter().getName(item);
+            result = data.nameGetter().getNameFromLocaleOrTZID(item);
         } else if (type != CLDRFile.TZ_EXEMPLAR) {
-            result = data.nameGetter().getName(type, item);
+            result = data.nameGetter().getNameFromTypenumCode(type, item);
         } else {
             String prefix = "//ldml/dates/timeZoneNames/zone[@type=\"" + item + "\"]/exemplarCity";
             result = data.getStringValue(prefix);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -232,7 +232,9 @@ public class GenerateG2xG2 {
             for (Iterator it = testSet.iterator(); it.hasNext(); ) {
                 String country = (String) it.next();
                 System.out.println(
-                        country + "\t" + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, country));
+                        country
+                                + "\t"
+                                + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, country));
             }
             return true;
         } else if (choice == 0) { // get available

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -219,7 +219,7 @@ public class GenerateG2xG2 {
                 String territory = it.next();
                 if (territory.charAt(0) < 'A') continue;
                 String locale = "haw-" + territory;
-                System.out.print(locale + ": " + english.getName(locale) + ", ");
+                System.out.print(locale + ": " + english.nameGetter().getName(locale) + ", ");
             }
             if (true) return true;
         }
@@ -232,7 +232,7 @@ public class GenerateG2xG2 {
             for (Iterator it = testSet.iterator(); it.hasNext(); ) {
                 String country = (String) it.next();
                 System.out.println(
-                        country + "\t" + english.getName(CLDRFile.CURRENCY_NAME, country));
+                        country + "\t" + english.nameGetter().getName(CLDRFile.CURRENCY_NAME, country));
             }
             return true;
         } else if (choice == 0) { // get available
@@ -335,9 +335,9 @@ public class GenerateG2xG2 {
                                 + "\t"
                                 + sourceLocale
                                 + "\t("
-                                + english.getName(sourceLocale)
+                                + english.nameGetter().getName(sourceLocale)
                                 + ": "
-                                + sourceData.getName(sourceLocale)
+                                + sourceData.nameGetter().getName(sourceLocale)
                                 + ")"
                                 + "\t"
                                 + priorityMap.get(item)
@@ -385,9 +385,9 @@ public class GenerateG2xG2 {
     private static String getItemName(CLDRFile data, int type, String item) {
         String result;
         if (type == CLDRFile.LANGUAGE_NAME) {
-            result = data.getName(item);
+            result = data.nameGetter().getName(item);
         } else if (type != CLDRFile.TZ_EXEMPLAR) {
-            result = data.getName(type, item);
+            result = data.nameGetter().getName(type, item);
         } else {
             String prefix = "//ldml/dates/timeZoneNames/zone[@type=\"" + item + "\"]/exemplarCity";
             result = data.getStringValue(prefix);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -219,7 +219,8 @@ public class GenerateG2xG2 {
                 String territory = it.next();
                 if (territory.charAt(0) < 'A') continue;
                 String locale = "haw-" + territory;
-                System.out.print(locale + ": " + english.nameGetter().getNameFromLocaleOrTZID(locale) + ", ");
+                System.out.print(
+                        locale + ": " + english.nameGetter().getNameFromBCP47(locale) + ", ");
             }
             if (true) return true;
         }
@@ -234,7 +235,8 @@ public class GenerateG2xG2 {
                 System.out.println(
                         country
                                 + "\t"
-                                + english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, country));
+                                + english.nameGetter()
+                                        .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, country));
             }
             return true;
         } else if (choice == 0) { // get available
@@ -337,9 +339,9 @@ public class GenerateG2xG2 {
                                 + "\t"
                                 + sourceLocale
                                 + "\t("
-                                + english.nameGetter().getNameFromLocaleOrTZID(sourceLocale)
+                                + english.nameGetter().getNameFromBCP47(sourceLocale)
                                 + ": "
-                                + sourceData.nameGetter().getNameFromLocaleOrTZID(sourceLocale)
+                                + sourceData.nameGetter().getNameFromBCP47(sourceLocale)
                                 + ")"
                                 + "\t"
                                 + priorityMap.get(item)
@@ -387,7 +389,7 @@ public class GenerateG2xG2 {
     private static String getItemName(CLDRFile data, int type, String item) {
         String result;
         if (type == CLDRFile.LANGUAGE_NAME) {
-            result = data.nameGetter().getNameFromLocaleOrTZID(item);
+            result = data.nameGetter().getNameFromBCP47(item);
         } else if (type != CLDRFile.TZ_EXEMPLAR) {
             result = data.nameGetter().getNameFromTypenumCode(type, item);
         } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
@@ -115,7 +115,8 @@ public class GenerateKaraList {
             log.println("\t\t\t<epos>n</epos>"); // this is the part of speech value. It is fixed.
             log.println("\t\t\t<sense>");
             if (hasAbbreviation) { // only applicable for the currency entries
-                String aename = english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
+                String aename =
+                        english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
                 if (aename != null) {
                     log.println(
                             "\t\t\t\t<eabbr>"
@@ -136,7 +137,7 @@ public class GenerateKaraList {
                                     + locale
                                     + "</tlanguage>\t<!-- "
                                     + TransliteratorUtilities.toXML.transliterate(
-                                            english.nameGetter().getNameFromLocaleOrTZID(locale))
+                                            english.nameGetter().getNameFromBCP47(locale))
                                     + " -->"); // We do use
                     // non-ISO
                     // values but
@@ -158,7 +159,9 @@ public class GenerateKaraList {
                                     + TransliteratorUtilities.toXML.transliterate(trans)
                                     + "</trans>");
                     if (hasAbbreviation) {
-                        String aename = cldrfile.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
+                        String aename =
+                                cldrfile.nameGetter()
+                                        .getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
                         if (aename != null && !aename.equals(id)) {
                             log.println(
                                     "\t\t\t\t\t<tabbr>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
@@ -97,7 +97,7 @@ public class GenerateKaraList {
         Set<String> errors = new HashSet<>();
         for (Iterator<String> it = availableCodes.iterator(); it.hasNext(); ) {
             String id = it.next();
-            String ename = english.getName(choice, id);
+            String ename = english.nameGetter().getName(choice, id);
             if (ename == null) ename = "[untranslated: " + id + "]";
             System.out.println(id + "\t" + ename);
             log.println("\t<entry>");
@@ -115,7 +115,7 @@ public class GenerateKaraList {
             log.println("\t\t\t<epos>n</epos>"); // this is the part of speech value. It is fixed.
             log.println("\t\t\t<sense>");
             if (hasAbbreviation) { // only applicable for the currency entries
-                String aename = english.getName(CLDRFile.CURRENCY_SYMBOL, id);
+                String aename = english.nameGetter().getName(CLDRFile.CURRENCY_SYMBOL, id);
                 if (aename != null) {
                     log.println(
                             "\t\t\t\t<eabbr>"
@@ -127,7 +127,7 @@ public class GenerateKaraList {
                 String locale = it2.next();
                 try {
                     CLDRFile cldrfile = cldrFactory.make(locale, true);
-                    String trans = cldrfile.getName(choice, id);
+                    String trans = cldrfile.nameGetter().getName(choice, id);
                     if (trans == null) continue;
                     log.println("\t\t\t\t<target>"); // one target block for each language
                     // String etrans = getName(english, "languages/language", locale, true);
@@ -136,7 +136,7 @@ public class GenerateKaraList {
                                     + locale
                                     + "</tlanguage>\t<!-- "
                                     + TransliteratorUtilities.toXML.transliterate(
-                                            english.getName(locale))
+                                            english.nameGetter().getName(locale))
                                     + " -->"); // We do use
                     // non-ISO
                     // values but
@@ -158,7 +158,7 @@ public class GenerateKaraList {
                                     + TransliteratorUtilities.toXML.transliterate(trans)
                                     + "</trans>");
                     if (hasAbbreviation) {
-                        String aename = cldrfile.getName(CLDRFile.CURRENCY_SYMBOL, id);
+                        String aename = cldrfile.nameGetter().getName(CLDRFile.CURRENCY_SYMBOL, id);
                         if (aename != null && !aename.equals(id)) {
                             log.println(
                                     "\t\t\t\t\t<tabbr>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
@@ -97,7 +97,7 @@ public class GenerateKaraList {
         Set<String> errors = new HashSet<>();
         for (Iterator<String> it = availableCodes.iterator(); it.hasNext(); ) {
             String id = it.next();
-            String ename = english.nameGetter().getName(choice, id);
+            String ename = english.nameGetter().getNameFromTypenumCode(choice, id);
             if (ename == null) ename = "[untranslated: " + id + "]";
             System.out.println(id + "\t" + ename);
             log.println("\t<entry>");
@@ -115,7 +115,7 @@ public class GenerateKaraList {
             log.println("\t\t\t<epos>n</epos>"); // this is the part of speech value. It is fixed.
             log.println("\t\t\t<sense>");
             if (hasAbbreviation) { // only applicable for the currency entries
-                String aename = english.nameGetter().getName(CLDRFile.CURRENCY_SYMBOL, id);
+                String aename = english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
                 if (aename != null) {
                     log.println(
                             "\t\t\t\t<eabbr>"
@@ -127,7 +127,7 @@ public class GenerateKaraList {
                 String locale = it2.next();
                 try {
                     CLDRFile cldrfile = cldrFactory.make(locale, true);
-                    String trans = cldrfile.nameGetter().getName(choice, id);
+                    String trans = cldrfile.nameGetter().getNameFromTypenumCode(choice, id);
                     if (trans == null) continue;
                     log.println("\t\t\t\t<target>"); // one target block for each language
                     // String etrans = getName(english, "languages/language", locale, true);
@@ -136,7 +136,7 @@ public class GenerateKaraList {
                                     + locale
                                     + "</tlanguage>\t<!-- "
                                     + TransliteratorUtilities.toXML.transliterate(
-                                            english.nameGetter().getName(locale))
+                                            english.nameGetter().getNameFromLocaleOrTZID(locale))
                                     + " -->"); // We do use
                     // non-ISO
                     // values but
@@ -158,7 +158,7 @@ public class GenerateKaraList {
                                     + TransliteratorUtilities.toXML.transliterate(trans)
                                     + "</trans>");
                     if (hasAbbreviation) {
-                        String aename = cldrfile.nameGetter().getName(CLDRFile.CURRENCY_SYMBOL, id);
+                        String aename = cldrfile.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
                         if (aename != null && !aename.equals(id)) {
                             log.println(
                                     "\t\t\t\t\t<tabbr>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
@@ -71,7 +71,7 @@ public class GenerateLanguageData {
                 xpp.setAttribute(-1, LDMLConstants.TYPE, languageCode);
                 String xpath = xpp.toString();
 
-                newEn.add(xpp.toString(), oldEn.getName(languageCode));
+                newEn.add(xpp.toString(), oldEn.nameGetter().getName(languageCode));
 
                 String oldValue = oldEn.getStringValue(xpath);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
@@ -71,7 +71,7 @@ public class GenerateLanguageData {
                 xpp.setAttribute(-1, LDMLConstants.TYPE, languageCode);
                 String xpath = xpp.toString();
 
-                newEn.add(xpp.toString(), oldEn.nameGetter().getNameFromLocaleOrTZID(languageCode));
+                newEn.add(xpp.toString(), oldEn.nameGetter().getNameFromBCP47(languageCode));
 
                 String oldValue = oldEn.getStringValue(xpath);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
@@ -71,7 +71,7 @@ public class GenerateLanguageData {
                 xpp.setAttribute(-1, LDMLConstants.TYPE, languageCode);
                 String xpath = xpp.toString();
 
-                newEn.add(xpp.toString(), oldEn.nameGetter().getName(languageCode));
+                newEn.add(xpp.toString(), oldEn.nameGetter().getNameFromLocaleOrTZID(languageCode));
 
                 String oldValue = oldEn.getStringValue(xpath);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
@@ -113,6 +113,6 @@ public class GenerateLanguageMatches {
             };
 
     private static String getName(String lang) {
-        return ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang, MENU);
+        return ENGLISH.nameGetter().getNameFromTypeCodeAltpicker(CLDRFile.LANGUAGE_NAME, lang, MENU);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
@@ -113,6 +113,7 @@ public class GenerateLanguageMatches {
             };
 
     private static String getName(String lang) {
-        return ENGLISH.nameGetter().getNameFromTypeCodeAltpicker(CLDRFile.LANGUAGE_NAME, lang, MENU);
+        return ENGLISH.nameGetter()
+                .getNameFromTypeCodeAltpicker(CLDRFile.LANGUAGE_NAME, lang, MENU);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
@@ -113,6 +113,6 @@ public class GenerateLanguageMatches {
             };
 
     private static String getName(String lang) {
-        return ENGLISH.getName(CLDRFile.LANGUAGE_NAME, lang, MENU);
+        return ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang, MENU);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
@@ -200,17 +200,17 @@ public class GenerateLikelySubtagTests {
                 + spacing
                 + (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang))
+                        : ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang))
                 + ";"
                 + spacing
                 + (script == null || script.equals("")
                         ? "?"
-                        : ENGLISH.nameGetter().getName(CLDRFile.SCRIPT_NAME, script))
+                        : ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script))
                 + ";"
                 + spacing
                 + (region == null || region.equals("")
                         ? "?"
-                        : ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, region))
+                        : ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
                 + spacing
                 + "}";
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
@@ -200,17 +200,17 @@ public class GenerateLikelySubtagTests {
                 + spacing
                 + (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : ENGLISH.getName(CLDRFile.LANGUAGE_NAME, lang))
+                        : ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang))
                 + ";"
                 + spacing
                 + (script == null || script.equals("")
                         ? "?"
-                        : ENGLISH.getName(CLDRFile.SCRIPT_NAME, script))
+                        : ENGLISH.nameGetter().getName(CLDRFile.SCRIPT_NAME, script))
                 + ";"
                 + spacing
                 + (region == null || region.equals("")
                         ? "?"
-                        : ENGLISH.getName(CLDRFile.TERRITORY_NAME, region))
+                        : ENGLISH.nameGetter().getName(CLDRFile.TERRITORY_NAME, region))
                 + spacing
                 + "}";
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
@@ -210,7 +210,8 @@ public class GenerateLikelySubtagTests {
                 + spacing
                 + (region == null || region.equals("")
                         ? "?"
-                        : ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
+                        : ENGLISH.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
                 + spacing
                 + "}";
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -666,7 +666,7 @@ public class GenerateLikelySubtags {
     public static String getNameSafe(String oldValue) {
         try {
             if (oldValue != null) {
-                String result = english.nameGetter().getName(oldValue);
+                String result = english.nameGetter().getNameFromLocaleOrTZID(oldValue);
                 if (result.startsWith("Unknown language ")) {
                     result = result.substring("Unknown language ".length());
                 }
@@ -1691,13 +1691,13 @@ public class GenerateLikelySubtags {
         return spacing.join(
                 (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang)),
+                        : english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang)),
                 (script == null || script.equals("")
                         ? "?"
-                        : english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)),
+                        : english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)),
                 (region == null || region.equals("")
                         ? "?"
-                        : english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region)));
+                        : english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region)));
     }
 
     static final String SEPARATOR =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -666,7 +666,7 @@ public class GenerateLikelySubtags {
     public static String getNameSafe(String oldValue) {
         try {
             if (oldValue != null) {
-                String result = english.getName(oldValue);
+                String result = english.nameGetter().getName(oldValue);
                 if (result.startsWith("Unknown language ")) {
                     result = result.substring("Unknown language ".length());
                 }
@@ -739,7 +739,7 @@ public class GenerateLikelySubtags {
                     //                        // if (SHOW_ADD)
                     //                        // System.out.println("Skipping:\t" + writtenLanguage
                     // + "\t" + region + "\t"
-                    //                        // + english.getName(locale)
+                    //                        // + english.nameGetter().getName(locale)
                     //                        // + "\t-- too small:\t" +
                     // number.format(literatePopulation));
                     //                        // continue;
@@ -1691,13 +1691,13 @@ public class GenerateLikelySubtags {
         return spacing.join(
                 (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : english.getName(CLDRFile.LANGUAGE_NAME, lang)),
+                        : english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, lang)),
                 (script == null || script.equals("")
                         ? "?"
-                        : english.getName(CLDRFile.SCRIPT_NAME, script)),
+                        : english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)),
                 (region == null || region.equals("")
                         ? "?"
-                        : english.getName(CLDRFile.TERRITORY_NAME, region)));
+                        : english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region)));
     }
 
     static final String SEPARATOR =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -666,7 +666,7 @@ public class GenerateLikelySubtags {
     public static String getNameSafe(String oldValue) {
         try {
             if (oldValue != null) {
-                String result = english.nameGetter().getNameFromLocaleOrTZID(oldValue);
+                String result = english.nameGetter().getNameFromBCP47(oldValue);
                 if (result.startsWith("Unknown language ")) {
                     result = result.substring("Unknown language ".length());
                 }
@@ -1691,13 +1691,16 @@ public class GenerateLikelySubtags {
         return spacing.join(
                 (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang)),
+                        : english.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang)),
                 (script == null || script.equals("")
                         ? "?"
-                        : english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)),
+                        : english.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)),
                 (region == null || region.equals("")
                         ? "?"
-                        : english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region)));
+                        : english.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region)));
     }
 
     static final String SEPARATOR =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
@@ -230,7 +230,7 @@ public class GenerateLocaleIDTestData {
             CLDRFile formattingLocaleFile, boolean onlyConstructCompound, String... locales) {
         Map<String, String> displayNames = new TreeMap<>();
         for (String locale : locales) {
-            String name = formattingLocaleFile.getName(locale, onlyConstructCompound);
+            String name = formattingLocaleFile.nameGetter().getName(locale, onlyConstructCompound);
             if (name.contains("null")) {
                 System.err.println("** REPLACE: " + locale + "; " + name);
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
@@ -230,7 +230,10 @@ public class GenerateLocaleIDTestData {
             CLDRFile formattingLocaleFile, boolean onlyConstructCompound, String... locales) {
         Map<String, String> displayNames = new TreeMap<>();
         for (String locale : locales) {
-            String name = formattingLocaleFile.nameGetter().getNameFromLocaleOrTZBool(locale, onlyConstructCompound);
+            String name =
+                    formattingLocaleFile
+                            .nameGetter()
+                            .getNameFromBCP47Bool(locale, onlyConstructCompound);
             if (name.contains("null")) {
                 System.err.println("** REPLACE: " + locale + "; " + name);
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
@@ -230,7 +230,7 @@ public class GenerateLocaleIDTestData {
             CLDRFile formattingLocaleFile, boolean onlyConstructCompound, String... locales) {
         Map<String, String> displayNames = new TreeMap<>();
         for (String locale : locales) {
-            String name = formattingLocaleFile.nameGetter().getName(locale, onlyConstructCompound);
+            String name = formattingLocaleFile.nameGetter().getNameFromLocaleOrTZBool(locale, onlyConstructCompound);
             if (name.contains("null")) {
                 System.err.println("** REPLACE: " + locale + "; " + name);
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -99,7 +99,7 @@ public class GeneratePluralRanges {
                 System.out.println(
                         locale
                                 + "\t"
-                                + english.nameGetter().getName(locale)
+                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                 + "\t"
                                 + rangeSample.start
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -99,7 +99,7 @@ public class GeneratePluralRanges {
                 System.out.println(
                         locale
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                + english.nameGetter().getNameFromBCP47(locale)
                                 + "\t"
                                 + rangeSample.start
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -99,7 +99,7 @@ public class GeneratePluralRanges {
                 System.out.println(
                         locale
                                 + "\t"
-                                + english.getName(locale)
+                                + english.nameGetter().getName(locale)
                                 + "\t"
                                 + rangeSample.start
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
@@ -43,7 +43,7 @@ public class GenerateSeedDurations {
         Set<String> warnings = new LinkedHashSet<>();
         for (String locale : cldrFactory.getAvailableLanguages()) {
             CLDRFile cldrFile = cldrFactory.make(locale, true);
-            String localeString = locale + "\t" + testInfo.getEnglish().getName(locale);
+            String localeString = locale + "\t" + testInfo.getEnglish().nameGetter().getName(locale);
             System.out.println("\n" + localeString);
 
             DateTimeFormats formats = new DateTimeFormats().set(cldrFile, "gregorian");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
@@ -44,7 +44,7 @@ public class GenerateSeedDurations {
         for (String locale : cldrFactory.getAvailableLanguages()) {
             CLDRFile cldrFile = cldrFactory.make(locale, true);
             String localeString =
-                    locale + "\t" + testInfo.getEnglish().nameGetter().getName(locale);
+                    locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
             System.out.println("\n" + localeString);
 
             DateTimeFormats formats = new DateTimeFormats().set(cldrFile, "gregorian");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
@@ -44,7 +44,7 @@ public class GenerateSeedDurations {
         for (String locale : cldrFactory.getAvailableLanguages()) {
             CLDRFile cldrFile = cldrFactory.make(locale, true);
             String localeString =
-                    locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
+                    locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
             System.out.println("\n" + localeString);
 
             DateTimeFormats formats = new DateTimeFormats().set(cldrFile, "gregorian");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
@@ -43,7 +43,8 @@ public class GenerateSeedDurations {
         Set<String> warnings = new LinkedHashSet<>();
         for (String locale : cldrFactory.getAvailableLanguages()) {
             CLDRFile cldrFile = cldrFactory.make(locale, true);
-            String localeString = locale + "\t" + testInfo.getEnglish().nameGetter().getName(locale);
+            String localeString =
+                    locale + "\t" + testInfo.getEnglish().nameGetter().getName(locale);
             System.out.println("\n" + localeString);
 
             DateTimeFormats formats = new DateTimeFormats().set(cldrFile, "gregorian");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -612,7 +612,7 @@ public class GenerateSidewaysView {
         String core = item;
         item = toHTML.transform(item);
         if (name) {
-            item = english.nameGetter().getNameFromLocaleOrTZID(core);
+            item = english.nameGetter().getNameFromBCP47(core);
             item = item == null ? "<i>null</i>" : toHTML.transform(item);
         }
         if (draft) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -612,7 +612,7 @@ public class GenerateSidewaysView {
         String core = item;
         item = toHTML.transform(item);
         if (name) {
-            item = english.getName(core);
+            item = english.nameGetter().getName(core);
             item = item == null ? "<i>null</i>" : toHTML.transform(item);
         }
         if (draft) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -612,7 +612,7 @@ public class GenerateSidewaysView {
         String core = item;
         item = toHTML.transform(item);
         if (name) {
-            item = english.nameGetter().getName(core);
+            item = english.nameGetter().getNameFromLocaleOrTZID(core);
             item = item == null ? "<i>null</i>" : toHTML.transform(item);
         }
         if (draft) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -309,7 +309,7 @@ class GenerateStatistics {
         String nativeName, englishName;
         draftLanguages.add(lang);
         nativeName = getFixedLanguageName(localeID, langScript);
-        englishName = english.getName(langScript);
+        englishName = english.nameGetter().getName(langScript);
         if (!lang.equals("en") && nativeName.equals(englishName)) {
             Log.logln(
                     (isDraft ? "D" : "")
@@ -399,7 +399,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        return cldr.getName(lang);
+        return cldr.nameGetter().getName(lang);
     }
 
     /**
@@ -414,7 +414,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        String name = cldr.getName("territory", country);
+        String name = cldr.nameGetter().getName("territory", country);
         if (false && HACK) {
             Object trial = fixCountryNames.get(name);
             if (trial != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -309,7 +309,7 @@ class GenerateStatistics {
         String nativeName, englishName;
         draftLanguages.add(lang);
         nativeName = getFixedLanguageName(localeID, langScript);
-        englishName = english.nameGetter().getNameFromLocaleOrTZID(langScript);
+        englishName = english.nameGetter().getNameFromBCP47(langScript);
         if (!lang.equals("en") && nativeName.equals(englishName)) {
             Log.logln(
                     (isDraft ? "D" : "")
@@ -399,7 +399,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        return cldr.nameGetter().getNameFromLocaleOrTZID(lang);
+        return cldr.nameGetter().getNameFromBCP47(lang);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -309,7 +309,7 @@ class GenerateStatistics {
         String nativeName, englishName;
         draftLanguages.add(lang);
         nativeName = getFixedLanguageName(localeID, langScript);
-        englishName = english.nameGetter().getName(langScript);
+        englishName = english.nameGetter().getNameFromLocaleOrTZID(langScript);
         if (!lang.equals("en") && nativeName.equals(englishName)) {
             Log.logln(
                     (isDraft ? "D" : "")
@@ -399,7 +399,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        return cldr.nameGetter().getName(lang);
+        return cldr.nameGetter().getNameFromLocaleOrTZID(lang);
     }
 
     /**
@@ -414,7 +414,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        String name = cldr.nameGetter().getName("territory", country);
+        String name = cldr.nameGetter().getNameFromTypestrCode("territory", country);
         if (false && HACK) {
             Object trial = fixCountryNames.get(name);
             if (trial != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -340,7 +340,7 @@ public class GetChanges {
                                 + "\t"
                                 + locale
                                 + "\t"
-                                + english.getName(locale)
+                                + english.nameGetter().getName(locale)
                                 + "\t"
                                 + ph
                                 + "\t«"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -340,7 +340,7 @@ public class GetChanges {
                                 + "\t"
                                 + locale
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                + english.nameGetter().getNameFromBCP47(locale)
                                 + "\t"
                                 + ph
                                 + "\t«"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -340,7 +340,7 @@ public class GetChanges {
                                 + "\t"
                                 + locale
                                 + "\t"
-                                + english.nameGetter().getName(locale)
+                                + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                 + "\t"
                                 + ph
                                 + "\t«"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
@@ -27,7 +27,7 @@ public class GetLanguageData {
         System.out.println("Code\tLang\tLpop\tApprox. Gdp");
         for (String language : sdata.getLanguages()) {
             final long pop = languageToPop.getCount(language);
-            System.out.print(language + "\t" + english.nameGetter().getNameFromLocaleOrTZID(language));
+            System.out.print(language + "\t" + english.nameGetter().getNameFromBCP47(language));
             if (pop > 0) {
                 Pair<OfficialStatus, String> status = isOfficialLanguageOfEUCountry(language);
                 System.out.print(
@@ -70,7 +70,8 @@ public class GetLanguageData {
                 System.out.println(
                         territory //
                                 + "\t"
-                                + english.nameGetter().getNameFromTypestrCode("territory", territory) //
+                                + english.nameGetter()
+                                        .getNameFromTypestrCode("territory", territory) //
                                 + "\t"
                                 + territoryPop //
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
@@ -27,7 +27,7 @@ public class GetLanguageData {
         System.out.println("Code\tLang\tLpop\tApprox. Gdp");
         for (String language : sdata.getLanguages()) {
             final long pop = languageToPop.getCount(language);
-            System.out.print(language + "\t" + english.getName(language));
+            System.out.print(language + "\t" + english.nameGetter().getName(language));
             if (pop > 0) {
                 Pair<OfficialStatus, String> status = isOfficialLanguageOfEUCountry(language);
                 System.out.print(
@@ -70,7 +70,7 @@ public class GetLanguageData {
                 System.out.println(
                         territory //
                                 + "\t"
-                                + english.getName("territory", territory) //
+                                + english.nameGetter().getName("territory", territory) //
                                 + "\t"
                                 + territoryPop //
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
@@ -27,7 +27,7 @@ public class GetLanguageData {
         System.out.println("Code\tLang\tLpop\tApprox. Gdp");
         for (String language : sdata.getLanguages()) {
             final long pop = languageToPop.getCount(language);
-            System.out.print(language + "\t" + english.nameGetter().getName(language));
+            System.out.print(language + "\t" + english.nameGetter().getNameFromLocaleOrTZID(language));
             if (pop > 0) {
                 Pair<OfficialStatus, String> status = isOfficialLanguageOfEUCountry(language);
                 System.out.print(
@@ -70,7 +70,7 @@ public class GetLanguageData {
                 System.out.println(
                         territory //
                                 + "\t"
-                                + english.nameGetter().getName("territory", territory) //
+                                + english.nameGetter().getNameFromTypestrCode("territory", territory) //
                                 + "\t"
                                 + territoryPop //
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
@@ -88,9 +88,9 @@ public class LSRSource implements Comparable<LSRSource> {
                         + (getSources().isEmpty() ? "" : "\" origin=\"" + getSourceString())
                         + "\"/>"
                         + "\t<!-- "
-                        + english.getName(source)
+                        + english.nameGetter().getName(source)
                         + " ➡︎ "
-                        + english.getName(target)
+                        + english.nameGetter().getName(target)
                         + " -->";
         return result;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
@@ -88,9 +88,9 @@ public class LSRSource implements Comparable<LSRSource> {
                         + (getSources().isEmpty() ? "" : "\" origin=\"" + getSourceString())
                         + "\"/>"
                         + "\t<!-- "
-                        + english.nameGetter().getName(source)
+                        + english.nameGetter().getNameFromLocaleOrTZID(source)
                         + " ➡︎ "
-                        + english.nameGetter().getName(target)
+                        + english.nameGetter().getNameFromLocaleOrTZID(target)
                         + " -->";
         return result;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
@@ -88,9 +88,9 @@ public class LSRSource implements Comparable<LSRSource> {
                         + (getSources().isEmpty() ? "" : "\" origin=\"" + getSourceString())
                         + "\"/>"
                         + "\t<!-- "
-                        + english.nameGetter().getNameFromLocaleOrTZID(source)
+                        + english.nameGetter().getNameFromBCP47(source)
                         + " ➡︎ "
-                        + english.nameGetter().getNameFromLocaleOrTZID(target)
+                        + english.nameGetter().getNameFromBCP47(target)
                         + " -->";
         return result;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LanguageCodeConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LanguageCodeConverter.java
@@ -126,7 +126,7 @@ public class LanguageCodeConverter {
             // if (languageAliases.containsKey(code)) {
             // continue;
             // }
-            // String cldrName = english.getName("language", code);
+            // String cldrName = english.nameGetter().getName("language", code);
             // if (cldrName != null && !cldrName.equals("private-use")) {
             // addNameToCode("cldr", code, cldrName);
             // }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
@@ -124,7 +124,7 @@ public class ListGrammarData {
                 continue;
             }
             // System.out.println(locale);
-            final String names = locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale);
+            final String names = locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale);
             for (Entry<PathHeader, String> entry : pathHeaderToValue.entrySet()) {
 
                 final PathHeader ph = entry.getKey();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
@@ -124,7 +124,7 @@ public class ListGrammarData {
                 continue;
             }
             // System.out.println(locale);
-            final String names = locale + "\t" + ENGLISH.nameGetter().getName(locale);
+            final String names = locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale);
             for (Entry<PathHeader, String> entry : pathHeaderToValue.entrySet()) {
 
                 final PathHeader ph = entry.getKey();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
@@ -124,7 +124,7 @@ public class ListGrammarData {
                 continue;
             }
             // System.out.println(locale);
-            final String names = locale + "\t" + ENGLISH.getName(locale);
+            final String names = locale + "\t" + ENGLISH.nameGetter().getName(locale);
             for (Entry<PathHeader, String> entry : pathHeaderToValue.entrySet()) {
 
                 final PathHeader ph = entry.getKey();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
@@ -71,7 +71,7 @@ public class ListGrammarInfo {
 
     private static String format(
             String locale, Collection<String> genders, Collection<String> rawCases) {
-        return english.getName(locale)
+        return english.nameGetter().getName(locale)
                 + " ("
                 + locale
                 + "/"
@@ -82,6 +82,6 @@ public class ListGrammarInfo {
     }
 
     public static String format(String locale, Collection<String> genders) {
-        return english.getName(locale) + " (" + locale + "/" + genders.size() + ")";
+        return english.nameGetter().getName(locale) + " (" + locale + "/" + genders.size() + ")";
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
@@ -71,7 +71,7 @@ public class ListGrammarInfo {
 
     private static String format(
             String locale, Collection<String> genders, Collection<String> rawCases) {
-        return english.nameGetter().getNameFromLocaleOrTZID(locale)
+        return english.nameGetter().getNameFromBCP47(locale)
                 + " ("
                 + locale
                 + "/"
@@ -82,6 +82,11 @@ public class ListGrammarInfo {
     }
 
     public static String format(String locale, Collection<String> genders) {
-        return english.nameGetter().getNameFromLocaleOrTZID(locale) + " (" + locale + "/" + genders.size() + ")";
+        return english.nameGetter().getNameFromBCP47(locale)
+                + " ("
+                + locale
+                + "/"
+                + genders.size()
+                + ")";
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
@@ -71,7 +71,7 @@ public class ListGrammarInfo {
 
     private static String format(
             String locale, Collection<String> genders, Collection<String> rawCases) {
-        return english.nameGetter().getName(locale)
+        return english.nameGetter().getNameFromLocaleOrTZID(locale)
                 + " ("
                 + locale
                 + "/"
@@ -82,6 +82,6 @@ public class ListGrammarInfo {
     }
 
     public static String format(String locale, Collection<String> genders) {
-        return english.nameGetter().getName(locale) + " (" + locale + "/" + genders.size() + ")";
+        return english.nameGetter().getNameFromLocaleOrTZID(locale) + " (" + locale + "/" + genders.size() + ")";
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -651,7 +651,8 @@ public class Misc {
         for (Iterator<String> it = zone_countries.keySet().iterator(); it.hasNext(); ) {
             String zoneID = it.next();
             String country = zone_countries.get(zoneID);
-            String countryName = desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
+            String countryName =
+                    desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = UTF16.valueOf(0x10FFFD) + country;
             reordered.put(countryName + "0" + zoneID, zoneID);
         }
@@ -663,7 +664,8 @@ public class Misc {
             String key = it.next();
             String zoneID = reordered.get(key);
             String country = zone_countries.get(zoneID);
-            String countryName = desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
+            String countryName =
+                    desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = country;
             log.println(
                     "<tr><th class='ID' colspan=\"4\"><table><tr><th class='I'>"
@@ -1198,7 +1200,9 @@ public class Misc {
                                 + key
                                 + "\" draft=\"unconfirmed\">"
                                 + TransliteratorUtilities.toXML.transliterate(
-                                        "TODO " + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, key))
+                                        "TODO "
+                                                + english.nameGetter()
+                                                        .getName(CLDRFile.TERRITORY_NAME, key))
                                 + "</territory>");
             }
             log2.println("</territories></localeDisplayNames>");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -281,7 +281,7 @@ public class Misc {
                                 + " => "
                                 + replacementCode
                                 + "; "
-                                + english.nameGetter().getName(type, replacementCode));
+                                + english.nameGetter().getNameFromTypestrCode(type, replacementCode));
             }
         }
     }
@@ -352,7 +352,7 @@ public class Misc {
         // do the header
         for (Iterator<String> it2 = priorities.iterator(); it2.hasNext(); ) {
             String locale = it2.next();
-            String englishLocaleName = english.nameGetter().getName(locale);
+            String englishLocaleName = english.nameGetter().getNameFromLocaleOrTZID(locale);
             out.println("<th>" + locale + " (" + englishLocaleName + ")" + "</th>");
         }
 
@@ -370,7 +370,7 @@ public class Misc {
                 out.println("<th>" + (++count) + "</th>");
                 out.println("<th>" + zone + "</th>");
                 String country = zone_country.get(zone);
-                String countryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
+                String countryName = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
                 out.println("<td>" + country + " (" + countryName + ")" + "</td>");
                 TimeZone tzone = TimeZone.getTimeZone(zone);
                 out.println("<td>" + offsetString(tzone) + "</td>");
@@ -477,7 +477,7 @@ public class Misc {
             String zone = it.next();
             new_old.put(zone, new TreeSet<String>(col));
             String country = zone_countries.get(zone);
-            String name = english.nameGetter().getName("territory", country) + " (" + country + ")";
+            String name = english.nameGetter().getNameFromTypestrCode("territory", country) + " (" + country + ")";
             Set<String> oldSet = country_zones.get(name);
             if (oldSet == null) country_zones.put(name, oldSet = new TreeSet<>(col));
             oldSet.add(zone);
@@ -652,7 +652,7 @@ public class Misc {
             String zoneID = it.next();
             String country = zone_countries.get(zoneID);
             String countryName =
-                    desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
+                    desiredLocaleFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = UTF16.valueOf(0x10FFFD) + country;
             reordered.put(countryName + "0" + zoneID, zoneID);
         }
@@ -665,7 +665,7 @@ public class Misc {
             String zoneID = reordered.get(key);
             String country = zone_countries.get(zoneID);
             String countryName =
-                    desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
+                    desiredLocaleFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = country;
             log.println(
                     "<tr><th class='ID' colspan=\"4\"><table><tr><th class='I'>"
@@ -1202,7 +1202,7 @@ public class Misc {
                                 + TransliteratorUtilities.toXML.transliterate(
                                         "TODO "
                                                 + english.nameGetter()
-                                                        .getName(CLDRFile.TERRITORY_NAME, key))
+                                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, key))
                                 + "</territory>");
             }
             log2.println("</territories></localeDisplayNames>");
@@ -1219,7 +1219,7 @@ public class Misc {
                 String key = it.next();
                 List<String> data = StandardCodes.make().getZoneData().get(key);
                 String countryCode = data.get(2);
-                String country = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode);
+                String country = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
                 if (!country.equals(lastCountry)) {
                     lastCountry = country;
                     log2.println("\t<!-- " + country + "-->");
@@ -1328,7 +1328,7 @@ public class Misc {
                 name = name.replace('_', ' ');
             }
         } else {
-            name = localization.nameGetter().getName(CLDRFile.TERRITORY_NAME, key);
+            name = localization.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, key);
             if (name == null) {
                 if (missing != null) missing[0].add(key);
                 name = key;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -281,7 +281,8 @@ public class Misc {
                                 + " => "
                                 + replacementCode
                                 + "; "
-                                + english.nameGetter().getNameFromTypestrCode(type, replacementCode));
+                                + english.nameGetter()
+                                        .getNameFromTypestrCode(type, replacementCode));
             }
         }
     }
@@ -352,7 +353,7 @@ public class Misc {
         // do the header
         for (Iterator<String> it2 = priorities.iterator(); it2.hasNext(); ) {
             String locale = it2.next();
-            String englishLocaleName = english.nameGetter().getNameFromLocaleOrTZID(locale);
+            String englishLocaleName = english.nameGetter().getNameFromBCP47(locale);
             out.println("<th>" + locale + " (" + englishLocaleName + ")" + "</th>");
         }
 
@@ -370,7 +371,9 @@ public class Misc {
                 out.println("<th>" + (++count) + "</th>");
                 out.println("<th>" + zone + "</th>");
                 String country = zone_country.get(zone);
-                String countryName = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                String countryName =
+                        english.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
                 out.println("<td>" + country + " (" + countryName + ")" + "</td>");
                 TimeZone tzone = TimeZone.getTimeZone(zone);
                 out.println("<td>" + offsetString(tzone) + "</td>");
@@ -477,7 +480,11 @@ public class Misc {
             String zone = it.next();
             new_old.put(zone, new TreeSet<String>(col));
             String country = zone_countries.get(zone);
-            String name = english.nameGetter().getNameFromTypestrCode("territory", country) + " (" + country + ")";
+            String name =
+                    english.nameGetter().getNameFromTypestrCode("territory", country)
+                            + " ("
+                            + country
+                            + ")";
             Set<String> oldSet = country_zones.get(name);
             if (oldSet == null) country_zones.put(name, oldSet = new TreeSet<>(col));
             oldSet.add(zone);
@@ -652,7 +659,9 @@ public class Misc {
             String zoneID = it.next();
             String country = zone_countries.get(zoneID);
             String countryName =
-                    desiredLocaleFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                    desiredLocaleFile
+                            .nameGetter()
+                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = UTF16.valueOf(0x10FFFD) + country;
             reordered.put(countryName + "0" + zoneID, zoneID);
         }
@@ -665,7 +674,9 @@ public class Misc {
             String zoneID = reordered.get(key);
             String country = zone_countries.get(zoneID);
             String countryName =
-                    desiredLocaleFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                    desiredLocaleFile
+                            .nameGetter()
+                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = country;
             log.println(
                     "<tr><th class='ID' colspan=\"4\"><table><tr><th class='I'>"
@@ -1202,7 +1213,8 @@ public class Misc {
                                 + TransliteratorUtilities.toXML.transliterate(
                                         "TODO "
                                                 + english.nameGetter()
-                                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, key))
+                                                        .getNameFromTypenumCode(
+                                                                CLDRFile.TERRITORY_NAME, key))
                                 + "</territory>");
             }
             log2.println("</territories></localeDisplayNames>");
@@ -1219,7 +1231,9 @@ public class Misc {
                 String key = it.next();
                 List<String> data = StandardCodes.make().getZoneData().get(key);
                 String countryCode = data.get(2);
-                String country = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
+                String country =
+                        english.nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
                 if (!country.equals(lastCountry)) {
                     lastCountry = country;
                     log2.println("\t<!-- " + country + "-->");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -281,7 +281,7 @@ public class Misc {
                                 + " => "
                                 + replacementCode
                                 + "; "
-                                + english.getName(type, replacementCode));
+                                + english.nameGetter().getName(type, replacementCode));
             }
         }
     }
@@ -352,7 +352,7 @@ public class Misc {
         // do the header
         for (Iterator<String> it2 = priorities.iterator(); it2.hasNext(); ) {
             String locale = it2.next();
-            String englishLocaleName = english.getName(locale);
+            String englishLocaleName = english.nameGetter().getName(locale);
             out.println("<th>" + locale + " (" + englishLocaleName + ")" + "</th>");
         }
 
@@ -370,7 +370,7 @@ public class Misc {
                 out.println("<th>" + (++count) + "</th>");
                 out.println("<th>" + zone + "</th>");
                 String country = zone_country.get(zone);
-                String countryName = english.getName(CLDRFile.TERRITORY_NAME, country);
+                String countryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
                 out.println("<td>" + country + " (" + countryName + ")" + "</td>");
                 TimeZone tzone = TimeZone.getTimeZone(zone);
                 out.println("<td>" + offsetString(tzone) + "</td>");
@@ -477,7 +477,7 @@ public class Misc {
             String zone = it.next();
             new_old.put(zone, new TreeSet<String>(col));
             String country = zone_countries.get(zone);
-            String name = english.getName("territory", country) + " (" + country + ")";
+            String name = english.nameGetter().getName("territory", country) + " (" + country + ")";
             Set<String> oldSet = country_zones.get(name);
             if (oldSet == null) country_zones.put(name, oldSet = new TreeSet<>(col));
             oldSet.add(zone);
@@ -651,7 +651,7 @@ public class Misc {
         for (Iterator<String> it = zone_countries.keySet().iterator(); it.hasNext(); ) {
             String zoneID = it.next();
             String country = zone_countries.get(zoneID);
-            String countryName = desiredLocaleFile.getName(CLDRFile.TERRITORY_NAME, country);
+            String countryName = desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = UTF16.valueOf(0x10FFFD) + country;
             reordered.put(countryName + "0" + zoneID, zoneID);
         }
@@ -663,7 +663,7 @@ public class Misc {
             String key = it.next();
             String zoneID = reordered.get(key);
             String country = zone_countries.get(zoneID);
-            String countryName = desiredLocaleFile.getName(CLDRFile.TERRITORY_NAME, country);
+            String countryName = desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
             if (countryName == null) countryName = country;
             log.println(
                     "<tr><th class='ID' colspan=\"4\"><table><tr><th class='I'>"
@@ -1198,7 +1198,7 @@ public class Misc {
                                 + key
                                 + "\" draft=\"unconfirmed\">"
                                 + TransliteratorUtilities.toXML.transliterate(
-                                        "TODO " + english.getName(CLDRFile.TERRITORY_NAME, key))
+                                        "TODO " + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, key))
                                 + "</territory>");
             }
             log2.println("</territories></localeDisplayNames>");
@@ -1215,7 +1215,7 @@ public class Misc {
                 String key = it.next();
                 List<String> data = StandardCodes.make().getZoneData().get(key);
                 String countryCode = data.get(2);
-                String country = english.getName(CLDRFile.TERRITORY_NAME, countryCode);
+                String country = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode);
                 if (!country.equals(lastCountry)) {
                     lastCountry = country;
                     log2.println("\t<!-- " + country + "-->");
@@ -1324,7 +1324,7 @@ public class Misc {
                 name = name.replace('_', ' ');
             }
         } else {
-            name = localization.getName(CLDRFile.TERRITORY_NAME, key);
+            name = localization.nameGetter().getName(CLDRFile.TERRITORY_NAME, key);
             if (name == null) {
                 if (missing != null) missing[0].add(key);
                 name = key;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
@@ -63,9 +63,9 @@ public class ScriptPopulations {
                             + "\t"
                             + langScriptLitPop.getCount(lang)
                             + "\t"
-                            + english.nameGetter().getName(baseLanguage)
+                            + english.nameGetter().getNameFromLocaleOrTZID(baseLanguage)
                             + "\t"
-                            + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
                             + "\t"
                             + officialStatus
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
@@ -63,9 +63,10 @@ public class ScriptPopulations {
                             + "\t"
                             + langScriptLitPop.getCount(lang)
                             + "\t"
-                            + english.nameGetter().getNameFromLocaleOrTZID(baseLanguage)
+                            + english.nameGetter().getNameFromBCP47(baseLanguage)
                             + "\t"
-                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
                             + "\t"
                             + officialStatus
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
@@ -63,9 +63,9 @@ public class ScriptPopulations {
                             + "\t"
                             + langScriptLitPop.getCount(lang)
                             + "\t"
-                            + english.getName(baseLanguage)
+                            + english.nameGetter().getName(baseLanguage)
                             + "\t"
-                            + english.getName(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
                             + "\t"
                             + officialStatus
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
@@ -42,7 +42,7 @@ public class ShowChildren {
         for (Entry<String, Set<String>> entry : parent2children.keyValuesSet()) {
             Map<String, Relation<String, String>> path2value2locales = new TreeMap<>();
             String parent = entry.getKey();
-            String parentName = english.nameGetter().getName(parent);
+            String parentName = english.nameGetter().getNameFromLocaleOrTZID(parent);
             CLDRFile parentFile = cldrFactory.make(parent, true);
 
             Set<String> children = entry.getValue();
@@ -99,7 +99,7 @@ public class ShowChildren {
             deviations.add(parent, path2value2locales.size());
         }
         for (String locale : deviations.getKeysetSortedByKey()) {
-            String parentName = english.nameGetter().getName(locale);
+            String parentName = english.nameGetter().getNameFromLocaleOrTZID(locale);
             System.out.println(parentName + "\t" + locale + "\t" + deviations.get(locale));
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
@@ -42,7 +42,7 @@ public class ShowChildren {
         for (Entry<String, Set<String>> entry : parent2children.keyValuesSet()) {
             Map<String, Relation<String, String>> path2value2locales = new TreeMap<>();
             String parent = entry.getKey();
-            String parentName = english.getName(parent);
+            String parentName = english.nameGetter().getName(parent);
             CLDRFile parentFile = cldrFactory.make(parent, true);
 
             Set<String> children = entry.getValue();
@@ -99,7 +99,7 @@ public class ShowChildren {
             deviations.add(parent, path2value2locales.size());
         }
         for (String locale : deviations.getKeysetSortedByKey()) {
-            String parentName = english.getName(locale);
+            String parentName = english.nameGetter().getName(locale);
             System.out.println(parentName + "\t" + locale + "\t" + deviations.get(locale));
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
@@ -42,7 +42,7 @@ public class ShowChildren {
         for (Entry<String, Set<String>> entry : parent2children.keyValuesSet()) {
             Map<String, Relation<String, String>> path2value2locales = new TreeMap<>();
             String parent = entry.getKey();
-            String parentName = english.nameGetter().getNameFromLocaleOrTZID(parent);
+            String parentName = english.nameGetter().getNameFromBCP47(parent);
             CLDRFile parentFile = cldrFactory.make(parent, true);
 
             Set<String> children = entry.getValue();
@@ -99,7 +99,7 @@ public class ShowChildren {
             deviations.add(parent, path2value2locales.size());
         }
         for (String locale : deviations.getKeysetSortedByKey()) {
-            String parentName = english.nameGetter().getNameFromLocaleOrTZID(locale);
+            String parentName = english.nameGetter().getNameFromBCP47(locale);
             System.out.println(parentName + "\t" + locale + "\t" + deviations.get(locale));
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -520,7 +520,8 @@ public class ShowData {
             String localeName = file.nameGetter().getName(locale);
             getScripts(localeName, scripts);
             if (!scripts.contains("Latn")) {
-                out.println(locale + "\t" + english.nameGetter().getName(locale) + "\t" + localeName);
+                out.println(
+                        locale + "\t" + english.nameGetter().getName(locale) + "\t" + localeName);
             }
             for (Iterator<String> it2 = UnicodeScripts.iterator(); it2.hasNext(); ) {
                 String script = it2.next();
@@ -540,7 +541,11 @@ public class ShowData {
             String script = it2.next();
             Object names = script_name_locales.get(script);
             out.println(
-                    script + "\t(" + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script) + ")\t" + names);
+                    script
+                            + "\t("
+                            + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
+                            + ")\t"
+                            + names);
         }
         out.close();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -517,16 +517,21 @@ public class ShowData {
             System.out.println(locale);
             CLDRFile file = cldrFactory.make(locale, false);
             if (file.isNonInheriting()) continue;
-            String localeName = file.nameGetter().getNameFromLocaleOrTZID(locale);
+            String localeName = file.nameGetter().getNameFromBCP47(locale);
             getScripts(localeName, scripts);
             if (!scripts.contains("Latn")) {
                 out.println(
-                        locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + localeName);
+                        locale
+                                + "\t"
+                                + english.nameGetter().getNameFromBCP47(locale)
+                                + "\t"
+                                + localeName);
             }
             for (Iterator<String> it2 = UnicodeScripts.iterator(); it2.hasNext(); ) {
                 String script = it2.next();
                 if (script.equals("Latn")) continue;
-                String name = file.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+                String name =
+                        file.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
                 if (getScripts(name, scripts).contains(script)) {
                     Map<String, Set<String>> names_locales = script_name_locales.get(script);
                     if (names_locales == null)
@@ -543,7 +548,8 @@ public class ShowData {
             out.println(
                     script
                             + "\t("
-                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
                             + ")\t"
                             + names);
         }
@@ -751,7 +757,7 @@ public class ShowData {
     }
 
     public static String getEnglishLocaleName(String locale) {
-        return english.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, CLDRFile.SHORT_ALTS);
+        return english.nameGetter().getNameFromBCP47BoolAlt(locale, true, CLDRFile.SHORT_ALTS);
     }
 
     private static String getLocaleNameAndCode(String locale) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -517,16 +517,16 @@ public class ShowData {
             System.out.println(locale);
             CLDRFile file = cldrFactory.make(locale, false);
             if (file.isNonInheriting()) continue;
-            String localeName = file.nameGetter().getName(locale);
+            String localeName = file.nameGetter().getNameFromLocaleOrTZID(locale);
             getScripts(localeName, scripts);
             if (!scripts.contains("Latn")) {
                 out.println(
-                        locale + "\t" + english.nameGetter().getName(locale) + "\t" + localeName);
+                        locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + localeName);
             }
             for (Iterator<String> it2 = UnicodeScripts.iterator(); it2.hasNext(); ) {
                 String script = it2.next();
                 if (script.equals("Latn")) continue;
-                String name = file.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+                String name = file.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
                 if (getScripts(name, scripts).contains(script)) {
                     Map<String, Set<String>> names_locales = script_name_locales.get(script);
                     if (names_locales == null)
@@ -543,7 +543,7 @@ public class ShowData {
             out.println(
                     script
                             + "\t("
-                            + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
                             + ")\t"
                             + names);
         }
@@ -751,7 +751,7 @@ public class ShowData {
     }
 
     public static String getEnglishLocaleName(String locale) {
-        return english.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS);
+        return english.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, CLDRFile.SHORT_ALTS);
     }
 
     private static String getLocaleNameAndCode(String locale) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -517,15 +517,15 @@ public class ShowData {
             System.out.println(locale);
             CLDRFile file = cldrFactory.make(locale, false);
             if (file.isNonInheriting()) continue;
-            String localeName = file.getName(locale);
+            String localeName = file.nameGetter().getName(locale);
             getScripts(localeName, scripts);
             if (!scripts.contains("Latn")) {
-                out.println(locale + "\t" + english.getName(locale) + "\t" + localeName);
+                out.println(locale + "\t" + english.nameGetter().getName(locale) + "\t" + localeName);
             }
             for (Iterator<String> it2 = UnicodeScripts.iterator(); it2.hasNext(); ) {
                 String script = it2.next();
                 if (script.equals("Latn")) continue;
-                String name = file.getName(CLDRFile.SCRIPT_NAME, script);
+                String name = file.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
                 if (getScripts(name, scripts).contains(script)) {
                     Map<String, Set<String>> names_locales = script_name_locales.get(script);
                     if (names_locales == null)
@@ -540,7 +540,7 @@ public class ShowData {
             String script = it2.next();
             Object names = script_name_locales.get(script);
             out.println(
-                    script + "\t(" + english.getName(CLDRFile.SCRIPT_NAME, script) + ")\t" + names);
+                    script + "\t(" + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script) + ")\t" + names);
         }
         out.close();
     }
@@ -746,7 +746,7 @@ public class ShowData {
     }
 
     public static String getEnglishLocaleName(String locale) {
-        return english.getName(locale, true, CLDRFile.SHORT_ALTS);
+        return english.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS);
     }
 
     private static String getLocaleNameAndCode(String locale) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
@@ -50,11 +50,11 @@ public class ShowLanguageData {
                 System.out.println(
                         language
                                 + "\t"
-                                + english.getName(language)
+                                + english.nameGetter().getName(language)
                                 + "\t"
                                 + territory
                                 + "\t"
-                                + english.getName(CLDRFile.TERRITORY_NAME, territory)
+                                + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
                                 + "\t"
                                 + litPop / (double) total);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
@@ -50,11 +50,12 @@ public class ShowLanguageData {
                 System.out.println(
                         language
                                 + "\t"
-                                + english.nameGetter().getNameFromLocaleOrTZID(language)
+                                + english.nameGetter().getNameFromBCP47(language)
                                 + "\t"
                                 + territory
                                 + "\t"
-                                + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                                + english.nameGetter()
+                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                                 + "\t"
                                 + litPop / (double) total);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
@@ -50,11 +50,11 @@ public class ShowLanguageData {
                 System.out.println(
                         language
                                 + "\t"
-                                + english.nameGetter().getName(language)
+                                + english.nameGetter().getNameFromLocaleOrTZID(language)
                                 + "\t"
                                 + territory
                                 + "\t"
-                                + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
+                                + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                                 + "\t"
                                 + litPop / (double) total);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -67,6 +67,7 @@ import org.unicode.cldr.util.Iso639Data.Type;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Log;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.CodeType;
@@ -94,6 +95,7 @@ public class ShowLanguages {
     static Factory cldrFactory =
             CLDRConfig.getInstance().getCldrFactory(); // .make(CLDRPaths.MAIN_DIRECTORY, ".*");
     static CLDRFile english = CLDRConfig.getInstance().getEnglish();
+    private static NameGetter englishNameGetter = english.nameGetter();
 
     public static void main(String[] args) throws IOException {
         System.out.println("Writing into " + FormattedFileWriter.CHART_TARGET_DIR);
@@ -623,19 +625,22 @@ public class ShowLanguages {
                 }
             }
         }
-        String languageName = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+        String languageName =
+                englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
         if (languageName == null) languageName = "???";
         String isLanguageTranslated = "";
         String nativeLanguageName =
                 nativeLanguage == null
                         ? null
-                        : nativeLanguage.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                        : nativeLanguage
+                                .nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
         if (nativeLanguageName == null || nativeLanguageName.equals(language)) {
             nativeLanguageName = "<i>n/a</i>";
             isLanguageTranslated = "n";
         }
 
-        String scriptName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
         // String nativeScriptName = nativeLanguage == null ? null :
         // nativeLanguage.getName(CLDRFile.SCRIPT_NAME,script);
         // if (nativeScriptName != null && !nativeScriptName.equals(script)) {
@@ -643,11 +648,14 @@ public class ShowLanguages {
         // }
 
         String isTerritoryTranslated = "";
-        String territoryName = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+        String territoryName =
+                englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
         String nativeTerritoryName =
                 nativeLanguage == null
                         ? null
-                        : nativeLanguage.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                        : nativeLanguage
+                                .nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
         if (nativeTerritoryName == null || nativeTerritoryName.equals(territory)) {
             nativeTerritoryName = "<i>n/a</i>";
             isTerritoryTranslated = "n";
@@ -694,7 +702,7 @@ public class ShowLanguages {
         if (temp != null) {
             return temp;
         }
-        String scriptName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
         scriptName = scriptName.toLowerCase(Locale.ENGLISH);
         temp = fixScriptGif.get(scriptName);
         if (temp != null) {
@@ -714,12 +722,14 @@ public class ShowLanguages {
             String script,
             String secondary) {
         try {
-            String languageName = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+            String languageName =
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
             if (languageName == null) {
                 languageName = "¿" + language + "?";
                 System.err.println("No English Language Name for:" + language);
             }
-            String scriptName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+            String scriptName =
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
             if (scriptName == null) {
                 scriptName = "¿" + script + "?";
                 System.err.println("No English Language Name for:" + script);
@@ -1139,7 +1149,7 @@ public class ShowLanguages {
             if (value == null || value.equals("") || value.equals("und")) {
                 return "\u00A0";
             }
-            String result = english.nameGetter().getNameFromTypenumCode(type, value);
+            String result = englishNameGetter.getNameFromTypenumCode(type, value);
             if (result == null) {
                 result = value;
             }
@@ -1271,7 +1281,8 @@ public class ShowLanguages {
                 // PopulationData territoryData =
                 // supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 String territoryName =
-                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territoryCode);
+                        englishNameGetter.getNameFromTypenumCode(
+                                CLDRFile.TERRITORY_NAME, territoryCode);
                 for (String languageCode :
                         supplementalDataInfo.getLanguagesForTerritoryWithPopulationData(
                                 territoryCode)) {
@@ -1363,7 +1374,9 @@ public class ShowLanguages {
         }
 
         private String getLanguageName(String languageCode) {
-            String result = english.nameGetter().getNameFromLocaleOrTZBoolAltpicker(languageCode, true, CLDRFile.SHORT_ALTS);
+            String result =
+                    englishNameGetter.getNameFromBCP47BoolAlt(
+                            languageCode, true, CLDRFile.SHORT_ALTS);
             if (!result.equals(languageCode)) return result;
             Set<String> names = Iso639Data.getNames(languageCode);
             if (names != null && names.size() != 0) {
@@ -1551,7 +1564,8 @@ public class ShowLanguages {
                 final String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : english.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, CLDRFile.SHORT_ALTS);
+                                : englishNameGetter.getNameFromBCP47BoolAlt(
+                                        locale, true, CLDRFile.SHORT_ALTS);
                 coverageGoalsTsv.println(
                         String.format(
                                 "%s\t;\t%s\t;\t%s\t;\t%s", organization, locale, level, name));
@@ -1679,7 +1693,8 @@ public class ShowLanguages {
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
-                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territoryCode);
+                        englishNameGetter.getNameFromTypenumCode(
+                                CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double territoryLiteracy = territoryData2.getLiteratePopulationPercent();
@@ -1819,7 +1834,8 @@ public class ShowLanguages {
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
-                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territoryCode);
+                        englishNameGetter.getNameFromTypenumCode(
+                                CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double population = territoryData2.getPopulation() / 1000000;
@@ -1948,8 +1964,8 @@ public class ShowLanguages {
         //                String territory = (String) it.next();
         //                String parent = (String) territory_parent.get(territory);
         //                System.out.println(territory + "\t" +
-        // english.nameGetter().getName(english.TERRITORY_NAME, territory) + "\t"
-        //                    + parent + "\t" + english.nameGetter().getName(english.TERRITORY_NAME,
+        // englishNameGetter.getName(english.TERRITORY_NAME, territory) + "\t"
+        //                    + parent + "\t" + englishNameGetter.getName(english.TERRITORY_NAME,
         // parent));
         //            }
         //        }
@@ -2044,7 +2060,8 @@ public class ShowLanguages {
             Map<String, String> name_script = new TreeMap<>();
             for (Iterator<String> it = sc.getAvailableCodes("script").iterator(); it.hasNext(); ) {
                 String script = it.next();
-                String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+                String name =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
                 if (name == null) name = script;
                 name_script.put(name, script);
                 /*
@@ -2058,14 +2075,16 @@ public class ShowLanguages {
             for (Iterator<String> it = sc.getAvailableCodes("language").iterator();
                     it.hasNext(); ) {
                 String language = it.next();
-                String names = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                String names =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
                 if (names == null) names = language;
                 name_language.put(names, language);
             }
             for (Iterator<String> it = sc.getAvailableCodes("language").iterator();
                     it.hasNext(); ) {
                 String language = it.next();
-                String names = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                String names =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
                 if (names == null) names = language;
                 String[] words = names.split(delimiter);
                 if (words.length > 1) {
@@ -2212,8 +2231,8 @@ public class ShowLanguages {
                                     + infoItem.getCurrency()
                                     + "</td>"
                                     + "<td class='target'>"
-                                    + english.nameGetter()
-                                            .getNameFromTypestrCode("currency", infoItem.getCurrency())
+                                    + englishNameGetter.getNameFromTypestrCode(
+                                            "currency", infoItem.getCurrency())
                                     + "</td>"
                                     + "</tr>");
                 }
@@ -2268,7 +2287,8 @@ public class ShowLanguages {
                         "<tr>"
                                 + "<td class='source nowrap'>"
                                 + TransliteratorUtilities.toHTML.transform(
-                                        english.nameGetter().getNameFromTypestrCode("currency", currency))
+                                        englishNameGetter.getNameFromTypestrCode(
+                                                "currency", currency))
                                 + "</td>"
                                 + "<td class='source'>"
                                 + CldrUtility.getDoubleLinkedText(currency)
@@ -2328,7 +2348,7 @@ public class ShowLanguages {
             // for (Iterator it = territoriesWithoutCurrencies.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(english.nameGetter().getName(CLDRFile.TERRITORY_NAME, it.next().toString(),
+            // pw.print(englishNameGetter.getName(CLDRFile.TERRITORY_NAME, it.next().toString(),
             // false));
             // }
             // pw.println("</td><td class='target'>");
@@ -2339,7 +2359,7 @@ public class ShowLanguages {
             // for (Iterator it = currenciesWithoutTerritories.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(english.nameGetter().getName(CLDRFile.CURRENCY_NAME, it.next().toString(),
+            // pw.print(englishNameGetter.getName(CLDRFile.CURRENCY_NAME, it.next().toString(),
             // false));
             // }
             // pw.println("</td></tr>");
@@ -2349,7 +2369,7 @@ public class ShowLanguages {
 
         private String getTerritoryName(String territory) {
             String name;
-            name = english.nameGetter().getNameFromTypestrCode("territory", territory);
+            name = englishNameGetter.getNameFromTypestrCode("territory", territory);
             if (name == null) {
                 name = sc.getData("territory", territory);
             }
@@ -2743,7 +2763,7 @@ public class ShowLanguages {
             } else {
                 int pos = oldcode.indexOf('*');
                 String code = pos < 0 ? oldcode : oldcode.substring(0, pos);
-                String ename = english.nameGetter().getNameFromTypenumCode(type, code);
+                String ename = englishNameGetter.getNameFromTypenumCode(type, code);
                 String nameString = ename == null ? code : ename;
                 return nameString.equals(oldcode)
                         ? nameString
@@ -2952,7 +2972,7 @@ public class ShowLanguages {
     private static SortedMap<String, String> getNameToCode(CodeType codeType, String cldrCodeType) {
         SortedMap<String, String> temp = new TreeMap<String, String>(col);
         for (String territory : StandardCodes.make().getAvailableCodes(codeType)) {
-            String name = english.nameGetter().getNameFromTypestrCode(cldrCodeType, territory);
+            String name = englishNameGetter.getNameFromTypestrCode(cldrCodeType, territory);
             temp.put(name == null ? territory : name, territory);
         }
         temp = Collections.unmodifiableSortedMap(temp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -623,19 +623,19 @@ public class ShowLanguages {
                 }
             }
         }
-        String languageName = english.getName(CLDRFile.LANGUAGE_NAME, language);
+        String languageName = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
         if (languageName == null) languageName = "???";
         String isLanguageTranslated = "";
         String nativeLanguageName =
                 nativeLanguage == null
                         ? null
-                        : nativeLanguage.getName(CLDRFile.LANGUAGE_NAME, language);
+                        : nativeLanguage.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
         if (nativeLanguageName == null || nativeLanguageName.equals(language)) {
             nativeLanguageName = "<i>n/a</i>";
             isLanguageTranslated = "n";
         }
 
-        String scriptName = english.getName(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
         // String nativeScriptName = nativeLanguage == null ? null :
         // nativeLanguage.getName(CLDRFile.SCRIPT_NAME,script);
         // if (nativeScriptName != null && !nativeScriptName.equals(script)) {
@@ -643,11 +643,11 @@ public class ShowLanguages {
         // }
 
         String isTerritoryTranslated = "";
-        String territoryName = english.getName(CLDRFile.TERRITORY_NAME, territory);
+        String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
         String nativeTerritoryName =
                 nativeLanguage == null
                         ? null
-                        : nativeLanguage.getName(CLDRFile.TERRITORY_NAME, territory);
+                        : nativeLanguage.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
         if (nativeTerritoryName == null || nativeTerritoryName.equals(territory)) {
             nativeTerritoryName = "<i>n/a</i>";
             isTerritoryTranslated = "n";
@@ -694,7 +694,7 @@ public class ShowLanguages {
         if (temp != null) {
             return temp;
         }
-        String scriptName = english.getName(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
         scriptName = scriptName.toLowerCase(Locale.ENGLISH);
         temp = fixScriptGif.get(scriptName);
         if (temp != null) {
@@ -714,12 +714,12 @@ public class ShowLanguages {
             String script,
             String secondary) {
         try {
-            String languageName = english.getName(CLDRFile.LANGUAGE_NAME, language);
+            String languageName = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
             if (languageName == null) {
                 languageName = "¿" + language + "?";
                 System.err.println("No English Language Name for:" + language);
             }
-            String scriptName = english.getName(CLDRFile.SCRIPT_NAME, script);
+            String scriptName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
             if (scriptName == null) {
                 scriptName = "¿" + script + "?";
                 System.err.println("No English Language Name for:" + script);
@@ -1139,7 +1139,7 @@ public class ShowLanguages {
             if (value == null || value.equals("") || value.equals("und")) {
                 return "\u00A0";
             }
-            String result = english.getName(type, value);
+            String result = english.nameGetter().getName(type, value);
             if (result == null) {
                 result = value;
             }
@@ -1270,7 +1270,7 @@ public class ShowLanguages {
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 // PopulationData territoryData =
                 // supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
-                String territoryName = english.getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
                 for (String languageCode :
                         supplementalDataInfo.getLanguagesForTerritoryWithPopulationData(
                                 territoryCode)) {
@@ -1362,7 +1362,7 @@ public class ShowLanguages {
         }
 
         private String getLanguageName(String languageCode) {
-            String result = english.getName(languageCode, true, CLDRFile.SHORT_ALTS);
+            String result = english.nameGetter().getName(languageCode, true, CLDRFile.SHORT_ALTS);
             if (!result.equals(languageCode)) return result;
             Set<String> names = Iso639Data.getNames(languageCode);
             if (names != null && names.size() != 0) {
@@ -1550,7 +1550,7 @@ public class ShowLanguages {
                 final String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : english.getName(locale, true, CLDRFile.SHORT_ALTS);
+                                : english.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS);
                 coverageGoalsTsv.println(
                         String.format(
                                 "%s\t;\t%s\t;\t%s\t;\t%s", organization, locale, level, name));
@@ -1677,7 +1677,7 @@ public class ShowLanguages {
                     .addColumn("Report Bug", "class='target'", null, "class='target'", false);
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
-                String territoryName = english.getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double territoryLiteracy = territoryData2.getLiteratePopulationPercent();
@@ -1816,7 +1816,7 @@ public class ShowLanguages {
             tablePrinter.addColumn("Report Bug", "class='target'", null, "class='target'", false);
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
-                String territoryName = english.getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double population = territoryData2.getPopulation() / 1000000;
@@ -1945,8 +1945,8 @@ public class ShowLanguages {
         //                String territory = (String) it.next();
         //                String parent = (String) territory_parent.get(territory);
         //                System.out.println(territory + "\t" +
-        // english.getName(english.TERRITORY_NAME, territory) + "\t"
-        //                    + parent + "\t" + english.getName(english.TERRITORY_NAME, parent));
+        // english.nameGetter().getName(english.TERRITORY_NAME, territory) + "\t"
+        //                    + parent + "\t" + english.nameGetter().getName(english.TERRITORY_NAME, parent));
         //            }
         //        }
 
@@ -2040,7 +2040,7 @@ public class ShowLanguages {
             Map<String, String> name_script = new TreeMap<>();
             for (Iterator<String> it = sc.getAvailableCodes("script").iterator(); it.hasNext(); ) {
                 String script = it.next();
-                String name = english.getName(CLDRFile.SCRIPT_NAME, script);
+                String name = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
                 if (name == null) name = script;
                 name_script.put(name, script);
                 /*
@@ -2054,14 +2054,14 @@ public class ShowLanguages {
             for (Iterator<String> it = sc.getAvailableCodes("language").iterator();
                     it.hasNext(); ) {
                 String language = it.next();
-                String names = english.getName(CLDRFile.LANGUAGE_NAME, language);
+                String names = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
                 if (names == null) names = language;
                 name_language.put(names, language);
             }
             for (Iterator<String> it = sc.getAvailableCodes("language").iterator();
                     it.hasNext(); ) {
                 String language = it.next();
-                String names = english.getName(CLDRFile.LANGUAGE_NAME, language);
+                String names = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
                 if (names == null) names = language;
                 String[] words = names.split(delimiter);
                 if (words.length > 1) {
@@ -2208,7 +2208,7 @@ public class ShowLanguages {
                                     + infoItem.getCurrency()
                                     + "</td>"
                                     + "<td class='target'>"
-                                    + english.getName("currency", infoItem.getCurrency())
+                                    + english.nameGetter().getName("currency", infoItem.getCurrency())
                                     + "</td>"
                                     + "</tr>");
                 }
@@ -2263,7 +2263,7 @@ public class ShowLanguages {
                         "<tr>"
                                 + "<td class='source nowrap'>"
                                 + TransliteratorUtilities.toHTML.transform(
-                                        english.getName("currency", currency))
+                                        english.nameGetter().getName("currency", currency))
                                 + "</td>"
                                 + "<td class='source'>"
                                 + CldrUtility.getDoubleLinkedText(currency)
@@ -2323,7 +2323,7 @@ public class ShowLanguages {
             // for (Iterator it = territoriesWithoutCurrencies.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(english.getName(CLDRFile.TERRITORY_NAME, it.next().toString(), false));
+            // pw.print(english.nameGetter().getName(CLDRFile.TERRITORY_NAME, it.next().toString(), false));
             // }
             // pw.println("</td><td class='target'>");
             // Set currenciesWithoutTerritories = new TreeSet();
@@ -2333,7 +2333,7 @@ public class ShowLanguages {
             // for (Iterator it = currenciesWithoutTerritories.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(english.getName(CLDRFile.CURRENCY_NAME, it.next().toString(), false));
+            // pw.print(english.nameGetter().getName(CLDRFile.CURRENCY_NAME, it.next().toString(), false));
             // }
             // pw.println("</td></tr>");
             // doFooter(pw);
@@ -2342,7 +2342,7 @@ public class ShowLanguages {
 
         private String getTerritoryName(String territory) {
             String name;
-            name = english.getName("territory", territory);
+            name = english.nameGetter().getName("territory", territory);
             if (name == null) {
                 name = sc.getData("territory", territory);
             }
@@ -2736,7 +2736,7 @@ public class ShowLanguages {
             } else {
                 int pos = oldcode.indexOf('*');
                 String code = pos < 0 ? oldcode : oldcode.substring(0, pos);
-                String ename = english.getName(type, code);
+                String ename = english.nameGetter().getName(type, code);
                 String nameString = ename == null ? code : ename;
                 return nameString.equals(oldcode)
                         ? nameString
@@ -2945,7 +2945,7 @@ public class ShowLanguages {
     private static SortedMap<String, String> getNameToCode(CodeType codeType, String cldrCodeType) {
         SortedMap<String, String> temp = new TreeMap<String, String>(col);
         for (String territory : StandardCodes.make().getAvailableCodes(codeType)) {
-            String name = english.getName(cldrCodeType, territory);
+            String name = english.nameGetter().getName(cldrCodeType, territory);
             temp.put(name == null ? territory : name, territory);
         }
         temp = Collections.unmodifiableSortedMap(temp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -623,19 +623,19 @@ public class ShowLanguages {
                 }
             }
         }
-        String languageName = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
+        String languageName = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
         if (languageName == null) languageName = "???";
         String isLanguageTranslated = "";
         String nativeLanguageName =
                 nativeLanguage == null
                         ? null
-                        : nativeLanguage.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
+                        : nativeLanguage.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
         if (nativeLanguageName == null || nativeLanguageName.equals(language)) {
             nativeLanguageName = "<i>n/a</i>";
             isLanguageTranslated = "n";
         }
 
-        String scriptName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
         // String nativeScriptName = nativeLanguage == null ? null :
         // nativeLanguage.getName(CLDRFile.SCRIPT_NAME,script);
         // if (nativeScriptName != null && !nativeScriptName.equals(script)) {
@@ -643,11 +643,11 @@ public class ShowLanguages {
         // }
 
         String isTerritoryTranslated = "";
-        String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+        String territoryName = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
         String nativeTerritoryName =
                 nativeLanguage == null
                         ? null
-                        : nativeLanguage.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                        : nativeLanguage.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
         if (nativeTerritoryName == null || nativeTerritoryName.equals(territory)) {
             nativeTerritoryName = "<i>n/a</i>";
             isTerritoryTranslated = "n";
@@ -694,7 +694,7 @@ public class ShowLanguages {
         if (temp != null) {
             return temp;
         }
-        String scriptName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
         scriptName = scriptName.toLowerCase(Locale.ENGLISH);
         temp = fixScriptGif.get(scriptName);
         if (temp != null) {
@@ -714,12 +714,12 @@ public class ShowLanguages {
             String script,
             String secondary) {
         try {
-            String languageName = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
+            String languageName = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
             if (languageName == null) {
                 languageName = "¿" + language + "?";
                 System.err.println("No English Language Name for:" + language);
             }
-            String scriptName = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+            String scriptName = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
             if (scriptName == null) {
                 scriptName = "¿" + script + "?";
                 System.err.println("No English Language Name for:" + script);
@@ -1139,7 +1139,7 @@ public class ShowLanguages {
             if (value == null || value.equals("") || value.equals("und")) {
                 return "\u00A0";
             }
-            String result = english.nameGetter().getName(type, value);
+            String result = english.nameGetter().getNameFromTypenumCode(type, value);
             if (result == null) {
                 result = value;
             }
@@ -1271,7 +1271,7 @@ public class ShowLanguages {
                 // PopulationData territoryData =
                 // supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 String territoryName =
-                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territoryCode);
                 for (String languageCode :
                         supplementalDataInfo.getLanguagesForTerritoryWithPopulationData(
                                 territoryCode)) {
@@ -1363,7 +1363,7 @@ public class ShowLanguages {
         }
 
         private String getLanguageName(String languageCode) {
-            String result = english.nameGetter().getName(languageCode, true, CLDRFile.SHORT_ALTS);
+            String result = english.nameGetter().getNameFromLocaleOrTZBoolAltpicker(languageCode, true, CLDRFile.SHORT_ALTS);
             if (!result.equals(languageCode)) return result;
             Set<String> names = Iso639Data.getNames(languageCode);
             if (names != null && names.size() != 0) {
@@ -1551,7 +1551,7 @@ public class ShowLanguages {
                 final String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : english.nameGetter().getName(locale, true, CLDRFile.SHORT_ALTS);
+                                : english.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, CLDRFile.SHORT_ALTS);
                 coverageGoalsTsv.println(
                         String.format(
                                 "%s\t;\t%s\t;\t%s\t;\t%s", organization, locale, level, name));
@@ -1679,7 +1679,7 @@ public class ShowLanguages {
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
-                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double territoryLiteracy = territoryData2.getLiteratePopulationPercent();
@@ -1819,7 +1819,7 @@ public class ShowLanguages {
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
-                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                        english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double population = territoryData2.getPopulation() / 1000000;
@@ -2044,7 +2044,7 @@ public class ShowLanguages {
             Map<String, String> name_script = new TreeMap<>();
             for (Iterator<String> it = sc.getAvailableCodes("script").iterator(); it.hasNext(); ) {
                 String script = it.next();
-                String name = english.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+                String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
                 if (name == null) name = script;
                 name_script.put(name, script);
                 /*
@@ -2058,14 +2058,14 @@ public class ShowLanguages {
             for (Iterator<String> it = sc.getAvailableCodes("language").iterator();
                     it.hasNext(); ) {
                 String language = it.next();
-                String names = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
+                String names = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
                 if (names == null) names = language;
                 name_language.put(names, language);
             }
             for (Iterator<String> it = sc.getAvailableCodes("language").iterator();
                     it.hasNext(); ) {
                 String language = it.next();
-                String names = english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, language);
+                String names = english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
                 if (names == null) names = language;
                 String[] words = names.split(delimiter);
                 if (words.length > 1) {
@@ -2213,7 +2213,7 @@ public class ShowLanguages {
                                     + "</td>"
                                     + "<td class='target'>"
                                     + english.nameGetter()
-                                            .getName("currency", infoItem.getCurrency())
+                                            .getNameFromTypestrCode("currency", infoItem.getCurrency())
                                     + "</td>"
                                     + "</tr>");
                 }
@@ -2268,7 +2268,7 @@ public class ShowLanguages {
                         "<tr>"
                                 + "<td class='source nowrap'>"
                                 + TransliteratorUtilities.toHTML.transform(
-                                        english.nameGetter().getName("currency", currency))
+                                        english.nameGetter().getNameFromTypestrCode("currency", currency))
                                 + "</td>"
                                 + "<td class='source'>"
                                 + CldrUtility.getDoubleLinkedText(currency)
@@ -2349,7 +2349,7 @@ public class ShowLanguages {
 
         private String getTerritoryName(String territory) {
             String name;
-            name = english.nameGetter().getName("territory", territory);
+            name = english.nameGetter().getNameFromTypestrCode("territory", territory);
             if (name == null) {
                 name = sc.getData("territory", territory);
             }
@@ -2743,7 +2743,7 @@ public class ShowLanguages {
             } else {
                 int pos = oldcode.indexOf('*');
                 String code = pos < 0 ? oldcode : oldcode.substring(0, pos);
-                String ename = english.nameGetter().getName(type, code);
+                String ename = english.nameGetter().getNameFromTypenumCode(type, code);
                 String nameString = ename == null ? code : ename;
                 return nameString.equals(oldcode)
                         ? nameString
@@ -2952,7 +2952,7 @@ public class ShowLanguages {
     private static SortedMap<String, String> getNameToCode(CodeType codeType, String cldrCodeType) {
         SortedMap<String, String> temp = new TreeMap<String, String>(col);
         for (String territory : StandardCodes.make().getAvailableCodes(codeType)) {
-            String name = english.nameGetter().getName(cldrCodeType, territory);
+            String name = english.nameGetter().getNameFromTypestrCode(cldrCodeType, territory);
             temp.put(name == null ? territory : name, territory);
         }
         temp = Collections.unmodifiableSortedMap(temp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1270,7 +1270,8 @@ public class ShowLanguages {
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 // PopulationData territoryData =
                 // supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
-                String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                String territoryName =
+                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
                 for (String languageCode :
                         supplementalDataInfo.getLanguagesForTerritoryWithPopulationData(
                                 territoryCode)) {
@@ -1677,7 +1678,8 @@ public class ShowLanguages {
                     .addColumn("Report Bug", "class='target'", null, "class='target'", false);
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
-                String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                String territoryName =
+                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double territoryLiteracy = territoryData2.getLiteratePopulationPercent();
@@ -1816,7 +1818,8 @@ public class ShowLanguages {
             tablePrinter.addColumn("Report Bug", "class='target'", null, "class='target'", false);
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
-                String territoryName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
+                String territoryName =
+                        english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double population = territoryData2.getPopulation() / 1000000;
@@ -1946,7 +1949,8 @@ public class ShowLanguages {
         //                String parent = (String) territory_parent.get(territory);
         //                System.out.println(territory + "\t" +
         // english.nameGetter().getName(english.TERRITORY_NAME, territory) + "\t"
-        //                    + parent + "\t" + english.nameGetter().getName(english.TERRITORY_NAME, parent));
+        //                    + parent + "\t" + english.nameGetter().getName(english.TERRITORY_NAME,
+        // parent));
         //            }
         //        }
 
@@ -2208,7 +2212,8 @@ public class ShowLanguages {
                                     + infoItem.getCurrency()
                                     + "</td>"
                                     + "<td class='target'>"
-                                    + english.nameGetter().getName("currency", infoItem.getCurrency())
+                                    + english.nameGetter()
+                                            .getName("currency", infoItem.getCurrency())
                                     + "</td>"
                                     + "</tr>");
                 }
@@ -2323,7 +2328,8 @@ public class ShowLanguages {
             // for (Iterator it = territoriesWithoutCurrencies.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(english.nameGetter().getName(CLDRFile.TERRITORY_NAME, it.next().toString(), false));
+            // pw.print(english.nameGetter().getName(CLDRFile.TERRITORY_NAME, it.next().toString(),
+            // false));
             // }
             // pw.println("</td><td class='target'>");
             // Set currenciesWithoutTerritories = new TreeSet();
@@ -2333,7 +2339,8 @@ public class ShowLanguages {
             // for (Iterator it = currenciesWithoutTerritories.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(english.nameGetter().getName(CLDRFile.CURRENCY_NAME, it.next().toString(), false));
+            // pw.print(english.nameGetter().getName(CLDRFile.CURRENCY_NAME, it.next().toString(),
+            // false));
             // }
             // pw.println("</td></tr>");
             // doFooter(pw);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -889,7 +889,9 @@ public class ShowLocaleCoverage {
                     tablePrinter
                             .addRow()
                             .addCell(language)
-                            .addCell(ENGLISH.nameGetter().getName(language, true, CLDRFile.SHORT_ALTS))
+                            .addCell(
+                                    ENGLISH.nameGetter()
+                                            .getName(language, true, CLDRFile.SHORT_ALTS))
                             .addCell(file.nameGetter().getName(language))
                             .addCell(script)
                             .addCell(defRegion)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -889,8 +889,8 @@ public class ShowLocaleCoverage {
                     tablePrinter
                             .addRow()
                             .addCell(language)
-                            .addCell(ENGLISH.getName(language, true, CLDRFile.SHORT_ALTS))
-                            .addCell(file.getName(language))
+                            .addCell(ENGLISH.nameGetter().getName(language, true, CLDRFile.SHORT_ALTS))
+                            .addCell(file.nameGetter().getName(language))
                             .addCell(script)
                             .addCell(defRegion)
                             .addCell(sublocales.size())
@@ -916,7 +916,7 @@ public class ShowLocaleCoverage {
                                         + " ;\t"
                                         + visibleLevelComputed
                                         + " ;\t"
-                                        + ENGLISH.getName(locale));
+                                        + ENGLISH.nameGetter().getName(locale));
                         // TODO decide whether to restore this
                         //                        Level higher = Level.UNDETERMINED;
                         //                        switch (computed) {
@@ -1175,9 +1175,9 @@ public class ShowLocaleCoverage {
                 specialFlag
                         + language
                         + "\t"
-                        + ENGLISH.getName(language)
+                        + ENGLISH.nameGetter().getName(language)
                         + "\t"
-                        + ENGLISH.getName("script", script)
+                        + ENGLISH.nameGetter().getName("script", script)
                         + "\t"
                         + cldrLocaleLevelGoal
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -891,8 +891,8 @@ public class ShowLocaleCoverage {
                             .addCell(language)
                             .addCell(
                                     ENGLISH.nameGetter()
-                                            .getName(language, true, CLDRFile.SHORT_ALTS))
-                            .addCell(file.nameGetter().getName(language))
+                                            .getNameFromLocaleOrTZBoolAltpicker(language, true, CLDRFile.SHORT_ALTS))
+                            .addCell(file.nameGetter().getNameFromLocaleOrTZID(language))
                             .addCell(script)
                             .addCell(defRegion)
                             .addCell(sublocales.size())
@@ -918,7 +918,7 @@ public class ShowLocaleCoverage {
                                         + " ;\t"
                                         + visibleLevelComputed
                                         + " ;\t"
-                                        + ENGLISH.nameGetter().getName(locale));
+                                        + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
                         // TODO decide whether to restore this
                         //                        Level higher = Level.UNDETERMINED;
                         //                        switch (computed) {
@@ -1177,9 +1177,9 @@ public class ShowLocaleCoverage {
                 specialFlag
                         + language
                         + "\t"
-                        + ENGLISH.nameGetter().getName(language)
+                        + ENGLISH.nameGetter().getNameFromLocaleOrTZID(language)
                         + "\t"
-                        + ENGLISH.nameGetter().getName("script", script)
+                        + ENGLISH.nameGetter().getNameFromTypestrCode("script", script)
                         + "\t"
                         + cldrLocaleLevelGoal
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -891,8 +891,9 @@ public class ShowLocaleCoverage {
                             .addCell(language)
                             .addCell(
                                     ENGLISH.nameGetter()
-                                            .getNameFromLocaleOrTZBoolAltpicker(language, true, CLDRFile.SHORT_ALTS))
-                            .addCell(file.nameGetter().getNameFromLocaleOrTZID(language))
+                                            .getNameFromBCP47BoolAlt(
+                                                    language, true, CLDRFile.SHORT_ALTS))
+                            .addCell(file.nameGetter().getNameFromBCP47(language))
                             .addCell(script)
                             .addCell(defRegion)
                             .addCell(sublocales.size())
@@ -918,7 +919,7 @@ public class ShowLocaleCoverage {
                                         + " ;\t"
                                         + visibleLevelComputed
                                         + " ;\t"
-                                        + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
+                                        + ENGLISH.nameGetter().getNameFromBCP47(locale));
                         // TODO decide whether to restore this
                         //                        Level higher = Level.UNDETERMINED;
                         //                        switch (computed) {
@@ -1177,7 +1178,7 @@ public class ShowLocaleCoverage {
                 specialFlag
                         + language
                         + "\t"
-                        + ENGLISH.nameGetter().getNameFromLocaleOrTZID(language)
+                        + ENGLISH.nameGetter().getNameFromBCP47(language)
                         + "\t"
                         + ENGLISH.nameGetter().getNameFromTypestrCode("script", script)
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -168,7 +168,7 @@ public class ShowPlurals {
             if (localeFilter != null && !localeFilter.equals(locale) || locale.equals("root")) {
                 continue;
             }
-            final String name = english.getName(locale);
+            final String name = english.nameGetter().getName(locale);
             String canonicalLocale = canonicalizer.transform(locale);
             if (!locale.equals(canonicalLocale)) {
                 String redirect =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -168,7 +168,7 @@ public class ShowPlurals {
             if (localeFilter != null && !localeFilter.equals(locale) || locale.equals("root")) {
                 continue;
             }
-            final String name = english.nameGetter().getNameFromLocaleOrTZID(locale);
+            final String name = english.nameGetter().getNameFromBCP47(locale);
             String canonicalLocale = canonicalizer.transform(locale);
             if (!locale.equals(canonicalLocale)) {
                 String redirect =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -168,7 +168,7 @@ public class ShowPlurals {
             if (localeFilter != null && !localeFilter.equals(locale) || locale.equals("root")) {
                 continue;
             }
-            final String name = english.nameGetter().getName(locale);
+            final String name = english.nameGetter().getNameFromLocaleOrTZID(locale);
             String canonicalLocale = canonicalizer.transform(locale);
             if (!locale.equals(canonicalLocale)) {
                 String redirect =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
@@ -200,7 +200,7 @@ public class ShowRegionalVariants {
                 grandSummary.println(
                         parent
                                 + "\t"
-                                + ENGLISH.getName(parent.toString())
+                                + ENGLISH.nameGetter().getName(parent.toString())
                                 + "\t"
                                 + totalChildDiffs
                                 + "\t"
@@ -213,13 +213,13 @@ public class ShowRegionalVariants {
                     summary.println(
                             parent
                                     + "\t"
-                                    + ENGLISH.getName(parent.toString())
+                                    + ENGLISH.nameGetter().getName(parent.toString())
                                     + "\t"
                                     + childDiffValue
                                     + "\t"
                                     + s
                                     + "\t"
-                                    + ENGLISH.getName(s.toString()));
+                                    + ENGLISH.nameGetter().getName(s.toString()));
                 }
 
                 ArrayList<CLDRFile> parentChain = new ArrayList<>();
@@ -324,7 +324,7 @@ public class ShowRegionalVariants {
             LanguageTagParser ltp = new LanguageTagParser().set(max);
             country = "(" + ltp.getRegion() + ")";
         }
-        return ENGLISH.getName(key.toString(), false, CLDRFile.SHORT_ALTS)
+        return ENGLISH.nameGetter().getName(key.toString(), false, CLDRFile.SHORT_ALTS)
                 + "\t"
                 + key
                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
@@ -200,7 +200,7 @@ public class ShowRegionalVariants {
                 grandSummary.println(
                         parent
                                 + "\t"
-                                + ENGLISH.nameGetter().getName(parent.toString())
+                                + ENGLISH.nameGetter().getNameFromLocaleOrTZID(parent.toString())
                                 + "\t"
                                 + totalChildDiffs
                                 + "\t"
@@ -213,13 +213,13 @@ public class ShowRegionalVariants {
                     summary.println(
                             parent
                                     + "\t"
-                                    + ENGLISH.nameGetter().getName(parent.toString())
+                                    + ENGLISH.nameGetter().getNameFromLocaleOrTZID(parent.toString())
                                     + "\t"
                                     + childDiffValue
                                     + "\t"
                                     + s
                                     + "\t"
-                                    + ENGLISH.nameGetter().getName(s.toString()));
+                                    + ENGLISH.nameGetter().getNameFromLocaleOrTZID(s.toString()));
                 }
 
                 ArrayList<CLDRFile> parentChain = new ArrayList<>();
@@ -324,7 +324,7 @@ public class ShowRegionalVariants {
             LanguageTagParser ltp = new LanguageTagParser().set(max);
             country = "(" + ltp.getRegion() + ")";
         }
-        return ENGLISH.nameGetter().getName(key.toString(), false, CLDRFile.SHORT_ALTS)
+        return ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(key.toString(), false, CLDRFile.SHORT_ALTS)
                 + "\t"
                 + key
                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
@@ -200,7 +200,7 @@ public class ShowRegionalVariants {
                 grandSummary.println(
                         parent
                                 + "\t"
-                                + ENGLISH.nameGetter().getNameFromLocaleOrTZID(parent.toString())
+                                + ENGLISH.nameGetter().getNameFromBCP47(parent.toString())
                                 + "\t"
                                 + totalChildDiffs
                                 + "\t"
@@ -213,13 +213,13 @@ public class ShowRegionalVariants {
                     summary.println(
                             parent
                                     + "\t"
-                                    + ENGLISH.nameGetter().getNameFromLocaleOrTZID(parent.toString())
+                                    + ENGLISH.nameGetter().getNameFromBCP47(parent.toString())
                                     + "\t"
                                     + childDiffValue
                                     + "\t"
                                     + s
                                     + "\t"
-                                    + ENGLISH.nameGetter().getNameFromLocaleOrTZID(s.toString()));
+                                    + ENGLISH.nameGetter().getNameFromBCP47(s.toString()));
                 }
 
                 ArrayList<CLDRFile> parentChain = new ArrayList<>();
@@ -324,7 +324,8 @@ public class ShowRegionalVariants {
             LanguageTagParser ltp = new LanguageTagParser().set(max);
             country = "(" + ltp.getRegion() + ")";
         }
-        return ENGLISH.nameGetter().getNameFromLocaleOrTZBoolAltpicker(key.toString(), false, CLDRFile.SHORT_ALTS)
+        return ENGLISH.nameGetter()
+                        .getNameFromBCP47BoolAlt(key.toString(), false, CLDRFile.SHORT_ALTS)
                 + "\t"
                 + key
                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -581,11 +581,11 @@ public class ShowStarredCoverage {
         }
 
         public String getName(final String written) {
-            String result = CldrConfig.getEnglish().nameGetter().getName(written);
+            String result = CldrConfig.getEnglish().nameGetter().getNameFromLocaleOrTZID(written);
             if (result.equals(written)) {
                 R2<List<String>, String> alias = languageFix.get(written);
                 if (alias != null) {
-                    result = CldrConfig.getEnglish().nameGetter().getName(alias.get0().get(0));
+                    result = CldrConfig.getEnglish().nameGetter().getNameFromLocaleOrTZID(alias.get0().get(0));
                 }
             }
             return result;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -581,11 +581,11 @@ public class ShowStarredCoverage {
         }
 
         public String getName(final String written) {
-            String result = CldrConfig.getEnglish().getName(written);
+            String result = CldrConfig.getEnglish().nameGetter().getName(written);
             if (result.equals(written)) {
                 R2<List<String>, String> alias = languageFix.get(written);
                 if (alias != null) {
-                    result = CldrConfig.getEnglish().getName(alias.get0().get(0));
+                    result = CldrConfig.getEnglish().nameGetter().getName(alias.get0().get(0));
                 }
             }
             return result;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -581,11 +581,14 @@ public class ShowStarredCoverage {
         }
 
         public String getName(final String written) {
-            String result = CldrConfig.getEnglish().nameGetter().getNameFromLocaleOrTZID(written);
+            String result = CldrConfig.getEnglish().nameGetter().getNameFromBCP47(written);
             if (result.equals(written)) {
                 R2<List<String>, String> alias = languageFix.get(written);
                 if (alias != null) {
-                    result = CldrConfig.getEnglish().nameGetter().getNameFromLocaleOrTZID(alias.get0().get(0));
+                    result =
+                            CldrConfig.getEnglish()
+                                    .nameGetter()
+                                    .getNameFromBCP47(alias.get0().get(0));
                 }
             }
             return result;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
@@ -292,7 +292,7 @@ public class VettingAdder {
                     Log.logln(
                             locale
                                     + " \t"
-                                    + english.nameGetter().getNameFromLocaleOrTZID(locale)
+                                    + english.nameGetter().getNameFromBCP47(locale)
                                     + "\texample: "
                                     + fullPath);
                     break;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
@@ -292,7 +292,7 @@ public class VettingAdder {
                     Log.logln(
                             locale
                                     + " \t"
-                                    + english.nameGetter().getName(locale)
+                                    + english.nameGetter().getNameFromLocaleOrTZID(locale)
                                     + "\texample: "
                                     + fullPath);
                     break;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
@@ -289,7 +289,7 @@ public class VettingAdder {
                 String path = it2.next();
                 String fullPath = cldr.getFullXPath(path);
                 if (fullPath.indexOf("[@draft=") >= 0) {
-                    Log.logln(locale + " \t" + english.getName(locale) + "\texample: " + fullPath);
+                    Log.logln(locale + " \t" + english.nameGetter().getName(locale) + "\texample: " + fullPath);
                     break;
                 }
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
@@ -289,7 +289,12 @@ public class VettingAdder {
                 String path = it2.next();
                 String fullPath = cldr.getFullXPath(path);
                 if (fullPath.indexOf("[@draft=") >= 0) {
-                    Log.logln(locale + " \t" + english.nameGetter().getName(locale) + "\texample: " + fullPath);
+                    Log.logln(
+                            locale
+                                    + " \t"
+                                    + english.nameGetter().getName(locale)
+                                    + "\texample: "
+                                    + fullPath);
                     break;
                 }
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
@@ -251,7 +251,7 @@ public class WritePluralRulesSpreadsheets {
     }
 
     private static String getName(String missing) {
-        return missing + "\t" + CLDRConfig.getInstance().getEnglish().nameGetter().getName(missing);
+        return missing + "\t" + CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(missing);
     }
 
     private static String getSamplePattern(PluralMinimalPairs samplePatterns, String start) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
@@ -251,7 +251,9 @@ public class WritePluralRulesSpreadsheets {
     }
 
     private static String getName(String missing) {
-        return missing + "\t" + CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(missing);
+        return missing
+                + "\t"
+                + CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(missing);
     }
 
     private static String getSamplePattern(PluralMinimalPairs samplePatterns, String start) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
@@ -251,7 +251,7 @@ public class WritePluralRulesSpreadsheets {
     }
 
     private static String getName(String missing) {
-        return missing + "\t" + CLDRConfig.getInstance().getEnglish().getName(missing);
+        return missing + "\t" + CLDRConfig.getInstance().getEnglish().nameGetter().getName(missing);
     }
 
     private static String getSamplePattern(PluralMinimalPairs samplePatterns, String start) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -323,6 +323,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
      * @param minimalDraftStatus
      */
     public CLDRFile(String localeId, List<File> dirs, DraftStatus minimalDraftStatus) {
+        this.nameGetter = new NameGetter(this);
         // order matters
         this.dataSource = XMLSource.getFrozenInstance(localeId, dirs, minimalDraftStatus);
         this.dtdType = dataSource.getXMLNormalizingDtdType();
@@ -330,6 +331,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     }
 
     public CLDRFile(XMLSource dataSource, XMLSource... resolvingParents) {
+        this.nameGetter = new NameGetter(this);
         List<XMLSource> sourceList = new ArrayList<>();
         sourceList.add(dataSource);
         sourceList.addAll(Arrays.asList(resolvingParents));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2382,6 +2382,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         }
     }
 
+    /** Why isn't this an enum? */
     public static final int NO_NAME = -1,
             LANGUAGE_NAME = 0,
             SCRIPT_NAME = 1,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -125,8 +125,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     private static boolean DEBUG_LOGGING = false;
 
     public static final String SUPPLEMENTAL_NAME = "supplementalData";
-    public static final String SUPPLEMENTAL_METADATA = "supplementalMetadata";
-    public static final String SUPPLEMENTAL_PREFIX = "supplemental";
+
     public static final String GEN_VERSION = "47";
     public static final List<String> SUPPLEMENTAL_NAMES =
             Arrays.asList(
@@ -293,7 +292,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         return dataSource.isNonInheriting();
     }
 
-    private NameGetter nameGetter;
+    private final NameGetter nameGetter;
 
     private static final boolean DEBUG_CLDR_FILE = false;
     private String creationTime = null; // only used if DEBUG_CLDR_FILE

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -8,8 +8,6 @@
  */
 package org.unicode.cldr.util;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
@@ -101,13 +99,6 @@ import org.xml.sax.helpers.XMLReaderFactory;
  */
 
 public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleStringProvider {
-
-    private static final String GETNAME_LOCALE_SEPARATOR =
-            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator";
-    private static final String GETNAME_LOCALE_PATTERN =
-            "//ldml/localeDisplayNames/localeDisplayPattern/localePattern";
-    private static final String GETNAME_LOCALE_KEY_TYPE_PATTERN =
-            "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern";
 
     private static final ImmutableSet<String> casesNominativeOnly =
             ImmutableSet.of(GrammaticalFeature.grammaticalCase.getDefault(null));
@@ -302,6 +293,8 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         return dataSource.isNonInheriting();
     }
 
+    private NameGetter nameGetter;
+
     private static final boolean DEBUG_CLDR_FILE = false;
     private String creationTime = null; // only used if DEBUG_CLDR_FILE
 
@@ -312,6 +305,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
      */
     public CLDRFile(XMLSource dataSource) {
         this.dataSource = dataSource;
+        this.nameGetter = new NameGetter(this);
 
         if (DEBUG_CLDR_FILE) {
             creationTime =
@@ -349,6 +343,10 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                     "📂 Created new CLDRFile(dataSource, XMLSource... resolvingParents) at "
                             + creationTime);
         }
+    }
+
+    public NameGetter nameGetter() {
+        return nameGetter;
     }
 
     public static CLDRFile loadFromFile(
@@ -2931,7 +2929,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
          * XPath where originally found. May be {@link GlossonymConstructor#PSEUDO_PATH} if the
          * value was constructed.
          *
-         * @see GlossonymnConstructor
+         * @see GlossonymConstructor
          */
         public String pathWhereFound;
 
@@ -3877,527 +3875,6 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         return result;
     }
 
-    /*
-     *******************************************************************************************
-     * TODO: move the code below here -- that is, the many (currently ten as of 2022-06-01)
-     * versions of getName and their subroutines and data -- to a new class in a separate file,
-     * and enable tracking similar to existing "pathWhereFound/localeWhereFound" but more general.
-     *
-     * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
-     *******************************************************************************************
-     */
-
-    static final Joiner JOIN_HYPHEN = Joiner.on('-');
-    static final Joiner JOIN_UNDERBAR = Joiner.on('_');
-
-    /** Utility for getting a name, given a type and code. */
-    public String getName(String type, String code) {
-        return getName(typeNameToCode(type), code);
-    }
-
-    public String getName(int type, String code) {
-        return getName(type, code, null, null);
-    }
-
-    public String getName(int type, String code, Set<String> paths) {
-        return getName(type, code, null, paths);
-    }
-
-    public String getName(int type, String code, Transform<String, String> altPicker) {
-        return getName(type, code, altPicker, null);
-    }
-
-    /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
-     *
-     * @param localeOrTZID
-     * @return
-     */
-    public synchronized String getName(String localeOrTZID) {
-        return getName(localeOrTZID, false);
-    }
-
-    public String getName(
-            LanguageTagParser lparser,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker) {
-        return getName(lparser, onlyConstructCompound, altPicker, null);
-    }
-
-    /**
-     * @param paths if non-null, will contain contributory paths on return
-     */
-    public String getName(
-            LanguageTagParser lparser,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker,
-            Set<String> paths) {
-        return getName(
-                lparser,
-                onlyConstructCompound,
-                altPicker,
-                getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
-                getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
-                getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
-                paths);
-    }
-
-    public synchronized String getName(
-            String localeOrTZID,
-            boolean onlyConstructCompound,
-            String localeKeyTypePattern,
-            String localePattern,
-            String localeSeparator) {
-        return getName(
-                localeOrTZID,
-                onlyConstructCompound,
-                localeKeyTypePattern,
-                localePattern,
-                localeSeparator,
-                null,
-                null);
-    }
-
-    /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
-     *
-     * @param localeOrTZID the locale or timezone ID
-     * @param onlyConstructCompound
-     * @return
-     */
-    public synchronized String getName(String localeOrTZID, boolean onlyConstructCompound) {
-        return getName(localeOrTZID, onlyConstructCompound, null);
-    }
-
-    /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
-     *
-     * @param localeOrTZID the locale or timezone ID
-     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
-     *     English"
-     * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
-     *     "English (U.K.)" instead of "English (United Kingdom)"
-     * @return
-     */
-    public synchronized String getName(
-            String localeOrTZID,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker) {
-        return getName(localeOrTZID, onlyConstructCompound, altPicker, null);
-    }
-
-    /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
-     *
-     * @param localeOrTZID the locale or timezone ID
-     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
-     *     English"
-     * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
-     *     "English (U.K.)" instead of "English (United Kingdom)"
-     * @return
-     */
-    public synchronized String getName(
-            String localeOrTZID,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker,
-            Set<String> paths) {
-        return getName(
-                localeOrTZID,
-                onlyConstructCompound,
-                getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
-                getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
-                getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
-                altPicker,
-                paths);
-    }
-
-    /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax. Only used by ExampleGenerator.
-     *
-     * @param localeOrTZID the locale or timezone ID
-     * @param onlyConstructCompound
-     * @param localeKeyTypePattern the pattern used to format key-type pairs
-     * @param localePattern the pattern used to format primary/secondary subtags
-     * @param localeSeparator the list separator for secondary subtags
-     * @param paths if non-null, fillin with contributory paths
-     * @return
-     */
-    public synchronized String getName(
-            String localeOrTZID,
-            boolean onlyConstructCompound,
-            String localeKeyTypePattern,
-            String localePattern,
-            String localeSeparator,
-            Transform<String, String> altPicker,
-            Set<String> paths) {
-        // Hack for seed
-        if (localePattern == null) {
-            localePattern = "{0} ({1})";
-        }
-        boolean isCompound = localeOrTZID.contains("_");
-        String name =
-                isCompound && onlyConstructCompound
-                        ? null
-                        : getName(LANGUAGE_NAME, localeOrTZID, altPicker, paths);
-
-        // TODO - handle arbitrary combinations
-        if (name != null && !name.contains("_") && !name.contains("-")) {
-            name = replaceBracketsForName(name);
-            return name;
-        }
-        LanguageTagParser lparser = new LanguageTagParser().set(localeOrTZID);
-        return getName(
-                lparser,
-                onlyConstructCompound,
-                altPicker,
-                localeKeyTypePattern,
-                localePattern,
-                localeSeparator,
-                paths);
-    }
-
-    public String getName(
-            LanguageTagParser lparser,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker,
-            String localeKeyTypePattern,
-            String localePattern,
-            String localeSeparator,
-            Set<String> paths) {
-        String name;
-        String original = null;
-
-        // we need to check for prefixes, for lang+script or lang+country
-        boolean haveScript = false;
-        boolean haveRegion = false;
-        // try lang+script
-        if (onlyConstructCompound) {
-            name = getName(LANGUAGE_NAME, original = lparser.getLanguage(), altPicker, paths);
-            if (name == null) name = original;
-        } else {
-            String x = lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT_REGION);
-            name = getName(LANGUAGE_NAME, x, altPicker, paths);
-            if (name != null) {
-                haveScript = haveRegion = true;
-            } else {
-                name =
-                        getName(
-                                LANGUAGE_NAME,
-                                lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT),
-                                altPicker,
-                                paths);
-                if (name != null) {
-                    haveScript = true;
-                } else {
-                    name =
-                            getName(
-                                    LANGUAGE_NAME,
-                                    lparser.toString(LanguageTagParser.LANGUAGE_REGION),
-                                    altPicker,
-                                    paths);
-                    if (name != null) {
-                        haveRegion = true;
-                    } else {
-                        name =
-                                getName(
-                                        LANGUAGE_NAME,
-                                        original = lparser.getLanguage(),
-                                        altPicker,
-                                        paths);
-                        if (name == null) {
-                            name = original;
-                        }
-                    }
-                }
-            }
-        }
-        name = replaceBracketsForName(name);
-        String extras = "";
-        if (!haveScript) {
-            extras =
-                    addDisplayName(
-                            lparser.getScript(),
-                            SCRIPT_NAME,
-                            localeSeparator,
-                            extras,
-                            altPicker,
-                            paths);
-        }
-        if (!haveRegion) {
-            extras =
-                    addDisplayName(
-                            lparser.getRegion(),
-                            TERRITORY_NAME,
-                            localeSeparator,
-                            extras,
-                            altPicker,
-                            paths);
-        }
-        List<String> variants = lparser.getVariants();
-        for (String orig : variants) {
-            extras = addDisplayName(orig, VARIANT_NAME, localeSeparator, extras, altPicker, paths);
-        }
-
-        // Look for key-type pairs.
-        main:
-        for (Map.Entry<String, List<String>> extension :
-                lparser.getLocaleExtensionsDetailed().entrySet()) {
-            String key = extension.getKey();
-            if (key.equals("h0")) {
-                continue;
-            }
-            List<String> keyValue = extension.getValue();
-            String oldFormatType =
-                    (key.equals("ca") ? JOIN_HYPHEN : JOIN_UNDERBAR)
-                            .join(keyValue); // default value
-            // Check if key/type pairs exist in the CLDRFile first.
-            String value = getKeyValueName(key, oldFormatType);
-            if (value != null) {
-                value = replaceBracketsForName(value);
-            } else {
-                // if we fail, then we construct from the key name and the value
-                String kname = getKeyName(key);
-                if (kname == null) {
-                    kname = key; // should not happen, but just in case
-                }
-                switch (key) {
-                    case "t":
-                        List<String> hybrid = lparser.getLocaleExtensionsDetailed().get("h0");
-                        if (hybrid != null) {
-                            kname = getKeyValueName("h0", JOIN_UNDERBAR.join(hybrid));
-                        }
-                        oldFormatType = getName(oldFormatType);
-                        break;
-                    case "h0":
-                        continue main;
-                    case "cu":
-                        oldFormatType =
-                                getName(
-                                        CURRENCY_SYMBOL,
-                                        oldFormatType.toUpperCase(Locale.ROOT),
-                                        paths);
-                        break;
-                    case "tz":
-                        if (paths != null) {
-                            throw new IllegalArgumentException(
-                                    "Error: getName(…) with paths doesn't handle timezones.");
-                        }
-                        oldFormatType =
-                                getTZName(
-                                        oldFormatType, "VVVV"); // TODO: paths not handled here, yet
-                        break;
-                    case "kr":
-                        oldFormatType = getReorderName(localeSeparator, keyValue, paths);
-                        break;
-                    case "rg":
-                    case "sd":
-                        oldFormatType = getName(SUBDIVISION_NAME, oldFormatType, paths);
-                        break;
-                    default:
-                        oldFormatType = JOIN_HYPHEN.join(keyValue);
-                }
-                value =
-                        MessageFormat.format(
-                                localeKeyTypePattern, new Object[] {kname, oldFormatType});
-                if (paths != null) {
-                    paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
-                }
-                value = replaceBracketsForName(value);
-            }
-            if (paths != null && !extras.isEmpty()) {
-                paths.add(GETNAME_LOCALE_SEPARATOR);
-            }
-            extras =
-                    extras.isEmpty()
-                            ? value
-                            : MessageFormat.format(localeSeparator, new Object[] {extras, value});
-        }
-        // now handle stray extensions
-        for (Map.Entry<String, List<String>> extension :
-                lparser.getExtensionsDetailed().entrySet()) {
-            String value =
-                    MessageFormat.format(
-                            localeKeyTypePattern,
-                            new Object[] {
-                                extension.getKey(), JOIN_HYPHEN.join(extension.getValue())
-                            });
-            if (paths != null) {
-                paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
-            }
-            extras =
-                    extras.isEmpty()
-                            ? value
-                            : MessageFormat.format(localeSeparator, new Object[] {extras, value});
-        }
-        // fix this -- shouldn't be hardcoded!
-        if (extras.length() == 0) {
-            return name;
-        }
-        if (paths != null) {
-            paths.add(GETNAME_LOCALE_PATTERN);
-        }
-        return MessageFormat.format(localePattern, new Object[] {name, extras});
-    }
-
-    private static final String replaceBracketsForName(String value) {
-        value = value.replace('(', '[').replace(')', ']').replace('（', '［').replace('）', '］');
-        return value;
-    }
-
-    /**
-     * Utility for getting the name, given a code.
-     *
-     * @param type
-     * @param code
-     * @param codeToAlt - if not null, is called on the code. If the result is not null, then that
-     *     is used for an alt value. If the alt path has a value it is used, otherwise the normal
-     *     one is used. For example, the transform could return "short" for PS or HK or MO, but not
-     *     US or GB.
-     * @param paths if non-null, will have contributory paths on return
-     * @return
-     */
-    public String getName(
-            int type, String code, Transform<String, String> codeToAlt, Set<String> paths) {
-        String path = getKey(type, code);
-        String result = null;
-        if (codeToAlt != null) {
-            String alt = codeToAlt.transform(code);
-            if (alt != null) {
-                String altPath = path + "[@alt=\"" + alt + "\"]";
-                result = getStringValueWithBaileyNotConstructed(altPath);
-                if (paths != null && result != null) {
-                    paths.add(altPath);
-                }
-            }
-        }
-        if (result == null) {
-            result = getStringValueWithBaileyNotConstructed(path);
-            if (paths != null && result != null) {
-                paths.add(path);
-            }
-        }
-        if (getLocaleID().equals("en")) {
-            CLDRFile.Status status = new CLDRFile.Status();
-            String sourceLocale = getSourceLocaleID(path, status);
-            if (result == null || !sourceLocale.equals("en")) {
-                if (type == LANGUAGE_NAME) {
-                    Set<String> set = Iso639Data.getNames(code);
-                    if (set != null) {
-                        return set.iterator().next();
-                    }
-                    Map<String, Map<String, String>> map =
-                            StandardCodes.getLStreg().get("language");
-                    Map<String, String> info = map.get(code);
-                    if (info != null) {
-                        result = info.get("Description");
-                    }
-                } else if (type == TERRITORY_NAME) {
-                    result = getLstrFallback("region", code, paths);
-                } else if (type == SCRIPT_NAME) {
-                    result = getLstrFallback("script", code, paths);
-                }
-            }
-        }
-        return result;
-    }
-
-    static final Pattern CLEAN_DESCRIPTION = Pattern.compile("([^\\(\\[]*)[\\(\\[].*");
-    static final Splitter DESCRIPTION_SEP = Splitter.on('▪');
-
-    private String getLstrFallback(String codeType, String code, Set<String> paths) {
-        Map<String, String> info = StandardCodes.getLStreg().get(codeType).get(code);
-        if (info != null) {
-            String temp = info.get("Description");
-            if (!temp.equalsIgnoreCase("Private use")) {
-                List<String> temp2 = DESCRIPTION_SEP.splitToList(temp);
-                temp = temp2.get(0);
-                final Matcher matcher = CLEAN_DESCRIPTION.matcher(temp);
-                if (matcher.lookingAt()) {
-                    temp = matcher.group(1).trim();
-                }
-                return temp;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Gets timezone name. Not optimized.
-     *
-     * @param tzcode
-     * @return
-     */
-    private String getTZName(String tzcode, String format) {
-        String longid = getLongTzid(tzcode);
-        if (tzcode.length() == 4 && !tzcode.equals("gaza")) {
-            return longid;
-        }
-        TimezoneFormatter tzf = new TimezoneFormatter(this);
-        return tzf.getFormattedZone(longid, format, 0);
-    }
-
-    private String getReorderName(
-            String localeSeparator, List<String> keyValues, Set<String> paths) {
-        String result = null;
-        for (String value : keyValues) {
-            String name =
-                    getName(
-                            SCRIPT_NAME,
-                            Character.toUpperCase(value.charAt(0)) + value.substring(1),
-                            paths);
-            if (name == null) {
-                name = getKeyValueName("kr", value);
-                if (name == null) {
-                    name = value;
-                }
-            }
-            result =
-                    result == null
-                            ? name
-                            : MessageFormat.format(localeSeparator, new Object[] {result, name});
-        }
-        return result;
-    }
-
-    /**
-     * Adds the display name for a subtag to a string.
-     *
-     * @param subtag the subtag
-     * @param type the type of the subtag
-     * @param separatorPattern the pattern to be used for separating display names in the resultant
-     *     string
-     * @param extras the string to be added to
-     * @return the modified display name string
-     */
-    private String addDisplayName(
-            String subtag,
-            int type,
-            String separatorPattern,
-            String extras,
-            Transform<String, String> altPicker,
-            Set<String> paths) {
-        if (subtag.length() == 0) {
-            return extras;
-        }
-        String sname = getName(type, subtag, altPicker, paths);
-        if (sname == null) {
-            sname = subtag;
-        }
-        sname = replaceBracketsForName(sname);
-
-        if (extras.length() == 0) {
-            extras += sname;
-        } else {
-            extras = MessageFormat.format(separatorPattern, new Object[] {extras, sname});
-        }
-        return extras;
-    }
-
     /**
      * Like getStringValueWithBailey, but reject constructed values, to prevent circularity problems
      * with getName
@@ -4411,7 +3888,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
      * @param path the given xpath
      * @return the string value, or null
      */
-    private String getStringValueWithBaileyNotConstructed(String path) {
+    String getStringValueWithBaileyNotConstructed(String path) {
         Output<String> pathWhereFound = new Output<>();
         final String value = getStringValueWithBailey(path, pathWhereFound, null);
         if (value == null || GlossonymConstructor.PSEUDO_PATH.equals(pathWhereFound.toString())) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -151,13 +151,13 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayVariant(CLDRLocale cldrLocale) {
-            if (file != null) return file.getName("variant", cldrLocale.getVariant());
+            if (file != null) return file.nameGetter().getName("variant", cldrLocale.getVariant());
             return tryForBetter(super.getDisplayVariant(cldrLocale), cldrLocale.getVariant());
         }
 
         @Override
         public String getDisplayName(CLDRLocale cldrLocale) {
-            if (file != null) return file.getName(cldrLocale.toDisplayLanguageTag(), true, null);
+            if (file != null) return file.nameGetter().getName(cldrLocale.toDisplayLanguageTag(), true, null);
             return super.getDisplayName(cldrLocale);
         }
 
@@ -167,26 +167,26 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
                 boolean onlyConstructCompound,
                 Transform<String, String> altPicker) {
             if (file != null)
-                return file.getName(
+                return file.nameGetter().getName(
                         cldrLocale.toDisplayLanguageTag(), onlyConstructCompound, altPicker);
             return super.getDisplayName(cldrLocale);
         }
 
         @Override
         public String getDisplayScript(CLDRLocale cldrLocale) {
-            if (file != null) return file.getName("script", cldrLocale.getScript());
+            if (file != null) return file.nameGetter().getName("script", cldrLocale.getScript());
             return tryForBetter(super.getDisplayScript(cldrLocale), cldrLocale.getScript());
         }
 
         @Override
         public String getDisplayLanguage(CLDRLocale cldrLocale) {
-            if (file != null) return file.getName("language", cldrLocale.getLanguage());
+            if (file != null) return file.nameGetter().getName("language", cldrLocale.getLanguage());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 
         @Override
         public String getDisplayCountry(CLDRLocale cldrLocale) {
-            if (file != null) return file.getName("territory", cldrLocale.getCountry());
+            if (file != null) return file.nameGetter().getName("territory", cldrLocale.getCountry());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -151,14 +151,14 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayVariant(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getName("variant", cldrLocale.getVariant());
+            if (file != null) return file.nameGetter().getNameFromTypestrCode("variant", cldrLocale.getVariant());
             return tryForBetter(super.getDisplayVariant(cldrLocale), cldrLocale.getVariant());
         }
 
         @Override
         public String getDisplayName(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getName(cldrLocale.toDisplayLanguageTag(), true, null);
+                return file.nameGetter().getNameFromLocaleOrTZBoolAltpicker(cldrLocale.toDisplayLanguageTag(), true, null);
             return super.getDisplayName(cldrLocale);
         }
 
@@ -169,7 +169,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
                 Transform<String, String> altPicker) {
             if (file != null)
                 return file.nameGetter()
-                        .getName(
+                        .getNameFromLocaleOrTZBoolAltpicker(
                                 cldrLocale.toDisplayLanguageTag(),
                                 onlyConstructCompound,
                                 altPicker);
@@ -178,21 +178,21 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayScript(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getName("script", cldrLocale.getScript());
+            if (file != null) return file.nameGetter().getNameFromTypestrCode("script", cldrLocale.getScript());
             return tryForBetter(super.getDisplayScript(cldrLocale), cldrLocale.getScript());
         }
 
         @Override
         public String getDisplayLanguage(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getName("language", cldrLocale.getLanguage());
+                return file.nameGetter().getNameFromTypestrCode("language", cldrLocale.getLanguage());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 
         @Override
         public String getDisplayCountry(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getName("territory", cldrLocale.getCountry());
+                return file.nameGetter().getNameFromTypestrCode("territory", cldrLocale.getCountry());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -151,14 +151,16 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayVariant(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getNameFromTypestrCode("variant", cldrLocale.getVariant());
+            if (file != null)
+                return file.nameGetter().getNameFromTypestrCode("variant", cldrLocale.getVariant());
             return tryForBetter(super.getDisplayVariant(cldrLocale), cldrLocale.getVariant());
         }
 
         @Override
         public String getDisplayName(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getNameFromLocaleOrTZBoolAltpicker(cldrLocale.toDisplayLanguageTag(), true, null);
+                return file.nameGetter()
+                        .getNameFromBCP47BoolAlt(cldrLocale.toDisplayLanguageTag(), true, null);
             return super.getDisplayName(cldrLocale);
         }
 
@@ -169,7 +171,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
                 Transform<String, String> altPicker) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromLocaleOrTZBoolAltpicker(
+                        .getNameFromBCP47BoolAlt(
                                 cldrLocale.toDisplayLanguageTag(),
                                 onlyConstructCompound,
                                 altPicker);
@@ -178,21 +180,24 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayScript(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getNameFromTypestrCode("script", cldrLocale.getScript());
+            if (file != null)
+                return file.nameGetter().getNameFromTypestrCode("script", cldrLocale.getScript());
             return tryForBetter(super.getDisplayScript(cldrLocale), cldrLocale.getScript());
         }
 
         @Override
         public String getDisplayLanguage(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getNameFromTypestrCode("language", cldrLocale.getLanguage());
+                return file.nameGetter()
+                        .getNameFromTypestrCode("language", cldrLocale.getLanguage());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 
         @Override
         public String getDisplayCountry(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getNameFromTypestrCode("territory", cldrLocale.getCountry());
+                return file.nameGetter()
+                        .getNameFromTypestrCode("territory", cldrLocale.getCountry());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -157,7 +157,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayName(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getName(cldrLocale.toDisplayLanguageTag(), true, null);
+            if (file != null)
+                return file.nameGetter().getName(cldrLocale.toDisplayLanguageTag(), true, null);
             return super.getDisplayName(cldrLocale);
         }
 
@@ -167,8 +168,11 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
                 boolean onlyConstructCompound,
                 Transform<String, String> altPicker) {
             if (file != null)
-                return file.nameGetter().getName(
-                        cldrLocale.toDisplayLanguageTag(), onlyConstructCompound, altPicker);
+                return file.nameGetter()
+                        .getName(
+                                cldrLocale.toDisplayLanguageTag(),
+                                onlyConstructCompound,
+                                altPicker);
             return super.getDisplayName(cldrLocale);
         }
 
@@ -180,13 +184,15 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         @Override
         public String getDisplayLanguage(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getName("language", cldrLocale.getLanguage());
+            if (file != null)
+                return file.nameGetter().getName("language", cldrLocale.getLanguage());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 
         @Override
         public String getDisplayCountry(CLDRLocale cldrLocale) {
-            if (file != null) return file.nameGetter().getName("territory", cldrLocale.getCountry());
+            if (file != null)
+                return file.nameGetter().getName("territory", cldrLocale.getCountry());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
@@ -601,7 +601,7 @@ public class CLDRTransforms {
             }
             try {
                 String name =
-                        CLDRConfig.getInstance().getEnglish().nameGetter().getName(sourceOrTarget);
+                        CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(sourceOrTarget);
                 return name;
             } catch (Exception e) {
                 return sourceOrTarget;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
@@ -600,7 +600,8 @@ public class CLDRTransforms {
                 return "Indic";
             }
             try {
-                String name = CLDRConfig.getInstance().getEnglish().nameGetter().getName(sourceOrTarget);
+                String name =
+                        CLDRConfig.getInstance().getEnglish().nameGetter().getName(sourceOrTarget);
                 return name;
             } catch (Exception e) {
                 return sourceOrTarget;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
@@ -601,7 +601,10 @@ public class CLDRTransforms {
             }
             try {
                 String name =
-                        CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(sourceOrTarget);
+                        CLDRConfig.getInstance()
+                                .getEnglish()
+                                .nameGetter()
+                                .getNameFromBCP47(sourceOrTarget);
                 return name;
             } catch (Exception e) {
                 return sourceOrTarget;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
@@ -600,7 +600,7 @@ public class CLDRTransforms {
                 return "Indic";
             }
             try {
-                String name = CLDRConfig.getInstance().getEnglish().getName(sourceOrTarget);
+                String name = CLDRConfig.getInstance().getEnglish().nameGetter().getName(sourceOrTarget);
                 return name;
             } catch (Exception e) {
                 return sourceOrTarget;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1100,7 +1100,7 @@ public class DateTimeFormats {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.nameGetter().getNameFromLocaleOrTZBool(localeID, true), localeID);
+            sorted.put(englishFile.nameGetter().getNameFromBCP47Bool(localeID, true), localeID);
         }
 
         writeCss(DIR);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1100,7 +1100,7 @@ public class DateTimeFormats {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.getName(localeID, true), localeID);
+            sorted.put(englishFile.nameGetter().getName(localeID, true), localeID);
         }
 
         writeCss(DIR);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1100,7 +1100,7 @@ public class DateTimeFormats {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.nameGetter().getName(localeID, true), localeID);
+            sorted.put(englishFile.nameGetter().getNameFromLocaleOrTZBool(localeID, true), localeID);
         }
 
         writeCss(DIR);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -33,7 +33,7 @@ public class DayPeriodsCheck {
                 case "groups":
                     StandardCodes sc = StandardCodes.make();
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    english.nameGetter().getName(LanguageGroup.uralic.iso);
+                    english.nameGetter().getNameFromLocaleOrTZID(LanguageGroup.uralic.iso);
 
                     for (LanguageGroup group : LanguageGroup.values()) {
                         System.out.println(
@@ -41,7 +41,7 @@ public class DayPeriodsCheck {
                                         + "\t"
                                         + group.iso
                                         + "\t"
-                                        + english.nameGetter().getName(group.iso));
+                                        + english.nameGetter().getNameFromLocaleOrTZID(group.iso));
                     }
 
                     for (LanguageGroup group : LanguageGroup.values()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -33,11 +33,11 @@ public class DayPeriodsCheck {
                 case "groups":
                     StandardCodes sc = StandardCodes.make();
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    english.getName(LanguageGroup.uralic.iso);
+                    english.nameGetter().getName(LanguageGroup.uralic.iso);
 
                     for (LanguageGroup group : LanguageGroup.values()) {
                         System.out.println(
-                                group + "\t" + group.iso + "\t" + english.getName(group.iso));
+                                group + "\t" + group.iso + "\t" + english.nameGetter().getName(group.iso));
                     }
 
                     for (LanguageGroup group : LanguageGroup.values()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -37,7 +37,11 @@ public class DayPeriodsCheck {
 
                     for (LanguageGroup group : LanguageGroup.values()) {
                         System.out.println(
-                                group + "\t" + group.iso + "\t" + english.nameGetter().getName(group.iso));
+                                group
+                                        + "\t"
+                                        + group.iso
+                                        + "\t"
+                                        + english.nameGetter().getName(group.iso));
                     }
 
                     for (LanguageGroup group : LanguageGroup.values()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -33,7 +33,7 @@ public class DayPeriodsCheck {
                 case "groups":
                     StandardCodes sc = StandardCodes.make();
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    english.nameGetter().getNameFromLocaleOrTZID(LanguageGroup.uralic.iso);
+                    english.nameGetter().getNameFromBCP47(LanguageGroup.uralic.iso);
 
                     for (LanguageGroup group : LanguageGroup.values()) {
                         System.out.println(
@@ -41,7 +41,7 @@ public class DayPeriodsCheck {
                                         + "\t"
                                         + group.iso
                                         + "\t"
-                                        + english.nameGetter().getNameFromLocaleOrTZID(group.iso));
+                                        + english.nameGetter().getNameFromBCP47(group.iso));
                     }
 
                     for (LanguageGroup group : LanguageGroup.values()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
@@ -284,7 +284,7 @@ public class DiffLanguageGroups {
     }
 
     public static String getName(String languageCode) {
-        String result = ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageCode);
+        String result = ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageCode);
         return result == null ? "(no name)" : result.replace(" (Other)", "");
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
@@ -284,7 +284,7 @@ public class DiffLanguageGroups {
     }
 
     public static String getName(String languageCode) {
-        String result = ENGLISH.getName(CLDRFile.LANGUAGE_NAME, languageCode);
+        String result = ENGLISH.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageCode);
         return result == null ? "(no name)" : result.replace(" (Other)", "");
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
@@ -284,7 +284,8 @@ public class DiffLanguageGroups {
     }
 
     public static String getName(String languageCode) {
-        String result = ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageCode);
+        String result =
+                ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageCode);
         return result == null ? "(no name)" : result.replace(" (Other)", "");
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
@@ -115,7 +115,7 @@ public class GlossonymConstructor {
             final String alt = parts.getAttributeValue(-1, "alt");
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
-            final String value = cldrFile.getName(type, true, altPicker);
+            final String value = cldrFile.nameGetter().getName(type, true, altPicker);
             if (!valueIsBogus(value)) {
                 return value;
             }
@@ -130,7 +130,7 @@ public class GlossonymConstructor {
             final String alt = parts.getAttributeValue(-1, "alt");
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
-            final String value = cldrFile.getName(type, true, altPicker, paths);
+            final String value = cldrFile.nameGetter().getName(type, true, altPicker, paths);
             if (!valueIsBogus(value)) {
                 return paths;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
@@ -115,7 +115,8 @@ public class GlossonymConstructor {
             final String alt = parts.getAttributeValue(-1, "alt");
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
-            final String value = cldrFile.nameGetter().getNameFromLocaleOrTZBoolAltpicker(type, true, altPicker);
+            final String value =
+                    cldrFile.nameGetter().getNameFromBCP47BoolAlt(type, true, altPicker);
             if (!valueIsBogus(value)) {
                 return value;
             }
@@ -130,7 +131,9 @@ public class GlossonymConstructor {
             final String alt = parts.getAttributeValue(-1, "alt");
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
-            final String value = cldrFile.nameGetter().getNameFromLocaleTZBoolAltpickerPaths(type, true, altPicker, paths);
+            final String value =
+                    cldrFile.nameGetter()
+                            .getNameFromBCP47BoolAltPaths(type, true, altPicker, paths);
             if (!valueIsBogus(value)) {
                 return paths;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
@@ -115,7 +115,7 @@ public class GlossonymConstructor {
             final String alt = parts.getAttributeValue(-1, "alt");
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
-            final String value = cldrFile.nameGetter().getName(type, true, altPicker);
+            final String value = cldrFile.nameGetter().getNameFromLocaleOrTZBoolAltpicker(type, true, altPicker);
             if (!valueIsBogus(value)) {
                 return value;
             }
@@ -130,7 +130,7 @@ public class GlossonymConstructor {
             final String alt = parts.getAttributeValue(-1, "alt");
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
-            final String value = cldrFile.nameGetter().getName(type, true, altPicker, paths);
+            final String value = cldrFile.nameGetter().getNameFromLocaleTZBoolAltpickerPaths(type, true, altPicker, paths);
             if (!valueIsBogus(value)) {
                 return paths;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
@@ -291,7 +291,8 @@ public enum LanguageGroup {
             case "":
                 break;
             default:
-                return cldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, ltp.getRegion());
+                return cldrFile.nameGetter()
+                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, ltp.getRegion());
         }
         switch (ltp.getScript()) {
             case "Hani":
@@ -303,7 +304,7 @@ public enum LanguageGroup {
         }
         return prefix
                 + cldrFile.nameGetter()
-                        .getNameFromLocaleOrTZID(ltp.getLanguage())
+                        .getNameFromBCP47(ltp.getLanguage())
                         .replace(" [Other]", "")
                         .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
@@ -302,7 +302,8 @@ public enum LanguageGroup {
                 throw new IllegalArgumentException("Need to fix code: " + ltp.getScript());
         }
         return prefix
-                + cldrFile.nameGetter().getName(ltp.getLanguage())
+                + cldrFile.nameGetter()
+                        .getName(ltp.getLanguage())
                         .replace(" [Other]", "")
                         .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
@@ -291,7 +291,7 @@ public enum LanguageGroup {
             case "":
                 break;
             default:
-                return cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, ltp.getRegion());
+                return cldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, ltp.getRegion());
         }
         switch (ltp.getScript()) {
             case "Hani":
@@ -303,7 +303,7 @@ public enum LanguageGroup {
         }
         return prefix
                 + cldrFile.nameGetter()
-                        .getName(ltp.getLanguage())
+                        .getNameFromLocaleOrTZID(ltp.getLanguage())
                         .replace(" [Other]", "")
                         .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
@@ -291,7 +291,7 @@ public enum LanguageGroup {
             case "":
                 break;
             default:
-                return cldrFile.getName(CLDRFile.TERRITORY_NAME, ltp.getRegion());
+                return cldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, ltp.getRegion());
         }
         switch (ltp.getScript()) {
             case "Hani":
@@ -302,7 +302,7 @@ public enum LanguageGroup {
                 throw new IllegalArgumentException("Need to fix code: " + ltp.getScript());
         }
         return prefix
-                + cldrFile.getName(ltp.getLanguage())
+                + cldrFile.nameGetter().getName(ltp.getLanguage())
                         .replace(" [Other]", "")
                         .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -22,16 +22,16 @@ public class NameGetter {
      */
     public NameGetter(CLDRFile cldrFile) {
         if (cldrFile == null) {
-            throw new RuntimeException("NameGetter must have non-null CLDRFile");
+            throw new IllegalArgumentException("NameGetter must have non-null CLDRFile");
         }
         this.cldrFile = cldrFile;
     }
 
-    private static final String GETNAME_LOCALE_SEPARATOR =
+    private static final String GETNAME_LOCALE_SEPARATOR_PATH =
             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator";
-    private static final String GETNAME_LOCALE_PATTERN =
+    private static final String GETNAME_LOCALE_PATTERN_PATH =
             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern";
-    private static final String GETNAME_LOCALE_KEY_TYPE_PATTERN =
+    private static final String GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH =
             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern";
 
     private static final Joiner JOIN_HYPHEN = Joiner.on('-');
@@ -102,9 +102,9 @@ public class NameGetter {
                 lparser,
                 onlyConstructCompound,
                 null,
-                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
-                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
-                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN_PATH),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR_PATH),
                 null);
     }
 
@@ -161,9 +161,9 @@ public class NameGetter {
         return getNameFromManyThings(
                 localeOrTZID,
                 onlyConstructCompound,
-                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
-                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
-                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN_PATH),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR_PATH),
                 altPicker,
                 paths);
     }
@@ -361,12 +361,12 @@ public class NameGetter {
                 }
                 value = MessageFormat.format(localeKeyTypePattern, kname, oldFormatType);
                 if (paths != null) {
-                    paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
+                    paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH);
                 }
             }
             value = replaceBracketsForName(value);
             if (paths != null && !extras.isEmpty()) {
-                paths.add(GETNAME_LOCALE_SEPARATOR);
+                paths.add(GETNAME_LOCALE_SEPARATOR_PATH);
             }
             extras =
                     extras.isEmpty() ? value : MessageFormat.format(localeSeparator, extras, value);
@@ -380,7 +380,7 @@ public class NameGetter {
                             extension.getKey(),
                             JOIN_HYPHEN.join(extension.getValue()));
             if (paths != null) {
-                paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
+                paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH);
             }
             extras =
                     extras.isEmpty() ? value : MessageFormat.format(localeSeparator, extras, value);
@@ -390,7 +390,7 @@ public class NameGetter {
             return name;
         }
         if (paths != null) {
-            paths.add(GETNAME_LOCALE_PATTERN);
+            paths.add(GETNAME_LOCALE_PATTERN_PATH);
         }
         return MessageFormat.format(localePattern, name, extras);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -299,15 +299,15 @@ public class NameGetter {
 
         // Look for key-type pairs.
         for (Map.Entry<String, List<String>> extension :
-            lparser.getLocaleExtensionsDetailed().entrySet()) {
+                lparser.getLocaleExtensionsDetailed().entrySet()) {
             String key = extension.getKey();
             if (key.equals("h0")) {
                 continue;
             }
             List<String> keyValue = extension.getValue();
             String oldFormatType =
-                (key.equals("ca") ? JOIN_HYPHEN : JOIN_UNDERBAR)
-                    .join(keyValue); // default value
+                    (key.equals("ca") ? JOIN_HYPHEN : JOIN_UNDERBAR)
+                            .join(keyValue); // default value
             // Check if key/type pairs exist in the CLDRFile first.
             String value = cldrFile.getKeyValueName(key, oldFormatType);
             if (value == null) {
@@ -326,19 +326,19 @@ public class NameGetter {
                         break;
                     case "cu":
                         oldFormatType =
-                            getName(
-                                CLDRFile.CURRENCY_SYMBOL,
-                                oldFormatType.toUpperCase(Locale.ROOT),
-                                paths);
+                                getName(
+                                        CLDRFile.CURRENCY_SYMBOL,
+                                        oldFormatType.toUpperCase(Locale.ROOT),
+                                        paths);
                         break;
                     case "tz":
                         if (paths != null) {
                             throw new IllegalArgumentException(
-                                "Error: getName(…) with paths doesn't handle timezones.");
+                                    "Error: getName(…) with paths doesn't handle timezones.");
                         }
                         oldFormatType =
-                            getTZName(
-                                oldFormatType, "VVVV"); // TODO: paths not handled here, yet
+                                getTZName(
+                                        oldFormatType, "VVVV"); // TODO: paths not handled here, yet
                         break;
                     case "kr":
                         oldFormatType = getReorderName(localeSeparator, keyValue, paths);
@@ -350,9 +350,7 @@ public class NameGetter {
                     default:
                         oldFormatType = JOIN_HYPHEN.join(keyValue);
                 }
-                value =
-                    MessageFormat.format(
-                        localeKeyTypePattern, kname, oldFormatType);
+                value = MessageFormat.format(localeKeyTypePattern, kname, oldFormatType);
                 if (paths != null) {
                     paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
                 }
@@ -362,9 +360,7 @@ public class NameGetter {
                 paths.add(GETNAME_LOCALE_SEPARATOR);
             }
             extras =
-                extras.isEmpty()
-                    ? value
-                    : MessageFormat.format(localeSeparator, extras, value);
+                    extras.isEmpty() ? value : MessageFormat.format(localeSeparator, extras, value);
         }
         // now handle stray extensions
         for (Map.Entry<String, List<String>> extension :
@@ -372,14 +368,13 @@ public class NameGetter {
             String value =
                     MessageFormat.format(
                             localeKeyTypePattern,
-                        extension.getKey(), JOIN_HYPHEN.join(extension.getValue()));
+                            extension.getKey(),
+                            JOIN_HYPHEN.join(extension.getValue()));
             if (paths != null) {
                 paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
             }
             extras =
-                    extras.isEmpty()
-                            ? value
-                            : MessageFormat.format(localeSeparator, extras, value);
+                    extras.isEmpty() ? value : MessageFormat.format(localeSeparator, extras, value);
         }
         // fix this -- shouldn't be hardcoded!
         if (extras.isEmpty()) {
@@ -503,10 +498,7 @@ public class NameGetter {
                     name = value;
                 }
             }
-            result =
-                    result == null
-                            ? name
-                            : MessageFormat.format(localeSeparator, result, name);
+            result = result == null ? name : MessageFormat.format(localeSeparator, result, name);
         }
         return result;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -1,0 +1,547 @@
+package org.unicode.cldr.util;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.ibm.icu.text.MessageFormat;
+import com.ibm.icu.text.Transform;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NameGetter {
+
+    private final CLDRFile cldrFile;
+
+    /**
+     * Construct a new NameGetter.
+     *
+     * @param cldrFile must not be null
+     */
+    public NameGetter(CLDRFile cldrFile) {
+        if (cldrFile == null) {
+            throw new RuntimeException("NameGetter must have non-null CLDRFile");
+        }
+        this.cldrFile = cldrFile;
+    }
+
+    private static final String GETNAME_LOCALE_SEPARATOR =
+            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator";
+    private static final String GETNAME_LOCALE_PATTERN =
+            "//ldml/localeDisplayNames/localeDisplayPattern/localePattern";
+    private static final String GETNAME_LOCALE_KEY_TYPE_PATTERN =
+            "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern";
+
+    private static final Joiner JOIN_HYPHEN = Joiner.on('-');
+    private static final Joiner JOIN_UNDERBAR = Joiner.on('_');
+
+    /** Utility for getting a name, given a type and code. */
+    public String getName(String type, String code) {
+        return getName(CLDRFile.typeNameToCode(type), code);
+    }
+
+    public String getName(int type, String code) {
+        return getName(type, code, null, null);
+    }
+
+    public String getName(int type, String code, Set<String> paths) {
+        return getName(type, code, null, paths);
+    }
+
+    public String getName(int type, String code, Transform<String, String> altPicker) {
+        return getName(type, code, altPicker, null);
+    }
+
+    /**
+     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
+     * the old "\@key=type" syntax.
+     *
+     * @param localeOrTZID
+     * @return
+     */
+    public synchronized String getName(String localeOrTZID) {
+        return getName(localeOrTZID, false);
+    }
+
+    public String getName(
+            LanguageTagParser lparser,
+            boolean onlyConstructCompound,
+            Transform<String, String> altPicker) {
+        return getName(lparser, onlyConstructCompound, altPicker, null);
+    }
+
+    /**
+     * @param paths if non-null, will contain contributory paths on return
+     */
+    public String getName(
+            LanguageTagParser lparser,
+            boolean onlyConstructCompound,
+            Transform<String, String> altPicker,
+            Set<String> paths) {
+        return getName(
+                lparser,
+                onlyConstructCompound,
+                altPicker,
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
+                paths);
+    }
+
+    public synchronized String getName(
+            String localeOrTZID,
+            boolean onlyConstructCompound,
+            String localeKeyTypePattern,
+            String localePattern,
+            String localeSeparator) {
+        return getName(
+                localeOrTZID,
+                onlyConstructCompound,
+                localeKeyTypePattern,
+                localePattern,
+                localeSeparator,
+                null,
+                null);
+    }
+
+    /**
+     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
+     * the old "\@key=type" syntax.
+     *
+     * @param localeOrTZID the locale or timezone ID
+     * @param onlyConstructCompound
+     * @return
+     */
+    public synchronized String getName(String localeOrTZID, boolean onlyConstructCompound) {
+        return getName(localeOrTZID, onlyConstructCompound, null);
+    }
+
+    /**
+     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
+     * the old "\@key=type" syntax.
+     *
+     * @param localeOrTZID the locale or timezone ID
+     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     *     English"
+     * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
+     *     "English (U.K.)" instead of "English (United Kingdom)"
+     * @return
+     */
+    public synchronized String getName(
+            String localeOrTZID,
+            boolean onlyConstructCompound,
+            Transform<String, String> altPicker) {
+        return getName(localeOrTZID, onlyConstructCompound, altPicker, null);
+    }
+
+    /**
+     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
+     * the old "\@key=type" syntax.
+     *
+     * @param localeOrTZID the locale or timezone ID
+     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     *     English"
+     * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
+     *     "English (U.K.)" instead of "English (United Kingdom)"
+     * @return
+     */
+    public synchronized String getName(
+            String localeOrTZID,
+            boolean onlyConstructCompound,
+            Transform<String, String> altPicker,
+            Set<String> paths) {
+        return getName(
+                localeOrTZID,
+                onlyConstructCompound,
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
+                cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
+                altPicker,
+                paths);
+    }
+
+    /**
+     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
+     * the old "\@key=type" syntax. Only used by ExampleGenerator.
+     *
+     * @param localeOrTZID the locale or timezone ID
+     * @param onlyConstructCompound
+     * @param localeKeyTypePattern the pattern used to format key-type pairs
+     * @param localePattern the pattern used to format primary/secondary subtags
+     * @param localeSeparator the list separator for secondary subtags
+     * @param paths if non-null, fillin with contributory paths
+     * @return
+     */
+    public synchronized String getName(
+            String localeOrTZID,
+            boolean onlyConstructCompound,
+            String localeKeyTypePattern,
+            String localePattern,
+            String localeSeparator,
+            Transform<String, String> altPicker,
+            Set<String> paths) {
+        // Hack for seed
+        if (localePattern == null) {
+            localePattern = "{0} ({1})";
+        }
+        boolean isCompound = localeOrTZID.contains("_");
+        String name =
+                isCompound && onlyConstructCompound
+                        ? null
+                        : getName(CLDRFile.LANGUAGE_NAME, localeOrTZID, altPicker, paths);
+
+        // TODO - handle arbitrary combinations
+        if (name != null && !name.contains("_") && !name.contains("-")) {
+            name = replaceBracketsForName(name);
+            return name;
+        }
+        LanguageTagParser lparser = new LanguageTagParser().set(localeOrTZID);
+        return getName(
+                lparser,
+                onlyConstructCompound,
+                altPicker,
+                localeKeyTypePattern,
+                localePattern,
+                localeSeparator,
+                paths);
+    }
+
+    public String getName(
+            LanguageTagParser lparser,
+            boolean onlyConstructCompound,
+            Transform<String, String> altPicker,
+            String localeKeyTypePattern,
+            String localePattern,
+            String localeSeparator,
+            Set<String> paths) {
+        String name;
+        String original;
+
+        // we need to check for prefixes, for lang+script or lang+country
+        boolean haveScript = false;
+        boolean haveRegion = false;
+        // try lang+script
+        if (onlyConstructCompound) {
+            name =
+                    getName(
+                            CLDRFile.LANGUAGE_NAME,
+                            original = lparser.getLanguage(),
+                            altPicker,
+                            paths);
+            if (name == null) name = original;
+        } else {
+            String x = lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT_REGION);
+            name = getName(CLDRFile.LANGUAGE_NAME, x, altPicker, paths);
+            if (name != null) {
+                haveScript = haveRegion = true;
+            } else {
+                name =
+                        getName(
+                                CLDRFile.LANGUAGE_NAME,
+                                lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT),
+                                altPicker,
+                                paths);
+                if (name != null) {
+                    haveScript = true;
+                } else {
+                    name =
+                            getName(
+                                    CLDRFile.LANGUAGE_NAME,
+                                    lparser.toString(LanguageTagParser.LANGUAGE_REGION),
+                                    altPicker,
+                                    paths);
+                    if (name != null) {
+                        haveRegion = true;
+                    } else {
+                        name =
+                                getName(
+                                        CLDRFile.LANGUAGE_NAME,
+                                        original = lparser.getLanguage(),
+                                        altPicker,
+                                        paths);
+                        if (name == null) {
+                            name = original;
+                        }
+                    }
+                }
+            }
+        }
+        name = replaceBracketsForName(name);
+        String extras = "";
+        if (!haveScript) {
+            extras =
+                    addDisplayName(
+                            lparser.getScript(),
+                            CLDRFile.SCRIPT_NAME,
+                            localeSeparator,
+                            extras,
+                            altPicker,
+                            paths);
+        }
+        if (!haveRegion) {
+            extras =
+                    addDisplayName(
+                            lparser.getRegion(),
+                            CLDRFile.TERRITORY_NAME,
+                            localeSeparator,
+                            extras,
+                            altPicker,
+                            paths);
+        }
+        List<String> variants = lparser.getVariants();
+        for (String orig : variants) {
+            extras =
+                    addDisplayName(
+                            orig, CLDRFile.VARIANT_NAME, localeSeparator, extras, altPicker, paths);
+        }
+
+        // Look for key-type pairs.
+        for (Map.Entry<String, List<String>> extension :
+            lparser.getLocaleExtensionsDetailed().entrySet()) {
+            String key = extension.getKey();
+            if (key.equals("h0")) {
+                continue;
+            }
+            List<String> keyValue = extension.getValue();
+            String oldFormatType =
+                (key.equals("ca") ? JOIN_HYPHEN : JOIN_UNDERBAR)
+                    .join(keyValue); // default value
+            // Check if key/type pairs exist in the CLDRFile first.
+            String value = cldrFile.getKeyValueName(key, oldFormatType);
+            if (value == null) {
+                // if we fail, then we construct from the key name and the value
+                String kname = cldrFile.getKeyName(key);
+                if (kname == null) {
+                    kname = key; // should not happen, but just in case
+                }
+                switch (key) {
+                    case "t":
+                        List<String> hybrid = lparser.getLocaleExtensionsDetailed().get("h0");
+                        if (hybrid != null) {
+                            kname = cldrFile.getKeyValueName("h0", JOIN_UNDERBAR.join(hybrid));
+                        }
+                        oldFormatType = getName(oldFormatType);
+                        break;
+                    case "cu":
+                        oldFormatType =
+                            getName(
+                                CLDRFile.CURRENCY_SYMBOL,
+                                oldFormatType.toUpperCase(Locale.ROOT),
+                                paths);
+                        break;
+                    case "tz":
+                        if (paths != null) {
+                            throw new IllegalArgumentException(
+                                "Error: getName(…) with paths doesn't handle timezones.");
+                        }
+                        oldFormatType =
+                            getTZName(
+                                oldFormatType, "VVVV"); // TODO: paths not handled here, yet
+                        break;
+                    case "kr":
+                        oldFormatType = getReorderName(localeSeparator, keyValue, paths);
+                        break;
+                    case "rg":
+                    case "sd":
+                        oldFormatType = getName(CLDRFile.SUBDIVISION_NAME, oldFormatType, paths);
+                        break;
+                    default:
+                        oldFormatType = JOIN_HYPHEN.join(keyValue);
+                }
+                value =
+                    MessageFormat.format(
+                        localeKeyTypePattern, kname, oldFormatType);
+                if (paths != null) {
+                    paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
+                }
+            }
+            value = replaceBracketsForName(value);
+            if (paths != null && !extras.isEmpty()) {
+                paths.add(GETNAME_LOCALE_SEPARATOR);
+            }
+            extras =
+                extras.isEmpty()
+                    ? value
+                    : MessageFormat.format(localeSeparator, extras, value);
+        }
+        // now handle stray extensions
+        for (Map.Entry<String, List<String>> extension :
+                lparser.getExtensionsDetailed().entrySet()) {
+            String value =
+                    MessageFormat.format(
+                            localeKeyTypePattern,
+                        extension.getKey(), JOIN_HYPHEN.join(extension.getValue()));
+            if (paths != null) {
+                paths.add(GETNAME_LOCALE_KEY_TYPE_PATTERN);
+            }
+            extras =
+                    extras.isEmpty()
+                            ? value
+                            : MessageFormat.format(localeSeparator, extras, value);
+        }
+        // fix this -- shouldn't be hardcoded!
+        if (extras.isEmpty()) {
+            return name;
+        }
+        if (paths != null) {
+            paths.add(GETNAME_LOCALE_PATTERN);
+        }
+        return MessageFormat.format(localePattern, name, extras);
+    }
+
+    private static String replaceBracketsForName(String value) {
+        value = value.replace('(', '[').replace(')', ']').replace('（', '［').replace('）', '］');
+        return value;
+    }
+
+    /**
+     * Utility for getting the name, given a code.
+     *
+     * @param type
+     * @param code
+     * @param codeToAlt - if not null, is called on the code. If the result is not null, then that
+     *     is used for an alt value. If the alt path has a value it is used, otherwise the normal
+     *     one is used. For example, the transform could return "short" for PS or HK or MO, but not
+     *     US or GB.
+     * @param paths if non-null, will have contributory paths on return
+     * @return
+     */
+    public String getName(
+            int type, String code, Transform<String, String> codeToAlt, Set<String> paths) {
+        String path = CLDRFile.getKey(type, code);
+        String result = null;
+        if (codeToAlt != null) {
+            String alt = codeToAlt.transform(code);
+            if (alt != null) {
+                String altPath = path + "[@alt=\"" + alt + "\"]";
+                result = cldrFile.getStringValueWithBaileyNotConstructed(altPath);
+                if (paths != null && result != null) {
+                    paths.add(altPath);
+                }
+            }
+        }
+        if (result == null) {
+            result = cldrFile.getStringValueWithBaileyNotConstructed(path);
+            if (paths != null && result != null) {
+                paths.add(path);
+            }
+        }
+        if (cldrFile.getLocaleID().equals("en")) {
+            CLDRFile.Status status = new CLDRFile.Status();
+            String sourceLocale = cldrFile.getSourceLocaleID(path, status);
+            if (result == null || !sourceLocale.equals("en")) {
+                if (type == CLDRFile.LANGUAGE_NAME) {
+                    Set<String> set = Iso639Data.getNames(code);
+                    if (set != null) {
+                        return set.iterator().next();
+                    }
+                    Map<String, Map<String, String>> map =
+                            StandardCodes.getLStreg().get("language");
+                    Map<String, String> info = map.get(code);
+                    if (info != null) {
+                        result = info.get("Description");
+                    }
+                } else if (type == CLDRFile.TERRITORY_NAME) {
+                    result = getLstrFallback("region", code);
+                } else if (type == CLDRFile.SCRIPT_NAME) {
+                    result = getLstrFallback("script", code);
+                }
+            }
+        }
+        return result;
+    }
+
+    static final Pattern CLEAN_DESCRIPTION = Pattern.compile("([^\\(\\[]*)[\\(\\[].*");
+    static final Splitter DESCRIPTION_SEP = Splitter.on('▪');
+
+    private String getLstrFallback(String codeType, String code) {
+        Map<String, String> info = StandardCodes.getLStreg().get(codeType).get(code);
+        if (info != null) {
+            String temp = info.get("Description");
+            if (!temp.equalsIgnoreCase("Private use")) {
+                List<String> temp2 = DESCRIPTION_SEP.splitToList(temp);
+                temp = temp2.get(0);
+                final Matcher matcher = CLEAN_DESCRIPTION.matcher(temp);
+                if (matcher.lookingAt()) {
+                    temp = matcher.group(1).trim();
+                }
+                return temp;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets timezone name. Not optimized.
+     *
+     * @param tzcode
+     * @return
+     */
+    private String getTZName(String tzcode, String format) {
+        String longid = CLDRFile.getLongTzid(tzcode);
+        if (tzcode.length() == 4 && !tzcode.equals("gaza")) {
+            return longid;
+        }
+        TimezoneFormatter tzf = new TimezoneFormatter(cldrFile);
+        return tzf.getFormattedZone(longid, format, 0);
+    }
+
+    private String getReorderName(
+            String localeSeparator, List<String> keyValues, Set<String> paths) {
+        String result = null;
+        for (String value : keyValues) {
+            String name =
+                    getName(
+                            CLDRFile.SCRIPT_NAME,
+                            Character.toUpperCase(value.charAt(0)) + value.substring(1),
+                            paths);
+            if (name == null) {
+                name = cldrFile.getKeyValueName("kr", value);
+                if (name == null) {
+                    name = value;
+                }
+            }
+            result =
+                    result == null
+                            ? name
+                            : MessageFormat.format(localeSeparator, result, name);
+        }
+        return result;
+    }
+
+    /**
+     * Adds the display name for a subtag to a string.
+     *
+     * @param subtag the subtag
+     * @param type the type of the subtag
+     * @param separatorPattern the pattern to be used for separating display names in the resultant
+     *     string
+     * @param extras the string to be added to
+     * @return the modified display name string
+     */
+    private String addDisplayName(
+            String subtag,
+            int type,
+            String separatorPattern,
+            String extras,
+            Transform<String, String> altPicker,
+            Set<String> paths) {
+        if (subtag.isEmpty()) {
+            return extras;
+        }
+        String sname = getName(type, subtag, altPicker, paths);
+        if (sname == null) {
+            sname = subtag;
+        }
+        sname = replaceBracketsForName(sname);
+
+        if (extras.isEmpty()) {
+            extras += sname;
+        } else {
+            extras = MessageFormat.format(separatorPattern, extras, sname);
+        }
+        return extras;
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -38,20 +38,20 @@ public class NameGetter {
     private static final Joiner JOIN_UNDERBAR = Joiner.on('_');
 
     /** Utility for getting a name, given a type and code. */
-    public String getName(String type, String code) {
-        return getName(CLDRFile.typeNameToCode(type), code);
+    public String getNameFromTypestrCode(String type, String code) {
+        return getNameFromTypenumCode(CLDRFile.typeNameToCode(type), code);
     }
 
-    public String getName(int type, String code) {
-        return getName(type, code, null, null);
+    public String getNameFromTypenumCode(int type, String code) {
+        return getNameFromTypeCodeTransformPaths(type, code, null, null);
     }
 
-    public String getName(int type, String code, Set<String> paths) {
-        return getName(type, code, null, paths);
+    public String getNameFromTypeCodePaths(int type, String code, Set<String> paths) {
+        return getNameFromTypeCodeTransformPaths(type, code, null, paths);
     }
 
-    public String getName(int type, String code, Transform<String, String> altPicker) {
-        return getName(type, code, altPicker, null);
+    public String getNameFromTypeCodeAltpicker(int type, String code, Transform<String, String> altPicker) {
+        return getNameFromTypeCodeTransformPaths(type, code, altPicker, null);
     }
 
     /**
@@ -61,26 +61,26 @@ public class NameGetter {
      * @param localeOrTZID
      * @return
      */
-    public synchronized String getName(String localeOrTZID) {
-        return getName(localeOrTZID, false);
+    public synchronized String getNameFromLocaleOrTZID(String localeOrTZID) {
+        return getNameFromLocaleOrTZBool(localeOrTZID, false);
     }
 
-    public String getName(
+    public String getNameFromParserBoolAltPicker(
             LanguageTagParser lparser,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker) {
-        return getName(lparser, onlyConstructCompound, altPicker, null);
+        return getNameFromParserBooleanAltpickerPaths(lparser, onlyConstructCompound, altPicker, null);
     }
 
     /**
      * @param paths if non-null, will contain contributory paths on return
      */
-    public String getName(
+    public String getNameFromParserBooleanAltpickerPaths(
             LanguageTagParser lparser,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker,
             Set<String> paths) {
-        return getName(
+        return getNameFromOtherThings(
                 lparser,
                 onlyConstructCompound,
                 altPicker,
@@ -90,13 +90,13 @@ public class NameGetter {
                 paths);
     }
 
-    public synchronized String getName(
+    public synchronized String getNameFromLocaleOrTZBoolEtc(
             String localeOrTZID,
             boolean onlyConstructCompound,
             String localeKeyTypePattern,
             String localePattern,
             String localeSeparator) {
-        return getName(
+        return getNameFrom7Things(
                 localeOrTZID,
                 onlyConstructCompound,
                 localeKeyTypePattern,
@@ -114,8 +114,8 @@ public class NameGetter {
      * @param onlyConstructCompound
      * @return
      */
-    public synchronized String getName(String localeOrTZID, boolean onlyConstructCompound) {
-        return getName(localeOrTZID, onlyConstructCompound, null);
+    public synchronized String getNameFromLocaleOrTZBool(String localeOrTZID, boolean onlyConstructCompound) {
+        return getNameFromLocaleOrTZBoolAltpicker(localeOrTZID, onlyConstructCompound, null);
     }
 
     /**
@@ -129,11 +129,11 @@ public class NameGetter {
      *     "English (U.K.)" instead of "English (United Kingdom)"
      * @return
      */
-    public synchronized String getName(
+    public synchronized String getNameFromLocaleOrTZBoolAltpicker(
             String localeOrTZID,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker) {
-        return getName(localeOrTZID, onlyConstructCompound, altPicker, null);
+        return getNameFromLocaleTZBoolAltpickerPaths(localeOrTZID, onlyConstructCompound, altPicker, null);
     }
 
     /**
@@ -147,12 +147,12 @@ public class NameGetter {
      *     "English (U.K.)" instead of "English (United Kingdom)"
      * @return
      */
-    public synchronized String getName(
+    public synchronized String getNameFromLocaleTZBoolAltpickerPaths(
             String localeOrTZID,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker,
             Set<String> paths) {
-        return getName(
+        return getNameFrom7Things(
                 localeOrTZID,
                 onlyConstructCompound,
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
@@ -174,7 +174,7 @@ public class NameGetter {
      * @param paths if non-null, fillin with contributory paths
      * @return
      */
-    public synchronized String getName(
+    public synchronized String getNameFrom7Things(
             String localeOrTZID,
             boolean onlyConstructCompound,
             String localeKeyTypePattern,
@@ -190,7 +190,7 @@ public class NameGetter {
         String name =
                 isCompound && onlyConstructCompound
                         ? null
-                        : getName(CLDRFile.LANGUAGE_NAME, localeOrTZID, altPicker, paths);
+                        : getNameFromTypeCodeTransformPaths(CLDRFile.LANGUAGE_NAME, localeOrTZID, altPicker, paths);
 
         // TODO - handle arbitrary combinations
         if (name != null && !name.contains("_") && !name.contains("-")) {
@@ -198,7 +198,7 @@ public class NameGetter {
             return name;
         }
         LanguageTagParser lparser = new LanguageTagParser().set(localeOrTZID);
-        return getName(
+        return getNameFromOtherThings(
                 lparser,
                 onlyConstructCompound,
                 altPicker,
@@ -208,7 +208,7 @@ public class NameGetter {
                 paths);
     }
 
-    public String getName(
+    public String getNameFromOtherThings(
             LanguageTagParser lparser,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker,
@@ -225,7 +225,7 @@ public class NameGetter {
         // try lang+script
         if (onlyConstructCompound) {
             name =
-                    getName(
+                    getNameFromTypeCodeTransformPaths(
                             CLDRFile.LANGUAGE_NAME,
                             original = lparser.getLanguage(),
                             altPicker,
@@ -233,12 +233,12 @@ public class NameGetter {
             if (name == null) name = original;
         } else {
             String x = lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT_REGION);
-            name = getName(CLDRFile.LANGUAGE_NAME, x, altPicker, paths);
+            name = getNameFromTypeCodeTransformPaths(CLDRFile.LANGUAGE_NAME, x, altPicker, paths);
             if (name != null) {
                 haveScript = haveRegion = true;
             } else {
                 name =
-                        getName(
+                        getNameFromTypeCodeTransformPaths(
                                 CLDRFile.LANGUAGE_NAME,
                                 lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT),
                                 altPicker,
@@ -247,7 +247,7 @@ public class NameGetter {
                     haveScript = true;
                 } else {
                     name =
-                            getName(
+                            getNameFromTypeCodeTransformPaths(
                                     CLDRFile.LANGUAGE_NAME,
                                     lparser.toString(LanguageTagParser.LANGUAGE_REGION),
                                     altPicker,
@@ -256,7 +256,7 @@ public class NameGetter {
                         haveRegion = true;
                     } else {
                         name =
-                                getName(
+                                getNameFromTypeCodeTransformPaths(
                                         CLDRFile.LANGUAGE_NAME,
                                         original = lparser.getLanguage(),
                                         altPicker,
@@ -322,11 +322,11 @@ public class NameGetter {
                         if (hybrid != null) {
                             kname = cldrFile.getKeyValueName("h0", JOIN_UNDERBAR.join(hybrid));
                         }
-                        oldFormatType = getName(oldFormatType);
+                        oldFormatType = getNameFromLocaleOrTZID(oldFormatType);
                         break;
                     case "cu":
                         oldFormatType =
-                                getName(
+                                getNameFromTypeCodePaths(
                                         CLDRFile.CURRENCY_SYMBOL,
                                         oldFormatType.toUpperCase(Locale.ROOT),
                                         paths);
@@ -345,7 +345,7 @@ public class NameGetter {
                         break;
                     case "rg":
                     case "sd":
-                        oldFormatType = getName(CLDRFile.SUBDIVISION_NAME, oldFormatType, paths);
+                        oldFormatType = getNameFromTypeCodePaths(CLDRFile.SUBDIVISION_NAME, oldFormatType, paths);
                         break;
                     default:
                         oldFormatType = JOIN_HYPHEN.join(keyValue);
@@ -387,8 +387,7 @@ public class NameGetter {
     }
 
     private static String replaceBracketsForName(String value) {
-        value = value.replace('(', '[').replace(')', ']').replace('（', '［').replace('）', '］');
-        return value;
+        return value.replace('(', '[').replace(')', ']').replace('（', '［').replace('）', '］');
     }
 
     /**
@@ -403,7 +402,7 @@ public class NameGetter {
      * @param paths if non-null, will have contributory paths on return
      * @return
      */
-    public String getName(
+    public String getNameFromTypeCodeTransformPaths(
             int type, String code, Transform<String, String> codeToAlt, Set<String> paths) {
         String path = CLDRFile.getKey(type, code);
         String result = null;
@@ -488,7 +487,7 @@ public class NameGetter {
         String result = null;
         for (String value : keyValues) {
             String name =
-                    getName(
+                    getNameFromTypeCodePaths(
                             CLDRFile.SCRIPT_NAME,
                             Character.toUpperCase(value.charAt(0)) + value.substring(1),
                             paths);
@@ -523,7 +522,7 @@ public class NameGetter {
         if (subtag.isEmpty()) {
             return extras;
         }
-        String sname = getName(type, subtag, altPicker, paths);
+        String sname = getNameFromTypeCodeTransformPaths(type, subtag, altPicker, paths);
         if (sname == null) {
             sname = subtag;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -37,11 +37,28 @@ public class NameGetter {
     private static final Joiner JOIN_HYPHEN = Joiner.on('-');
     private static final Joiner JOIN_UNDERBAR = Joiner.on('_');
 
-    /** Utility for getting a name, given a type and code. */
+    /**
+     * Get a name, given a type (as a String) and a code.
+     *
+     * <p>Ideally getNameFromTypestrCode and getNameFromTypenumCode should be replaced by a method
+     * that takes an enum rather than String or int. Compare StandardCodes.CodeType, and the
+     * integers defined in the vicinity of CLDRFile.TERRITORY_NAME
+     *
+     * @param type a string such as "currency", "language", "region", "script", "territory", ...
+     * @param code a code such as "JP"
+     * @return the name
+     */
     public String getNameFromTypestrCode(String type, String code) {
         return getNameFromTypenumCode(CLDRFile.typeNameToCode(type), code);
     }
 
+    /**
+     * Get a name, given a type (as a int) and a code.
+     *
+     * @param type the type such as CLDRFile.TERRITORY_NAME
+     * @param code a code such as "JP"
+     * @return the name
+     */
     public String getNameFromTypenumCode(int type, String code) {
         return getNameFromTypeCodeTransformPaths(type, code, null, null);
     }
@@ -50,7 +67,8 @@ public class NameGetter {
         return getNameFromTypeCodeTransformPaths(type, code, null, paths);
     }
 
-    public String getNameFromTypeCodeAltpicker(int type, String code, Transform<String, String> altPicker) {
+    public String getNameFromTypeCodeAltpicker(
+            int type, String code, Transform<String, String> altPicker) {
         return getNameFromTypeCodeTransformPaths(type, code, altPicker, null);
     }
 
@@ -58,45 +76,45 @@ public class NameGetter {
      * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
      * the old "\@key=type" syntax.
      *
-     * @param localeOrTZID
-     * @return
+     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
+     * @return the name of the given bcp47 identifier
      */
-    public synchronized String getNameFromLocaleOrTZID(String localeOrTZID) {
-        return getNameFromLocaleOrTZBool(localeOrTZID, false);
-    }
-
-    public String getNameFromParserBoolAltPicker(
-            LanguageTagParser lparser,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker) {
-        return getNameFromParserBooleanAltpickerPaths(lparser, onlyConstructCompound, altPicker, null);
+    public synchronized String getNameFromBCP47(String localeOrTZID) {
+        return getNameFromBCP47Bool(localeOrTZID, false);
     }
 
     /**
-     * @param paths if non-null, will contain contributory paths on return
+     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
+     * the old "\@key=type" syntax.
+     *
+     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
+     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     *     English"
+     * @return the name of the given bcp47 identifier
      */
-    public String getNameFromParserBooleanAltpickerPaths(
-            LanguageTagParser lparser,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker,
-            Set<String> paths) {
+    public synchronized String getNameFromBCP47Bool(
+            String localeOrTZID, boolean onlyConstructCompound) {
+        return getNameFromBCP47BoolAlt(localeOrTZID, onlyConstructCompound, null);
+    }
+
+    public String getNameFromParserBool(LanguageTagParser lparser, boolean onlyConstructCompound) {
         return getNameFromOtherThings(
                 lparser,
                 onlyConstructCompound,
-                altPicker,
+                null,
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN),
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR),
-                paths);
+                null);
     }
 
-    public synchronized String getNameFromLocaleOrTZBoolEtc(
+    public synchronized String getNameFromBCP47Etc(
             String localeOrTZID,
             boolean onlyConstructCompound,
             String localeKeyTypePattern,
             String localePattern,
             String localeSeparator) {
-        return getNameFrom7Things(
+        return getNameFromManyThings(
                 localeOrTZID,
                 onlyConstructCompound,
                 localeKeyTypePattern,
@@ -110,49 +128,37 @@ public class NameGetter {
      * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
      * the old "\@key=type" syntax.
      *
-     * @param localeOrTZID the locale or timezone ID
-     * @param onlyConstructCompound
-     * @return
-     */
-    public synchronized String getNameFromLocaleOrTZBool(String localeOrTZID, boolean onlyConstructCompound) {
-        return getNameFromLocaleOrTZBoolAltpicker(localeOrTZID, onlyConstructCompound, null);
-    }
-
-    /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
-     *
-     * @param localeOrTZID the locale or timezone ID
+     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
      * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
      *     English"
      * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
      *     "English (U.K.)" instead of "English (United Kingdom)"
-     * @return
+     * @return the name of the given bcp47 identifier
      */
-    public synchronized String getNameFromLocaleOrTZBoolAltpicker(
+    public synchronized String getNameFromBCP47BoolAlt(
             String localeOrTZID,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker) {
-        return getNameFromLocaleTZBoolAltpickerPaths(localeOrTZID, onlyConstructCompound, altPicker, null);
+        return getNameFromBCP47BoolAltPaths(localeOrTZID, onlyConstructCompound, altPicker, null);
     }
 
     /**
      * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
      * the old "\@key=type" syntax.
      *
-     * @param localeOrTZID the locale or timezone ID
+     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
      * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
      *     English"
      * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
      *     "English (U.K.)" instead of "English (United Kingdom)"
-     * @return
+     * @return the name of the given bcp47 identifier
      */
-    public synchronized String getNameFromLocaleTZBoolAltpickerPaths(
+    public synchronized String getNameFromBCP47BoolAltPaths(
             String localeOrTZID,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker,
             Set<String> paths) {
-        return getNameFrom7Things(
+        return getNameFromManyThings(
                 localeOrTZID,
                 onlyConstructCompound,
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN),
@@ -166,15 +172,16 @@ public class NameGetter {
      * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
      * the old "\@key=type" syntax. Only used by ExampleGenerator.
      *
-     * @param localeOrTZID the locale or timezone ID
-     * @param onlyConstructCompound
+     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
+     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     *     English"
      * @param localeKeyTypePattern the pattern used to format key-type pairs
      * @param localePattern the pattern used to format primary/secondary subtags
      * @param localeSeparator the list separator for secondary subtags
      * @param paths if non-null, fillin with contributory paths
-     * @return
+     * @return the name of the given bcp47 identifier
      */
-    public synchronized String getNameFrom7Things(
+    private synchronized String getNameFromManyThings(
             String localeOrTZID,
             boolean onlyConstructCompound,
             String localeKeyTypePattern,
@@ -190,7 +197,8 @@ public class NameGetter {
         String name =
                 isCompound && onlyConstructCompound
                         ? null
-                        : getNameFromTypeCodeTransformPaths(CLDRFile.LANGUAGE_NAME, localeOrTZID, altPicker, paths);
+                        : getNameFromTypeCodeTransformPaths(
+                                CLDRFile.LANGUAGE_NAME, localeOrTZID, altPicker, paths);
 
         // TODO - handle arbitrary combinations
         if (name != null && !name.contains("_") && !name.contains("-")) {
@@ -208,7 +216,7 @@ public class NameGetter {
                 paths);
     }
 
-    public String getNameFromOtherThings(
+    private String getNameFromOtherThings(
             LanguageTagParser lparser,
             boolean onlyConstructCompound,
             Transform<String, String> altPicker,
@@ -322,7 +330,7 @@ public class NameGetter {
                         if (hybrid != null) {
                             kname = cldrFile.getKeyValueName("h0", JOIN_UNDERBAR.join(hybrid));
                         }
-                        oldFormatType = getNameFromLocaleOrTZID(oldFormatType);
+                        oldFormatType = getNameFromBCP47(oldFormatType);
                         break;
                     case "cu":
                         oldFormatType =
@@ -337,15 +345,16 @@ public class NameGetter {
                                     "Error: getName(…) with paths doesn't handle timezones.");
                         }
                         oldFormatType =
-                                getTZName(
-                                        oldFormatType, "VVVV"); // TODO: paths not handled here, yet
+                                getTZName(oldFormatType); // TODO: paths not handled here, yet
                         break;
                     case "kr":
                         oldFormatType = getReorderName(localeSeparator, keyValue, paths);
                         break;
                     case "rg":
                     case "sd":
-                        oldFormatType = getNameFromTypeCodePaths(CLDRFile.SUBDIVISION_NAME, oldFormatType, paths);
+                        oldFormatType =
+                                getNameFromTypeCodePaths(
+                                        CLDRFile.SUBDIVISION_NAME, oldFormatType, paths);
                         break;
                     default:
                         oldFormatType = JOIN_HYPHEN.join(keyValue);
@@ -393,16 +402,16 @@ public class NameGetter {
     /**
      * Utility for getting the name, given a code.
      *
-     * @param type
-     * @param code
+     * @param type the type such as CLDRFile.TERRITORY_NAME
+     * @param code the code such as "JP"
      * @param codeToAlt - if not null, is called on the code. If the result is not null, then that
      *     is used for an alt value. If the alt path has a value it is used, otherwise the normal
      *     one is used. For example, the transform could return "short" for PS or HK or MO, but not
      *     US or GB.
      * @param paths if non-null, will have contributory paths on return
-     * @return
+     * @return the name
      */
-    public String getNameFromTypeCodeTransformPaths(
+    private String getNameFromTypeCodeTransformPaths(
             int type, String code, Transform<String, String> codeToAlt, Set<String> paths) {
         String path = CLDRFile.getKey(type, code);
         String result = null;
@@ -447,7 +456,7 @@ public class NameGetter {
         return result;
     }
 
-    static final Pattern CLEAN_DESCRIPTION = Pattern.compile("([^\\(\\[]*)[\\(\\[].*");
+    static final Pattern CLEAN_DESCRIPTION = Pattern.compile("([^(\\[]*)[(\\[].*");
     static final Splitter DESCRIPTION_SEP = Splitter.on('▪');
 
     private String getLstrFallback(String codeType, String code) {
@@ -470,16 +479,16 @@ public class NameGetter {
     /**
      * Gets timezone name. Not optimized.
      *
-     * @param tzcode
-     * @return
+     * @param tzcode the code such as "gaza"
+     * @return timezone name
      */
-    private String getTZName(String tzcode, String format) {
+    private String getTZName(String tzcode) {
         String longid = CLDRFile.getLongTzid(tzcode);
         if (tzcode.length() == 4 && !tzcode.equals("gaza")) {
             return longid;
         }
         TimezoneFormatter tzf = new TimezoneFormatter(cldrFile);
-        return tzf.getFormattedZone(longid, format, 0);
+        return tzf.getFormattedZone(longid, "VVVV", 0);
     }
 
     private String getReorderName(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -1012,7 +1012,8 @@ public class PathDescription {
                     MessageFormat.format(MessageFormat.autoQuoteApostrophe(description), code);
         } else if (path.contains("exemplarCity")) {
             String regionCode = ZONE2COUNTRY.get(attributes.get(0));
-            String englishRegionName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, regionCode);
+            String englishRegionName =
+                    english.nameGetter().getName(CLDRFile.TERRITORY_NAME, regionCode);
             description =
                     MessageFormat.format(
                             MessageFormat.autoQuoteApostrophe(description), englishRegionName);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -994,7 +994,7 @@ public class PathDescription {
                     code = "the timezone “" + codeName + "”";
                     found = true;
                 } else if (country != null) {
-                    String countryName = english.getName("territory", country);
+                    String countryName = english.nameGetter().getName("territory", country);
                     if (countryName != null) {
                         if (!codeName.equals(countryName)) {
                             code = "the city “" + codeName + "” (in " + countryName + ")";
@@ -1012,7 +1012,7 @@ public class PathDescription {
                     MessageFormat.format(MessageFormat.autoQuoteApostrophe(description), code);
         } else if (path.contains("exemplarCity")) {
             String regionCode = ZONE2COUNTRY.get(attributes.get(0));
-            String englishRegionName = english.getName(CLDRFile.TERRITORY_NAME, regionCode);
+            String englishRegionName = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, regionCode);
             description =
                     MessageFormat.format(
                             MessageFormat.autoQuoteApostrophe(description), englishRegionName);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -994,7 +994,7 @@ public class PathDescription {
                     code = "the timezone “" + codeName + "”";
                     found = true;
                 } else if (country != null) {
-                    String countryName = english.nameGetter().getName("territory", country);
+                    String countryName = english.nameGetter().getNameFromTypestrCode("territory", country);
                     if (countryName != null) {
                         if (!codeName.equals(countryName)) {
                             code = "the city “" + codeName + "” (in " + countryName + ")";
@@ -1013,7 +1013,7 @@ public class PathDescription {
         } else if (path.contains("exemplarCity")) {
             String regionCode = ZONE2COUNTRY.get(attributes.get(0));
             String englishRegionName =
-                    english.nameGetter().getName(CLDRFile.TERRITORY_NAME, regionCode);
+                    english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, regionCode);
             description =
                     MessageFormat.format(
                             MessageFormat.autoQuoteApostrophe(description), englishRegionName);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -994,7 +994,8 @@ public class PathDescription {
                     code = "the timezone “" + codeName + "”";
                     found = true;
                 } else if (country != null) {
-                    String countryName = english.nameGetter().getNameFromTypestrCode("territory", country);
+                    String countryName =
+                            english.nameGetter().getNameFromTypestrCode("territory", country);
                     if (countryName != null) {
                         if (!codeName.equals(countryName)) {
                             code = "the city “" + codeName + "” (in " + countryName + ")";
@@ -1013,7 +1014,8 @@ public class PathDescription {
         } else if (path.contains("exemplarCity")) {
             String regionCode = ZONE2COUNTRY.get(attributes.get(0));
             String englishRegionName =
-                    english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, regionCode);
+                    english.nameGetter()
+                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, regionCode);
             description =
                     MessageFormat.format(
                             MessageFormat.autoQuoteApostrophe(description), englishRegionName);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1416,7 +1416,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 languageOnlyPart = source0;
                             }
 
-                            return englishFile.getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
+                            return englishFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
                                     + " \u25BA "
                                     + source0;
                         }
@@ -1431,7 +1431,7 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (script == null) {
                                 script = likelySubtags.getLikelyScript(language);
                             }
-                            String scriptName = englishFile.getName(CLDRFile.SCRIPT_NAME, script);
+                            String scriptName = englishFile.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
                             return "Languages in "
                                     + (script.equals("Hans") || script.equals("Hant")
                                             ? "Han Script"
@@ -1449,7 +1449,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                     String territory = getSubdivisionsTerritory(source, null);
                                     String container = Containment.getContainer(territory);
                                     order = Containment.getOrder(territory);
-                                    return englishFile.getName(CLDRFile.TERRITORY_NAME, container);
+                                    return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, container);
                                 }
                             });
             functionMap.put(
@@ -1483,7 +1483,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                                     : "003"; // was Integer.valueOf(subcontinent) ==
                                     // 5
                                     return "Territories ("
-                                            + englishFile.getName(
+                                            + englishFile.nameGetter().getName(
                                                     CLDRFile.TERRITORY_NAME, theSubContinent)
                                             + ")";
                                 case "001":
@@ -1491,7 +1491,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                     return "Geographic Regions"; // not in containment
                                 default:
                                     return "Territories ("
-                                            + englishFile.getName(
+                                            + englishFile.nameGetter().getName(
                                                     CLDRFile.TERRITORY_NAME, theContinent)
                                             + ")";
                             }
@@ -1533,7 +1533,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 }
                             }
                             if (singlePageTerritories.contains(theTerritory)) {
-                                return englishFile.getName(CLDRFile.TERRITORY_NAME, theTerritory);
+                                return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, theTerritory);
                             }
                             String theContinent = Containment.getContinent(theTerritory);
                             final String subcontinent = Containment.getSubcontinent(theTerritory);
@@ -1549,19 +1549,19 @@ public class PathHeader implements Comparable<PathHeader> {
                                     } catch (NumberFormatException ex) {
                                         theSubContinent = "009";
                                     }
-                                    return englishFile.getName(
+                                    return englishFile.nameGetter().getName(
                                             CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 19: // Americas - For the timeZonePage, we just group North
                                     // America & South America
                                     theSubContinent =
                                             Integer.parseInt(subcontinent) == 5 ? "005" : "003";
-                                    return englishFile.getName(
+                                    return englishFile.nameGetter().getName(
                                             CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 142: // Asia
-                                    return englishFile.getName(
+                                    return englishFile.nameGetter().getName(
                                             CLDRFile.TERRITORY_NAME, subcontinent);
                                 default:
-                                    return englishFile.getName(
+                                    return englishFile.nameGetter().getName(
                                             CLDRFile.TERRITORY_NAME, theContinent);
                             }
                         }
@@ -1660,7 +1660,7 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (PathHeader.UNIFORM_CONTINENTS) {
                                 String container = getMetazonePageTerritory(source);
                                 order = Containment.getOrder(container);
-                                return englishFile.getName(CLDRFile.TERRITORY_NAME, container);
+                                return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, container);
                             } else {
                                 String continent = metazoneToContinent.get(source);
                                 if (continent == null) {
@@ -1770,13 +1770,13 @@ public class PathHeader implements Comparable<PathHeader> {
 
                             if (territory.equals("ZZ")) {
                                 order = 999;
-                                return englishFile.getName(CLDRFile.TERRITORY_NAME, territory)
+                                return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
                                         + ": "
                                         + source0;
                             } else {
                                 return catFromTerritory.transform(territory)
                                         + ": "
-                                        + englishFile.getName(CLDRFile.TERRITORY_NAME, territory)
+                                        + englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
                                         + tenderOrNot;
                             }
                         }
@@ -1798,7 +1798,7 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (territory.equals("ZZ")) {
                                 order = 999;
                                 subContinent =
-                                        englishFile.getName(CLDRFile.TERRITORY_NAME, territory);
+                                        englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
                             } else {
                                 subContinent = catFromTerritory.transform(territory);
                             }
@@ -2188,7 +2188,7 @@ public class PathHeader implements Comparable<PathHeader> {
             } else {
                 languageOnlyPart = s;
             }
-            final String name = englishFile.getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
+            final String name = englishFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
             return name == null ? "?" : name.substring(0, 1).toUpperCase();
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -636,6 +636,7 @@ public class PathHeader implements Comparable<PathHeader> {
         static final Relation<SectionPage, String> sectionPageToPaths =
                 Relation.of(new TreeMap<>(), HashSet.class);
         private static CLDRFile englishFile;
+        private static NameGetter englishNameGetter;
         private final Set<String> matchersFound = new HashSet<>();
 
         /**
@@ -656,6 +657,7 @@ public class PathHeader implements Comparable<PathHeader> {
             synchronized (Factory.class) {
                 if (englishFile == null) {
                     englishFile = englishFile2;
+                    englishNameGetter = englishFile.nameGetter();
                 }
             }
         }
@@ -1416,9 +1418,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                 languageOnlyPart = source0;
                             }
 
-                            return englishFile
-                                            .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
+                            return englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.LANGUAGE_NAME, languageOnlyPart)
                                     + " \u25BA "
                                     + source0;
                         }
@@ -1434,7 +1435,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                 script = likelySubtags.getLikelyScript(language);
                             }
                             String scriptName =
-                                    englishFile.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+                                    englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.SCRIPT_NAME, script);
                             return "Languages in "
                                     + (script.equals("Hans") || script.equals("Hant")
                                             ? "Han Script"
@@ -1452,9 +1454,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                     String territory = getSubdivisionsTerritory(source, null);
                                     String container = Containment.getContainer(territory);
                                     order = Containment.getOrder(territory);
-                                    return englishFile
-                                            .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, container);
+                                    return englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, container);
                                 }
                             });
             functionMap.put(
@@ -1488,20 +1489,16 @@ public class PathHeader implements Comparable<PathHeader> {
                                                     : "003"; // was Integer.valueOf(subcontinent) ==
                                     // 5
                                     return "Territories ("
-                                            + englishFile
-                                                    .nameGetter()
-                                                    .getNameFromTypenumCode(
-                                                            CLDRFile.TERRITORY_NAME,
-                                                            theSubContinent)
+                                            + englishNameGetter.getNameFromTypenumCode(
+                                                    CLDRFile.TERRITORY_NAME, theSubContinent)
                                             + ")";
                                 case "001":
                                 case "ZZ":
                                     return "Geographic Regions"; // not in containment
                                 default:
                                     return "Territories ("
-                                            + englishFile
-                                                    .nameGetter()
-                                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theContinent)
+                                            + englishNameGetter.getNameFromTypenumCode(
+                                                    CLDRFile.TERRITORY_NAME, theContinent)
                                             + ")";
                             }
                         }
@@ -1542,9 +1539,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                 }
                             }
                             if (singlePageTerritories.contains(theTerritory)) {
-                                return englishFile
-                                        .nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theTerritory);
+                                return englishNameGetter.getNameFromTypenumCode(
+                                        CLDRFile.TERRITORY_NAME, theTerritory);
                             }
                             String theContinent = Containment.getContinent(theTerritory);
                             final String subcontinent = Containment.getSubcontinent(theTerritory);
@@ -1560,24 +1556,20 @@ public class PathHeader implements Comparable<PathHeader> {
                                     } catch (NumberFormatException ex) {
                                         theSubContinent = "009";
                                     }
-                                    return englishFile
-                                            .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theSubContinent);
+                                    return englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 19: // Americas - For the timeZonePage, we just group North
                                     // America & South America
                                     theSubContinent =
                                             Integer.parseInt(subcontinent) == 5 ? "005" : "003";
-                                    return englishFile
-                                            .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theSubContinent);
+                                    return englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 142: // Asia
-                                    return englishFile
-                                            .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, subcontinent);
+                                    return englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, subcontinent);
                                 default:
-                                    return englishFile
-                                            .nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theContinent);
+                                    return englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, theContinent);
                             }
                         }
                     });
@@ -1675,9 +1667,8 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (PathHeader.UNIFORM_CONTINENTS) {
                                 String container = getMetazonePageTerritory(source);
                                 order = Containment.getOrder(container);
-                                return englishFile
-                                        .nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, container);
+                                return englishNameGetter.getNameFromTypenumCode(
+                                        CLDRFile.TERRITORY_NAME, container);
                             } else {
                                 String continent = metazoneToContinent.get(source);
                                 if (continent == null) {
@@ -1787,17 +1778,15 @@ public class PathHeader implements Comparable<PathHeader> {
 
                             if (territory.equals("ZZ")) {
                                 order = 999;
-                                return englishFile
-                                                .nameGetter()
-                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                                return englishNameGetter.getNameFromTypenumCode(
+                                                CLDRFile.TERRITORY_NAME, territory)
                                         + ": "
                                         + source0;
                             } else {
                                 return catFromTerritory.transform(territory)
                                         + ": "
-                                        + englishFile
-                                                .nameGetter()
-                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                                        + englishNameGetter.getNameFromTypenumCode(
+                                                CLDRFile.TERRITORY_NAME, territory)
                                         + tenderOrNot;
                             }
                         }
@@ -1819,9 +1808,8 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (territory.equals("ZZ")) {
                                 order = 999;
                                 subContinent =
-                                        englishFile
-                                                .nameGetter()
-                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                                        englishNameGetter.getNameFromTypenumCode(
+                                                CLDRFile.TERRITORY_NAME, territory);
                             } else {
                                 subContinent = catFromTerritory.transform(territory);
                             }
@@ -2212,7 +2200,8 @@ public class PathHeader implements Comparable<PathHeader> {
                 languageOnlyPart = s;
             }
             final String name =
-                    englishFile.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
+                    englishNameGetter.getNameFromTypenumCode(
+                            CLDRFile.LANGUAGE_NAME, languageOnlyPart);
             return name == null ? "?" : name.substring(0, 1).toUpperCase();
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1418,7 +1418,7 @@ public class PathHeader implements Comparable<PathHeader> {
 
                             return englishFile
                                             .nameGetter()
-                                            .getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
+                                            .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
                                     + " \u25BA "
                                     + source0;
                         }
@@ -1434,7 +1434,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 script = likelySubtags.getLikelyScript(language);
                             }
                             String scriptName =
-                                    englishFile.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+                                    englishFile.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
                             return "Languages in "
                                     + (script.equals("Hans") || script.equals("Hant")
                                             ? "Han Script"
@@ -1454,7 +1454,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                     order = Containment.getOrder(territory);
                                     return englishFile
                                             .nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, container);
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, container);
                                 }
                             });
             functionMap.put(
@@ -1490,7 +1490,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                     return "Territories ("
                                             + englishFile
                                                     .nameGetter()
-                                                    .getName(
+                                                    .getNameFromTypenumCode(
                                                             CLDRFile.TERRITORY_NAME,
                                                             theSubContinent)
                                             + ")";
@@ -1501,7 +1501,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                     return "Territories ("
                                             + englishFile
                                                     .nameGetter()
-                                                    .getName(CLDRFile.TERRITORY_NAME, theContinent)
+                                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theContinent)
                                             + ")";
                             }
                         }
@@ -1544,7 +1544,7 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (singlePageTerritories.contains(theTerritory)) {
                                 return englishFile
                                         .nameGetter()
-                                        .getName(CLDRFile.TERRITORY_NAME, theTerritory);
+                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theTerritory);
                             }
                             String theContinent = Containment.getContinent(theTerritory);
                             final String subcontinent = Containment.getSubcontinent(theTerritory);
@@ -1562,22 +1562,22 @@ public class PathHeader implements Comparable<PathHeader> {
                                     }
                                     return englishFile
                                             .nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, theSubContinent);
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 19: // Americas - For the timeZonePage, we just group North
                                     // America & South America
                                     theSubContinent =
                                             Integer.parseInt(subcontinent) == 5 ? "005" : "003";
                                     return englishFile
                                             .nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, theSubContinent);
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 142: // Asia
                                     return englishFile
                                             .nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, subcontinent);
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, subcontinent);
                                 default:
                                     return englishFile
                                             .nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, theContinent);
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, theContinent);
                             }
                         }
                     });
@@ -1677,7 +1677,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 order = Containment.getOrder(container);
                                 return englishFile
                                         .nameGetter()
-                                        .getName(CLDRFile.TERRITORY_NAME, container);
+                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, container);
                             } else {
                                 String continent = metazoneToContinent.get(source);
                                 if (continent == null) {
@@ -1789,7 +1789,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 order = 999;
                                 return englishFile
                                                 .nameGetter()
-                                                .getName(CLDRFile.TERRITORY_NAME, territory)
+                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                                         + ": "
                                         + source0;
                             } else {
@@ -1797,7 +1797,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                         + ": "
                                         + englishFile
                                                 .nameGetter()
-                                                .getName(CLDRFile.TERRITORY_NAME, territory)
+                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                                         + tenderOrNot;
                             }
                         }
@@ -1821,7 +1821,7 @@ public class PathHeader implements Comparable<PathHeader> {
                                 subContinent =
                                         englishFile
                                                 .nameGetter()
-                                                .getName(CLDRFile.TERRITORY_NAME, territory);
+                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
                             } else {
                                 subContinent = catFromTerritory.transform(territory);
                             }
@@ -2212,7 +2212,7 @@ public class PathHeader implements Comparable<PathHeader> {
                 languageOnlyPart = s;
             }
             final String name =
-                    englishFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
+                    englishFile.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
             return name == null ? "?" : name.substring(0, 1).toUpperCase();
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1416,7 +1416,9 @@ public class PathHeader implements Comparable<PathHeader> {
                                 languageOnlyPart = source0;
                             }
 
-                            return englishFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
+                            return englishFile
+                                            .nameGetter()
+                                            .getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart)
                                     + " \u25BA "
                                     + source0;
                         }
@@ -1431,7 +1433,8 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (script == null) {
                                 script = likelySubtags.getLikelyScript(language);
                             }
-                            String scriptName = englishFile.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
+                            String scriptName =
+                                    englishFile.nameGetter().getName(CLDRFile.SCRIPT_NAME, script);
                             return "Languages in "
                                     + (script.equals("Hans") || script.equals("Hant")
                                             ? "Han Script"
@@ -1449,7 +1452,9 @@ public class PathHeader implements Comparable<PathHeader> {
                                     String territory = getSubdivisionsTerritory(source, null);
                                     String container = Containment.getContainer(territory);
                                     order = Containment.getOrder(territory);
-                                    return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, container);
+                                    return englishFile
+                                            .nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, container);
                                 }
                             });
             functionMap.put(
@@ -1483,16 +1488,20 @@ public class PathHeader implements Comparable<PathHeader> {
                                                     : "003"; // was Integer.valueOf(subcontinent) ==
                                     // 5
                                     return "Territories ("
-                                            + englishFile.nameGetter().getName(
-                                                    CLDRFile.TERRITORY_NAME, theSubContinent)
+                                            + englishFile
+                                                    .nameGetter()
+                                                    .getName(
+                                                            CLDRFile.TERRITORY_NAME,
+                                                            theSubContinent)
                                             + ")";
                                 case "001":
                                 case "ZZ":
                                     return "Geographic Regions"; // not in containment
                                 default:
                                     return "Territories ("
-                                            + englishFile.nameGetter().getName(
-                                                    CLDRFile.TERRITORY_NAME, theContinent)
+                                            + englishFile
+                                                    .nameGetter()
+                                                    .getName(CLDRFile.TERRITORY_NAME, theContinent)
                                             + ")";
                             }
                         }
@@ -1533,7 +1542,9 @@ public class PathHeader implements Comparable<PathHeader> {
                                 }
                             }
                             if (singlePageTerritories.contains(theTerritory)) {
-                                return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, theTerritory);
+                                return englishFile
+                                        .nameGetter()
+                                        .getName(CLDRFile.TERRITORY_NAME, theTerritory);
                             }
                             String theContinent = Containment.getContinent(theTerritory);
                             final String subcontinent = Containment.getSubcontinent(theTerritory);
@@ -1549,20 +1560,24 @@ public class PathHeader implements Comparable<PathHeader> {
                                     } catch (NumberFormatException ex) {
                                         theSubContinent = "009";
                                     }
-                                    return englishFile.nameGetter().getName(
-                                            CLDRFile.TERRITORY_NAME, theSubContinent);
+                                    return englishFile
+                                            .nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 19: // Americas - For the timeZonePage, we just group North
                                     // America & South America
                                     theSubContinent =
                                             Integer.parseInt(subcontinent) == 5 ? "005" : "003";
-                                    return englishFile.nameGetter().getName(
-                                            CLDRFile.TERRITORY_NAME, theSubContinent);
+                                    return englishFile
+                                            .nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, theSubContinent);
                                 case 142: // Asia
-                                    return englishFile.nameGetter().getName(
-                                            CLDRFile.TERRITORY_NAME, subcontinent);
+                                    return englishFile
+                                            .nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, subcontinent);
                                 default:
-                                    return englishFile.nameGetter().getName(
-                                            CLDRFile.TERRITORY_NAME, theContinent);
+                                    return englishFile
+                                            .nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, theContinent);
                             }
                         }
                     });
@@ -1660,7 +1675,9 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (PathHeader.UNIFORM_CONTINENTS) {
                                 String container = getMetazonePageTerritory(source);
                                 order = Containment.getOrder(container);
-                                return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, container);
+                                return englishFile
+                                        .nameGetter()
+                                        .getName(CLDRFile.TERRITORY_NAME, container);
                             } else {
                                 String continent = metazoneToContinent.get(source);
                                 if (continent == null) {
@@ -1770,13 +1787,17 @@ public class PathHeader implements Comparable<PathHeader> {
 
                             if (territory.equals("ZZ")) {
                                 order = 999;
-                                return englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
+                                return englishFile
+                                                .nameGetter()
+                                                .getName(CLDRFile.TERRITORY_NAME, territory)
                                         + ": "
                                         + source0;
                             } else {
                                 return catFromTerritory.transform(territory)
                                         + ": "
-                                        + englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
+                                        + englishFile
+                                                .nameGetter()
+                                                .getName(CLDRFile.TERRITORY_NAME, territory)
                                         + tenderOrNot;
                             }
                         }
@@ -1798,7 +1819,9 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (territory.equals("ZZ")) {
                                 order = 999;
                                 subContinent =
-                                        englishFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                                        englishFile
+                                                .nameGetter()
+                                                .getName(CLDRFile.TERRITORY_NAME, territory);
                             } else {
                                 subContinent = catFromTerritory.transform(territory);
                             }
@@ -2188,7 +2211,8 @@ public class PathHeader implements Comparable<PathHeader> {
             } else {
                 languageOnlyPart = s;
             }
-            final String name = englishFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
+            final String name =
+                    englishFile.nameGetter().getName(CLDRFile.LANGUAGE_NAME, languageOnlyPart);
             return name == null ? "?" : name.substring(0, 1).toUpperCase();
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
@@ -334,7 +334,7 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
                     // }
                     Map<String, String> fullLocales = new TreeMap<>();
                     for (String localeId : locales) {
-                        String name = english.getName(localeId);
+                        String name = english.nameGetter().getName(localeId);
                         fullLocales.put(name, localeId);
                     }
                     out.print(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
@@ -334,7 +334,7 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
                     // }
                     Map<String, String> fullLocales = new TreeMap<>();
                     for (String localeId : locales) {
-                        String name = english.nameGetter().getNameFromLocaleOrTZID(localeId);
+                        String name = english.nameGetter().getNameFromBCP47(localeId);
                         fullLocales.put(name, localeId);
                     }
                     out.print(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
@@ -334,7 +334,7 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
                     // }
                     Map<String, String> fullLocales = new TreeMap<>();
                     for (String localeId : locales) {
-                        String name = english.nameGetter().getName(localeId);
+                        String name = english.nameGetter().getNameFromLocaleOrTZID(localeId);
                         fullLocales.put(name, localeId);
                     }
                     out.print(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -128,7 +128,7 @@ public class TestUtilities {
             "zh_Hans_US_SAAHO"
         };
         for (String test : tests) {
-            System.out.println(test + "\t" + english.getName(test) + "\t" + french.getName(test));
+            System.out.println(test + "\t" + english.nameGetter().getName(test) + "\t" + french.nameGetter().getName(test));
         }
     }
 
@@ -1016,18 +1016,18 @@ public class TestUtilities {
         for (Iterator<String> it = sc.getGoodAvailableCodes("language").iterator();
                 it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.getName(CLDRFile.LANGUAGE_NAME, code));
+            out.println(code + "\t" + english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("territory").iterator();
                 it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.getName(CLDRFile.TERRITORY_NAME, code));
+            out.println(code + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("script").iterator(); it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.getName(CLDRFile.SCRIPT_NAME, code));
+            out.println(code + "\t" + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, code));
         }
         out.close();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -131,9 +131,9 @@ public class TestUtilities {
             System.out.println(
                     test
                             + "\t"
-                            + english.nameGetter().getName(test)
+                            + english.nameGetter().getNameFromLocaleOrTZID(test)
                             + "\t"
-                            + french.nameGetter().getName(test));
+                            + french.nameGetter().getNameFromLocaleOrTZID(test));
         }
     }
 
@@ -1021,18 +1021,18 @@ public class TestUtilities {
         for (Iterator<String> it = sc.getGoodAvailableCodes("language").iterator();
                 it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.nameGetter().getName(CLDRFile.LANGUAGE_NAME, code));
+            out.println(code + "\t" + english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("territory").iterator();
                 it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, code));
+            out.println(code + "\t" + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("script").iterator(); it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, code));
+            out.println(code + "\t" + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code));
         }
         out.close();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -128,7 +128,12 @@ public class TestUtilities {
             "zh_Hans_US_SAAHO"
         };
         for (String test : tests) {
-            System.out.println(test + "\t" + english.nameGetter().getName(test) + "\t" + french.nameGetter().getName(test));
+            System.out.println(
+                    test
+                            + "\t"
+                            + english.nameGetter().getName(test)
+                            + "\t"
+                            + french.nameGetter().getName(test));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -131,9 +131,9 @@ public class TestUtilities {
             System.out.println(
                     test
                             + "\t"
-                            + english.nameGetter().getNameFromLocaleOrTZID(test)
+                            + english.nameGetter().getNameFromBCP47(test)
                             + "\t"
-                            + french.nameGetter().getNameFromLocaleOrTZID(test));
+                            + french.nameGetter().getNameFromBCP47(test));
         }
     }
 
@@ -1021,18 +1021,30 @@ public class TestUtilities {
         for (Iterator<String> it = sc.getGoodAvailableCodes("language").iterator();
                 it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code));
+            out.println(
+                    code
+                            + "\t"
+                            + english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("territory").iterator();
                 it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code));
+            out.println(
+                    code
+                            + "\t"
+                            + english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("script").iterator(); it.hasNext(); ) {
             String code = it.next();
-            out.println(code + "\t" + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code));
+            out.println(
+                    code
+                            + "\t"
+                            + english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code));
         }
         out.close();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -1015,6 +1015,7 @@ public class TestUtilities {
         Factory mainCldrFactory =
                 Factory.make(CLDRPaths.COMMON_DIRECTORY + "main" + File.separator, ".*");
         CLDRFile english = mainCldrFactory.make("en", true);
+        NameGetter englishNameGetter = english.nameGetter();
         PrintWriter out =
                 FileUtilities.openUTF8Writer(CLDRPaths.GEN_DIRECTORY, "country_language_names.txt");
         StandardCodes sc = StandardCodes.make();
@@ -1024,8 +1025,8 @@ public class TestUtilities {
             out.println(
                     code
                             + "\t"
-                            + english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code));
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.LANGUAGE_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("territory").iterator();
@@ -1034,8 +1035,8 @@ public class TestUtilities {
             out.println(
                     code
                             + "\t"
-                            + english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code));
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.TERRITORY_NAME, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("script").iterator(); it.hasNext(); ) {
@@ -1043,8 +1044,7 @@ public class TestUtilities {
             out.println(
                     code
                             + "\t"
-                            + english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code));
+                            + englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code));
         }
         out.close();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -214,7 +214,7 @@ public class TimezoneFormatter extends UFormat {
 
     private String getName(int territory_name, String country, boolean skipDraft2) {
         checkForDraft(CLDRFile.getKey(territory_name, country));
-        return desiredLocaleFile.getName(territory_name, country);
+        return desiredLocaleFile.nameGetter().getName(territory_name, country);
     }
 
     private void checkForDraft(String cleanPath) {
@@ -613,7 +613,7 @@ public class TimezoneFormatter extends UFormat {
     }
 
     private String getLocalizedCountryName(String zoneIdsCountry) {
-        String countryName = desiredLocaleFile.getName(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
+        String countryName = desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
         if (countryName == null) {
             countryName = zoneIdsCountry;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -613,7 +613,8 @@ public class TimezoneFormatter extends UFormat {
     }
 
     private String getLocalizedCountryName(String zoneIdsCountry) {
-        String countryName = desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
+        String countryName =
+                desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
         if (countryName == null) {
             countryName = zoneIdsCountry;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -214,7 +214,7 @@ public class TimezoneFormatter extends UFormat {
 
     private String getName(int territory_name, String country, boolean skipDraft2) {
         checkForDraft(CLDRFile.getKey(territory_name, country));
-        return desiredLocaleFile.nameGetter().getName(territory_name, country);
+        return desiredLocaleFile.nameGetter().getNameFromTypenumCode(territory_name, country);
     }
 
     private void checkForDraft(String cleanPath) {
@@ -614,7 +614,7 @@ public class TimezoneFormatter extends UFormat {
 
     private String getLocalizedCountryName(String zoneIdsCountry) {
         String countryName =
-                desiredLocaleFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
+                desiredLocaleFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
         if (countryName == null) {
             countryName = zoneIdsCountry;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -614,7 +614,9 @@ public class TimezoneFormatter extends UFormat {
 
     private String getLocalizedCountryName(String zoneIdsCountry) {
         String countryName =
-                desiredLocaleFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
+                desiredLocaleFile
+                        .nameGetter()
+                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
         if (countryName == null) {
             countryName = zoneIdsCountry;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -116,7 +116,9 @@ public class VerifyCompactNumbers {
             }
 
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, locale + ".html");
-            String title = "Verify Number Formats: " + englishCldrFile.nameGetter().getNameFromLocaleOrTZID(locale);
+            String title =
+                    "Verify Number Formats: "
+                            + englishCldrFile.nameGetter().getNameFromBCP47(locale);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -135,7 +137,7 @@ public class VerifyCompactNumbers {
 
             out.println("</body></html>");
             out.close();
-            indexMap.put(english.nameGetter().getNameFromLocaleOrTZID(locale), locale + ".html");
+            indexMap.put(english.nameGetter().getNameFromBCP47(locale), locale + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Numbers")) {
             DateTimeFormats.writeIndexMap(indexMap, index);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -116,7 +116,7 @@ public class VerifyCompactNumbers {
             }
 
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, locale + ".html");
-            String title = "Verify Number Formats: " + englishCldrFile.nameGetter().getName(locale);
+            String title = "Verify Number Formats: " + englishCldrFile.nameGetter().getNameFromLocaleOrTZID(locale);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -135,7 +135,7 @@ public class VerifyCompactNumbers {
 
             out.println("</body></html>");
             out.close();
-            indexMap.put(english.nameGetter().getName(locale), locale + ".html");
+            indexMap.put(english.nameGetter().getNameFromLocaleOrTZID(locale), locale + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Numbers")) {
             DateTimeFormats.writeIndexMap(indexMap, index);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -116,7 +116,7 @@ public class VerifyCompactNumbers {
             }
 
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, locale + ".html");
-            String title = "Verify Number Formats: " + englishCldrFile.getName(locale);
+            String title = "Verify Number Formats: " + englishCldrFile.nameGetter().getName(locale);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -135,7 +135,7 @@ public class VerifyCompactNumbers {
 
             out.println("</body></html>");
             out.close();
-            indexMap.put(english.getName(locale), locale + ".html");
+            indexMap.put(english.nameGetter().getName(locale), locale + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Numbers")) {
             DateTimeFormats.writeIndexMap(indexMap, index);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -272,7 +272,7 @@ public class VerifyZones {
             }
             CLDRFile cldrFile = factory2.make(localeID, true);
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, localeID + ".html");
-            String title = "Verify Time Zones: " + englishCldrFile.nameGetter().getName(localeID);
+            String title = "Verify Time Zones: " + englishCldrFile.nameGetter().getNameFromLocaleOrTZID(localeID);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -290,7 +290,7 @@ public class VerifyZones {
             out.println("</body></html>");
             out.close();
 
-            indexMap.put(english.nameGetter().getName(localeID), localeID + ".html");
+            indexMap.put(english.nameGetter().getNameFromLocaleOrTZID(localeID), localeID + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Time Zones")) {
             DateTimeFormats.writeIndexMap(indexMap, index);
@@ -453,7 +453,7 @@ public class VerifyZones {
             TimeZone currentZone = TimeZone.getTimeZone(tzid);
             TimeZone tz = currentZone;
             String englishGrouping =
-                    englishCldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, grouping);
+                    englishCldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, grouping);
 
             String metazoneInfo =
                     englishGrouping
@@ -469,7 +469,7 @@ public class VerifyZones {
                 continue;
             }
             String englishTerritory =
-                    englishCldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode2);
+                    englishCldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode2);
             output.addRow()
                     .addCell(metazoneInfo)
                     .addCell(englishTerritory + ": " + tzid.replace("/", "/\u200B"));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -272,7 +272,7 @@ public class VerifyZones {
             }
             CLDRFile cldrFile = factory2.make(localeID, true);
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, localeID + ".html");
-            String title = "Verify Time Zones: " + englishCldrFile.getName(localeID);
+            String title = "Verify Time Zones: " + englishCldrFile.nameGetter().getName(localeID);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -290,7 +290,7 @@ public class VerifyZones {
             out.println("</body></html>");
             out.close();
 
-            indexMap.put(english.getName(localeID), localeID + ".html");
+            indexMap.put(english.nameGetter().getName(localeID), localeID + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Time Zones")) {
             DateTimeFormats.writeIndexMap(indexMap, index);
@@ -452,7 +452,7 @@ public class VerifyZones {
             String grouping = row.getContainer();
             TimeZone currentZone = TimeZone.getTimeZone(tzid);
             TimeZone tz = currentZone;
-            String englishGrouping = englishCldrFile.getName(CLDRFile.TERRITORY_NAME, grouping);
+            String englishGrouping = englishCldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, grouping);
 
             String metazoneInfo =
                     englishGrouping
@@ -468,7 +468,7 @@ public class VerifyZones {
                 continue;
             }
             String englishTerritory =
-                    englishCldrFile.getName(CLDRFile.TERRITORY_NAME, countryCode2);
+                    englishCldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, countryCode2);
             output.addRow()
                     .addCell(metazoneInfo)
                     .addCell(englishTerritory + ": " + tzid.replace("/", "/\u200B"));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -272,7 +272,8 @@ public class VerifyZones {
             }
             CLDRFile cldrFile = factory2.make(localeID, true);
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, localeID + ".html");
-            String title = "Verify Time Zones: " + englishCldrFile.nameGetter().getNameFromLocaleOrTZID(localeID);
+            String title =
+                    "Verify Time Zones: " + englishCldrFile.nameGetter().getNameFromBCP47(localeID);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -290,7 +291,7 @@ public class VerifyZones {
             out.println("</body></html>");
             out.close();
 
-            indexMap.put(english.nameGetter().getNameFromLocaleOrTZID(localeID), localeID + ".html");
+            indexMap.put(english.nameGetter().getNameFromBCP47(localeID), localeID + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Time Zones")) {
             DateTimeFormats.writeIndexMap(indexMap, index);
@@ -453,7 +454,9 @@ public class VerifyZones {
             TimeZone currentZone = TimeZone.getTimeZone(tzid);
             TimeZone tz = currentZone;
             String englishGrouping =
-                    englishCldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, grouping);
+                    englishCldrFile
+                            .nameGetter()
+                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, grouping);
 
             String metazoneInfo =
                     englishGrouping
@@ -469,7 +472,9 @@ public class VerifyZones {
                 continue;
             }
             String englishTerritory =
-                    englishCldrFile.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode2);
+                    englishCldrFile
+                            .nameGetter()
+                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode2);
             output.addRow()
                     .addCell(metazoneInfo)
                     .addCell(englishTerritory + ": " + tzid.replace("/", "/\u200B"));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -452,7 +452,8 @@ public class VerifyZones {
             String grouping = row.getContainer();
             TimeZone currentZone = TimeZone.getTimeZone(tzid);
             TimeZone tz = currentZone;
-            String englishGrouping = englishCldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, grouping);
+            String englishGrouping =
+                    englishCldrFile.nameGetter().getName(CLDRFile.TERRITORY_NAME, grouping);
 
             String metazoneInfo =
                     englishGrouping

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1335,7 +1335,7 @@ public class VettingViewer<T> {
     private String getName(String localeID) {
         Set<String> contents = supplementalDataInfo.getEquivalentsForLocale(localeID);
         // put in special character that can be split on later
-        return englishFile.getName(localeID, true, CLDRFile.SHORT_ALTS)
+        return englishFile.nameGetter().getName(localeID, true, CLDRFile.SHORT_ALTS)
                 + SPLIT_CHAR
                 + gatherCodes(contents);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1335,7 +1335,7 @@ public class VettingViewer<T> {
     private String getName(String localeID) {
         Set<String> contents = supplementalDataInfo.getEquivalentsForLocale(localeID);
         // put in special character that can be split on later
-        return englishFile.nameGetter().getName(localeID, true, CLDRFile.SHORT_ALTS)
+        return englishFile.nameGetter().getNameFromLocaleOrTZBoolAltpicker(localeID, true, CLDRFile.SHORT_ALTS)
                 + SPLIT_CHAR
                 + gatherCodes(contents);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1335,7 +1335,7 @@ public class VettingViewer<T> {
     private String getName(String localeID) {
         Set<String> contents = supplementalDataInfo.getEquivalentsForLocale(localeID);
         // put in special character that can be split on later
-        return englishFile.nameGetter().getNameFromLocaleOrTZBoolAltpicker(localeID, true, CLDRFile.SHORT_ALTS)
+        return englishFile.nameGetter().getNameFromBCP47BoolAlt(localeID, true, CLDRFile.SHORT_ALTS)
                 + SPLIT_CHAR
                 + gatherCodes(contents);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -299,7 +299,10 @@ public class WikipediaOfficialLanguages {
                         sInfo == null ? OfficialStatus.unknown : sInfo.getOfficialStatus();
                 if (!areCompatible(info.status, cldrStatus)) {
                     System.out.print(
-                            region + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
+                            region
+                                    + "\t"
+                                    + english.nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, region));
 
                     System.out.println(
                             "\t"
@@ -322,7 +325,10 @@ public class WikipediaOfficialLanguages {
                     OfficialStatus officialStatus = sInfo.getOfficialStatus();
                     if (OfficialStatus.unknown != officialStatus) {
                         System.out.print(
-                                region + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
+                                region
+                                        + "\t"
+                                        + english.nameGetter()
+                                                .getName(CLDRFile.TERRITORY_NAME, region));
 
                         System.out.println(
                                 "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -302,13 +302,13 @@ public class WikipediaOfficialLanguages {
                             region
                                     + "\t"
                                     + english.nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, region));
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
 
                     System.out.println(
                             "\t"
                                     + info.language
                                     + "\t"
-                                    + english.nameGetter().getName(info.language)
+                                    + english.nameGetter().getNameFromLocaleOrTZID(info.language)
                                     + "\t"
                                     + info.status
                                     + "\t"
@@ -328,13 +328,13 @@ public class WikipediaOfficialLanguages {
                                 region
                                         + "\t"
                                         + english.nameGetter()
-                                                .getName(CLDRFile.TERRITORY_NAME, region));
+                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
 
                         System.out.println(
                                 "\t"
                                         + r2
                                         + "\t"
-                                        + english.nameGetter().getName(r2)
+                                        + english.nameGetter().getNameFromLocaleOrTZID(r2)
                                         + "\t"
                                         + "CLDR-ONLY"
                                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -299,13 +299,13 @@ public class WikipediaOfficialLanguages {
                         sInfo == null ? OfficialStatus.unknown : sInfo.getOfficialStatus();
                 if (!areCompatible(info.status, cldrStatus)) {
                     System.out.print(
-                            region + "\t" + english.getName(CLDRFile.TERRITORY_NAME, region));
+                            region + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
 
                     System.out.println(
                             "\t"
                                     + info.language
                                     + "\t"
-                                    + english.getName(info.language)
+                                    + english.nameGetter().getName(info.language)
                                     + "\t"
                                     + info.status
                                     + "\t"
@@ -322,13 +322,13 @@ public class WikipediaOfficialLanguages {
                     OfficialStatus officialStatus = sInfo.getOfficialStatus();
                     if (OfficialStatus.unknown != officialStatus) {
                         System.out.print(
-                                region + "\t" + english.getName(CLDRFile.TERRITORY_NAME, region));
+                                region + "\t" + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
 
                         System.out.println(
                                 "\t"
                                         + r2
                                         + "\t"
-                                        + english.getName(r2)
+                                        + english.nameGetter().getName(r2)
                                         + "\t"
                                         + "CLDR-ONLY"
                                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -302,13 +302,14 @@ public class WikipediaOfficialLanguages {
                             region
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
+                                            .getNameFromTypenumCode(
+                                                    CLDRFile.TERRITORY_NAME, region));
 
                     System.out.println(
                             "\t"
                                     + info.language
                                     + "\t"
-                                    + english.nameGetter().getNameFromLocaleOrTZID(info.language)
+                                    + english.nameGetter().getNameFromBCP47(info.language)
                                     + "\t"
                                     + info.status
                                     + "\t"
@@ -328,13 +329,14 @@ public class WikipediaOfficialLanguages {
                                 region
                                         + "\t"
                                         + english.nameGetter()
-                                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
+                                                .getNameFromTypenumCode(
+                                                        CLDRFile.TERRITORY_NAME, region));
 
                         System.out.println(
                                 "\t"
                                         + r2
                                         + "\t"
-                                        + english.nameGetter().getNameFromLocaleOrTZID(r2)
+                                        + english.nameGetter().getNameFromBCP47(r2)
                                         + "\t"
                                         + "CLDR-ONLY"
                                         + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
@@ -159,7 +159,7 @@ public class CheckLanguageCodeConverter {
         if (goodCode.startsWith("x_")) {
             return "Private use: " + goodCode.substring(2);
         }
-        return english.nameGetter().getName(goodCode);
+        return english.nameGetter().getNameFromLocaleOrTZID(goodCode);
     }
 
     public static void printLine(LanguageLine entry) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
@@ -159,7 +159,7 @@ public class CheckLanguageCodeConverter {
         if (goodCode.startsWith("x_")) {
             return "Private use: " + goodCode.substring(2);
         }
-        return english.nameGetter().getNameFromLocaleOrTZID(goodCode);
+        return english.nameGetter().getNameFromBCP47(goodCode);
     }
 
     public static void printLine(LanguageLine entry) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
@@ -159,7 +159,7 @@ public class CheckLanguageCodeConverter {
         if (goodCode.startsWith("x_")) {
             return "Private use: " + goodCode.substring(2);
         }
-        return english.getName(goodCode);
+        return english.nameGetter().getName(goodCode);
     }
 
     public static void printLine(LanguageLine entry) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
@@ -291,7 +291,7 @@ public class CheckYear {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.getName(localeID, true), localeID);
+            sorted.put(englishFile.nameGetter().getName(localeID, true), localeID);
             data.put(localeID, new LocaleInfo());
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
@@ -291,7 +291,7 @@ public class CheckYear {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.nameGetter().getNameFromLocaleOrTZBool(localeID, true), localeID);
+            sorted.put(englishFile.nameGetter().getNameFromBCP47Bool(localeID, true), localeID);
             data.put(localeID, new LocaleInfo());
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
@@ -291,7 +291,7 @@ public class CheckYear {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.nameGetter().getName(localeID, true), localeID);
+            sorted.put(englishFile.nameGetter().getNameFromLocaleOrTZBool(localeID, true), localeID);
             data.put(localeID, new LocaleInfo());
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
@@ -85,7 +85,9 @@ public class LanguageInfoTest extends TestFmwk {
     public static String getName(String item) {
         return item.contains("*")
                 ? "n/a"
-                : item.contains("$") ? item : testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(item);
+                : item.contains("$")
+                        ? item
+                        : testInfo.getEnglish().nameGetter().getNameFromBCP47(item);
     }
 
     public static void main(String[] args) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
@@ -85,7 +85,7 @@ public class LanguageInfoTest extends TestFmwk {
     public static String getName(String item) {
         return item.contains("*")
                 ? "n/a"
-                : item.contains("$") ? item : testInfo.getEnglish().nameGetter().getName(item);
+                : item.contains("$") ? item : testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(item);
     }
 
     public static void main(String[] args) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
@@ -85,7 +85,7 @@ public class LanguageInfoTest extends TestFmwk {
     public static String getName(String item) {
         return item.contains("*")
                 ? "n/a"
-                : item.contains("$") ? item : testInfo.getEnglish().getName(item);
+                : item.contains("$") ? item : testInfo.getEnglish().nameGetter().getName(item);
     }
 
     public static void main(String[] args) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -236,7 +236,7 @@ public class LanguageTest extends TestFmwk {
                         ? "?"
                         : testInfo.getEnglish()
                                 .nameGetter()
-                                .getName(CLDRFile.TERRITORY_NAME, parser.getRegion()));
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, parser.getRegion()));
     }
 
     Set<String> getUnicodeScripts() {
@@ -259,7 +259,7 @@ public class LanguageTest extends TestFmwk {
     }
 
     private String getScriptName(String script) {
-        String name = testInfo.getEnglish().nameGetter().getName("script", script);
+        String name = testInfo.getEnglish().nameGetter().getNameFromTypestrCode("script", script);
         if (name != null && !name.equals(script)) {
             return name;
         }
@@ -278,7 +278,7 @@ public class LanguageTest extends TestFmwk {
     }
 
     private String getLanguageName(String language) {
-        String name = testInfo.getEnglish().nameGetter().getName("language", language);
+        String name = testInfo.getEnglish().nameGetter().getNameFromTypestrCode("language", language);
         if (name != null && !name.equals(language)) {
             return name;
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -234,8 +234,8 @@ public class LanguageTest extends TestFmwk {
                 + "; "
                 + (parser.getRegion().isEmpty()
                         ? "?"
-                        : testInfo.getEnglish()
-                                .getName(CLDRFile.TERRITORY_NAME, parser.getRegion()));
+                        : testInfo.getEnglish().
+                                nameGetter().getName(CLDRFile.TERRITORY_NAME, parser.getRegion()));
     }
 
     Set<String> getUnicodeScripts() {
@@ -258,7 +258,7 @@ public class LanguageTest extends TestFmwk {
     }
 
     private String getScriptName(String script) {
-        String name = testInfo.getEnglish().getName("script", script);
+        String name = testInfo.getEnglish().nameGetter().getName("script", script);
         if (name != null && !name.equals(script)) {
             return name;
         }
@@ -277,7 +277,7 @@ public class LanguageTest extends TestFmwk {
     }
 
     private String getLanguageName(String language) {
-        String name = testInfo.getEnglish().getName("language", language);
+        String name = testInfo.getEnglish().nameGetter().getName("language", language);
         if (name != null && !name.equals(language)) {
             return name;
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -234,8 +234,9 @@ public class LanguageTest extends TestFmwk {
                 + "; "
                 + (parser.getRegion().isEmpty()
                         ? "?"
-                        : testInfo.getEnglish().
-                                nameGetter().getName(CLDRFile.TERRITORY_NAME, parser.getRegion()));
+                        : testInfo.getEnglish()
+                                .nameGetter()
+                                .getName(CLDRFile.TERRITORY_NAME, parser.getRegion()));
     }
 
     Set<String> getUnicodeScripts() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -17,6 +17,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.Counter2;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData;
@@ -228,15 +229,15 @@ public class LanguageTest extends TestFmwk {
 
     private String getLocaleName(String input) {
         LanguageTagParser parser = new LanguageTagParser().set(input);
+        NameGetter nameGetter = testInfo.getEnglish().nameGetter();
         return (parser.getLanguage().isEmpty() ? "?" : getLanguageName(parser.getLanguage()))
                 + "; "
                 + (parser.getScript().isEmpty() ? "?" : getScriptName(parser.getScript()))
                 + "; "
                 + (parser.getRegion().isEmpty()
                         ? "?"
-                        : testInfo.getEnglish()
-                                .nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, parser.getRegion()));
+                        : nameGetter.getNameFromTypenumCode(
+                                CLDRFile.TERRITORY_NAME, parser.getRegion()));
     }
 
     Set<String> getUnicodeScripts() {
@@ -259,7 +260,8 @@ public class LanguageTest extends TestFmwk {
     }
 
     private String getScriptName(String script) {
-        String name = testInfo.getEnglish().nameGetter().getNameFromTypestrCode("script", script);
+        NameGetter nameGetter = testInfo.getEnglish().nameGetter();
+        String name = nameGetter.getNameFromTypestrCode("script", script);
         if (name != null && !name.equals(script)) {
             return name;
         }
@@ -278,7 +280,8 @@ public class LanguageTest extends TestFmwk {
     }
 
     private String getLanguageName(String language) {
-        String name = testInfo.getEnglish().nameGetter().getNameFromTypestrCode("language", language);
+        NameGetter nameGetter = testInfo.getEnglish().nameGetter();
+        String name = nameGetter.getNameFromTypestrCode("language", language);
         if (name != null && !name.equals(language)) {
             return name;
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -375,14 +375,16 @@ public class LikelySubtagsTest extends TestFmwk {
                                 "Missing likely subtags for region: "
                                         + region
                                         + "\t"
-                                        + english.nameGetter().getNameFromTypestrCode("territory", region));
+                                        + english.nameGetter()
+                                                .getNameFromTypestrCode("territory", region));
                     }
                 } else { // container
                     logln(
                             "Missing likely subtags for macroregion (fix to exclude regions having 'en'): "
                                     + region
                                     + "\t"
-                                    + english.nameGetter().getNameFromTypestrCode("territory", region));
+                                    + english.nameGetter()
+                                            .getNameFromTypestrCode("territory", region));
                 }
             } else {
                 logln("Likely subtags for region: " + region + ":\t " + likely);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -375,14 +375,14 @@ public class LikelySubtagsTest extends TestFmwk {
                                 "Missing likely subtags for region: "
                                         + region
                                         + "\t"
-                                        + english.nameGetter().getName("territory", region));
+                                        + english.nameGetter().getNameFromTypestrCode("territory", region));
                     }
                 } else { // container
                     logln(
                             "Missing likely subtags for macroregion (fix to exclude regions having 'en'): "
                                     + region
                                     + "\t"
-                                    + english.nameGetter().getName("territory", region));
+                                    + english.nameGetter().getNameFromTypestrCode("territory", region));
                 }
             } else {
                 logln("Likely subtags for region: " + region + ":\t " + likely);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -375,14 +375,14 @@ public class LikelySubtagsTest extends TestFmwk {
                                 "Missing likely subtags for region: "
                                         + region
                                         + "\t"
-                                        + english.getName("territory", region));
+                                        + english.nameGetter().getName("territory", region));
                     }
                 } else { // container
                     logln(
                             "Missing likely subtags for macroregion (fix to exclude regions having 'en'): "
                                     + region
                                     + "\t"
-                                    + english.getName("territory", region));
+                                    + english.nameGetter().getName("territory", region));
                 }
             } else {
                 logln("Likely subtags for region: " + region + ":\t " + likely);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LocaleMatcherTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LocaleMatcherTest.java
@@ -112,7 +112,7 @@ public class LocaleMatcherTest extends TestFmwk {
     // {
     //                continue;
     //            }
-    //            System.out.println(locale + "\t" + CONFIG.getEnglish().getName(locale) + "\t" +
+    //            System.out.println(locale + "\t" + CONFIG.getEnglish().nameGetter().getName(locale) + "\t" +
     // parentId + "\t" + parentIdSimple);
     //        }
     //    }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LocaleMatcherTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LocaleMatcherTest.java
@@ -112,7 +112,8 @@ public class LocaleMatcherTest extends TestFmwk {
     // {
     //                continue;
     //            }
-    //            System.out.println(locale + "\t" + CONFIG.getEnglish().nameGetter().getName(locale) + "\t" +
+    //            System.out.println(locale + "\t" +
+    // CONFIG.getEnglish().nameGetter().getName(locale) + "\t" +
     // parentId + "\t" + parentIdSimple);
     //        }
     //    }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -29,7 +29,10 @@ public class StandardCodesTest extends TestFmwk {
                 continue;
             }
             for (String locale : sc.getLocaleCoverageLocales(org)) {
-                String name = locale.equals("*") ? "ALL" : testInfo.getEnglish().nameGetter().getName(locale);
+                String name =
+                        locale.equals("*")
+                                ? "ALL"
+                                : testInfo.getEnglish().nameGetter().getName(locale);
                 logln(
                         org
                                 + "\t;\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -32,7 +32,7 @@ public class StandardCodesTest extends TestFmwk {
                 String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
+                                : testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
                 logln(
                         org
                                 + "\t;\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -32,7 +32,7 @@ public class StandardCodesTest extends TestFmwk {
                 String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : testInfo.getEnglish().nameGetter().getName(locale);
+                                : testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
                 logln(
                         org
                                 + "\t;\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -29,7 +29,7 @@ public class StandardCodesTest extends TestFmwk {
                 continue;
             }
             for (String locale : sc.getLocaleCoverageLocales(org)) {
-                String name = locale.equals("*") ? "ALL" : testInfo.getEnglish().getName(locale);
+                String name = locale.equals("*") ? "ALL" : testInfo.getEnglish().nameGetter().getName(locale);
                 logln(
                         org
                                 + "\t;\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -430,7 +430,9 @@ public class TestAttributeValues extends TestFmwk {
         logln(
                 language
                         + "\t"
-                        + config.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
+                        + config.getEnglish()
+                                .nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
                         + "\t"
                         + languageInfo);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -430,7 +430,7 @@ public class TestAttributeValues extends TestFmwk {
         logln(
                 language
                         + "\t"
-                        + config.getEnglish().getName(CLDRFile.LANGUAGE_NAME, language)
+                        + config.getEnglish().nameGetter().getName(CLDRFile.LANGUAGE_NAME, language)
                         + "\t"
                         + languageInfo);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -430,7 +430,7 @@ public class TestAttributeValues extends TestFmwk {
         logln(
                 language
                         + "\t"
-                        + config.getEnglish().nameGetter().getName(CLDRFile.LANGUAGE_NAME, language)
+                        + config.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
                         + "\t"
                         + languageInfo);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -543,7 +543,7 @@ public class TestBasic extends TestFmwkPlus {
         for (String locale : getInclusion() <= 5 ? eightPointLocales : cldrFactory.getAvailable()) {
             CLDRFile file = testInfo.getCLDRFile(locale, resolved);
             if (file.isNonInheriting()) continue;
-            logln(locale + "\t-\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getNameFromBCP47(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -619,7 +619,7 @@ public class TestBasic extends TestFmwkPlus {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            logln(locale + "\t-\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getNameFromBCP47(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -1124,7 +1124,7 @@ public class TestBasic extends TestFmwkPlus {
                     "Locale:"
                             + localeID
                             + " ("
-                            + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(localeID)
+                            + testInfo.getEnglish().nameGetter().getNameFromBCP47(localeID)
                             + ")";
 
             if (!collations.contains(localeID)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -543,7 +543,7 @@ public class TestBasic extends TestFmwkPlus {
         for (String locale : getInclusion() <= 5 ? eightPointLocales : cldrFactory.getAvailable()) {
             CLDRFile file = testInfo.getCLDRFile(locale, resolved);
             if (file.isNonInheriting()) continue;
-            logln(locale + "\t-\t" + english.getName(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getName(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -619,7 +619,7 @@ public class TestBasic extends TestFmwkPlus {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            logln(locale + "\t-\t" + english.getName(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getName(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -1121,7 +1121,7 @@ public class TestBasic extends TestFmwkPlus {
             warnings.clear();
 
             String name =
-                    "Locale:" + localeID + " (" + testInfo.getEnglish().getName(localeID) + ")";
+                    "Locale:" + localeID + " (" + testInfo.getEnglish().nameGetter().getName(localeID) + ")";
 
             if (!collations.contains(localeID)) {
                 warnings.put(MissingType.collation, "missing");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -1121,7 +1121,11 @@ public class TestBasic extends TestFmwkPlus {
             warnings.clear();
 
             String name =
-                    "Locale:" + localeID + " (" + testInfo.getEnglish().nameGetter().getName(localeID) + ")";
+                    "Locale:"
+                            + localeID
+                            + " ("
+                            + testInfo.getEnglish().nameGetter().getName(localeID)
+                            + ")";
 
             if (!collations.contains(localeID)) {
                 warnings.put(MissingType.collation, "missing");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -543,7 +543,7 @@ public class TestBasic extends TestFmwkPlus {
         for (String locale : getInclusion() <= 5 ? eightPointLocales : cldrFactory.getAvailable()) {
             CLDRFile file = testInfo.getCLDRFile(locale, resolved);
             if (file.isNonInheriting()) continue;
-            logln(locale + "\t-\t" + english.nameGetter().getName(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -619,7 +619,7 @@ public class TestBasic extends TestFmwkPlus {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            logln(locale + "\t-\t" + english.nameGetter().getName(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getNameFromLocaleOrTZID(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -1124,7 +1124,7 @@ public class TestBasic extends TestFmwkPlus {
                     "Locale:"
                             + localeID
                             + " ("
-                            + testInfo.getEnglish().nameGetter().getName(localeID)
+                            + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(localeID)
                             + ")";
 
             if (!collations.contains(localeID)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -85,7 +85,7 @@ public class TestCLDRFile extends TestFmwk {
         };
         CLDRFile english = testInfo.getEnglish();
         for (String[] test : tests) {
-            assertEquals("", test[1], english.getName(test[0]));
+            assertEquals("", test[1], english.nameGetter().getName(test[0]));
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -85,7 +85,7 @@ public class TestCLDRFile extends TestFmwk {
         };
         CLDRFile english = testInfo.getEnglish();
         for (String[] test : tests) {
-            assertEquals("", test[1], english.nameGetter().getNameFromLocaleOrTZID(test[0]));
+            assertEquals("", test[1], english.nameGetter().getNameFromBCP47(test[0]));
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -85,7 +85,7 @@ public class TestCLDRFile extends TestFmwk {
         };
         CLDRFile english = testInfo.getEnglish();
         for (String[] test : tests) {
-            assertEquals("", test[1], english.nameGetter().getName(test[0]));
+            assertEquals("", test[1], english.nameGetter().getNameFromLocaleOrTZID(test[0]));
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -162,7 +162,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                     && CLDRLocale.getInstance(locale).getParent().equals(CLDRLocale.ROOT)) {
                 official1MSetNames.put(
                         localeAndSize.getValue(),
-                        "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
+                        "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
             }
         }
         if (!official1MSetNames.isEmpty()) {
@@ -180,7 +180,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         coverageLocales.removeAll(additionsToTranslate);
 
         for (String locale : localesForNames) {
-            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
+            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
         }
 
         logln("\nmainLocales:" + composeList(mainLocales, "\n\t", new StringBuilder()));
@@ -243,7 +243,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             temp.removeAll(set);
             Set<String> temp2 = new TreeSet<>();
             for (String locale : temp) {
-                temp2.add(locale + "\t" + ENGLISH.nameGetter().getName(locale));
+                temp2.add(locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
             }
             errln(title + ": Missing:\t" + temp.size() + "\n\t" + Joiner.on("\n\t").join(temp2));
         }
@@ -344,7 +344,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                     "cldr level = max for "
                             + locale
                             + " ("
-                            + ENGLISH.nameGetter().getName(locale)
+                            + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale)
                             + ")",
                     cldrLevel,
                     maxLevel);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -162,7 +162,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                     && CLDRLocale.getInstance(locale).getParent().equals(CLDRLocale.ROOT)) {
                 official1MSetNames.put(
                         localeAndSize.getValue(),
-                        "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
+                        "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale));
             }
         }
         if (!official1MSetNames.isEmpty()) {
@@ -180,7 +180,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         coverageLocales.removeAll(additionsToTranslate);
 
         for (String locale : localesForNames) {
-            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
+            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale));
         }
 
         logln("\nmainLocales:" + composeList(mainLocales, "\n\t", new StringBuilder()));
@@ -243,7 +243,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             temp.removeAll(set);
             Set<String> temp2 = new TreeSet<>();
             for (String locale : temp) {
-                temp2.add(locale + "\t" + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale));
+                temp2.add(locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale));
             }
             errln(title + ": Missing:\t" + temp.size() + "\n\t" + Joiner.on("\n\t").join(temp2));
         }
@@ -344,7 +344,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                     "cldr level = max for "
                             + locale
                             + " ("
-                            + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale)
+                            + ENGLISH.nameGetter().getNameFromBCP47(locale)
                             + ")",
                     cldrLevel,
                     maxLevel);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -161,7 +161,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             if (!localesForNames.contains(locale)
                     && CLDRLocale.getInstance(locale).getParent().equals(CLDRLocale.ROOT)) {
                 official1MSetNames.put(
-                        localeAndSize.getValue(), "\t" + locale + "\t" + ENGLISH.getName(locale));
+                        localeAndSize.getValue(), "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
             }
         }
         if (!official1MSetNames.isEmpty()) {
@@ -179,7 +179,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         coverageLocales.removeAll(additionsToTranslate);
 
         for (String locale : localesForNames) {
-            logln("\n" + locale + "\t" + ENGLISH.getName(locale));
+            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
         }
 
         logln("\nmainLocales:" + composeList(mainLocales, "\n\t", new StringBuilder()));
@@ -242,7 +242,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             temp.removeAll(set);
             Set<String> temp2 = new TreeSet<>();
             for (String locale : temp) {
-                temp2.add(locale + "\t" + ENGLISH.getName(locale));
+                temp2.add(locale + "\t" + ENGLISH.nameGetter().getName(locale));
             }
             errln(title + ": Missing:\t" + temp.size() + "\n\t" + Joiner.on("\n\t").join(temp2));
         }
@@ -340,7 +340,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             Level maxLevel =
                     Level.max(specialLevel, Level.max(orgToLevel.values().toArray(new Level[0])));
             assertEquals(
-                    "cldr level = max for " + locale + " (" + ENGLISH.getName(locale) + ")",
+                    "cldr level = max for " + locale + " (" + ENGLISH.nameGetter().getName(locale) + ")",
                     cldrLevel,
                     maxLevel);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -161,7 +161,8 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             if (!localesForNames.contains(locale)
                     && CLDRLocale.getInstance(locale).getParent().equals(CLDRLocale.ROOT)) {
                 official1MSetNames.put(
-                        localeAndSize.getValue(), "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
+                        localeAndSize.getValue(),
+                        "\t" + locale + "\t" + ENGLISH.nameGetter().getName(locale));
             }
         }
         if (!official1MSetNames.isEmpty()) {
@@ -340,7 +341,11 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             Level maxLevel =
                     Level.max(specialLevel, Level.max(orgToLevel.values().toArray(new Level[0])));
             assertEquals(
-                    "cldr level = max for " + locale + " (" + ENGLISH.nameGetter().getName(locale) + ")",
+                    "cldr level = max for "
+                            + locale
+                            + " ("
+                            + ENGLISH.nameGetter().getName(locale)
+                            + ")",
                     cldrLevel,
                     maxLevel);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -97,7 +97,7 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedLong " + locale,
                 combinedLong,
-                french.getName(locale));
+                french.nameGetter().getName(locale));
         String combinedShort = otherNames.length > 0 ? otherNames[0] : combinedLong;
         String uncombinedLong = otherNames.length > 1 ? otherNames[1] : combinedLong;
         String uncombinedShort = otherNames.length > 2 ? otherNames[2] : uncombinedLong;
@@ -105,15 +105,15 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedShort " + locale,
                 combinedShort,
-                french.getName(locale, false, SHORT_ALT_PICKER));
+                french.nameGetter().getName(locale, false, SHORT_ALT_PICKER));
         assertEquals(
                 "Test variant formatting uncombinedLong " + locale,
                 uncombinedLong,
-                french.getName(locale, true));
+                french.nameGetter().getName(locale, true));
         assertEquals(
                 "Test variant formatting uncombinedShort " + locale,
                 uncombinedShort,
-                french.getName(locale, true, SHORT_ALT_PICKER));
+                french.nameGetter().getName(locale, true, SHORT_ALT_PICKER));
     }
 
     public void TestEmptyCLDRFile() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -18,6 +18,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRLocale.CLDRFormatter;
 import org.unicode.cldr.util.CLDRLocale.FormatBehavior;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.SimpleFactory;
 
 /**
@@ -94,10 +95,11 @@ public class TestCLDRUtils extends TestFmwk {
      */
     private void checkNames(
             CLDRFile french, String locale, String combinedLong, String... otherNames) {
+        NameGetter frenchNameGetter = french.nameGetter();
         assertEquals(
                 "Test variant formatting combinedLong " + locale,
                 combinedLong,
-                french.nameGetter().getNameFromLocaleOrTZID(locale));
+                frenchNameGetter.getNameFromBCP47(locale));
         String combinedShort = otherNames.length > 0 ? otherNames[0] : combinedLong;
         String uncombinedLong = otherNames.length > 1 ? otherNames[1] : combinedLong;
         String uncombinedShort = otherNames.length > 2 ? otherNames[2] : uncombinedLong;
@@ -105,15 +107,15 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedShort " + locale,
                 combinedShort,
-                french.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, false, SHORT_ALT_PICKER));
+                frenchNameGetter.getNameFromBCP47BoolAlt(locale, false, SHORT_ALT_PICKER));
         assertEquals(
                 "Test variant formatting uncombinedLong " + locale,
                 uncombinedLong,
-                french.nameGetter().getNameFromLocaleOrTZBool(locale, true));
+                frenchNameGetter.getNameFromBCP47Bool(locale, true));
         assertEquals(
                 "Test variant formatting uncombinedShort " + locale,
                 uncombinedShort,
-                french.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, SHORT_ALT_PICKER));
+                frenchNameGetter.getNameFromBCP47BoolAlt(locale, true, SHORT_ALT_PICKER));
     }
 
     public void TestEmptyCLDRFile() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -97,7 +97,7 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedLong " + locale,
                 combinedLong,
-                french.nameGetter().getName(locale));
+                french.nameGetter().getNameFromLocaleOrTZID(locale));
         String combinedShort = otherNames.length > 0 ? otherNames[0] : combinedLong;
         String uncombinedLong = otherNames.length > 1 ? otherNames[1] : combinedLong;
         String uncombinedShort = otherNames.length > 2 ? otherNames[2] : uncombinedLong;
@@ -105,15 +105,15 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedShort " + locale,
                 combinedShort,
-                french.nameGetter().getName(locale, false, SHORT_ALT_PICKER));
+                french.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, false, SHORT_ALT_PICKER));
         assertEquals(
                 "Test variant formatting uncombinedLong " + locale,
                 uncombinedLong,
-                french.nameGetter().getName(locale, true));
+                french.nameGetter().getNameFromLocaleOrTZBool(locale, true));
         assertEquals(
                 "Test variant formatting uncombinedShort " + locale,
                 uncombinedShort,
-                french.nameGetter().getName(locale, true, SHORT_ALT_PICKER));
+                french.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, SHORT_ALT_PICKER));
     }
 
     public void TestEmptyCLDRFile() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -1385,7 +1385,11 @@ public class TestCheckCLDR extends TestFmwk {
                     }
                 }
                 System.out.print(
-                        locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + cldrLevel);
+                        locale
+                                + "\t"
+                                + english.nameGetter().getNameFromBCP47(locale)
+                                + "\t"
+                                + cldrLevel);
                 for (LimitedStatus limitedStatus : LimitedStatus.values()) {
                     System.out.print("\t" + limitedStatus + ":\t" + counter.get(limitedStatus));
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -1384,7 +1384,8 @@ public class TestCheckCLDR extends TestFmwk {
                         counter.add(LimitedStatus.disallowed, 1);
                     }
                 }
-                System.out.print(locale + "\t" + english.nameGetter().getName(locale) + "\t" + cldrLevel);
+                System.out.print(
+                        locale + "\t" + english.nameGetter().getName(locale) + "\t" + cldrLevel);
                 for (LimitedStatus limitedStatus : LimitedStatus.values()) {
                     System.out.print("\t" + limitedStatus + ":\t" + counter.get(limitedStatus));
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -1385,7 +1385,7 @@ public class TestCheckCLDR extends TestFmwk {
                     }
                 }
                 System.out.print(
-                        locale + "\t" + english.nameGetter().getName(locale) + "\t" + cldrLevel);
+                        locale + "\t" + english.nameGetter().getNameFromLocaleOrTZID(locale) + "\t" + cldrLevel);
                 for (LimitedStatus limitedStatus : LimitedStatus.values()) {
                     System.out.print("\t" + limitedStatus + ":\t" + counter.get(limitedStatus));
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -1384,7 +1384,7 @@ public class TestCheckCLDR extends TestFmwk {
                         counter.add(LimitedStatus.disallowed, 1);
                     }
                 }
-                System.out.print(locale + "\t" + english.getName(locale) + "\t" + cldrLevel);
+                System.out.print(locale + "\t" + english.nameGetter().getName(locale) + "\t" + cldrLevel);
                 for (LimitedStatus limitedStatus : LimitedStatus.values()) {
                     System.out.print("\t" + limitedStatus + ":\t" + counter.get(limitedStatus));
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -135,7 +135,7 @@ public class TestCoverage extends TestFmwkPlus {
     }
 
     private String getLocaleAndName(String locale) {
-        return locale + "\t" + testInfo.getEnglish().nameGetter().getName(locale);
+        return locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
     }
 
     private String showColumn(Set items) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -135,7 +135,7 @@ public class TestCoverage extends TestFmwkPlus {
     }
 
     private String getLocaleAndName(String locale) {
-        return locale + "\t" + testInfo.getEnglish().getName(locale);
+        return locale + "\t" + testInfo.getEnglish().nameGetter().getName(locale);
     }
 
     private String showColumn(Set items) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -135,7 +135,7 @@ public class TestCoverage extends TestFmwkPlus {
     }
 
     private String getLocaleAndName(String locale) {
-        return locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
+        return locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
     }
 
     private String showColumn(Set items) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -1196,7 +1196,8 @@ public class TestCoverageLevel extends TestFmwkPlus {
                     typeAndInfo.getValue().get3(); // it looks like the targetLevel is ignored
 
             for (String code : Sets.union(idPartMap.keySet(), setRoot)) {
-                String displayName = testInfo.getEnglish().nameGetter().getNameFromTypenumCode(type, code);
+                String displayName =
+                        testInfo.getEnglish().nameGetter().getNameFromTypenumCode(type, code);
                 String path = CLDRFile.getKey(type, code);
                 Level level = coverageLevel.getLevel(path);
                 data.put(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -392,7 +392,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
 
         @Override
         public String transform(String source) {
-            String result = ENGLISH.getName(field, source);
+            String result = ENGLISH.nameGetter().getName(field, source);
             String extra = "";
             if (field == CLDRFile.LANGUAGE_NAME) {
                 String lang = isBigLanguage(source);
@@ -1196,7 +1196,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
                     typeAndInfo.getValue().get3(); // it looks like the targetLevel is ignored
 
             for (String code : Sets.union(idPartMap.keySet(), setRoot)) {
-                String displayName = testInfo.getEnglish().getName(type, code);
+                String displayName = testInfo.getEnglish().nameGetter().getName(type, code);
                 String path = CLDRFile.getKey(type, code);
                 Level level = coverageLevel.getLevel(path);
                 data.put(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -392,7 +392,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
 
         @Override
         public String transform(String source) {
-            String result = ENGLISH.nameGetter().getName(field, source);
+            String result = ENGLISH.nameGetter().getNameFromTypenumCode(field, source);
             String extra = "";
             if (field == CLDRFile.LANGUAGE_NAME) {
                 String lang = isBigLanguage(source);
@@ -1196,7 +1196,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
                     typeAndInfo.getValue().get3(); // it looks like the targetLevel is ignored
 
             for (String code : Sets.union(idPartMap.keySet(), setRoot)) {
-                String displayName = testInfo.getEnglish().nameGetter().getName(type, code);
+                String displayName = testInfo.getEnglish().nameGetter().getNameFromTypenumCode(type, code);
                 String path = CLDRFile.getKey(type, code);
                 Level level = coverageLevel.getLevel(path);
                 data.put(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
@@ -48,7 +48,7 @@ public class TestDayPeriods extends TestFmwkPlus {
             logln(
                     locale
                             + "\t"
-                            + CONFIG.getEnglish().getName(locale)
+                            + CONFIG.getEnglish().nameGetter().getName(locale)
                             + "\t"
                             + dayPeriodFormat
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
@@ -48,7 +48,7 @@ public class TestDayPeriods extends TestFmwkPlus {
             logln(
                     locale
                             + "\t"
-                            + CONFIG.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale)
+                            + CONFIG.getEnglish().nameGetter().getNameFromBCP47(locale)
                             + "\t"
                             + dayPeriodFormat
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
@@ -48,7 +48,7 @@ public class TestDayPeriods extends TestFmwkPlus {
             logln(
                     locale
                             + "\t"
-                            + CONFIG.getEnglish().nameGetter().getName(locale)
+                            + CONFIG.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale)
                             + "\t"
                             + dayPeriodFormat
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1550,7 +1550,7 @@ public class TestExampleGenerator extends TestFmwk {
                                 + "\"]",
                         Pair.of("gender", unitGender));
             }
-            String localeName = CLDRConfig.getInstance().getEnglish().nameGetter().getName(locale);
+            String localeName = CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
             boolean pluralOnly = true;
             if (paths.isEmpty()) {
                 pluralSheet.add(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1550,7 +1550,7 @@ public class TestExampleGenerator extends TestFmwk {
                                 + "\"]",
                         Pair.of("gender", unitGender));
             }
-            String localeName = CLDRConfig.getInstance().getEnglish().getName(locale);
+            String localeName = CLDRConfig.getInstance().getEnglish().nameGetter().getName(locale);
             boolean pluralOnly = true;
             if (paths.isEmpty()) {
                 pluralSheet.add(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1550,7 +1550,8 @@ public class TestExampleGenerator extends TestFmwk {
                                 + "\"]",
                         Pair.of("gender", unitGender));
             }
-            String localeName = CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
+            String localeName =
+                    CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(locale);
             boolean pluralOnly = true;
             if (paths.isEmpty()) {
                 pluralSheet.add(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -168,7 +168,9 @@ public class TestInheritance extends TestFmwk {
                     continue;
                 }
                 System.out.print(
-                        language + "\t" + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(language));
+                        language
+                                + "\t"
+                                + testInfo.getEnglish().nameGetter().getNameFromBCP47(language));
 
                 M3<OfficialStatus, String, Boolean> officialChildren =
                         languageToOfficialChildren.get(language);
@@ -195,7 +197,10 @@ public class TestInheritance extends TestFmwk {
             LanguageTagParser ltp = new LanguageTagParser().set(s);
             String script = ltp.getScript();
             if (script.length() != 0) {
-                b.append(testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script));
+                b.append(
+                        testInfo.getEnglish()
+                                .nameGetter()
+                                .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script));
             }
             String region = ltp.getRegion();
             if (region.length() != 0) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -167,7 +167,8 @@ public class TestInheritance extends TestFmwk {
                 if (!testOrg.contains(language)) {
                     continue;
                 }
-                System.out.print(language + "\t" + testInfo.getEnglish().nameGetter().getName(language));
+                System.out.print(
+                        language + "\t" + testInfo.getEnglish().nameGetter().getName(language));
 
                 M3<OfficialStatus, String, Boolean> officialChildren =
                         languageToOfficialChildren.get(language);
@@ -201,7 +202,10 @@ public class TestInheritance extends TestFmwk {
                 if (script.length() != 0) {
                     b.append("-");
                 }
-                b.append(testInfo.getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
+                b.append(
+                        testInfo.getEnglish()
+                                .nameGetter()
+                                .getName(CLDRFile.TERRITORY_NAME, region));
             }
             b.append(" [").append(s);
             if (showStatus) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -168,7 +168,7 @@ public class TestInheritance extends TestFmwk {
                     continue;
                 }
                 System.out.print(
-                        language + "\t" + testInfo.getEnglish().nameGetter().getName(language));
+                        language + "\t" + testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(language));
 
                 M3<OfficialStatus, String, Boolean> officialChildren =
                         languageToOfficialChildren.get(language);
@@ -195,7 +195,7 @@ public class TestInheritance extends TestFmwk {
             LanguageTagParser ltp = new LanguageTagParser().set(s);
             String script = ltp.getScript();
             if (script.length() != 0) {
-                b.append(testInfo.getEnglish().nameGetter().getName(CLDRFile.SCRIPT_NAME, script));
+                b.append(testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script));
             }
             String region = ltp.getRegion();
             if (region.length() != 0) {
@@ -205,7 +205,7 @@ public class TestInheritance extends TestFmwk {
                 b.append(
                         testInfo.getEnglish()
                                 .nameGetter()
-                                .getName(CLDRFile.TERRITORY_NAME, region));
+                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
             }
             b.append(" [").append(s);
             if (showStatus) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -167,7 +167,7 @@ public class TestInheritance extends TestFmwk {
                 if (!testOrg.contains(language)) {
                     continue;
                 }
-                System.out.print(language + "\t" + testInfo.getEnglish().getName(language));
+                System.out.print(language + "\t" + testInfo.getEnglish().nameGetter().getName(language));
 
                 M3<OfficialStatus, String, Boolean> officialChildren =
                         languageToOfficialChildren.get(language);
@@ -194,14 +194,14 @@ public class TestInheritance extends TestFmwk {
             LanguageTagParser ltp = new LanguageTagParser().set(s);
             String script = ltp.getScript();
             if (script.length() != 0) {
-                b.append(testInfo.getEnglish().getName(CLDRFile.SCRIPT_NAME, script));
+                b.append(testInfo.getEnglish().nameGetter().getName(CLDRFile.SCRIPT_NAME, script));
             }
             String region = ltp.getRegion();
             if (region.length() != 0) {
                 if (script.length() != 0) {
                     b.append("-");
                 }
-                b.append(testInfo.getEnglish().getName(CLDRFile.TERRITORY_NAME, region));
+                b.append(testInfo.getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, region));
             }
             b.append(" [").append(s);
             if (showStatus) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
@@ -126,7 +126,7 @@ public class TestLanguageGroup extends TestFmwk {
             case "grk":
                 return "Hellenic";
             default:
-                return ENGLISH.getName(code).replace(" [Other]", "");
+                return ENGLISH.nameGetter().getName(code).replace(" [Other]", "");
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
@@ -126,7 +126,7 @@ public class TestLanguageGroup extends TestFmwk {
             case "grk":
                 return "Hellenic";
             default:
-                return ENGLISH.nameGetter().getName(code).replace(" [Other]", "");
+                return ENGLISH.nameGetter().getNameFromLocaleOrTZID(code).replace(" [Other]", "");
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
@@ -126,7 +126,7 @@ public class TestLanguageGroup extends TestFmwk {
             case "grk":
                 return "Hellenic";
             default:
-                return ENGLISH.nameGetter().getNameFromLocaleOrTZID(code).replace(" [Other]", "");
+                return ENGLISH.nameGetter().getNameFromBCP47(code).replace(" [Other]", "");
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -490,7 +490,8 @@ public class TestLocale extends TestFmwkPlus {
                     assertEquals("example " + row[3], row[5], ExampleGenerator.simplify(example));
                 }
             }
-            String displayName = f.nameGetter().getName(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
+            String displayName =
+                    f.nameGetter().getName(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
             assertEquals("locale " + row[3], row[4], displayName);
         }
     }
@@ -498,7 +499,9 @@ public class TestLocale extends TestFmwkPlus {
     public void TestLocaleNamePattern() {
         assertEquals("Locale name", "Chinese", testInfo.getEnglish().nameGetter().getName("zh"));
         assertEquals(
-                "Locale name", "Chinese (United States)", testInfo.getEnglish().nameGetter().getName("zh-US"));
+                "Locale name",
+                "Chinese (United States)",
+                testInfo.getEnglish().nameGetter().getName("zh-US"));
         assertEquals(
                 "Locale name",
                 "Chinese (Arabic, United States)",
@@ -506,7 +509,10 @@ public class TestLocale extends TestFmwkPlus {
         CLDRFile japanese = testInfo.getCLDRFile("ja", true);
         assertEquals("Locale name", "中国語", japanese.nameGetter().getName("zh"));
         assertEquals("Locale name", "中国語 (アメリカ合衆国)", japanese.nameGetter().getName("zh-US"));
-        assertEquals("Locale name", "中国語 (アラビア文字\u3001アメリカ合衆国)", japanese.nameGetter().getName("zh-Arab-US"));
+        assertEquals(
+                "Locale name",
+                "中国語 (アラビア文字\u3001アメリカ合衆国)",
+                japanese.nameGetter().getName("zh-Arab-US"));
     }
 
     public void TestLocaleDisplay() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -43,6 +43,7 @@ import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleValidator;
 import org.unicode.cldr.util.LocaleValidator.AllowedMatch;
 import org.unicode.cldr.util.LocaleValidator.AllowedValid;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.StandardCodes;
@@ -474,14 +475,15 @@ public class TestLocale extends TestFmwkPlus {
                 "Territorie: {0}");
         CLDRFile f = new CLDRFile(dxs, root);
         ExampleGenerator eg = new ExampleGenerator(f, testInfo.getEnglish());
+        NameGetter nameGetter = f.nameGetter();
         for (String[] row : tests) {
             if (row[0] != null) {
                 int typeCode = CLDRFile.typeNameToCode(row[0]);
-                String standAlone = f.nameGetter().getNameFromTypenumCode(typeCode, row[1]);
+                String standAlone = nameGetter.getNameFromTypenumCode(typeCode, row[1]);
                 logln(typeCode + ": " + standAlone);
                 if (!assertEquals("stand-alone " + row[3], row[2], standAlone)) {
                     typeCode = CLDRFile.typeNameToCode(row[0]);
-                    standAlone = f.nameGetter().getNameFromTypenumCode(typeCode, row[1]);
+                    standAlone = nameGetter.getNameFromTypenumCode(typeCode, row[1]);
                 }
 
                 if (row[5] != null) {
@@ -491,28 +493,31 @@ public class TestLocale extends TestFmwkPlus {
                 }
             }
             String displayName =
-                    f.nameGetter().getNameFromLocaleOrTZBoolEtc(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
+                    nameGetter.getNameFromBCP47Etc(
+                            row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
             assertEquals("locale " + row[3], row[4], displayName);
         }
     }
 
     public void TestLocaleNamePattern() {
-        assertEquals("Locale name", "Chinese", testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh"));
+        NameGetter englishNameGetter = testInfo.getEnglish().nameGetter();
+        assertEquals("Locale name", "Chinese", englishNameGetter.getNameFromBCP47("zh"));
         assertEquals(
                 "Locale name",
                 "Chinese (United States)",
-                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh-US"));
+                englishNameGetter.getNameFromBCP47("zh-US"));
         assertEquals(
                 "Locale name",
                 "Chinese (Arabic, United States)",
-                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh-Arab-US"));
+                englishNameGetter.getNameFromBCP47("zh-Arab-US"));
         CLDRFile japanese = testInfo.getCLDRFile("ja", true);
-        assertEquals("Locale name", "中国語", japanese.nameGetter().getNameFromLocaleOrTZID("zh"));
-        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japanese.nameGetter().getNameFromLocaleOrTZID("zh-US"));
+        NameGetter japaneseNameGetter = japanese.nameGetter();
+        assertEquals("Locale name", "中国語", japaneseNameGetter.getNameFromBCP47("zh"));
+        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japaneseNameGetter.getNameFromBCP47("zh-US"));
         assertEquals(
                 "Locale name",
                 "中国語 (アラビア文字\u3001アメリカ合衆国)",
-                japanese.nameGetter().getNameFromLocaleOrTZID("zh-Arab-US"));
+                japaneseNameGetter.getNameFromBCP47("zh-Arab-US"));
     }
 
     public void TestLocaleDisplay() {
@@ -589,7 +594,7 @@ public class TestLocale extends TestFmwkPlus {
                 //                assertEquals("LTP(BCP47)=>ICU=>BCP47", bcp47, roundTripId);
 
                 canonicalizer.transform(ltp);
-                String name = cldrFile.nameGetter().getNameFromParserBoolAltPicker(ltp, compound, null);
+                String name = cldrFile.nameGetter().getNameFromParserBool(ltp, compound);
                 if (assertEquals(cldrFile.getLocaleID() + "; " + localeId, expected, name)) {
                     formattedExamplesForSpec
                             .append("<tr><td>")
@@ -668,7 +673,7 @@ public class TestLocale extends TestFmwkPlus {
         if (locale.equals("en-t-d0-accents")) {
             int debug = 0;
         }
-        String name = cldrFile.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, null);
+        String name = cldrFile.nameGetter().getNameFromBCP47BoolAlt(locale, true, null);
         if (isVerbose()) {
             System.out.println(locale + "; " + name);
         }
@@ -685,22 +690,23 @@ public class TestLocale extends TestFmwkPlus {
     }
 
     public void TestExtendedLanguage() {
+        NameGetter englishNameGetter = testInfo.getEnglish().nameGetter();
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese",
-                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh_Hans"));
+                englishNameGetter.getNameFromBCP47("zh_Hans"));
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese (Singapore)",
-                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh_Hans_SG"));
+                englishNameGetter.getNameFromBCP47("zh_Hans_SG"));
         assertEquals(
                 "Extended language translation",
                 "American English",
-                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("en-US"));
+                englishNameGetter.getNameFromBCP47("en-US"));
         assertEquals(
                 "Extended language translation",
                 "American English (Arabic)",
-                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("en-Arab-US"));
+                englishNameGetter.getNameFromBCP47("en-Arab-US"));
     }
 
     public void testAllVariants() {
@@ -854,7 +860,7 @@ public class TestLocale extends TestFmwkPlus {
                         + "\n\t\tstructure:\t"
                         + ltp.toString(Format.structure));
         try {
-            String name = testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
+            String name = testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
             logln("\tname:\t" + name);
         } catch (Exception e) {
             errln("Name for " + locale + "; " + e.getMessage());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -477,11 +477,11 @@ public class TestLocale extends TestFmwkPlus {
         for (String[] row : tests) {
             if (row[0] != null) {
                 int typeCode = CLDRFile.typeNameToCode(row[0]);
-                String standAlone = f.getName(typeCode, row[1]);
+                String standAlone = f.nameGetter().getName(typeCode, row[1]);
                 logln(typeCode + ": " + standAlone);
                 if (!assertEquals("stand-alone " + row[3], row[2], standAlone)) {
                     typeCode = CLDRFile.typeNameToCode(row[0]);
-                    standAlone = f.getName(typeCode, row[1]);
+                    standAlone = f.nameGetter().getName(typeCode, row[1]);
                 }
 
                 if (row[5] != null) {
@@ -490,23 +490,23 @@ public class TestLocale extends TestFmwkPlus {
                     assertEquals("example " + row[3], row[5], ExampleGenerator.simplify(example));
                 }
             }
-            String displayName = f.getName(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
+            String displayName = f.nameGetter().getName(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
             assertEquals("locale " + row[3], row[4], displayName);
         }
     }
 
     public void TestLocaleNamePattern() {
-        assertEquals("Locale name", "Chinese", testInfo.getEnglish().getName("zh"));
+        assertEquals("Locale name", "Chinese", testInfo.getEnglish().nameGetter().getName("zh"));
         assertEquals(
-                "Locale name", "Chinese (United States)", testInfo.getEnglish().getName("zh-US"));
+                "Locale name", "Chinese (United States)", testInfo.getEnglish().nameGetter().getName("zh-US"));
         assertEquals(
                 "Locale name",
                 "Chinese (Arabic, United States)",
-                testInfo.getEnglish().getName("zh-Arab-US"));
+                testInfo.getEnglish().nameGetter().getName("zh-Arab-US"));
         CLDRFile japanese = testInfo.getCLDRFile("ja", true);
-        assertEquals("Locale name", "中国語", japanese.getName("zh"));
-        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japanese.getName("zh-US"));
-        assertEquals("Locale name", "中国語 (アラビア文字\u3001アメリカ合衆国)", japanese.getName("zh-Arab-US"));
+        assertEquals("Locale name", "中国語", japanese.nameGetter().getName("zh"));
+        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japanese.nameGetter().getName("zh-US"));
+        assertEquals("Locale name", "中国語 (アラビア文字\u3001アメリカ合衆国)", japanese.nameGetter().getName("zh-Arab-US"));
     }
 
     public void TestLocaleDisplay() {
@@ -583,7 +583,7 @@ public class TestLocale extends TestFmwkPlus {
                 //                assertEquals("LTP(BCP47)=>ICU=>BCP47", bcp47, roundTripId);
 
                 canonicalizer.transform(ltp);
-                String name = cldrFile.getName(ltp, compound, null);
+                String name = cldrFile.nameGetter().getName(ltp, compound, null);
                 if (assertEquals(cldrFile.getLocaleID() + "; " + localeId, expected, name)) {
                     formattedExamplesForSpec
                             .append("<tr><td>")
@@ -662,7 +662,7 @@ public class TestLocale extends TestFmwkPlus {
         if (locale.equals("en-t-d0-accents")) {
             int debug = 0;
         }
-        String name = cldrFile.getName(locale, true, null);
+        String name = cldrFile.nameGetter().getName(locale, true, null);
         if (isVerbose()) {
             System.out.println(locale + "; " + name);
         }
@@ -682,19 +682,19 @@ public class TestLocale extends TestFmwkPlus {
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese",
-                testInfo.getEnglish().getName("zh_Hans"));
+                testInfo.getEnglish().nameGetter().getName("zh_Hans"));
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese (Singapore)",
-                testInfo.getEnglish().getName("zh_Hans_SG"));
+                testInfo.getEnglish().nameGetter().getName("zh_Hans_SG"));
         assertEquals(
                 "Extended language translation",
                 "American English",
-                testInfo.getEnglish().getName("en-US"));
+                testInfo.getEnglish().nameGetter().getName("en-US"));
         assertEquals(
                 "Extended language translation",
                 "American English (Arabic)",
-                testInfo.getEnglish().getName("en-Arab-US"));
+                testInfo.getEnglish().nameGetter().getName("en-Arab-US"));
     }
 
     public void testAllVariants() {
@@ -848,7 +848,7 @@ public class TestLocale extends TestFmwkPlus {
                         + "\n\t\tstructure:\t"
                         + ltp.toString(Format.structure));
         try {
-            String name = testInfo.getEnglish().getName(locale);
+            String name = testInfo.getEnglish().nameGetter().getName(locale);
             logln("\tname:\t" + name);
         } catch (Exception e) {
             errln("Name for " + locale + "; " + e.getMessage());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -477,11 +477,11 @@ public class TestLocale extends TestFmwkPlus {
         for (String[] row : tests) {
             if (row[0] != null) {
                 int typeCode = CLDRFile.typeNameToCode(row[0]);
-                String standAlone = f.nameGetter().getName(typeCode, row[1]);
+                String standAlone = f.nameGetter().getNameFromTypenumCode(typeCode, row[1]);
                 logln(typeCode + ": " + standAlone);
                 if (!assertEquals("stand-alone " + row[3], row[2], standAlone)) {
                     typeCode = CLDRFile.typeNameToCode(row[0]);
-                    standAlone = f.nameGetter().getName(typeCode, row[1]);
+                    standAlone = f.nameGetter().getNameFromTypenumCode(typeCode, row[1]);
                 }
 
                 if (row[5] != null) {
@@ -491,28 +491,28 @@ public class TestLocale extends TestFmwkPlus {
                 }
             }
             String displayName =
-                    f.nameGetter().getName(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
+                    f.nameGetter().getNameFromLocaleOrTZBoolEtc(row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
             assertEquals("locale " + row[3], row[4], displayName);
         }
     }
 
     public void TestLocaleNamePattern() {
-        assertEquals("Locale name", "Chinese", testInfo.getEnglish().nameGetter().getName("zh"));
+        assertEquals("Locale name", "Chinese", testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh"));
         assertEquals(
                 "Locale name",
                 "Chinese (United States)",
-                testInfo.getEnglish().nameGetter().getName("zh-US"));
+                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh-US"));
         assertEquals(
                 "Locale name",
                 "Chinese (Arabic, United States)",
-                testInfo.getEnglish().nameGetter().getName("zh-Arab-US"));
+                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh-Arab-US"));
         CLDRFile japanese = testInfo.getCLDRFile("ja", true);
-        assertEquals("Locale name", "中国語", japanese.nameGetter().getName("zh"));
-        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japanese.nameGetter().getName("zh-US"));
+        assertEquals("Locale name", "中国語", japanese.nameGetter().getNameFromLocaleOrTZID("zh"));
+        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japanese.nameGetter().getNameFromLocaleOrTZID("zh-US"));
         assertEquals(
                 "Locale name",
                 "中国語 (アラビア文字\u3001アメリカ合衆国)",
-                japanese.nameGetter().getName("zh-Arab-US"));
+                japanese.nameGetter().getNameFromLocaleOrTZID("zh-Arab-US"));
     }
 
     public void TestLocaleDisplay() {
@@ -589,7 +589,7 @@ public class TestLocale extends TestFmwkPlus {
                 //                assertEquals("LTP(BCP47)=>ICU=>BCP47", bcp47, roundTripId);
 
                 canonicalizer.transform(ltp);
-                String name = cldrFile.nameGetter().getName(ltp, compound, null);
+                String name = cldrFile.nameGetter().getNameFromParserBoolAltPicker(ltp, compound, null);
                 if (assertEquals(cldrFile.getLocaleID() + "; " + localeId, expected, name)) {
                     formattedExamplesForSpec
                             .append("<tr><td>")
@@ -668,7 +668,7 @@ public class TestLocale extends TestFmwkPlus {
         if (locale.equals("en-t-d0-accents")) {
             int debug = 0;
         }
-        String name = cldrFile.nameGetter().getName(locale, true, null);
+        String name = cldrFile.nameGetter().getNameFromLocaleOrTZBoolAltpicker(locale, true, null);
         if (isVerbose()) {
             System.out.println(locale + "; " + name);
         }
@@ -688,19 +688,19 @@ public class TestLocale extends TestFmwkPlus {
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese",
-                testInfo.getEnglish().nameGetter().getName("zh_Hans"));
+                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh_Hans"));
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese (Singapore)",
-                testInfo.getEnglish().nameGetter().getName("zh_Hans_SG"));
+                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("zh_Hans_SG"));
         assertEquals(
                 "Extended language translation",
                 "American English",
-                testInfo.getEnglish().nameGetter().getName("en-US"));
+                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("en-US"));
         assertEquals(
                 "Extended language translation",
                 "American English (Arabic)",
-                testInfo.getEnglish().nameGetter().getName("en-Arab-US"));
+                testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID("en-Arab-US"));
     }
 
     public void testAllVariants() {
@@ -854,7 +854,7 @@ public class TestLocale extends TestFmwkPlus {
                         + "\n\t\tstructure:\t"
                         + ltp.toString(Format.structure));
         try {
-            String name = testInfo.getEnglish().nameGetter().getName(locale);
+            String name = testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(locale);
             logln("\tname:\t" + name);
         } catch (Exception e) {
             errln("Name for " + locale + "; " + e.getMessage());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -295,11 +295,13 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                         continue;
                     }
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    String typeName = english.nameGetter().getNameFromTypestrCode(typeCompat, subtag);
+                    String typeName =
+                            english.nameGetter().getNameFromTypestrCode(typeCompat, subtag);
                     String replacementName =
                             preferredValueCompat == null
                                     ? "???"
-                                    : english.nameGetter().getNameFromTypestrCode(typeCompat, replacementString);
+                                    : english.nameGetter()
+                                            .getNameFromTypestrCode(typeCompat, replacementString);
                     addExceptions.add(
                             ".put(\""
                                     + subtag

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -295,11 +295,11 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                         continue;
                     }
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    String typeName = english.getName(typeCompat, subtag);
+                    String typeName = english.nameGetter().getName(typeCompat, subtag);
                     String replacementName =
                             preferredValueCompat == null
                                     ? "???"
-                                    : english.getName(typeCompat, replacementString);
+                                    : english.nameGetter().getName(typeCompat, replacementString);
                     addExceptions.add(
                             ".put(\""
                                     + subtag

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -295,11 +295,11 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                         continue;
                     }
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    String typeName = english.nameGetter().getName(typeCompat, subtag);
+                    String typeName = english.nameGetter().getNameFromTypestrCode(typeCompat, subtag);
                     String replacementName =
                             preferredValueCompat == null
                                     ? "???"
-                                    : english.nameGetter().getName(typeCompat, replacementString);
+                                    : english.nameGetter().getNameFromTypestrCode(typeCompat, replacementString);
                     addExceptions.add(
                             ".put(\""
                                     + subtag

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -48,6 +48,7 @@ import org.unicode.cldr.util.GrammarInfo.GenderValues;
 import org.unicode.cldr.util.Iso3166Data;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathDescription;
@@ -82,6 +83,7 @@ public class TestPathHeader extends TestFmwkPlus {
     static final CLDRConfig info = CLDRConfig.getInstance();
     static final Factory factory = info.getCommonAndSeedAndMainAndAnnotationsFactory();
     static final CLDRFile english = factory.make("en", true);
+    static final NameGetter englishNameGetter = english.nameGetter();
     static final SupplementalDataInfo supplemental = info.getSupplementalDataInfo();
     static PathHeader.Factory pathHeaderFactory = PathHeader.getFactory(english);
     private EnumSet<PageId> badZonePages = EnumSet.of(PageId.UnknownT);
@@ -857,7 +859,7 @@ public class TestPathHeader extends TestFmwkPlus {
     private String getNameAndOrder(String territory) {
         return territory
                 + "\t"
-                + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                + englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                 + "\t"
                 + Containment.getOrder(territory);
     }
@@ -976,10 +978,15 @@ public class TestPathHeader extends TestFmwkPlus {
                 assertEquals("S. America special case", "005", revision);
             }
             if (isVerbose()) {
-                String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, cont);
-                String name2 = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, sub);
-                String name3 = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
-                String name4 = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, revision);
+                String name =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, cont);
+                String name2 =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, sub);
+                String name3 =
+                        englishNameGetter.getNameFromTypenumCode(
+                                CLDRFile.TERRITORY_NAME, territory);
+                String name4 =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, revision);
 
                 logln(
                         metazone + "\t" + continent + "\t" + name + "\t" + name2 + "\t" + name3

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -857,7 +857,7 @@ public class TestPathHeader extends TestFmwkPlus {
     private String getNameAndOrder(String territory) {
         return territory
                 + "\t"
-                + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
+                + english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
                 + "\t"
                 + Containment.getOrder(territory);
     }
@@ -976,10 +976,10 @@ public class TestPathHeader extends TestFmwkPlus {
                 assertEquals("S. America special case", "005", revision);
             }
             if (isVerbose()) {
-                String name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, cont);
-                String name2 = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, sub);
-                String name3 = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
-                String name4 = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, revision);
+                String name = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, cont);
+                String name2 = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, sub);
+                String name3 = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                String name4 = english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, revision);
 
                 logln(
                         metazone + "\t" + continent + "\t" + name + "\t" + name2 + "\t" + name3

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -857,7 +857,7 @@ public class TestPathHeader extends TestFmwkPlus {
     private String getNameAndOrder(String territory) {
         return territory
                 + "\t"
-                + english.getName(CLDRFile.TERRITORY_NAME, territory)
+                + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory)
                 + "\t"
                 + Containment.getOrder(territory);
     }
@@ -976,10 +976,10 @@ public class TestPathHeader extends TestFmwkPlus {
                 assertEquals("S. America special case", "005", revision);
             }
             if (isVerbose()) {
-                String name = english.getName(CLDRFile.TERRITORY_NAME, cont);
-                String name2 = english.getName(CLDRFile.TERRITORY_NAME, sub);
-                String name3 = english.getName(CLDRFile.TERRITORY_NAME, territory);
-                String name4 = english.getName(CLDRFile.TERRITORY_NAME, revision);
+                String name = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, cont);
+                String name2 = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, sub);
+                String name3 = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, territory);
+                String name4 = english.nameGetter().getName(CLDRFile.TERRITORY_NAME, revision);
 
                 logln(
                         metazone + "\t" + continent + "\t" + name + "\t" + name2 + "\t" + name3

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1314,7 +1314,7 @@ public class TestPersonNameFormatter extends TestFmwk {
                     "Checking\t"
                             + locale
                             + "\t"
-                            + ENGLISH.nameGetter().getName(locale)
+                            + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale)
                             + "\t"
                             + order
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1314,7 +1314,7 @@ public class TestPersonNameFormatter extends TestFmwk {
                     "Checking\t"
                             + locale
                             + "\t"
-                            + ENGLISH.getName(locale)
+                            + ENGLISH.nameGetter().getName(locale)
                             + "\t"
                             + order
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1314,7 +1314,7 @@ public class TestPersonNameFormatter extends TestFmwk {
                     "Checking\t"
                             + locale
                             + "\t"
-                            + ENGLISH.nameGetter().getNameFromLocaleOrTZID(locale)
+                            + ENGLISH.nameGetter().getNameFromBCP47(locale)
                             + "\t"
                             + order
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -201,16 +201,16 @@ public class TestScriptMetadata extends TestFmwkPlus {
             lines.add(
                     Row.of(
                             info.idUsage,
-                            english.nameGetter().getName(CLDRFile.TERRITORY_NAME, continent),
+                            english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, continent),
                             info.idUsage
                                     + "\t"
                                     + english.nameGetter()
-                                            .getName(CLDRFile.TERRITORY_NAME, container)
+                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, container)
                                     + "\t"
                                     + scriptCode
                                     + "\t"
                                     + english.nameGetter()
-                                            .getName(CLDRFile.SCRIPT_NAME, scriptCode)));
+                                            .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, scriptCode)));
         }
         for (Row.R3<IdUsage, String, String> s : lines) {
             logln(s.get2());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -204,11 +204,13 @@ public class TestScriptMetadata extends TestFmwkPlus {
                             english.nameGetter().getName(CLDRFile.TERRITORY_NAME, continent),
                             info.idUsage
                                     + "\t"
-                                    + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, container)
+                                    + english.nameGetter()
+                                            .getName(CLDRFile.TERRITORY_NAME, container)
                                     + "\t"
                                     + scriptCode
                                     + "\t"
-                                    + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, scriptCode)));
+                                    + english.nameGetter()
+                                            .getName(CLDRFile.SCRIPT_NAME, scriptCode)));
         }
         for (Row.R3<IdUsage, String, String> s : lines) {
             logln(s.get2());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -201,16 +201,19 @@ public class TestScriptMetadata extends TestFmwkPlus {
             lines.add(
                     Row.of(
                             info.idUsage,
-                            english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, continent),
+                            english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, continent),
                             info.idUsage
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, container)
+                                            .getNameFromTypenumCode(
+                                                    CLDRFile.TERRITORY_NAME, container)
                                     + "\t"
                                     + scriptCode
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, scriptCode)));
+                                            .getNameFromTypenumCode(
+                                                    CLDRFile.SCRIPT_NAME, scriptCode)));
         }
         for (Row.R3<IdUsage, String, String> s : lines) {
             logln(s.get2());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -201,14 +201,14 @@ public class TestScriptMetadata extends TestFmwkPlus {
             lines.add(
                     Row.of(
                             info.idUsage,
-                            english.getName(CLDRFile.TERRITORY_NAME, continent),
+                            english.nameGetter().getName(CLDRFile.TERRITORY_NAME, continent),
                             info.idUsage
                                     + "\t"
-                                    + english.getName(CLDRFile.TERRITORY_NAME, container)
+                                    + english.nameGetter().getName(CLDRFile.TERRITORY_NAME, container)
                                     + "\t"
                                     + scriptCode
                                     + "\t"
-                                    + english.getName(CLDRFile.SCRIPT_NAME, scriptCode)));
+                                    + english.nameGetter().getName(CLDRFile.SCRIPT_NAME, scriptCode)));
         }
         for (Row.R3<IdUsage, String, String> s : lines) {
             logln(s.get2());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSubdivisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSubdivisions.java
@@ -100,7 +100,7 @@ public class TestSubdivisions extends TestFmwkPlus {
             R2<List<String>, String> subdivisionAlias = subdivisionAliases.get(subdivision);
             if (subdivisionAlias != null) {
                 // String countryName =
-                // CLDRConfig.getInstance().getEnglish().getName(CLDRFile.TERRITORY_NAME, country);
+                // CLDRConfig.getInstance().getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
                 // assertEquals("country " + country + " = subdivision " + subdivision, countryName,
                 // value);
                 continue;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -870,7 +870,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         if (code.isEmpty()) {
             return;
         }
-        String name = testInfo.getEnglish().nameGetter().getName(languageName, code);
+        String name = testInfo.getEnglish().nameGetter().getNameFromTypenumCode(languageName, code);
         if (!code.equals(name)) {
             b.add(code + "=" + name);
         }
@@ -1070,7 +1070,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
         @Override
         public String transform(String code) {
-            return file.nameGetter().getName(codeType, code) + " [" + code + "]";
+            return file.nameGetter().getNameFromTypenumCode(codeType, code) + " [" + code + "]";
         }
     }
 
@@ -1238,7 +1238,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     }
 
     private String getRegionName(String region) {
-        return testInfo.getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, region);
+        return testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
     }
 
     private Map<String, Integer> getRecursiveContainment(
@@ -1316,7 +1316,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         // now show the items we found
         for (Scope scope : scopeToCodes.keySet()) {
             for (String language : scopeToCodes.getAll(scope)) {
-                String name = testInfo.getEnglish().nameGetter().getName(language);
+                String name = testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(language);
                 if (name == null || name.equals(language)) {
                     Set<String> set = Iso639Data.getNames(language);
                     if (set != null) {
@@ -1537,7 +1537,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                 + "\t"
                                 + testInfo.getEnglish()
                                         .nameGetter()
-                                        .getName(CLDRFile.CURRENCY_NAME, currency));
+                                        .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency));
             }
         }
         // fix up
@@ -1574,7 +1574,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         for (String currency : modernCurrencyCodes.keySet()) {
             Set<Pair<String, CurrencyDateInfo>> data = modernCurrencyCodes.getAll(currency);
             final String name =
-                    testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
+                    testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
 
             Set<String> isoCountries = isoCurrenciesToCountries.getAll(currency);
             if (isoCountries == null) {
@@ -1649,7 +1649,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                         + nonModernCurrencyCodes);
         for (String currency : nonModernCurrencyCodes.keySet()) {
             final String name =
-                    testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
+                    testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
             if (name == null) {
                 errln("No English name for currency " + currency);
                 continue;
@@ -1692,7 +1692,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                         + "\t"
                                         + testInfo.getEnglish()
                                                 .nameGetter()
-                                                .getName(
+                                                .getNameFromTypenumCode(
                                                         CLDRFile.CURRENCY_NAME,
                                                         dateInfo.getCurrency()));
                     }
@@ -2142,7 +2142,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         Set<String> tempNames = new TreeSet<>();
         for (String langCode : temp) {
             tempNames.add(
-                    testInfo.getEnglish().nameGetter().getName(CLDRFile.LANGUAGE_NAME, langCode)
+                    testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, langCode)
                             + " ("
                             + langCode
                             + ")");
@@ -2224,7 +2224,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     private String codeAndName(String macro) {
         // TODO Auto-generated method stub
-        return CLDRConfig.getInstance().getEnglish().nameGetter().getName(macro)
+        return CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(macro)
                 + " ("
                 + macro
                 + ")";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -870,7 +870,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         if (code.isEmpty()) {
             return;
         }
-        String name = testInfo.getEnglish().getName(languageName, code);
+        String name = testInfo.getEnglish().nameGetter().getName(languageName, code);
         if (!code.equals(name)) {
             b.add(code + "=" + name);
         }
@@ -1070,7 +1070,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
         @Override
         public String transform(String code) {
-            return file.getName(codeType, code) + " [" + code + "]";
+            return file.nameGetter().getName(codeType, code) + " [" + code + "]";
         }
     }
 
@@ -1238,7 +1238,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     }
 
     private String getRegionName(String region) {
-        return testInfo.getEnglish().getName(CLDRFile.TERRITORY_NAME, region);
+        return testInfo.getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, region);
     }
 
     private Map<String, Integer> getRecursiveContainment(
@@ -1316,7 +1316,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         // now show the items we found
         for (Scope scope : scopeToCodes.keySet()) {
             for (String language : scopeToCodes.getAll(scope)) {
-                String name = testInfo.getEnglish().getName(language);
+                String name = testInfo.getEnglish().nameGetter().getName(language);
                 if (name == null || name.equals(language)) {
                     Set<String> set = Iso639Data.getNames(language);
                     if (set != null) {
@@ -1535,7 +1535,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                 + "\t"
                                 + dateInfo.toString()
                                 + "\t"
-                                + testInfo.getEnglish().getName(CLDRFile.CURRENCY_NAME, currency));
+                                + testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency));
             }
         }
         // fix up
@@ -1571,7 +1571,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
         for (String currency : modernCurrencyCodes.keySet()) {
             Set<Pair<String, CurrencyDateInfo>> data = modernCurrencyCodes.getAll(currency);
-            final String name = testInfo.getEnglish().getName(CLDRFile.CURRENCY_NAME, currency);
+            final String name = testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
 
             Set<String> isoCountries = isoCurrenciesToCountries.getAll(currency);
             if (isoCountries == null) {
@@ -1645,7 +1645,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                         + "\t"
                         + nonModernCurrencyCodes);
         for (String currency : nonModernCurrencyCodes.keySet()) {
-            final String name = testInfo.getEnglish().getName(CLDRFile.CURRENCY_NAME, currency);
+            final String name = testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
             if (name == null) {
                 errln("No English name for currency " + currency);
                 continue;
@@ -1687,7 +1687,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                         + dateInfo
                                         + "\t"
                                         + testInfo.getEnglish()
-                                                .getName(
+                                                .nameGetter().getName(
                                                         CLDRFile.CURRENCY_NAME,
                                                         dateInfo.getCurrency()));
                     }
@@ -2137,7 +2137,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         Set<String> tempNames = new TreeSet<>();
         for (String langCode : temp) {
             tempNames.add(
-                    testInfo.getEnglish().getName(CLDRFile.LANGUAGE_NAME, langCode)
+                    testInfo.getEnglish().nameGetter().getName(CLDRFile.LANGUAGE_NAME, langCode)
                             + " ("
                             + langCode
                             + ")");
@@ -2219,6 +2219,6 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     private String codeAndName(String macro) {
         // TODO Auto-generated method stub
-        return CLDRConfig.getInstance().getEnglish().getName(macro) + " (" + macro + ")";
+        return CLDRConfig.getInstance().getEnglish().nameGetter().getName(macro) + " (" + macro + ")";
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1535,7 +1535,9 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                 + "\t"
                                 + dateInfo.toString()
                                 + "\t"
-                                + testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency));
+                                + testInfo.getEnglish()
+                                        .nameGetter()
+                                        .getName(CLDRFile.CURRENCY_NAME, currency));
             }
         }
         // fix up
@@ -1571,7 +1573,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
         for (String currency : modernCurrencyCodes.keySet()) {
             Set<Pair<String, CurrencyDateInfo>> data = modernCurrencyCodes.getAll(currency);
-            final String name = testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
+            final String name =
+                    testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
 
             Set<String> isoCountries = isoCurrenciesToCountries.getAll(currency);
             if (isoCountries == null) {
@@ -1645,7 +1648,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                         + "\t"
                         + nonModernCurrencyCodes);
         for (String currency : nonModernCurrencyCodes.keySet()) {
-            final String name = testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
+            final String name =
+                    testInfo.getEnglish().nameGetter().getName(CLDRFile.CURRENCY_NAME, currency);
             if (name == null) {
                 errln("No English name for currency " + currency);
                 continue;
@@ -1687,7 +1691,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                         + dateInfo
                                         + "\t"
                                         + testInfo.getEnglish()
-                                                .nameGetter().getName(
+                                                .nameGetter()
+                                                .getName(
                                                         CLDRFile.CURRENCY_NAME,
                                                         dateInfo.getCurrency()));
                     }
@@ -2219,6 +2224,9 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     private String codeAndName(String macro) {
         // TODO Auto-generated method stub
-        return CLDRConfig.getInstance().getEnglish().nameGetter().getName(macro) + " (" + macro + ")";
+        return CLDRConfig.getInstance().getEnglish().nameGetter().getName(macro)
+                + " ("
+                + macro
+                + ")";
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -71,6 +71,7 @@ import org.unicode.cldr.util.LanguageTagCanonicalizer;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PluralRanges;
@@ -99,6 +100,7 @@ import org.unicode.cldr.util.Validity.Status;
 
 public class TestSupplementalInfo extends TestFmwkPlus {
     static CLDRConfig testInfo = CLDRConfig.getInstance();
+    private static NameGetter englishNameGetter = testInfo.getEnglish().nameGetter();
 
     private static final StandardCodes STANDARD_CODES = StandardCodes.make();
 
@@ -870,7 +872,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         if (code.isEmpty()) {
             return;
         }
-        String name = testInfo.getEnglish().nameGetter().getNameFromTypenumCode(languageName, code);
+        String name = englishNameGetter.getNameFromTypenumCode(languageName, code);
         if (!code.equals(name)) {
             b.add(code + "=" + name);
         }
@@ -1238,7 +1240,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     }
 
     private String getRegionName(String region) {
-        return testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
+        return englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
     }
 
     private Map<String, Integer> getRecursiveContainment(
@@ -1316,7 +1318,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         // now show the items we found
         for (Scope scope : scopeToCodes.keySet()) {
             for (String language : scopeToCodes.getAll(scope)) {
-                String name = testInfo.getEnglish().nameGetter().getNameFromLocaleOrTZID(language);
+                String name = englishNameGetter.getNameFromBCP47(language);
                 if (name == null || name.equals(language)) {
                     Set<String> set = Iso639Data.getNames(language);
                     if (set != null) {
@@ -1535,9 +1537,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                 + "\t"
                                 + dateInfo.toString()
                                 + "\t"
-                                + testInfo.getEnglish()
-                                        .nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency));
+                                + englishNameGetter.getNameFromTypenumCode(
+                                        CLDRFile.CURRENCY_NAME, currency));
             }
         }
         // fix up
@@ -1574,7 +1575,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         for (String currency : modernCurrencyCodes.keySet()) {
             Set<Pair<String, CurrencyDateInfo>> data = modernCurrencyCodes.getAll(currency);
             final String name =
-                    testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
 
             Set<String> isoCountries = isoCurrenciesToCountries.getAll(currency);
             if (isoCountries == null) {
@@ -1649,7 +1650,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                         + nonModernCurrencyCodes);
         for (String currency : nonModernCurrencyCodes.keySet()) {
             final String name =
-                    testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
             if (name == null) {
                 errln("No English name for currency " + currency);
                 continue;
@@ -1690,11 +1691,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                         + "\t"
                                         + dateInfo
                                         + "\t"
-                                        + testInfo.getEnglish()
-                                                .nameGetter()
-                                                .getNameFromTypenumCode(
-                                                        CLDRFile.CURRENCY_NAME,
-                                                        dateInfo.getCurrency()));
+                                        + englishNameGetter.getNameFromTypenumCode(
+                                                CLDRFile.CURRENCY_NAME, dateInfo.getCurrency()));
                     }
                 }
             }
@@ -2142,7 +2140,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         Set<String> tempNames = new TreeSet<>();
         for (String langCode : temp) {
             tempNames.add(
-                    testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, langCode)
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, langCode)
                             + " ("
                             + langCode
                             + ")");
@@ -2224,7 +2222,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     private String codeAndName(String macro) {
         // TODO Auto-generated method stub
-        return CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(macro)
+        return CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(macro)
                 + " ("
                 + macro
                 + ")";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
@@ -82,7 +82,7 @@ public class TestUnContainment extends TestFmwkPlus {
     }
 
     private String name(String code) {
-        String name = testInfo.getEnglish().getName(CLDRFile.TERRITORY_NAME, code);
+        String name = testInfo.getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, code);
         return name + " (" + code + ")";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
@@ -82,7 +82,10 @@ public class TestUnContainment extends TestFmwkPlus {
     }
 
     private String name(String code) {
-        String name = testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code);
+        String name =
+                testInfo.getEnglish()
+                        .nameGetter()
+                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code);
         return name + " (" + code + ")";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
@@ -82,7 +82,7 @@ public class TestUnContainment extends TestFmwkPlus {
     }
 
     private String name(String code) {
-        String name = testInfo.getEnglish().nameGetter().getName(CLDRFile.TERRITORY_NAME, code);
+        String name = testInfo.getEnglish().nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code);
         return name + " (" + code + ")";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -570,7 +570,10 @@ public class TestValidity extends TestFmwkPlus {
                 + TransliteratorUtilities.toXML.transform(
                         CLDRConfig.getInstance().getEnglish().nameGetter().getName(code)
                                 + " ⇒ "
-                                + CLDRConfig.getInstance().getEnglish().nameGetter().getName(lstrReplacement))
+                                + CLDRConfig.getInstance()
+                                        .getEnglish()
+                                        .nameGetter()
+                                        .getName(lstrReplacement))
                 + " -->";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -568,12 +568,12 @@ public class TestValidity extends TestFmwkPlus {
                 + "\"/>"
                 + " <!-- "
                 + TransliteratorUtilities.toXML.transform(
-                        CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(code)
+                        CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(code)
                                 + " ⇒ "
                                 + CLDRConfig.getInstance()
                                         .getEnglish()
                                         .nameGetter()
-                                        .getNameFromLocaleOrTZID(lstrReplacement))
+                                        .getNameFromBCP47(lstrReplacement))
                 + " -->";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -568,9 +568,9 @@ public class TestValidity extends TestFmwkPlus {
                 + "\"/>"
                 + " <!-- "
                 + TransliteratorUtilities.toXML.transform(
-                        CLDRConfig.getInstance().getEnglish().getName(code)
+                        CLDRConfig.getInstance().getEnglish().nameGetter().getName(code)
                                 + " ⇒ "
-                                + CLDRConfig.getInstance().getEnglish().getName(lstrReplacement))
+                                + CLDRConfig.getInstance().getEnglish().nameGetter().getName(lstrReplacement))
                 + " -->";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -568,12 +568,12 @@ public class TestValidity extends TestFmwkPlus {
                 + "\"/>"
                 + " <!-- "
                 + TransliteratorUtilities.toXML.transform(
-                        CLDRConfig.getInstance().getEnglish().nameGetter().getName(code)
+                        CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromLocaleOrTZID(code)
                                 + " ⇒ "
                                 + CLDRConfig.getInstance()
                                         .getEnglish()
                                         .nameGetter()
-                                        .getName(lstrReplacement))
+                                        .getNameFromLocaleOrTZID(lstrReplacement))
                 + " -->";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
@@ -83,7 +83,7 @@ public class XLocaleMatcherTest extends TestFmwk {
     // {
     //                continue;
     //            }
-    //            System.out.println(locale + "\t" + CONFIG.getEnglish().getName(locale) + "\t" +
+    //            System.out.println(locale + "\t" + CONFIG.getEnglish().nameGetter().getName(locale) + "\t" +
     // parentId + "\t" + parentIdSimple);
     //        }
     //    }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/XLocaleMatcherTest.java
@@ -83,7 +83,8 @@ public class XLocaleMatcherTest extends TestFmwk {
     // {
     //                continue;
     //            }
-    //            System.out.println(locale + "\t" + CONFIG.getEnglish().nameGetter().getName(locale) + "\t" +
+    //            System.out.println(locale + "\t" +
+    // CONFIG.getEnglish().nameGetter().getName(locale) + "\t" +
     // parentId + "\t" + parentIdSimple);
     //        }
     //    }

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -400,7 +400,8 @@ public class GenerateLanguageContainment {
         if (true) {
             // check on items
             for (String check : Arrays.asList("sw", "km", "ksh", "wae", "kea", "mfe", "th", "lo")) {
-                System.out.println("Checking " + ENGLISH.nameGetter().getName(check) + "[" + check + "]");
+                System.out.println(
+                        "Checking " + ENGLISH.nameGetter().getName(check) + "[" + check + "]");
                 Collection<String> entities = QUERY_HELPER.codeToEntity.get(check);
                 if (entities.isEmpty()) {
                     System.out.println("no code for " + check + ": " + entities);

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -237,7 +237,7 @@ public class GenerateLanguageContainment {
             code ->
                     code.equals(LocaleNames.MUL)
                             ? LocaleNames.ROOT
-                            : ENGLISH.nameGetter().getName(code) + " (" + code + ")";
+                            : ENGLISH.nameGetter().getNameFromLocaleOrTZID(code) + " (" + code + ")";
 
     static final Set<String> COLLECTIONS;
 
@@ -401,7 +401,7 @@ public class GenerateLanguageContainment {
             // check on items
             for (String check : Arrays.asList("sw", "km", "ksh", "wae", "kea", "mfe", "th", "lo")) {
                 System.out.println(
-                        "Checking " + ENGLISH.nameGetter().getName(check) + "[" + check + "]");
+                        "Checking " + ENGLISH.nameGetter().getNameFromLocaleOrTZID(check) + "[" + check + "]");
                 Collection<String> entities = QUERY_HELPER.codeToEntity.get(check);
                 if (entities.isEmpty()) {
                     System.out.println("no code for " + check + ": " + entities);

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -237,7 +237,7 @@ public class GenerateLanguageContainment {
             code ->
                     code.equals(LocaleNames.MUL)
                             ? LocaleNames.ROOT
-                            : ENGLISH.getName(code) + " (" + code + ")";
+                            : ENGLISH.nameGetter().getName(code) + " (" + code + ")";
 
     static final Set<String> COLLECTIONS;
 
@@ -400,7 +400,7 @@ public class GenerateLanguageContainment {
         if (true) {
             // check on items
             for (String check : Arrays.asList("sw", "km", "ksh", "wae", "kea", "mfe", "th", "lo")) {
-                System.out.println("Checking " + ENGLISH.getName(check) + "[" + check + "]");
+                System.out.println("Checking " + ENGLISH.nameGetter().getName(check) + "[" + check + "]");
                 Collection<String> entities = QUERY_HELPER.codeToEntity.get(check);
                 if (entities.isEmpty()) {
                     System.out.println("no code for " + check + ": " + entities);

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -237,7 +237,7 @@ public class GenerateLanguageContainment {
             code ->
                     code.equals(LocaleNames.MUL)
                             ? LocaleNames.ROOT
-                            : ENGLISH.nameGetter().getNameFromLocaleOrTZID(code) + " (" + code + ")";
+                            : ENGLISH.nameGetter().getNameFromBCP47(code) + " (" + code + ")";
 
     static final Set<String> COLLECTIONS;
 
@@ -401,7 +401,11 @@ public class GenerateLanguageContainment {
             // check on items
             for (String check : Arrays.asList("sw", "km", "ksh", "wae", "kea", "mfe", "th", "lo")) {
                 System.out.println(
-                        "Checking " + ENGLISH.nameGetter().getNameFromLocaleOrTZID(check) + "[" + check + "]");
+                        "Checking "
+                                + ENGLISH.nameGetter().getNameFromBCP47(check)
+                                + "["
+                                + check
+                                + "]");
                 Collection<String> entities = QUERY_HELPER.codeToEntity.get(check);
                 if (entities.isEmpty()) {
                     System.out.println("no code for " + check + ": " + entities);

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
@@ -35,6 +35,7 @@ import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.StandardCodes;
@@ -63,6 +64,7 @@ public class SubdivisionNode {
             CaseMap.toTitle().wholeString().noLowercase();
     static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
     static final CLDRFile ENGLISH_CLDR = CLDR_CONFIG.getEnglish();
+    static final NameGetter englishNameGetter = ENGLISH_CLDR.nameGetter();
     static final Normalizer2 nfc = Normalizer2.getNFCInstance();
 
     public static String convertToCldr(String regionOrSubdivision) {
@@ -263,7 +265,8 @@ public class SubdivisionNode {
                     SubdivisionInfo.SUBDIVISION_ALIASES_FORMER.get(value);
             if (subdivisionAlias != null) {
                 String country = subdivisionAlias.get0().get(0);
-                cldrName = ENGLISH_CLDR.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                cldrName =
+                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
                 if (cldrName != null) {
                     return fixName(cldrName);
                 }
@@ -612,7 +615,8 @@ public class SubdivisionNode {
                     result.append(", ");
                 }
                 if (SubdivisionNames.isRegionCode(s)) {
-                    result.append(ENGLISH_CLDR.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, s));
+                    result.append(
+                            englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, s));
                 } else {
                     result.append(sdset.getBestName(s, useIso));
                 }

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
@@ -263,7 +263,7 @@ public class SubdivisionNode {
                     SubdivisionInfo.SUBDIVISION_ALIASES_FORMER.get(value);
             if (subdivisionAlias != null) {
                 String country = subdivisionAlias.get0().get(0);
-                cldrName = ENGLISH_CLDR.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
+                cldrName = ENGLISH_CLDR.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
                 if (cldrName != null) {
                     return fixName(cldrName);
                 }
@@ -612,7 +612,7 @@ public class SubdivisionNode {
                     result.append(", ");
                 }
                 if (SubdivisionNames.isRegionCode(s)) {
-                    result.append(ENGLISH_CLDR.nameGetter().getName(CLDRFile.TERRITORY_NAME, s));
+                    result.append(ENGLISH_CLDR.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, s));
                 } else {
                     result.append(sdset.getBestName(s, useIso));
                 }

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
@@ -263,7 +263,7 @@ public class SubdivisionNode {
                     SubdivisionInfo.SUBDIVISION_ALIASES_FORMER.get(value);
             if (subdivisionAlias != null) {
                 String country = subdivisionAlias.get0().get(0);
-                cldrName = ENGLISH_CLDR.getName(CLDRFile.TERRITORY_NAME, country);
+                cldrName = ENGLISH_CLDR.nameGetter().getName(CLDRFile.TERRITORY_NAME, country);
                 if (cldrName != null) {
                     return fixName(cldrName);
                 }
@@ -612,7 +612,7 @@ public class SubdivisionNode {
                     result.append(", ");
                 }
                 if (SubdivisionNames.isRegionCode(s)) {
-                    result.append(ENGLISH_CLDR.getName(CLDRFile.TERRITORY_NAME, s));
+                    result.append(ENGLISH_CLDR.nameGetter().getName(CLDRFile.TERRITORY_NAME, s));
                 } else {
                     result.append(sdset.getBestName(s, useIso));
                 }


### PR DESCRIPTION
-Each CLDRFile has a NameGetter; all getName methods moved to NameGetter

-Give GetName methods distinct names for clarify and to avoid excessive overloading

-Make methods private where possible

-Move some calls to nameGetter() out of loops, re-use

-Remove some dead code

-Comments

CLDR-15830

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
