### PR TITLE
CLDR-18227 Add definitions for Tech Preview and Final Candidate

### DIFF
--- a/docs/site/index/process.md
+++ b/docs/site/index/process.md
@@ -8,7 +8,7 @@ title: CLDR Process
 
 This document describes the Unicode CLDR Technical Committee's process for data collection, resolution, public feedback and release.
 
-- The process is designed to be light-weight; in particular, the meetings are frequent, short, and informal. Most of the work is by email or phone, with a database recording requested changes (See [Requesting Changes](/requesting_changes)).
+- The process is designed to be light-weight; in particular, the meetings are frequent, short, and informal. Most of the discussion happens over email or in virtual meetings, with a database recording requested changes (see [Requesting Changes](/requesting_changes)).
 - When gathering data for a region and language, it is important to have multiple sources for that data to produce the most commonly used data. The initial versions of the data were based on best available sources, and updates with new and improvements are released twice a year with work by contributors inside and outside of the Unicode Consortium.
 - It is important to note that CLDR is a Repository, not a Registration. That is, contributors should NOT expect that their suggestions will simply be adopted into the repository; instead, it will be vetted by other contributors.
 - The [CLDR Survey Tool](https://st.unicode.org) is the main channel for collecting data, and bug/feature requests are tracked in a database ([file a ticket](/requesting_changes#how-to-file-a-ticket)).
@@ -24,7 +24,15 @@ The [UTS #35: Locale Data Markup Language (LDML)](https://www.unicode.org/report
 
 - Requests for changes are entered in the bug/feature request database ([file a ticket](/requesting_changes#how-to-file-a-ticket)).
 - Structural changes are always backwards-compatible. That is, previous files will continue to work. Deprecated elements remain, although their usage is strongly discouraged.
-- There is a standing policy for structural changes that require non-trivial code for proper implementation, such as time zone fallback or alias mechanisms. These require design discussions in the Technical Committee that demonstrates correct function according to the proposed specification.
+- There is a standing policy for structural changes that require non-trivial code for proper implementation, such as time zone fallback or alias mechanisms. These require design discussions in the [CLDR Design Working Group](https://cldr.unicode.org/cldr-tc/design-wg) and approval by the [CLDR Technical Committee](https://cldr.unicode.org/cldr-tc). Complex changes may require prototypes that demonstrate correct function according to the proposed specification.
+- New sections may be added to the specification with the status of _Technical Preview_ or _Final Candidate_. That depends on how comprehensive the new section is, what type of feedback the Technical Committee requires, and whether the feedback period needs to extend across one or more releases. These terms mean:
+    - **Technical Preview** - The specification section is fairly complete but not stable, included in the release to gather feedback.
+Features may be modified or removed based upon feedback.
+A section in Technical Preview remains in Technical Preview in the following release if more feedback is needed, or could advance to stable.
+It is similar to elements marked with [@TECHPREVIEW in the DTD as described in the LDML](https://www.unicode.org/reports/tr35/#dtd-annotations).
+    - **Final Candidate** - The specification section is complete and considered ready for release, and is expected to become stable in the next release. An optional Final Candidate stage follows a period of feedback in Technical Preview where final feedback is desired. Changes will only be made if serious issues are discovered during this feedback period.
+
+
 
 ## Data- Submission and Vetting
 

--- a/docs/site/index/process.md
+++ b/docs/site/index/process.md
@@ -28,7 +28,7 @@ The [UTS #35: Locale Data Markup Language (LDML)](https://www.unicode.org/report
 - New sections may be added to the specification with the status of _Technical Preview_ or _Final Candidate_. That depends on how comprehensive the new section is, what type of feedback the Technical Committee requires, and whether the feedback period needs to extend across one or more releases. These terms mean:
     - **Technical Preview** - The specification section is fairly complete but not stable, included in the release to gather feedback.
 Features may be modified or removed based upon feedback.
-A section in Technical Preview remains in Technical Preview in the following release if more feedback is needed, or could advance to stable.
+A section in Technical Preview may remain in Technical Preview in the following release if more feedback is needed, or could advance to Final Canidate or to stable.
 It is similar to elements marked with [@TECHPREVIEW in the DTD as described in the LDML](https://www.unicode.org/reports/tr35/#dtd-annotations).
     - **Final Candidate** - The specification section is complete and considered ready for release, and is expected to become stable in the next release. An optional Final Candidate stage follows a period of feedback in Technical Preview where final feedback is desired. Changes will only be made if serious issues are discovered during this feedback period.
 


### PR DESCRIPTION
CLDR-18227

Add definitions for Tech Preview and Final Candidate as part of the Spec changes section of the CLDR Process page

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
