### PR TITLE
CLDR-18105 Remove parent locale for Haitian Creole

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -451,7 +451,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="mai" to="mai_Deva_IN"/>		<!--Maithili‧?‧?	➡ Maithili‧Devanagari‧India-->
 		<likelySubtag from="mak" to="mak_Latn_ID"/>		<!--Makasar‧?‧?	➡ Makasar‧Latin‧Indonesia-->
 		<likelySubtag from="man" to="man_Latn_GM"/>		<!--Mandingo‧?‧?	➡ Mandingo‧Latin‧Gambia-->
-		<likelySubtag from="man_GN" to="man_Nkoo_GN"/>		<!--Mandingo‧?‧Guinea	➡ Mandingo‧N’Ko‧Guinea-->
 		<likelySubtag from="man_Nkoo" to="man_Nkoo_GN"/>		<!--Mandingo‧N’Ko‧?	➡ Mandingo‧N’Ko‧Guinea-->
 		<likelySubtag from="mas" to="mas_Latn_KE"/>		<!--Masai‧?‧?	➡ Masai‧Latin‧Kenya-->
 		<likelySubtag from="maz" to="maz_Latn_MX"/>		<!--Central Mazahua‧?‧?	➡ Central Mazahua‧Latin‧Mexico-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -3149,7 +3149,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="fr" populationPercent="27" officialStatus="official" references="R1352"/>	<!--French-->
 			<languagePopulation type="ff" populationPercent="26"/>	<!--Fula-->
 			<languagePopulation type="man" populationPercent="23"/>	<!--Mandingo-->
-			<languagePopulation type="man_Nkoo" literacyPercent="50" populationPercent="23" references="R1021"/>	<!--Mandingo (N’Ko)-->
+			<languagePopulation type="man_Nkoo" literacyPercent="25" populationPercent="23" references="R1021"/>	<!--Mandingo (N’Ko)-->
 			<languagePopulation type="sus" populationPercent="11"/>	<!--Susu-->
 			<languagePopulation type="nqo" populationPercent="5" references="R1286"/>	<!--N’Ko-->
 			<languagePopulation type="kpe" populationPercent="3.8"/>	<!--Kpelle-->
@@ -5513,7 +5513,6 @@ XXX Code for transations where no currency is involved
 		<parentLocale parent="en_150" locales="en_AT en_BE en_CH en_DE en_DK en_FI en_NL en_SE en_SI"/>
 		<parentLocale parent="en_IN" locales="hi_Latn"/>
 		<parentLocale parent="es_419" locales="es_AR es_BO es_BR es_BZ es_CL es_CO es_CR es_CU es_DO es_EC es_GT es_HN es_JP es_MX es_NI es_PA es_PE es_PR es_PY es_SV es_US es_UY es_VE"/>
-		<parentLocale parent="fr_HT" locales="ht"/>
 		<parentLocale parent="no" locales="nb nn no_NO"/>
 		<parentLocale parent="pt_PT" locales="pt_AO pt_CH pt_CV pt_FR pt_GQ pt_GW pt_LU pt_MO pt_MZ pt_ST pt_TL"/>
 		<parentLocale parent="zh_Hant_HK" locales="zh_Hant_MO"/>

--- a/common/testData/localeIdentifiers/likelySubtags.txt
+++ b/common/testData/localeIdentifiers/likelySubtags.txt
@@ -513,11 +513,6 @@ hsb-AQ ;	hsb-Latn-AQ ;	hsb-AQ ;
 hsb-DE ;	hsb-Latn-DE ;	hsb ;	
 hsb-Egyp ;	hsb-Egyp-DE ;	hsb-Egyp ;	
 hsb-Latn ;	hsb-Latn-DE ;	hsb ;	
-ht ;	ht-Latn-HT ;	ht ;	
-ht-AQ ;	ht-Latn-AQ ;	ht-AQ ;	
-ht-Egyp ;	ht-Egyp-HT ;	ht-Egyp ;	
-ht-HT ;	ht-Latn-HT ;	ht ;	
-ht-Latn ;	ht-Latn-HT ;	ht ;	
 hu ;	hu-Latn-HU ;	hu ;	
 hu-AQ ;	hu-Latn-AQ ;	hu-AQ ;	
 hu-Egyp ;	hu-Egyp-HU ;	hu-Egyp ;	
@@ -1575,9 +1570,9 @@ und-NP ;	ne-Deva-NP ;	ne ;
 und-NR ;	en-Latn-NR ;	en-NR ;	
 und-NU ;	en-Latn-NU ;	en-NU ;	
 und-NZ ;	en-Latn-NZ ;	en-NZ ;	
-und-Nkoo ;	man-Nkoo-GN ;	man-Nkoo ;	man-GN
+und-Nkoo ;	man-Nkoo-GN ;	man-Nkoo ;	
 und-Nkoo-AQ ;	man-Nkoo-AQ ;	 ;	
-und-Nkoo-GN ;	man-Nkoo-GN ;	man-Nkoo ;	man-GN
+und-Nkoo-GN ;	man-Nkoo-GN ;	man-Nkoo ;	
 und-OM ;	ar-Arab-OM ;	ar-OM ;	
 und-Olck ;	sat-Olck-IN ;	sat ;	
 und-Olck-AQ ;	sat-Olck-AQ ;	sat-AQ ;	

--- a/common/testData/localeIdentifiers/localeDisplayName.txt
+++ b/common/testData/localeIdentifiers/localeDisplayName.txt
@@ -1308,32 +1308,6 @@ nl-Latn-BE; flamšćina (łaćonsce)
 zh-Hans-fonipa; chinšćina [zjednorjena] (FONIPA)
 
 
-@locale=ht
-@languageDisplay=standard
-
-en-MM; anglais (Myanmar [Birmanie])
-es; espagnol
-es-419; espagnol (Amérique latine)
-es-Cyrl-MX; espagnol (cyrillique, Mexique)
-hi-Latn; hindi (latin)
-nl-BE; néerlandais (Belgique)
-nl-Latn-BE; néerlandais (latin, Belgique)
-zh-Hans-fonipa; chinois (simplifié, alphabet phonétique international)
-
-
-@locale=ht
-@languageDisplay=dialect
-
-en-MM; anglais (Myanmar [Birmanie])
-es; espagnol
-es-419; espagnol d’Amérique latine
-es-Cyrl-MX; espagnol du Mexique (cyrillique)
-hi-Latn; hindi (latin)
-nl-BE; flamand
-nl-Latn-BE; flamand (latin)
-zh-Hans-fonipa; chinois simplifié (alphabet phonétique international)
-
-
 @locale=hu
 @languageDisplay=standard
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestInheritance.java
@@ -373,10 +373,7 @@ public class TestInheritance extends TestFmwk {
                             "nn",
                             "nb",
                             // Per CLDR-15276 hi-Latn can have an explicit parent
-                            "hi_Latn",
-                            // Per CLDR-17587 Haitian Creole is largely influenced by French and is
-                            // best boot-strapped by French
-                            "ht"));
+                            "hi_Latn"));
 
     public void TestParentLocaleInvariants() {
         // Testing invariant relationships in parent locales - See


### PR DESCRIPTION
Haitian Creole `ht` is erroneously being reported as "modern coverage" because its parent locale `fr_HT` is technically fully populated (since that, in turn, inherits from `fr`)

See the incorrect characterization in the v47 charts https://www.unicode.org/cldr/charts/47/supplemental/locale_coverage.html#ht

The quickest way to register the language as not submitted is to just remove the parent locale.

CLDR-18105

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
