### PR TITLE
CLDR-18226 Fix chr-chr_FONIPA transform rule

### DIFF
--- a/common/testData/transforms/chr-fonipa-t-chr.txt
+++ b/common/testData/transforms/chr-fonipa-t-chr.txt
@@ -573,7 +573,7 @@
 ᏗᎦᎪᏗ	diɡaɡodi
 ᎤᎾᎵᎪᎯ	unaliɡohi
 ᎠᏍᏓᏩᏗᏒ	asdawadisə̃
-ᎫᏢᎥᏍᎬ	ɡut͡ɬə̃ə̃sɡə̃
+ᎫᏢᎥᏍᎬ	ɡut͡ɬə̃sɡə̃
 ᎣᏂᏯᎨᏍᏙᏗ	onijaɡesdodi
 ᏑᏓᎴᎩ	sudaleɡi
 ᏍᏉᎯᏧᏈ	skʷohit͡sukʷi
@@ -723,7 +723,7 @@
 ᎠᏓᏠᎯᏍᏗ	adat͡ɬohisdi
 ᏗᎦᎴᏴᏗᏍᎩ	diɡalejə̃disɡi
 ᎾᎾᏛᏁᎲ	nanadə̃nehə̃
-ᎦᏃᎸᎥᏍᎬ	ɡanolə̃ə̃sɡə̃
+ᎦᏃᎸᎥᏍᎬ	ɡanolə̃sɡə̃
 ᎤᎭᎸᏂ	uhalə̃ni
 ᏩᎦᎸᎳᏗᏴ	waɡalə̃ladijə̃
 ᏗᎬᏔᏂᏓᏍᏗ	diɡə̃tanidasdi

--- a/common/transforms/chr-chr_FONIPA.xml
+++ b/common/transforms/chr-chr_FONIPA.xml
@@ -137,7 +137,7 @@ e e+ → eː;
 i i+ → iː;
 o o+ → oː;
 u u+ → uː;
-ə̃ {ə̃}+ → ə̃;
+ə̃ ə̃+ → ə̃;
 			]]></tRule>
 		</transform>
 	</transforms>


### PR DESCRIPTION
CLDR-18226

- [ ] This PR completes the ticket.

`ə̃ {ə̃}+ → ə̃;` is an invalid rule, `{` and `}` denote context, and the `+` quantifier cannot follow a context. The intention here was probably to group the decomposed character, but quantifiers apply back to the last space anyway.

ALLOW_MANY_COMMITS=true
