### PR TITLE
CLDR-18150 Fix private-use units to avoid validity constraints

### DIFF
--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -943,10 +943,9 @@ per
     * 100
 
 <a name='pu_single_unit' href='#pu_single_unit'>pu_single_unit</a> 
-<br/>:= "xxx-" single_unit 
-<br/>   | "x-" single_unit
+<br/>:= := ("xxx-" | "x-") [a-z0-9]{3,8}
 * *Examples:*
-    * xxx-square-knuts (a Harry Potter unit)  
+    * square-xxx-knuts (a Harry Potter unit)  
 * *Notes:*
     * "x-" is only for backwards compatibility; it is deprecated and should not be generated
     * See [Private-Use Units](https://github.com/unicode-org/cldr/edit/main/docs/ldml/tr35-general.md#Private_Use_Units)


### PR DESCRIPTION
CLDR-18150

This is to fix a regression introduced by [CLDR-15948: Clarify the well-formedness and validity of certain Unicode CLDR identifiers for MF2](https://unicode-org.atlassian.net/browse/CLDR-15948).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
