### PR TITLE
CLDR-17014 Illustrate/fix extra-path bug

### DIFF
--- a/tools/cldr-apps/src/test/resources/org/unicode/cldr/web/data/TestSTFactory.xml
+++ b/tools/cldr-apps/src/test/resources/org/unicode/cldr/web/data/TestSTFactory.xml
@@ -236,4 +236,8 @@
 	<!-- 8 votes is not enough to change an already-approved item, so the original value (comma) should still be approved -->
 	<verify status="approved" locale="fr" xpath="//ldml/numbers/symbols[@numberSystem='latn']/decimal">,</verify>
 
+	<vote name="A" locale="mul" xpath="//ldml/dates/timeZoneNames/metazone[@type='Alaska']/long/generic">aksalA</vote>
+	<vote name="B" locale="mul" xpath="//ldml/dates/timeZoneNames/metazone[@type='Alaska']/long/generic">aksalA</vote>
+	<vote name="C" locale="mul" xpath="//ldml/dates/timeZoneNames/metazone[@type='Alaska']/long/generic">aksalA</vote>
+	<verify status="approved" locale="mul" xpath="//ldml/dates/timeZoneNames/metazone[@type='Alaska']/long/generic" >aksalA</verify>
 </TestSTFactory>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrXmlWriter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrXmlWriter.java
@@ -35,7 +35,7 @@ public class CldrXmlWriter {
 
         xmlSource = cldrFile.dataSource;
         orderedSet = new TreeSet<>(cldrFile.getComparator());
-        xmlSource.forEach(orderedSet::add);
+        cldrFile.fullIterable().forEach(orderedSet::add);
         if (orderedSet.size() > 0) { // May not have any elements.
             final String firstPath = orderedSet.iterator().next();
             firstFullPath = cldrFile.getFullXPath(firstPath);


### PR DESCRIPTION
-Writing a CLDRFile to XML failed for extra paths such as this metazone path as shown by the new test in TestSTFactory.xml

-Using cldrFile.fullIterable.forEach instead of xmlSource.forEach in CldrXmlWriter fixes the bug

CLDR-17014

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
