### PR TITLE
CLDR-18207 SBRS 47 Update misc additional versions and dates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ on the CLDR development site.
 
 ## Copyright
 
-Copyright &copy; 1991-2024 Unicode, Inc.
+Copyright &copy; 1991-2025 Unicode, Inc.
 All rights reserved. [Terms of use][]
 
 [Survey Tool]: https://cldr.unicode.org/index/survey-tool

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2004-2024 Unicode, Inc.
+Copyright © 2004-2025 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For current CLDR release information, see [cldr.unicode.org](https://cldr.unicod
 
 ## Status
 
-Update: 2024-10-25
+Update: 2025-01-07
 
 <!-- [inapplicable lines are commented out.]-->
 **Note:**  CLDR 47 is in development and not recommended for use at this stage.
@@ -45,7 +45,7 @@ A source formatter is now used, please see [spotless](./tools/README.md#spotless
 
 ### Copyright & Licenses
 
-Copyright © 2004-2024 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.
+Copyright © 2004-2025 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.
 
 A CLA is required to contribute to this project - please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) file (or start a Pull Request) for more information.
 

--- a/common/testData/_readme.txt
+++ b/common/testData/_readme.txt
@@ -1,5 +1,5 @@
 # Data for testing expected behavior of CLDR operations
-#  Copyright © 1991-2020 Unicode, Inc.
+#  Copyright © 1991-2025 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
 #  Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)

--- a/common/testData/personNameTest/_header.txt
+++ b/common/testData/personNameTest/_header.txt
@@ -1,5 +1,5 @@
 # Test data for personName formats
-#  Copyright © 1991-2024 Unicode, Inc.
+#  Copyright © 1991-2025 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
 #  SPDX-License-Identifier: Unicode-DFS-2016
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,6 @@ CLDR main page: [https://www.unicode.org/cldr](unicode.org/cldr)
 
 ##### Copyright
 
-Copyright &copy; 1991-2024 Unicode, Inc.
+Copyright &copy; 1991-2025 Unicode, Inc.
 All rights reserved.
 [Terms of use](https://www.unicode.org/copyright.html)

--- a/docs/ldml/tr35-collation.md
+++ b/docs/ldml/tr35-collation.md
@@ -1177,7 +1177,7 @@ However, for stroke order, the label string is the stroke count (second characte
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -2716,7 +2716,7 @@ For example, a conformant specification must reject the following inputs:
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-general.md
+++ b/docs/ldml/tr35-general.md
@@ -3133,7 +3133,7 @@ For example, for gram-per-meter, the first line above means:
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-info.md
+++ b/docs/ldml/tr35-info.md
@@ -1471,7 +1471,7 @@ As an example, ICU only uses the unit preferences (with rg, ms, and/or mu and th
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2873,7 +2873,7 @@ The following are the design principles for the IDs.
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-messageFormat.md
+++ b/docs/ldml/tr35-messageFormat.md
@@ -2,7 +2,7 @@
 
 # Unicode Locale Data Markup Language (LDML)<br/>Part 9: Message Format
 
-|Version|46.1 (draft)            |
+|Version|47 (draft)              |
 |-------|------------------------|
 |Editors|Addison Phillips and [other CLDR committee members](tr35.md#Acknowledgments)|
 
@@ -4523,7 +4523,7 @@ Romulo Cintra chaired the chair group.
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -1482,7 +1482,7 @@ To add spacing, insert a non-breaking space (U+00A0) at the positions in item 2 
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35-personNames.md
+++ b/docs/ldml/tr35-personNames.md
@@ -1119,7 +1119,7 @@ To make an initial when there are multiple words, an implementation might produc
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|47 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2024-11-12|
+|Date|2025-01-07|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-75/tr35.html">https://www.unicode.org/reports/tr35/tr35-75/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-74/tr35.html">https://www.unicode.org/reports/tr35/tr35-74/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|
@@ -4367,7 +4367,7 @@ Click on **Previous Version** in the header until you get to the desired version
 
 * * *
 
-© 2024–2024 Unicode, Inc.
+© 2024–2025 Unicode, Inc.
 This publication is protected by copyright, and permission must be obtained from Unicode, Inc.
 prior to any reproduction, modification, or other use not permitted by the [Terms of Use](https://www.unicode.org/copyright.html).
 Specifically, you may make copies of this publication and may annotate and translate it solely for personal or internal business purposes and not for public distribution,

--- a/readme.html
+++ b/readme.html
@@ -2,7 +2,7 @@
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
-    <meta name="COPYRIGHT" content= "Copyright (c) 2004-2024 Unicode, Inc. All rights reserved.">
+    <meta name="COPYRIGHT" content= "Copyright (c) 2004-2025 Unicode, Inc. All rights reserved.">
     <title>readme.html</title>
   </head>
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/package.html
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/package.html
@@ -14,7 +14,7 @@ For terms of use, see http://www.unicode.org/terms_of_use.html
 <body bgcolor="white">
 	<h1>CLDR Tools</h1>
 	<p>All files supplied here are:</p>
-	<pre>* Copyright (c) 2004-2007, Unicode Inc, and others.  All Rights Reserved.
+	<pre>* Copyright (c) 2004-2025, Unicode Inc, and others.  All Rights Reserved.
 * For terms of use, see <a
 			href="http://unicode.org/copyright.html#Exhibit1">http://unicode.org/copyright.html#Exhibit1</a>
 	</pre>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
 			SNAPSHOT for the ICU version that we want, so this should only need updating
 			when the ICU version changes e.g. from 74.0.1, to 74.1, to 75.0.1, then to 75.1.
 			You can use github actions in icu to manually push the latest SNAPSHOT version. -->
-		<icu4j.version>76.1-SNAPSHOT</icu4j.version>
+		<icu4j.version>77.0.1-SNAPSHOT</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.3.1</maven-surefire-plugin-version>
 		<assertj-version>3.11.1</assertj-version>


### PR DESCRIPTION
CLDR-18207

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18207)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

- Restore `docs/ldml/tr35-messageFormat.md` to have version 47
- Update `tools/pom.xml` to use ICU 77.0.1
- Update spec & readme dates
- Update at least some copyright dates for 2025:
    - `README.md`, `CONTRIBUTING.md`, `LICENSE`, `readme.html`, `docs/README.md`
    - Spec copyright. **The range was 2024-2024 so updated the end year to 2025, but shouldn't the start year be earlier?**
    - Misc files: `common/testData/_readme.txt`, `common/testData/personNameTest/_header.txt`, `tools/cldr-code/src/main/resources/org/unicode/cldr/package.html`
    - There is probably a standard header file that provides copyright and other info for java files, xml files, etc. but I did not find or update that (perhaps there is a BRS task to run a tool that updates these, did not run that).
- There are probably other files that need copyright updates, can be a separate PR.

ALLOW_MANY_COMMITS=true
