### PR TITLE
CLDR-15830 Use getNameFromTypenumCode instead of getNameFromTypestrCode

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -1048,7 +1048,8 @@ public class CLDRTest extends TestFmwk {
                 public Object transform(Object source) {
                     if (english == null) english = cldrFactory.make("en", true);
                     return english.nameGetter()
-                                    .getNameFromTypestrCode("currency", source.toString())
+                                    .getNameFromTypenumCode(
+                                            CLDRFile.CURRENCY_NAME, source.toString())
                             + " ("
                             + source
                             + ")";
@@ -1191,9 +1192,11 @@ public class CLDRTest extends TestFmwk {
             }
         }
         logln("Missing English currency names");
+        NameGetter englishNameGetter = english.nameGetter();
         for (Iterator<String> it = legalCurrencies.iterator(); it.hasNext(); ) {
             String currency = it.next();
-            String name = english.nameGetter().getNameFromTypestrCode("currency", currency);
+            String name =
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
             if (name == null) {
                 String standardName = sc.getFullData("currency", currency).get(0);
                 logln("\t\t\t<currency type=\"" + currency + "\">");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -439,14 +439,10 @@ public class ConvertLanguageData {
             BasicLanguageData.Type oldValue = oldDataToType.get(s);
             BasicLanguageData.Type newValue = newDataToType.get(s);
             if (!CldrUtility.equals(oldValue, newValue)) {
+                int code = s.length() == 4 ? CLDRFile.SCRIPT_NAME : CLDRFile.TERRITORY_NAME;
+                String name = englishNameGetter.getNameFromTypenumCode(code, s);
                 temp.setLength(0);
-                temp.append("[")
-                        .append(s)
-                        .append(":")
-                        .append(
-                                englishNameGetter.getNameFromTypestrCode(
-                                        s.length() == 4 ? "script" : "region", s))
-                        .append("] ");
+                temp.append("[").append(s).append(":").append(name).append("] ");
                 if (oldValue == null) {
                     temp.append(" added as ").append(newValue);
                 } else if (newValue == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -562,7 +562,8 @@ public class CountItems {
                             "# "
                                     + newCountry
                                     + "\t"
-                                    + nameGetter.getNameFromTypestrCode("territory", newCountry));
+                                    + nameGetter.getNameFromTypenumCode(
+                                            CLDRFile.TERRITORY_NAME, newCountry));
                     lastCountry = newCountry;
                 }
                 Log.println("\t'" + oldName + "'\t>\t'" + newName + "';");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathUtilities;
 import org.unicode.cldr.util.PatternCache;
@@ -155,13 +156,13 @@ class ExtractMessages {
                 System.out.println("\titems: " + itemCount);
                 totalCount += itemCount;
             }
-
+            NameGetter englishNameGetter = english.nameGetter();
             for (String name : skipped) {
                 System.out.println(
                         "\tSkipping, no CLDR locale file: "
                                 + name
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(name));
+                                + englishNameGetter.getNameFromBCP47(name));
             }
             double deltaTime = System.currentTimeMillis() - startTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");
@@ -448,10 +449,13 @@ class ExtractMessages {
         DataHandler(Type type, String pattern) {
             this.type = type;
             matcher = PatternCache.get(pattern).matcher("");
+            NameGetter englishNameGetter = english.nameGetter();
             switch (type) {
                 case LANGUAGE:
                     for (String code : sc.getAvailableCodes("language")) {
-                        String name = english.nameGetter().getNameFromTypestrCode("language", code);
+                        String name =
+                                englishNameGetter.getNameFromTypenumCode(
+                                        CLDRFile.LANGUAGE_NAME, code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -493,7 +497,8 @@ class ExtractMessages {
                 case REGION:
                     for (String code : sc.getAvailableCodes("territory")) {
                         String name =
-                                english.nameGetter().getNameFromTypestrCode("territory", code);
+                                englishNameGetter.getNameFromTypenumCode(
+                                        CLDRFile.TERRITORY_NAME, code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -532,7 +537,9 @@ class ExtractMessages {
                     break;
                 case CURRENCY:
                     for (String code : sc.getAvailableCodes("currency")) {
-                        String name = english.nameGetter().getNameFromTypestrCode("currency", code);
+                        String name =
+                                englishNameGetter.getNameFromTypenumCode(
+                                        CLDRFile.CURRENCY_NAME, code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -21,6 +21,7 @@ import org.unicode.cldr.util.Containment;
 import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.PreferredAndAllowedHour;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
@@ -261,21 +262,24 @@ public class FindPreferredHours {
             if (tag.equals("h")) {
                 tag += "*";
             }
-
+            NameGetter englishNameGetter = ENGLISH.nameGetter();
             System.out.println(
                     tag
                             + "\t"
                             + region
                             + "\t"
-                            + ENGLISH.nameGetter().getNameFromTypestrCode("territory", region)
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.TERRITORY_NAME, region)
                             + "\t"
                             + subcontinent
                             + "\t"
-                            + ENGLISH.nameGetter().getNameFromTypestrCode("territory", subcontinent)
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.TERRITORY_NAME, subcontinent)
                             + "\t"
                             + continent
                             + "\t"
-                            + ENGLISH.nameGetter().getNameFromTypestrCode("territory", continent)
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.TERRITORY_NAME, continent)
                             + "\t"
                             + showInfo(preferredSet));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -644,7 +644,7 @@ public class GenerateEnums {
                     format(popData.getPopulation()),
                     format(popData.getLiteratePopulation() / popData.getPopulation()),
                     format(popData.getGdp()),
-                    englishNameGetter.getNameFromTypestrCode("territory", territory));
+                    englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory));
             // remove all the ISO 639-3 until they are part of BCP 47
             // we need to remove in earlier pass so we have the count
             Set<String> languages = new TreeSet<>();
@@ -742,7 +742,8 @@ public class GenerateEnums {
                             + "\t"
                             + region
                             + "\t"
-                            + englishNameGetter.getNameFromTypestrCode("territory", region));
+                            + englishNameGetter.getNameFromTypenumCode(
+                                    CLDRFile.TERRITORY_NAME, region));
         }
 
         showGeneratedCommentEnd(DATA_INDENT);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -414,7 +414,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        String name = cldr.nameGetter().getNameFromTypestrCode("territory", country);
+        String name = cldr.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
         if (false && HACK) {
             Object trial = fixCountryNames.get(name);
             if (trial != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
@@ -71,7 +71,8 @@ public class GetLanguageData {
                         territory //
                                 + "\t"
                                 + english.nameGetter()
-                                        .getNameFromTypestrCode("territory", territory) //
+                                        .getNameFromTypenumCode(
+                                                CLDRFile.TERRITORY_NAME, territory) //
                                 + "\t"
                                 + territoryPop //
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -43,6 +43,7 @@ import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso3166Data;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.StandardCodes;
@@ -266,6 +267,7 @@ public class Misc {
     private static void listObsoletes() {
         // java.util.TimeZone t;
         StandardCodes sc = StandardCodes.make();
+        NameGetter englishNameGetter = english.nameGetter();
         for (Iterator<String> typeIt = sc.getAvailableTypes().iterator(); typeIt.hasNext(); ) {
             String type = typeIt.next();
             System.out.println(type);
@@ -276,13 +278,13 @@ public class Misc {
                 if (list.size() < 3) continue;
                 String replacementCode = list.get(2);
                 if (replacementCode.length() == 0) continue;
-                System.out.println(
-                        code
-                                + " => "
-                                + replacementCode
-                                + "; "
-                                + english.nameGetter()
-                                        .getNameFromTypestrCode(type, replacementCode));
+                /*
+                 * TODO: use getNameFromTypenumCode instead of getNameFromTypestrCode here.
+                 * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
+                 * type is derived from sc.getAvailableTypes()
+                 */
+                String name = englishNameGetter.getNameFromTypestrCode(type, replacementCode);
+                System.out.println(code + " => " + replacementCode + "; " + name);
             }
         }
     }
@@ -481,7 +483,7 @@ public class Misc {
             new_old.put(zone, new TreeSet<String>(col));
             String country = zone_countries.get(zone);
             String name =
-                    english.nameGetter().getNameFromTypestrCode("territory", country)
+                    english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country)
                             + " ("
                             + country
                             + ")";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -2231,8 +2231,8 @@ public class ShowLanguages {
                                     + infoItem.getCurrency()
                                     + "</td>"
                                     + "<td class='target'>"
-                                    + englishNameGetter.getNameFromTypestrCode(
-                                            "currency", infoItem.getCurrency())
+                                    + englishNameGetter.getNameFromTypenumCode(
+                                            CLDRFile.CURRENCY_NAME, infoItem.getCurrency())
                                     + "</td>"
                                     + "</tr>");
                 }
@@ -2287,8 +2287,8 @@ public class ShowLanguages {
                         "<tr>"
                                 + "<td class='source nowrap'>"
                                 + TransliteratorUtilities.toHTML.transform(
-                                        englishNameGetter.getNameFromTypestrCode(
-                                                "currency", currency))
+                                        englishNameGetter.getNameFromTypenumCode(
+                                                CLDRFile.CURRENCY_NAME, currency))
                                 + "</td>"
                                 + "<td class='source'>"
                                 + CldrUtility.getDoubleLinkedText(currency)
@@ -2369,7 +2369,7 @@ public class ShowLanguages {
 
         private String getTerritoryName(String territory) {
             String name;
-            name = englishNameGetter.getNameFromTypestrCode("territory", territory);
+            name = englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
             if (name == null) {
                 name = sc.getData("territory", territory);
             }
@@ -2972,6 +2972,12 @@ public class ShowLanguages {
     private static SortedMap<String, String> getNameToCode(CodeType codeType, String cldrCodeType) {
         SortedMap<String, String> temp = new TreeMap<String, String>(col);
         for (String territory : StandardCodes.make().getAvailableCodes(codeType)) {
+            /*
+             * TODO: use getNameFromTypenumCode instead of getNameFromTypestrCode here.
+             * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
+             * codeType is either CodeType.territory or CodeType.currency
+             * cldrCodeType is either "region" or "currency"
+             */
             String name = englishNameGetter.getNameFromTypestrCode(cldrCodeType, territory);
             temp.put(name == null ? territory : name, territory);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -1180,7 +1180,7 @@ public class ShowLocaleCoverage {
                         + "\t"
                         + ENGLISH.nameGetter().getNameFromBCP47(language)
                         + "\t"
-                        + ENGLISH.nameGetter().getNameFromTypestrCode("script", script)
+                        + ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
                         + "\t"
                         + cldrLocaleLevelGoal
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2531,7 +2531,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         if (type.equalsIgnoreCase("region")) {
             type = "territory";
         }
-        for (int i = 0; i < LIMIT_TYPES; ++i) {
+        for (int i = 0; i <= LIMIT_TYPES; ++i) {
             if (type.equalsIgnoreCase(getNameName(i))) {
                 return i;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -152,7 +152,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         @Override
         public String getDisplayVariant(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getNameFromTypestrCode("variant", cldrLocale.getVariant());
+                return file.nameGetter()
+                        .getNameFromTypenumCode(CLDRFile.VARIANT_NAME, cldrLocale.getVariant());
             return tryForBetter(super.getDisplayVariant(cldrLocale), cldrLocale.getVariant());
         }
 
@@ -181,7 +182,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         @Override
         public String getDisplayScript(CLDRLocale cldrLocale) {
             if (file != null)
-                return file.nameGetter().getNameFromTypestrCode("script", cldrLocale.getScript());
+                return file.nameGetter()
+                        .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, cldrLocale.getScript());
             return tryForBetter(super.getDisplayScript(cldrLocale), cldrLocale.getScript());
         }
 
@@ -189,7 +191,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayLanguage(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromTypestrCode("language", cldrLocale.getLanguage());
+                        .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, cldrLocale.getLanguage());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 
@@ -197,7 +199,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayCountry(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromTypestrCode("territory", cldrLocale.getCountry());
+                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, cldrLocale.getCountry());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -995,7 +995,8 @@ public class PathDescription {
                     found = true;
                 } else if (country != null) {
                     String countryName =
-                            english.nameGetter().getNameFromTypestrCode("territory", country);
+                            english.nameGetter()
+                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
                     if (countryName != null) {
                         if (!codeName.equals(countryName)) {
                             code = "the city “" + codeName + "” (in " + countryName + ")";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -261,7 +261,7 @@ public class LanguageTest extends TestFmwk {
 
     private String getScriptName(String script) {
         NameGetter nameGetter = testInfo.getEnglish().nameGetter();
-        String name = nameGetter.getNameFromTypestrCode("script", script);
+        String name = nameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
         if (name != null && !name.equals(script)) {
             return name;
         }
@@ -281,7 +281,7 @@ public class LanguageTest extends TestFmwk {
 
     private String getLanguageName(String language) {
         NameGetter nameGetter = testInfo.getEnglish().nameGetter();
-        String name = nameGetter.getNameFromTypestrCode("language", language);
+        String name = nameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
         if (name != null && !name.equals(language)) {
             return name;
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -376,7 +376,8 @@ public class LikelySubtagsTest extends TestFmwk {
                                         + region
                                         + "\t"
                                         + english.nameGetter()
-                                                .getNameFromTypestrCode("territory", region));
+                                                .getNameFromTypenumCode(
+                                                        CLDRFile.TERRITORY_NAME, region));
                     }
                 } else { // container
                     logln(
@@ -384,7 +385,8 @@ public class LikelySubtagsTest extends TestFmwk {
                                     + region
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypestrCode("territory", region));
+                                            .getNameFromTypenumCode(
+                                                    CLDRFile.TERRITORY_NAME, region));
                 }
             } else {
                 logln("Likely subtags for region: " + region + ":\t " + likely);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -18,6 +18,7 @@ import org.unicode.cldr.util.LsrvCanonicalizer;
 import org.unicode.cldr.util.LsrvCanonicalizer.ReplacementRule;
 import org.unicode.cldr.util.LsrvCanonicalizer.TestDataTypes;
 import org.unicode.cldr.util.LsrvCanonicalizer.XLanguageTag;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -295,13 +296,18 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                         continue;
                     }
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    String typeName =
-                            english.nameGetter().getNameFromTypestrCode(typeCompat, subtag);
+                    NameGetter englishNameGetter = english.nameGetter();
+                    /*
+                     * TODO: use getNameFromTypenumCode instead of getNameFromTypestrCode here (twice).
+                     * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
+                     * typeCompat is derived from StandardCodes.LstrType.toCompatString
+                     */
+                    String typeName = englishNameGetter.getNameFromTypestrCode(typeCompat, subtag);
                     String replacementName =
                             preferredValueCompat == null
                                     ? "???"
-                                    : english.nameGetter()
-                                            .getNameFromTypestrCode(typeCompat, replacementString);
+                                    : englishNameGetter.getNameFromTypestrCode(
+                                            typeCompat, replacementString);
                     addExceptions.add(
                             ".put(\""
                                     + subtag

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -389,4 +389,23 @@ public class TestCLDRFile {
             baselineFactory.make("es_MX".toString(), true);
         }
     }
+
+    @Test
+    public void TestTypeNameToCode() {
+        assertEquals(CLDRFile.LANGUAGE_NAME, CLDRFile.typeNameToCode("language"));
+        assertEquals(CLDRFile.TERRITORY_NAME, CLDRFile.typeNameToCode("territory"));
+        assertEquals(CLDRFile.VARIANT_NAME, CLDRFile.typeNameToCode("variant"));
+        assertEquals(CLDRFile.CURRENCY_NAME, CLDRFile.typeNameToCode("currency"));
+        assertEquals(CLDRFile.CURRENCY_SYMBOL, CLDRFile.typeNameToCode("currency-symbol"));
+        assertEquals(CLDRFile.TZ_EXEMPLAR, CLDRFile.typeNameToCode("exemplar-city"));
+        assertEquals(CLDRFile.TZ_GENERIC_LONG, CLDRFile.typeNameToCode("tz-generic-long"));
+        assertEquals(CLDRFile.TZ_GENERIC_SHORT, CLDRFile.typeNameToCode("tz-generic-short"));
+        assertEquals(CLDRFile.TZ_STANDARD_LONG, CLDRFile.typeNameToCode("tz-standard-long"));
+        assertEquals(CLDRFile.TZ_STANDARD_SHORT, CLDRFile.typeNameToCode("tz-standard-short"));
+        assertEquals(CLDRFile.TZ_DAYLIGHT_LONG, CLDRFile.typeNameToCode("tz-daylight-long"));
+        assertEquals(CLDRFile.TZ_DAYLIGHT_SHORT, CLDRFile.typeNameToCode("tz-daylight-short"));
+        assertEquals(CLDRFile.KEY_NAME, CLDRFile.typeNameToCode("key"));
+        assertEquals(CLDRFile.KEY_TYPE_NAME, CLDRFile.typeNameToCode("key|type"));
+        assertEquals(CLDRFile.SUBDIVISION_NAME, CLDRFile.typeNameToCode("subdivision"));
+    }
 }


### PR DESCRIPTION
-Switch almost all calls to use integer instead of string

-TODO comments for 3 exceptions where getting integer is challenging

-Fix off-by-one bug in CLDRFile.typeNameToCode

-New unit test for CLDRFile.typeNameToCode

-Move some calls to nameGetter() out of loops, re-use

CLDR-15830

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
