### PR TITLE
CLDR-15830 Extensive refactoring of NameGetter; new enum NameType

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/LocaleTree.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/LocaleTree.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CLDRLocale.CLDRFormatter;
+import org.unicode.cldr.util.NameGetter;
 
 public class LocaleTree {
     CLDRFormatter displayLocale;
@@ -97,7 +98,7 @@ public class LocaleTree {
     }
 
     public String getLocaleDisplayName(CLDRLocale locale) {
-        return displayLocale.getDisplayName(locale, true, null);
+        return displayLocale.getDisplayName(locale, NameGetter.NameOpt.COMPOUND_ONLY, null);
     }
 
     public Map<String, CLDRLocale> getMap() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -48,7 +48,8 @@ public class GenerateLanguageData {
             Map<String, String> languageNameToCode = new TreeMap<>();
             NameGetter nameGetter = english.nameGetter();
             for (String languageCode : info.getLanguages()) {
-                languageNameToCode.put(nameGetter.getNameFromBCP47(languageCode), languageCode);
+                languageNameToCode.put(
+                        nameGetter.getNameFromIdentifier(languageCode), languageCode);
             }
             out.println("\n@sheet:CLDR County Data");
             out.println("code\tgdp\tlit-pop\tpopulation\tliteracy");
@@ -74,7 +75,7 @@ public class GenerateLanguageData {
             Map<String, Counter2<String>> langToCountriesOfficial = new TreeMap<>();
 
             for (String languageCode : info.getLanguages()) {
-                String languageName = nameGetter.getNameFromBCP47(languageCode);
+                String languageName = nameGetter.getNameFromIdentifier(languageCode);
 
                 String baseLanguage = languageCode;
                 ltp.set(languageCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/GenerateLanguageData.java
@@ -16,6 +16,7 @@ import org.unicode.cldr.util.Counter2;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
@@ -93,7 +94,7 @@ public class GenerateLanguageData {
                 for (String territory : territories) {
                     PopulationData terrData = info.getPopulationDataForTerritory(territory);
                     String territoryName =
-                            nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                            nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory);
 
                     PopulationData data =
                             info.getLanguageAndTerritoryPopulationData(languageCode, territory);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/Misc.java
@@ -139,7 +139,11 @@ public class Misc {
                 }
             }
             System.out.println(
-                    string + "\t" + defCon + "\t" + english.nameGetter().getNameFromBCP47(defCon));
+                    string
+                            + "\t"
+                            + defCon
+                            + "\t"
+                            + english.nameGetter().getNameFromIdentifier(defCon));
         }
     }
 
@@ -329,7 +333,7 @@ public class Misc {
             if (temp != null) {
                 baseLanguage = temp.get0().get(0);
             }
-            String englishName = english.nameGetter().getNameFromBCP47(baseLanguage);
+            String englishName = english.nameGetter().getNameFromIdentifier(baseLanguage);
             CLDRFile cldrFile = factory.make(baseLanguage, false);
             UnicodeSet set = cldrFile.getExemplarSet("", WinningChoice.WINNING);
             int script = -1;
@@ -340,7 +344,7 @@ public class Misc {
                     break;
                 }
             }
-            String nativeName = cldrFile.nameGetter().getNameFromBCP47(baseLanguage);
+            String nativeName = cldrFile.nameGetter().getNameFromIdentifier(baseLanguage);
             nameAndInfo.add(
                     englishName
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/XLocaleDistance.java
@@ -32,6 +32,7 @@ import org.unicode.cldr.draft.XLikelySubtags.LSR;
 import org.unicode.cldr.draft.XLocaleDistance.RegionMapper.Builder;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 public class XLocaleDistance {
@@ -971,7 +972,7 @@ public class XLocaleDistance {
                 } else {
                     result.append(
                             english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, region));
                 }
             case 2:
                 String script = alt.get(1);
@@ -981,7 +982,7 @@ public class XLocaleDistance {
                     result.insert(
                             0,
                             english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, script));
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, script));
                 }
             case 1:
                 String language = alt.get(0);
