### PR TITLE
CLDR-18136 Fix datetimeSkeleton typo in yue

### DIFF
--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -2874,7 +2874,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<dateFormatLength type="long">
 						<dateFormat>
 							<pattern>y年M月d日</pattern>
-							<datetimeSkeleton>yMdMM</datetimeSkeleton>
+							<datetimeSkeleton>yMMMd</datetimeSkeleton>
 						</dateFormat>
 					</dateFormatLength>
 					<dateFormatLength type="medium">


### PR DESCRIPTION
CLDR-18136

A typo originating in #4217 that I found after testing CLDR 46.1 BETA1 in ICU4X.