### PR TITLE
CLDR-18095 Remove Japonic languageGroup from Altaic

### DIFF
--- a/common/supplemental/languageGroup.xml
+++ b/common/supplemental/languageGroup.xml
@@ -63,7 +63,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<languageGroup parent="ira">ae atn avd bal bgn bhh bjm bqi bsg ckb def deh esh fa fay gbz glk goz gzi hac hrz isk jdt jpr kfm kgn kho kiu ku lki lrc lrl lsa luz mnj mzn ntz nyq okh oru os pal peo prc ps rat rdb sdb sdf sdh sgh sgr sgy shm siy smy sog soj sqo srh srz tg tks tly tov ttt vaf vmh wbl wne xbc xco xkc xkj xkp xme xmn xpr xsc yah yai ydg ysc zum zza</languageGroup>
 		<languageGroup parent="iro">cay chr lre moh ntw one ono see sqn tus</languageGroup>
 		<languageGroup parent="itc">la osc roa spx umc xae xfa xhr xum xve xvo xvs</languageGroup>
-		<languageGroup parent="jpx">ja</languageGroup>
+		<languageGroup parent="jpx">ams ja kzg mvi ojp okn ryn rys ryu tkn xug yoi yox</languageGroup>
 		<languageGroup parent="kar">blk bwe eky ghk jkm jkp kjp kjt ksw kvl kvq kvt kvu kvy kxf kxk pdu pwo pww wea</languageGroup>
 		<languageGroup parent="kdo">acz eli lmd taz tlo</languageGroup>
 		<languageGroup parent="khi">gku gnk gwj hgm hio hnh hts huc knw kqu kqz ktz kwz naq ngh nhr nmn sad shg tyu vaj xam xii xuu</languageGroup>
@@ -71,7 +71,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<languageGroup parent="map">aaw agn agz bbn bnd don fox iba kvo kzl laz lbq lnd mli mqx mth mvp mvv myw plc plw poz put pwm riu rjg sew slu snc tkd trb trx tvm wah waz wrx ymn</languageGroup>
 		<languageGroup parent="mkh">aem bgk bgl blr brb btq caq cbn cmo cog crv crw cwg dnu hkn hnu huo jah jhi kfj kha kjg kjm km kns kpm krr krv kxm lbn lcp lnh lwl mhe mlf mml mnq mnw mqt mra mtq mzt ncb nik nuo omx oyb pbv pcb pce pkt pll pnx prk prt rbb ril rka rmx sbo scb scq sea sed smu sqq ssm stg sti stt sxm syo sza szc tdf tea tef tgr thm tlq tmo tnz tou tpu tyh ukk uuu vi vwa wbm xao xkk xko xnh yin</languageGroup>
 		<languageGroup parent="mno">cgc mbb mbd mbi mqk msm mta</languageGroup>
-		<languageGroup parent="mul">aav afa aqa aql art auf aus awd azc cau cba cdd cpe crp dra esx euq hmx hok ine iro jpx kgp khi ko map myn nic omq paa qwe sal sgn sio sit ssa tai tup tut und urj wak xnd ypk</languageGroup>
+		<languageGroup parent="mul">aav afa ain aqa aql art auf aus awd azc cau cba cdd cpe crp dra esx euq hmx hok ine iro jje jpx kgp khi ko map myn nic okm oko omq paa pkc qwe sal sgn sio sit ssa tai tup tut und urj wak xnd xpy ypk zkg</languageGroup>
 		<languageGroup parent="mun">agi asr biy cdz ekl gaq gbj hoc jun kfp kfq khr ksz mjx pcj sat srb trd unr</languageGroup>
 		<languageGroup parent="myn">acr agu caa cac cak chf cob ctu emy hus itz ixl jac kek kjb knj lac mam mhc mop poc poh quc qum quv toj ttc tzh tzj tzo usp yua</languageGroup>
 		<languageGroup parent="nah">azd azn azz naz nch nci ncj ncl ngu nhc nhe nhg nhk nhm nhn nhp nhq nht nhv nhw nhx nhy nhz nlv nsu nuz ppl</languageGroup>
@@ -107,7 +107,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<languageGroup parent="tbq">adi adl apt bee bft bfu bqh bro brx cda cdn cgk chx dka drd duu dz dzl ghe ghh ght gro gvr gyo hut jda jna jul kbg kfk khg kkf kte kzq lae lbf lbj lhm lkh loy mrg nbt neh njz nmm npa nun ola ole prx rgk rnp sbu scp scu sgt sip skj spt syw taj tdg tgf tgj ths tpq tsj tsk ttz twm xkf xkz xns xsr xzh zau</languageGroup>
 		<languageGroup parent="trk">aib alt atv az azb ba bgx chg cjs clw crh cv dlg gag ili jct kaa kdr kim kjh kk klj kmz krc kum ky nog otk oui qwm qxq sah slr sty tk tr tt tyv ug uum uz xbo xpc xqa ybe zkh zkz</languageGroup>
 		<languageGroup parent="tup">aan ait ama api aqz arr arx asn asu aux avv awe awt cin cod eme gn gnw gub gui gun guq gvj gvo gyr jor jua jur kay kgk kpn ktn kuq kyr kyz mav mdz mnd mpu msp myu nhd omg oym paf pah pak pog psm pta pto skf srq sru taf tpj tpk tpn tpr tqb twt urb uru urz wir wyr xaj xiy xmo yrl yuq</languageGroup>
-		<languageGroup parent="tut">ain ams jje kzg mvi ojp okm okn oko pkc ryn rys ryu tkn trk tuw xgn xhc xpy xug yoi yox zkg zkt</languageGroup>
+		<languageGroup parent="tut">trk tuw xgn xhc zkt</languageGroup>
 		<languageGroup parent="tuw">eve evn gld juc mnc neg oaa oac orh sjo ude ulc</languageGroup>
 		<languageGroup parent="urj">fiu omk rts syd xcv ykg yux</languageGroup>
 		<languageGroup parent="wak">dtd has hei kwk myh nuk</languageGroup>


### PR DESCRIPTION
CLDR-18095

The Altaic hypothesis, while really fun, is largely discredited. This change organizes the Japonic languages into a group, and removes them & Koreanic languages from the Altaic language group. FWIW there is no ISO 639-5 Koreanic group.

I'm happy to make more LangaugeGroup changes, I just limited this to the discussion in the specific ticket.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
