### PR TITLE
CLDR-18220 Dashboard Other category for all other paths

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDashData.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDashData.mjs
@@ -248,7 +248,9 @@ let fetchErr = "";
 
 let viewSetDataCallback = null;
 
-function doFetch(callback) {
+function doFetch(callback, opts) {
+  opts = opts || {};
+  const { includeOther } = opts;
   viewSetDataCallback = callback;
   fetchErr = "";
   const locale = cldrStatus.getCurrentLocale();
@@ -257,7 +259,8 @@ function doFetch(callback) {
     fetchErr = cldrText.get("dash_needs_locale_and_coverage");
     return;
   }
-  const url = `api/summary/dashboard/${locale}/${level}`;
+  const qs = includeOther ? "?includeOther=true" : "";
+  const url = `api/summary/dashboard/${locale}/${level}${qs}`;
   cldrAjax
     .doFetch(url)
     .then(cldrAjax.handleFetchErrors)

--- a/tools/cldr-apps/js/src/esm/cldrText.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrText.mjs
@@ -569,6 +569,7 @@ const strings = {
   notification_category_warning:
     "The Survey Tool detected a warning about the winning value.",
   notification_category_reports: "A Report has not been completed.",
+  notification_category_other: "All other values",
 
   progress_page: "Your voting in this page",
   progress_voter: "Your voting in this locale",

--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -55,6 +55,13 @@
           </template>
         </span>
         <span class="right-control">
+          <span
+            v-if="!includeOther"
+            class="cldr-nav-btn"
+            @click="reloadIncludeOther"
+          >
+            <input type="checkbox" />&nbsp;Other
+          </span>
           <a-spin v-if="downloadMessage">
             <i>{{ downloadMessage }}</i>
           </a-spin>
@@ -214,6 +221,7 @@ export default {
       catCheckboxIsUnchecked: {}, // default unchecked = false, checked = true
       catIsHidden: {}, // default hidden = false, visible = true
       updatingVisibility: false,
+      includeOther: false,
     };
   },
 
@@ -287,6 +295,16 @@ export default {
       this.fetchData();
     },
 
+    reloadIncludeOther() {
+      this.catIsHidden["Other"] = false;
+      this.catCheckboxIsUnchecked["Other"] = false;
+      this.includeOther = true;
+      this.reloadDashboard();
+    },
+    reloadWithoutOther() {
+      this.includeOther = false;
+      this.reloadDashboard();
+    },
     fetchData() {
       this.locale = cldrStatus.getCurrentLocale();
       this.level = cldrCoverage.effectiveName(this.locale);
@@ -298,7 +316,7 @@ export default {
       }
       this.localeName = cldrLoad.getLocaleName(this.locale);
       this.loadingMessage = `Loading ${this.localeName} dashboard at ${this.level} level`;
-      cldrDashData.doFetch(this.setData);
+      cldrDashData.doFetch(this.setData, { includeOther: this.includeOther });
       this.fetchErr = cldrDashData.getFetchError();
     },
 
@@ -434,6 +452,14 @@ export default {
       // long delay between the time the user clicks the checkbox and the time that the checkbox
       // changes its state.
       // NOTE: this complication may be unnecessary now that DashboardScroller is in use.
+      if (category === "Other") {
+        // special case: Unchecking Other reloads without Other.
+        nextTick().then(() => {
+          this.reloadWithoutOther();
+        });
+        return;
+      }
+
       this.catCheckboxIsUnchecked[category] = !event.target.checked; // redundant?
       const USE_NEXT_TICK = true;
       this.updatingVisibility = true;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -230,7 +230,11 @@ public class Dashboard {
      * @return the ReviewOutput
      */
     public ReviewOutput get(
-            CLDRLocale locale, UserRegistry.User user, Level coverageLevel, String xpath) {
+            CLDRLocale locale,
+            UserRegistry.User user,
+            Level coverageLevel,
+            String xpath,
+            boolean includeOther) {
         final SurveyMain sm = CookieSession.sm;
         Organization usersOrg = Organization.unaffiliated;
         if (user != null) {
@@ -242,6 +246,10 @@ public class Dashboard {
                         sm.getSupplementalDataInfo(), sourceFactory, new STUsersChoice(sm));
         EnumSet<NotificationCategory> choiceSet =
                 VettingViewer.getDashboardNotificationCategories(usersOrg);
+        if (includeOther) {
+            // user requested all categories
+            choiceSet.add(NotificationCategory.other);
+        }
         VettingParameters args = new VettingParameters(choiceSet, locale, coverageLevel);
         if (user != null) {
             args.setUserAndOrganization(user.id, usersOrg);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -14,12 +14,14 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -476,6 +478,13 @@ public class Summary {
             @PathParam("locale") @Schema(required = true, description = "Locale ID") String locale,
             @PathParam("level") @Schema(required = true, description = "Coverage Level")
                     String level,
+            @QueryParam("includeOther")
+                    @DefaultValue("false")
+                    @Schema(
+                            required = false,
+                            description = "Include all rows ('Other' category)",
+                            example = "true")
+                    boolean includeOther,
             @HeaderParam(Auth.SESSION_HEADER) String sessionString) {
         CLDRLocale loc = CLDRLocale.getInstance(locale);
         CookieSession cs = Auth.getSession(sessionString);
@@ -486,7 +495,8 @@ public class Summary {
 
         // *Beware*  org.unicode.cldr.util.Level (coverage) ≠ VoteResolver.Level (user)
         Level coverageLevel = org.unicode.cldr.util.Level.fromString(level);
-        ReviewOutput ret = new Dashboard().get(loc, cs.user, coverageLevel, null /* xpath */);
+        ReviewOutput ret =
+                new Dashboard().get(loc, cs.user, coverageLevel, null /* xpath */, includeOther);
         ret.coverageLevel = coverageLevel.name();
 
         return Response.ok().entity(ret).build();
@@ -551,7 +561,7 @@ public class Summary {
             coverageLevel = org.unicode.cldr.util.Level.fromString(level);
         }
         ReviewOutput reviewOutput =
-                new Dashboard().get(loc, target, coverageLevel, null /* xpath */);
+                new Dashboard().get(loc, target, coverageLevel, null /* xpath */, false);
         reviewOutput.coverageLevel = coverageLevel.name();
 
         ParticipationResults participationResults =

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -402,7 +402,7 @@ public class VoteAPIHelper {
             String baseXp, CLDRLocale locale, CookieSession mySession) {
         Level coverageLevel = Level.get(mySession.getEffectiveCoverageLevel(locale.toString()));
         Dashboard.ReviewOutput ro =
-                new Dashboard().get(locale, mySession.user, coverageLevel, baseXp);
+                new Dashboard().get(locale, mySession.user, coverageLevel, baseXp, false);
         return ro.getNotifications();
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/NotificationCategory.java
@@ -57,7 +57,8 @@ public enum NotificationCategory {
 
     /** You have abstained, or not yet voted for any value */
     abstained('A', "Abstained", "You have abstained, or not yet voted for any value."),
-    ;
+
+    other('O', "Other", "All other values");
 
     public final char abbreviation;
     public final String buttonLabel;


### PR DESCRIPTION
CLDR-18220

- [X] This PR completes the ticket.

- Adds a new notification category 'other'. It's not included in the default choice sets.
- The query param includeOther=true adds this category.
- UI in the dashboard makes the Other category look like similar categories, except that
  internally it reloads with the query param set/unset. (This reduces load in the normal case.)

The benefit here is especially in being able to download a spreadsheet of all values in a coverage
level.

## UI

### Unchecked

![image](https://github.com/user-attachments/assets/6ade9344-806e-434f-ad80-4361803594fb)

### Checked

![image](https://github.com/user-attachments/assets/6b789a50-ba71-4c48-85b1-61f163755cf6)

### Downloaded

<img width="987" alt="image" src="https://github.com/user-attachments/assets/5d408d78-664b-4e10-92c4-ad30dc25376c" />

[Dash_csw_default(2).xlsx](https://github.com/user-attachments/files/18414370/Dash_csw_default.2.xlsx)



ALLOW_MANY_COMMITS=true