@@ -991,7 +992,7 @@ public class XLocaleDistance {
                     result.insert(
                             0,
                             english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, language));
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, language));
                 }
         }
         return Joiner.on("; ").join(alt);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -413,7 +413,7 @@ public class CLDRTest extends TestFmwk {
         String name = localeNameCache.get(locale);
         if (name != null) return name;
         if (english == null) english = cldrFactory.make("en", true);
-        String result = english.nameGetter().getNameFromBCP47(locale);
+        String result = english.nameGetter().getNameFromIdentifier(locale);
         /*
          * Collection c = Utility.splitList(locale, '_', false, null);
          * String[] pieces = new String[c.size()];

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -494,9 +495,14 @@ public class CLDRTest extends TestFmwk {
     public void TestDisplayNameCollisions() {
         if (disableUntilLater("TestDisplayNameCollisions")) return;
 
-        Map<String, String>[] maps = new HashMap[CLDRFile.LIMIT_TYPES];
-        for (int i = 0; i < maps.length; ++i) {
-            maps[i] = new HashMap<>();
+        Set<NameType> nameTypeSet = EnumSet.allOf(NameType.class);
+        Map<String, String>[] maps = new HashMap[nameTypeSet.size()];
+        Map<NameType, Integer> nameTypeIntegerMap = new HashMap();
+        int j = 0;
+        for (NameType nameType : NameType.values()) {
+            maps[j] = new HashMap<>();
+            nameTypeIntegerMap.put(nameType, j);
+            ++j;
         }
         Set<String> collisions = new TreeSet<>();
         for (Iterator<String> it = locales.iterator(); it.hasNext(); ) {
@@ -509,22 +515,17 @@ public class CLDRTest extends TestFmwk {
 
             for (Iterator<String> it2 = item.iterator(); it2.hasNext(); ) {
                 String xpath = it2.next();
-                int nameType = CLDRFile.getNameType(xpath);
-                if (nameType < 0) continue;
+                NameType nameType = NameType.fromPath(xpath);
+                if (nameType == NameType.NONE) continue;
                 String value = item.getStringValue(xpath);
-                String xpath2 = maps[nameType].get(value);
+                int nameTypeIndex = nameTypeIntegerMap.get(nameType);
+                String xpath2 = maps[nameTypeIndex].get(value);
                 if (xpath2 == null) {
-                    maps[nameType].put(value, xpath);
+                    maps[nameTypeIndex].put(value, xpath);
                     continue;
                 }
-                collisions.add(
-                        CLDRFile.getNameTypeName(nameType)
-                                + "\t"
-                                + value
-                                + "\t"
-                                + xpath
-                                + "\t"
-                                + xpath2);
+                String theName = nameType.getNameTypeName();
+                collisions.add(theName + "\t" + value + "\t" + xpath + "\t" + xpath2);
                 surveyInfo.add(
                         locale
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.ICUServiceBuilder;
 import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PluralRulesUtil;
@@ -577,7 +578,7 @@ public class CheckNumbers extends FactoryCheckCLDR {
     private void checkCurrencyFormats(
             String path, String fullPath, String value, List result, boolean generateExamples)
             throws ParseException {
-        DecimalFormat x = icuServiceBuilder.getCurrencyFormat(CLDRFile.getCode(path));
+        DecimalFormat x = icuServiceBuilder.getCurrencyFormat(NameType.getCode(path));
         addOrTestSamples(x, x.toPattern(), value, result, generateExamples);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -1986,7 +1986,7 @@ public class ConsoleCheckCLDR {
      */
     private static String getLocaleAndName(String locale) {
         String localizedName =
-                CheckCLDR.getDisplayInformation().nameGetter().getNameFromBCP47(locale);
+                CheckCLDR.getDisplayInformation().nameGetter().getNameFromIdentifier(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return locale + " [" + localizedName + "]";
     }
@@ -2000,7 +2000,7 @@ public class ConsoleCheckCLDR {
      */
     private static String getNameAndLocale(String locale, boolean linkToXml) {
         String localizedName =
-                CheckCLDR.getDisplayInformation().nameGetter().getNameFromBCP47(locale);
+                CheckCLDR.getDisplayInformation().nameGetter().getNameFromIdentifier(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         if (linkToXml) {
             locale =
@@ -2015,7 +2015,7 @@ public class ConsoleCheckCLDR {
 
     private static String getLocaleName(String locale) {
         String localizedName =
-                CheckCLDR.getDisplayInformation().nameGetter().getNameFromBCP47(locale);
+                CheckCLDR.getDisplayInformation().nameGetter().getNameFromIdentifier(locale);
         if (localizedName == null || localizedName.equals(locale)) return locale;
         return localizedName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/EmojiSubdivisionNames.java
@@ -146,7 +146,7 @@ public class EmojiSubdivisionNames {
                                     + "\t"
                                     + rank
                                     + "\t"
-                                    + nameGetter.getNameFromBCP47(locale)
+                                    + nameGetter.getNameFromIdentifier(locale)
                                     + "\t"
                                     + locale);
                     for (String sd : SUBDIVISIONS) {
@@ -173,7 +173,7 @@ public class EmojiSubdivisionNames {
                             + "\t"
                             + rank
                             + "\t"
-                            + english.nameGetter().getNameFromBCP47(locale)
+                            + english.nameGetter().getNameFromIdentifier(locale)
                             + "\t"
                             + locale);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -69,6 +69,7 @@ import org.unicode.cldr.util.ICUServiceBuilder;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PathDescription;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PluralSamples;
@@ -903,7 +904,7 @@ public class ExampleGenerator {
         if ("category-list".equals(parts.getAttributeValue(-1, "type"))) {
             CLDRFile cfile = getCldrFile();
             SimpleFormatter initialPattern = SimpleFormatter.compile(setBackground(value));
-            String path = CLDRFile.getKey(CLDRFile.TERRITORY_NAME, "FR");
+            String path = NameType.TERRITORY.getKeyPath("FR");
             String regionName = cfile.getStringValue(path);
             String flagName =
                     cfile.getStringValue("//ldml/characterLabels/characterLabel[@type=\"flag\"]");
@@ -957,7 +958,7 @@ public class ExampleGenerator {
             CLDRFile cfile,
             SimpleFormatter initialPattern,
             List<String> examples) {
-        String path = CLDRFile.getKey(CLDRFile.TERRITORY_NAME, isoRegionCode);
+        String path = NameType.TERRITORY.getKeyPath(isoRegionCode);
         String regionName = cfile.getStringValue(path);
         examples.add(
                 invertBackground(
@@ -2413,8 +2414,7 @@ public class ExampleGenerator {
                 result =
                         setBackground(
                                 cldrFile.nameGetter()
-                                        .getNameFromTypenumCode(
-                                                CLDRFile.TERRITORY_NAME, countryCode));
+                                        .getNameFromTypeEnumCode(NameType.TERRITORY, countryCode));
             }
         } else if (parts.contains("zone")) { // {0} Time
             result = value; // trivial -- is this beneficial?
@@ -2424,8 +2424,7 @@ public class ExampleGenerator {
                             value,
                             setBackground(
                                     cldrFile.nameGetter()
-                                            .getNameFromTypenumCode(
-                                                    CLDRFile.TERRITORY_NAME, "JP")));
+                                            .getNameFromTypeEnumCode(NameType.TERRITORY, "JP")));
             result =
                     addExampleResult(
                             format(
@@ -3168,11 +3167,11 @@ public class ExampleGenerator {
                     if (languageName == null) {
                         languageName =
                                 cldrFile.getStringValueWithBailey(
-                                        CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, ltp.getLanguage()));
+                                        NameType.LANGUAGE.getKeyPath(ltp.getLanguage()));
                         if (languageName == null) {
                             languageName =
                                     cldrFile.getStringValueWithBailey(
-                                            CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, "en"));
+                                            NameType.LANGUAGE.getKeyPath("en"));
                         }
                         if (languageName == null) {
                             languageName = ltp.getLanguage();
@@ -3181,11 +3180,11 @@ public class ExampleGenerator {
                     if (scriptName == null) {
                         scriptName =
                                 cldrFile.getStringValueWithBailey(
-                                        CLDRFile.getKey(CLDRFile.SCRIPT_NAME, ltp.getScript()));
+                                        NameType.SCRIPT.getKeyPath(ltp.getScript()));
                         if (scriptName == null) {
                             scriptName =
                                     cldrFile.getStringValueWithBailey(
-                                            CLDRFile.getKey(CLDRFile.SCRIPT_NAME, "Latn"));
+                                            NameType.SCRIPT.getKeyPath("Latn"));
                         }
                         if (scriptName == null) {
                             scriptName = ltp.getScript();
@@ -3194,11 +3193,11 @@ public class ExampleGenerator {
                     if (territoryName == null) {
                         territoryName =
                                 cldrFile.getStringValueWithBailey(
-                                        CLDRFile.getKey(CLDRFile.TERRITORY_NAME, ltp.getRegion()));
+                                        NameType.TERRITORY.getKeyPath(ltp.getRegion()));
                         if (territoryName == null) {
                             territoryName =
                                     cldrFile.getStringValueWithBailey(
-                                            CLDRFile.getKey(CLDRFile.TERRITORY_NAME, "US"));
+                                            NameType.TERRITORY.getKeyPath("US"));
                         }
                         if (territoryName == null) {
                             territoryName = ltp.getRegion();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -759,7 +759,7 @@ public class ExampleGenerator {
                         final String name =
                                 localeId.equals("und")
                                         ? "«any other»"
-                                        : nameGetter2.getNameFromBCP47(localeId);
+                                        : nameGetter2.getNameFromIdentifier(localeId);
                         examples.add(localeId + " = " + name);
                     }
                     break;
@@ -3116,9 +3116,9 @@ public class ExampleGenerator {
             for (int i = 0; i < locales.size(); i++) {
                 examples.add(
                         invertBackground(
-                                nameGetter.getNameFromBCP47Etc(
+                                nameGetter.getNameFromIdentifierEtc(
                                         locales.get(i),
-                                        false,
+                                        NameGetter.NameOpt.DEFAULT,
                                         localeKeyTypePattern,
                                         localePattern,
                                         localeSeparator)));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
@@ -208,7 +208,8 @@ public class QuickCheck {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            System.out.println(locale + "\t-\t" + english.nameGetter().getNameFromBCP47(locale));
+            System.out.println(
+                    locale + "\t-\t" + english.nameGetter().getNameFromIdentifier(locale));
             DtdType dtdType = null;
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
@@ -239,7 +239,7 @@ public class TestMisc {
         }
         NameGetter nameGetter = english.nameGetter();
         for (Pair<Integer, String> p : rel) {
-            System.out.println(p + "\t" + nameGetter.getNameFromBCP47(p.getSecond()));
+            System.out.println(p + "\t" + nameGetter.getNameFromIdentifier(p.getSecond()));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
@@ -17,6 +17,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.StandardCodes;
@@ -164,7 +165,7 @@ public class TestSupplementalData {
                 Set<String> otherLanguagesLeftover = new TreeSet<>(otherLanguages);
                 otherLanguagesLeftover.removeAll(languages);
                 String territoryString =
-                        nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                        nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory);
                 if (otherLanguagesLeftover.size() != 0) {
                     for (String other : otherLanguagesLeftover) {
                         String name = nameGetter.getNameFromBCP47(other);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestSupplementalData.java
@@ -168,7 +168,7 @@ public class TestSupplementalData {
                         nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory);
                 if (otherLanguagesLeftover.size() != 0) {
                     for (String other : otherLanguagesLeftover) {
-                        String name = nameGetter.getNameFromBCP47(other);
+                        String name = nameGetter.getNameFromIdentifier(other);
                         System.out.println(
                                 territoryString + "\t" + territory + "\t" + name + "\t" + other);
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -178,7 +178,7 @@ public class ChartAnnotations extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = nameGetter.getNameFromBCP47Bool(locale, true);
+            String name = nameGetter.getNameFromIndentifierCompoundOnly(locale);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -189,7 +189,7 @@ public class ChartAnnotations extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = nameGetter.getNameFromBCP47Bool("en", true);
+            String ename = nameGetter.getNameFromIndentifierCompoundOnly("en");
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartAnnotations.java
@@ -178,7 +178,7 @@ public class ChartAnnotations extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = nameGetter.getNameFromIndentifierCompoundOnly(locale);
+            String name = nameGetter.getNameFromIdentifierCompoundOnly(locale);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -189,7 +189,7 @@ public class ChartAnnotations extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = nameGetter.getNameFromIndentifierCompoundOnly("en");
+            String ename = nameGetter.getNameFromIdentifierCompoundOnly("en");
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartCollation.java
@@ -29,6 +29,7 @@ import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.FileCopier;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.XMLFileReader;
@@ -230,7 +231,10 @@ public class ChartCollation extends Chart {
             }
             new Subchart(
                             ENGLISH.nameGetter()
-                                    .getNameFromBCP47BoolAlt(locale, true, CLDRFile.SHORT_ALTS),
+                                    .getNameFromIdentifierOptAlt(
+                                            locale,
+                                            NameGetter.NameOpt.COMPOUND_ONLY,
+                                            CLDRFile.SHORT_ALTS),
                             locale,
                             data)
                     .writeChart(anchors);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDayPeriods.java
@@ -92,7 +92,7 @@ public class ChartDayPeriods extends Chart {
                     tablePrinter
                             .addRow()
                             .addCell(group)
-                            .addCell(ENGLISH.nameGetter().getNameFromBCP47(locale))
+                            .addCell(ENGLISH.nameGetter().getNameFromIdentifier(locale))
                             .addCell(locale)
                             // .addCell(type)
                             .addCell(df.format(time))

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -1011,7 +1011,7 @@ public class ChartDelta extends Chart {
                     .addCell(coverageLevel)
                     .finishRow();
         }
-        String title = ENGLISH.nameGetter().getNameFromBCP47(file) + " " + chartNameCap;
+        String title = ENGLISH.nameGetter().getNameFromIdentifier(file) + " " + chartNameCap;
         writeTable(anchors, file, tablePrinter, title, tsvFile);
 
         diff.clear();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
@@ -166,7 +166,7 @@ public class ChartGrammaticalForms extends Chart {
             }
             Set<String> failures = new LinkedHashSet<>();
             GrammarInfo grammarInfo = SDI.getGrammarInfo(localeId, false);
-            String localeName = CONFIG.getEnglish().nameGetter().getNameFromBCP47(localeId);
+            String localeName = CONFIG.getEnglish().nameGetter().getNameFromIdentifier(localeId);
             for (GrammaticalFeature feature : GrammaticalFeature.values()) {
                 Map<GrammaticalScope, Set<String>> scopeToValues =
                         grammarInfo.get(GrammaticalTarget.nominal, feature);
@@ -905,7 +905,7 @@ public class ChartGrammaticalForms extends Chart {
                             powerTable));
 
             if (!info.isEmpty()) {
-                String name = ENGLISH.nameGetter().getNameFromBCP47(locale);
+                String name = ENGLISH.nameGetter().getNameFromIdentifier(locale);
                 new Subchart(name + ": Unit Grammar Info", locale, info).writeChart(anchors);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageGroups.java
@@ -182,7 +182,7 @@ public class ChartLanguageGroups extends Chart {
                 : langCode.equals("zh")
                         ? "Mandarin Chinese"
                         : ENGLISH.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, langCode)
+                                .getNameFromTypeEnumCode(NameType.LANGUAGE, langCode)
                                 .replace(" (Other)", "")
                                 .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLanguageMatching.java
@@ -4,6 +4,7 @@ import com.ibm.icu.impl.Row.R4;
 import java.io.IOException;
 import java.util.List;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.NameGetter;
 
 public class ChartLanguageMatching extends Chart {
 
@@ -80,7 +81,8 @@ public class ChartLanguageMatching extends Chart {
     private String getName(String codeWithStars, boolean user) {
         if (!codeWithStars.contains("*") && !codeWithStars.contains("$")) {
             return ENGLISH.nameGetter()
-                    .getNameFromBCP47BoolAlt(codeWithStars, true, CLDRFile.SHORT_ALTS);
+                    .getNameFromIdentifierOptAlt(
+                            codeWithStars, NameGetter.NameOpt.COMPOUND_ONLY, CLDRFile.SHORT_ALTS);
         }
         String[] parts = codeWithStars.split("_");
         if (parts[0].equals("*")) {
@@ -100,8 +102,10 @@ public class ChartLanguageMatching extends Chart {
         }
         String result =
                 ENGLISH.nameGetter()
-                        .getNameFromBCP47BoolAlt(
-                                String.join("_", parts), true, CLDRFile.SHORT_ALTS);
+                        .getNameFromIdentifierOptAlt(
+                                String.join("_", parts),
+                                NameGetter.NameOpt.COMPOUND_ONLY,
+                                CLDRFile.SHORT_ALTS);
         if (user) {
             result =
                     result.replace("Xxxx", "any-script")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartPersonName.java
@@ -34,7 +34,7 @@ public class ChartPersonName extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.nameGetter().getNameFromBCP47(locale) + ": Person Names";
+        return ENGLISH.nameGetter().getNameFromIdentifier(locale) + ": Person Names";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -102,7 +102,7 @@ public class ChartSubdivisionNames extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.nameGetter().getNameFromBCP47Bool(locale, true);
+            String name = ENGLISH.nameGetter().getNameFromIndentifierCompoundOnly(locale);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -113,7 +113,7 @@ public class ChartSubdivisionNames extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.nameGetter().getNameFromBCP47Bool("en", true);
+            String ename = ENGLISH.nameGetter().getNameFromIndentifierCompoundOnly("en");
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.FileCopier;
 import org.unicode.cldr.util.LanguageGroup;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.Validity;
@@ -166,8 +167,8 @@ public class ChartSubdivisionNames extends Chart {
                         .addRow()
                         .addCell(
                                 english.nameGetter()
-                                        .getNameFromTypenumCode(
-                                                CLDRFile.TERRITORY_NAME,
+                                        .getNameFromTypeEnumCode(
+                                                NameType.TERRITORY,
                                                 code.substring(0, 2).toUpperCase(Locale.ENGLISH)))
                         .addCell(code);
                 for (Entry<String, String> nameAndLocale : nameToCode.entrySet()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisionNames.java
@@ -102,7 +102,7 @@ public class ChartSubdivisionNames extends Chart {
             if (locale.startsWith("en")) {
                 int debug = 0;
             }
-            String name = ENGLISH.nameGetter().getNameFromIndentifierCompoundOnly(locale);
+            String name = ENGLISH.nameGetter().getNameFromIdentifierCompoundOnly(locale);
             int baseEnd = locale.indexOf('_');
             ULocale loc = new ULocale(baseEnd < 0 ? locale : locale.substring(0, baseEnd));
             LanguageGroup group = LanguageGroup.get(loc);
@@ -113,7 +113,7 @@ public class ChartSubdivisionNames extends Chart {
         for (Entry<LanguageGroup, Set<R3<Integer, String, String>>> groupPairs :
                 groupToNameAndCodeSorted.keyValuesSet()) {
             LanguageGroup group = groupPairs.getKey();
-            String ename = ENGLISH.nameGetter().getNameFromIndentifierCompoundOnly("en");
+            String ename = ENGLISH.nameGetter().getNameFromIdentifierCompoundOnly("en");
             nameToCode.clear();
             nameToCode.put(ename, "en"); // always have english first
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSubdivisions.java
@@ -11,8 +11,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.TransliteratorUtilities;
 import org.unicode.cldr.util.Validity;
@@ -126,7 +126,7 @@ public class ChartSubdivisions extends Chart {
                         .addRow()
                         .addCell(
                                 ENGLISH.nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
+                                        .getNameFromTypeEnumCode(NameType.TERRITORY, region))
                         .addCell(region)
                         .addCell(name1)
                         // .addCell(type)
@@ -143,7 +143,7 @@ public class ChartSubdivisions extends Chart {
                     .addRow()
                     .addCell(
                             ENGLISH.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, region))
                     .addCell(region)
                     .addCell(
                             regionAliases == null

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
@@ -34,7 +34,7 @@ public class ChartSupplemental extends Chart {
 
     @Override
     public String getTitle() {
-        return ENGLISH.nameGetter().getNameFromBCP47(locale) + ": Overall Errors";
+        return ENGLISH.nameGetter().getNameFromIdentifier(locale) + ": Overall Errors";
     }
 
     @Override

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
@@ -11,6 +11,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.CurrencyDateInfo;
@@ -67,7 +68,7 @@ public class CheckEnglishCurrencyNames {
         for (String currency : modernCurrencyCodes2territory.keySet()) {
             final String name =
                     englishNameGetter
-                            .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
+                            .getNameFromTypeEnumCode(NameType.CURRENCY, currency)
                             .toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
@@ -77,7 +78,7 @@ public class CheckEnglishCurrencyNames {
         for (String currency : currencyCodesWithDates.keySet()) {
             final String name =
                     englishNameGetter
-                            .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency)
+                            .getNameFromTypeEnumCode(NameType.CURRENCY, currency)
                             .toLowerCase();
             if (name.contains("new") || name.contains("old")) {
                 System.out.println(currency + "\t" + name);
@@ -141,18 +142,18 @@ public class CheckEnglishCurrencyNames {
                                     ? "N/A"
                                     : nativeLanguage
                                             .nameGetter()
-                                            .getNameFromTypenumCode(
-                                                    CLDRFile.CURRENCY_SYMBOL, currency);
+                                            .getNameFromTypeEnumCode(
+                                                    NameType.CURRENCY_SYMBOL, currency);
                     System.out.println(
                             currency
                                     + "\t"
-                                    + englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.CURRENCY_NAME, currency)
+                                    + englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.CURRENCY, currency)
                                     + "\t"
                                     + territory
                                     + "\t"
-                                    + englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, territory)
+                                    + englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, territory)
                                     + "\t"
                                     + language
                                     + "\t"
@@ -181,8 +182,8 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     territory
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.TERRITORY_NAME, territory));
+                            + englishNameGetter.getNameFromTypeEnumCode(
+                                    NameType.TERRITORY, territory));
         }
         System.out.format("Collected usage data\n");
         for (Entry<String, Set<String>> currencyAndSymbols : currency2symbols.keyValuesSet()) {
@@ -191,8 +192,7 @@ public class CheckEnglishCurrencyNames {
             System.out.println(
                     currency
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.CURRENCY_NAME, currency)
+                            + englishNameGetter.getNameFromTypeEnumCode(NameType.CURRENCY, currency)
                             + "\t"
                             + symbols.size()
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEnglishCurrencyNames.java
@@ -157,7 +157,7 @@ public class CheckEnglishCurrencyNames {
                                     + "\t"
                                     + language
                                     + "\t"
-                                    + englishNameGetter.getNameFromBCP47(language)
+                                    + englishNameGetter.getNameFromIdentifier(language)
                                     + "\t"
                                     + symbol);
                     // TODO add script

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
@@ -41,7 +41,7 @@ public class CheckLanguageNameCoverage {
                             + "\t"
                             + level
                             + "\t"
-                            + config.getEnglish().nameGetter().getNameFromBCP47(langCode));
+                            + config.getEnglish().nameGetter().getNameFromIdentifier(langCode));
         }
         for (String langCode : map.keySet()) {
             String path = NameType.LANGUAGE.getKeyPath(langCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckLanguageNameCoverage.java
@@ -10,8 +10,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.test.CoverageLevel2;
 import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.Validity;
 import org.unicode.cldr.util.Validity.Status;
@@ -34,7 +34,7 @@ public class CheckLanguageNameCoverage {
                                 "ku", "la", "lb", "mg", "mt", "mi", "sm", "gd", "st", "sn", "so",
                                 "su", "tg", "xh", "yi", "yo"));
         for (String langCode : targets) {
-            String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);
+            String path = NameType.LANGUAGE.getKeyPath(langCode);
             Level level = coverages.getLevel(path);
             System.out.println(
                     langCode
@@ -44,7 +44,7 @@ public class CheckLanguageNameCoverage {
                             + config.getEnglish().nameGetter().getNameFromBCP47(langCode));
         }
         for (String langCode : map.keySet()) {
-            String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, langCode);
+            String path = NameType.LANGUAGE.getKeyPath(langCode);
             Level level = coverages.getLevel(path);
             if (level == null) continue;
             levelToLangs.put(level, langCode);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareOyster.java
@@ -4,6 +4,7 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.DraftStatus;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.NameType;
 
 public class CompareOyster {
 
@@ -24,7 +25,7 @@ public class CompareOyster {
                             + itemRegion
                             + "\t"
                             + file.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, itemRegion));
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, itemRegion));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -108,7 +108,7 @@ public class CompareSuppress {
     }
 
     public static String langAndName(CLDRFile english, String base) {
-        return base + "\t" + english.nameGetter().getNameFromBCP47(base);
+        return base + "\t" + english.nameGetter().getNameFromIdentifier(base);
     }
 
     public static String scriptAndName(CLDRFile english, String suppressScript) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareSuppress.java
@@ -11,6 +11,7 @@ import java.util.TreeSet;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -113,6 +114,6 @@ public class CompareSuppress {
     public static String scriptAndName(CLDRFile english, String suppressScript) {
         return suppressScript
                 + "\t"
-                + english.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, suppressScript);
+                + english.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, suppressScript);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -50,6 +50,7 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleIDParser.Level;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SpreadSheet;
@@ -1064,7 +1065,7 @@ public class ConvertLanguageData {
 
     public static String getCountryCodeAndName(String code) {
         if (code == null) return null;
-        return englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code)
+        return englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, code)
                 + " ["
                 + code
                 + "]";
@@ -2563,12 +2564,12 @@ public class ConvertLanguageData {
     }
 
     private static String getULocaleScriptName(String scriptCode) {
-        return englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, scriptCode);
+        return englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, scriptCode);
         // return ULocale.getDisplayScript("und_" + scriptCode, ULocale.ENGLISH);
     }
 
     private static String getULocaleCountryName(String countryCode) {
-        return englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
+        return englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, countryCode);
         // return ULocale.getDisplayCountry("und_" + countryCode, ULocale.ENGLISH);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -262,7 +262,7 @@ public class ConvertLanguageData {
 
     public static String getLanguageCodeAndName(String code) {
         if (code == null) return null;
-        return englishNameGetter.getNameFromBCP47(code) + " [" + code + "]";
+        return englishNameGetter.getNameFromIdentifier(code) + " [" + code + "]";
     }
 
     private static String getReplacement(String oldDefault, Set<String> defaultLocaleContent) {
@@ -384,7 +384,8 @@ public class ConvertLanguageData {
                                     "changing <languageData>",
                                     languageSubtag
                                             + "\t"
-                                            + englishNameGetter.getNameFromBCP47(languageSubtag),
+                                            + englishNameGetter.getNameFromIdentifier(
+                                                    languageSubtag),
                                     problem));
                 }
             }
@@ -991,7 +992,8 @@ public class ConvertLanguageData {
 
         public String getLanguageName() {
             String cldrResult =
-                    getExcelQuote(englishNameGetter.getNameFromBCP47Bool(languageCode, true));
+                    getExcelQuote(
+                            englishNameGetter.getNameFromIndentifierCompoundOnly(languageCode));
             //            String result = getLanguageName2();
             //            if (!result.equalsIgnoreCase(cldrResult)) {
             //                if (null == oldToFixed.put(result, cldrResult)) {
@@ -2559,7 +2561,7 @@ public class ConvertLanguageData {
     }
 
     private static String getULocaleLocaleName(String languageCode) {
-        return englishNameGetter.getNameFromBCP47Bool(languageCode, true);
+        return englishNameGetter.getNameFromIndentifierCompoundOnly(languageCode);
         // return new ULocale(languageCode).getDisplayName();
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -993,7 +993,7 @@ public class ConvertLanguageData {
         public String getLanguageName() {
             String cldrResult =
                     getExcelQuote(
-                            englishNameGetter.getNameFromIndentifierCompoundOnly(languageCode));
+                            englishNameGetter.getNameFromIdentifierCompoundOnly(languageCode));
             //            String result = getLanguageName2();
             //            if (!result.equalsIgnoreCase(cldrResult)) {
             //                if (null == oldToFixed.put(result, cldrResult)) {
@@ -2561,7 +2561,7 @@ public class ConvertLanguageData {
     }
 
     private static String getULocaleLocaleName(String languageCode) {
-        return englishNameGetter.getNameFromIndentifierCompoundOnly(languageCode);
+        return englishNameGetter.getNameFromIdentifierCompoundOnly(languageCode);
         // return new ULocale(languageCode).getDisplayName();
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -439,8 +439,8 @@ public class ConvertLanguageData {
             BasicLanguageData.Type oldValue = oldDataToType.get(s);
             BasicLanguageData.Type newValue = newDataToType.get(s);
             if (!CldrUtility.equals(oldValue, newValue)) {
-                int code = s.length() == 4 ? CLDRFile.SCRIPT_NAME : CLDRFile.TERRITORY_NAME;
-                String name = englishNameGetter.getNameFromTypenumCode(code, s);
+                NameType nameType = s.length() == 4 ? NameType.SCRIPT : NameType.TERRITORY;
+                String name = englishNameGetter.getNameFromTypeEnumCode(nameType, s);
                 temp.setLength(0);
                 temp.append("[").append(s).append(":").append(name).append("] ");
                 if (oldValue == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -1105,7 +1105,7 @@ public class CountItems {
             System.out.println(
                     locale
                             + "\t"
-                            + nameGetter.getNameFromBCP47(locale)
+                            + nameGetter.getNameFromIdentifier(locale)
                             + "\t"
                             + onlyLocales.get(locale));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -53,6 +53,7 @@ import org.unicode.cldr.util.IsoRegionData;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Log;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
@@ -487,8 +488,8 @@ public class CountItems {
             }
             results.put(
                     item,
-                    nameGetter.getNameFromTypenumCode(
-                            CLDRFile.TERRITORY_NAME, containees.iterator().next()));
+                    nameGetter.getNameFromTypeEnumCode(
+                            NameType.TERRITORY, containees.iterator().next()));
         }
         return results;
     }
@@ -562,8 +563,8 @@ public class CountItems {
                             "# "
                                     + newCountry
                                     + "\t"
-                                    + nameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, newCountry));
+                                    + nameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, newCountry));
                     lastCountry = newCountry;
                 }
                 Log.println("\t'" + oldName + "'\t>\t'" + newName + "';");
@@ -1007,7 +1008,7 @@ public class CountItems {
             } else {
                 result = region;
             }
-            String name = nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, result);
+            String name = nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, result);
             if (!(duplicateDestroyer.contains(alpha3 + result + name))) {
                 duplicateDestroyer.add(alpha3 + result + name);
                 System.out.println(
@@ -1021,7 +1022,7 @@ public class CountItems {
             }
         }
         for (String region : missingRegions) {
-            String name = nameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
+            String name = nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, region);
             System.err.println("ERROR: Missing " + codeType + " code for " + region + "\t" + name);
         }
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -321,7 +321,7 @@ public class CountItems {
     public static void genSupplementalZoneData(boolean skipUnaliased) throws IOException {
         RuleBasedCollator col = CollatorHelper.ROOT_NUMERIC;
         StandardCodes sc = StandardCodes.make();
-        Map<String, String> zone_country = sc.getZoneToCounty();
+        Map<String, String> zone_country = sc.getZoneToCountry();
         Map<String, Set<String>> country_zone = sc.getCountryToZoneSet();
         Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
         CLDRFile english = cldrFactory.make("en", true);
@@ -433,7 +433,7 @@ public class CountItems {
         CLDRConfig testInfo = ToolConfig.getToolInstance();
         Map<String, Map<String, String>> map =
                 testInfo.getSupplementalDataInfo().getMetazoneToRegionToZone();
-        Map zoneToCountry = StandardCodes.make().getZoneToCounty();
+        Map zoneToCountry = StandardCodes.make().getZoneToCountry();
         Set<Pair<String, String>> results = new TreeSet<>();
         Map<String, String> countryToContinent =
                 getCountryToContinent(testInfo.getSupplementalDataInfo(), testInfo.getEnglish());
@@ -1075,7 +1075,7 @@ public class CountItems {
         Set<String> singleCountriesSet =
                 new TreeSet<>(CldrUtility.splitList(singleCountriesList, ' '));
 
-        Map<String, String> zone_countries = StandardCodes.make().getZoneToCounty();
+        Map<String, String> zone_countries = StandardCodes.make().getZoneToCountry();
         Map<String, Set<String>> countries_zoneSet = StandardCodes.make().getCountryToZoneSet();
         System.out.println();
         i = 0;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
@@ -21,6 +21,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.LanguageTagCanonicalizer;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
@@ -150,8 +151,7 @@ public class DeriveScripts {
                         + ";\t"
                         + scriptField
                         + "\t# "
-                        + english.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
+                        + english.nameGetter().getNameFromTypeEnumCode(NameType.LANGUAGE, language)
                         + ";\t"
                         + status
                         + ";\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DeriveScripts.java
@@ -206,7 +206,7 @@ public class DeriveScripts {
                                 + "\t"
                                 + lang
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(lang)
+                                + english.nameGetter().getNameFromIdentifier(lang)
                                 + "\t"
                                 + scripts
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
@@ -36,7 +36,7 @@ public class DiffWithParent {
             for (String locale : cldrFactory.getAvailable()) {
                 if (fileMatcher.reset(locale).matches()) {
                     System.out.println(
-                            locale + "\t" + english.nameGetter().getNameFromBCP47(locale));
+                            locale + "\t" + english.nameGetter().getNameFromIdentifier(locale));
                     CLDRFile file = cldrFactory.make(locale, false);
                     String parentLocale = LocaleIDParser.getParent(locale);
                     CLDRFile parent = cldrFactory.make(parentLocale, true); // use
@@ -78,7 +78,7 @@ public class DiffWithParent {
                     String title =
                             locale
                                     + " "
-                                    + english.nameGetter().getNameFromBCP47(locale)
+                                    + english.nameGetter().getNameFromIdentifier(locale)
                                     + " Diff with Parent";
                     out.println(
                             "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -92,7 +92,7 @@ class ExtractMessages {
                             "Skipping, no CLDR locale file: "
                                     + name
                                     + "\t"
-                                    + english.nameGetter().getNameFromBCP47(name)
+                                    + english.nameGetter().getNameFromIdentifier(name)
                                     + "\t"
                                     + e1.getClass().getName()
                                     + "\t"
@@ -163,7 +163,7 @@ class ExtractMessages {
                         "\tSkipping, no CLDR locale file: "
                                 + name
                                 + "\t"
-                                + englishNameGetter.getNameFromBCP47(name));
+                                + englishNameGetter.getNameFromIdentifier(name));
             }
             double deltaTime = System.currentTimeMillis() - startTime;
             System.out.println("Elapsed: " + deltaTime / 1000.0 + " seconds");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ExtractMessages.java
@@ -23,6 +23,7 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathUtilities;
 import org.unicode.cldr.util.PatternCache;
@@ -454,8 +455,7 @@ class ExtractMessages {
                 case LANGUAGE:
                     for (String code : sc.getAvailableCodes("language")) {
                         String name =
-                                englishNameGetter.getNameFromTypenumCode(
-                                        CLDRFile.LANGUAGE_NAME, code);
+                                englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -497,8 +497,7 @@ class ExtractMessages {
                 case REGION:
                     for (String code : sc.getAvailableCodes("territory")) {
                         String name =
-                                englishNameGetter.getNameFromTypenumCode(
-                                        CLDRFile.TERRITORY_NAME, code);
+                                englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -538,8 +537,7 @@ class ExtractMessages {
                 case CURRENCY:
                     for (String code : sc.getAvailableCodes("currency")) {
                         String name =
-                                englishNameGetter.getNameFromTypenumCode(
-                                        CLDRFile.CURRENCY_NAME, code);
+                                englishNameGetter.getNameFromTypeEnumCode(NameType.CURRENCY, code);
                         if (name == null) {
                             // System.out.println("Missing name for: " + code);
                             continue;
@@ -713,11 +711,11 @@ class ExtractMessages {
         String getPath(String id) {
             switch (type) {
                 case LANGUAGE:
-                    return CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, id);
+                    return NameType.LANGUAGE.getKeyPath(id);
                 case REGION:
-                    return CLDRFile.getKey(CLDRFile.TERRITORY_NAME, id);
+                    return NameType.TERRITORY.getKeyPath(id);
                 case CURRENCY:
-                    return CLDRFile.getKey(CLDRFile.CURRENCY_NAME, id);
+                    return NameType.CURRENCY.getKeyPath(id);
                 case TIMEZONE:
                     return "//ldml/dates/timeZoneNames/zone[@type=\"$1\"]/exemplarCity"
                             .replace("$1", id);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPluralDifferences.java
@@ -137,7 +137,7 @@ public class FindPluralDifferences {
                                     + ToolConfig.getToolInstance()
                                             .getEnglish()
                                             .nameGetter()
-                                            .getNameFromBCP47(locale)
+                                            .getNameFromIdentifier(locale)
                                     + "\t"
                                     + locale
                                     + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -22,6 +22,7 @@ import org.unicode.cldr.util.DateTimeCanonicalizer.DateTimePatternType;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PreferredAndAllowedHour;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
@@ -268,18 +269,17 @@ public class FindPreferredHours {
                             + "\t"
                             + region
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.TERRITORY_NAME, region)
+                            + englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, region)
                             + "\t"
                             + subcontinent
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.TERRITORY_NAME, subcontinent)
+                            + englishNameGetter.getNameFromTypeEnumCode(
+                                    NameType.TERRITORY, subcontinent)
                             + "\t"
                             + continent
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.TERRITORY_NAME, continent)
+                            + englishNameGetter.getNameFromTypeEnumCode(
+                                    NameType.TERRITORY, continent)
                             + "\t"
                             + showInfo(preferredSet));
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
@@ -42,7 +42,7 @@ public class FixTransformNames {
     private void run(String[] args) {
         CLDRFile file = testInfo.getEnglish();
         for (String lang : StandardCodes.make().getAvailableCodes(CodeType.language)) {
-            String name = file.nameGetter().getNameFromBCP47(lang);
+            String name = file.nameGetter().getNameFromIdentifier(lang);
             if (!name.equals(lang)) {
                 fieldToCode.put(name, lang);
                 languageCodes.add(lang);
@@ -252,7 +252,7 @@ public class FixTransformNames {
             }
             return result;
         }
-        return english.nameGetter().getNameFromBCP47(target.replace('-', '_'));
+        return english.nameGetter().getNameFromIdentifier(target.replace('-', '_'));
     }
 
     private String add(String result, NameType type, String code) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FixTransformNames.java
@@ -20,6 +20,7 @@ import org.unicode.cldr.util.CLDRTransforms.Direction;
 import org.unicode.cldr.util.CLDRTransforms.ParsedTransformID;
 import org.unicode.cldr.util.CLDRTransforms.Visibility;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.CodeType;
 import org.unicode.cldr.util.With;
@@ -244,25 +245,25 @@ public class FixTransformNames {
         ltp.set(target);
         if (ltp.getLanguage().equals("und")) {
             String result = "";
-            result = add(result, CLDRFile.SCRIPT_NAME, ltp.getScript());
-            result = add(result, CLDRFile.TERRITORY_NAME, ltp.getRegion());
+            result = add(result, NameType.SCRIPT, ltp.getScript());
+            result = add(result, NameType.TERRITORY, ltp.getRegion());
             for (String v : ltp.getVariants()) {
-                result = add(result, CLDRFile.VARIANT_NAME, v);
+                result = add(result, NameType.VARIANT, v);
             }
             return result;
         }
         return english.nameGetter().getNameFromBCP47(target.replace('-', '_'));
     }
 
-    private String add(String result, int type, String code) {
+    private String add(String result, NameType type, String code) {
         if (code.isEmpty()) {
             return result;
         }
         if (result.length() != 0) {
             result += ", ";
         }
-        String temp = english.nameGetter().getNameFromTypenumCode(type, code);
-        if (type == CLDRFile.SCRIPT_NAME && fieldToCode.containsKey(temp)) {
+        String temp = english.nameGetter().getNameFromTypeEnumCode(type, code);
+        if (type == NameType.SCRIPT && fieldToCode.containsKey(temp)) {
             temp += "*";
         }
         return result + (temp == null ? code : temp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -107,7 +107,7 @@ public class GenerateChangeChart {
                 final String summaryLine =
                         locale
                                 + "\t"
-                                + ENGLISH.nameGetter().getNameFromBCP47(locale)
+                                + ENGLISH.nameGetter().getNameFromIdentifier(locale)
                                 + "\t"
                                 + counter;
                 System.out.println(summaryLine);
@@ -230,7 +230,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.nameGetter().getNameFromBCP47(locale.toString());
+            final String name = ENGLISH.nameGetter().getNameFromIdentifier(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();
@@ -301,7 +301,7 @@ public class GenerateChangeChart {
                 String newValue,
                 String engValue,
                 int votes) {
-            final String name = ENGLISH.nameGetter().getNameFromBCP47(locale.toString());
+            final String name = ENGLISH.nameGetter().getNameFromIdentifier(locale.toString());
             PageId pageId = pathHeader.getPageId();
             String header = pathHeader.getHeader();
             String code = pathHeader.getCode();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -106,7 +106,7 @@ public class GenerateComparison {
         unifiedList.addAll(newList);
         Set<R2<String, String>> pairs = new TreeSet<>();
         for (String code : unifiedList) {
-            pairs.add(Row.of(english.nameGetter().getNameFromBCP47(code), code));
+            pairs.add(Row.of(english.nameGetter().getNameFromIdentifier(code), code));
         }
 
         prettyPathMaker = new PrettyPath();
@@ -205,7 +205,7 @@ public class GenerateComparison {
             // href='likely_subtags.html#und_{0}'>{0}</a>",
             // "class='source'", true)
 
-            final String localeDisplayName = english.nameGetter().getNameFromBCP47(locale);
+            final String localeDisplayName = english.nameGetter().getNameFromIdentifier(locale);
             TablePrinter table =
                     new TablePrinter()
                             .setCaption("Changes in " + localeDisplayName + " (" + locale + ")")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -34,6 +34,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralType;
 import org.unicode.cldr.util.XPathParts;
@@ -420,13 +421,13 @@ public class GenerateCoverageLevels {
                     new StringBuilder(
                             script
                                     + "\t"
-                                    + englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.SCRIPT_NAME, script)
+                                    + englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.SCRIPT, script)
                                     + "\t"
                                     + lang
                                     + "\t"
-                                    + englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.LANGUAGE_NAME, lang));
+                                    + englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.LANGUAGE, lang));
             if (header != null) {
                 header.append("Code\tScript\tCode\tLocale");
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -343,7 +343,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : rbnfFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
+            System.out.println(locale + "\t" + englishNameGetter.getNameFromIdentifier(locale));
             getRBNFData(locale, rbnfFactory.make(locale, true), ordinals, spellout, localesFound);
         }
         markData(
@@ -381,7 +381,7 @@ public class GenerateCoverageLevels {
         localesFound.clear();
         for (String locale : collationFactory.getAvailable()) {
             if (localeFilter.skipLocale(locale, null)) continue;
-            System.out.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
+            System.out.println(locale + "\t" + englishNameGetter.getNameFromIdentifier(locale));
             getCollationData(locale, collationFactory.make(locale, true), localesFound);
         }
         markData(
@@ -395,7 +395,7 @@ public class GenerateCoverageLevels {
 
         System.out.println("gathering main data");
         for (String locale : mainAvailable) {
-            System.out.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
+            System.out.println(locale + "\t" + englishNameGetter.getNameFromIdentifier(locale));
             LevelData levelData = mapLevelData.get(locale);
             getMainData(locale, levelData, cldrFactory.make(locale, true));
         }
@@ -433,7 +433,7 @@ public class GenerateCoverageLevels {
             }
             // Now print the information
             samples2.println();
-            samples2.println(locale + "\t" + englishNameGetter.getNameFromBCP47(locale));
+            samples2.println(locale + "\t" + englishNameGetter.getNameFromIdentifier(locale));
             double weightedFound = 0;
             double weightedMissing = 0;
             long missingCountTotal = 0;
@@ -500,7 +500,7 @@ public class GenerateCoverageLevels {
             summary.println(
                     locale
                             + "\t"
-                            + englishNameGetter.getNameFromBCP47(locale)
+                            + englishNameGetter.getNameFromIdentifier(locale)
                             + "\t"
                             + summaryLine2);
             if (header != null) {
@@ -564,7 +564,7 @@ public class GenerateCoverageLevels {
                 System.out.println(
                         locale
                                 + "\t"
-                                + englishNameGetter.getNameFromBCP47(locale)
+                                + englishNameGetter.getNameFromIdentifier(locale)
                                 + "\t"
                                 + "missing "
                                 + title);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriodChart.java
@@ -108,7 +108,7 @@ public class GenerateDayPeriodChart {
                                 + "\t"
                                 + locale
                                 + "\t"
-                                + ENGLISH.nameGetter().getNameFromBCP47(locale));
+                                + ENGLISH.nameGetter().getNameFromIdentifier(locale));
                 DayPeriodInfo dayPeriod = getFixedDayPeriodInfo(type, locale);
                 doRow(dayPeriod);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -219,7 +219,7 @@ public class GenerateDerivedAnnotations {
                                 + "\t"
                                 + level
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(locale)
+                                + english.nameGetter().getNameFromIdentifier(locale)
                                 + "\t"
                                 + failures.size()
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -31,6 +31,7 @@ import org.unicode.cldr.util.Emoji;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.StandardCodes;
@@ -178,8 +179,7 @@ public class GenerateDerivedAnnotations {
                         }
                         shortName =
                                 main.nameGetter()
-                                        .getNameFromTypenumCode(
-                                                CLDRFile.CURRENCY_NAME, currencyCode);
+                                        .getNameFromTypeEnumCode(NameType.CURRENCY, currencyCode);
                         if (shortName.contentEquals(currencyCode)) {
                             shortName = null; // don't want fallback raw code
                         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -674,7 +674,7 @@ public class GenerateEnums {
                         format(popData.getPopulation()),
                         format(popData.getLiteratePopulation() / popData.getPopulation()),
                         (count == 0 ? ";" : ""),
-                        englishNameGetter.getNameFromBCP47(language));
+                        englishNameGetter.getNameFromIdentifier(language));
             }
         }
         Log.close();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -35,6 +35,7 @@ import org.unicode.cldr.util.Iso639Data.Scope;
 import org.unicode.cldr.util.Iso639Data.Type;
 import org.unicode.cldr.util.Log;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo;
@@ -137,7 +138,7 @@ public class GenerateEnums {
     }
 
     private String getName(String code) {
-        String result = englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, code);
+        String result = englishNameGetter.getNameFromTypeEnumCode(NameType.CURRENCY, code);
         if (result == null) {
             result = code;
             System.out.println("Failed to find: " + code);
@@ -176,8 +177,7 @@ public class GenerateEnums {
         int len = "  /** Arabic */                                        Arab,".length();
         for (Iterator<String> it = scripts.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName =
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code);
+            String englishName = englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, code);
             if (englishName == null) continue;
             printRow(Log.getLog(), code, null, "script", code_replacements, len);
             // Log.println(" /**" + englishName + "*/ " + code + ",");
@@ -225,8 +225,7 @@ public class GenerateEnums {
 
         for (Iterator<String> it = languages.iterator(); it.hasNext(); ) {
             String code = it.next();
-            String englishName =
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, code);
+            String englishName = englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, code);
             if (englishName == null) continue;
             System.out.println("     /**" + englishName + "*/    " + code + ",");
         }
@@ -644,7 +643,7 @@ public class GenerateEnums {
                     format(popData.getPopulation()),
                     format(popData.getLiteratePopulation() / popData.getPopulation()),
                     format(popData.getGdp()),
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory));
+                    englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory));
             // remove all the ISO 639-3 until they are part of BCP 47
             // we need to remove in earlier pass so we have the count
             Set<String> languages = new TreeSet<>();
@@ -742,8 +741,8 @@ public class GenerateEnums {
                             + "\t"
                             + region
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.TERRITORY_NAME, region));
+                            + englishNameGetter.getNameFromTypeEnumCode(
+                                    NameType.TERRITORY, region));
         }
 
         showGeneratedCommentEnd(DATA_INDENT);
@@ -883,8 +882,8 @@ public class GenerateEnums {
                                 ? getEnglishName(codeName)
                                 : type.equals("currency")
                                         ? getName(codeName)
-                                        : englishNameGetter.getNameFromTypenumCode(
-                                                CLDRFile.SCRIPT_NAME, codeName);
+                                        : englishNameGetter.getNameFromTypeEnumCode(
+                                                NameType.SCRIPT, codeName);
         resolvedEnglishName = doFallbacks.transliterate(resolvedEnglishName);
 
         String prefix = CODE_INDENT + "/** " + resolvedEnglishName; // + " - " +
@@ -921,7 +920,7 @@ public class GenerateEnums {
         if (codeName.length() > 3) codeName = codeName.substring(2); // fix UN name
         String name = extraNames.get(codeName);
         if (name != null) return name;
-        name = englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, codeName);
+        name = englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, codeName);
         if (name != null) return name;
         return codeName;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -220,7 +220,7 @@ public class GenerateG2xG2 {
                 if (territory.charAt(0) < 'A') continue;
                 String locale = "haw-" + territory;
                 System.out.print(
-                        locale + ": " + english.nameGetter().getNameFromBCP47(locale) + ", ");
+                        locale + ": " + english.nameGetter().getNameFromIdentifier(locale) + ", ");
             }
             if (true) return true;
         }
@@ -339,9 +339,9 @@ public class GenerateG2xG2 {
                                 + "\t"
                                 + sourceLocale
                                 + "\t("
-                                + english.nameGetter().getNameFromBCP47(sourceLocale)
+                                + english.nameGetter().getNameFromIdentifier(sourceLocale)
                                 + ": "
-                                + sourceData.nameGetter().getNameFromBCP47(sourceLocale)
+                                + sourceData.nameGetter().getNameFromIdentifier(sourceLocale)
                                 + ")"
                                 + "\t"
                                 + priorityMap.get(item)
@@ -389,7 +389,7 @@ public class GenerateG2xG2 {
     private static String getItemName(CLDRFile data, NameType type, String item) {
         String result;
         if (type == NameType.LANGUAGE) {
-            result = data.nameGetter().getNameFromBCP47(item);
+            result = data.nameGetter().getNameFromIdentifier(item);
         } else if (type != NameType.TZ_EXEMPLAR) {
             result = data.nameGetter().getNameFromTypeEnumCode(type, item);
         } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -135,8 +135,7 @@ public class GenerateG2xG2 {
             String code = it.next();
             String priority = priorityMap.get(code);
             if (priority == null) continue;
-            int type = getType(code);
-            // if (type != CLDRFile.TERRITORY_NAME) continue;
+            NameType type = getType(code);
             priority_set.add(new String[] {priority, type + "", code});
         }
         String lastPriority = "";
@@ -167,15 +166,15 @@ public class GenerateG2xG2 {
             CLDRFile sourceData = cldrFactory.make(sourceLocale, true);
             pw.println();
             String title = sourceLocale;
-            checkItems(pw, title, sourceData, CLDRFile.LANGUAGE_NAME, targetLanguageSet);
-            checkItems(pw, title, sourceData, CLDRFile.SCRIPT_NAME, targetScriptSet);
-            checkItems(pw, title, sourceData, CLDRFile.TERRITORY_NAME, targetRegionSet);
-            checkItems(pw, title, sourceData, CLDRFile.CURRENCY_NAME, targetCurrencySet);
+            checkItems(pw, title, sourceData, NameType.LANGUAGE, targetLanguageSet);
+            checkItems(pw, title, sourceData, NameType.SCRIPT, targetScriptSet);
+            checkItems(pw, title, sourceData, NameType.TERRITORY, targetRegionSet);
+            checkItems(pw, title, sourceData, NameType.CURRENCY, targetCurrencySet);
             // only check timezones if exemplar characters don't include a-z
             String v = sourceData.getStringValue("//ldml/characters/exemplarCharacters");
             UnicodeSet exemplars = new UnicodeSet(v);
             if (exemplars.contains('a', 'z')) continue;
-            checkItems(pw, title, sourceData, CLDRFile.TZ_EXEMPLAR, targetTZSet);
+            checkItems(pw, title, sourceData, NameType.TZ_EXEMPLAR, targetTZSet);
         }
         pw.println();
         pw.println("Sizes - incremental");
@@ -322,7 +321,7 @@ public class GenerateG2xG2 {
             PrintWriter pw,
             String sourceLocale,
             CLDRFile sourceData,
-            int type,
+            NameType type,
             Set<String> targetItemSet) {
         for (Iterator<String> it2 = targetItemSet.iterator(); it2.hasNext(); ) {
             String item = it2.next();
@@ -359,40 +358,40 @@ public class GenerateG2xG2 {
         return getItemName(data, getType(item), item);
     }
 
-    private static int getType(String item) {
-        int type = CLDRFile.LANGUAGE_NAME;
-        if (item.indexOf('/') >= 0) type = CLDRFile.TZ_EXEMPLAR; // America/Los_Angeles
-        else if (item.length() == 4) type = CLDRFile.SCRIPT_NAME; // Hant
-        else if (item.charAt(0) <= '9') type = CLDRFile.TERRITORY_NAME; // 001
+    private static NameType getType(String item) {
+        NameType type = NameType.LANGUAGE;
+        if (item.indexOf('/') >= 0) type = NameType.TZ_EXEMPLAR; // America/Los_Angeles
+        else if (item.length() == 4) type = NameType.SCRIPT; // Hant
+        else if (item.charAt(0) <= '9') type = NameType.TERRITORY; // 001
         else if (item.charAt(0) < 'a') {
-            if (item.length() == 3) type = CLDRFile.CURRENCY_NAME;
-            else type = CLDRFile.TERRITORY_NAME; // US or USD
+            if (item.length() == 3) type = NameType.CURRENCY;
+            else type = NameType.TERRITORY; // US or USD
         }
         return type;
     }
 
     private static String getTypeName(String item) {
         switch (getType(item)) {
-            case CLDRFile.LANGUAGE_NAME:
+            case LANGUAGE:
                 return "Lang";
-            case CLDRFile.TZ_EXEMPLAR:
+            case TZ_EXEMPLAR:
                 return "Zone";
-            case CLDRFile.SCRIPT_NAME:
+            case SCRIPT:
                 return "Script";
-            case CLDRFile.TERRITORY_NAME:
+            case TERRITORY:
                 return "Region";
-            case CLDRFile.CURRENCY_NAME:
+            case CURRENCY:
                 return "Curr.";
         }
         return "?";
     }
 
-    private static String getItemName(CLDRFile data, int type, String item) {
+    private static String getItemName(CLDRFile data, NameType type, String item) {
         String result;
-        if (type == CLDRFile.LANGUAGE_NAME) {
+        if (type == NameType.LANGUAGE) {
             result = data.nameGetter().getNameFromBCP47(item);
-        } else if (type != CLDRFile.TZ_EXEMPLAR) {
-            result = data.nameGetter().getNameFromTypenumCode(type, item);
+        } else if (type != NameType.TZ_EXEMPLAR) {
+            result = data.nameGetter().getNameFromTypeEnumCode(type, item);
         } else {
             String prefix = "//ldml/dates/timeZoneNames/zone[@type=\"" + item + "\"]/exemplarCity";
             result = data.getStringValue(prefix);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -25,6 +25,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
@@ -236,7 +237,7 @@ public class GenerateG2xG2 {
                         country
                                 + "\t"
                                 + english.nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, country));
+                                        .getNameFromTypeEnumCode(NameType.CURRENCY, country));
             }
             return true;
         } else if (choice == 0) { // get available

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
@@ -132,7 +132,7 @@ public class GenerateKaraList {
                                     + locale
                                     + "</tlanguage>\t<!-- "
                                     + TransliteratorUtilities.toXML.transliterate(
-                                            english.nameGetter().getNameFromBCP47(locale))
+                                            english.nameGetter().getNameFromIdentifier(locale))
                                     + " -->"); // We do use
                     // non-ISO
                     // values but

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateKaraList.java
@@ -10,6 +10,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.TransliteratorUtilities;
 
@@ -27,9 +28,9 @@ public class GenerateKaraList {
         locales.remove("zh");
         StandardCodes codes = StandardCodes.make();
         log.println("<root>");
-        printCodes(log, locales, codes.getAvailableCodes("language"), CLDRFile.LANGUAGE_NAME);
-        printCodes(log, locales, codes.getAvailableCodes("territory"), CLDRFile.TERRITORY_NAME);
-        printCodes(log, locales, codes.getAvailableCodes("currency"), CLDRFile.CURRENCY_NAME);
+        printCodes(log, locales, codes.getAvailableCodes("language"), NameType.LANGUAGE);
+        printCodes(log, locales, codes.getAvailableCodes("territory"), NameType.TERRITORY);
+        printCodes(log, locales, codes.getAvailableCodes("currency"), NameType.CURRENCY);
         // printCodes(log, locales, codes.getAvailableCodes("script"),
         // "//ldml/localeDisplayNames/scripts/script",
         // "script");
@@ -84,20 +85,15 @@ public class GenerateKaraList {
      * </hom>
      * </entry>
      */
-    /**
-     * @param log
-     * @param locales
-     * @param availableCodes
-     * @param choice TODO
-     */
+
     private static void printCodes(
-            PrintWriter log, Set<String> locales, Set<String> availableCodes, int choice) {
-        boolean hasAbbreviation = choice == CLDRFile.CURRENCY_NAME;
+            PrintWriter log, Set<String> locales, Set<String> availableCodes, NameType nameType) {
+        boolean hasAbbreviation = nameType == NameType.CURRENCY;
         // boolean skipDraft = true;
         Set<String> errors = new HashSet<>();
         for (Iterator<String> it = availableCodes.iterator(); it.hasNext(); ) {
             String id = it.next();
-            String ename = english.nameGetter().getNameFromTypenumCode(choice, id);
+            String ename = english.nameGetter().getNameFromTypeEnumCode(nameType, id);
             if (ename == null) ename = "[untranslated: " + id + "]";
             System.out.println(id + "\t" + ename);
             log.println("\t<entry>");
@@ -105,8 +101,7 @@ public class GenerateKaraList {
                     "\t\t<hdterm>"
                             + TransliteratorUtilities.toXML.transliterate(ename)
                             + "</hdterm>\t<!-- "
-                            + TransliteratorUtilities.toXML.transliterate(
-                                    CLDRFile.getNameName(choice))
+                            + TransliteratorUtilities.toXML.transliterate(nameType.getNameName())
                             + ": "
                             + id
                             + " -->"); // English
@@ -116,7 +111,7 @@ public class GenerateKaraList {
             log.println("\t\t\t<sense>");
             if (hasAbbreviation) { // only applicable for the currency entries
                 String aename =
-                        english.nameGetter().getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
+                        english.nameGetter().getNameFromTypeEnumCode(NameType.CURRENCY_SYMBOL, id);
                 if (aename != null) {
                     log.println(
                             "\t\t\t\t<eabbr>"
@@ -128,7 +123,7 @@ public class GenerateKaraList {
                 String locale = it2.next();
                 try {
                     CLDRFile cldrfile = cldrFactory.make(locale, true);
-                    String trans = cldrfile.nameGetter().getNameFromTypenumCode(choice, id);
+                    String trans = cldrfile.nameGetter().getNameFromTypeEnumCode(nameType, id);
                     if (trans == null) continue;
                     log.println("\t\t\t\t<target>"); // one target block for each language
                     // String etrans = getName(english, "languages/language", locale, true);
@@ -161,7 +156,7 @@ public class GenerateKaraList {
                     if (hasAbbreviation) {
                         String aename =
                                 cldrfile.nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.CURRENCY_SYMBOL, id);
+                                        .getNameFromTypeEnumCode(NameType.CURRENCY_SYMBOL, id);
                         if (aename != null && !aename.equals(id)) {
                             log.println(
                                     "\t\t\t\t\t<tabbr>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageData.java
@@ -71,7 +71,7 @@ public class GenerateLanguageData {
                 xpp.setAttribute(-1, LDMLConstants.TYPE, languageCode);
                 String xpath = xpp.toString();
 
-                newEn.add(xpp.toString(), oldEn.nameGetter().getNameFromBCP47(languageCode));
+                newEn.add(xpp.toString(), oldEn.nameGetter().getNameFromIdentifier(languageCode));
 
                 String oldValue = oldEn.getStringValue(xpath);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLanguageMatches.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -113,7 +114,6 @@ public class GenerateLanguageMatches {
             };
 
     private static String getName(String lang) {
-        return ENGLISH.nameGetter()
-                .getNameFromTypeCodeAltpicker(CLDRFile.LANGUAGE_NAME, lang, MENU);
+        return ENGLISH.nameGetter().getNameFromTypeCodeAltpicker(NameType.LANGUAGE, lang, MENU);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtagTests.java
@@ -13,6 +13,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 @Deprecated
@@ -200,18 +201,17 @@ public class GenerateLikelySubtagTests {
                 + spacing
                 + (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang))
+                        : ENGLISH.nameGetter().getNameFromTypeEnumCode(NameType.LANGUAGE, lang))
                 + ";"
                 + spacing
                 + (script == null || script.equals("")
                         ? "?"
-                        : ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script))
+                        : ENGLISH.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script))
                 + ";"
                 + spacing
                 + (region == null || region.equals("")
                         ? "?"
-                        : ENGLISH.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region))
+                        : ENGLISH.nameGetter().getNameFromTypeEnumCode(NameType.TERRITORY, region))
                 + spacing
                 + "}";
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -46,6 +46,7 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LocaleScriptInfo;
 import org.unicode.cldr.util.LocaleValidator;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -1691,16 +1692,14 @@ public class GenerateLikelySubtags {
         return spacing.join(
                 (lang.equals(LocaleNames.UND)
                         ? "?"
-                        : english.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, lang)),
+                        : english.nameGetter().getNameFromTypeEnumCode(NameType.LANGUAGE, lang)),
                 (script == null || script.equals("")
                         ? "?"
-                        : english.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)),
+                        : english.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script)),
                 (region == null || region.equals("")
                         ? "?"
                         : english.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region)));
+                                .getNameFromTypeEnumCode(NameType.TERRITORY, region)));
     }
 
     static final String SEPARATOR =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -667,7 +667,7 @@ public class GenerateLikelySubtags {
     public static String getNameSafe(String oldValue) {
         try {
             if (oldValue != null) {
-                String result = english.nameGetter().getNameFromBCP47(oldValue);
+                String result = english.nameGetter().getNameFromIdentifier(oldValue);
                 if (result.startsWith("Unknown language ")) {
                     result = result.substring("Unknown language ".length());
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
@@ -236,7 +236,7 @@ public class GenerateLocaleIDTestData {
         Map<String, String> displayNames = new TreeMap<>();
         for (String locale : locales) {
             String name =
-                    formattingLocaleFile.nameGetter().getNameFromIndentifierOpt(locale, nameOpt);
+                    formattingLocaleFile.nameGetter().getNameFromIdentifierOpt(locale, nameOpt);
             if (name.contains("null")) {
                 System.err.println("** REPLACE: " + locale + "; " + name);
             } else {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLocaleIDTestData.java
@@ -25,6 +25,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LsrvCanonicalizer;
 import org.unicode.cldr.util.LsrvCanonicalizer.TestDataTypes;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.StandardCodes.LstrType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.TempPrintWriter;
@@ -116,15 +117,16 @@ public class GenerateLocaleIDTestData {
                             + "@locale=en\n"
                             + "@languageDisplay=standard\n");
             pw.println("\n# Simple cases: Language, script, region, variants\n");
-            showDisplayNames(pw, ENGLISH, true, testInputLocales);
+            showDisplayNames(pw, ENGLISH, NameGetter.NameOpt.COMPOUND_ONLY, testInputLocales);
             pw.println(
                     "\n#Note that the order of the variants is alphabetized before generating names\n");
-            showDisplayNames(pw, ENGLISH, true, "en-Latn-GB-scouse-fonipa");
+            showDisplayNames(
+                    pw, ENGLISH, NameGetter.NameOpt.COMPOUND_ONLY, "en-Latn-GB-scouse-fonipa");
             pw.println("\n# Add extensions, and verify their order\n");
             showDisplayNames(
                     pw,
                     ENGLISH,
-                    true,
+                    NameGetter.NameOpt.COMPOUND_ONLY,
                     "en-u-nu-thai-ca-islamic-civil",
                     "hi-u-nu-latn-t-en-h0-hybrid",
                     "en-u-nu-deva-t-de");
@@ -132,7 +134,7 @@ public class GenerateLocaleIDTestData {
             showDisplayNames(
                     pw,
                     ENGLISH,
-                    true,
+                    NameGetter.NameOpt.COMPOUND_ONLY,
                     "fr-z-zz-zzz-v-vv-vvv-u-uu-uuu-t-ru-Cyrl-s-ss-sss-a-aa-aaa-x-u-x");
 
             pw.println(
@@ -185,7 +187,8 @@ public class GenerateLocaleIDTestData {
                         if (upper.containsSome(value)) {
                             System.err.println("** FIX NAME: " + sampleLocale);
                         } else {
-                            showDisplayNames(pw, ENGLISH, true, sampleLocale);
+                            showDisplayNames(
+                                    pw, ENGLISH, NameGetter.NameOpt.COMPOUND_ONLY, sampleLocale);
                         }
                     }
                 }
@@ -196,7 +199,8 @@ public class GenerateLocaleIDTestData {
             Factory factory = CLDR_CONFIG.getCldrFactory();
             CoverageInfo coverageInfo = CLDR_CONFIG.getCoverageInfo();
             for (String locale : factory.getAvailableLanguages()) {
-                for (boolean onlyConstructCompound : List.of(true, false)) {
+                for (NameGetter.NameOpt nameOpt :
+                        List.of(NameGetter.NameOpt.COMPOUND_ONLY, NameGetter.NameOpt.DEFAULT)) {
                     CLDRFile cldrFile =
                             factory.make(
                                     locale,
@@ -213,10 +217,11 @@ public class GenerateLocaleIDTestData {
                     }
 
                     Map<String, String> displayNames =
-                            prepareDisplayNames(cldrFile, onlyConstructCompound, testInputLocales);
+                            prepareDisplayNames(cldrFile, nameOpt, testInputLocales);
 
                     pw.println("\n@locale=" + locale);
-                    String languageDisplayVal = onlyConstructCompound ? "standard" : "dialect";
+                    String languageDisplayVal =
+                            nameOpt == NameGetter.NameOpt.COMPOUND_ONLY ? "standard" : "dialect";
                     pw.println("@languageDisplay=" + languageDisplayVal + "\n");
 
                     showDisplayNames(pw, displayNames);
@@ -227,13 +232,11 @@ public class GenerateLocaleIDTestData {
     }
 
     private static Map<String, String> prepareDisplayNames(
-            CLDRFile formattingLocaleFile, boolean onlyConstructCompound, String... locales) {
+            CLDRFile formattingLocaleFile, NameGetter.NameOpt nameOpt, String... locales) {
         Map<String, String> displayNames = new TreeMap<>();
         for (String locale : locales) {
             String name =
-                    formattingLocaleFile
-                            .nameGetter()
-                            .getNameFromBCP47Bool(locale, onlyConstructCompound);
+                    formattingLocaleFile.nameGetter().getNameFromIndentifierOpt(locale, nameOpt);
             if (name.contains("null")) {
                 System.err.println("** REPLACE: " + locale + "; " + name);
             } else {
@@ -250,10 +253,9 @@ public class GenerateLocaleIDTestData {
     private static void showDisplayNames(
             TempPrintWriter pw,
             CLDRFile formattingLocaleFile,
-            boolean onlyConstructCompound,
+            NameGetter.NameOpt nameOpt,
             String... locales) {
-        showDisplayNames(
-                pw, prepareDisplayNames(formattingLocaleFile, onlyConstructCompound, locales));
+        showDisplayNames(pw, prepareDisplayNames(formattingLocaleFile, nameOpt, locales));
     }
 
     private static void showDisplayNames(TempPrintWriter pw, Map<String, String> displayNames) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -99,7 +99,7 @@ public class GeneratePluralRanges {
                 System.out.println(
                         locale
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(locale)
+                                + english.nameGetter().getNameFromIdentifier(locale)
                                 + "\t"
                                 + rangeSample.start
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSeedDurations.java
@@ -44,7 +44,9 @@ public class GenerateSeedDurations {
         for (String locale : cldrFactory.getAvailableLanguages()) {
             CLDRFile cldrFile = cldrFactory.make(locale, true);
             String localeString =
-                    locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
+                    locale
+                            + "\t"
+                            + testInfo.getEnglish().nameGetter().getNameFromIdentifier(locale);
             System.out.println("\n" + localeString);
 
             DateTimeFormats formats = new DateTimeFormats().set(cldrFile, "gregorian");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -612,7 +612,7 @@ public class GenerateSidewaysView {
         String core = item;
         item = toHTML.transform(item);
         if (name) {
-            item = english.nameGetter().getNameFromBCP47(core);
+            item = english.nameGetter().getNameFromIdentifier(core);
             item = item == null ? "<i>null</i>" : toHTML.transform(item);
         }
         if (draft) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -30,6 +30,7 @@ import org.unicode.cldr.util.CollatorHelper;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Log;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.TransliteratorUtilities;
 
@@ -414,7 +415,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        String name = cldr.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+        String name = cldr.nameGetter().getNameFromTypeEnumCode(NameType.TERRITORY, country);
         if (false && HACK) {
             Object trial = fixCountryNames.get(name);
             if (trial != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateStatistics.java
@@ -310,7 +310,7 @@ class GenerateStatistics {
         String nativeName, englishName;
         draftLanguages.add(lang);
         nativeName = getFixedLanguageName(localeID, langScript);
-        englishName = english.nameGetter().getNameFromBCP47(langScript);
+        englishName = english.nameGetter().getNameFromIdentifier(langScript);
         if (!lang.equals("en") && nativeName.equals(englishName)) {
             Log.logln(
                     (isDraft ? "D" : "")
@@ -400,7 +400,7 @@ class GenerateStatistics {
             }
         }
         CLDRFile cldr = factory.make(localeID, true);
-        return cldr.nameGetter().getNameFromBCP47(lang);
+        return cldr.nameGetter().getNameFromIdentifier(lang);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -340,7 +340,7 @@ public class GetChanges {
                                 + "\t"
                                 + locale
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(locale)
+                                + english.nameGetter().getNameFromIdentifier(locale)
                                 + "\t"
                                 + ph
                                 + "\t«"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
@@ -5,6 +5,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
@@ -71,8 +72,7 @@ public class GetLanguageData {
                         territory //
                                 + "\t"
                                 + english.nameGetter()
-                                        .getNameFromTypenumCode(
-                                                CLDRFile.TERRITORY_NAME, territory) //
+                                        .getNameFromTypeEnumCode(NameType.TERRITORY, territory) //
                                 + "\t"
                                 + territoryPop //
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetLanguageData.java
@@ -28,7 +28,8 @@ public class GetLanguageData {
         System.out.println("Code\tLang\tLpop\tApprox. Gdp");
         for (String language : sdata.getLanguages()) {
             final long pop = languageToPop.getCount(language);
-            System.out.print(language + "\t" + english.nameGetter().getNameFromBCP47(language));
+            System.out.print(
+                    language + "\t" + english.nameGetter().getNameFromIdentifier(language));
             if (pop > 0) {
                 Pair<OfficialStatus, String> status = isOfficialLanguageOfEUCountry(language);
                 System.out.print(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/LSRSource.java
@@ -88,9 +88,9 @@ public class LSRSource implements Comparable<LSRSource> {
                         + (getSources().isEmpty() ? "" : "\" origin=\"" + getSourceString())
                         + "\"/>"
                         + "\t<!-- "
-                        + english.nameGetter().getNameFromBCP47(source)
+                        + english.nameGetter().getNameFromIdentifier(source)
                         + " ➡︎ "
-                        + english.nameGetter().getNameFromBCP47(target)
+                        + english.nameGetter().getNameFromIdentifier(target)
                         + " -->";
         return result;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarData.java
@@ -124,7 +124,7 @@ public class ListGrammarData {
                 continue;
             }
             // System.out.println(locale);
-            final String names = locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale);
+            final String names = locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale);
             for (Entry<PathHeader, String> entry : pathHeaderToValue.entrySet()) {
 
                 final PathHeader ph = entry.getKey();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListGrammarInfo.java
@@ -71,7 +71,7 @@ public class ListGrammarInfo {
 
     private static String format(
             String locale, Collection<String> genders, Collection<String> rawCases) {
-        return english.nameGetter().getNameFromBCP47(locale)
+        return english.nameGetter().getNameFromIdentifier(locale)
                 + " ("
                 + locale
                 + "/"
@@ -82,7 +82,7 @@ public class ListGrammarInfo {
     }
 
     public static String format(String locale, Collection<String> genders) {
-        return english.nameGetter().getNameFromBCP47(locale)
+        return english.nameGetter().getNameFromIdentifier(locale)
                 + " ("
                 + locale
                 + "/"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -272,8 +272,8 @@ public class Misc {
         for (Iterator<StandardCodes.CodeType> typeIt = sc.getAvailableTypesEnum().iterator();
                 typeIt.hasNext(); ) {
             StandardCodes.CodeType type = typeIt.next();
-            int typeNum = type.toCldrTypeNum();
-            if (typeNum == CLDRFile.NO_NAME) {
+            NameType nameType = type.toNameType();
+            if (nameType == NameType.NONE) {
                 System.out.println("listObsoletes skipping " + type);
                 continue;
             }
@@ -285,7 +285,7 @@ public class Misc {
                 if (list.size() < 3) continue;
                 String replacementCode = list.get(2);
                 if (replacementCode == null || replacementCode.length() == 0) continue;
-                String name = englishNameGetter.getNameFromTypenumCode(typeNum, replacementCode);
+                String name = englishNameGetter.getNameFromTypeEnumCode(nameType, replacementCode);
                 System.out.println(code + " => " + replacementCode + "; " + name);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -44,6 +44,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.Iso3166Data;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.StandardCodes;
@@ -375,8 +376,7 @@ public class Misc {
                 out.println("<th>" + zone + "</th>");
                 String country = zone_country.get(zone);
                 String countryName =
-                        english.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                        english.nameGetter().getNameFromTypeEnumCode(NameType.TERRITORY, country);
                 out.println("<td>" + country + " (" + countryName + ")" + "</td>");
                 TimeZone tzone = TimeZone.getTimeZone(zone);
                 out.println("<td>" + offsetString(tzone) + "</td>");
@@ -484,7 +484,7 @@ public class Misc {
             new_old.put(zone, new TreeSet<String>(col));
             String country = zone_countries.get(zone);
             String name =
-                    english.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country)
+                    english.nameGetter().getNameFromTypeEnumCode(NameType.TERRITORY, country)
                             + " ("
                             + country
                             + ")";
@@ -664,7 +664,7 @@ public class Misc {
             String countryName =
                     desiredLocaleFile
                             .nameGetter()
-                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                            .getNameFromTypeEnumCode(NameType.TERRITORY, country);
             if (countryName == null) countryName = UTF16.valueOf(0x10FFFD) + country;
             reordered.put(countryName + "0" + zoneID, zoneID);
         }
@@ -679,7 +679,7 @@ public class Misc {
             String countryName =
                     desiredLocaleFile
                             .nameGetter()
-                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                            .getNameFromTypeEnumCode(NameType.TERRITORY, country);
             if (countryName == null) countryName = country;
             log.println(
                     "<tr><th class='ID' colspan=\"4\"><table><tr><th class='I'>"
@@ -1216,8 +1216,8 @@ public class Misc {
                                 + TransliteratorUtilities.toXML.transliterate(
                                         "TODO "
                                                 + english.nameGetter()
-                                                        .getNameFromTypenumCode(
-                                                                CLDRFile.TERRITORY_NAME, key))
+                                                        .getNameFromTypeEnumCode(
+                                                                NameType.TERRITORY, key))
                                 + "</territory>");
             }
             log2.println("</territories></localeDisplayNames>");
@@ -1236,7 +1236,7 @@ public class Misc {
                 String countryCode = data.get(2);
                 String country =
                         english.nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode);
+                                .getNameFromTypeEnumCode(NameType.TERRITORY, countryCode);
                 if (!country.equals(lastCountry)) {
                     lastCountry = country;
                     log2.println("\t<!-- " + country + "-->");
@@ -1345,7 +1345,7 @@ public class Misc {
                 name = name.replace('_', ' ');
             }
         } else {
-            name = localization.nameGetter().getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, key);
+            name = localization.nameGetter().getNameFromTypeEnumCode(NameType.TERRITORY, key);
             if (name == null) {
                 if (missing != null) missing[0].add(key);
                 name = key;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -357,7 +357,7 @@ public class Misc {
         // do the header
         for (Iterator<String> it2 = priorities.iterator(); it2.hasNext(); ) {
             String locale = it2.next();
-            String englishLocaleName = english.nameGetter().getNameFromBCP47(locale);
+            String englishLocaleName = english.nameGetter().getNameFromIdentifier(locale);
             out.println("<th>" + locale + " (" + englishLocaleName + ")" + "</th>");
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -363,7 +363,7 @@ public class Misc {
 
         // now the rows
         out.println("</tr>");
-        Map<String, String> zone_country = sc.getZoneToCounty();
+        Map<String, String> zone_country = sc.getZoneToCountry();
         int count = 0;
         for (Iterator<Integer> it = offset_zone_locale_name.keySet().iterator(); it.hasNext(); ) {
             Integer offset = it.next();
@@ -475,7 +475,7 @@ public class Misc {
     static void printZoneAliases() {
         RuleBasedCollator col = CollatorHelper.ROOT_NUMERIC;
         StandardCodes sc = StandardCodes.make();
-        Map<String, String> zone_countries = sc.getZoneToCounty();
+        Map<String, String> zone_countries = sc.getZoneToCountry();
         Map<String, String> old_new = sc.getZoneLinkold_new();
         Map<String, Set<String>> new_old = new TreeMap<>(col);
         Map<String, Set<String>> country_zones = new TreeMap<>(col);
@@ -652,7 +652,7 @@ public class Misc {
         col.setNumericCollation(true);
         Set<String> orderedAliases = new TreeSet<>(col);
 
-        Map<String, String> zone_countries = StandardCodes.make().getZoneToCounty();
+        Map<String, String> zone_countries = StandardCodes.make().getZoneToCountry();
         // Map<String, Set<String>> countries_zoneSet = StandardCodes.make().getCountryToZoneSet();
 
         Map<String, String> reordered = new TreeMap<>(col);
@@ -1033,17 +1033,17 @@ public class Misc {
             System.out.println(++counter + "\t" + key + "\t" + zoneData.get(key));
         }
         Set<String> missing2 = new TreeSet<>(sc.getZoneData().keySet());
-        missing2.removeAll(sc.getZoneToCounty().keySet());
+        missing2.removeAll(sc.getZoneToCountry().keySet());
         System.out.println(missing2);
         missing2.clear();
-        missing2.addAll(sc.getZoneToCounty().keySet());
+        missing2.addAll(sc.getZoneToCountry().keySet());
         missing2.removeAll(sc.getZoneData().keySet());
         System.out.println(missing2);
         if (true) return;
 
         Map<String, Map<String, String>> country_city_data = new TreeMap<>();
         Map<String, String> territoryName_code = new HashMap<>();
-        Map<String, String> zone_to_country = sc.getZoneToCounty();
+        Map<String, String> zone_to_country = sc.getZoneToCountry();
         for (Iterator<String> it = territories.iterator(); it.hasNext(); ) {
             String code = it.next();
             territoryName_code.put(sc.getData("territory", code), code);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -268,8 +268,14 @@ public class Misc {
         // java.util.TimeZone t;
         StandardCodes sc = StandardCodes.make();
         NameGetter englishNameGetter = english.nameGetter();
-        for (Iterator<String> typeIt = sc.getAvailableTypes().iterator(); typeIt.hasNext(); ) {
-            String type = typeIt.next();
+        for (Iterator<StandardCodes.CodeType> typeIt = sc.getAvailableTypesEnum().iterator();
+                typeIt.hasNext(); ) {
+            StandardCodes.CodeType type = typeIt.next();
+            int typeNum = type.toCldrTypeNum();
+            if (typeNum == CLDRFile.NO_NAME) {
+                System.out.println("listObsoletes skipping " + type);
+                continue;
+            }
             System.out.println(type);
             for (Iterator<String> codeIt = sc.getAvailableCodes(type).iterator();
                     codeIt.hasNext(); ) {
@@ -277,13 +283,8 @@ public class Misc {
                 List<String> list = sc.getFullData(type, code);
                 if (list.size() < 3) continue;
                 String replacementCode = list.get(2);
-                if (replacementCode.length() == 0) continue;
-                /*
-                 * TODO: use getNameFromTypenumCode instead of getNameFromTypestrCode here.
-                 * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
-                 * type is derived from sc.getAvailableTypes()
-                 */
-                String name = englishNameGetter.getNameFromTypestrCode(type, replacementCode);
+                if (replacementCode == null || replacementCode.length() == 0) continue;
+                String name = englishNameGetter.getNameFromTypenumCode(typeNum, replacementCode);
                 System.out.println(code + " => " + replacementCode + "; " + name);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
@@ -7,6 +7,7 @@ import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
 import org.unicode.cldr.util.SupplementalDataInfo.PopulationData;
@@ -65,8 +66,7 @@ public class ScriptPopulations {
                             + "\t"
                             + english.nameGetter().getNameFromBCP47(baseLanguage)
                             + "\t"
-                            + english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script)
                             + "\t"
                             + officialStatus
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ScriptPopulations.java
@@ -64,7 +64,7 @@ public class ScriptPopulations {
                             + "\t"
                             + langScriptLitPop.getCount(lang)
                             + "\t"
-                            + english.nameGetter().getNameFromBCP47(baseLanguage)
+                            + english.nameGetter().getNameFromIdentifier(baseLanguage)
                             + "\t"
                             + english.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script)
                             + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
@@ -42,7 +42,7 @@ public class ShowChildren {
         for (Entry<String, Set<String>> entry : parent2children.keyValuesSet()) {
             Map<String, Relation<String, String>> path2value2locales = new TreeMap<>();
             String parent = entry.getKey();
-            String parentName = english.nameGetter().getNameFromBCP47(parent);
+            String parentName = english.nameGetter().getNameFromIdentifier(parent);
             CLDRFile parentFile = cldrFactory.make(parent, true);
 
             Set<String> children = entry.getValue();
@@ -99,7 +99,7 @@ public class ShowChildren {
             deviations.add(parent, path2value2locales.size());
         }
         for (String locale : deviations.getKeysetSortedByKey()) {
-            String parentName = english.nameGetter().getNameFromBCP47(locale);
+            String parentName = english.nameGetter().getNameFromIdentifier(locale);
             System.out.println(parentName + "\t" + locale + "\t" + deviations.get(locale));
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.util.FileCopier;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.SectionId;
 import org.unicode.cldr.util.StringId;
@@ -530,8 +531,7 @@ public class ShowData {
             for (Iterator<String> it2 = UnicodeScripts.iterator(); it2.hasNext(); ) {
                 String script = it2.next();
                 if (script.equals("Latn")) continue;
-                String name =
-                        file.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+                String name = file.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script);
                 if (getScripts(name, scripts).contains(script)) {
                     Map<String, Set<String>> names_locales = script_name_locales.get(script);
                     if (names_locales == null)
@@ -548,8 +548,7 @@ public class ShowData {
             out.println(
                     script
                             + "\t("
-                            + english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
+                            + english.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script)
                             + ")\t"
                             + names);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.util.FileCopier;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.SectionId;
@@ -518,13 +519,13 @@ public class ShowData {
             System.out.println(locale);
             CLDRFile file = cldrFactory.make(locale, false);
             if (file.isNonInheriting()) continue;
-            String localeName = file.nameGetter().getNameFromBCP47(locale);
+            String localeName = file.nameGetter().getNameFromIdentifier(locale);
             getScripts(localeName, scripts);
             if (!scripts.contains("Latn")) {
                 out.println(
                         locale
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(locale)
+                                + english.nameGetter().getNameFromIdentifier(locale)
                                 + "\t"
                                 + localeName);
             }
@@ -756,7 +757,9 @@ public class ShowData {
     }
 
     public static String getEnglishLocaleName(String locale) {
-        return english.nameGetter().getNameFromBCP47BoolAlt(locale, true, CLDRFile.SHORT_ALTS);
+        return english.nameGetter()
+                .getNameFromIdentifierOptAlt(
+                        locale, NameGetter.NameOpt.COMPOUND_ONLY, CLDRFile.SHORT_ALTS);
     }
 
     private static String getLocaleNameAndCode(String locale) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
@@ -51,7 +51,7 @@ public class ShowLanguageData {
                 System.out.println(
                         language
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(language)
+                                + english.nameGetter().getNameFromIdentifier(language)
                                 + "\t"
                                 + territory
                                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguageData.java
@@ -5,6 +5,7 @@ import java.util.TreeMap;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.Counter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.OfficialStatus;
@@ -55,7 +56,7 @@ public class ShowLanguageData {
                                 + territory
                                 + "\t"
                                 + english.nameGetter()
-                                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                                        .getNameFromTypeEnumCode(NameType.TERRITORY, territory)
                                 + "\t"
                                 + litPop / (double) total);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -2965,20 +2965,15 @@ public class ShowLanguages {
         return territory_languages;
     }
 
-    static final Map<String, String> NAME_TO_REGION = getNameToCode(CodeType.territory, "region");
+    static final Map<String, String> NAME_TO_REGION =
+            getNameToCode(CodeType.territory, CLDRFile.TERRITORY_NAME);
     static final Map<String, String> NAME_TO_CURRENCY =
-            getNameToCode(CodeType.currency, "currency");
+            getNameToCode(CodeType.currency, CLDRFile.CURRENCY_NAME);
 
-    private static SortedMap<String, String> getNameToCode(CodeType codeType, String cldrCodeType) {
+    private static SortedMap<String, String> getNameToCode(CodeType codeType, int cldrCodeType) {
         SortedMap<String, String> temp = new TreeMap<String, String>(col);
         for (String territory : StandardCodes.make().getAvailableCodes(codeType)) {
-            /*
-             * TODO: use getNameFromTypenumCode instead of getNameFromTypestrCode here.
-             * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
-             * codeType is either CodeType.territory or CodeType.currency
-             * cldrCodeType is either "region" or "currency"
-             */
-            String name = englishNameGetter.getNameFromTypestrCode(cldrCodeType, territory);
+            String name = englishNameGetter.getNameFromTypenumCode(cldrCodeType, territory);
             temp.put(name == null ? territory : name, territory);
         }
         temp = Collections.unmodifiableSortedMap(temp);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1051,9 +1051,8 @@ public class ShowLanguages {
                         element = "timezone";
                         name = replacement + "*";
                     } else {
-                        int typeCode = CLDRFile.typeNameToCode(element);
-                        if (typeCode != CLDRFile.NO_NAME) {
-                            NameType nameType = NameType.fromCldrInt(typeCode);
+                        NameType nameType = NameType.typeNameToCode(element);
+                        if (nameType != NameType.NONE) {
                             name = getName(nameType, replacement, false);
                         } else {
                             name = "*" + replacement;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1372,8 +1372,8 @@ public class ShowLanguages {
 
         private String getLanguageName(String languageCode) {
             String result =
-                    englishNameGetter.getNameFromBCP47BoolAlt(
-                            languageCode, true, CLDRFile.SHORT_ALTS);
+                    englishNameGetter.getNameFromIdentifierOptAlt(
+                            languageCode, NameGetter.NameOpt.COMPOUND_ONLY, CLDRFile.SHORT_ALTS);
             if (!result.equals(languageCode)) return result;
             Set<String> names = Iso639Data.getNames(languageCode);
             if (names != null && names.size() != 0) {
@@ -1561,8 +1561,10 @@ public class ShowLanguages {
                 final String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : englishNameGetter.getNameFromBCP47BoolAlt(
-                                        locale, true, CLDRFile.SHORT_ALTS);
+                                : englishNameGetter.getNameFromIdentifierOptAlt(
+                                        locale,
+                                        NameGetter.NameOpt.COMPOUND_ONLY,
+                                        CLDRFile.SHORT_ALTS);
                 coverageGoalsTsv.println(
                         String.format(
                                 "%s\t;\t%s\t;\t%s\t;\t%s", organization, locale, level, name));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -68,6 +68,7 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.Log;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.CodeType;
@@ -626,7 +627,7 @@ public class ShowLanguages {
             }
         }
         String languageName =
-                englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, language);
         if (languageName == null) languageName = "???";
         String isLanguageTranslated = "";
         String nativeLanguageName =
@@ -634,13 +635,13 @@ public class ShowLanguages {
                         ? null
                         : nativeLanguage
                                 .nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                                .getNameFromTypeEnumCode(NameType.LANGUAGE, language);
         if (nativeLanguageName == null || nativeLanguageName.equals(language)) {
             nativeLanguageName = "<i>n/a</i>";
             isLanguageTranslated = "n";
         }
 
-        String scriptName = englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, script);
         // String nativeScriptName = nativeLanguage == null ? null :
         // nativeLanguage.getName(CLDRFile.SCRIPT_NAME,script);
         // if (nativeScriptName != null && !nativeScriptName.equals(script)) {
@@ -649,13 +650,13 @@ public class ShowLanguages {
 
         String isTerritoryTranslated = "";
         String territoryName =
-                englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory);
         String nativeTerritoryName =
                 nativeLanguage == null
                         ? null
                         : nativeLanguage
                                 .nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+                                .getNameFromTypeEnumCode(NameType.TERRITORY, territory);
         if (nativeTerritoryName == null || nativeTerritoryName.equals(territory)) {
             nativeTerritoryName = "<i>n/a</i>";
             isTerritoryTranslated = "n";
@@ -702,7 +703,7 @@ public class ShowLanguages {
         if (temp != null) {
             return temp;
         }
-        String scriptName = englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+        String scriptName = englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, script);
         scriptName = scriptName.toLowerCase(Locale.ENGLISH);
         temp = fixScriptGif.get(scriptName);
         if (temp != null) {
@@ -723,13 +724,12 @@ public class ShowLanguages {
             String secondary) {
         try {
             String languageName =
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                    englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, language);
             if (languageName == null) {
                 languageName = "¿" + language + "?";
                 System.err.println("No English Language Name for:" + language);
             }
-            String scriptName =
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+            String scriptName = englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, script);
             if (scriptName == null) {
                 scriptName = "¿" + script + "?";
                 System.err.println("No English Language Name for:" + script);
@@ -865,7 +865,7 @@ public class ShowLanguages {
                         if (iso4217.equals("DEFAULT")) defaultDigits = digits;
                         else
                             currency_fractions.put(
-                                    getName(CLDRFile.CURRENCY_NAME, iso4217, false), digits);
+                                    getName(NameType.CURRENCY, iso4217, false), digits);
                         continue;
                     }
                     // <region iso3166="AR">
@@ -879,8 +879,8 @@ public class ShowLanguages {
                         if (to == null) to = "\u221E";
                         String from = attributes.get("from");
                         if (from == null) from = "-\u221E";
-                        String countryName = getName(CLDRFile.TERRITORY_NAME, iso3166, false);
-                        String currencyName = getName(CLDRFile.CURRENCY_NAME, iso4217, false);
+                        String countryName = getName(NameType.TERRITORY, iso3166, false);
+                        String currencyName = getName(NameType.CURRENCY, iso4217, false);
                         Set info = territory_currency.get(countryName);
                         if (info == null)
                             territory_currency.put(countryName, info = new TreeSet(col3));
@@ -1052,8 +1052,9 @@ public class ShowLanguages {
                         name = replacement + "*";
                     } else {
                         int typeCode = CLDRFile.typeNameToCode(element);
-                        if (typeCode >= 0) {
-                            name = getName(typeCode, replacement, false);
+                        if (typeCode != CLDRFile.NO_NAME) {
+                            NameType nameType = NameType.fromCldrInt(typeCode);
+                            name = getName(nameType, replacement, false);
                         } else {
                             name = "*" + replacement;
                         }
@@ -1062,10 +1063,7 @@ public class ShowLanguages {
                         territoryAliases.put(type, name);
                         aliases.add(
                                 new String[] {
-                                    element,
-                                    getName(CLDRFile.TERRITORY_NAME, type, false),
-                                    name,
-                                    reason
+                                    element, getName(NameType.TERRITORY, type, false), name, reason
                                 });
                     } else {
                         aliases.add(new String[] {element, type, name, reason});
@@ -1125,12 +1123,12 @@ public class ShowLanguages {
                 targetParsed.set(target);
                 tablePrinter
                         .addRow()
-                        .addCell(getName(CLDRFile.LANGUAGE_NAME, sourceParsed.getLanguage()))
-                        .addCell(getName(CLDRFile.SCRIPT_NAME, sourceParsed.getScript()))
-                        .addCell(getName(CLDRFile.TERRITORY_NAME, sourceParsed.getRegion()))
-                        .addCell(getName(CLDRFile.LANGUAGE_NAME, targetParsed.getLanguage()))
-                        .addCell(getName(CLDRFile.SCRIPT_NAME, targetParsed.getScript()))
-                        .addCell(getName(CLDRFile.TERRITORY_NAME, targetParsed.getRegion()))
+                        .addCell(getName(NameType.LANGUAGE, sourceParsed.getLanguage()))
+                        .addCell(getName(NameType.SCRIPT, sourceParsed.getScript()))
+                        .addCell(getName(NameType.TERRITORY, sourceParsed.getRegion()))
+                        .addCell(getName(NameType.LANGUAGE, targetParsed.getLanguage()))
+                        .addCell(getName(NameType.SCRIPT, targetParsed.getScript()))
+                        .addCell(getName(NameType.TERRITORY, targetParsed.getRegion()))
                         .addCell(source)
                         .addCell(target)
                         .finishRow();
@@ -1145,11 +1143,11 @@ public class ShowLanguages {
             }
         }
 
-        private String getName(final int type, final String value) {
+        private String getName(final NameType nameType, final String value) {
             if (value == null || value.equals("") || value.equals("und")) {
                 return "\u00A0";
             }
-            String result = englishNameGetter.getNameFromTypenumCode(type, value);
+            String result = englishNameGetter.getNameFromTypeEnumCode(nameType, value);
             if (result == null) {
                 result = value;
             }
@@ -1281,8 +1279,8 @@ public class ShowLanguages {
                 // PopulationData territoryData =
                 // supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 String territoryName =
-                        englishNameGetter.getNameFromTypenumCode(
-                                CLDRFile.TERRITORY_NAME, territoryCode);
+                        englishNameGetter.getNameFromTypeEnumCode(
+                                NameType.TERRITORY, territoryCode);
                 for (String languageCode :
                         supplementalDataInfo.getLanguagesForTerritoryWithPopulationData(
                                 territoryCode)) {
@@ -1693,8 +1691,8 @@ public class ShowLanguages {
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
-                        englishNameGetter.getNameFromTypenumCode(
-                                CLDRFile.TERRITORY_NAME, territoryCode);
+                        englishNameGetter.getNameFromTypeEnumCode(
+                                NameType.TERRITORY, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double territoryLiteracy = territoryData2.getLiteratePopulationPercent();
@@ -1834,17 +1832,17 @@ public class ShowLanguages {
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
-                        englishNameGetter.getNameFromTypenumCode(
-                                CLDRFile.TERRITORY_NAME, territoryCode);
+                        englishNameGetter.getNameFromTypeEnumCode(
+                                NameType.TERRITORY, territoryCode);
                 PopulationData territoryData2 =
                         supplementalDataInfo.getPopulationDataForTerritory(territoryCode);
                 double population = territoryData2.getPopulation() / 1000000;
                 double gdp = territoryData2.getGdp() / 1000000;
 
                 Map<String, Set<String>> worldData =
-                        territoryData.get(getName(CLDRFile.TERRITORY_NAME, "001", false));
+                        territoryData.get(getName(NameType.TERRITORY, "001", false));
                 Map<String, Set<String>> countryData =
-                        territoryData.get(getName(CLDRFile.TERRITORY_NAME, territoryCode, false));
+                        territoryData.get(getName(NameType.TERRITORY, territoryCode, false));
 
                 tablePrinter
                         .addRow()
@@ -1943,7 +1941,7 @@ public class ShowLanguages {
             StringBuilder buffer = new StringBuilder();
             for (String code : currencies) {
                 if (buffer.length() != 0) buffer.append(",<br>");
-                buffer.append(getName(CLDRFile.CURRENCY_NAME, code, false));
+                buffer.append(getName(NameType.CURRENCY, code, false));
             }
             return buffer.toString();
         }
@@ -1985,7 +1983,7 @@ public class ShowLanguages {
             String[] territories = territoriesList.split("\\s+");
             territoryTypes.add(type);
             for (int i = 0; i < territories.length; ++i) {
-                String territory = getName(CLDRFile.TERRITORY_NAME, territories[i], false);
+                String territory = getName(NameType.TERRITORY, territories[i], false);
                 Map<String, Set<String>> s = territoryData.get(territory);
                 if (s == null) {
                     territoryData.put(territory, s = new TreeMap<>());
@@ -2015,7 +2013,7 @@ public class ShowLanguages {
             }
             pw.println("</tr>");
 
-            String worldName = getName(CLDRFile.TERRITORY_NAME, "001", false);
+            String worldName = getName(NameType.TERRITORY, "001", false);
             Map<String, Set<String>> worldData = territoryData.get(worldName);
             for (Iterator<String> it = territoryData.keySet().iterator(); it.hasNext(); ) {
                 String country = it.next();
@@ -2060,8 +2058,7 @@ public class ShowLanguages {
             Map<String, String> name_script = new TreeMap<>();
             for (Iterator<String> it = sc.getAvailableCodes("script").iterator(); it.hasNext(); ) {
                 String script = it.next();
-                String name =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+                String name = englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, script);
                 if (name == null) name = script;
                 name_script.put(name, script);
                 /*
@@ -2076,7 +2073,7 @@ public class ShowLanguages {
                     it.hasNext(); ) {
                 String language = it.next();
                 String names =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                        englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, language);
                 if (names == null) names = language;
                 name_language.put(names, language);
             }
@@ -2084,7 +2081,7 @@ public class ShowLanguages {
                     it.hasNext(); ) {
                 String language = it.next();
                 String names =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+                        englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, language);
                 if (names == null) names = language;
                 String[] words = names.split(delimiter);
                 if (words.length > 1) {
@@ -2106,9 +2103,9 @@ public class ShowLanguages {
                             if (langSet != null) System.out.print("*");
                             System.out.print(
                                     "?\tSame script?\t + "
-                                            + getName(CLDRFile.LANGUAGE_NAME, language, false)
+                                            + getName(NameType.LANGUAGE, language, false)
                                             + "\t & "
-                                            + getName(CLDRFile.LANGUAGE_NAME, language2, false));
+                                            + getName(NameType.LANGUAGE, language2, false));
                             langSet = (Set<String>) language_scripts.get(language2);
                             if (langSet != null) System.out.print("*");
                             System.out.println();
@@ -2231,8 +2228,8 @@ public class ShowLanguages {
                                     + infoItem.getCurrency()
                                     + "</td>"
                                     + "<td class='target'>"
-                                    + englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.CURRENCY_NAME, infoItem.getCurrency())
+                                    + englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.CURRENCY, infoItem.getCurrency())
                                     + "</td>"
                                     + "</tr>");
                 }
@@ -2287,8 +2284,8 @@ public class ShowLanguages {
                         "<tr>"
                                 + "<td class='source nowrap'>"
                                 + TransliteratorUtilities.toHTML.transform(
-                                        englishNameGetter.getNameFromTypenumCode(
-                                                CLDRFile.CURRENCY_NAME, currency))
+                                        englishNameGetter.getNameFromTypeEnumCode(
+                                                NameType.CURRENCY, currency))
                                 + "</td>"
                                 + "<td class='source'>"
                                 + CldrUtility.getDoubleLinkedText(currency)
@@ -2348,7 +2345,7 @@ public class ShowLanguages {
             // for (Iterator it = territoriesWithoutCurrencies.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(englishNameGetter.getName(CLDRFile.TERRITORY_NAME, it.next().toString(),
+            // pw.print(englishNameGetter.getName(NameType.TERRITORY, it.next().toString(),
             // false));
             // }
             // pw.println("</td><td class='target'>");
@@ -2359,7 +2356,7 @@ public class ShowLanguages {
             // for (Iterator it = currenciesWithoutTerritories.iterator(); it.hasNext();) {
             // if (first) first = false;
             // else pw.print(", ");
-            // pw.print(englishNameGetter.getName(CLDRFile.CURRENCY_NAME, it.next().toString(),
+            // pw.print(englishNameGetter.getName(NameType.CURRENCY, it.next().toString(),
             // false));
             // }
             // pw.println("</td></tr>");
@@ -2369,7 +2366,7 @@ public class ShowLanguages {
 
         private String getTerritoryName(String territory) {
             String name;
-            name = englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory);
+            name = englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory);
             if (name == null) {
                 name = sc.getData("territory", territory);
             }
@@ -2606,7 +2603,7 @@ public class ShowLanguages {
         // }
         public void printContains2(
                 PrintWriter pw, String lead, String start, int depth, boolean isFirst) {
-            String name = depth == 4 ? start : getName(CLDRFile.TERRITORY_NAME, start, false);
+            String name = depth == 4 ? start : getName(NameType.TERRITORY, start, false);
             if (!isFirst) pw.print(lead);
             int count = getTotalContainedItems(start, depth);
             pw.print(
@@ -2692,8 +2689,8 @@ public class ShowLanguages {
                 if (data.get(0).equals("PRIVATE USE")) continue;
                 if (data.size() < 3) continue;
                 if (!"".equals(data.get(2))) continue;
-
-                String itemName = getName(source, item, true);
+                NameType nameType = NameType.fromCldrInt(source);
+                String itemName = getName(nameType, item, true);
                 missingItemsNamed.add(itemName);
             }
             pw.println("<div align='center'><table>");
@@ -2723,13 +2720,13 @@ public class ShowLanguages {
                     new TreeMap<String, Set<String>>(col);
             for (Iterator<String> it = data.keySet().iterator(); it.hasNext(); ) {
                 String territory = it.next();
-                String territoryName = getName(source, territory, true);
+                String territoryName = getName(NameType.fromCldrInt(source), territory, true);
                 Set<String> s = territory_languageNames.get(territoryName);
                 if (s == null)
                     territory_languageNames.put(territoryName, s = new TreeSet<String>(col));
                 for (Iterator<String> it2 = data.get(territory).iterator(); it2.hasNext(); ) {
                     String language = it2.next();
-                    String languageName = getName(target, language, true);
+                    String languageName = getName(NameType.fromCldrInt(target), language, true);
                     s.add(languageName);
                 }
             }
@@ -2750,20 +2747,17 @@ public class ShowLanguages {
             pw.println("</table></div>");
         }
 
-        /**
-         * @param codeFirst TODO
-         */
-        private String getName(int type, String oldcode, boolean codeFirst) {
+        private String getName(NameType nameType, String oldcode, boolean codeFirst) {
             if (oldcode.contains(" ")) {
                 String[] result = oldcode.split("\\s+");
                 for (int i = 0; i < result.length; ++i) {
-                    result[i] = getName(type, result[i], codeFirst);
+                    result[i] = getName(nameType, result[i], codeFirst);
                 }
                 return CldrUtility.join(Arrays.asList(result), ", ");
             } else {
                 int pos = oldcode.indexOf('*');
                 String code = pos < 0 ? oldcode : oldcode.substring(0, pos);
-                String ename = englishNameGetter.getNameFromTypenumCode(type, code);
+                String ename = englishNameGetter.getNameFromTypeEnumCode(nameType, code);
                 String nameString = ename == null ? code : ename;
                 return nameString.equals(oldcode)
                         ? nameString
@@ -2785,8 +2779,8 @@ public class ShowLanguages {
                     @Override
                     public int compare(Object o1, Object o2) {
                         return col.compare(
-                                getName(CLDRFile.TERRITORY_NAME, (String) o1, false),
-                                getName(CLDRFile.TERRITORY_NAME, (String) o2, false));
+                                getName(NameType.TERRITORY, (String) o1, false),
+                                getName(NameType.TERRITORY, (String) o2, false));
                     }
                 };
 
@@ -2841,7 +2835,7 @@ public class ShowLanguages {
             //            }
             //            pw.println("<h2>Groupings and Deprecated Regions</h2>");
             //            for (String region : nameToContainers) {
-            //                String name = getName(CLDRFile.TERRITORY_NAME, region, false);
+            //                String name = getName(NameType.TERRITORY, region, false);
             //                Set<String> dep = deprecated.get(region);
             //                Set<String> gro = grouping.get(region);
             //                Iterator<String> depIt = (dep == null ? Collections.EMPTY_SET :
@@ -2849,9 +2843,9 @@ public class ShowLanguages {
             //                Iterator<String> groIt = (gro == null ? Collections.EMPTY_SET :
             // gro).iterator();
             //                while (depIt.hasNext() || groIt.hasNext()) {
-            //                    String dep1 = depIt.hasNext() ? getName(CLDRFile.TERRITORY_NAME,
+            //                    String dep1 = depIt.hasNext() ? getName(NameType.TERRITORY,
             // depIt.next(), false) : "";
-            //                    String gro1 = groIt.hasNext() ? getName(CLDRFile.TERRITORY_NAME,
+            //                    String gro1 = groIt.hasNext() ? getName(NameType.TERRITORY,
             // groIt.next(), false) : "";
             //                    tablePrinter2.addRow()
             //                    .addCell(name)
@@ -2893,10 +2887,8 @@ public class ShowLanguages {
                     supplementalDataInfo.getTerritoryToContained(containmentStyle);
 
             for (Entry<String, String> containerRegion : grouping.keyValueSet()) {
-                String container =
-                        getName(CLDRFile.TERRITORY_NAME, containerRegion.getKey(), false);
-                String containee =
-                        getName(CLDRFile.TERRITORY_NAME, containerRegion.getValue(), false);
+                String container = getName(NameType.TERRITORY, containerRegion.getKey(), false);
+                String containee = getName(NameType.TERRITORY, containerRegion.getValue(), false);
                 tablePrinter2.addRow().addCell(container).addCell(containee).finishRow();
             }
             pw.println(tablePrinter2.toTable());
@@ -2905,9 +2897,9 @@ public class ShowLanguages {
         public void showContainers(PrintWriter pw, Entry<String, Set<String>> regionContained) {
             String region = regionContained.getKey();
             Set<String> contained = regionContained.getValue();
-            pw.println("<ul><li>" + getName(CLDRFile.TERRITORY_NAME, region, false) + "<ul>");
+            pw.println("<ul><li>" + getName(NameType.TERRITORY, region, false) + "<ul>");
             for (String sub : contained) {
-                pw.println("<li>" + getName(CLDRFile.TERRITORY_NAME, sub, false) + "</li>");
+                pw.println("<li>" + getName(NameType.TERRITORY, sub, false) + "</li>");
             }
             pw.println("</ul></li></ul>");
         }
@@ -2918,7 +2910,7 @@ public class ShowLanguages {
             if (len > 3) {
                 return; // skip long items
             }
-            currentRow.add(getName(CLDRFile.TERRITORY_NAME, start, false));
+            currentRow.add(getName(NameType.TERRITORY, start, false));
             // Collection<String> contains = (Collection<String>) group_contains.get(start);
             Collection<String> contains = supplementalDataInfo.getContainmentCore().get(start);
             if (contains == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -399,12 +399,12 @@ public class ShowLanguages {
     }
 
     private static Set<String> getLanguagesToShow() {
-        return getEnglishTypes("language", CLDRFile.LANGUAGE_NAME);
+        return getEnglishTypes("language", NameType.LANGUAGE);
     }
 
-    private static Set<String> getEnglishTypes(String type, int code) {
+    private static Set<String> getEnglishTypes(String type, NameType nameType) {
         Set<String> result = new HashSet<>(sc.getSurveyToolDisplayCodes(type));
-        for (Iterator<String> it = english.getAvailableIterator(code); it.hasNext(); ) {
+        for (Iterator<String> it = english.getAvailableIterator(nameType); it.hasNext(); ) {
             XPathParts parts = XPathParts.getFrozenInstance(it.next());
             String newType = parts.getAttributeValue(-1, "type");
             if (!result.contains(newType)) {
@@ -415,7 +415,7 @@ public class ShowLanguages {
     }
 
     private static Set<String> getScriptsToShow() {
-        return getEnglishTypes("script", CLDRFile.SCRIPT_NAME);
+        return getEnglishTypes("script", NameType.SCRIPT);
     }
 
     private static void printScriptLanguageTerritory(LanguageInfo linfo, PrintWriter pw)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -51,6 +51,7 @@ import org.unicode.cldr.util.LanguageTagCanonicalizer;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
@@ -1180,7 +1181,7 @@ public class ShowLocaleCoverage {
                         + "\t"
                         + ENGLISH.nameGetter().getNameFromBCP47(language)
                         + "\t"
-                        + ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script)
+                        + ENGLISH.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script)
                         + "\t"
                         + cldrLocaleLevelGoal
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -51,6 +51,7 @@ import org.unicode.cldr.util.LanguageTagCanonicalizer;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
@@ -892,9 +893,11 @@ public class ShowLocaleCoverage {
                             .addCell(language)
                             .addCell(
                                     ENGLISH.nameGetter()
-                                            .getNameFromBCP47BoolAlt(
-                                                    language, true, CLDRFile.SHORT_ALTS))
-                            .addCell(file.nameGetter().getNameFromBCP47(language))
+                                            .getNameFromIdentifierOptAlt(
+                                                    language,
+                                                    NameGetter.NameOpt.COMPOUND_ONLY,
+                                                    CLDRFile.SHORT_ALTS))
+                            .addCell(file.nameGetter().getNameFromIdentifier(language))
                             .addCell(script)
                             .addCell(defRegion)
                             .addCell(sublocales.size())
@@ -920,7 +923,7 @@ public class ShowLocaleCoverage {
                                         + " ;\t"
                                         + visibleLevelComputed
                                         + " ;\t"
-                                        + ENGLISH.nameGetter().getNameFromBCP47(locale));
+                                        + ENGLISH.nameGetter().getNameFromIdentifier(locale));
                         // TODO decide whether to restore this
                         //                        Level higher = Level.UNDETERMINED;
                         //                        switch (computed) {
@@ -1179,7 +1182,7 @@ public class ShowLocaleCoverage {
                 specialFlag
                         + language
                         + "\t"
-                        + ENGLISH.nameGetter().getNameFromBCP47(language)
+                        + ENGLISH.nameGetter().getNameFromIdentifier(language)
                         + "\t"
                         + ENGLISH.nameGetter().getNameFromTypeEnumCode(NameType.SCRIPT, script)
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -168,7 +168,7 @@ public class ShowPlurals {
             if (localeFilter != null && !localeFilter.equals(locale) || locale.equals("root")) {
                 continue;
             }
-            final String name = english.nameGetter().getNameFromBCP47(locale);
+            final String name = english.nameGetter().getNameFromIdentifier(locale);
             String canonicalLocale = canonicalizer.transform(locale);
             if (!locale.equals(canonicalLocale)) {
                 String redirect =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
@@ -27,6 +27,7 @@ import org.unicode.cldr.util.ChainedMap.M4;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
+import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.SectionId;
 import org.unicode.cldr.util.StandardCodes;
@@ -200,7 +201,7 @@ public class ShowRegionalVariants {
                 grandSummary.println(
                         parent
                                 + "\t"
-                                + ENGLISH.nameGetter().getNameFromBCP47(parent.toString())
+                                + ENGLISH.nameGetter().getNameFromIdentifier(parent.toString())
                                 + "\t"
                                 + totalChildDiffs
                                 + "\t"
@@ -213,13 +214,13 @@ public class ShowRegionalVariants {
                     summary.println(
                             parent
                                     + "\t"
-                                    + ENGLISH.nameGetter().getNameFromBCP47(parent.toString())
+                                    + ENGLISH.nameGetter().getNameFromIdentifier(parent.toString())
                                     + "\t"
                                     + childDiffValue
                                     + "\t"
                                     + s
                                     + "\t"
-                                    + ENGLISH.nameGetter().getNameFromBCP47(s.toString()));
+                                    + ENGLISH.nameGetter().getNameFromIdentifier(s.toString()));
                 }
 
                 ArrayList<CLDRFile> parentChain = new ArrayList<>();
@@ -325,7 +326,8 @@ public class ShowRegionalVariants {
             country = "(" + ltp.getRegion() + ")";
         }
         return ENGLISH.nameGetter()
-                        .getNameFromBCP47BoolAlt(key.toString(), false, CLDRFile.SHORT_ALTS)
+                        .getNameFromIdentifierOptAlt(
+                                key.toString(), NameGetter.NameOpt.DEFAULT, CLDRFile.SHORT_ALTS)
                 + "\t"
                 + key
                 + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -581,14 +581,14 @@ public class ShowStarredCoverage {
         }
 
         public String getName(final String written) {
-            String result = CldrConfig.getEnglish().nameGetter().getNameFromBCP47(written);
+            String result = CldrConfig.getEnglish().nameGetter().getNameFromIdentifier(written);
             if (result.equals(written)) {
                 R2<List<String>, String> alias = languageFix.get(written);
                 if (alias != null) {
                     result =
                             CldrConfig.getEnglish()
                                     .nameGetter()
-                                    .getNameFromBCP47(alias.get0().get(0));
+                                    .getNameFromIdentifier(alias.get0().get(0));
                 }
             }
             return result;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowZoneEquivalences.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowZoneEquivalences.java
@@ -82,7 +82,7 @@ public class ShowZoneEquivalences {
                             ArrayComparator.COMPARABLE,
                             ArrayComparator.COMPARABLE
                         });
-        Map<String, String> zone_countries = sc.getZoneToCounty();
+        Map<String, String> zone_countries = sc.getZoneToCountry();
 
         TreeSet<Object[]> country_inflection_names = new TreeSet<Object[]>(ac);
         PrintWriter out = FileUtilities.openUTF8Writer(CLDRPaths.GEN_DIRECTORY, "inflections.txt");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
@@ -292,7 +292,7 @@ public class VettingAdder {
                     Log.logln(
                             locale
                                     + " \t"
-                                    + english.nameGetter().getNameFromBCP47(locale)
+                                    + english.nameGetter().getNameFromIdentifier(locale)
                                     + "\texample: "
                                     + fullPath);
                     break;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
@@ -253,7 +253,7 @@ public class WritePluralRulesSpreadsheets {
     private static String getName(String missing) {
         return missing
                 + "\t"
-                + CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(missing);
+                + CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromIdentifier(missing);
     }
 
     private static String getSamplePattern(PluralMinimalPairs samplePatterns, String start) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Annotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Annotations.java
@@ -434,7 +434,7 @@ public class Annotations {
                 }
             } else if (EmojiConstants.REGIONAL_INDICATORS.containsAll(code)) {
                 String countryCode = EmojiConstants.getFlagCode(code);
-                String path = CLDRFile.getKey(CLDRFile.TERRITORY_NAME, countryCode);
+                String path = NameType.TERRITORY.getKeyPath(countryCode);
                 String regionName = getStringValue(path);
                 if (regionName == null) {
                     regionName = ENGLISH_MARKER + ENGLISH.getStringValueWithBailey(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2390,14 +2390,12 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             CURRENCY_NAME = 4,
             CURRENCY_SYMBOL = 5,
             TZ_EXEMPLAR = 6,
-            TZ_START = TZ_EXEMPLAR,
             TZ_GENERIC_LONG = 7,
             TZ_GENERIC_SHORT = 8,
             TZ_STANDARD_LONG = 9,
             TZ_STANDARD_SHORT = 10,
             TZ_DAYLIGHT_LONG = 11,
             TZ_DAYLIGHT_SHORT = 12,
-            TZ_LIMIT = 13,
             KEY_NAME = 13,
             KEY_TYPE_NAME = 14,
             SUBDIVISION_NAME = 15,
@@ -2441,6 +2439,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
     /**
      * @return the xpath used to access data of a given type
      */
+    @Deprecated
     public static String getKey(int type, String code) {
         switch (type) {
             case VARIANT_NAME:

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2343,26 +2343,6 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         return item.startsWith("//ldml[@draft=\"unconfirmed\"]");
     }
 
-    @Deprecated
-    public static final int NO_NAME = -1,
-            LANGUAGE_NAME = 0,
-            SCRIPT_NAME = 1,
-            TERRITORY_NAME = 2,
-            VARIANT_NAME = 3,
-            CURRENCY_NAME = 4,
-            CURRENCY_SYMBOL = 5,
-            TZ_EXEMPLAR = 6,
-            TZ_GENERIC_LONG = 7,
-            TZ_GENERIC_SHORT = 8,
-            TZ_STANDARD_LONG = 9,
-            TZ_STANDARD_SHORT = 10,
-            TZ_DAYLIGHT_LONG = 11,
-            TZ_DAYLIGHT_SHORT = 12,
-            KEY_NAME = 13,
-            KEY_TYPE_NAME = 14,
-            SUBDIVISION_NAME = 15,
-            LIMIT_TYPES = 15;
-
     public Iterator<String> getAvailableIterator(NameType type) {
         String s = type.getPathStart();
         return iterator(s);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2369,7 +2369,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             if (!xpath.startsWith(NameTable[i][0])) continue;
             if (xpath.indexOf(NameTable[i][1], NameTable[i][0].length()) >= 0) return i;
         }
-        return -1;
+        return NO_NAME;
     }
 
     /** Gets the display name for a type */
@@ -2418,19 +2418,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         {"//ldml/localeDisplayNames/keys/key[@type=\"", "\"]", "key"},
         {"//ldml/localeDisplayNames/types/type[@key=\"", "\"][@type=\"", "\"]", "key|type"},
         {"//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"", "\"]", "subdivision"},
-
-        /**
-         * <long> <generic>Newfoundland Time</generic> <standard>Newfoundland Standard
-         * Time</standard> <daylight>Newfoundland Daylight Time</daylight> </long> - <short>
-         * <generic>NT</generic> <standard>NST</standard> <daylight>NDT</daylight> </short>
-         */
     };
-
-    // private static final String[] TYPE_NAME = {"language", "script", "territory", "variant",
-    // "currency",
-    // "currency-symbol",
-    // "tz-exemplar",
-    // "tz-generic-long", "tz-generic-short"};
 
     public Iterator<String> getAvailableIterator(int type) {
         return iterator(NameTable[type][0]);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2420,8 +2420,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         {"//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"", "\"]", "subdivision"},
     };
 
-    public Iterator<String> getAvailableIterator(int type) {
-        return iterator(NameTable[type][0]);
+    public Iterator<String> getAvailableIterator(NameType type) {
+        int cldrInt = type.toCldrInt();
+        return iterator(NameTable[cldrInt][0]);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2343,45 +2343,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         return item.startsWith("//ldml[@draft=\"unconfirmed\"]");
     }
 
-    // public Collection keySet(Matcher regexMatcher, Collection output) {
-    // if (output == null) output = new ArrayList(0);
-    // for (Iterator it = keySet().iterator(); it.hasNext();) {
-    // String path = (String)it.next();
-    // if (regexMatcher.reset(path).matches()) {
-    // output.add(path);
-    // }
-    // }
-    // return output;
-    // }
-
-    // public Collection keySet(String regexPattern, Collection output) {
-    // return keySet(PatternCache.get(regexPattern).matcher(""), output);
-    // }
-
-    /**
-     * Gets the type of a given xpath, eg script, territory, ... TODO move to separate class
-     *
-     * @param xpath
-     * @return
-     */
-    public static int getNameType(String xpath) {
-        for (int i = 0; i < NameTable.length; ++i) {
-            if (!xpath.startsWith(NameTable[i][0])) continue;
-            if (xpath.indexOf(NameTable[i][1], NameTable[i][0].length()) >= 0) return i;
-        }
-        return NO_NAME;
-    }
-
-    /** Gets the display name for a type */
-    public static String getNameTypeName(int index) {
-        try {
-            return getNameName(index);
-        } catch (Exception e) {
-            return "Illegal Type Name: " + index;
-        }
-    }
-
-    /** Why isn't this an enum? */
+    @Deprecated
     public static final int NO_NAME = -1,
             LANGUAGE_NAME = 0,
             SCRIPT_NAME = 1,
@@ -2401,63 +2363,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
             SUBDIVISION_NAME = 15,
             LIMIT_TYPES = 15;
 
-    private static final String[][] NameTable = {
-        {"//ldml/localeDisplayNames/languages/language[@type=\"", "\"]", "language"},
-        {"//ldml/localeDisplayNames/scripts/script[@type=\"", "\"]", "script"},
-        {"//ldml/localeDisplayNames/territories/territory[@type=\"", "\"]", "territory"},
-        {"//ldml/localeDisplayNames/variants/variant[@type=\"", "\"]", "variant"},
-        {"//ldml/numbers/currencies/currency[@type=\"", "\"]/displayName", "currency"},
-        {"//ldml/numbers/currencies/currency[@type=\"", "\"]/symbol", "currency-symbol"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/exemplarCity", "exemplar-city"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/long/generic", "tz-generic-long"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/short/generic", "tz-generic-short"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/long/standard", "tz-standard-long"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/short/standard", "tz-standard-short"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/long/daylight", "tz-daylight-long"},
-        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/short/daylight", "tz-daylight-short"},
-        {"//ldml/localeDisplayNames/keys/key[@type=\"", "\"]", "key"},
-        {"//ldml/localeDisplayNames/types/type[@key=\"", "\"][@type=\"", "\"]", "key|type"},
-        {"//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"", "\"]", "subdivision"},
-    };
-
     public Iterator<String> getAvailableIterator(NameType type) {
-        int cldrInt = type.toCldrInt();
-        return iterator(NameTable[cldrInt][0]);
-    }
-
-    /**
-     * @return the xpath used to access data of a given type
-     */
-    @Deprecated
-    public static String getKey(int type, String code) {
-        switch (type) {
-            case VARIANT_NAME:
-                code = code.toUpperCase(Locale.ROOT);
-                break;
-            case KEY_NAME:
-                code = fixKeyName(code);
-                break;
-            case TZ_DAYLIGHT_LONG:
-            case TZ_DAYLIGHT_SHORT:
-            case TZ_EXEMPLAR:
-            case TZ_GENERIC_LONG:
-            case TZ_GENERIC_SHORT:
-            case TZ_STANDARD_LONG:
-            case TZ_STANDARD_SHORT:
-                code = getLongTzid(code);
-                break;
-        }
-        String[] nameTableRow = NameTable[type];
-        if (code.contains("|")) {
-            String[] codes = code.split("\\|");
-            return nameTableRow[0]
-                    + fixKeyName(codes[0])
-                    + nameTableRow[1]
-                    + codes[1]
-                    + nameTableRow[2];
-        } else {
-            return nameTableRow[0] + code + nameTableRow[1];
-        }
+        String s = type.getPathStart();
+        return iterator(s);
     }
 
     static final Relation<R2<String, String>, String> bcp47AliasMap =
@@ -2492,39 +2400,9 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         FIX_KEY_NAME = temp.build();
     }
 
-    private static String fixKeyName(String code) {
+    static String fixKeyName(String code) {
         String result = FIX_KEY_NAME.get(code);
         return result == null ? code : result;
-    }
-
-    /**
-     * @return the code used to access data of a given type from the path. Null if not found.
-     */
-    public static String getCode(String path) {
-        int type = getNameType(path);
-        if (type == NO_NAME) {
-            throw new IllegalArgumentException("Illegal type in path: " + path);
-        }
-        String[] nameTableRow = NameTable[type];
-        int start = nameTableRow[0].length();
-        int end = path.indexOf(nameTableRow[1], start);
-        return path.substring(start, end);
-    }
-
-    /**
-     * @param type a string such as "language", "script", "territory", "region", ...
-     * @return the corresponding integer
-     */
-    public static int typeNameToCode(String type) {
-        if (type.equalsIgnoreCase("region")) {
-            type = "territory";
-        }
-        for (int i = 0; i <= LIMIT_TYPES; ++i) {
-            if (type.equalsIgnoreCase(getNameName(i))) {
-                return i;
-            }
-        }
-        return -1;
     }
 
     /** For use in getting short names. */
@@ -2535,12 +2413,6 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                     return "short";
                 }
             };
-
-    /** Returns the name of a type. */
-    public static String getNameName(int choice) {
-        String[] nameTableRow = NameTable[choice];
-        return nameTableRow[nameTableRow.length - 1];
-    }
 
     /**
      * Get standard ordering for elements.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -2502,7 +2502,7 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
      */
     public static String getCode(String path) {
         int type = getNameType(path);
-        if (type < 0) {
+        if (type == NO_NAME) {
             throw new IllegalArgumentException("Illegal type in path: " + path);
         }
         String[] nameTableRow = NameTable[type];

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -31,7 +31,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
         String getDisplayName(
                 CLDRLocale cldrLocale,
-                boolean onlyConstructCompound,
+                NameGetter.NameOpt nameOpt,
                 Transform<String, String> altPicker);
 
         String getDisplayLanguage(CLDRLocale cldrLocale);
@@ -113,7 +113,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         @Override
         public String getDisplayName(
                 CLDRLocale cldrLocale,
-                boolean onlyConstructCompound,
+                NameGetter.NameOpt nameOpt,
                 Transform<String, String> altPicker) {
             return getDisplayName(cldrLocale);
         }
@@ -161,21 +161,22 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayName(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromBCP47BoolAlt(cldrLocale.toDisplayLanguageTag(), true, null);
+                        .getNameFromIdentifierOptAlt(
+                                cldrLocale.toDisplayLanguageTag(),
+                                NameGetter.NameOpt.COMPOUND_ONLY,
+                                null);
             return super.getDisplayName(cldrLocale);
         }
 
         @Override
         public String getDisplayName(
                 CLDRLocale cldrLocale,
-                boolean onlyConstructCompound,
+                NameGetter.NameOpt nameOpt,
                 Transform<String, String> altPicker) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromBCP47BoolAlt(
-                                cldrLocale.toDisplayLanguageTag(),
-                                onlyConstructCompound,
-                                altPicker);
+                        .getNameFromIdentifierOptAlt(
+                                cldrLocale.toDisplayLanguageTag(), nameOpt, altPicker);
             return super.getDisplayName(cldrLocale);
         }
 
@@ -557,8 +558,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         return getDisplayVariant(getDefaultFormatter());
     }
 
-    public String getDisplayName(boolean combined, Transform<String, String> picker) {
-        return getDisplayName(getDefaultFormatter(), combined, picker);
+    public String getDisplayName(NameGetter.NameOpt nameOpt, Transform<String, String> picker) {
+        return getDisplayName(getDefaultFormatter(), nameOpt, picker);
     }
 
     /**
@@ -659,8 +660,8 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
     }
 
     public String getDisplayName(
-            NameFormatter engFormat, boolean combined, Transform<String, String> picker) {
-        return engFormat.getDisplayName(this, combined, picker);
+            NameFormatter engFormat, NameGetter.NameOpt nameOpt, Transform<String, String> picker) {
+        return engFormat.getDisplayName(this, nameOpt, picker);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -153,7 +153,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayVariant(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.VARIANT_NAME, cldrLocale.getVariant());
+                        .getNameFromTypeEnumCode(NameType.VARIANT, cldrLocale.getVariant());
             return tryForBetter(super.getDisplayVariant(cldrLocale), cldrLocale.getVariant());
         }
 
@@ -183,7 +183,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayScript(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, cldrLocale.getScript());
+                        .getNameFromTypeEnumCode(NameType.SCRIPT, cldrLocale.getScript());
             return tryForBetter(super.getDisplayScript(cldrLocale), cldrLocale.getScript());
         }
 
@@ -191,7 +191,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayLanguage(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, cldrLocale.getLanguage());
+                        .getNameFromTypeEnumCode(NameType.LANGUAGE, cldrLocale.getLanguage());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 
@@ -199,7 +199,7 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
         public String getDisplayCountry(CLDRLocale cldrLocale) {
             if (file != null)
                 return file.nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, cldrLocale.getCountry());
+                        .getNameFromTypeEnumCode(NameType.TERRITORY, cldrLocale.getCountry());
             return tryForBetter(super.getDisplayLanguage(cldrLocale), cldrLocale.getLanguage());
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
@@ -604,7 +604,7 @@ public class CLDRTransforms {
                         CLDRConfig.getInstance()
                                 .getEnglish()
                                 .nameGetter()
-                                .getNameFromBCP47(sourceOrTarget);
+                                .getNameFromIdentifier(sourceOrTarget);
                 return name;
             } catch (Exception e) {
                 return sourceOrTarget;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CoreCoverageInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CoreCoverageInfo.java
@@ -174,7 +174,7 @@ public class CoreCoverageInfo {
         String bestScript = script.isEmpty() ? maxScript : script;
         String bestRegion = region.isEmpty() ? maxRegion : region;
 
-        String languagePath = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, baseLanguage);
+        String languagePath = NameType.LANGUAGE.getKeyPath(baseLanguage);
         String languageName = resolvedFile.getStringValue(languagePath);
         if (languageName == null) {
             detailedErrors.put(CoreItems.own_language, languagePath);
@@ -188,7 +188,7 @@ public class CoreCoverageInfo {
         if (bestRegion.isEmpty()) {
             detailedErrors.put(CoreItems.own_regions, "//supplementalData/likelySubtags");
         } else {
-            String regionPath = CLDRFile.getKey(CLDRFile.TERRITORY_NAME, bestRegion);
+            String regionPath = NameType.TERRITORY.getKeyPath(bestRegion);
             String regionName = file.getStringValue(regionPath);
             if (regionName == null) {
                 detailedErrors.put(CoreItems.own_regions, regionPath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1101,8 +1101,7 @@ public class DateTimeFormats {
                 continue;
             }
             sorted.put(
-                    englishFile.nameGetter().getNameFromIndentifierCompoundOnly(localeID),
-                    localeID);
+                    englishFile.nameGetter().getNameFromIdentifierCompoundOnly(localeID), localeID);
         }
 
         writeCss(DIR);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1100,7 +1100,9 @@ public class DateTimeFormats {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.nameGetter().getNameFromBCP47Bool(localeID, true), localeID);
+            sorted.put(
+                    englishFile.nameGetter().getNameFromIndentifierCompoundOnly(localeID),
+                    localeID);
         }
 
         writeCss(DIR);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodsCheck.java
@@ -33,7 +33,7 @@ public class DayPeriodsCheck {
                 case "groups":
                     StandardCodes sc = StandardCodes.make();
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
-                    english.nameGetter().getNameFromBCP47(LanguageGroup.uralic.iso);
+                    english.nameGetter().getNameFromIdentifier(LanguageGroup.uralic.iso);
 
                     for (LanguageGroup group : LanguageGroup.values()) {
                         System.out.println(
@@ -41,7 +41,7 @@ public class DayPeriodsCheck {
                                         + "\t"
                                         + group.iso
                                         + "\t"
-                                        + english.nameGetter().getNameFromBCP47(group.iso));
+                                        + english.nameGetter().getNameFromIdentifier(group.iso));
                     }
 
                     for (LanguageGroup group : LanguageGroup.values()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
@@ -285,7 +285,7 @@ public class DiffLanguageGroups {
 
     public static String getName(String languageCode) {
         String result =
-                ENGLISH.nameGetter().getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, languageCode);
+                ENGLISH.nameGetter().getNameFromTypeEnumCode(NameType.LANGUAGE, languageCode);
         return result == null ? "(no name)" : result.replace(" (Other)", "");
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GlossonymConstructor.java
@@ -116,7 +116,9 @@ public class GlossonymConstructor {
             final CLDRFile.SimpleAltPicker altPicker =
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
             final String value =
-                    cldrFile.nameGetter().getNameFromBCP47BoolAlt(type, true, altPicker);
+                    cldrFile.nameGetter()
+                            .getNameFromIdentifierOptAlt(
+                                    type, NameGetter.NameOpt.COMPOUND_ONLY, altPicker);
             if (!valueIsBogus(value)) {
                 return value;
             }
@@ -133,7 +135,8 @@ public class GlossonymConstructor {
                     (alt == null) ? null : new CLDRFile.SimpleAltPicker(alt);
             final String value =
                     cldrFile.nameGetter()
-                            .getNameFromBCP47BoolAltPaths(type, true, altPicker, paths);
+                            .getNameFromIdentifierOptAltPaths(
+                                    type, NameGetter.NameOpt.COMPOUND_ONLY, altPicker, paths);
             if (!valueIsBogus(value)) {
                 return paths;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
@@ -304,7 +304,7 @@ public enum LanguageGroup {
         }
         return prefix
                 + cldrFile.nameGetter()
-                        .getNameFromBCP47(ltp.getLanguage())
+                        .getNameFromIdentifier(ltp.getLanguage())
                         .replace(" [Other]", "")
                         .replace(" languages", "");
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LanguageGroup.java
@@ -292,7 +292,7 @@ public enum LanguageGroup {
                 break;
             default:
                 return cldrFile.nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, ltp.getRegion());
+                        .getNameFromTypeEnumCode(NameType.TERRITORY, ltp.getRegion());
         }
         switch (ltp.getScript()) {
             case "Hani":

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -27,6 +27,11 @@ public class NameGetter {
         this.cldrFile = cldrFile;
     }
 
+    public enum NameOpt {
+        DEFAULT,
+        COMPOUND_ONLY
+    }
+
     private static final String GETNAME_LOCALE_SEPARATOR_PATH =
             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator";
     private static final String GETNAME_LOCALE_PATTERN_PATH =
@@ -54,34 +59,39 @@ public class NameGetter {
     }
 
     /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
+     * Returns the name of the given identifier. Note that extensions must be specified using the
+     * old "\@key=type" syntax.
      *
-     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
-     * @return the name of the given bcp47 identifier
+     * @param localeOrTZID the identifier, BCP47 or extension thereof, such as for locale or
+     *     timezone ID
+     * @return the name of the given identifier
      */
-    public synchronized String getNameFromBCP47(String localeOrTZID) {
-        return getNameFromBCP47Bool(localeOrTZID, false);
+    public synchronized String getNameFromIdentifier(String localeOrTZID) {
+        return getNameFromIndentifierOpt(localeOrTZID, NameOpt.DEFAULT);
+    }
+
+    public String getNameFromIndentifierCompoundOnly(String localeOrTZID) {
+        return getNameFromIndentifierOpt(localeOrTZID, NameOpt.COMPOUND_ONLY);
     }
 
     /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
+     * Returns the name of the given identifier. Note that extensions must be specified using the
+     * old "\@key=type" syntax.
      *
-     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
-     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     * @param localeOrTZID the identifier, BCP47 or extension thereof, such as for locale or
+     *     timezone ID
+     * @param nameOpt if COMPOUND_ONLY, returns "English (United Kingdom)" instead of "British
      *     English"
-     * @return the name of the given bcp47 identifier
+     * @return the name of the given identifier
      */
-    public synchronized String getNameFromBCP47Bool(
-            String localeOrTZID, boolean onlyConstructCompound) {
-        return getNameFromBCP47BoolAlt(localeOrTZID, onlyConstructCompound, null);
+    public synchronized String getNameFromIndentifierOpt(String localeOrTZID, NameOpt nameOpt) {
+        return getNameFromIdentifierOptAlt(localeOrTZID, nameOpt, null);
     }
 
-    public String getNameFromParserBool(LanguageTagParser lparser, boolean onlyConstructCompound) {
+    public String getNameFromParserOpt(LanguageTagParser lparser, NameOpt nameOpt) {
         return getNameFromOtherThings(
                 lparser,
-                onlyConstructCompound,
+                nameOpt,
                 null,
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH),
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN_PATH),
@@ -89,15 +99,15 @@ public class NameGetter {
                 null);
     }
 
-    public synchronized String getNameFromBCP47Etc(
+    public synchronized String getNameFromIdentifierEtc(
             String localeOrTZID,
-            boolean onlyConstructCompound,
+            NameOpt nameOpt,
             String localeKeyTypePattern,
             String localePattern,
             String localeSeparator) {
         return getNameFromManyThings(
                 localeOrTZID,
-                onlyConstructCompound,
+                nameOpt,
                 localeKeyTypePattern,
                 localePattern,
                 localeSeparator,
@@ -106,42 +116,42 @@ public class NameGetter {
     }
 
     /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
+     * Returns the name of the given identifier. Note that extensions must be specified using the
+     * old "\@key=type" syntax.
      *
-     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
-     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     * @param localeOrTZID the identifier, BCP47 or extension thereof, such as for locale or
+     *     timezone ID
+     * @param nameOpt if COMPOUND_ONLY, returns "English (United Kingdom)" instead of "British
      *     English"
      * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
      *     "English (U.K.)" instead of "English (United Kingdom)"
-     * @return the name of the given bcp47 identifier
+     * @return the name of the given identifier
      */
-    public synchronized String getNameFromBCP47BoolAlt(
-            String localeOrTZID,
-            boolean onlyConstructCompound,
-            Transform<String, String> altPicker) {
-        return getNameFromBCP47BoolAltPaths(localeOrTZID, onlyConstructCompound, altPicker, null);
+    public synchronized String getNameFromIdentifierOptAlt(
+            String localeOrTZID, NameOpt nameOpt, Transform<String, String> altPicker) {
+        return getNameFromIdentifierOptAltPaths(localeOrTZID, nameOpt, altPicker, null);
     }
 
     /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax.
+     * Returns the name of the given identifier. Note that extensions must be specified using the
+     * old "\@key=type" syntax.
      *
-     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
-     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     * @param localeOrTZID the identifier, BCP47 or extension thereof, such as for locale or
+     *     timezone ID
+     * @param nameOpt if COMPOUND_ONLY, returns "English (United Kingdom)" instead of "British
      *     English"
      * @param altPicker Used to select particular alts. For example, SHORT_ALTS can be used to get
      *     "English (U.K.)" instead of "English (United Kingdom)"
-     * @return the name of the given bcp47 identifier
+     * @return the name of the given identifier
      */
-    public synchronized String getNameFromBCP47BoolAltPaths(
+    public synchronized String getNameFromIdentifierOptAltPaths(
             String localeOrTZID,
-            boolean onlyConstructCompound,
+            NameOpt nameOpt,
             Transform<String, String> altPicker,
             Set<String> paths) {
         return getNameFromManyThings(
                 localeOrTZID,
-                onlyConstructCompound,
+                nameOpt,
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_KEY_TYPE_PATTERN_PATH),
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_PATTERN_PATH),
                 cldrFile.getWinningValueWithBailey(GETNAME_LOCALE_SEPARATOR_PATH),
@@ -150,21 +160,22 @@ public class NameGetter {
     }
 
     /**
-     * Returns the name of the given bcp47 identifier. Note that extensions must be specified using
-     * the old "\@key=type" syntax. Only used by ExampleGenerator.
+     * Returns the name of the given identifier. Note that extensions must be specified using the
+     * old "\@key=type" syntax. Only used by ExampleGenerator.
      *
-     * @param localeOrTZID the bcp47 identifier (locale or timezone ID)
-     * @param onlyConstructCompound if true, returns "English (United Kingdom)" instead of "British
+     * @param localeOrTZID the identifier, BCP47 or extension thereof, such as for locale or
+     *     timezone ID
+     * @param nameOpt if COMPOUND_ONLY, returns "English (United Kingdom)" instead of "British
      *     English"
      * @param localeKeyTypePattern the pattern used to format key-type pairs
      * @param localePattern the pattern used to format primary/secondary subtags
      * @param localeSeparator the list separator for secondary subtags
      * @param paths if non-null, fillin with contributory paths
-     * @return the name of the given bcp47 identifier
+     * @return the name of the given identifier
      */
     private synchronized String getNameFromManyThings(
             String localeOrTZID,
-            boolean onlyConstructCompound,
+            NameOpt nameOpt,
             String localeKeyTypePattern,
             String localePattern,
             String localeSeparator,
@@ -176,7 +187,7 @@ public class NameGetter {
         }
         boolean isCompound = localeOrTZID.contains("_");
         String name =
-                isCompound && onlyConstructCompound
+                isCompound && nameOpt == NameOpt.COMPOUND_ONLY
                         ? null
                         : getNameFromTypeCodeTransformPaths(
                                 NameType.LANGUAGE, localeOrTZID, altPicker, paths);
@@ -189,7 +200,7 @@ public class NameGetter {
         LanguageTagParser lparser = new LanguageTagParser().set(localeOrTZID);
         return getNameFromOtherThings(
                 lparser,
-                onlyConstructCompound,
+                nameOpt,
                 altPicker,
                 localeKeyTypePattern,
                 localePattern,
@@ -199,7 +210,7 @@ public class NameGetter {
 
     private String getNameFromOtherThings(
             LanguageTagParser lparser,
-            boolean onlyConstructCompound,
+            NameOpt nameOpt,
             Transform<String, String> altPicker,
             String localeKeyTypePattern,
             String localePattern,
@@ -212,12 +223,12 @@ public class NameGetter {
         boolean haveScript = false;
         boolean haveRegion = false;
         // try lang+script
-        if (onlyConstructCompound) {
+        if (nameOpt == NameOpt.COMPOUND_ONLY) {
             name =
                     getNameFromTypeCodeTransformPaths(
                             NameType.LANGUAGE, original = lparser.getLanguage(), altPicker, paths);
             if (name == null) name = original;
-        } else {
+        } else { // nameOpt == NameOpt.DEFAULT
             String x = lparser.toString(LanguageTagParser.LANGUAGE_SCRIPT_REGION);
             name = getNameFromTypeCodeTransformPaths(NameType.LANGUAGE, x, altPicker, paths);
             if (name != null) {
@@ -308,7 +319,7 @@ public class NameGetter {
                         if (hybrid != null) {
                             kname = cldrFile.getKeyValueName("h0", JOIN_UNDERBAR.join(hybrid));
                         }
-                        oldFormatType = getNameFromBCP47(oldFormatType);
+                        oldFormatType = getNameFromIdentifier(oldFormatType);
                         break;
                     case "cu":
                         oldFormatType =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -67,11 +67,11 @@ public class NameGetter {
      * @return the name of the given identifier
      */
     public synchronized String getNameFromIdentifier(String localeOrTZID) {
-        return getNameFromIndentifierOpt(localeOrTZID, NameOpt.DEFAULT);
+        return getNameFromIdentifierOpt(localeOrTZID, NameOpt.DEFAULT);
     }
 
-    public String getNameFromIndentifierCompoundOnly(String localeOrTZID) {
-        return getNameFromIndentifierOpt(localeOrTZID, NameOpt.COMPOUND_ONLY);
+    public String getNameFromIdentifierCompoundOnly(String localeOrTZID) {
+        return getNameFromIdentifierOpt(localeOrTZID, NameOpt.COMPOUND_ONLY);
     }
 
     /**
@@ -84,7 +84,7 @@ public class NameGetter {
      *     English"
      * @return the name of the given identifier
      */
-    public synchronized String getNameFromIndentifierOpt(String localeOrTZID, NameOpt nameOpt) {
+    public synchronized String getNameFromIdentifierOpt(String localeOrTZID, NameOpt nameOpt) {
         return getNameFromIdentifierOptAlt(localeOrTZID, nameOpt, null);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -48,19 +48,6 @@ public class NameGetter {
         return getNameFromTypeCodeTransformPaths(type, code, null, null);
     }
 
-    /**
-     * Get a name, given a type (as a int) and a code.
-     *
-     * @param type the type (integer) such as CLDRFile.TERRITORY_NAME
-     * @param code a code such as "JP"
-     * @return the name
-     */
-    @Deprecated
-    public String getNameFromTypenumCode(int type, String code) {
-        NameType nameType = NameType.fromCldrInt(type);
-        return getNameFromTypeCodeTransformPaths(nameType, code, null, null);
-    }
-
     public String getNameFromTypeCodeAltpicker(
             NameType type, String code, Transform<String, String> altPicker) {
         return getNameFromTypeCodeTransformPaths(type, code, altPicker, null);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameGetter.java
@@ -38,21 +38,6 @@ public class NameGetter {
     private static final Joiner JOIN_UNDERBAR = Joiner.on('_');
 
     /**
-     * Get a name, given a type (as a String) and a code.
-     *
-     * <p>Ideally getNameFromTypestrCode and getNameFromTypenumCode should be replaced by a method
-     * that takes an enum rather than String or int. Compare StandardCodes.CodeType, and the
-     * integers defined in the vicinity of CLDRFile.TERRITORY_NAME
-     *
-     * @param type a string such as "currency", "language", "region", "script", "territory", ...
-     * @param code a code such as "JP"
-     * @return the name
-     */
-    public String getNameFromTypestrCode(String type, String code) {
-        return getNameFromTypenumCode(CLDRFile.typeNameToCode(type), code);
-    }
-
-    /**
      * Get a name, given a type (as a int) and a code.
      *
      * @param type the type such as CLDRFile.TERRITORY_NAME

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
@@ -1,5 +1,7 @@
 package org.unicode.cldr.util;
 
+import java.util.Locale;
+
 public enum NameType {
     NONE,
     LANGUAGE,
@@ -19,13 +21,34 @@ public enum NameType {
     KEY_TYPE,
     SUBDIVISION;
 
+    // Caution: the presence of "key|type" presents difficulties for refactoring.
+    // The row with "key|type" has four strings, while the others have three.
+    private static final String[][] NameTable = {
+        {"//ldml/localeDisplayNames/languages/language[@type=\"", "\"]", "language"},
+        {"//ldml/localeDisplayNames/scripts/script[@type=\"", "\"]", "script"},
+        {"//ldml/localeDisplayNames/territories/territory[@type=\"", "\"]", "territory"},
+        {"//ldml/localeDisplayNames/variants/variant[@type=\"", "\"]", "variant"},
+        {"//ldml/numbers/currencies/currency[@type=\"", "\"]/displayName", "currency"},
+        {"//ldml/numbers/currencies/currency[@type=\"", "\"]/symbol", "currency-symbol"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/exemplarCity", "exemplar-city"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/long/generic", "tz-generic-long"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/short/generic", "tz-generic-short"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/long/standard", "tz-standard-long"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/short/standard", "tz-standard-short"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/long/daylight", "tz-daylight-long"},
+        {"//ldml/dates/timeZoneNames/zone[@type=\"", "\"]/short/daylight", "tz-daylight-short"},
+        {"//ldml/localeDisplayNames/keys/key[@type=\"", "\"]", "key"},
+        {"//ldml/localeDisplayNames/types/type[@key=\"", "\"][@type=\"", "\"]", "key|type"},
+        {"//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"", "\"]", "subdivision"},
+    };
+
     public static NameType fromPath(String xpath) {
-        int cldrInt = CLDRFile.getNameType(xpath);
+        int cldrInt = getNameTypeFromTable(xpath);
         return fromCldrInt(cldrInt);
     }
 
     @Deprecated
-    public int toCldrInt() {
+    private int toCldrInt() {
         switch (this) {
             case NONE:
                 return CLDRFile.NO_NAME;
@@ -106,20 +129,74 @@ public enum NameType {
         throw new RuntimeException("Unrecognized typeNum in fromCldrInt: " + typeNum);
     }
 
+    /**
+     * @return the xpath used to access data of a given type
+     */
     public String getKeyPath(String code) {
-        return CLDRFile.getKey(this.toCldrInt(), code);
+        switch (this) {
+            case VARIANT:
+                code = code.toUpperCase(Locale.ROOT);
+                break;
+            case KEY:
+                code = CLDRFile.fixKeyName(code);
+                break;
+            case TZ_DAYLIGHT_LONG:
+            case TZ_DAYLIGHT_SHORT:
+            case TZ_EXEMPLAR:
+            case TZ_GENERIC_LONG:
+            case TZ_GENERIC_SHORT:
+            case TZ_STANDARD_LONG:
+            case TZ_STANDARD_SHORT:
+                code = CLDRFile.getLongTzid(code);
+                break;
+        }
+        String[] nameTableRow = NameTable[this.toCldrInt()];
+        if (code.contains("|")) {
+            String[] codes = code.split("\\|");
+            return nameTableRow[0]
+                    + CLDRFile.fixKeyName(codes[0])
+                    + nameTableRow[1]
+                    + codes[1]
+                    + nameTableRow[2];
+        } else {
+            return nameTableRow[0] + code + nameTableRow[1];
+        }
     }
 
     public String getNameName() {
-        return CLDRFile.getNameName(this.toCldrInt());
+        int index = this.toCldrInt();
+        String[] nameTableRow = NameTable[index];
+        return nameTableRow[nameTableRow.length - 1];
     }
 
+    /** Gets the display name for a type */
     public String getNameTypeName() {
-        return CLDRFile.getNameTypeName(this.toCldrInt());
+        int index = this.toCldrInt();
+        try {
+            String[] nameTableRow = NameTable[index];
+            return nameTableRow[nameTableRow.length - 1];
+        } catch (Exception e) {
+            return "Illegal Type Name: " + index;
+        }
     }
 
+    /**
+     * Get the code used to access data of a given type from the path.
+     *
+     * <p>For example, given //ldml/localeDisplayNames/languages/language[@type="mul"], return "mul"
+     *
+     * @param path the xpath
+     * @return the code, or null if not found
+     */
     public static String getCode(String path) {
-        return CLDRFile.getCode(path);
+        int type = getNameTypeFromTable(path);
+        if (type == CLDRFile.NO_NAME) {
+            throw new IllegalArgumentException("Illegal type in path: " + path);
+        }
+        String[] nameTableRow = NameTable[type];
+        int start = nameTableRow[0].length();
+        int end = path.indexOf(nameTableRow[1], start);
+        return path.substring(start, end);
     }
 
     /**
@@ -127,7 +204,41 @@ public enum NameType {
      * @return the corresponding NameType
      */
     public static NameType typeNameToCode(String typeString) {
-        int cldrInt = CLDRFile.typeNameToCode(typeString);
+        if (typeString.equalsIgnoreCase("region")) {
+            typeString = "territory";
+        }
+        int cldrInt = -1;
+        for (int i = 0; i <= CLDRFile.LIMIT_TYPES; ++i) {
+            String[] nameTableRow = NameTable[i];
+            String s = nameTableRow[nameTableRow.length - 1];
+            if (typeString.equalsIgnoreCase(s)) {
+                cldrInt = i;
+                break;
+            }
+        }
+        if (cldrInt == -1) {
+            return NONE;
+        }
         return fromCldrInt(cldrInt);
+    }
+
+    /**
+     * Get the string to match the beginning of paths corresponding to this NameType
+     *
+     * <p>For example, for LANGUAGE return "//ldml/localeDisplayNames/languages/language[@type=\""
+     *
+     * @return the string
+     */
+    public String getPathStart() {
+        int index = this.toCldrInt();
+        return NameTable[index][0];
+    }
+
+    private static int getNameTypeFromTable(String xpath) {
+        for (int i = 0; i < NameTable.length; ++i) {
+            if (!xpath.startsWith(NameTable[i][0])) continue;
+            if (xpath.indexOf(NameTable[i][1], NameTable[i][0].length()) >= 0) return i;
+        }
+        return CLDRFile.NO_NAME;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.util;
 
 public enum NameType {
+    NONE,
     LANGUAGE,
     SCRIPT,
     TERRITORY,
@@ -18,9 +19,16 @@ public enum NameType {
     KEY_TYPE,
     SUBDIVISION;
 
+    public static NameType fromPath(String xpath) {
+        int cldrInt = CLDRFile.getNameType(xpath);
+        return fromCldrInt(cldrInt);
+    }
+
     @Deprecated
     public int toCldrInt() {
         switch (this) {
+            case NONE:
+                return CLDRFile.NO_NAME;
             case LANGUAGE:
                 return CLDRFile.LANGUAGE_NAME;
             case SCRIPT:
@@ -54,12 +62,14 @@ public enum NameType {
             case SUBDIVISION:
                 return CLDRFile.SUBDIVISION_NAME;
         }
-        return CLDRFile.NO_NAME;
+        throw new RuntimeException("Unrecognized NameType in toCldrInt: " + this);
     }
 
     @Deprecated
     public static NameType fromCldrInt(int typeNum) {
         switch (typeNum) {
+            case CLDRFile.NO_NAME:
+                return NONE;
             case CLDRFile.LANGUAGE_NAME:
                 return LANGUAGE;
             case CLDRFile.SCRIPT_NAME:
@@ -102,5 +112,9 @@ public enum NameType {
 
     public String getNameName() {
         return CLDRFile.getNameName(this.toCldrInt());
+    }
+
+    public String getNameTypeName() {
+        return CLDRFile.getNameTypeName(this.toCldrInt());
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
@@ -1,0 +1,106 @@
+package org.unicode.cldr.util;
+
+public enum NameType {
+    LANGUAGE,
+    SCRIPT,
+    TERRITORY,
+    VARIANT,
+    CURRENCY,
+    CURRENCY_SYMBOL,
+    TZ_EXEMPLAR,
+    TZ_GENERIC_LONG,
+    TZ_GENERIC_SHORT,
+    TZ_STANDARD_LONG,
+    TZ_STANDARD_SHORT,
+    TZ_DAYLIGHT_LONG,
+    TZ_DAYLIGHT_SHORT,
+    KEY,
+    KEY_TYPE,
+    SUBDIVISION;
+
+    @Deprecated
+    public int toCldrInt() {
+        switch (this) {
+            case LANGUAGE:
+                return CLDRFile.LANGUAGE_NAME;
+            case SCRIPT:
+                return CLDRFile.SCRIPT_NAME;
+            case TERRITORY:
+                return CLDRFile.TERRITORY_NAME;
+            case VARIANT:
+                return CLDRFile.VARIANT_NAME;
+            case CURRENCY:
+                return CLDRFile.CURRENCY_NAME;
+            case CURRENCY_SYMBOL:
+                return CLDRFile.CURRENCY_SYMBOL;
+            case TZ_EXEMPLAR:
+                return CLDRFile.TZ_EXEMPLAR;
+            case TZ_GENERIC_LONG:
+                return CLDRFile.TZ_GENERIC_LONG;
+            case TZ_GENERIC_SHORT:
+                return CLDRFile.TZ_GENERIC_SHORT;
+            case TZ_STANDARD_LONG:
+                return CLDRFile.TZ_STANDARD_LONG;
+            case TZ_STANDARD_SHORT:
+                return CLDRFile.TZ_STANDARD_SHORT;
+            case TZ_DAYLIGHT_LONG:
+                return CLDRFile.TZ_DAYLIGHT_LONG;
+            case TZ_DAYLIGHT_SHORT:
+                return CLDRFile.TZ_DAYLIGHT_SHORT;
+            case KEY:
+                return CLDRFile.KEY_NAME;
+            case KEY_TYPE:
+                return CLDRFile.KEY_TYPE_NAME;
+            case SUBDIVISION:
+                return CLDRFile.SUBDIVISION_NAME;
+        }
+        return CLDRFile.NO_NAME;
+    }
+
+    @Deprecated
+    public static NameType fromCldrInt(int typeNum) {
+        switch (typeNum) {
+            case CLDRFile.LANGUAGE_NAME:
+                return LANGUAGE;
+            case CLDRFile.SCRIPT_NAME:
+                return SCRIPT;
+            case CLDRFile.TERRITORY_NAME:
+                return TERRITORY;
+            case CLDRFile.VARIANT_NAME:
+                return VARIANT;
+            case CLDRFile.CURRENCY_NAME:
+                return CURRENCY;
+            case CLDRFile.CURRENCY_SYMBOL:
+                return CURRENCY_SYMBOL;
+            case CLDRFile.TZ_EXEMPLAR:
+                return TZ_EXEMPLAR;
+            case CLDRFile.TZ_GENERIC_LONG:
+                return TZ_GENERIC_LONG;
+            case CLDRFile.TZ_GENERIC_SHORT:
+                return TZ_GENERIC_SHORT;
+            case CLDRFile.TZ_STANDARD_LONG:
+                return TZ_STANDARD_LONG;
+            case CLDRFile.TZ_STANDARD_SHORT:
+                return TZ_STANDARD_SHORT;
+            case CLDRFile.TZ_DAYLIGHT_LONG:
+                return TZ_DAYLIGHT_LONG;
+            case CLDRFile.TZ_DAYLIGHT_SHORT:
+                return TZ_DAYLIGHT_SHORT;
+            case CLDRFile.KEY_NAME:
+                return KEY;
+            case CLDRFile.KEY_TYPE_NAME:
+                return KEY_TYPE;
+            case CLDRFile.SUBDIVISION_NAME:
+                return SUBDIVISION;
+        }
+        throw new RuntimeException("Unrecognized typeNum in fromCldrInt: " + typeNum);
+    }
+
+    public String getKeyPath(String code) {
+        return CLDRFile.getKey(this.toCldrInt(), code);
+    }
+
+    public String getNameName() {
+        return CLDRFile.getNameName(this.toCldrInt());
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
@@ -117,4 +117,13 @@ public enum NameType {
     public String getNameTypeName() {
         return CLDRFile.getNameTypeName(this.toCldrInt());
     }
+
+    public static String getCode(String path) {
+        return CLDRFile.getCode(path);
+    }
+
+    public static NameType getNameType(String xpath) {
+        int cldrInt = CLDRFile.getNameType(xpath);
+        return fromCldrInt(cldrInt);
+    }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
@@ -122,8 +122,12 @@ public enum NameType {
         return CLDRFile.getCode(path);
     }
 
-    public static NameType getNameType(String xpath) {
-        int cldrInt = CLDRFile.getNameType(xpath);
+    /**
+     * @param typeString a string such as "language", "script", "territory", "region", ...
+     * @return the corresponding NameType
+     */
+    public static NameType typeNameToCode(String typeString) {
+        int cldrInt = CLDRFile.typeNameToCode(typeString);
         return fromCldrInt(cldrInt);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NameType.java
@@ -21,7 +21,8 @@ public enum NameType {
     KEY_TYPE,
     SUBDIVISION;
 
-    // Caution: the presence of "key|type" presents difficulties for refactoring.
+    // The order of rows must correspond to INDEX_LANGUAGE, INDEX_SCRIPT, etc.
+    // Caution: the presence of "key|type" presents complications for refactoring.
     // The row with "key|type" has four strings, while the others have three.
     private static final String[][] NameTable = {
         {"//ldml/localeDisplayNames/languages/language[@type=\"", "\"]", "language"},
@@ -42,91 +43,120 @@ public enum NameType {
         {"//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"", "\"]", "subdivision"},
     };
 
-    public static NameType fromPath(String xpath) {
-        int cldrInt = getNameTypeFromTable(xpath);
-        return fromCldrInt(cldrInt);
-    }
+    /**
+     * The numeric values of these constants must correspond to the order of rows in NameTable. For
+     * example, the first row is for "language", which must match INDEX_LANGUAGE = 0. The second row
+     * is for "script", which must match INDEX_SCRIPT = 1. As a special case, the row for "key|type"
+     * must match INDEX_KEY_TYPE.
+     */
+    private static final int INDEX_NONE = -1,
+            INDEX_LANGUAGE = 0,
+            INDEX_SCRIPT = 1,
+            INDEX_TERRITORY = 2,
+            INDEX_VARIANT = 3,
+            INDEX_CURRENCY = 4,
+            INDEX_CURRENCY_SYMBOL = 5,
+            INDEX_TZ_EXEMPLAR = 6,
+            INDEX_TZ_GENERIC_LONG = 7,
+            INDEX_TZ_GENERIC_SHORT = 8,
+            INDEX_TZ_STANDARD_LONG = 9,
+            INDEX_TZ_STANDARD_SHORT = 10,
+            INDEX_TZ_DAYLIGHT_LONG = 11,
+            INDEX_TZ_DAYLIGHT_SHORT = 12,
+            INDEX_KEY = 13,
+            INDEX_KEY_TYPE = 14,
+            INDEX_SUBDIVISION = 15,
+            INDEX_MAX = 15;
 
-    @Deprecated
-    private int toCldrInt() {
+    private int nameTableIndex() {
         switch (this) {
             case NONE:
-                return CLDRFile.NO_NAME;
+                return INDEX_NONE;
             case LANGUAGE:
-                return CLDRFile.LANGUAGE_NAME;
+                return INDEX_LANGUAGE;
             case SCRIPT:
-                return CLDRFile.SCRIPT_NAME;
+                return INDEX_SCRIPT;
             case TERRITORY:
-                return CLDRFile.TERRITORY_NAME;
+                return INDEX_TERRITORY;
             case VARIANT:
-                return CLDRFile.VARIANT_NAME;
+                return INDEX_VARIANT;
             case CURRENCY:
-                return CLDRFile.CURRENCY_NAME;
+                return INDEX_CURRENCY;
             case CURRENCY_SYMBOL:
-                return CLDRFile.CURRENCY_SYMBOL;
+                return INDEX_CURRENCY_SYMBOL;
             case TZ_EXEMPLAR:
-                return CLDRFile.TZ_EXEMPLAR;
+                return INDEX_TZ_EXEMPLAR;
             case TZ_GENERIC_LONG:
-                return CLDRFile.TZ_GENERIC_LONG;
+                return INDEX_TZ_GENERIC_LONG;
             case TZ_GENERIC_SHORT:
-                return CLDRFile.TZ_GENERIC_SHORT;
+                return INDEX_TZ_GENERIC_SHORT;
             case TZ_STANDARD_LONG:
-                return CLDRFile.TZ_STANDARD_LONG;
+                return INDEX_TZ_STANDARD_LONG;
             case TZ_STANDARD_SHORT:
-                return CLDRFile.TZ_STANDARD_SHORT;
+                return INDEX_TZ_STANDARD_SHORT;
             case TZ_DAYLIGHT_LONG:
-                return CLDRFile.TZ_DAYLIGHT_LONG;
+                return INDEX_TZ_DAYLIGHT_LONG;
             case TZ_DAYLIGHT_SHORT:
-                return CLDRFile.TZ_DAYLIGHT_SHORT;
+                return INDEX_TZ_DAYLIGHT_SHORT;
             case KEY:
-                return CLDRFile.KEY_NAME;
+                return INDEX_KEY;
             case KEY_TYPE:
-                return CLDRFile.KEY_TYPE_NAME;
+                return INDEX_KEY_TYPE;
             case SUBDIVISION:
-                return CLDRFile.SUBDIVISION_NAME;
+                return INDEX_SUBDIVISION;
         }
-        throw new RuntimeException("Unrecognized NameType in toCldrInt: " + this);
+        throw new RuntimeException("Unrecognized NameType in nameTableIndex: " + this);
     }
 
-    @Deprecated
-    public static NameType fromCldrInt(int typeNum) {
-        switch (typeNum) {
-            case CLDRFile.NO_NAME:
+    private static NameType fromNameTableIndex(int index) {
+        switch (index) {
+            case INDEX_NONE:
                 return NONE;
-            case CLDRFile.LANGUAGE_NAME:
+            case INDEX_LANGUAGE:
                 return LANGUAGE;
-            case CLDRFile.SCRIPT_NAME:
+            case INDEX_SCRIPT:
                 return SCRIPT;
-            case CLDRFile.TERRITORY_NAME:
+            case INDEX_TERRITORY:
                 return TERRITORY;
-            case CLDRFile.VARIANT_NAME:
+            case INDEX_VARIANT:
                 return VARIANT;
-            case CLDRFile.CURRENCY_NAME:
+            case INDEX_CURRENCY:
                 return CURRENCY;
-            case CLDRFile.CURRENCY_SYMBOL:
+            case INDEX_CURRENCY_SYMBOL:
                 return CURRENCY_SYMBOL;
-            case CLDRFile.TZ_EXEMPLAR:
+            case INDEX_TZ_EXEMPLAR:
                 return TZ_EXEMPLAR;
-            case CLDRFile.TZ_GENERIC_LONG:
+            case INDEX_TZ_GENERIC_LONG:
                 return TZ_GENERIC_LONG;
-            case CLDRFile.TZ_GENERIC_SHORT:
+            case INDEX_TZ_GENERIC_SHORT:
                 return TZ_GENERIC_SHORT;
-            case CLDRFile.TZ_STANDARD_LONG:
+            case INDEX_TZ_STANDARD_LONG:
                 return TZ_STANDARD_LONG;
-            case CLDRFile.TZ_STANDARD_SHORT:
+            case INDEX_TZ_STANDARD_SHORT:
                 return TZ_STANDARD_SHORT;
-            case CLDRFile.TZ_DAYLIGHT_LONG:
+            case INDEX_TZ_DAYLIGHT_LONG:
                 return TZ_DAYLIGHT_LONG;
-            case CLDRFile.TZ_DAYLIGHT_SHORT:
+            case INDEX_TZ_DAYLIGHT_SHORT:
                 return TZ_DAYLIGHT_SHORT;
-            case CLDRFile.KEY_NAME:
+            case INDEX_KEY:
                 return KEY;
-            case CLDRFile.KEY_TYPE_NAME:
+            case INDEX_KEY_TYPE:
                 return KEY_TYPE;
-            case CLDRFile.SUBDIVISION_NAME:
+            case INDEX_SUBDIVISION:
                 return SUBDIVISION;
         }
-        throw new RuntimeException("Unrecognized typeNum in fromCldrInt: " + typeNum);
+        throw new RuntimeException("Unrecognized index in fromNameTableIndex: " + index);
+    }
+
+    /**
+     * Get the NameType corresponding to the given path.
+     *
+     * @param xpath the given path, such as "//ldml/localeDisplayNames/scripts/script[@type=\""
+     * @return the NameType, such as SCRIPT
+     */
+    public static NameType fromPath(String xpath) {
+        int index = getIndexFromTable(xpath);
+        return fromNameTableIndex(index);
     }
 
     /**
@@ -150,8 +180,9 @@ public enum NameType {
                 code = CLDRFile.getLongTzid(code);
                 break;
         }
-        String[] nameTableRow = NameTable[this.toCldrInt()];
+        String[] nameTableRow = NameTable[this.nameTableIndex()];
         if (code.contains("|")) {
+            // Special handling for "key|type" for KEY_TYPE
             String[] codes = code.split("\\|");
             return nameTableRow[0]
                     + CLDRFile.fixKeyName(codes[0])
@@ -164,14 +195,14 @@ public enum NameType {
     }
 
     public String getNameName() {
-        int index = this.toCldrInt();
+        int index = this.nameTableIndex();
         String[] nameTableRow = NameTable[index];
         return nameTableRow[nameTableRow.length - 1];
     }
 
     /** Gets the display name for a type */
     public String getNameTypeName() {
-        int index = this.toCldrInt();
+        int index = this.nameTableIndex();
         try {
             String[] nameTableRow = NameTable[index];
             return nameTableRow[nameTableRow.length - 1];
@@ -189,11 +220,11 @@ public enum NameType {
      * @return the code, or null if not found
      */
     public static String getCode(String path) {
-        int type = getNameTypeFromTable(path);
-        if (type == CLDRFile.NO_NAME) {
+        int index = getIndexFromTable(path);
+        if (index == INDEX_NONE) {
             throw new IllegalArgumentException("Illegal type in path: " + path);
         }
-        String[] nameTableRow = NameTable[type];
+        String[] nameTableRow = NameTable[index];
         int start = nameTableRow[0].length();
         int end = path.indexOf(nameTableRow[1], start);
         return path.substring(start, end);
@@ -207,19 +238,19 @@ public enum NameType {
         if (typeString.equalsIgnoreCase("region")) {
             typeString = "territory";
         }
-        int cldrInt = -1;
-        for (int i = 0; i <= CLDRFile.LIMIT_TYPES; ++i) {
+        int index = INDEX_NONE;
+        for (int i = 0; i <= INDEX_MAX; ++i) {
             String[] nameTableRow = NameTable[i];
             String s = nameTableRow[nameTableRow.length - 1];
             if (typeString.equalsIgnoreCase(s)) {
-                cldrInt = i;
+                index = i;
                 break;
             }
         }
-        if (cldrInt == -1) {
+        if (index == INDEX_NONE) {
             return NONE;
         }
-        return fromCldrInt(cldrInt);
+        return fromNameTableIndex(index);
     }
 
     /**
@@ -230,15 +261,15 @@ public enum NameType {
      * @return the string
      */
     public String getPathStart() {
-        int index = this.toCldrInt();
+        int index = this.nameTableIndex();
         return NameTable[index][0];
     }
 
-    private static int getNameTypeFromTable(String xpath) {
+    private static int getIndexFromTable(String xpath) {
         for (int i = 0; i < NameTable.length; ++i) {
             if (!xpath.startsWith(NameTable[i][0])) continue;
             if (xpath.indexOf(NameTable[i][1], NameTable[i][0].length()) >= 0) return i;
         }
-        return CLDRFile.NO_NAME;
+        return INDEX_NONE;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -996,7 +996,7 @@ public class PathDescription {
                 } else if (country != null) {
                     String countryName =
                             english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, country);
                     if (countryName != null) {
                         if (!codeName.equals(countryName)) {
                             code = "the city “" + codeName + "” (in " + countryName + ")";
@@ -1015,8 +1015,7 @@ public class PathDescription {
         } else if (path.contains("exemplarCity")) {
             String regionCode = ZONE2COUNTRY.get(attributes.get(0));
             String englishRegionName =
-                    english.nameGetter()
-                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, regionCode);
+                    english.nameGetter().getNameFromTypeEnumCode(NameType.TERRITORY, regionCode);
             description =
                     MessageFormat.format(
                             MessageFormat.autoQuoteApostrophe(description), englishRegionName);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -860,7 +860,7 @@ public class PathDescription {
 
     private static final StandardCodes STANDARD_CODES = StandardCodes.make();
     private static final Map<String, String> ZONE2COUNTRY =
-            STANDARD_CODES.zoneParser.getZoneToCounty();
+            STANDARD_CODES.zoneParser.getZoneToCountry();
 
     static RegexLookup<String> parseLookupString() {
         return new RegexLookup<String>().loadFromString(pathDescriptionString);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -2200,8 +2200,7 @@ public class PathHeader implements Comparable<PathHeader> {
                 languageOnlyPart = s;
             }
             final String name =
-                    englishNameGetter.getNameFromTypenumCode(
-                            CLDRFile.LANGUAGE_NAME, languageOnlyPart);
+                    englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, languageOnlyPart);
             return name == null ? "?" : name.substring(0, 1).toUpperCase();
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -1418,8 +1418,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                 languageOnlyPart = source0;
                             }
 
-                            return englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.LANGUAGE_NAME, languageOnlyPart)
+                            return englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.LANGUAGE, languageOnlyPart)
                                     + " \u25BA "
                                     + source0;
                         }
@@ -1435,8 +1435,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                 script = likelySubtags.getLikelyScript(language);
                             }
                             String scriptName =
-                                    englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.SCRIPT_NAME, script);
+                                    englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.SCRIPT, script);
                             return "Languages in "
                                     + (script.equals("Hans") || script.equals("Hant")
                                             ? "Han Script"
@@ -1454,8 +1454,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                     String territory = getSubdivisionsTerritory(source, null);
                                     String container = Containment.getContainer(territory);
                                     order = Containment.getOrder(territory);
-                                    return englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, container);
+                                    return englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, container);
                                 }
                             });
             functionMap.put(
@@ -1489,16 +1489,16 @@ public class PathHeader implements Comparable<PathHeader> {
                                                     : "003"; // was Integer.valueOf(subcontinent) ==
                                     // 5
                                     return "Territories ("
-                                            + englishNameGetter.getNameFromTypenumCode(
-                                                    CLDRFile.TERRITORY_NAME, theSubContinent)
+                                            + englishNameGetter.getNameFromTypeEnumCode(
+                                                    NameType.TERRITORY, theSubContinent)
                                             + ")";
                                 case "001":
                                 case "ZZ":
                                     return "Geographic Regions"; // not in containment
                                 default:
                                     return "Territories ("
-                                            + englishNameGetter.getNameFromTypenumCode(
-                                                    CLDRFile.TERRITORY_NAME, theContinent)
+                                            + englishNameGetter.getNameFromTypeEnumCode(
+                                                    NameType.TERRITORY, theContinent)
                                             + ")";
                             }
                         }
@@ -1539,8 +1539,8 @@ public class PathHeader implements Comparable<PathHeader> {
                                 }
                             }
                             if (singlePageTerritories.contains(theTerritory)) {
-                                return englishNameGetter.getNameFromTypenumCode(
-                                        CLDRFile.TERRITORY_NAME, theTerritory);
+                                return englishNameGetter.getNameFromTypeEnumCode(
+                                        NameType.TERRITORY, theTerritory);
                             }
                             String theContinent = Containment.getContinent(theTerritory);
                             final String subcontinent = Containment.getSubcontinent(theTerritory);
@@ -1556,20 +1556,20 @@ public class PathHeader implements Comparable<PathHeader> {
                                     } catch (NumberFormatException ex) {
                                         theSubContinent = "009";
                                     }
-                                    return englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, theSubContinent);
+                                    return englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, theSubContinent);
                                 case 19: // Americas - For the timeZonePage, we just group North
                                     // America & South America
                                     theSubContinent =
                                             Integer.parseInt(subcontinent) == 5 ? "005" : "003";
-                                    return englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, theSubContinent);
+                                    return englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, theSubContinent);
                                 case 142: // Asia
-                                    return englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, subcontinent);
+                                    return englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, subcontinent);
                                 default:
-                                    return englishNameGetter.getNameFromTypenumCode(
-                                            CLDRFile.TERRITORY_NAME, theContinent);
+                                    return englishNameGetter.getNameFromTypeEnumCode(
+                                            NameType.TERRITORY, theContinent);
                             }
                         }
                     });
@@ -1667,8 +1667,8 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (PathHeader.UNIFORM_CONTINENTS) {
                                 String container = getMetazonePageTerritory(source);
                                 order = Containment.getOrder(container);
-                                return englishNameGetter.getNameFromTypenumCode(
-                                        CLDRFile.TERRITORY_NAME, container);
+                                return englishNameGetter.getNameFromTypeEnumCode(
+                                        NameType.TERRITORY, container);
                             } else {
                                 String continent = metazoneToContinent.get(source);
                                 if (continent == null) {
@@ -1778,15 +1778,15 @@ public class PathHeader implements Comparable<PathHeader> {
 
                             if (territory.equals("ZZ")) {
                                 order = 999;
-                                return englishNameGetter.getNameFromTypenumCode(
-                                                CLDRFile.TERRITORY_NAME, territory)
+                                return englishNameGetter.getNameFromTypeEnumCode(
+                                                NameType.TERRITORY, territory)
                                         + ": "
                                         + source0;
                             } else {
                                 return catFromTerritory.transform(territory)
                                         + ": "
-                                        + englishNameGetter.getNameFromTypenumCode(
-                                                CLDRFile.TERRITORY_NAME, territory)
+                                        + englishNameGetter.getNameFromTypeEnumCode(
+                                                NameType.TERRITORY, territory)
                                         + tenderOrNot;
                             }
                         }
@@ -1808,8 +1808,8 @@ public class PathHeader implements Comparable<PathHeader> {
                             if (territory.equals("ZZ")) {
                                 order = 999;
                                 subContinent =
-                                        englishNameGetter.getNameFromTypenumCode(
-                                                CLDRFile.TERRITORY_NAME, territory);
+                                        englishNameGetter.getNameFromTypeEnumCode(
+                                                NameType.TERRITORY, territory);
                             } else {
                                 subContinent = catFromTerritory.transform(territory);
                             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSnapshot.java
@@ -334,7 +334,7 @@ public class PluralSnapshot implements Comparable<PluralSnapshot> {
                     // }
                     Map<String, String> fullLocales = new TreeMap<>();
                     for (String localeId : locales) {
-                        String name = english.nameGetter().getNameFromBCP47(localeId);
+                        String name = english.nameGetter().getNameFromIdentifier(localeId);
                         fullLocales.put(name, localeId);
                     }
                     out.print(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -1452,8 +1452,8 @@ public class StandardCodes {
      * @deprecated
      */
     @Deprecated
-    public Map<String, String> getZoneToCounty() {
-        return zoneParser.getZoneToCounty();
+    public Map<String, String> getZoneToCountry() {
+        return zoneParser.getZoneToCountry();
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -68,20 +68,20 @@ public class StandardCodes {
             return CodeType.valueOf(name);
         }
 
-        public int toCldrTypeNum() {
+        public NameType toNameType() {
             switch (this) {
                 case language:
-                    return CLDRFile.LANGUAGE_NAME;
+                    return NameType.LANGUAGE;
                 case script:
-                    return CLDRFile.SCRIPT_NAME;
+                    return NameType.SCRIPT;
                 case territory:
-                    return CLDRFile.TERRITORY_NAME;
+                    return NameType.TERRITORY;
                 case variant:
-                    return CLDRFile.VARIANT_NAME;
+                    return NameType.VARIANT;
                 case currency:
-                    return CLDRFile.CURRENCY_NAME;
+                    return NameType.CURRENCY;
                 default:
-                    return CLDRFile.NO_NAME;
+                    return NameType.NONE;
             }
         }
     }
@@ -1042,24 +1042,24 @@ public class StandardCodes {
             }
         }
 
-        public int toCldrTypeNum() {
+        public NameType toNameType() {
             switch (this) {
                 case region:
-                    return CLDRFile.TERRITORY_NAME;
+                    return NameType.TERRITORY;
                 case language:
                 case legacy:
                 case redundant:
-                    return CLDRFile.LANGUAGE_NAME;
+                    return NameType.LANGUAGE;
                 case script:
-                    return CLDRFile.SCRIPT_NAME;
+                    return NameType.SCRIPT;
                 case variant:
-                    return CLDRFile.VARIANT_NAME;
+                    return NameType.VARIANT;
                 case currency:
-                    return CLDRFile.CURRENCY_NAME;
+                    return NameType.CURRENCY;
                 case subdivision:
-                    return CLDRFile.SUBDIVISION_NAME;
+                    return NameType.SUBDIVISION;
                 default:
-                    return CLDRFile.NO_NAME;
+                    return NameType.NONE;
             }
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -67,6 +67,23 @@ public class StandardCodes {
             }
             return CodeType.valueOf(name);
         }
+
+        public int toCldrTypeNum() {
+            switch (this) {
+                case language:
+                    return CLDRFile.LANGUAGE_NAME;
+                case script:
+                    return CLDRFile.SCRIPT_NAME;
+                case territory:
+                    return CLDRFile.TERRITORY_NAME;
+                case variant:
+                    return CLDRFile.VARIANT_NAME;
+                case currency:
+                    return CLDRFile.CURRENCY_NAME;
+                default:
+                    return CLDRFile.NO_NAME;
+            }
+        }
     }
 
     private static final Set<CodeType> TypeSet =
@@ -1022,6 +1039,27 @@ public class StandardCodes {
                     return "language";
                 default:
                     return toString();
+            }
+        }
+
+        public int toCldrTypeNum() {
+            switch (this) {
+                case region:
+                    return CLDRFile.TERRITORY_NAME;
+                case language:
+                case legacy:
+                case redundant:
+                    return CLDRFile.LANGUAGE_NAME;
+                case script:
+                    return CLDRFile.SCRIPT_NAME;
+                case variant:
+                    return CLDRFile.VARIANT_NAME;
+                case currency:
+                    return CLDRFile.CURRENCY_NAME;
+                case subdivision:
+                    return CLDRFile.SUBDIVISION_NAME;
+                default:
+                    return CLDRFile.NO_NAME;
             }
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -131,9 +131,9 @@ public class TestUtilities {
             System.out.println(
                     test
                             + "\t"
-                            + english.nameGetter().getNameFromBCP47(test)
+                            + english.nameGetter().getNameFromIdentifier(test)
                             + "\t"
-                            + french.nameGetter().getNameFromBCP47(test));
+                            + french.nameGetter().getNameFromIdentifier(test));
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -1025,8 +1025,7 @@ public class TestUtilities {
             out.println(
                     code
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.LANGUAGE_NAME, code));
+                            + englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("territory").iterator();
@@ -1035,16 +1034,13 @@ public class TestUtilities {
             out.println(
                     code
                             + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(
-                                    CLDRFile.TERRITORY_NAME, code));
+                            + englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, code));
         }
         out.println("****");
         for (Iterator<String> it = sc.getGoodAvailableCodes("script").iterator(); it.hasNext(); ) {
             String code = it.next();
             out.println(
-                    code
-                            + "\t"
-                            + englishNameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, code));
+                    code + "\t" + englishNameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, code));
         }
         out.close();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -616,7 +616,7 @@ public class TimezoneFormatter extends UFormat {
         String countryName =
                 desiredLocaleFile
                         .nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, zoneIdsCountry);
+                        .getNameFromTypeEnumCode(NameType.TERRITORY, zoneIdsCountry);
         if (countryName == null) {
             countryName = zoneIdsCountry;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -212,11 +212,6 @@ public class TimezoneFormatter extends UFormat {
         return desiredLocaleFile.getWinningValue(cleanPath);
     }
 
-    private String getName(int territory_name, String country, boolean skipDraft2) {
-        checkForDraft(CLDRFile.getKey(territory_name, country));
-        return desiredLocaleFile.nameGetter().getNameFromTypenumCode(territory_name, country);
-    }
-
     private void checkForDraft(String cleanPath) {
         String xpath = desiredLocaleFile.getFullXPath(cleanPath);
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyCompactNumbers.java
@@ -118,7 +118,7 @@ public class VerifyCompactNumbers {
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, locale + ".html");
             String title =
                     "Verify Number Formats: "
-                            + englishCldrFile.nameGetter().getNameFromBCP47(locale);
+                            + englishCldrFile.nameGetter().getNameFromIdentifier(locale);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -137,7 +137,7 @@ public class VerifyCompactNumbers {
 
             out.println("</body></html>");
             out.close();
-            indexMap.put(english.nameGetter().getNameFromBCP47(locale), locale + ".html");
+            indexMap.put(english.nameGetter().getNameFromIdentifier(locale), locale + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Numbers")) {
             DateTimeFormats.writeIndexMap(indexMap, index);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -456,7 +456,7 @@ public class VerifyZones {
             String englishGrouping =
                     englishCldrFile
                             .nameGetter()
-                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, grouping);
+                            .getNameFromTypeEnumCode(NameType.TERRITORY, grouping);
 
             String metazoneInfo =
                     englishGrouping
@@ -474,7 +474,7 @@ public class VerifyZones {
             String englishTerritory =
                     englishCldrFile
                             .nameGetter()
-                            .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, countryCode2);
+                            .getNameFromTypeEnumCode(NameType.TERRITORY, countryCode2);
             output.addRow()
                     .addCell(metazoneInfo)
                     .addCell(englishTerritory + ": " + tzid.replace("/", "/\u200B"));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VerifyZones.java
@@ -273,7 +273,8 @@ public class VerifyZones {
             CLDRFile cldrFile = factory2.make(localeID, true);
             PrintWriter out = FileUtilities.openUTF8Writer(DIR, localeID + ".html");
             String title =
-                    "Verify Time Zones: " + englishCldrFile.nameGetter().getNameFromBCP47(localeID);
+                    "Verify Time Zones: "
+                            + englishCldrFile.nameGetter().getNameFromIdentifier(localeID);
             out.println(
                     "<!doctype HTML PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN'><html><head>\n"
                             + "<meta http-equiv='Content-Type' content='text/html; charset=utf-8'>\n"
@@ -291,7 +292,7 @@ public class VerifyZones {
             out.println("</body></html>");
             out.close();
 
-            indexMap.put(english.nameGetter().getNameFromBCP47(localeID), localeID + ".html");
+            indexMap.put(english.nameGetter().getNameFromIdentifier(localeID), localeID + ".html");
         }
         try (PrintWriter index = DateTimeFormats.openIndex(DIR, "Time Zones")) {
             DateTimeFormats.writeIndexMap(indexMap, index);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1335,7 +1335,10 @@ public class VettingViewer<T> {
     private String getName(String localeID) {
         Set<String> contents = supplementalDataInfo.getEquivalentsForLocale(localeID);
         // put in special character that can be split on later
-        return englishFile.nameGetter().getNameFromBCP47BoolAlt(localeID, true, CLDRFile.SHORT_ALTS)
+        return englishFile
+                        .nameGetter()
+                        .getNameFromIdentifierOptAlt(
+                                localeID, NameGetter.NameOpt.COMPOUND_ONLY, CLDRFile.SHORT_ALTS)
                 + SPLIT_CHAR
                 + gatherCodes(contents);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -302,8 +302,7 @@ public class WikipediaOfficialLanguages {
                             region
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(
-                                                    CLDRFile.TERRITORY_NAME, region));
+                                            .getNameFromTypeEnumCode(NameType.TERRITORY, region));
 
                     System.out.println(
                             "\t"
@@ -329,8 +328,8 @@ public class WikipediaOfficialLanguages {
                                 region
                                         + "\t"
                                         + english.nameGetter()
-                                                .getNameFromTypenumCode(
-                                                        CLDRFile.TERRITORY_NAME, region));
+                                                .getNameFromTypeEnumCode(
+                                                        NameType.TERRITORY, region));
 
                         System.out.println(
                                 "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/WikipediaOfficialLanguages.java
@@ -308,7 +308,7 @@ public class WikipediaOfficialLanguages {
                             "\t"
                                     + info.language
                                     + "\t"
-                                    + english.nameGetter().getNameFromBCP47(info.language)
+                                    + english.nameGetter().getNameFromIdentifier(info.language)
                                     + "\t"
                                     + info.status
                                     + "\t"
@@ -335,7 +335,7 @@ public class WikipediaOfficialLanguages {
                                 "\t"
                                         + r2
                                         + "\t"
-                                        + english.nameGetter().getNameFromBCP47(r2)
+                                        + english.nameGetter().getNameFromIdentifier(r2)
                                         + "\t"
                                         + "CLDR-ONLY"
                                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -1601,7 +1601,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
         static {
             StandardCodes sc = StandardCodes.make();
             Map<String, Set<String>> countries_zoneSet = sc.getCountryToZoneSet();
-            Map<String, String> zone_countries = sc.getZoneToCounty();
+            Map<String, String> zone_countries = sc.getZoneToCountry();
             List<NameType> nameTypeList =
                     List.of(
                             NameType.LANGUAGE,

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -1602,30 +1602,38 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             StandardCodes sc = StandardCodes.make();
             Map<String, Set<String>> countries_zoneSet = sc.getCountryToZoneSet();
             Map<String, String> zone_countries = sc.getZoneToCounty();
-
-            for (int typeNo = 0; typeNo <= CLDRFile.TZ_START; ++typeNo) {
-                String type = CLDRFile.getNameName(typeNo);
+            List<NameType> nameTypeList =
+                    List.of(
+                            NameType.LANGUAGE,
+                            NameType.SCRIPT,
+                            NameType.TERRITORY,
+                            NameType.VARIANT,
+                            NameType.CURRENCY,
+                            NameType.CURRENCY_SYMBOL,
+                            NameType.TZ_EXEMPLAR);
+            for (NameType nameType : nameTypeList) {
+                String type = nameType.getNameName();
                 String type2 =
-                        (typeNo == CLDRFile.CURRENCY_SYMBOL)
-                                ? CLDRFile.getNameName(CLDRFile.CURRENCY_NAME)
-                                : (typeNo >= CLDRFile.TZ_START) ? "tzid" : type;
+                        (nameType == NameType.CURRENCY_SYMBOL)
+                                ? NameType.CURRENCY.getNameName()
+                                : (nameType == NameType.TZ_EXEMPLAR) ? "tzid" : type;
                 Set<String> codes = sc.getSurveyToolDisplayCodes(type2);
                 for (Iterator<String> codeIt = codes.iterator(); codeIt.hasNext(); ) {
                     String code = codeIt.next();
                     String value = code;
-                    if (typeNo == CLDRFile.TZ_EXEMPLAR) { // skip single-zone countries
+                    if (nameType == NameType.TZ_EXEMPLAR) { // skip single-zone countries
                         if (SKIP_SINGLEZONES) {
                             String country = zone_countries.get(code);
                             Set<String> s = countries_zoneSet.get(country);
                             if (s != null && s.size() == 1) continue;
                         }
                         value = TimezoneFormatter.getFallbackName(value);
-                    } else if (typeNo == CLDRFile.LANGUAGE_NAME) {
+                    } else if (nameType == NameType.LANGUAGE) {
                         if (ROOT_ID.equals(value)) {
                             continue;
                         }
                     }
-                    addFallbackCode(typeNo, code, value);
+                    addFallbackCode(nameType, code, value);
                 }
             }
 
@@ -1635,48 +1643,48 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 "pt_BR", "pt_PT", "ro_MD", "sw_CD", "zh_Hans", "zh_Hant"
             };
             for (String extraCode : extraCodes) {
-                addFallbackCode(CLDRFile.LANGUAGE_NAME, extraCode, extraCode);
+                addFallbackCode(NameType.LANGUAGE, extraCode, extraCode);
             }
 
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "en_GB", "en_GB", "short");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "en_US", "en_US", "short");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "az", "az", "short");
+            addFallbackCode(NameType.LANGUAGE, "en_GB", "en_GB", "short");
+            addFallbackCode(NameType.LANGUAGE, "en_US", "en_US", "short");
+            addFallbackCode(NameType.LANGUAGE, "az", "az", "short");
 
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "ckb", "ckb", "menu");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "ckb", "ckb", "variant");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "hi_Latn", "hi_Latn", "variant");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "yue", "yue", "menu");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "zh", "zh", "menu");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "zh_Hans", "zh", "long");
-            addFallbackCode(CLDRFile.LANGUAGE_NAME, "zh_Hant", "zh", "long");
+            addFallbackCode(NameType.LANGUAGE, "ckb", "ckb", "menu");
+            addFallbackCode(NameType.LANGUAGE, "ckb", "ckb", "variant");
+            addFallbackCode(NameType.LANGUAGE, "hi_Latn", "hi_Latn", "variant");
+            addFallbackCode(NameType.LANGUAGE, "yue", "yue", "menu");
+            addFallbackCode(NameType.LANGUAGE, "zh", "zh", "menu");
+            addFallbackCode(NameType.LANGUAGE, "zh_Hans", "zh", "long");
+            addFallbackCode(NameType.LANGUAGE, "zh_Hant", "zh", "long");
 
-            addFallbackCode(CLDRFile.SCRIPT_NAME, "Hans", "Hans", "stand-alone");
-            addFallbackCode(CLDRFile.SCRIPT_NAME, "Hant", "Hant", "stand-alone");
+            addFallbackCode(NameType.SCRIPT, "Hans", "Hans", "stand-alone");
+            addFallbackCode(NameType.SCRIPT, "Hant", "Hant", "stand-alone");
 
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "GB", "GB", "short");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "HK", "HK", "short");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "MO", "MO", "short");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "PS", "PS", "short");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "US", "US", "short");
+            addFallbackCode(NameType.TERRITORY, "GB", "GB", "short");
+            addFallbackCode(NameType.TERRITORY, "HK", "HK", "short");
+            addFallbackCode(NameType.TERRITORY, "MO", "MO", "short");
+            addFallbackCode(NameType.TERRITORY, "PS", "PS", "short");
+            addFallbackCode(NameType.TERRITORY, "US", "US", "short");
 
             addFallbackCode(
-                    CLDRFile.TERRITORY_NAME, "CD", "CD", "variant"); // add other geopolitical items
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "CG", "CG", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "CI", "CI", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "CZ", "CZ", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "FK", "FK", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "TL", "TL", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "SZ", "SZ", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "IO", "IO", "biot");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "IO", "IO", "chagos");
+                    NameType.TERRITORY, "CD", "CD", "variant"); // add other geopolitical items
+            addFallbackCode(NameType.TERRITORY, "CG", "CG", "variant");
+            addFallbackCode(NameType.TERRITORY, "CI", "CI", "variant");
+            addFallbackCode(NameType.TERRITORY, "CZ", "CZ", "variant");
+            addFallbackCode(NameType.TERRITORY, "FK", "FK", "variant");
+            addFallbackCode(NameType.TERRITORY, "TL", "TL", "variant");
+            addFallbackCode(NameType.TERRITORY, "SZ", "SZ", "variant");
+            addFallbackCode(NameType.TERRITORY, "IO", "IO", "biot");
+            addFallbackCode(NameType.TERRITORY, "IO", "IO", "chagos");
 
             // new alternate name
 
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "NZ", "NZ", "variant");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "TR", "TR", "variant");
+            addFallbackCode(NameType.TERRITORY, "NZ", "NZ", "variant");
+            addFallbackCode(NameType.TERRITORY, "TR", "TR", "variant");
 
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "XA", "XA");
-            addFallbackCode(CLDRFile.TERRITORY_NAME, "XB", "XB");
+            addFallbackCode(NameType.TERRITORY, "XA", "XA");
+            addFallbackCode(NameType.TERRITORY, "XB", "XB");
 
             addFallbackCode(
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/eras/eraAbbr/era[@type=\"0\"]",
@@ -1726,16 +1734,17 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             allowDuplicates = Collections.unmodifiableMap(allowDuplicates);
         }
 
-        private static void addFallbackCode(int typeNo, String code, String value) {
-            addFallbackCode(typeNo, code, value, null);
+        private static void addFallbackCode(NameType nameType, String code, String value) {
+            addFallbackCode(nameType, code, value, null);
         }
 
-        private static void addFallbackCode(int typeNo, String code, String value, String alt) {
-            String fullpath = CLDRFile.getKey(typeNo, code);
+        private static void addFallbackCode(
+                NameType nameType, String code, String value, String alt) {
+            String fullpath = nameType.getKeyPath(code);
             String distinguishingPath = addFallbackCodeToConstructedItems(fullpath, value, alt);
-            if (typeNo == CLDRFile.LANGUAGE_NAME
-                    || typeNo == CLDRFile.SCRIPT_NAME
-                    || typeNo == CLDRFile.TERRITORY_NAME) {
+            if (nameType == NameType.LANGUAGE
+                    || nameType == NameType.SCRIPT
+                    || nameType == NameType.TERRITORY) {
                 allowDuplicates.put(distinguishingPath, code);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ZoneParser.java
@@ -30,7 +30,7 @@ public class ZoneParser {
     /**
      * @return mapping from zone id to country. If a zone has no country, then XX is used.
      */
-    public Map<String, String> getZoneToCounty() {
+    public Map<String, String> getZoneToCountry() {
         if (zone_to_country == null) make_zone_to_country();
         return zone_to_country;
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckLanguageCodeConverter.java
@@ -159,7 +159,7 @@ public class CheckLanguageCodeConverter {
         if (goodCode.startsWith("x_")) {
             return "Private use: " + goodCode.substring(2);
         }
-        return english.nameGetter().getNameFromBCP47(goodCode);
+        return english.nameGetter().getNameFromIdentifier(goodCode);
     }
 
     public static void printLine(LanguageLine entry) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
@@ -292,8 +292,7 @@ public class CheckYear {
                 continue;
             }
             sorted.put(
-                    englishFile.nameGetter().getNameFromIndentifierCompoundOnly(localeID),
-                    localeID);
+                    englishFile.nameGetter().getNameFromIdentifierCompoundOnly(localeID), localeID);
             data.put(localeID, new LocaleInfo());
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
@@ -291,7 +291,9 @@ public class CheckYear {
                 System.out.println("Skipping default content: " + localeID);
                 continue;
             }
-            sorted.put(englishFile.nameGetter().getNameFromBCP47Bool(localeID, true), localeID);
+            sorted.put(
+                    englishFile.nameGetter().getNameFromIndentifierCompoundOnly(localeID),
+                    localeID);
             data.put(localeID, new LocaleInfo());
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageInfoTest.java
@@ -87,7 +87,7 @@ public class LanguageInfoTest extends TestFmwk {
                 ? "n/a"
                 : item.contains("$")
                         ? item
-                        : testInfo.getEnglish().nameGetter().getNameFromBCP47(item);
+                        : testInfo.getEnglish().nameGetter().getNameFromIdentifier(item);
     }
 
     public static void main(String[] args) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -14,10 +14,10 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.Counter2;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.BasicLanguageData;
@@ -236,8 +236,8 @@ public class LanguageTest extends TestFmwk {
                 + "; "
                 + (parser.getRegion().isEmpty()
                         ? "?"
-                        : nameGetter.getNameFromTypenumCode(
-                                CLDRFile.TERRITORY_NAME, parser.getRegion()));
+                        : nameGetter.getNameFromTypeEnumCode(
+                                NameType.TERRITORY, parser.getRegion()));
     }
 
     Set<String> getUnicodeScripts() {
@@ -261,7 +261,7 @@ public class LanguageTest extends TestFmwk {
 
     private String getScriptName(String script) {
         NameGetter nameGetter = testInfo.getEnglish().nameGetter();
-        String name = nameGetter.getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script);
+        String name = nameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, script);
         if (name != null && !name.equals(script)) {
             return name;
         }
@@ -281,7 +281,7 @@ public class LanguageTest extends TestFmwk {
 
     private String getLanguageName(String language) {
         NameGetter nameGetter = testInfo.getEnglish().nameGetter();
-        String name = nameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language);
+        String name = nameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, language);
         if (name != null && !name.equals(language)) {
             return name;
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleValidator;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.ScriptToExemplars;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -344,7 +345,7 @@ public class LikelySubtagsTest extends TestFmwk {
             } else {
                 logln("Likely subtags for " + language + ":\t " + likely);
             }
-            String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, language);
+            String path = NameType.LANGUAGE.getKeyPath(language);
             String englishName = english.getStringValue(path);
             if (englishName == null) {
                 Level covLevel = ccl.getEffectiveCoverageLevel(language);
@@ -376,8 +377,8 @@ public class LikelySubtagsTest extends TestFmwk {
                                         + region
                                         + "\t"
                                         + english.nameGetter()
-                                                .getNameFromTypenumCode(
-                                                        CLDRFile.TERRITORY_NAME, region));
+                                                .getNameFromTypeEnumCode(
+                                                        NameType.TERRITORY, region));
                     }
                 } else { // container
                     logln(
@@ -385,13 +386,12 @@ public class LikelySubtagsTest extends TestFmwk {
                                     + region
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(
-                                                    CLDRFile.TERRITORY_NAME, region));
+                                            .getNameFromTypeEnumCode(NameType.TERRITORY, region));
                 }
             } else {
                 logln("Likely subtags for region: " + region + ":\t " + likely);
             }
-            String path = CLDRFile.getKey(CLDRFile.TERRITORY_NAME, region);
+            String path = NameType.TERRITORY.getKeyPath(region);
             String englishName = english.getStringValue(path);
             if (englishName == null) {
                 errln("Missing English translation for: " + region);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/StandardCodesTest.java
@@ -32,7 +32,7 @@ public class StandardCodesTest extends TestFmwk {
                 String name =
                         locale.equals("*")
                                 ? "ALL"
-                                : testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
+                                : testInfo.getEnglish().nameGetter().getNameFromIdentifier(locale);
                 logln(
                         org
                                 + "\t;\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -39,7 +39,6 @@ import org.unicode.cldr.util.AttributeValueValidity.AttributeValueSpec;
 import org.unicode.cldr.util.AttributeValueValidity.MatcherPattern;
 import org.unicode.cldr.util.AttributeValueValidity.Status;
 import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRPaths;
 import org.unicode.cldr.util.ChainedMap;
 import org.unicode.cldr.util.ChainedMap.M4;
@@ -47,6 +46,7 @@ import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdData.ValueStatus;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.LanguageInfo;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
@@ -432,7 +432,7 @@ public class TestAttributeValues extends TestFmwk {
                         + "\t"
                         + config.getEnglish()
                                 .nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, language)
+                                .getNameFromTypeEnumCode(NameType.LANGUAGE, language)
                         + "\t"
                         + languageInfo);
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -543,7 +543,7 @@ public class TestBasic extends TestFmwkPlus {
         for (String locale : getInclusion() <= 5 ? eightPointLocales : cldrFactory.getAvailable()) {
             CLDRFile file = testInfo.getCLDRFile(locale, resolved);
             if (file.isNonInheriting()) continue;
-            logln(locale + "\t-\t" + english.nameGetter().getNameFromBCP47(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getNameFromIdentifier(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -619,7 +619,7 @@ public class TestBasic extends TestFmwkPlus {
             DisplayAndInputProcessor displayAndInputProcessor =
                     new DisplayAndInputProcessor(file, false);
 
-            logln(locale + "\t-\t" + english.nameGetter().getNameFromBCP47(locale));
+            logln(locale + "\t-\t" + english.nameGetter().getNameFromIdentifier(locale));
 
             for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
                 String path = it.next();
@@ -1124,7 +1124,7 @@ public class TestBasic extends TestFmwkPlus {
                     "Locale:"
                             + localeID
                             + " ("
-                            + testInfo.getEnglish().nameGetter().getNameFromBCP47(localeID)
+                            + testInfo.getEnglish().nameGetter().getNameFromIdentifier(localeID)
                             + ")";
 
             if (!collations.contains(localeID)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -85,7 +85,7 @@ public class TestCLDRFile extends TestFmwk {
         };
         CLDRFile english = testInfo.getEnglish();
         for (String[] test : tests) {
-            assertEquals("", test[1], english.nameGetter().getNameFromBCP47(test[0]));
+            assertEquals("", test[1], english.nameGetter().getNameFromIdentifier(test[0]));
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -163,7 +163,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                     && CLDRLocale.getInstance(locale).getParent().equals(CLDRLocale.ROOT)) {
                 official1MSetNames.put(
                         localeAndSize.getValue(),
-                        "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale));
+                        "\t" + locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale));
             }
         }
         if (!official1MSetNames.isEmpty()) {
@@ -181,7 +181,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         coverageLocales.removeAll(additionsToTranslate);
 
         for (String locale : localesForNames) {
-            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale));
+            logln("\n" + locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale));
         }
 
         logln("\nmainLocales:" + composeList(mainLocales, "\n\t", new StringBuilder()));
@@ -244,7 +244,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             temp.removeAll(set);
             Set<String> temp2 = new TreeSet<>();
             for (String locale : temp) {
-                temp2.add(locale + "\t" + ENGLISH.nameGetter().getNameFromBCP47(locale));
+                temp2.add(locale + "\t" + ENGLISH.nameGetter().getNameFromIdentifier(locale));
             }
             errln(title + ": Missing:\t" + temp.size() + "\n\t" + Joiner.on("\n\t").join(temp2));
         }
@@ -345,7 +345,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                     "cldr level = max for "
                             + locale
                             + " ("
-                            + ENGLISH.nameGetter().getNameFromBCP47(locale)
+                            + ENGLISH.nameGetter().getNameFromIdentifier(locale)
                             + ")",
                     cldrLevel,
                     maxLevel);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -30,6 +30,7 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.LocaleNames;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -95,7 +96,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         CoverageLevel2 coverageLeveler = CoverageLevel2.getInstance(LocaleNames.UND);
         Multimap<Level, String> levelToLanguage = TreeMultimap.create();
         for (String locale : valid) {
-            String path = CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, locale);
+            String path = NameType.LANGUAGE.getKeyPath(locale);
             Level level = coverageLeveler.getLevel(path);
             levelToLanguage.put(level, locale);
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -112,7 +112,7 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting uncombinedLong " + locale,
                 uncombinedLong,
-                frenchNameGetter.getNameFromIndentifierCompoundOnly(locale));
+                frenchNameGetter.getNameFromIdentifierCompoundOnly(locale));
         assertEquals(
                 "Test variant formatting uncombinedShort " + locale,
                 uncombinedShort,

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRUtils.java
@@ -99,7 +99,7 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedLong " + locale,
                 combinedLong,
-                frenchNameGetter.getNameFromBCP47(locale));
+                frenchNameGetter.getNameFromIdentifier(locale));
         String combinedShort = otherNames.length > 0 ? otherNames[0] : combinedLong;
         String uncombinedLong = otherNames.length > 1 ? otherNames[1] : combinedLong;
         String uncombinedShort = otherNames.length > 2 ? otherNames[2] : uncombinedLong;
@@ -107,15 +107,17 @@ public class TestCLDRUtils extends TestFmwk {
         assertEquals(
                 "Test variant formatting combinedShort " + locale,
                 combinedShort,
-                frenchNameGetter.getNameFromBCP47BoolAlt(locale, false, SHORT_ALT_PICKER));
+                frenchNameGetter.getNameFromIdentifierOptAlt(
+                        locale, NameGetter.NameOpt.DEFAULT, SHORT_ALT_PICKER));
         assertEquals(
                 "Test variant formatting uncombinedLong " + locale,
                 uncombinedLong,
-                frenchNameGetter.getNameFromBCP47Bool(locale, true));
+                frenchNameGetter.getNameFromIndentifierCompoundOnly(locale));
         assertEquals(
                 "Test variant formatting uncombinedShort " + locale,
                 uncombinedShort,
-                frenchNameGetter.getNameFromBCP47BoolAlt(locale, true, SHORT_ALT_PICKER));
+                frenchNameGetter.getNameFromIdentifierOptAlt(
+                        locale, NameGetter.NameOpt.COMPOUND_ONLY, SHORT_ALT_PICKER));
     }
 
     public void TestEmptyCLDRFile() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -1387,7 +1387,7 @@ public class TestCheckCLDR extends TestFmwk {
                 System.out.print(
                         locale
                                 + "\t"
-                                + english.nameGetter().getNameFromBCP47(locale)
+                                + english.nameGetter().getNameFromIdentifier(locale)
                                 + "\t"
                                 + cldrLevel);
                 for (LimitedStatus limitedStatus : LimitedStatus.values()) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverage.java
@@ -135,7 +135,7 @@ public class TestCoverage extends TestFmwkPlus {
     }
 
     private String getLocaleAndName(String locale) {
-        return locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
+        return locale + "\t" + testInfo.getEnglish().nameGetter().getNameFromIdentifier(locale);
     }
 
     private String showColumn(Set items) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -52,6 +52,7 @@ import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LogicalGrouping;
 import org.unicode.cldr.util.LogicalGrouping.PathType;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
@@ -1167,27 +1168,25 @@ public class TestCoverageLevel extends TestFmwkPlus {
 
         Map<String, CoverageStatus> data = new TreeMap<>();
 
-        // This is a map from integers (representing language, script or region; should rewrite to
-        // use enums)
-        // to a row of data:
+        // This is a map from NameType to a row of data:
         //      name,
         //      map code => best cldr org level,
         //      codes in root
         //      expected coverage levels levels
         // should change the row of data into a class; would be much easier to understand
 
-        ImmutableMap<Integer, R4<String, Map<String, Level>, Set<String>, Level>> typeToInfo =
+        ImmutableMap<NameType, R4<String, Map<String, Level>, Set<String>, Level>> typeToInfo =
                 ImmutableMap.of(
-                        CLDRFile.LANGUAGE_NAME,
+                        NameType.LANGUAGE,
                         Row.of("language", langs, langsRoot, Level.MODERN),
-                        CLDRFile.SCRIPT_NAME,
+                        NameType.SCRIPT,
                         Row.of("script", scripts, scriptsRoot, Level.MODERATE),
-                        CLDRFile.TERRITORY_NAME,
+                        NameType.TERRITORY,
                         Row.of("region", regions, regionsRoot, Level.MODERATE));
 
-        for (Entry<Integer, R4<String, Map<String, Level>, Set<String>, Level>> typeAndInfo :
+        for (Entry<NameType, R4<String, Map<String, Level>, Set<String>, Level>> typeAndInfo :
                 typeToInfo.entrySet()) {
-            int type = typeAndInfo.getKey();
+            NameType type = typeAndInfo.getKey();
             String name = typeAndInfo.getValue().get0();
             Map<String, Level> idPartMap =
                     typeAndInfo.getValue().get1(); // map from code to best cldr level
@@ -1197,8 +1196,8 @@ public class TestCoverageLevel extends TestFmwkPlus {
 
             for (String code : Sets.union(idPartMap.keySet(), setRoot)) {
                 String displayName =
-                        testInfo.getEnglish().nameGetter().getNameFromTypenumCode(type, code);
-                String path = CLDRFile.getKey(type, code);
+                        testInfo.getEnglish().nameGetter().getNameFromTypeEnumCode(type, code);
+                String path = type.getKeyPath(code);
                 Level level = coverageLevel.getLevel(path);
                 data.put(
                         name + "\t" + code,

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -10,7 +10,6 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
-import com.ibm.icu.impl.Row.R2;
 import com.ibm.icu.impl.Row.R4;
 import com.ibm.icu.text.CompactDecimalFormat;
 import com.ibm.icu.text.CompactDecimalFormat.CompactStyle;
@@ -368,48 +367,6 @@ public class TestCoverageLevel extends TestFmwkPlus {
     static final Date NOW = new Date();
 
     private static final boolean DEBUG = false;
-
-    static class TypeName implements Transform<String, String> {
-        private final int field;
-        private final Map<String, R2<List<String>, String>> dep;
-
-        public TypeName(int field) {
-            this.field = field;
-            switch (field) {
-                case CLDRFile.LANGUAGE_NAME:
-                    dep = SDI.getLocaleAliasInfo().get("language");
-                    break;
-                case CLDRFile.TERRITORY_NAME:
-                    dep = SDI.getLocaleAliasInfo().get("territory");
-                    break;
-                case CLDRFile.SCRIPT_NAME:
-                    dep = SDI.getLocaleAliasInfo().get("script");
-                    break;
-                default:
-                    dep = null;
-                    break;
-            }
-        }
-
-        @Override
-        public String transform(String source) {
-            String result = ENGLISH.nameGetter().getNameFromTypenumCode(field, source);
-            String extra = "";
-            if (field == CLDRFile.LANGUAGE_NAME) {
-                String lang = isBigLanguage(source);
-                extra = lang == null ? "X" : lang;
-            } else if (field == CLDRFile.CURRENCY_NAME) {
-                Date last = currencyToLast.get(source);
-                extra = last == null ? "?" : last.compareTo(NOW) < 0 ? "old" : "";
-            }
-            R2<List<String>, String> depValue = dep == null ? null : dep.get(source);
-            if (depValue != null) {
-                extra += extra.isEmpty() ? "" : "-";
-                extra += depValue.get1();
-            }
-            return result + (extra.isEmpty() ? "" : "\t" + extra);
-        }
-    }
 
     RegexLookup<Level> exceptions =
             RegexLookup.of(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
@@ -48,7 +48,7 @@ public class TestDayPeriods extends TestFmwkPlus {
             logln(
                     locale
                             + "\t"
-                            + CONFIG.getEnglish().nameGetter().getNameFromBCP47(locale)
+                            + CONFIG.getEnglish().nameGetter().getNameFromIdentifier(locale)
                             + "\t"
                             + dayPeriodFormat
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1551,7 +1551,10 @@ public class TestExampleGenerator extends TestFmwk {
                         Pair.of("gender", unitGender));
             }
             String localeName =
-                    CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(locale);
+                    CLDRConfig.getInstance()
+                            .getEnglish()
+                            .nameGetter()
+                            .getNameFromIdentifier(locale);
             boolean pluralOnly = true;
             if (paths.isEmpty()) {
                 pluralSheet.add(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -32,6 +32,7 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Iso3166Data;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleIDParser;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
@@ -200,7 +201,7 @@ public class TestInheritance extends TestFmwk {
                 b.append(
                         testInfo.getEnglish()
                                 .nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.SCRIPT_NAME, script));
+                                .getNameFromTypeEnumCode(NameType.SCRIPT, script));
             }
             String region = ltp.getRegion();
             if (region.length() != 0) {
@@ -210,7 +211,7 @@ public class TestInheritance extends TestFmwk {
                 b.append(
                         testInfo.getEnglish()
                                 .nameGetter()
-                                .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region));
+                                .getNameFromTypeEnumCode(NameType.TERRITORY, region));
             }
             b.append(" [").append(s);
             if (showStatus) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -171,7 +171,9 @@ public class TestInheritance extends TestFmwk {
                 System.out.print(
                         language
                                 + "\t"
-                                + testInfo.getEnglish().nameGetter().getNameFromBCP47(language));
+                                + testInfo.getEnglish()
+                                        .nameGetter()
+                                        .getNameFromIdentifier(language));
 
                 M3<OfficialStatus, String, Boolean> officialChildren =
                         languageToOfficialChildren.get(language);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLanguageGroup.java
@@ -126,7 +126,7 @@ public class TestLanguageGroup extends TestFmwk {
             case "grk":
                 return "Hellenic";
             default:
-                return ENGLISH.nameGetter().getNameFromBCP47(code).replace(" [Other]", "");
+                return ENGLISH.nameGetter().getNameFromIdentifier(code).replace(" [Other]", "");
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -494,31 +494,36 @@ public class TestLocale extends TestFmwkPlus {
                 }
             }
             String displayName =
-                    nameGetter.getNameFromBCP47Etc(
-                            row[3], true, "{0}={1}", "{0} ({1})", "{0}, {1}");
+                    nameGetter.getNameFromIdentifierEtc(
+                            row[3],
+                            NameGetter.NameOpt.COMPOUND_ONLY,
+                            "{0}={1}",
+                            "{0} ({1})",
+                            "{0}, {1}");
             assertEquals("locale " + row[3], row[4], displayName);
         }
     }
 
     public void TestLocaleNamePattern() {
         NameGetter englishNameGetter = testInfo.getEnglish().nameGetter();
-        assertEquals("Locale name", "Chinese", englishNameGetter.getNameFromBCP47("zh"));
+        assertEquals("Locale name", "Chinese", englishNameGetter.getNameFromIdentifier("zh"));
         assertEquals(
                 "Locale name",
                 "Chinese (United States)",
-                englishNameGetter.getNameFromBCP47("zh-US"));
+                englishNameGetter.getNameFromIdentifier("zh-US"));
         assertEquals(
                 "Locale name",
                 "Chinese (Arabic, United States)",
-                englishNameGetter.getNameFromBCP47("zh-Arab-US"));
+                englishNameGetter.getNameFromIdentifier("zh-Arab-US"));
         CLDRFile japanese = testInfo.getCLDRFile("ja", true);
         NameGetter japaneseNameGetter = japanese.nameGetter();
-        assertEquals("Locale name", "中国語", japaneseNameGetter.getNameFromBCP47("zh"));
-        assertEquals("Locale name", "中国語 (アメリカ合衆国)", japaneseNameGetter.getNameFromBCP47("zh-US"));
+        assertEquals("Locale name", "中国語", japaneseNameGetter.getNameFromIdentifier("zh"));
+        assertEquals(
+                "Locale name", "中国語 (アメリカ合衆国)", japaneseNameGetter.getNameFromIdentifier("zh-US"));
         assertEquals(
                 "Locale name",
                 "中国語 (アラビア文字\u3001アメリカ合衆国)",
-                japaneseNameGetter.getNameFromBCP47("zh-Arab-US"));
+                japaneseNameGetter.getNameFromIdentifier("zh-Arab-US"));
     }
 
     public void TestLocaleDisplay() {
@@ -529,7 +534,7 @@ public class TestLocale extends TestFmwkPlus {
         LanguageTagCanonicalizer canonicalizer = new LanguageTagCanonicalizer(LstrType.redundant);
 
         CLDRFile cldrFile = null;
-        boolean compound = true;
+        NameGetter.NameOpt nameOpt = NameGetter.NameOpt.COMPOUND_ONLY;
         StringBuilder formattedExamplesForSpec = new StringBuilder("\nformattedExamplesForSpec\n");
         File[] paths = {
             new File(CLDRPaths.MAIN_DIRECTORY), new File(CLDRPaths.SUBDIVISIONS_DIRECTORY),
@@ -550,10 +555,10 @@ public class TestLocale extends TestFmwkPlus {
                         case "@languageDisplay":
                             switch (parts[1]) {
                                 case "standard":
-                                    compound = true;
+                                    nameOpt = NameGetter.NameOpt.COMPOUND_ONLY;
                                     break;
                                 case "dialect":
-                                    compound = false;
+                                    nameOpt = NameGetter.NameOpt.DEFAULT;
                                     break;
                             }
                             break;
@@ -595,7 +600,7 @@ public class TestLocale extends TestFmwkPlus {
                 //                assertEquals("LTP(BCP47)=>ICU=>BCP47", bcp47, roundTripId);
 
                 canonicalizer.transform(ltp);
-                String name = cldrFile.nameGetter().getNameFromParserBool(ltp, compound);
+                String name = cldrFile.nameGetter().getNameFromParserOpt(ltp, nameOpt);
                 if (assertEquals(cldrFile.getLocaleID() + "; " + localeId, expected, name)) {
                     formattedExamplesForSpec
                             .append("<tr><td>")
@@ -674,7 +679,10 @@ public class TestLocale extends TestFmwkPlus {
         if (locale.equals("en-t-d0-accents")) {
             int debug = 0;
         }
-        String name = cldrFile.nameGetter().getNameFromBCP47BoolAlt(locale, true, null);
+        String name =
+                cldrFile.nameGetter()
+                        .getNameFromIdentifierOptAlt(
+                                locale, NameGetter.NameOpt.COMPOUND_ONLY, null);
         if (isVerbose()) {
             System.out.println(locale + "; " + name);
         }
@@ -695,19 +703,19 @@ public class TestLocale extends TestFmwkPlus {
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese",
-                englishNameGetter.getNameFromBCP47("zh_Hans"));
+                englishNameGetter.getNameFromIdentifier("zh_Hans"));
         assertEquals(
                 "Extended language translation",
                 "Simplified Chinese (Singapore)",
-                englishNameGetter.getNameFromBCP47("zh_Hans_SG"));
+                englishNameGetter.getNameFromIdentifier("zh_Hans_SG"));
         assertEquals(
                 "Extended language translation",
                 "American English",
-                englishNameGetter.getNameFromBCP47("en-US"));
+                englishNameGetter.getNameFromIdentifier("en-US"));
         assertEquals(
                 "Extended language translation",
                 "American English (Arabic)",
-                englishNameGetter.getNameFromBCP47("en-Arab-US"));
+                englishNameGetter.getNameFromIdentifier("en-Arab-US"));
     }
 
     public void testAllVariants() {
@@ -861,7 +869,7 @@ public class TestLocale extends TestFmwkPlus {
                         + "\n\t\tstructure:\t"
                         + ltp.toString(Format.structure));
         try {
-            String name = testInfo.getEnglish().nameGetter().getNameFromBCP47(locale);
+            String name = testInfo.getEnglish().nameGetter().getNameFromIdentifier(locale);
             logln("\tname:\t" + name);
         } catch (Exception e) {
             errln("Name for " + locale + "; " + e.getMessage());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -239,7 +239,7 @@ public class TestLocale extends TestFmwkPlus {
             if (!xpath.startsWith("//ldml/localeDisplayNames/")) {
                 continue;
             }
-            switch (NameType.getNameType(xpath)) {
+            switch (NameType.fromPath(xpath)) {
                 case LANGUAGE:
                     checkLocale("English xpath", NameType.getCode(xpath), ltp);
                     break;
@@ -455,8 +455,7 @@ public class TestLocale extends TestFmwkPlus {
             if (row[0] == null) {
                 continue;
             }
-            int typeCode = CLDRFile.typeNameToCode(row[0]);
-            NameType nameType = NameType.fromCldrInt(typeCode);
+            NameType nameType = NameType.typeNameToCode(row[0]);
             String path = nameType.getKeyPath(row[1]);
             dxs.putValueAtDPath(path, row[2]);
         }
@@ -480,13 +479,11 @@ public class TestLocale extends TestFmwkPlus {
         NameGetter nameGetter = f.nameGetter();
         for (String[] row : tests) {
             if (row[0] != null) {
-                int typeCode = CLDRFile.typeNameToCode(row[0]);
-                NameType nameType = NameType.fromCldrInt(typeCode);
+                NameType nameType = NameType.typeNameToCode(row[0]);
                 String standAlone = nameGetter.getNameFromTypeEnumCode(nameType, row[1]);
-                logln(typeCode + ": " + standAlone);
+                logln(nameType + ": " + standAlone);
                 if (!assertEquals("stand-alone " + row[3], row[2], standAlone)) {
-                    typeCode = CLDRFile.typeNameToCode(row[0]);
-                    nameType = NameType.fromCldrInt(typeCode);
+                    nameType = NameType.typeNameToCode(row[0]);
                     standAlone = nameGetter.getNameFromTypeEnumCode(nameType, row[1]);
                 }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -44,6 +44,7 @@ import org.unicode.cldr.util.LocaleValidator;
 import org.unicode.cldr.util.LocaleValidator.AllowedMatch;
 import org.unicode.cldr.util.LocaleValidator.AllowedValid;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.SimpleXMLSource;
 import org.unicode.cldr.util.StandardCodes;
@@ -238,15 +239,15 @@ public class TestLocale extends TestFmwkPlus {
             if (!xpath.startsWith("//ldml/localeDisplayNames/")) {
                 continue;
             }
-            switch (CLDRFile.getNameType(xpath)) {
-                case 0:
-                    checkLocale("English xpath", CLDRFile.getCode(xpath), ltp);
+            switch (NameType.getNameType(xpath)) {
+                case LANGUAGE:
+                    checkLocale("English xpath", NameType.getCode(xpath), ltp);
                     break;
-                case 1:
-                    checkScript("English xpath", CLDRFile.getCode(xpath));
+                case SCRIPT:
+                    checkScript("English xpath", NameType.getCode(xpath));
                     break;
-                case 2:
-                    checkRegion("English xpath", CLDRFile.getCode(xpath));
+                case TERRITORY:
+                    checkRegion("English xpath", NameType.getCode(xpath));
                     break;
             }
         }
@@ -455,7 +456,8 @@ public class TestLocale extends TestFmwkPlus {
                 continue;
             }
             int typeCode = CLDRFile.typeNameToCode(row[0]);
-            String path = CLDRFile.getKey(typeCode, row[1]);
+            NameType nameType = NameType.fromCldrInt(typeCode);
+            String path = nameType.getKeyPath(row[1]);
             dxs.putValueAtDPath(path, row[2]);
         }
         // create a cldrfile from it and test
@@ -479,15 +481,17 @@ public class TestLocale extends TestFmwkPlus {
         for (String[] row : tests) {
             if (row[0] != null) {
                 int typeCode = CLDRFile.typeNameToCode(row[0]);
-                String standAlone = nameGetter.getNameFromTypenumCode(typeCode, row[1]);
+                NameType nameType = NameType.fromCldrInt(typeCode);
+                String standAlone = nameGetter.getNameFromTypeEnumCode(nameType, row[1]);
                 logln(typeCode + ": " + standAlone);
                 if (!assertEquals("stand-alone " + row[3], row[2], standAlone)) {
                     typeCode = CLDRFile.typeNameToCode(row[0]);
-                    standAlone = nameGetter.getNameFromTypenumCode(typeCode, row[1]);
+                    nameType = NameType.fromCldrInt(typeCode);
+                    standAlone = nameGetter.getNameFromTypeEnumCode(nameType, row[1]);
                 }
 
                 if (row[5] != null) {
-                    String path = CLDRFile.getKey(typeCode, row[1]);
+                    String path = nameType.getKeyPath(row[1]);
                     String example = eg.getExampleHtml(path, "?" + row[2] + "?");
                     assertEquals("example " + row[3], row[5], ExampleGenerator.simplify(example));
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -297,17 +297,18 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                     }
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
                     NameGetter englishNameGetter = english.nameGetter();
-                    /*
-                     * TODO: use getNameFromTypenumCode instead of getNameFromTypestrCode here (twice).
-                     * Reference: https://unicode-org.atlassian.net/browse/CLDR-15830
-                     * typeCompat is derived from StandardCodes.LstrType.toCompatString
-                     */
-                    String typeName = englishNameGetter.getNameFromTypestrCode(typeCompat, subtag);
+                    int typeNum = type.toCldrTypeNum();
+                    if (typeNum == CLDRFile.NO_NAME) {
+                        System.out.println(
+                                "TestAgainstLanguageSubtagRegistry skipping type " + type);
+                        continue;
+                    }
+                    String typeName = englishNameGetter.getNameFromTypenumCode(typeNum, subtag);
                     String replacementName =
                             preferredValueCompat == null
                                     ? "???"
-                                    : englishNameGetter.getNameFromTypestrCode(
-                                            typeCompat, replacementString);
+                                    : englishNameGetter.getNameFromTypenumCode(
+                                            typeNum, replacementString);
                     addExceptions.add(
                             ".put(\""
                                     + subtag

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLsrvCanonicalizer.java
@@ -19,6 +19,7 @@ import org.unicode.cldr.util.LsrvCanonicalizer.ReplacementRule;
 import org.unicode.cldr.util.LsrvCanonicalizer.TestDataTypes;
 import org.unicode.cldr.util.LsrvCanonicalizer.XLanguageTag;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.StandardCodes.LstrField;
 import org.unicode.cldr.util.StandardCodes.LstrType;
@@ -297,18 +298,18 @@ public class TestLsrvCanonicalizer extends TestFmwk {
                     }
                     CLDRFile english = CLDRConfig.getInstance().getEnglish();
                     NameGetter englishNameGetter = english.nameGetter();
-                    int typeNum = type.toCldrTypeNum();
-                    if (typeNum == CLDRFile.NO_NAME) {
+                    NameType nameType = type.toNameType();
+                    if (nameType == NameType.NONE) {
                         System.out.println(
                                 "TestAgainstLanguageSubtagRegistry skipping type " + type);
                         continue;
                     }
-                    String typeName = englishNameGetter.getNameFromTypenumCode(typeNum, subtag);
+                    String typeName = englishNameGetter.getNameFromTypeEnumCode(nameType, subtag);
                     String replacementName =
                             preferredValueCompat == null
                                     ? "???"
-                                    : englishNameGetter.getNameFromTypenumCode(
-                                            typeNum, replacementString);
+                                    : englishNameGetter.getNameFromTypeEnumCode(
+                                            nameType, replacementString);
                     addExceptions.add(
                             ".put(\""
                                     + subtag

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -49,6 +49,7 @@ import org.unicode.cldr.util.Iso3166Data;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PathDescription;
@@ -859,7 +860,7 @@ public class TestPathHeader extends TestFmwkPlus {
     private String getNameAndOrder(String territory) {
         return territory
                 + "\t"
-                + englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, territory)
+                + englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory)
                 + "\t"
                 + Containment.getOrder(territory);
     }
@@ -978,15 +979,12 @@ public class TestPathHeader extends TestFmwkPlus {
                 assertEquals("S. America special case", "005", revision);
             }
             if (isVerbose()) {
-                String name =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, cont);
-                String name2 =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, sub);
+                String name = englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, cont);
+                String name2 = englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, sub);
                 String name3 =
-                        englishNameGetter.getNameFromTypenumCode(
-                                CLDRFile.TERRITORY_NAME, territory);
+                        englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, territory);
                 String name4 =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, revision);
+                        englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, revision);
 
                 logln(
                         metazone + "\t" + continent + "\t" + name + "\t" + name2 + "\t" + name3

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -1314,7 +1314,7 @@ public class TestPersonNameFormatter extends TestFmwk {
                     "Checking\t"
                             + locale
                             + "\t"
-                            + ENGLISH.nameGetter().getNameFromBCP47(locale)
+                            + ENGLISH.nameGetter().getNameFromIdentifier(locale)
                             + "\t"
                             + order
                             + "\t"

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -144,10 +144,11 @@ public class TestScriptMetadata extends TestFmwkPlus {
 
     // lifted from ShowLanguages
     private static Set<String> getEnglishTypes(
-            String type, int code, StandardCodes sc, CLDRFile english) {
+            String type, NameType nameType, StandardCodes sc, CLDRFile english) {
         Set<String> result = new HashSet<>(sc.getSurveyToolDisplayCodes(type));
-        for (Iterator<String> it = english.getAvailableIterator(code); it.hasNext(); ) {
-            XPathParts parts = XPathParts.getFrozenInstance(it.next());
+        for (Iterator<String> it = english.getAvailableIterator(nameType); it.hasNext(); ) {
+            String xpath = it.next();
+            XPathParts parts = XPathParts.getFrozenInstance(xpath);
             String newType = parts.getAttributeValue(-1, "type");
             if (!result.contains(newType)) {
                 result.add(newType);
@@ -158,7 +159,7 @@ public class TestScriptMetadata extends TestFmwkPlus {
 
     // lifted from ShowLanguages
     private static Set<String> getScriptsToShow(StandardCodes sc, CLDRFile english) {
-        return getEnglishTypes("script", CLDRFile.SCRIPT_NAME, sc, english);
+        return getEnglishTypes("script", NameType.SCRIPT, sc, english);
     }
 
     public void TestShowLanguages() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -29,6 +29,7 @@ import org.unicode.cldr.draft.ScriptMetadata.Trinary;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.Containment;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.With;
 import org.unicode.cldr.util.XPathParts;
@@ -202,18 +203,16 @@ public class TestScriptMetadata extends TestFmwkPlus {
                     Row.of(
                             info.idUsage,
                             english.nameGetter()
-                                    .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, continent),
+                                    .getNameFromTypeEnumCode(NameType.TERRITORY, continent),
                             info.idUsage
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(
-                                                    CLDRFile.TERRITORY_NAME, container)
+                                            .getNameFromTypeEnumCode(NameType.TERRITORY, container)
                                     + "\t"
                                     + scriptCode
                                     + "\t"
                                     + english.nameGetter()
-                                            .getNameFromTypenumCode(
-                                                    CLDRFile.SCRIPT_NAME, scriptCode)));
+                                            .getNameFromTypeEnumCode(NameType.SCRIPT, scriptCode)));
         }
         for (Row.R3<IdUsage, String, String> s : lines) {
             logln(s.get2());

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1319,7 +1319,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         // now show the items we found
         for (Scope scope : scopeToCodes.keySet()) {
             for (String language : scopeToCodes.getAll(scope)) {
-                String name = englishNameGetter.getNameFromBCP47(language);
+                String name = englishNameGetter.getNameFromIdentifier(language);
                 if (name == null || name.equals(language)) {
                     Set<String> set = Iso639Data.getNames(language);
                     if (set != null) {
@@ -2223,7 +2223,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     private String codeAndName(String macro) {
         // TODO Auto-generated method stub
-        return CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(macro)
+        return CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromIdentifier(macro)
                 + " ("
                 + macro
                 + ")";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1064,16 +1064,16 @@ public class TestSupplementalInfo extends TestFmwkPlus {
 
     public static class NameCodeTransform implements StringTransform {
         private final CLDRFile file;
-        private final int codeType;
+        private final NameType nameType;
 
-        public NameCodeTransform(CLDRFile file, int code) {
+        public NameCodeTransform(CLDRFile file, NameType nameType) {
             this.file = file;
-            this.codeType = code;
+            this.nameType = nameType;
         }
 
         @Override
         public String transform(String code) {
-            return file.nameGetter().getNameFromTypenumCode(codeType, code) + " [" + code + "]";
+            return file.nameGetter().getNameFromTypeEnumCode(nameType, code) + " [" + code + "]";
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -72,6 +72,7 @@ import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PluralRanges;
@@ -861,18 +862,18 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         Set<String> b = new LinkedHashSet<>();
         for (String ss : s) {
             ltp.set(ss);
-            addName(CLDRFile.LANGUAGE_NAME, ltp.getLanguage(), b);
-            addName(CLDRFile.SCRIPT_NAME, ltp.getScript(), b);
-            addName(CLDRFile.TERRITORY_NAME, ltp.getRegion(), b);
+            addName(NameType.LANGUAGE, ltp.getLanguage(), b);
+            addName(NameType.SCRIPT, ltp.getScript(), b);
+            addName(NameType.TERRITORY, ltp.getRegion(), b);
         }
         return Joiner.on("; ").join(b);
     }
 
-    private void addName(int languageName, String code, Set<String> b) {
+    private void addName(NameType nameType, String code, Set<String> b) {
         if (code.isEmpty()) {
             return;
         }
-        String name = englishNameGetter.getNameFromTypenumCode(languageName, code);
+        String name = englishNameGetter.getNameFromTypeEnumCode(nameType, code);
         if (!code.equals(name)) {
             b.add(code + "=" + name);
         }
@@ -1240,7 +1241,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
     }
 
     private String getRegionName(String region) {
-        return englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, region);
+        return englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, region);
     }
 
     private Map<String, Integer> getRecursiveContainment(
@@ -1537,8 +1538,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                 + "\t"
                                 + dateInfo.toString()
                                 + "\t"
-                                + englishNameGetter.getNameFromTypenumCode(
-                                        CLDRFile.CURRENCY_NAME, currency));
+                                + englishNameGetter.getNameFromTypeEnumCode(
+                                        NameType.CURRENCY, currency));
             }
         }
         // fix up
@@ -1575,7 +1576,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         for (String currency : modernCurrencyCodes.keySet()) {
             Set<Pair<String, CurrencyDateInfo>> data = modernCurrencyCodes.getAll(currency);
             final String name =
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
+                    englishNameGetter.getNameFromTypeEnumCode(NameType.CURRENCY, currency);
 
             Set<String> isoCountries = isoCurrenciesToCountries.getAll(currency);
             if (isoCountries == null) {
@@ -1650,7 +1651,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                         + nonModernCurrencyCodes);
         for (String currency : nonModernCurrencyCodes.keySet()) {
             final String name =
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.CURRENCY_NAME, currency);
+                    englishNameGetter.getNameFromTypeEnumCode(NameType.CURRENCY, currency);
             if (name == null) {
                 errln("No English name for currency " + currency);
                 continue;
@@ -1691,8 +1692,8 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                         + "\t"
                                         + dateInfo
                                         + "\t"
-                                        + englishNameGetter.getNameFromTypenumCode(
-                                                CLDRFile.CURRENCY_NAME, dateInfo.getCurrency()));
+                                        + englishNameGetter.getNameFromTypeEnumCode(
+                                                NameType.CURRENCY, dateInfo.getCurrency()));
                     }
                 }
             }
@@ -2110,7 +2111,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             Set<String> modern = new TreeSet<>();
             Set<String> comprehensive = new TreeSet<>();
             for (String lang : temp) {
-                Level level = coverageLevel.getLevel(CLDRFile.getKey(CLDRFile.LANGUAGE_NAME, lang));
+                Level level = coverageLevel.getLevel(NameType.LANGUAGE.getKeyPath(lang));
                 if (level.compareTo(Level.MODERN) <= 0) {
                     modern.add(lang);
                 } else {
@@ -2140,7 +2141,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         Set<String> tempNames = new TreeSet<>();
         for (String langCode : temp) {
             tempNames.add(
-                    englishNameGetter.getNameFromTypenumCode(CLDRFile.LANGUAGE_NAME, langCode)
+                    englishNameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, langCode)
                             + " ("
                             + langCode
                             + ")");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1058,7 +1058,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                                     missing24only,
                                     "\n\t\t",
                                     new NameCodeTransform(
-                                            testInfo.getEnglish(), CLDRFile.TERRITORY_NAME)));
+                                            testInfo.getEnglish(), NameType.TERRITORY)));
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnContainment.java
@@ -16,8 +16,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.util.CLDRConfig;
-import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.SupplementalDataInfo;
 
 public class TestUnContainment extends TestFmwkPlus {
@@ -85,7 +85,7 @@ public class TestUnContainment extends TestFmwkPlus {
         String name =
                 testInfo.getEnglish()
                         .nameGetter()
-                        .getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, code);
+                        .getNameFromTypeEnumCode(NameType.TERRITORY, code);
         return name + " (" + code + ")";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -568,12 +568,15 @@ public class TestValidity extends TestFmwkPlus {
                 + "\"/>"
                 + " <!-- "
                 + TransliteratorUtilities.toXML.transform(
-                        CLDRConfig.getInstance().getEnglish().nameGetter().getNameFromBCP47(code)
+                        CLDRConfig.getInstance()
+                                        .getEnglish()
+                                        .nameGetter()
+                                        .getNameFromIdentifier(code)
                                 + " ⇒ "
                                 + CLDRConfig.getInstance()
                                         .getEnglish()
                                         .nameGetter()
-                                        .getNameFromBCP47(lstrReplacement))
+                                        .getNameFromIdentifier(lstrReplacement))
                 + " -->";
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -392,22 +392,6 @@ public class TestCLDRFile {
 
     @Test
     public void TestTypeNameToCode() {
-        assertEquals(CLDRFile.LANGUAGE_NAME, CLDRFile.typeNameToCode("language"));
-        assertEquals(CLDRFile.TERRITORY_NAME, CLDRFile.typeNameToCode("territory"));
-        assertEquals(CLDRFile.VARIANT_NAME, CLDRFile.typeNameToCode("variant"));
-        assertEquals(CLDRFile.CURRENCY_NAME, CLDRFile.typeNameToCode("currency"));
-        assertEquals(CLDRFile.CURRENCY_SYMBOL, CLDRFile.typeNameToCode("currency-symbol"));
-        assertEquals(CLDRFile.TZ_EXEMPLAR, CLDRFile.typeNameToCode("exemplar-city"));
-        assertEquals(CLDRFile.TZ_GENERIC_LONG, CLDRFile.typeNameToCode("tz-generic-long"));
-        assertEquals(CLDRFile.TZ_GENERIC_SHORT, CLDRFile.typeNameToCode("tz-generic-short"));
-        assertEquals(CLDRFile.TZ_STANDARD_LONG, CLDRFile.typeNameToCode("tz-standard-long"));
-        assertEquals(CLDRFile.TZ_STANDARD_SHORT, CLDRFile.typeNameToCode("tz-standard-short"));
-        assertEquals(CLDRFile.TZ_DAYLIGHT_LONG, CLDRFile.typeNameToCode("tz-daylight-long"));
-        assertEquals(CLDRFile.TZ_DAYLIGHT_SHORT, CLDRFile.typeNameToCode("tz-daylight-short"));
-        assertEquals(CLDRFile.KEY_NAME, CLDRFile.typeNameToCode("key"));
-        assertEquals(CLDRFile.KEY_TYPE_NAME, CLDRFile.typeNameToCode("key|type"));
-        assertEquals(CLDRFile.SUBDIVISION_NAME, CLDRFile.typeNameToCode("subdivision"));
-
         assertEquals(NameType.LANGUAGE, NameType.typeNameToCode("language"));
         assertEquals(NameType.TERRITORY, NameType.typeNameToCode("territory"));
         assertEquals(NameType.VARIANT, NameType.typeNameToCode("variant"));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -407,5 +407,21 @@ public class TestCLDRFile {
         assertEquals(CLDRFile.KEY_NAME, CLDRFile.typeNameToCode("key"));
         assertEquals(CLDRFile.KEY_TYPE_NAME, CLDRFile.typeNameToCode("key|type"));
         assertEquals(CLDRFile.SUBDIVISION_NAME, CLDRFile.typeNameToCode("subdivision"));
+
+        assertEquals(NameType.LANGUAGE, NameType.typeNameToCode("language"));
+        assertEquals(NameType.TERRITORY, NameType.typeNameToCode("territory"));
+        assertEquals(NameType.VARIANT, NameType.typeNameToCode("variant"));
+        assertEquals(NameType.CURRENCY, NameType.typeNameToCode("currency"));
+        assertEquals(NameType.CURRENCY_SYMBOL, NameType.typeNameToCode("currency-symbol"));
+        assertEquals(NameType.TZ_EXEMPLAR, NameType.typeNameToCode("exemplar-city"));
+        assertEquals(NameType.TZ_GENERIC_LONG, NameType.typeNameToCode("tz-generic-long"));
+        assertEquals(NameType.TZ_GENERIC_SHORT, NameType.typeNameToCode("tz-generic-short"));
+        assertEquals(NameType.TZ_STANDARD_LONG, NameType.typeNameToCode("tz-standard-long"));
+        assertEquals(NameType.TZ_STANDARD_SHORT, NameType.typeNameToCode("tz-standard-short"));
+        assertEquals(NameType.TZ_DAYLIGHT_LONG, NameType.typeNameToCode("tz-daylight-long"));
+        assertEquals(NameType.TZ_DAYLIGHT_SHORT, NameType.typeNameToCode("tz-daylight-short"));
+        assertEquals(NameType.KEY, NameType.typeNameToCode("key"));
+        assertEquals(NameType.KEY_TYPE, NameType.typeNameToCode("key|type"));
+        assertEquals(NameType.SUBDIVISION, NameType.typeNameToCode("subdivision"));
     }
 }

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/GenerateLanguageContainment.java
@@ -237,7 +237,7 @@ public class GenerateLanguageContainment {
             code ->
                     code.equals(LocaleNames.MUL)
                             ? LocaleNames.ROOT
-                            : ENGLISH.nameGetter().getNameFromBCP47(code) + " (" + code + ")";
+                            : ENGLISH.nameGetter().getNameFromIdentifier(code) + " (" + code + ")";
 
     static final Set<String> COLLECTIONS;
 
@@ -402,7 +402,7 @@ public class GenerateLanguageContainment {
             for (String check : Arrays.asList("sw", "km", "ksh", "wae", "kea", "mfe", "th", "lo")) {
                 System.out.println(
                         "Checking "
-                                + ENGLISH.nameGetter().getNameFromBCP47(check)
+                                + ENGLISH.nameGetter().getNameFromIdentifier(check)
                                 + "["
                                 + check
                                 + "]");

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/SubdivisionNode.java
@@ -36,6 +36,7 @@ import org.unicode.cldr.util.ChainedMap.M3;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.NameGetter;
+import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.StandardCodes;
@@ -265,8 +266,7 @@ public class SubdivisionNode {
                     SubdivisionInfo.SUBDIVISION_ALIASES_FORMER.get(value);
             if (subdivisionAlias != null) {
                 String country = subdivisionAlias.get0().get(0);
-                cldrName =
-                        englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, country);
+                cldrName = englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, country);
                 if (cldrName != null) {
                     return fixName(cldrName);
                 }
@@ -615,8 +615,7 @@ public class SubdivisionNode {
                     result.append(", ");
                 }
                 if (SubdivisionNames.isRegionCode(s)) {
-                    result.append(
-                            englishNameGetter.getNameFromTypenumCode(CLDRFile.TERRITORY_NAME, s));
+                    result.append(englishNameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, s));
                 } else {
                     result.append(sdset.getBestName(s, useIso));
                 }


### PR DESCRIPTION
CLDR-15830

-New enum NameType replaces integers CLDRFile.LANGUAGE_NAME, etc.; avoid arithmetic based on such integers

-Encapsulate in NameType all dependencies on ordering of NameType.LANGUAGE, etc.

-Move related methods and NameTable from CLDRFile to NameType

-Rename NameGetter.getNameFromBCP47 to getNameFromIdentifier, etc., since identifiers may not be only BCP47; change some comments accordingly

-Avoid boolean parameter onlyConstructCompound; use enum NameGetter.NameOpt instead, values COMPOUND_ONLY and DEFAULT

-Fix all 3 TODO comments added in previous PR 4228

-Fix typo: rename getZoneToCounty to getZoneToCountry (country, not county)

-Remove dead code, including ShowLanguages.printMissing, ShowLanguages.print, TestCoverageLevel.TypeName

-Remove some commented-out code

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
