### PR TITLE
CLDR-18220 Improve Dashboard Other category for all other paths

### DIFF
--- a/tools/cldr-apps/js/src/views/DashboardWidget.vue
+++ b/tools/cldr-apps/js/src/views/DashboardWidget.vue
@@ -56,6 +56,7 @@
         </span>
         <span class="right-control">
           <span
+            title="Include ALL paths in selected coverage level. May be very large!"
             v-if="!includeOther"
             class="cldr-nav-btn"
             @click="reloadIncludeOther"

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -561,7 +561,13 @@ public class Summary {
             coverageLevel = org.unicode.cldr.util.Level.fromString(level);
         }
         ReviewOutput reviewOutput =
-                new Dashboard().get(loc, target, coverageLevel, null /* xpath */, false);
+                new Dashboard()
+                        .get(
+                                loc,
+                                target,
+                                coverageLevel,
+                                null /* xpath */,
+                                false /* includeOther */);
         reviewOutput.coverageLevel = coverageLevel.name();
 
         ParticipationResults participationResults =

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -402,7 +402,13 @@ public class VoteAPIHelper {
             String baseXp, CLDRLocale locale, CookieSession mySession) {
         Level coverageLevel = Level.get(mySession.getEffectiveCoverageLevel(locale.toString()));
         Dashboard.ReviewOutput ro =
-                new Dashboard().get(locale, mySession.user, coverageLevel, baseXp, false);
+                new Dashboard()
+                        .get(
+                                locale,
+                                mySession.user,
+                                coverageLevel,
+                                baseXp,
+                                false /* includeOther */);
         return ro.getNotifications();
     }
 


### PR DESCRIPTION
CLDR-18220

address comments in #4273 

## UI Review
<img width="518" alt="image" src="https://github.com/user-attachments/assets/3db9fc33-1ed4-443d-9baa-f63622769f56" />


- [X] This PR completes the ticket.

- Adds a new notification category 'other'. It's not included in the default choice sets.
- The query param includeOther=true adds this category.
- UI in the dashboard makes the Other category look like similar categories, except that
  internally it reloads with the query param set/unset. (This reduces load in the normal case.)

The benefit here is especially in being able to download a spreadsheet of all values in a coverage
level.

ALLOW_MANY_COMMITS=true
