### PR TITLE
CLDR-18217 Refactor by removing Iterable interface from CLDRFile

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/CompareCLDRFile.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/CompareCLDRFile.java
@@ -22,7 +22,7 @@ public class CompareCLDRFile {
             this.file = f;
             this.title = t;
 
-            for (String s : f) {
+            for (String s : f.iterableDefault()) {
                 xpaths.add(s);
             }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -2604,7 +2604,7 @@ public class SurveyAjax extends HttpServlet {
         CLDRFile baseFile = stf.make(loc.getBaseName(), false);
 
         Set<String> all = new TreeSet<>();
-        for (String x : cf) {
+        for (String x : cf.iterableDefault()) {
             if (x.startsWith("//ldml/identity")) {
                 continue;
             }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMenus.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMenus.java
@@ -34,7 +34,7 @@ public class SurveyMenus implements Iterable<SurveyMenus.Section> {
 
         CLDRFile b = stFactory.sm.getEnglishFile();
         phf = PathHeader.getFactory(b);
-        for (String xp : b) {
+        for (String xp : b.iterableDefault()) {
             phf.fromPath(xp);
         }
         for (String xp : b.getExtraPaths()) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
@@ -46,7 +46,7 @@ public class VettingViewerQueue {
      */
     private static int pathCount(CLDRFile f) {
         int jj = 0;
-        for (@SuppressWarnings("unused") String s : f) {
+        for (@SuppressWarnings("unused") String s : f.iterableDefault()) {
             jj++;
         }
         return jj;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -103,7 +103,7 @@ public class VoteAPIHelper {
             resp.addAll(test.getPossibleProblems());
 
             // add all non-path status
-            for (final String x : cldrFile) {
+            for (final String x : cldrFile.iterableDefault()) {
                 List<CheckStatus> result = new ArrayList<CheckStatus>();
                 test.check(x, result, cldrFile.getStringValue(x));
                 for (final CheckStatus s : result) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Whatis.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Whatis.java
@@ -94,7 +94,7 @@ public class Whatis {
                 continue;
             }
             XpathResult r = null;
-            for (String xp : f) {
+            for (String xp : f.iterableDefault()) {
                 String str = f.getStringValue(xp);
                 what.pathsSearched++;
                 if (str.contains(q2)) {

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSTFactory.java
@@ -73,7 +73,7 @@ public class TestSTFactory {
         STFactory fac = getFactory();
         CLDRFile mt = fac.make(locale, false);
         BallotBox<User> box = fac.ballotBoxForLocale(locale);
-        mt.iterator();
+        mt.iteratorWithoutExtras();
         final String somePath = "//ldml/localeDisplayNames/keys/key[@type=\"collation\"]";
         box.getValues(somePath);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/api/CldrFileDataSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/api/CldrFileDataSource.java
@@ -29,7 +29,7 @@ final class CldrFileDataSource implements CldrData {
         Iterator<String> paths;
         switch (order) {
             case ARBITRARY:
-                paths = source.iterator();
+                paths = source.iteratorWithoutExtras();
                 break;
 
             case NESTED_GROUPING:
@@ -42,11 +42,11 @@ final class CldrFileDataSource implements CldrData {
                 // visited
                 // consecutively. It also (like DTD ordering) greatly improves the performance when
                 // parsing paths because consecutive paths share common parent elements.
-                paths = source.iterator(null, Comparator.naturalOrder());
+                paths = source.iteratorWithoutExtras(null, Comparator.naturalOrder());
                 break;
 
             case DTD:
-                paths = source.iterator(null, source.getComparator());
+                paths = source.iteratorWithoutExtras(null, source.getComparator());
                 break;
 
             default:

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/ExtractCountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/ExtractCountItems.java
@@ -153,7 +153,7 @@ public class ExtractCountItems {
 
     SampleData getSamples(
             CLDRFile cldr, int keywordCount, String prefix, Map<String, SampleData> data) {
-        for (String path : With.in(cldr.iterator(prefix, cldr.getComparator()))) {
+        for (String path : With.in(cldr.iteratorWithoutExtras(prefix, cldr.getComparator()))) {
             if (!path.contains("@count")) {
                 continue;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/JsonConverter.java
@@ -63,7 +63,8 @@ public class JsonConverter {
                     file.isNonInheriting() ? suppInfo : mainInfo;
             final Item main = new TableItem(null);
             DtdType dtdType = null;
-            for (Iterator<String> it = file.iterator("", file.getComparator()); it.hasNext(); ) {
+            for (Iterator<String> it = file.iteratorWithoutExtras("", file.getComparator());
+                    it.hasNext(); ) {
                 final String xpath = it.next();
                 final String fullXpath = file.getFullXPath(xpath);
                 String value = file.getStringValue(xpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -562,7 +562,8 @@ public class Ldml2JsonConverter {
         // read paths in DTD order. The order is critical for JSON processing.
         final CLDRFile.Status status = new CLDRFile.Status();
         for (Iterator<String> it =
-                        file.iterator("", DtdData.getInstance(fileDtdType).getDtdComparator(null));
+                        file.iteratorWithoutExtras(
+                                "", DtdData.getInstance(fileDtdType).getDtdComparator(null));
                 it.hasNext(); ) {
             int cv = Level.UNDETERMINED.getLevel();
             final String path = it.next();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIXUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIXUtilities.java
@@ -168,7 +168,8 @@ public class POSIXUtilities {
                             + "\"]/substitute";
 
             for (Iterator<String> it =
-                            char_fallbk.iterator(SearchLocation, char_fallbk.getComparator());
+                            char_fallbk.iteratorWithoutExtras(
+                                    SearchLocation, char_fallbk.getComparator());
                     it.hasNext() && !SubFound; ) {
                 String path = it.next();
                 substituteString = char_fallbk.getStringValue(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/BuildIcuCompactDecimalFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/BuildIcuCompactDecimalFormat.java
@@ -141,7 +141,7 @@ public class BuildIcuCompactDecimalFormat {
                         ? "//ldml/numbers/decimalFormats[@numberSystem=\"latn\"]/decimalFormatLength"
                         : "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength";
 
-        Iterator<String> it = resolvedCldrFile.iterator(prefix);
+        Iterator<String> it = resolvedCldrFile.iteratorWithoutExtras(prefix);
 
         String styleString = style.toString().toLowerCase(Locale.ENGLISH);
         while (it.hasNext()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -138,7 +138,7 @@ public class CLDRTest extends TestFmwk {
             boolean isPOSIX = locale.indexOf("POSIX") >= 0;
             logln("Testing: " + locale);
             CLDRFile item = cldrFactory.make(locale, false);
-            for (String xpath : item) {
+            for (String xpath : item.iterableDefault()) {
                 NumericType type = NumericType.getNumericType(xpath);
                 if (type == NumericType.NOT_NUMERIC) continue;
                 String value = item.getStringValue(xpath);
@@ -186,7 +186,7 @@ public class CLDRTest extends TestFmwk {
                 // Whenever two values for the same xpath are different, we remove from
                 // currentValues, and add to
                 // okValues
-                for (String xpath : item) {
+                for (String xpath : item.iterableDefault()) {
                     if (okValues.contains(xpath)) continue;
                     if (xpath.startsWith("//ldml/identity/")) continue; // skip identity elements
                     String v = item.getStringValue(xpath);
@@ -255,7 +255,7 @@ public class CLDRTest extends TestFmwk {
             int count = 0;
             localeMissing.clear();
             file:
-            for (String xpath : plain) {
+            for (String xpath : plain.iterableDefault()) {
                 for (int i = 0; i < EXEMPLAR_SKIPS.length; ++i) {
                     if (xpath.indexOf(EXEMPLAR_SKIPS[i]) > 0) continue file; // skip some items.
                 }
@@ -512,7 +512,7 @@ public class CLDRTest extends TestFmwk {
             }
             collisions.clear();
 
-            for (Iterator<String> it2 = item.iterator(); it2.hasNext(); ) {
+            for (Iterator<String> it2 = item.iteratorWithoutExtras(); it2.hasNext(); ) {
                 String xpath = it2.next();
                 NameType nameType = NameType.fromPath(xpath);
                 if (nameType == NameType.NONE) continue;
@@ -551,7 +551,7 @@ public class CLDRTest extends TestFmwk {
      */
     public static void checkAttributeValidity(
             CLDRFile item, Map<String, Set<String>> badCodes, Set<String> xpathFailures) {
-        for (Iterator<String> it2 = item.iterator(); it2.hasNext(); ) {
+        for (Iterator<String> it2 = item.iteratorWithoutExtras(); it2.hasNext(); ) {
             String xpath = it2.next();
             XPathParts parts = XPathParts.getFrozenInstance(item.getFullXPath(xpath));
             for (int i = 0; i < parts.size(); ++i) {
@@ -762,7 +762,7 @@ public class CLDRTest extends TestFmwk {
         boolean SHOW = false;
         Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
         CLDRFile supp = cldrFactory.make(CLDRFile.SUPPLEMENTAL_NAME, false);
-        for (Iterator<String> it = supp.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = supp.iteratorWithoutExtras(); it.hasNext(); ) {
             String path = it.next();
             try {
                 XPathParts parts = XPathParts.getFrozenInstance(supp.getFullXPath(path));
@@ -1360,7 +1360,7 @@ public class CLDRTest extends TestFmwk {
             // Walk through all the xpaths, adding to currentValues
             // Whenever two values for the same xpath are different, we remove from currentValues,
             // and add to okValues
-            for (Iterator<String> it2 = item.iterator(); it2.hasNext(); ) {
+            for (Iterator<String> it2 = item.iteratorWithoutExtras(); it2.hasNext(); ) {
                 String xpath = it2.next();
                 if (xpath.indexOf("[@type=\"narrow\"]") >= 0) {
                     String value = item.getStringValue(xpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
@@ -305,7 +305,7 @@ public class CheckConsistentCasing extends FactoryCheckCLDR {
         boolean isRoot = "root".equals(resolved.getLocaleID());
         Set<String> missing = !DEBUG ? null : new TreeSet<>();
 
-        for (String path : resolved) {
+        for (String path : resolved.iterableDefault()) {
             if (!isRoot) {
                 String locale2 = resolved.getSourceLocaleID(path, null);
                 if (locale2.equals("root") || locale2.equals("code-fallback")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -220,7 +220,8 @@ public class CheckDates extends FactoryCheckCLDR {
 
         // load gregorian appendItems
         for (Iterator<String> it =
-                        resolved.iterator("//ldml/dates/calendars/calendar[@type=\"gregorian\"]");
+                        resolved.iteratorWithoutExtras(
+                                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]");
                 it.hasNext(); ) {
             String path = it.next();
             String value = resolved.getWinningValue(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDisplayCollisions.java
@@ -855,7 +855,8 @@ public class CheckDisplayCollisions extends FactoryCheckCLDR {
         // Pick up all instances in English where the exemplarCity and territory match
         // and include them as exceptions.
         exceptions = new HashMap<>();
-        for (Iterator<String> it = english.iterator(Type.ZONE.getPrefix()); it.hasNext(); ) {
+        for (Iterator<String> it = english.iteratorWithoutExtras(Type.ZONE.getPrefix());
+                it.hasNext(); ) {
             String xpath = it.next();
             if (!xpath.endsWith("/exemplarCity")) continue;
             String value = english.getStringValue(xpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ConsoleCheckCLDR.java
@@ -1686,7 +1686,7 @@ public class ConsoleCheckCLDR {
             boolean noaliases,
             boolean filterDraft,
             Collection<String> target) {
-        for (Iterator<String> pit = file.iterator(pathFilter); pit.hasNext(); ) {
+        for (Iterator<String> pit = file.iteratorWithoutExtras(pathFilter); pit.hasNext(); ) {
             String path = pit.next();
             addPrettyPath(file, pathHeaderFactory, noaliases, filterDraft, target, path);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CoverageLevel2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CoverageLevel2.java
@@ -392,7 +392,8 @@ public class CoverageLevel2 {
                         CLDRPaths.COMMON_DIRECTORY + "supplemental-temp/coverageLevels2.xml");
 
         CLDRFile cldrFile = testInfo.getCldrFactory().make(locale, true);
-        Set<String> paths = Builder.with(new TreeSet<String>()).addAll(cldrFile).get();
+        Set<String> paths =
+                Builder.with(new TreeSet<String>()).addAll(cldrFile.iterableDefault()).get();
         PathHeader.Factory phf = PathHeader.getFactory();
         Map<PathHeader, String> diff = new TreeMap<>();
         Map<PathHeader, String> same = new TreeMap<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DateOrder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DateOrder.java
@@ -68,7 +68,7 @@ public class DateOrder implements Comparable<DateOrder> {
             Matcher typeMatcher = PatternCache.get("\\[@type=\"([^\"]*)\"]").matcher("");
             int[] soFar = new int[50];
             int lenSoFar = 0;
-            for (String path : resolved) {
+            for (String path : resolved.iterableDefault()) {
                 if (DateTimePatternType.STOCK_AVAILABLE_INTERVAL_PATTERNS.contains(
                         DateTimePatternType.fromPath(path))) {
                     if (path.contains("[@id=\"Ed\"]")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
@@ -255,7 +255,7 @@ class FlexibleDateFromCLDR {
         // ...dateTimeFormats/availableFormats/dateFormatItem[@id="..."][@count="..."][@draft="..."]
         // ...dateTimeFormats/availableFormats/dateFormatItem[@id="..."][@alt="variant"]
         boolean isRoot = file.getLocaleID().equals("root");
-        for (Iterator<String> it = file.iterator(toppath); it.hasNext(); ) {
+        for (Iterator<String> it = file.iteratorWithoutExtras(toppath); it.hasNext(); ) {
             String path = it.next();
             int startIndex = path.indexOf(DATE_FORMAT_ITEM_ID_PREFIX);
             if (startIndex < 0 || path.indexOf("[@alt=", startIndex) >= 0) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateTime.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateTime.java
@@ -132,7 +132,8 @@ public class FlexibleDateTime {
         {
             Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
             CLDRFile supp = cldrFactory.make(CLDRFile.SUPPLEMENTAL_NAME, false);
-            for (Iterator<String> it = supp.iterator("//supplementalData/metadata/alias/");
+            for (Iterator<String> it =
+                            supp.iteratorWithoutExtras("//supplementalData/metadata/alias/");
                     it.hasNext(); ) {
                 String path = it.next();
                 XPathParts parts = XPathParts.getFrozenInstance(supp.getFullXPath(path));
@@ -374,7 +375,7 @@ public class FlexibleDateTime {
                 System.out.println();
             }
             CLDRFile item = cldrFactory.make(locale, false);
-            for (String xpath : item) {
+            for (String xpath : item.iterableDefault()) {
                 if (!isGregorianPattern(xpath)) {
                     continue;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/OutdatedPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/OutdatedPaths.java
@@ -166,7 +166,7 @@ public class OutdatedPaths {
         Map<Long, PathHeader> result = new HashMap<>();
         CLDRFile english = factory.make("en", true);
         PathHeader.Factory pathHeaders = PathHeader.getFactory(english);
-        for (String s : english) {
+        for (String s : english.iterableDefault()) {
             long id = StringId.getId(s);
             PathHeader pathHeader = pathHeaders.fromPath(s);
             result.put(id, pathHeader);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/QuickCheck.java
@@ -212,7 +212,7 @@ public class QuickCheck {
                     locale + "\t-\t" + english.nameGetter().getNameFromIdentifier(locale));
             DtdType dtdType = null;
 
-            for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = file.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 if (path.endsWith("/alias")) {
                     continue;
@@ -341,7 +341,7 @@ public class QuickCheck {
             }
 
             CLDRFile root = cldrFactory.make("root", true);
-            for (Iterator<String> it = root.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = root.iteratorWithoutExtras(); it.hasNext(); ) {
                 pathToLocale.removeAll(it.next());
             }
             if (showInfo)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMetadata.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMetadata.java
@@ -209,7 +209,7 @@ public class TestMetadata {
 
     private static void testZones(CLDRFile metadata) {
         String zoneList = null;
-        for (Iterator<String> it = metadata.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = metadata.iteratorWithoutExtras(); it.hasNext(); ) {
             String key = it.next();
             if (key.indexOf("\"$tzid\"") >= 0) {
                 zoneList = metadata.getStringValue(key);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMetazones.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMetazones.java
@@ -141,7 +141,7 @@ public class TestMetazones {
             CLDRFile file,
             Relation<String, DateRangeAndZone> mzoneToData,
             Relation<String, DateRangeAndZone> zoneToDateRanges) {
-        for (String path : file) {
+        for (String path : file.iterableDefault()) {
             if (path.contains("/usesMetazone")) {
                 /*
                  * Sample: <zone type="Asia/Yerevan"> <usesMetazone to="1991-09-23"
@@ -787,7 +787,7 @@ public class TestMetazones {
     }
 
     boolean fileHasMetazones(CLDRFile file) {
-        for (String path : file) {
+        for (String path : file.iterableDefault()) {
             if (path.contains("usesMetazone")) return true;
         }
         return false;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
@@ -212,7 +212,8 @@ public class TestMisc {
         CLDRFile en = cldrFactory.make("root", true);
         Status status = new Status();
         Matcher m = PatternCache.get("gregorian.*dayPeriods").matcher("");
-        for (Iterator<String> it = en.iterator(null, en.getComparator()); it.hasNext(); ) {
+        for (Iterator<String> it = en.iteratorWithoutExtras(null, en.getComparator());
+                it.hasNext(); ) {
             String path = it.next();
             if (!m.reset(path).find()) {
                 continue;
@@ -564,7 +565,7 @@ public class TestMisc {
             if (cldrFile.isNonInheriting()) {
                 continue;
             }
-            for (Iterator<String> it2 = cldrFile.iterator(); it2.hasNext(); ) {
+            for (Iterator<String> it2 = cldrFile.iteratorWithoutExtras(); it2.hasNext(); ) {
                 String path = it2.next();
                 if (dtdType == null) {
                     dtdType = DtdType.fromPath(path);
@@ -607,7 +608,7 @@ public class TestMisc {
         String requestedLocale = "en";
         CLDRFile cldrFile = cldrFactory.make(requestedLocale, true);
         CLDRFile.Status status = new CLDRFile.Status();
-        for (Iterator<String> it = cldrFile.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = cldrFile.iteratorWithoutExtras(); it.hasNext(); ) {
             String requestedPath = it.next();
             String localeWhereFound = cldrFile.getSourceLocaleID(requestedPath, status);
             if (!localeWhereFound.equals(requestedLocale)
@@ -638,7 +639,8 @@ public class TestMisc {
         HashMap<String, Set<String>> foundItems = new HashMap<>();
         TreeSet<String> problems = new TreeSet<>();
         for (Iterator<String> it =
-                        cldrFile.iterator("", new UTF16.StringComparator(true, false, 0));
+                        cldrFile.iteratorWithoutExtras(
+                                "", new UTF16.StringComparator(true, false, 0));
                 it.hasNext(); ) {
             String requestedPath = it.next();
             XPathParts parts = XPathParts.getFrozenInstance(requestedPath);
@@ -714,7 +716,8 @@ public class TestMisc {
         CLDRFile supp = cldrFactory.make("supplementalData", false);
         CLDRFile temp = SimpleFactory.makeFile("supplemental");
         temp.setNonInheriting(true);
-        for (Iterator<String> it = supp.iterator(null, supp.getComparator()); it.hasNext(); ) {
+        for (Iterator<String> it = supp.iteratorWithoutExtras(null, supp.getComparator());
+                it.hasNext(); ) {
             String path = it.next();
             String value = supp.getStringValue(path);
             String fullPath = supp.getFullXPath(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRCompare.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRCompare.java
@@ -76,13 +76,13 @@ public class CLDRCompare {
                 CLDRFile newCldrFile = null;
                 try {
                     newCldrFile = cldrFactory.make(file, false);
-                    newCldrFile.forEach(paths::add);
+                    newCldrFile.iterableDefault().forEach(paths::add);
                 } catch (Exception e) {
                 }
                 CLDRFile oldCldrFile = null;
                 try {
                     oldCldrFile = oldFactory.make(file, false);
-                    oldCldrFile.forEach(paths::add);
+                    oldCldrFile.iterableDefault().forEach(paths::add);
                 } catch (Exception e1) {
                 }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRFilePseudolocalizer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRFilePseudolocalizer.java
@@ -403,7 +403,7 @@ public class CLDRFilePseudolocalizer {
         // Create input CLDRFile object resolving inherited data.
         CLDRFile input = factory.make(ORIGINAL_LOCALE, false);
         XMLSource outputSource = new SimpleXMLSource(outputLocale);
-        for (String xpath : input) {
+        for (String xpath : input.iterableWithoutExtras()) {
             String fullPath = input.getFullXPath(xpath);
             String value = input.getStringValue(xpath);
             if (!value.isEmpty()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRFileTransformer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRFileTransformer.java
@@ -239,7 +239,7 @@ public class CLDRFileTransformer {
         outputParent = factory.make(inputLocale, false);
         XMLSource outputSource = new SimpleXMLSource(localeTransform.toString());
         DisplayAndInputProcessor daip = new DisplayAndInputProcessor(output, true);
-        for (String xpath : input) {
+        for (String xpath : input.iterableDefault()) {
             String value = input.getStringValue(xpath);
             if (CldrUtility.INHERITANCE_MARKER.equals(value)) {
                 final String foundIn = input.getSourceLocaleID(xpath, null);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRFormat.java
@@ -98,8 +98,8 @@ public class CLDRFormat {
     private static String findFirstDifference(CLDRFile cldrFile, CLDRFile regenFile) {
         keys1.clear();
         keys2.clear();
-        cldrFile.forEach(keys1::add);
-        regenFile.forEach(keys2::add);
+        cldrFile.iterableDefault().forEach(keys1::add);
+        regenFile.iterableDefault().forEach(keys2::add);
         if (!keys1.equals(keys2)) {
             Set<String> missing = new TreeSet<>(keys1);
             missing.removeAll(keys2);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -516,11 +516,11 @@ public class CLDRModify {
                                 "//ldml/dates/calendars/calendar[@type=\"persian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"abbreviated\"]/alias";
                         System.out.println(k.getStringValue(testPath));
                         TreeSet s = new TreeSet();
-                        k.forEach(s::add);
+                        k.iterableDefault().forEach(s::add);
 
                         System.out.println(k.getStringValue(testPath));
                         Set orderedSet = new TreeSet(k.getComparator());
-                        k.forEach(orderedSet::add);
+                        k.iterableDefault().forEach(orderedSet::add);
                         for (Iterator it3 = orderedSet.iterator(); it3.hasNext(); ) {
                             String path = (String) it3.next();
                             if (path.equals(testPath)) {
@@ -665,7 +665,7 @@ public class CLDRModify {
 
     private static void removePosix(CLDRFile toMergeIn) {
         Set<String> toRemove = new HashSet<>();
-        for (String xpath : toMergeIn) {
+        for (String xpath : toMergeIn.iterableDefault()) {
             if (xpath.startsWith("//ldml/posix")) toRemove.add(xpath);
         }
         toMergeIn.removeAll(toRemove, false);
@@ -2532,7 +2532,7 @@ public class CLDRModify {
                             resolved = factory.make(cldrFileToFilter.getLocaleID(), true);
                         }
 
-                        for (String xpath : vxmlCommonMainFile) {
+                        for (String xpath : vxmlCommonMainFile.iterableDefault()) {
                             String vxmlValue = vxmlCommonMainFile.getStringValue(xpath);
                             if (vxmlValue == null) {
                                 continue;
@@ -3003,7 +3003,7 @@ public class CLDRModify {
                         String localeL1 =
                                 parentChain.get(parentChain.size() - 2); // get last before root
                         CLDRFile fileL1 = factory.make(localeL1, false); // only unresolved paths
-                        for (String path : fileL1) {
+                        for (String path : fileL1.iterableDefault()) {
                             if (!pathsHandled.contains(path)) {
                                 handlePath(path);
                             }
@@ -3195,13 +3195,13 @@ public class CLDRModify {
         Map<String, ValuePair> haveSameValues = new TreeMap<>();
         CLDRFile resolvedFile = cldrFactory.make(key, true);
         // get only those paths that are not in "root"
-        resolvedFile.forEach(skipPaths::add);
+        resolvedFile.iterableDefault().forEach(skipPaths::add);
 
         // first, collect all the paths
         for (String locale : availableChildren) {
             if (locale.indexOf("POSIX") >= 0) continue;
             CLDRFile item = cldrFactory.make(locale, false);
-            for (String xpath : item) {
+            for (String xpath : item.iterableDefault()) {
                 if (skipPaths.contains(xpath)) continue;
                 // skip certain elements
                 if (xpath.indexOf("/identity") >= 0) continue;
@@ -3248,7 +3248,7 @@ public class CLDRModify {
         CLDRFile replacements = SimpleFactory.makeFile("temp");
         fixList.setFile(k, inputOptions, cldrFactory, removal, replacements);
 
-        for (String xpath : k) {
+        for (String xpath : k.iterableDefault()) {
             fixList.handlePath(xpath);
         }
         fixList.handleEnd();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartGrammaticalForms.java
@@ -463,7 +463,7 @@ public class ChartGrammaticalForms extends Chart {
             Set<String> unitsToAddGrammar = new TreeSet<>(rawUnitsToAddGrammar);
             Map<PathHeader, String> minimalInfo = new TreeMap<>();
             PathHeader.Factory phf = PathHeader.getFactory();
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (!path.startsWith("//ldml/units/unitLength[@type=\"long\"]/unit")) {
                     if (path.startsWith("//ldml/numbers/minimalPairs/")) {
                         if (!path.contains("ordinal")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartSupplemental.java
@@ -60,7 +60,7 @@ public class ChartSupplemental extends Chart {
             pp.addAll(test.getPossibleProblems());
 
             // add all non-path status
-            for (final String x : cldrFile) {
+            for (final String x : cldrFile.iterableDefault()) {
                 List<CheckStatus> result = new ArrayList<CheckStatus>();
                 test.check(x, result, cldrFile.getStringValue(x));
                 for (final CheckStatus s : result) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEmojiAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CheckEmojiAnnotations.java
@@ -28,7 +28,7 @@ public class CheckEmojiAnnotations {
         UnicodeSet rgiNoVariant = Emoji.getAllRgiNoES();
         CLDRFile root = CLDRConfig.getInstance().getAnnotationsFactory().make("en", false);
         UnicodeSet rootEmoji = new UnicodeSet();
-        for (String path : root) {
+        for (String path : root.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String cp = parts.getAttributeValue(-1, "cp");
             if (cp != null && rgiNoVariant.contains(cp) == chooseEmoji) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareData.java
@@ -63,7 +63,7 @@ public class CompareData {
                 try {
                     CLDRFile oldFile = oldFactory.make(locale, false);
                     pathsSeen.clear();
-                    for (Iterator<String> it2 = file.iterator(); it2.hasNext(); ) {
+                    for (Iterator<String> it2 = file.iteratorWithoutExtras(); it2.hasNext(); ) {
                         String path = it2.next();
                         String value = file.getStringValue(path);
                         String oldValue = oldFile.getStringValue(path);
@@ -76,14 +76,14 @@ public class CompareData {
                         }
                         pathsSeen.add(path);
                     }
-                    for (Iterator<String> it2 = oldFile.iterator(); it2.hasNext(); ) {
+                    for (Iterator<String> it2 = oldFile.iteratorWithoutExtras(); it2.hasNext(); ) {
                         String path = it2.next();
                         if (!pathsSeen.contains(path)) {
                             deletedItems++;
                         }
                     }
                 } catch (Exception e) {
-                    newItems = size(file.iterator());
+                    newItems = size(file.iteratorWithoutExtras());
                 }
                 String langScript =
                         new LocaleIDParser().set(file.getLocaleID()).getLanguageScript();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareEmoji.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareEmoji.java
@@ -119,7 +119,7 @@ public class CompareEmoji {
     }
 
     public static void getDataIn(CLDRFile cldrfile, Map<String, EmojiData> result, Status status) {
-        for (String path : cldrfile) {
+        for (String path : cldrfile.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String cp = parts.getAttributeValue(-1, "cp");
             if (cp == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareEn.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareEn.java
@@ -80,7 +80,7 @@ public class CompareEn {
             // walk through all the new paths and values to check them.
 
             TreeSet<String> paths = new TreeSet<>();
-            en_GB.forEach(paths::add);
+            en_GB.iterableDefault().forEach(paths::add);
 
             for (String path : paths) {
                 // skip certain paths
@@ -183,8 +183,8 @@ public class CompareEn {
                 // walk through all the new paths and values to check them.
 
                 TreeSet<PathHeader> paths = new TreeSet<>();
-                en_GB.forEach(x -> paths.add(phf.fromPath(x)));
-                en_001.forEach(x -> paths.add(phf.fromPath(x)));
+                en_GB.iterableDefault().forEach(x -> paths.add(phf.fromPath(x)));
+                en_001.iterableDefault().forEach(x -> paths.add(phf.fromPath(x)));
 
                 main:
                 for (PathHeader pathHeader : paths) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareLocales.java
@@ -102,7 +102,7 @@ public class CompareLocales {
             prefix = "\t";
             CLDRFile cldrFile = factory.make(locale, true);
             files.add(cldrFile);
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 paths.add(path);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CompareResolved.java
@@ -124,8 +124,8 @@ public class CompareResolved {
             // get the union of paths
 
             Set<String> sortedPaths = new TreeSet<>(); // could sort by PathHeader also
-            sortedPaths.addAll(Sets.newTreeSet(sourceFile));
-            sortedPaths.addAll(Sets.newTreeSet(compareFile));
+            sortedPaths.addAll(Sets.newTreeSet(sourceFile.iterableDefault()));
+            sortedPaths.addAll(Sets.newTreeSet(compareFile.iterableDefault()));
 
             // cycle over the union of paths
             int filterCount = 0;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -659,7 +659,8 @@ public class ConvertLanguageData {
             // Set<String> available = cldrFactory.getAvailable();
             CLDRFile supplemental = cldrFactory.make("supplementalData", true);
             for (Iterator<String> it =
-                            supplemental.iterator("//supplementalData/languageData/language");
+                            supplemental.iteratorWithoutExtras(
+                                    "//supplementalData/languageData/language");
                     it.hasNext(); ) {
                 String xpath = it.next();
                 XPathParts parts = XPathParts.getFrozenInstance(xpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CopySubdivisionsIntoMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CopySubdivisionsIntoMain.java
@@ -102,7 +102,8 @@ public class CopySubdivisionsIntoMain {
             CLDRFile subdivisionFileOut = null;
 
             for (Iterator<String> subdivisionIterator =
-                            mainFile.iterator(SubdivisionNames.SUBDIVISION_PATH_PREFIX);
+                            mainFile.iteratorWithoutExtras(
+                                    SubdivisionNames.SUBDIVISION_PATH_PREFIX);
                     subdivisionIterator.hasNext(); ) {
                 String path = subdivisionIterator.next();
                 String value = mainFile.getStringValue(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -1144,7 +1144,7 @@ public class CountItems {
             CLDRFile item = cldrFactory.make(locale, false);
 
             temp.clear();
-            for (Iterator<String> it2 = item.iterator(); it2.hasNext(); ) {
+            for (Iterator<String> it2 = item.iteratorWithoutExtras(); it2.hasNext(); ) {
                 String path = it2.next();
                 if (alt.reset(path).matches()) {
                     continue;
@@ -1158,7 +1158,7 @@ public class CountItems {
 
             CLDRFile itemResolved = cldrFactory.make(locale, true);
             temp.clear();
-            itemResolved.forEach(temp::add);
+            itemResolved.iterableDefault().forEach(temp::add);
             int resolvedCurrent = temp.size();
 
             System.out.println(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffCldr.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffCldr.java
@@ -103,7 +103,7 @@ public class DiffCldr {
                 CLDRFile cldrFile = factory.make(locale, isBase);
                 DtdData dtdData = cldrFile.getDtdData();
                 CLDRFile cldrFileResolved = factory.make(locale, true);
-                for (String distinguishedPath : With.in(cldrFile.iterator())) {
+                for (String distinguishedPath : With.in(cldrFile.iteratorWithoutExtras())) {
                     String path = cldrFile.getFullXPath(distinguishedPath);
 
                     XPathParts pathPlain = XPathParts.getFrozenInstance(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/DiffWithParent.java
@@ -42,7 +42,7 @@ public class DiffWithParent {
                     CLDRFile parent = cldrFactory.make(parentLocale, true); // use
                     // resolved
                     // parent
-                    for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
+                    for (Iterator<String> it = file.iteratorWithoutExtras(); it.hasNext(); ) {
                         String path = it.next();
                         String value = file.getStringValue(path);
                         String fullPath = file.getFullXPath(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FilterFactory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FilterFactory.java
@@ -131,7 +131,7 @@ public class FilterFactory extends Factory {
                         .getLocaleCoverageLevel(organization, rawFile.getLocaleID())
                         .getLevel();
         CoverageInfo covInfo = CLDRConfig.getInstance().getCoverageInfo();
-        for (String xpath : rawFile) {
+        for (String xpath : rawFile.iterableDefault()) {
             // Locale metadata shouldn't be stripped.
             int level = covInfo.getCoverageValue(xpath, rawFile.getLocaleID());
             if (level > minLevel) {
@@ -151,7 +151,7 @@ public class FilterFactory extends Factory {
         String parent = LocaleIDParser.getParent(rawFile.getLocaleID());
         CLDRFile resolvedParent = rawFactory.make(parent, true);
         List<String> duplicatePaths = new ArrayList<>();
-        for (String xpath : rawFile) {
+        for (String xpath : rawFile.iterableDefault()) {
             if (xpath.startsWith("//ldml/identity")) {
                 continue;
             }
@@ -288,10 +288,10 @@ public class FilterFactory extends Factory {
                         file.add(filteringPath, value);
                     }
                 } else {
-                    Iterator<String> iterator = file.iterator();
+                    Iterator<String> iterator = file.iteratorWithoutExtras();
                     if (filteringPath != null) {
                         Matcher matcher = PatternCache.get(filteringPath).matcher("");
-                        iterator = file.iterator(matcher);
+                        iterator = file.iteratorWithoutExtras(matcher);
                     }
                     while (iterator.hasNext()) {
                         String xpath = iterator.next();
@@ -327,7 +327,7 @@ public class FilterFactory extends Factory {
         public void modifyFile(CLDRFile file) {
             if (xpathLookup.size() > 0) {
                 Output<String[]> arguments = new Output<>();
-                for (String xpath : file) {
+                for (String xpath : file.iterableDefault()) {
                     String newValue = xpathLookup.get(xpath, null, arguments, null, null);
                     if (newValue != null) {
                         String newPath = RegexLookup.replace(newValue, arguments.value);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindFlipFlops.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindFlipFlops.java
@@ -113,7 +113,7 @@ public class FindFlipFlops {
         CLDRFile[] files = new CLDRFile[factories.length];
         DisplayAndInputProcessor[] processors = new DisplayAndInputProcessor[factories.length];
         setUpFilesAndProcessors(fileName, files, processors);
-        for (String xpath : files[0]) {
+        for (String xpath : files[0].iterableDefault()) {
             xpath = xpath.intern();
             final String base = getProcessedStringValue(xpath, files[0], processors[0]);
             final ArrayList<String> history = new ArrayList<>();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindHardInheritance.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindHardInheritance.java
@@ -127,7 +127,7 @@ public class FindHardInheritance {
         CLDRFile cldrFile = factory.make(localeId, true, DraftStatus.contributed);
         CLDRFile unresolvedCldrFile = factory.make(localeId, false, DraftStatus.contributed);
 
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (path.startsWith("//ldml/identity/")) {
                 continue;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindPreferredHours.java
@@ -124,7 +124,7 @@ public class FindPreferredHours {
             // continue;
             // }
             final CLDRFile cldrFile = factory.make(locale, true);
-            for (String path : With.in(cldrFile)) {
+            for (String path : With.in(cldrFile.iterableDefault())) {
                 // if (path.contains("/timeFormats")) {
                 // System.out.println(path);
                 // }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindWidths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/FindWidths.java
@@ -48,7 +48,7 @@ public class FindWidths {
         Map<PathHeader, Data> maxWidths = new TreeMap<>();
         Set<String> sampleLocales = StandardCodes.make().getLocaleCoverageLocales("google");
 
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             PathHeader ph = phf.fromPath(path);
             PageId pageId = ph.getPageId();
             SectionId sectionId = ph.getSectionId();
@@ -66,7 +66,7 @@ public class FindWidths {
             }
             System.out.println(locale);
             CLDRFile file = CLDR_FACTORY.make(locale, false);
-            for (String path : file) {
+            for (String path : file.iterableDefault()) {
                 PathHeader ph = phf.fromPath(path);
                 Integer englishWidth = englishWidths.get(ph);
                 if (englishWidth == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateAliases.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateAliases.java
@@ -260,7 +260,7 @@ public class GenerateAliases {
                 wholeAliasCache.put(localeID, false);
                 return false;
             }
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (path.startsWith("//ldml/identity")) {
                     continue;
                 } else if (path.startsWith("//ldml/alias")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateBirth.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateBirth.java
@@ -300,7 +300,7 @@ public class GenerateBirth {
             System.out.println(String.format("%s\tDone", file));
             birthToPaths = Relation.of(new TreeMap<CldrVersion, Set<String>>(), TreeSet.class);
             pathToBirthCurrentPrevious = new HashMap<>();
-            for (String xpath : files[0]) {
+            for (String xpath : files[0].iterableDefault()) {
                 xpath = xpath.intern();
                 if (xpath.contains("[@type=\"ar\"]")) {
                     int debug = 0;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCasingChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCasingChart.java
@@ -114,7 +114,7 @@ public class GenerateCasingChart {
             Level level = StandardCodes.make().getLocaleCoverageLevel("cldr", locale);
             boolean hasCasedLetters = changesUpper.containsSome(exemplars);
             Set<String> items = new LinkedHashSet<>();
-            cldrFile.iterator("//ldml/contextTransforms").forEachRemaining(items::add);
+            cldrFile.iteratorWithoutExtras("//ldml/contextTransforms").forEachRemaining(items::add);
             if (!hasCasedLetters) {
                 if (items.size() != 0) {
                     System.out.println(locale + "Uncased language has context!!!");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateChangeChart.java
@@ -76,7 +76,7 @@ public class GenerateChangeChart {
                     counter.add(s, 0); // just to have values
                 }
 
-                for (String path : oldFile) {
+                for (String path : oldFile.iterableDefault()) {
                     Level level = coverage.getCoverageLevel(path, locale);
                     if (level.compareTo(Level.MODERN) > 0) {
                         continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateComparison.java
@@ -178,11 +178,11 @@ public class GenerateComparison {
             Set<String> paths;
             try {
                 paths = new HashSet<>();
-                oldFile.forEach(paths::add);
+                oldFile.iterableDefault().forEach(paths::add);
                 if (oldList.contains(locale)) {
                     paths.addAll(oldFile.getExtraPaths());
                 }
-                newFile.forEach(paths::add);
+                newFile.iterableDefault().forEach(paths::add);
                 if (newList.contains(locale)) {
                     paths.addAll(newFile.getExtraPaths());
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateCoverageLevels.java
@@ -105,7 +105,7 @@ public class GenerateCoverageLevels {
         String locale = "en";
         Set<String> sorted =
                 Builder.with(new TreeSet<String>())
-                        .addAll(cldrFile.iterator())
+                        .addAll(cldrFile.iteratorWithoutExtras())
                         .addAll(cldrFile.getExtraPaths())
                         .get();
         Set<R3<Level, String, Inheritance>> items = new TreeSet<>(new RowComparator());
@@ -517,7 +517,7 @@ public class GenerateCoverageLevels {
             Set<String> ordinals,
             Set<String> spellout,
             Set<String> others) {
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (path.endsWith("/alias")) {
                 continue;
             }
@@ -628,7 +628,7 @@ public class GenerateCoverageLevels {
 
     private static void getCollationData(
             String locale, CLDRFile cldrFile, Set<String> localesFound) {
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (path.endsWith("/alias")) {
                 continue;
             }
@@ -665,7 +665,7 @@ public class GenerateCoverageLevels {
         Status status = new Status();
         Set<String> sorted =
                 Builder.with(new TreeSet<String>())
-                        .addAll(cldrFile.iterator())
+                        .addAll(cldrFile.iteratorWithoutExtras())
                         .addAll(cldrFile.getExtraPaths())
                         .get();
         CoverageInfo coverageInfo = CLDRConfig.getInstance().getCoverageInfo();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriods.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDayPeriods.java
@@ -85,7 +85,7 @@ public class GenerateDayPeriods {
         Map<DayPeriod, String> result = new TreeMap<>();
         final String dayPeriodLocalization =
                 "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dayPeriods/dayPeriodContext[@type=\"stand-alone\"]/dayPeriodWidth[@type=\"wide\"]"; // [@type=\"stand-alone\"]/dayPeriodWidth[@type=\"wide\"]"
-        for (String path2 : With.in(localeFile.iterator())) {
+        for (String path2 : With.in(localeFile.iteratorWithoutExtras())) {
             if (!path2.startsWith(dayPeriodLocalization) || path2.endsWith("/alias")) {
                 continue;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedAnnotations.java
@@ -244,7 +244,7 @@ public class GenerateDerivedAnnotations {
             CLDRFile cldrFileResolved = factory.make(locale, true);
             Set<String> toRemove = new TreeSet<>(); // TreeSet just makes debugging easier
             boolean gotOne = false;
-            for (String xpath : cldrFileUnresolved) {
+            for (String xpath : cldrFileUnresolved.iterableDefault()) {
                 if (xpath.startsWith("//ldml/identity")) {
                     continue;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnglishChanged.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnglishChanged.java
@@ -53,8 +53,8 @@ public class GenerateEnglishChanged {
         CLDRFile englishLastRelease = factoryLastRelease.make("en", true);
 
         Set<String> paths = new TreeSet<>();
-        With.in(englishTrunk).toCollection(paths);
-        With.in(englishLastRelease).toCollection(paths);
+        With.in(englishTrunk.iterableDefault()).toCollection(paths);
+        With.in(englishLastRelease.iterableDefault()).toCollection(paths);
         PathStarrer starrer = new PathStarrer();
         final String placeholder = "×";
         starrer.setSubstitutionPattern(placeholder);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnums.java
@@ -439,7 +439,8 @@ public class GenerateEnums {
         unlimitedCurrencyCodes =
                 Relation.of(new TreeMap<String, Set<String>>(), TreeSet.class, null);
         for (Iterator<String> it =
-                        supplementalData.iterator("//supplementalData/currencyData/region");
+                        supplementalData.iteratorWithoutExtras(
+                                "//supplementalData/currencyData/region");
                 it.hasNext(); ) {
             String path = it.next();
             XPathParts parts = XPathParts.getFrozenInstance(path);
@@ -508,7 +509,8 @@ public class GenerateEnums {
     public void getContainment() {
         // <group type="001" contains="002 009 019 142 150"/> <!--World -->
         for (Iterator<String> it =
-                        supplementalData.iterator("//supplementalData/territoryContainment/group");
+                        supplementalData.iteratorWithoutExtras(
+                                "//supplementalData/territoryContainment/group");
                 it.hasNext(); ) {
             String path = it.next();
             String fullPath = supplementalData.getFullXPath(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateExampleDependencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateExampleDependencies.java
@@ -84,7 +84,7 @@ public class GenerateExampleDependencies {
         cldrFile.disableCaching();
 
         Set<String> paths = new TreeSet<>(cldrFile.getComparator());
-        cldrFile.forEach(paths::add); // time-consuming
+        cldrFile.iterableDefault().forEach(paths::add); // time-consuming
 
         ExampleGenerator egTest = new ExampleGenerator(cldrFile, englishFile);
         // Caching MUST be disabled for egTest.ICUServiceBuilder to prevent some dependencies from

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateG2xG2.java
@@ -406,7 +406,7 @@ public class GenerateG2xG2 {
             territory_currency = new TreeMap<>();
             Factory cldrFactory = Factory.make(CLDRPaths.MAIN_DIRECTORY, ".*");
             CLDRFile supp = cldrFactory.make(CLDRFile.SUPPLEMENTAL_NAME, false);
-            for (String path : supp) {
+            for (String path : supp.iterableDefault()) {
                 if (path.indexOf("/currencyData") >= 0) {
                     // <region iso3166="AR">
                     // <currency iso4217="ARS" from="1992-01-01"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateNumberingSystemAliases.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateNumberingSystemAliases.java
@@ -79,7 +79,7 @@ public class GenerateNumberingSystemAliases {
                 xpp.setElement(-1, element);
                 xpp.setAttribute(-1, "numberSystem", ns);
                 final String basePath = xpp.toString();
-                if (!root.iterator(basePath).hasNext()) {
+                if (!root.iteratorWithoutExtras(basePath).hasNext()) {
                     missing.put(Pair.of(ns, element), basePath);
                 }
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateProductionData.java
@@ -347,7 +347,8 @@ public class GenerateProductionData {
             boolean debugLocale = localeId.equals("pt");
 
             ImmutableSet<String> sortedPaths =
-                    ImmutableSortedSet.copyOf(cldrFileUnresolved); // sort for debugging
+                    ImmutableSortedSet.copyOf(
+                            cldrFileUnresolved.iterableDefault()); // sort for debugging
 
             for (String xpath : sortedPaths) {
                 if (xpath.startsWith("//ldml/identity")) {
@@ -511,7 +512,7 @@ public class GenerateProductionData {
 
                 // double-check results
                 int count = 0;
-                for (String xpath : outCldrFile) {
+                for (String xpath : outCldrFile.iterableDefault()) {
                     if (debugPath != null
                             && localeId.equals(debugLocale)
                             && xpath.equals(debugPath)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateSidewaysView.java
@@ -720,7 +720,7 @@ public class GenerateSidewaysView {
                 continue;
             }
             if (cldrFile.isNonInheriting()) continue;
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (pathMatcher != null && !pathMatcher.reset(path).matches()) {
                     continue;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTempDateData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTempDateData.java
@@ -36,7 +36,8 @@ public class GenerateTempDateData {
             System.out.println(locale);
             boolean gotOne = false;
             for (Iterator<String> it2 =
-                            file.iterator("//ldml/dates/calendars/calendar[@type=\"gregorian\"]/");
+                            file.iteratorWithoutExtras(
+                                    "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/");
                     it2.hasNext(); ) {
                 String path = it2.next();
                 if (path.indexOf("dateTimeFormats/availableFormats/dateFormatItem") >= 0) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GetChanges.java
@@ -106,7 +106,7 @@ public class GetChanges {
 
         int countNew = 0;
         int countChanged = 0;
-        for (String path : vxmlFileUnresolved) {
+        for (String path : vxmlFileUnresolved.iterableDefault()) {
             if (path.contains("/identity")) {
                 continue;
             }
@@ -240,7 +240,7 @@ public class GetChanges {
         Output<String> pathWhereFound = new Output<>();
 
         CLDRFile englishCldrFile = trunkFactory.make("en", false);
-        final Set<String> paths = ImmutableSet.copyOf(englishCldrFile.iterator());
+        final Set<String> paths = ImmutableSet.copyOf(englishCldrFile.iteratorWithoutExtras());
         System.out.println("english paths: " + paths.size());
 
         Multimap<String, PathHeader> missing = TreeMultimap.create();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListCoverageLevels.java
@@ -68,7 +68,7 @@ public class ListCoverageLevels {
             CLDRFile file = mainAndAnnotationsFactory.make(locale, false);
             CoverageLevel2 coverageLeveler = CoverageLevel2.getInstance(locale);
             System.out.println(locale);
-            for (String path : file) {
+            for (String path : file.iterableDefault()) {
                 Level level = coverageLeveler.getLevel(path);
                 String skeleton = starrer.set(path);
                 levelToCounter.get(level).add(skeleton);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListUnits.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListUnits.java
@@ -205,7 +205,8 @@ public class ListUnits {
                         + main.getFirst().toPattern(false)
                         + ", "
                         + main.getSecond().toPattern(false));
-        for (Iterator<String> it = cldrFile.iterator("//ldml/numbers/otherNumberingSystems");
+        for (Iterator<String> it =
+                        cldrFile.iteratorWithoutExtras("//ldml/numbers/otherNumberingSystems");
                 it.hasNext(); ) {
             String path = it.next();
             String otherNumberingSystem = cldrFile.getWinningValue(path);
@@ -286,7 +287,7 @@ public class ListUnits {
 
     private static Set<String> getUnits(CLDRFile cldrFile, Task task, Map<String, Data> extra) {
         Set<String> seen = new TreeSet<>();
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (!path.contains("/unit")) {
                 continue;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/Misc.java
@@ -1128,7 +1128,7 @@ public class Misc {
         CLDRFile english = cldrFactory.make("en", true);
         Collator col = Collator.getInstance(new ULocale(locale));
         CLDRFile supp = cldrFactory.make(CLDRFile.SUPPLEMENTAL_NAME, false);
-        for (Iterator<String> it = supp.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = supp.iteratorWithoutExtras(); it.hasNext(); ) {
             String path = it.next();
             XPathParts parts = XPathParts.getFrozenInstance(supp.getFullXPath(path));
             Map<String, String> m = parts.findAttributes("language");
@@ -1136,7 +1136,7 @@ public class Misc {
 
         // territories
         Map<String, Collection<String>> groups = new TreeMap<>();
-        for (Iterator<String> it = supp.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = supp.iteratorWithoutExtras(); it.hasNext(); ) {
             String path = it.next();
             XPathParts parts = XPathParts.getFrozenInstance(supp.getFullXPath(path));
             Map<String, String> m = parts.findAttributes("territoryContainment");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PivotData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PivotData.java
@@ -68,7 +68,8 @@ public class PivotData {
             throws IOException {
         CLDRFile supplementalMetadata = cldrFactory.make("supplementalMetadata", false);
         if (false)
-            for (Iterator<String> it = supplementalMetadata.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = supplementalMetadata.iteratorWithoutExtras();
+                    it.hasNext(); ) {
                 System.out.println(it.next());
             }
         String defaultContentList =
@@ -131,7 +132,7 @@ public class PivotData {
             throw new IllegalArgumentException("File cannot be completely aliased: " + localeID);
         }
 
-        for (Iterator<String> it = me.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = me.iteratorWithoutExtras(); it.hasNext(); ) {
             String path = it.next();
             if (path.startsWith("//ldml/identity")) continue;
             String fullPath = me.getFullXPath(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PluralMinimalPairs.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PluralMinimalPairs.java
@@ -34,7 +34,8 @@ public class PluralMinimalPairs {
         try {
             samplePatterns = new PluralMinimalPairs();
             CLDRFile cldrFile = factory.make(ulocale, true);
-            for (Iterator<String> it = cldrFile.iterator("//ldml/numbers/minimalPairs/");
+            for (Iterator<String> it =
+                            cldrFile.iteratorWithoutExtras("//ldml/numbers/minimalPairs/");
                     it.hasNext(); ) {
                 String path = it.next();
                 String foundLocale = cldrFile.getSourceLocaleID(path, null);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PrepareRootAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PrepareRootAnnotations.java
@@ -18,7 +18,7 @@ public class PrepareRootAnnotations {
         Factory factoryAnnotations = SimpleFactory.make(CLDRPaths.ANNOTATIONS_DIRECTORY, ".*");
         CLDRFile oldAnnotations = factoryAnnotations.make("root", false);
         UnicodeMap<String> oldValues = new UnicodeMap<>();
-        for (String path : oldAnnotations) {
+        for (String path : oldAnnotations.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             if (parts.getElement(1).equals("identity")) {
                 continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/RemoveEmptyCldrFiles.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/RemoveEmptyCldrFiles.java
@@ -26,7 +26,7 @@ public class RemoveEmptyCldrFiles {
     }
 
     private static boolean isEmpty(CLDRFile cldrFile) {
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (!path.contains("/identity")) {
                 return false;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowChildren.java
@@ -48,7 +48,7 @@ public class ShowChildren {
             Set<String> children = entry.getValue();
             for (String child : children) {
                 CLDRFile file = cldrFactory.make(child, false);
-                for (String path : file) {
+                for (String path : file.iterableDefault()) {
                     if (path.startsWith("//ldml/identity")
                             || path.endsWith("/alias")
                             || path.endsWith("/commonlyUsed")) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowCoverageLevels.java
@@ -27,7 +27,7 @@ public class ShowCoverageLevels {
         CoverageInfo coverageInfo = CLDRConfig.getInstance().getCoverageInfo();
         for (String locale : testInfo.getCldrFactory().getAvailable()) {
             CLDRFile cldrFileToCheck = testInfo.getCldrFactory().make(locale, true);
-            for (String path : cldrFileToCheck) {
+            for (String path : cldrFileToCheck.iterableDefault()) {
                 String fullPath = cldrFileToCheck.getFullXPath(path);
                 if (fullPath == null) {
                     continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowData.java
@@ -187,13 +187,13 @@ public class ShowData {
 
                 // get all of the paths
                 Set<String> allPaths = new HashSet<>();
-                file.forEach(allPaths::add);
+                file.iterableDefault().forEach(allPaths::add);
 
                 if (!locale.equals("root")) {
                     for (String childLocale : children) {
                         CLDRFile childCldrFile = cldrFactory.make(childLocale, false);
                         if (childCldrFile != null) {
-                            childCldrFile.forEach(allPaths::add);
+                            childCldrFile.iterableDefault().forEach(allPaths::add);
                         }
                         sublocales.put(childLocale, childCldrFile);
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowInconsistentAvailable.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowInconsistentAvailable.java
@@ -160,7 +160,7 @@ public class ShowInconsistentAvailable {
         CLDRFile cldrFile = f.make(locale, false);
         DateIntervalInfo fInfo = new DateIntervalInfo(new ULocale(locale)).freeze();
 
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             String value = cldrFile.getStringValue(path);
             if (value == null || value.isBlank() || value.equals("↑↑↑")) {
                 continue;
@@ -211,7 +211,7 @@ public class ShowInconsistentAvailable {
         Set<String> calendars = new TreeSet<>();
         final CLDRFile root = CONFIG.getRoot();
 
-        for (String path : root) {
+        for (String path : root.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             if (!parts.getElement(-1).equals("dateFormatItem")) {
                 continue;
@@ -276,7 +276,7 @@ public class ShowInconsistentAvailable {
 
         Multimap<String, PathHeader> sorted = TreeMultimap.create();
 
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             if (!parts.getElement(-1).equals("dateFormatItem")) {
                 continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -824,7 +824,7 @@ public class ShowLanguages {
 
         public LanguageInfo(Factory cldrFactory) throws IOException {
             CLDRFile supp = cldrFactory.make(CLDRFile.SUPPLEMENTAL_NAME, false);
-            for (Iterator<String> it = supp.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = supp.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 String fullPath = supp.getFullXPath(path);
                 if (fullPath == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPathHeaderDescriptions.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPathHeaderDescriptions.java
@@ -94,7 +94,7 @@ public class ShowPathHeaderDescriptions {
 
         Set<String> urls = new TreeSet<>();
 
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             PathHeader pathHeader = phf.fromPath(path);
             String pdx = pathDescriptionFactory.getRawDescription(path, null);
             String url;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowRegionalVariants.java
@@ -136,7 +136,7 @@ public class ShowRegionalVariants {
                     // childDiffs.add(child, 0); // make sure it shows up
                     String childString = child.toString();
                     CLDRFile childFile = FACTORY.make(childString, false, DraftStatus.contributed);
-                    for (String path : childFile) {
+                    for (String path : childFile.iterableDefault()) {
                         if (SKIP_SUPPRESSED_PATHS) {
                             if (path.contains("/currency") && path.contains("/symbol")) {
                                 continue;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -386,7 +386,7 @@ public class ShowStarredCoverage {
 
         Counter<Level> counter = new Counter<>();
         TreeSet<PathHeader> pathHeaders = new TreeSet<>();
-        for (String path : file) {
+        for (String path : file.iterableDefault()) {
             if (path.endsWith("/alias") || path.startsWith("//ldml/identity")) {
                 continue;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VettingAdder.java
@@ -140,7 +140,7 @@ public class VettingAdder {
             fixXML(dir, locale + ".xml", dir, fixedLocale);
             CLDRFile cldr =
                     SimpleFactory.makeFromFile(dir + fixedLocale, locale, DraftStatus.approved);
-            for (Iterator<String> it3 = cldr.iterator(); it3.hasNext(); ) {
+            for (Iterator<String> it3 = cldr.iteratorWithoutExtras(); it3.hasNext(); ) {
                 String path = it3.next();
                 String value = cldr.getStringValue(path);
                 String fullPath = cldr.getFullXPath(path);
@@ -285,7 +285,7 @@ public class VettingAdder {
         for (Iterator<String> it = availableLocales.iterator(); it.hasNext(); ) {
             String locale = it.next();
             CLDRFile cldr = cldrFactory.make(locale, false);
-            for (Iterator<String> it2 = cldr.iterator(); it2.hasNext(); ) {
+            for (Iterator<String> it2 = cldr.iteratorWithoutExtras(); it2.hasNext(); ) {
                 String path = it2.next();
                 String fullPath = cldr.getFullXPath(path);
                 if (fullPath.indexOf("[@draft=") >= 0) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/resolver/ResolverUtils.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/resolver/ResolverUtils.java
@@ -28,13 +28,13 @@ public class ResolverUtils {
      * Get the set of paths with non-null values from a CLDR file (including all extra paths).
      *
      * @param file the CLDRFile from which to extract paths
-     * @return a Set containing all the paths returned by {@link CLDRFile#iterator()}, plus those
-     *     from {@link CLDRFile#getExtraPaths(java.util.Collection)}
+     * @return a Set containing all the paths returned by {@link CLDRFile#iteratorWithoutExtras()},
+     *     plus those from {@link CLDRFile#getExtraPaths(java.util.Collection)}
      */
     public static Set<String> getAllPaths(CLDRFile file) {
         String locale = file.getLocaleID();
         Set<String> paths = new HashSet<>();
-        for (String path : file) {
+        for (String path : file.iterableDefault()) {
             paths.add(path);
         }
         for (String path : file.getExtraPaths()) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CharacterFallbacks.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CharacterFallbacks.java
@@ -25,7 +25,8 @@ public class CharacterFallbacks {
                 DtdData.getInstance(DtdType.supplementalData).getDtdComparator(null);
 
         for (Iterator<String> it =
-                        characterFallbacks.iterator("//supplementalData/characters/", comp);
+                        characterFallbacks.iteratorWithoutExtras(
+                                "//supplementalData/characters/", comp);
                 it.hasNext(); ) {
             String path = it.next();
             String fullPath = characterFallbacks.getFullXPath(path);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -232,7 +232,7 @@ public class DateTimeFormats {
         // appendItems result.setAppendItemFormat(getAppendFormatNumber(formatName), value);
         for (String path :
                 With.in(
-                        file.iterator(
+                        file.iteratorWithoutExtras(
                                 "//ldml/dates/calendars/calendar[@type=\""
                                         + calendarID
                                         + "\"]/dateTimeFormats/appendItems/appendItem"))) {
@@ -248,7 +248,7 @@ public class DateTimeFormats {
 
         // field names result.setAppendItemName(i, value);
         // ldml/dates/fields/field[@type="day"]/displayName
-        for (String path : With.in(file.iterator("//ldml/dates/fields/field"))) {
+        for (String path : With.in(file.iteratorWithoutExtras("//ldml/dates/fields/field"))) {
             if (!path.contains("displayName")) {
                 continue;
             }
@@ -265,7 +265,7 @@ public class DateTimeFormats {
 
         for (String path :
                 With.in(
-                        file.iterator(
+                        file.iteratorWithoutExtras(
                                 "//ldml/dates/calendars/calendar[@type=\""
                                         + calendarID
                                         + "\"]/dateTimeFormats/availableFormats/dateFormatItem"))) {
@@ -288,7 +288,7 @@ public class DateTimeFormats {
         // ldml/dates/calendars/calendar[@type=\"gregorian\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"yMMMEd\"]/greatestDifference[@id=\"d\"]
         for (String path :
                 With.in(
-                        file.iterator(
+                        file.iteratorWithoutExtras(
                                 "//ldml/dates/calendars/calendar[@type=\""
                                         + calendarID
                                         + "\"]/dateTimeFormats/intervalFormats/intervalFormatItem"))) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodConverter.java
@@ -159,7 +159,7 @@ public class DayPeriodConverter {
                 // System.out.println("\t<dayPeriodContext type=\"stand-alone\">");
                 // System.out.println("\t\t<dayPeriodWidth type=\"wide\">");
                 CLDRFile cldrFile = factory.make(locale, false);
-                for (String path : cldrFile) {
+                for (String path : cldrFile.iterableDefault()) {
                     if (path.endsWith("/alias")) {
                         continue;
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdDataCheck.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdDataCheck.java
@@ -220,7 +220,7 @@ public class DtdDataCheck {
                 Comparator<String> comp = dtdData.getDtdComparator(null);
                 CLDRFile test = ToolConfig.getToolInstance().getEnglish();
                 Set<String> sorted = new TreeSet(test.getComparator());
-                test.forEach(sorted::add);
+                test.iterableDefault().forEach(sorted::add);
                 String[] sortedArray = sorted.toArray(new String[sorted.size()]);
 
                 // compare for identity

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtractCollationRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtractCollationRules.java
@@ -26,7 +26,7 @@ public class ExtractCollationRules {
 
         String context = null;
 
-        for (Iterator it = file.iterator("//ldml/collations", file.getComparator());
+        for (Iterator it = file.iteratorWithoutExtras("//ldml/collations", file.getComparator());
                 it.hasNext(); ) {
 
             // System.out.print(rules.substring(lastLen, rules.length()));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -779,7 +779,8 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
             for (String path :
                     With.in(
                             config.getRoot()
-                                    .iterator("//ldml/units/unitLength[@type=\"short\"]/unit"))) {
+                                    .iteratorWithoutExtras(
+                                            "//ldml/units/unitLength[@type=\"short\"]/unit"))) {
                 XPathParts parts = XPathParts.getFrozenInstance(path);
                 String unit = parts.getAttributeValue(3, "type");
                 // Add simple units

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TestUtilities.java
@@ -149,7 +149,7 @@ public class TestUtilities {
         StringBuilder result = new StringBuilder();
         Relation<String, String> message_paths =
                 Relation.of(new TreeMap<String, Set<String>>(), TreeSet.class);
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             String value = english.getStringValue(path);
             result.setLength(0);
             String examples = englishExampleGenerator.getExampleHtml(path, value);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TimezoneFormatter.java
@@ -776,7 +776,7 @@ public class TimezoneFormatter extends UFormat {
         String countryPrefix = "//ldml/localeDisplayNames/territories/territory[@type=\"";
         Map<String, Comparable> localizedNonWall = new HashMap<>();
         Set<String> skipDuplicates = new HashSet<>();
-        for (Iterator<String> it = desiredLocaleFile.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = desiredLocaleFile.iteratorWithoutExtras(); it.hasNext(); ) {
             String path = it.next();
             // dumb, simple implementation
             if (path.startsWith(prefix)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/personname/PersonNameFormatter.java
@@ -1916,7 +1916,7 @@ public class PersonNameFormatter {
         Map<ULocale, Order> _localeToOrder = new TreeMap<>();
 
         // read out the data and order it properly
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (path.startsWith("//ldml/personNames") && !path.endsWith("/alias")) {
                 String value = cldrFile.getStringValue(path);
                 // System.out.println(path + ",\t" + value);
@@ -2130,7 +2130,7 @@ public class PersonNameFormatter {
                         new TreeMap<SampleType, Object>(),
                         new TreeMap<ModifiedField, Object>(),
                         String.class);
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (path.startsWith("//ldml/personNames/sampleName")) {
                 // ldml/personNames/sampleName[@item="full"]/nameField[@type="prefix"]
                 String value = cldrFile.getStringValue(path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/CheckYear.java
@@ -335,7 +335,7 @@ public class CheckYear {
             }
             for (String path :
                     With.in(
-                            file.iterator(
+                            file.iteratorWithoutExtras(
                                     "//ldml/dates/calendars/calendar[@type=\""
                                             + calendarID
                                             + "\"]/dateTimeFormats/availableFormats/dateFormatItem"))) {
@@ -346,7 +346,7 @@ public class CheckYear {
             }
             for (String path :
                     With.in(
-                            file.iterator(
+                            file.iteratorWithoutExtras(
                                     "//ldml/dates/calendars/calendar[@type=\""
                                             + calendarID
                                             + "\"]/dateTimeFormats/intervalFormats/intervalFormatItem"))) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NumberingSystemsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/NumberingSystemsTest.java
@@ -17,7 +17,7 @@ public class NumberingSystemsTest extends TestFmwk {
 
     public void TestFile() {
         CLDRFile file = testInfo.getSupplementalFactory().make("numberingSystems", false);
-        for (String path : file) {
+        for (String path : file.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             if (!"numberingSystems".equals(parts.getElement(1))) {
                 continue;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -45,7 +45,7 @@ public class TestAlt extends TestFmwk {
 
         for (String locale : available) {
             CLDRFile cldrFile = cldrFactory.make(locale, false);
-            for (String xpath : cldrFile) {
+            for (String xpath : cldrFile.iterableDefault()) {
                 if (altPaths.containsKey(xpath)) {
                     continue;
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -520,11 +520,14 @@ public class TestAnnotations extends TestFmwkPlus {
         Factory factoryAnnotations = SimpleFactory.make(CLDRPaths.ANNOTATIONS_DIRECTORY, ".*");
         ImmutableSet<String> rootPaths =
                 ImmutableSortedSet.copyOf(
-                        factoryAnnotations.make("root", false).iterator("//ldml/annotations/"));
+                        factoryAnnotations
+                                .make("root", false)
+                                .iteratorWithoutExtras("//ldml/annotations/"));
 
         CLDRFile englishAnnotations = factoryAnnotations.make("en", false);
         ImmutableSet<String> englishPaths =
-                ImmutableSortedSet.copyOf(englishAnnotations.iterator("//ldml/annotations/"));
+                ImmutableSortedSet.copyOf(
+                        englishAnnotations.iteratorWithoutExtras("//ldml/annotations/"));
 
         Set<String> superfluous2 = setDifference(rootPaths, englishPaths);
         assertTrue("en contains root", superfluous2.isEmpty());
@@ -540,7 +543,9 @@ public class TestAnnotations extends TestFmwkPlus {
         for (String locale : factoryAnnotations.getAvailable()) {
             ImmutableSet<String> currentPaths =
                     ImmutableSortedSet.copyOf(
-                            factoryAnnotations.make(locale, false).iterator("//ldml/annotations/"));
+                            factoryAnnotations
+                                    .make(locale, false)
+                                    .iteratorWithoutExtras("//ldml/annotations/"));
             Set<String> superfluous = setDifference(currentPaths, rootPaths);
             if (!assertTrue("root contains " + locale, superfluous.isEmpty())) {
                 int debug = 0;
@@ -647,7 +652,7 @@ public class TestAnnotations extends TestFmwkPlus {
         Set<String> nonEmojiPages = expectedMap.values();
         UnicodeMap<Pair<String, String>> failures = new UnicodeMap<>();
         PathHeader.Factory phf = PathHeader.getFactory();
-        for (String path : root) {
+        for (String path : root.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String cp = parts.getAttributeValue(-1, "cp");
             if (cp == null) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBCP47.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBCP47.java
@@ -51,13 +51,15 @@ public class TestBCP47 extends TestFmwk {
                     new TreeMap<String, Object>(), new TreeMap<String, Object>(), String.class);
 
     static {
-        for (String path : With.in(ENGLISH.iterator("//ldml/localeDisplayNames/keys/key"))) {
+        for (String path :
+                With.in(ENGLISH.iteratorWithoutExtras("//ldml/localeDisplayNames/keys/key"))) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String value = ENGLISH.getStringValue(path);
             String key = parts.getAttributeValue(-1, "type");
             keyTypeTranslations.put(key, "", value);
         }
-        for (String path : With.in(ENGLISH.iterator("//ldml/localeDisplayNames/types/type"))) {
+        for (String path :
+                With.in(ENGLISH.iteratorWithoutExtras("//ldml/localeDisplayNames/types/type"))) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String value = ENGLISH.getStringValue(path);
             String key = parts.getAttributeValue(-1, "key");
@@ -66,7 +68,7 @@ public class TestBCP47 extends TestFmwk {
         }
         for (String path :
                 With.in(
-                        ENGLISH.iterator(
+                        ENGLISH.iteratorWithoutExtras(
                                 "//ldml/localeDisplayNames/transformNames/transformName"))) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String value = ENGLISH.getStringValue(path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBasic.java
@@ -205,7 +205,7 @@ public class TestBasic extends TestFmwkPlus {
                 ) {
                     CLDRFile cldrfile =
                             CLDRFile.loadFromFile(fileName, "temp", DraftStatus.unconfirmed);
-                    for (String xpath : cldrfile) {
+                    for (String xpath : cldrfile.iterableDefault()) {
                         String fullPath = cldrfile.getFullXPath(xpath);
                         if (fullPath == null) {
                             fullPath = cldrfile.getFullXPath(xpath);
@@ -426,7 +426,7 @@ public class TestBasic extends TestFmwkPlus {
                             .freeze();
             UnicodeSet badSoFar = new UnicodeSet();
 
-            for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = file.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 if (path.endsWith("/alias")) {
                     continue;
@@ -545,7 +545,7 @@ public class TestBasic extends TestFmwkPlus {
             if (file.isNonInheriting()) continue;
             logln(locale + "\t-\t" + english.nameGetter().getNameFromIdentifier(locale));
 
-            for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = file.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 if (path.endsWith("/alias")) {
                     continue;
@@ -621,7 +621,7 @@ public class TestBasic extends TestFmwkPlus {
 
             logln(locale + "\t-\t" + english.nameGetter().getNameFromIdentifier(locale));
 
-            for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = file.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 if (dtdType == null) {
                     dtdType = DtdType.fromPath(path);
@@ -805,7 +805,7 @@ public class TestBasic extends TestFmwkPlus {
                 continue;
             }
             // we check that the default content locale is always empty
-            for (Iterator<String> it = cldrFile.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = cldrFile.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 if (path.contains("/identity")) {
                     continue;
@@ -907,7 +907,7 @@ public class TestBasic extends TestFmwkPlus {
         PathHeader.Factory phf = PathHeader.getFactory(testInfo.getEnglish());
         for (String child : children) {
             CLDRFile cldrFile = testInfo.getCLDRFile(child, false);
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (path.contains("/identity")) {
                     continue;
                 }
@@ -1047,7 +1047,7 @@ public class TestBasic extends TestFmwkPlus {
         final String localeParent = LocaleIDParser.getParent(locale);
         CLDRFile parentFile = testInfo.getCLDRFile(localeParent, true);
         int funnyCount = 0;
-        for (Iterator<String> it = cldrFile.iterator("", cldrFile.getComparator());
+        for (Iterator<String> it = cldrFile.iteratorWithoutExtras("", cldrFile.getComparator());
                 it.hasNext(); ) {
             String path = it.next();
             if (path.contains("/identity")) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -447,7 +447,7 @@ public class TestCLDRFile extends TestFmwk {
 
     public void checkLocale(CLDRFile cldr) {
         Matcher m = PatternCache.get("gregorian.*eras").matcher("");
-        for (Iterator<String> it = cldr.iterator("", new UTF16.StringComparator());
+        for (Iterator<String> it = cldr.iteratorWithoutExtras("", new UTF16.StringComparator());
                 it.hasNext(); ) {
             String path = it.next();
             if (m.reset(path).find() && !path.contains("alias")) {
@@ -496,7 +496,7 @@ public class TestCLDRFile extends TestFmwk {
 
         deltaTime = System.currentTimeMillis();
         for (int j = 0; j < 2; ++j) {
-            for (Iterator<String> it = english.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = english.iteratorWithoutExtras(); it.hasNext(); ) {
                 String dpath = it.next();
                 String value = english.getStringValue(dpath);
                 Set<String> paths = english.getPathsWithValue(value, "", null, null);
@@ -908,7 +908,7 @@ public class TestCLDRFile extends TestFmwk {
 
     public void TestSwissHighGerman() {
         CLDRFile swissHighGerman = testInfo.getCommonSeedExemplarsFactory().make("de_CH", true);
-        for (String xpath : swissHighGerman) {
+        for (String xpath : swissHighGerman.iterableDefault()) {
             if (xpath.equals("//ldml/characters/exemplarCharacters[@type=\"auxiliary\"]")) {
                 continue;
             }
@@ -930,7 +930,7 @@ public class TestCLDRFile extends TestFmwk {
         PathHeader.Factory pathHeaderFactory = PathHeader.getFactory(testInfo.getEnglish());
         Status status = new Status();
 
-        for (String xpath : af) {
+        for (String xpath : af.iterableDefault()) {
             if (missing.contains(xpath)) {
                 String value = af.getStringValue(xpath);
                 String source = af.getSourceLocaleID(xpath, status);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckAltOnly.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckAltOnly.java
@@ -176,7 +176,7 @@ public class TestCheckAltOnly extends TestFmwk {
             possibleErrors.clear();
         }
         Map<String, List<CheckStatus>> found = new HashMap<>();
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             String value = cldrFile.getStringValue(path);
             ch.check(path, path, value, options, possibleErrors);
             if (!possibleErrors.isEmpty()) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -122,7 +122,7 @@ public class TestCheckCLDR extends TestFmwk {
         List<CheckStatus> possibleErrors = new ArrayList<>();
         final CLDRFile english = testInfo.getEnglish();
         c.setCldrFileToCheck(english, new CheckCLDR.Options(options), possibleErrors);
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             c.check(
                     path,
                     english.getFullXPath(path),
@@ -156,7 +156,7 @@ public class TestCheckCLDR extends TestFmwk {
             List<CheckStatus> possibleErrors = new ArrayList<>();
             int pathCount = 0;
             double startTime = System.currentTimeMillis();
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 String fullPath = cldrFile.getFullXPath(path);
                 String value = cldrFile.getStringValue(path);
                 bundle.check(fullPath, possibleErrors, value);
@@ -515,7 +515,7 @@ public class TestCheckCLDR extends TestFmwk {
         CLDRFile patched = nativeFile; // new CLDRFile(override);
         PathHeader.Factory pathHeaderFactory = PathHeader.getFactory(english);
         Set<PathHeader> sorted = new TreeSet<>();
-        for (String path : patched) {
+        for (String path : patched.iterableDefault()) {
             final PathHeader pathHeader = pathHeaderFactory.fromPath(path);
             if (pathHeader != null) {
                 sorted.add(pathHeader);
@@ -1073,7 +1073,7 @@ public class TestCheckCLDR extends TestFmwk {
             CLDRFile cldrFileUnresolved = testInfo.getCldrFactory().make(locale, false);
 
             Set<PathHeader> sorted = new TreeSet<>();
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 PathHeader ph = pathHeaderFactory.fromPath(path);
                 sorted.add(ph);
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckDisplayCollisions.java
@@ -166,7 +166,7 @@ public class TestCheckDisplayCollisions extends TestFmwkPlus {
             possibleErrors.clear();
         }
         Map<String, List<CheckStatus>> found = new HashMap<>();
-        for (String path : cldrFileResolved) {
+        for (String path : cldrFileResolved.iterableDefault()) {
             String value = cldrFileResolved.getStringValue(path);
             // System.out.println(path + "\t" + value);
             if (path.equals(deciLong)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFactory.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrFactory.java
@@ -92,7 +92,7 @@ public class TestCldrFactory extends TestFmwkPlus {
 
     private Status checkAnnotations(CLDRFile cldrFile) {
         Status status = Status.none;
-        for (String xpath : cldrFile) {
+        for (String xpath : cldrFile.iterableWithoutExtras()) {
             if (xpath.startsWith("//ldml/identity")) continue;
             boolean isAnnotation = xpath.startsWith("//ldml/annotation");
             if (isAnnotation) {
@@ -125,7 +125,7 @@ public class TestCldrFactory extends TestFmwkPlus {
      */
     private String getUncontainedPath(CLDRFile subset, CLDRFile superset) {
         int debugCount = 0;
-        for (String xpath : subset) {
+        for (String xpath : subset.iterableWithoutExtras()) {
             if (++debugCount < 100) {
                 logln(debugCount + "\t" + xpath);
             }
@@ -148,8 +148,8 @@ public class TestCldrFactory extends TestFmwkPlus {
     private String differentPathValue(CLDRFile a, CLDRFile b) {
         int debugCount = 0;
         Set<String> paths = new TreeSet<>();
-        a.forEach(paths::add);
-        b.forEach(paths::add);
+        a.iterableDefault().forEach(paths::add);
+        b.iterableDefault().forEach(paths::add);
         for (String xpath : paths) {
             if (++debugCount < 100) {
                 logln(debugCount + "\t" + xpath);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrResolver.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCldrResolver.java
@@ -77,7 +77,7 @@ public class TestCldrResolver extends TestFmwkPlus {
             // Resolve with the tool
             CLDRFile file = resolver.resolveLocale(locale);
             Map<String, String> values = new HashMap<String, String>();
-            for (String path : file) {
+            for (String path : file.iterableDefault()) {
                 values.put(path, file.getStringValue(path));
             }
             return values;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollators.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCollators.java
@@ -88,7 +88,7 @@ public class TestCollators extends TestFmwk {
             CLDRFile cldrFile = cldrFactory.make(locale, false); // don't need resolved
             Set<String> results = new LinkedHashSet<>();
             Matcher m = TYPE.matcher("");
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (m.reset(path).matches()) {
                     String type = m.group(1);
                     boolean newOne = results.add(type);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -1073,7 +1073,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
 
         // Get root LSR codes
 
-        for (String path : root) {
+        for (String path : root.iterableDefault()) {
             if (!path.startsWith("//ldml/localeDisplayNames/")) {
                 continue;
             }
@@ -1269,7 +1269,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
         Output<String> pathWhereFound = new Output<>();
         Output<String> localeWhereFound = new Output<>();
         Set<Row.R5<String, String, Boolean, Boolean, Level>> inherited = new TreeSet<>();
-        for (String path : ENGLISH) {
+        for (String path : ENGLISH.iterableDefault()) {
             String value = ENGLISH.getStringValueWithBailey(path, pathWhereFound, localeWhereFound);
             final boolean samePath = path.equals(pathWhereFound.value);
             final boolean sameLocale = "en".equals(localeWhereFound.value);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDTDAttributes.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDTDAttributes.java
@@ -561,7 +561,7 @@ public class TestDTDAttributes extends TestFmwkPlus {
             for (String locale : testInfo.getCldrFactory().getAvailable()) {
                 CLDRFile file = testInfo.getCLDRFile(locale, false);
                 NodeData nodeData = null;
-                for (String xpath : file) {
+                for (String xpath : file.iterableDefault()) {
                     String value = file.getStringValue(xpath);
                     String fullXpath = file.getFullXPath(xpath);
                     XPathParts parts = XPathParts.getFrozenInstance(fullXpath);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDateOrder.java
@@ -116,7 +116,7 @@ public class TestDateOrder extends TestFmwk {
         Factory phf = PathHeader.getFactory();
 
         Set<PathHeader> paths = new TreeSet<>();
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             if (!path.startsWith("//ldml/dates/calendars/calendar[@type=\"gregorian\"]")) {
                 continue;
             } else if (path.startsWith(stockTimePathPrefix)

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDayPeriods.java
@@ -80,7 +80,7 @@ public class TestDayPeriods extends TestFmwkPlus {
             List<DayPeriod> periods = periodInfo.getPeriods();
             CLDRFile cldrFile = CONFIG.getCLDRFile(locale, false);
             for (Iterator<String> it =
-                            cldrFile.iterator(
+                            cldrFile.iteratorWithoutExtras(
                                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/dayPeriods/");
                     it.hasNext(); ) {
                 String path = it.next();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -342,7 +342,7 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
     private void showCldrFile(final CLDRFile cldrFile) {
         DisplayAndInputProcessor daip = new DisplayAndInputProcessor(cldrFile, true);
         Exception[] internalException = new Exception[1];
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             String value = cldrFile.getStringValue(path);
             if (value == null) {
                 continue; // values may be null, from extraPaths

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -925,7 +925,7 @@ public class TestExampleGenerator extends TestFmwk {
         final CLDRFile cldrFile = exampleGenerator.getCldrFile();
         for (String xpath :
                 With.in(
-                        cldrFile.iterator(
+                        cldrFile.iteratorWithoutExtras(
                                 "//ldml/dates/timeZoneNames", cldrFile.getComparator()))) {
             String value = cldrFile.getStringValue(xpath);
             String actual = exampleGenerator.getExampleHtml(xpath, value);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -860,7 +860,7 @@ public class TestInheritance extends TestFmwk {
         for (String locale : testInfo.getCldrFactory().getAvailable()) {
             CLDRFile cldrFileToCheck = testInfo.getCLDRFile(locale, false);
             int errors = 0;
-            for (String path : cldrFileToCheck) {
+            for (String path : cldrFileToCheck.iterableDefault()) {
                 if (!pathMatcher.reset(path).find()) {
                     continue;
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestLocale.java
@@ -235,7 +235,7 @@ public class TestLocale extends TestFmwkPlus {
         }
         // now check English-resolved
         CLDRFile english = testInfo.getEnglish();
-        for (String xpath : english) {
+        for (String xpath : english.iterableDefault()) {
             if (!xpath.startsWith("//ldml/localeDisplayNames/")) {
                 continue;
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestOutdatedPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestOutdatedPaths.java
@@ -24,7 +24,7 @@ public class TestOutdatedPaths extends TestFmwkPlus {
 
     public void TestBirths() {
         Multimap<CldrVersion, String> birthToPaths = TreeMultimap.create();
-        for (String path : testInfo.getEnglish()) {
+        for (String path : testInfo.getEnglish().iterableDefault()) {
             CldrVersion birth = outdatedPaths.getEnglishBirth(path);
             if (birth == null) birth = CldrVersion.unknown;
             birthToPaths.put(birth, path);
@@ -67,7 +67,7 @@ public class TestOutdatedPaths extends TestFmwkPlus {
 
         Map<PathHeader, String> sorted = new TreeMap<PathHeader, String>();
         logln(locale + " total outdated:\t" + outdatedPaths.countOutdated(locale));
-        for (String spath : cldrFile) {
+        for (String spath : cldrFile.iterableDefault()) {
             if (outdatedPaths.isOutdated(locale, spath)) {
                 sorted.put(pathHeaders.fromPath(spath), "");
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -887,7 +887,7 @@ public class TestPathHeader extends TestFmwkPlus {
             Set<String> alreadySeen) {
         CLDRFile nativeFile = info.getCLDRFile(localeID, resolved);
         int count = 0;
-        for (String path : nativeFile) {
+        for (String path : nativeFile.iterableDefault()) {
             if (alreadySeen.contains(path)) {
                 continue;
             }
@@ -1003,7 +1003,7 @@ public class TestPathHeader extends TestFmwkPlus {
         Map<String, String> collide = new TreeMap<>();
 
         logln("Traversing Paths");
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             PathHeader pathHeader = pathHeaderFactory.fromPath(path);
             String value = english.getStringValue(path);
             if (pathHeader == null) {
@@ -1416,7 +1416,8 @@ public class TestPathHeader extends TestFmwkPlus {
                 CLDRConfig.getInstance().getSupplementalFactory().make("supplementalData", false);
         List<String> failures = new ArrayList<>();
         Multimap<String, String> pathValuePairs = LinkedListMultimap.create();
-        for (String test : With.in(supplementalFile.iterator("//supplementalData/weekData"))) {
+        for (String test :
+                With.in(supplementalFile.iteratorWithoutExtras("//supplementalData/weekData"))) {
             failures.clear();
             XPathParts parts = XPathParts.getFrozenInstance(supplementalFile.getFullXPath(test));
             supplementalFile.getDtdData().getRegularizedPaths(parts, pathValuePairs);
@@ -1475,7 +1476,7 @@ public class TestPathHeader extends TestFmwkPlus {
         PathHeader.Factory phf = PathHeader.getFactory(CLDRConfig.getInstance().getEnglish());
         Counter<PageId> counterPageId = new Counter<>();
         Counter<PageId> counterPageIdAll = new Counter<>();
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             Level level =
                     CLDRConfig.getInstance()
                             .getSupplementalDataInfo()
@@ -1704,7 +1705,7 @@ public class TestPathHeader extends TestFmwkPlus {
             PathHeader.Factory phf = PathHeader.getFactory();
             Counter<PageId> c = new Counter<>();
             counters.add(c);
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 PathHeader ph = phf.fromPath(path);
                 c.add(ph.getPageId(), 1);
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathLookup.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathLookup.java
@@ -95,7 +95,7 @@ public class TestPathLookup extends TestFmwkPlus {
     public int countMatches(CLDRFile cldrFile) {
         String locale = cldrFile.getLocaleID();
         int count = 0;
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             String value = cldrFile.getStringValue(path);
             if (DowngradePaths.lookingAt("en", path, value)) {
                 logln(String.format("%s\t%s\t%s", locale, path, value));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -53,9 +53,9 @@ public class TestPaths extends TestFmwkPlus {
 
     public void VerifyEnglishVsRoot() {
         HashSet<String> rootPaths = new HashSet<>();
-        testInfo.getRoot().forEach(rootPaths::add);
+        testInfo.getRoot().iterableDefault().forEach(rootPaths::add);
         HashSet<String> englishPaths = new HashSet<>();
-        testInfo.getEnglish().forEach(englishPaths::add);
+        testInfo.getEnglish().iterableDefault().forEach(englishPaths::add);
         englishPaths.removeAll(rootPaths);
         if (englishPaths.size() == 0) {
             return;
@@ -136,7 +136,7 @@ public class TestPaths extends TestFmwkPlus {
             logln("Testing path headers and values for locale => " + locale);
             final Collection<String> extraPaths = file.getExtraPaths();
 
-            for (Iterator<String> it = file.iterator(); it.hasNext(); ) {
+            for (Iterator<String> it = file.iteratorWithoutExtras(); it.hasNext(); ) {
                 String path = it.next();
                 if (isExemptLocale && path.equals(exemptPathIfLocale)) {
                     logKnownIssue("CLDR-17544", "Can't reproduce locally");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPerf.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPerf.java
@@ -30,7 +30,7 @@ public class TestPerf extends TestFmwkPlus {
 
     static {
         Set<String> testPaths_ = new HashSet<String>();
-        CLDRConfig.getInstance().getEnglish().forEach(testPaths_::add);
+        CLDRConfig.getInstance().getEnglish().iterableDefault().forEach(testPaths_::add);
         testPaths = Collections.unmodifiableSet(testPaths_);
         Set<String> sorted = new TreeSet<String>(CLDRFile.getComparator(DtdType.ldml));
         sorted.addAll(testPaths);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -489,7 +489,7 @@ public class TestPersonNameFormatter extends TestFmwk {
         for (String localeId : Arrays.asList("en")) {
             final CLDRFile cldrFile = factory.make(localeId, true);
             ExampleGenerator exampleGenerator2 = new ExampleGenerator(cldrFile, ENGLISH);
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (path.startsWith("//ldml/personNames") && !path.endsWith("/alias")) {
                     XPathParts parts = XPathParts.getFrozenInstance(path);
                     String value = ENGLISH.getStringValue(path);
@@ -573,7 +573,7 @@ public class TestPersonNameFormatter extends TestFmwk {
         // List all the paths that have dependencies, so we can verify they are ok
 
         PathStarrer ps = new PathStarrer().setSubstitutionPattern("*");
-        for (String path : resolved) {
+        for (String path : resolved.iterableDefault()) {
             if (path.startsWith("//ldml/personNames") && !path.endsWith("/alias")) {
                 logln(ps.set(path));
             }
@@ -1470,7 +1470,7 @@ public class TestPersonNameFormatter extends TestFmwk {
     public void showMissingGiven() {
         for (String locale : StandardCodes.make().getLocaleCoverageLocales(Organization.cldr)) {
             CLDRFile cldrFile = factory.make(locale, false);
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (!path.startsWith("//ldml/personNames/personName")) {
                     continue;
                 }
@@ -1509,7 +1509,7 @@ public class TestPersonNameFormatter extends TestFmwk {
             CLDRFile cldrFile = factory.make(locale, false);
             StringBuilder b = new StringBuilder();
 
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (!path.startsWith("//ldml/personNames/personName")) {
                     continue;
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestStringByteConverter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestStringByteConverter.java
@@ -100,7 +100,7 @@ public class TestStringByteConverter {
         totalUtf8Bytes = totalBytes = 0;
         Factory cldrFactory = Factory.make(org.unicode.cldr.util.CLDRPaths.MAIN_DIRECTORY, ".*");
         CLDRFile file = cldrFactory.make(locale, false);
-        for (String path : file) {
+        for (String path : file.iterableDefault()) {
             if (path.contains("exemplarCh")) {
                 continue;
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -211,7 +211,7 @@ public class TestTransforms extends TestFmwkPlus {
 
             Set<String> latinFromCyrillicSucceeds = new TreeSet<>();
             Set<String> latinFromCyrillicFails = new TreeSet<>();
-            for (String path : uzCyrl) {
+            for (String path : uzCyrl.iterableDefault()) {
                 String latnValue = uzLatn.getStringValue(path);
                 if (latnValue == null) {
                     continue;
@@ -885,7 +885,7 @@ public class TestTransforms extends TestFmwkPlus {
             }
             badPlusSample.clear();
             CLDRFile file = factory.make(locale, false);
-            for (String path : file) {
+            for (String path : file.iterableWithoutExtras()) {
                 if (path.contains("/exemplar") || path.contains("/parseLenients")) {
                     continue;
                 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -189,7 +189,7 @@ public class TestUnits extends TestFmwk {
     public void TestSpaceInNarrowUnits() {
         final CLDRFile english = CLDR_CONFIG.getEnglish();
         final Matcher m = Pattern.compile("narrow.*unitPattern").matcher("");
-        for (String path : english) {
+        for (String path : english.iterableDefault()) {
             if (m.reset(path).find()) {
                 String value = english.getStringValue(path);
                 if (value.contains("} ")) {
@@ -2460,7 +2460,7 @@ public class TestUnits extends TestFmwk {
     }
 
     public Set<String> getUnits(CLDRFile root, Set<String> unitLongIds) {
-        for (String path : root) {
+        for (String path : root.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             int item = parts.findElement("unit");
             if (item == -1) {
@@ -2831,7 +2831,7 @@ public class TestUnits extends TestFmwk {
             checkUnits.setCldrFileToCheck(cldrFile, options, possibleErrors);
 
             for (String path :
-                    StreamSupport.stream(cldrFile.spliterator(), false)
+                    StreamSupport.stream(cldrFile.iterableDefault().spliterator(), false)
                             .sorted()
                             .collect(Collectors.toList())) {
                 UnitPathType pathType =
@@ -3018,7 +3018,7 @@ public class TestUnits extends TestFmwk {
                             new TreeMap<String, Object>(),
                             Boolean.class);
 
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableWithoutExtras()) {
                 if (!path.startsWith("//ldml/units/unitLength[@type=\"long\"]/unit[@type=")) {
                     continue;
                 }
@@ -3242,7 +3242,7 @@ public class TestUnits extends TestFmwk {
      */
     public Set<String> checkCldrFileUnits(String title, final CLDRFile cldrFile) {
         Set<String> shortUnitsFound = new TreeSet<>();
-        for (String path : cldrFile) {
+        for (String path : cldrFile.iterableDefault()) {
             if (!path.startsWith("//ldml/units/unitLength")) {
                 continue;
             }
@@ -3294,7 +3294,7 @@ public class TestUnits extends TestFmwk {
     public void TestEnglishDisplayNames() {
         CLDRFile en = CLDRConfig.getInstance().getEnglish();
         ImmutableSet<String> unitSkips = ImmutableSet.of("temperature-generic", "graphics-em");
-        for (String path : en) {
+        for (String path : en.iterableDefault()) {
             if (path.startsWith("//ldml/units/unitLength[@type=\"long\"]")
                     && path.endsWith("/displayName")) {
                 if (path.contains("coordinateUnit")) {
@@ -3371,7 +3371,8 @@ public class TestUnits extends TestFmwk {
         for (String path :
                 With.in(
                         config.getRoot()
-                                .iterator("//ldml/units/unitLength[@type=\"short\"]/unit"))) {
+                                .iteratorWithoutExtras(
+                                        "//ldml/units/unitLength[@type=\"short\"]/unit"))) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             String longUnit = parts.getAttributeValue(3, "type");
             // Add simple units

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/UnicodeSetPrettyPrinterTest.java
@@ -251,7 +251,7 @@ public class UnicodeSetPrettyPrinterTest extends TestFmwk {
                 localeNeedsEscape.addAll(source);
             }
             CLDRFile cldrFile2 = cldrFactory.make(locale, false); // just existing paths
-            for (String path : cldrFile2) {
+            for (String path : cldrFile2.iterableDefault()) {
                 String value = cldrFile2.getStringValue(path);
                 if (value.equals("↑↑↑")) {
                     continue;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -151,7 +151,7 @@ public class TestCLDRFile {
             /*final String value = */ file.getStringValue(xpath);
         }
 
-        for (Iterator<String> i = file.iterator(); i.hasNext(); ) {
+        for (Iterator<String> i = file.iteratorWithoutExtras(); i.hasNext(); ) {
             final String xpath = i.next();
             assertNotNull(xpath, subdir + ":" + id + " xpath");
             /*final String value = */ file.getStringValue(xpath);
@@ -159,7 +159,7 @@ public class TestCLDRFile {
         // This is to simulate what is in the LDML2JsonConverter
         final Comparator<String> comparator =
                 DtdData.getInstance(file.getDtdType()).getDtdComparator(null);
-        for (Iterator<String> it = file.iterator("", comparator); it.hasNext(); ) {
+        for (Iterator<String> it = file.iteratorWithoutExtras("", comparator); it.hasNext(); ) {
             final String xpath = it.next();
             assertNotNull(xpath, subdir + ":" + id + " xpath");
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPUAs.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPUAs.java
@@ -34,7 +34,7 @@ public class TestPUAs {
             CLDRFile cldrFile = INSTANCE.collatorFactory.make(locale, false); // don't need resolved
             Matcher m = INSTANCE.COLLATOR_TYPE.matcher("");
             Set<String> results = new LinkedHashSet<>();
-            for (String path : cldrFile) {
+            for (String path : cldrFile.iterableDefault()) {
                 if (m.reset(path).matches()) {
                     String type = m.group(1);
                     boolean newOne = results.add(type);

--- a/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/WikiSubdivisionLanguages.java
+++ b/tools/cldr-rdf/src/main/java/org/unicode/cldr/tool/WikiSubdivisionLanguages.java
@@ -387,7 +387,7 @@ public final class WikiSubdivisionLanguages {
         Set<String> toRemove = new HashSet<>();
         Map<String, String> toAdd = new HashMap<>();
 
-        for (String path : fileSubdivisions) {
+        for (String path : fileSubdivisions.iterableDefault()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
             if (!"subdivision".equals(parts.getElement(-1))) {
                 continue;


### PR DESCRIPTION
-Instead of Iterable interface, use new methods iterableDefault, iterableWithoutExtras

-Private boolean CLDRFile.DEFAULT_ITERABLE_INCLUDES_EXTRAS determines whether iterableDefault calls fullIterable or iterableWithoutExtras

-Call iterableWithoutExtras directly where tests would otherwise fail with DEFAULT_ITERABLE_INCLUDES_EXTRAS true

-Rename original iterator method to iteratorWithoutExtras

-Iterable and iterator are distinct: iterableWithoutExtras references iteratorWithoutExtras

-There is not yet any iteratorDefault (only iterableDefault)

CLDR-18217

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
