### PR TITLE
CLDR-17760 syr, delete obsolete decimalFormats/currencyFormats without numberSystem

### DIFF
--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -4402,13 +4402,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<symbols numberSystem="vaii">
 			<timeSeparator draft="unconfirmed">↑↑↑</timeSeparator>
 		</symbols>
-		<decimalFormats>
-			<decimalFormatLength>
-				<decimalFormat>
-					<pattern draft="unconfirmed">#,##0.###;#,##0.###-</pattern>
-				</decimalFormat>
-			</decimalFormatLength>
-		</decimalFormats>
 		<decimalFormats numberSystem="latn">
 			<decimalFormatLength>
 				<decimalFormat>
@@ -4430,13 +4423,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</percentFormat>
 			</percentFormatLength>
 		</percentFormats>
-		<currencyFormats>
-			<currencyFormatLength>
-				<currencyFormat type="standard">
-					<pattern draft="unconfirmed">¤ #,##0.00;¤ #,##0.00-</pattern>
-				</currencyFormat>
-			</currencyFormatLength>
-		</currencyFormats>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
 				<currencyFormat type="standard">


### PR DESCRIPTION
CLDR-17760

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17760)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In `syr`, delete the obsolete `<decimalFormats>` and ` <currencyFormats>` elements that do **_not_** have a `numberSystem` attribute at all (these probably date from when the `syr` data was first added in xml to the seed directory years ago). These do not show up in Survey Tool and (I think) are ignored by ICU code. The current version of these elements does have a `numberSystem` attribute, and `syr` does also have `<decimalFormats>` and ` <currencyFormats>` elements (and also `<percentFormats>`) **_with_** `numberSystem="latn"`; these are the ones that appear in Survey Tool and get used by the code.

ALLOW_MANY_COMMITS=true
