### PR TITLE
CLDR-18233 Remove ISO 639-5 language families from Likely Subtag

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -580,6 +580,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="pdt" to="pdt_Latn_CA"/>		<!--Plautdietsch‧?‧?	➡ Plautdietsch‧Latin‧Canada-->
 		<likelySubtag from="peo" to="peo_Xpeo_IR"/>		<!--Old Persian‧?‧?	➡ Old Persian‧Old Persian‧Iran-->
 		<likelySubtag from="pfl" to="pfl_Latn_DE"/>		<!--Palatine German‧?‧?	➡ Palatine German‧Latin‧Germany-->
+		<likelySubtag from="pgd" to="pgd_Khar_PK"/>		<!--Gāndhārī‧?‧?	➡ Gāndhārī‧Kharoshthi‧Pakistan-->
 		<likelySubtag from="phn" to="phn_Phnx_LB"/>		<!--Phoenician‧?‧?	➡ Phoenician‧Phoenician‧Lebanon-->
 		<likelySubtag from="pis" to="pis_Latn_SB"/>		<!--Pijin‧?‧?	➡ Pijin‧Latin‧Solomon Islands-->
 		<likelySubtag from="pka" to="pka_Brah_IN"/>		<!--Ardhamāgadhī Prākrit‧?‧?	➡ Ardhamāgadhī Prākrit‧Brahmi‧India-->
@@ -594,7 +595,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="pon" to="pon_Latn_FM"/>		<!--Pohnpeian‧?‧?	➡ Pohnpeian‧Latin‧Micronesia-->
 		<likelySubtag from="ppl" to="ppl_Latn_SV"/>		<!--Pipil‧?‧?	➡ Pipil‧Latin‧El Salvador-->
 		<likelySubtag from="pqm" to="pqm_Latn_CA"/>		<!--Maliseet-Passamaquoddy‧?‧?	➡ Maliseet-Passamaquoddy‧Latin‧Canada-->
-		<likelySubtag from="pra" to="pra_Khar_PK"/>		<!--Prakrit languages‧?‧?	➡ Prakrit languages‧Kharoshthi‧Pakistan-->
 		<likelySubtag from="prd" to="prd_Arab_IR"/>		<!--Parsi-Dari‧?‧?	➡ Parsi-Dari‧Arabic‧Iran-->
 		<likelySubtag from="prg" to="prg_Latn_PL"/>		<!--Prussian‧?‧?	➡ Prussian‧Latin‧Poland-->
 		<likelySubtag from="ps" to="ps_Arab_AF"/>		<!--Pashto‧?‧?	➡ Pashto‧Arabic‧Afghanistan-->
@@ -1174,7 +1174,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Kali" to="eky_Kali_MM"/>		<!--?‧Kayah Li‧?	➡ Eastern Kayah‧Kayah Li‧Myanmar (Burma)-->
 		<likelySubtag from="und_Kana" to="ja_Kana_JP"/>		<!--?‧Katakana‧?	➡ Japanese‧Katakana‧Japan-->
 		<likelySubtag from="und_Kawi" to="kaw_Kawi_ID"/>		<!--?‧Kawi‧?	➡ Kawi‧Kawi‧Indonesia-->
-		<likelySubtag from="und_Khar" to="pra_Khar_PK"/>		<!--?‧Kharoshthi‧?	➡ Prakrit languages‧Kharoshthi‧Pakistan-->
+		<likelySubtag from="und_Khar" to="pgd_Khar_PK"/>		<!--?‧Kharoshthi‧?	➡ Gāndhārī‧Kharoshthi‧Pakistan-->
 		<likelySubtag from="und_Khmr" to="km_Khmr_KH"/>		<!--?‧Khmer‧?	➡ Khmer‧Khmer‧Cambodia-->
 		<likelySubtag from="und_Khoj" to="sd_Khoj_IN"/>		<!--?‧Khojki‧?	➡ Sindhi‧Khojki‧India-->
 		<likelySubtag from="und_Kits" to="zkt_Kits_CN"/>		<!--?‧Khitan small script‧?	➡ Kitan‧Khitan small script‧China-->
@@ -5649,7 +5649,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="pfa" to="pfa_Latn_FM" origin="sil1"/>		<!--Pááfang‧?‧?	➡ Pááfang‧Latin‧Micronesia-->
 		<likelySubtag from="pfe" to="pfe_Latn_CM" origin="sil1"/>		<!--Pere‧?‧?	➡ Pere‧Latin‧Cameroon-->
 		<likelySubtag from="pga" to="pga_Latn_SS" origin="sil1"/>		<!--Sudanese Creole Arabic‧?‧?	➡ Sudanese Creole Arabic‧Latin‧South Sudan-->
-		<likelySubtag from="pgd" to="pgd_Khar_PK" origin="sil1"/>		<!--Gāndhārī‧?‧?	➡ Gāndhārī‧Kharoshthi‧Pakistan-->
 		<likelySubtag from="pgg" to="pgg_Deva_IN" origin="sil1"/>		<!--Pangwali‧?‧?	➡ Pangwali‧Devanagari‧India-->
 		<likelySubtag from="pgi" to="pgi_Latn_PG" origin="sil1"/>		<!--Pagi‧?‧?	➡ Pagi‧Latin‧Papua New Guinea-->
 		<likelySubtag from="pgk" to="pgk_Latn_VU" origin="sil1"/>		<!--Rerep‧?‧?	➡ Rerep‧Latin‧Vanuatu-->
@@ -5783,6 +5782,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="pps" to="pps_Latn_MX" origin="sil1"/>		<!--San Luís Temalacayuca Popoloca‧?‧?	➡ San Luís Temalacayuca Popoloca‧Latin‧Mexico-->
 		<likelySubtag from="ppt" to="ppt_Latn_PG" origin="sil1"/>		<!--Pare‧?‧?	➡ Pare‧Latin‧Papua New Guinea-->
 		<likelySubtag from="pqa" to="pqa_Latn_NG" origin="sil1"/>		<!--Pa'a‧?‧?	➡ Pa'a‧Latin‧Nigeria-->
+		<likelySubtag from="pra" to="pra_Khar_PK" origin="sil1"/>		<!--Prakrit languages‧?‧?	➡ Prakrit languages‧Kharoshthi‧Pakistan-->
 		<likelySubtag from="prc" to="prc_Arab_AF" origin="sil1"/>		<!--Parachi‧?‧?	➡ Parachi‧Arabic‧Afghanistan-->
 		<likelySubtag from="pre" to="pre_Latn_ST" origin="sil1"/>		<!--Principense‧?‧?	➡ Principense‧Latin‧São Tomé & Príncipe-->
 		<likelySubtag from="prf" to="prf_Latn_PH" origin="sil1"/>		<!--Paranan‧?‧?	➡ Paranan‧Latin‧Philippines-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2095,9 +2095,10 @@ XXX Code for transations where no currency is involved
 		<language type="pdt" scripts="Latn"/>
 		<language type="peo" scripts="Xpeo"/>
 		<language type="pfl" scripts="Latn"/>
+		<language type="pgd" scripts="Khar"/>
 		<language type="phn" scripts="Phnx"/>
-		<language type="pi" scripts="Mymr"/>
-		<language type="pi" scripts="Sinh Deva Thai" alt="secondary"/>
+		<language type="pi" scripts="Sinh"/>
+		<language type="pi" scripts="Deva Khar Mymr Thai" alt="secondary"/>
 		<language type="pis" scripts="Latn"/>
 		<language type="pis" territories="SB" alt="secondary"/>
 		<language type="pko" scripts="Latn"/>
@@ -2165,7 +2166,8 @@ XXX Code for transations where no currency is involved
 		<language type="rw" territories="UG" alt="secondary"/>
 		<language type="rwk" scripts="Latn"/>
 		<language type="ryu" scripts="Kana"/>
-		<language type="sa" scripts="Deva Gran Shrd Sidd Sinh" territories="IN" alt="secondary"/>
+		<language type="sa" scripts="Deva"/>
+		<language type="sa" scripts="Gran Khar Shrd Sidd Sinh" territories="IN" alt="secondary"/>
 		<language type="sad" scripts="Latn"/>
 		<language type="saf" scripts="Latn"/>
 		<language type="sah" scripts="Cyrl"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -1752,6 +1752,7 @@ public class GenerateLikelySubtags {
             for (Entry<String, LSRSource> entry : silData.entrySet()) {
                 CLDRLocale source = CLDRLocale.getInstance(entry.getKey());
                 String lang = source.getLanguage();
+                // HERE add ISO 639 check
                 if (!fluffup.containsKey(lang)) {
                     silMap.put(entry.getKey(), entry.getValue().getLsrString());
                     if (!entry.getValue().getSources().isEmpty()) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Script_Metadata.csv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Script_Metadata.csv
@@ -77,7 +77,7 @@ WR,Name,Script_Code,Age,Size,Sample,Sample_Code,Origin Country,~Density,Likely L
 75,Inscriptional_Pahlavi,Phli,5.2,27,𐭠,10B60,Iran,1,Pahlavi,pal,Exclusion,Yes,no,no,no,no
 76,Inscriptional_Parthian,Prti,5.2,30,𐭀,10B40,Iran,1,Parthian,xpr,Exclusion,Yes,no,no,no,no
 77,Kaithi,Kthi,5.2,66,𑂃,11083,India,1,Bhojpuri,bho,Exclusion,no,no,min,no,no
-78,Kharoshthi,Khar,4.1,65,𐨀,10A00,Pakistan,1,Gandhari,pra,Exclusion,Yes,no,Yes,no,no
+78,Kharoshthi,Khar,4.1,65,𐨀,10A00,Pakistan,1,Gandhari,pgd,Exclusion,Yes,no,Yes,no,no
 79,Linear_B,Linb,4.0,211,𐀀,10000,Greece,1,Mycenaean Greek,gmy,Exclusion,no,no,no,Yes,no
 80,Lycian,Lyci,5.1,29,𐊀,10280,Turkey,1,Lycian,xlc,Exclusion,no,no,no,no,no
 81,Lydian,Lydi,5.1,27,𐤠,10920,Turkey,1,Lydian,xld,Exclusion,Yes,no,no,no,no
@@ -171,3 +171,8 @@ WR,Name,Script_Code,Age,Size,Sample,Sample_Code,Origin Country,~Density,Likely L
 169,Sunuwar,Sunu,16.0,0,𑯄,11BC4,Nepal,1,Sunuwar,suz,Exclusion,no,no,no,no,no
 170,Todhri,Todr,16.0,0,𐗂,105C2,Albania,1,Albanian,sq,Exclusion,no,no,no,no,no
 171,Tulu-Tigalari,Tutg,16.0,0,𑎒,11392,India,1,Sanskrit,sa,Exclusion,no,no,Yes,no,no
+172,Beria Erfe,Berf,17.0,0,𖺡,16EA1,Sudan,1,Zaghawa,zag,Exclusion,no,no,min,no,Yes,no
+173,Chisoi,Chis,17.0,0,𖶓,16D93,India,1,Kurmali,kyw,Exclusion,no,no,min,no,no,no
+174,Sidetic,Sidt,17.0,0,𐥐,10950,Turkey,1,Sidetic,xsd,Exclusion,Yes,no,no,no,no,no
+175,Tai Yo,Tayo,17.0,0,𞛕,1E6D5,Vietnam,1,Tai Yo,tyj,Exclusion,no,Yes,Yes,no,no,no
+176,Tolong Siki,Tols,17.0,0,𑷆,11DC6,India,1,Kurukh,kru,Exclusion,no,no,min,no,no,no

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -546,6 +546,8 @@ mhn	Mocheno	primary	Latn	Latin
 mi	Maori	primary	Latn	Latin
 mic	Mi'kmaw	primary	Latn	Latin
 min	Minangkabau	primary	Latn	Latin
+mis	Uncoded	primary	Zyyy	Undetermined
+mis	Uncoded	secondary	Nshu	Nüshu
 mk	Macedonian	primary	Cyrl	Cyrillic
 ml	Malayalam	primary	Mlym	Malayalam
 mls	Masalit	primary	Latn	Latin
@@ -655,11 +657,13 @@ pdc	Pennsylvania German	primary	Latn	Latin
 pdt	Plautdietsch	primary	Latn	Latin
 peo	Old Persian	primary	Xpeo	Old Persian
 pfl	Palatine German	primary	Latn	Latin
+pgd	Gandhari	primary	Khar	Kharothi
 phn	Phoenician	primary	Phnx	Phoenician
-pi	Pali	primary	Mymr	Myanmar
+pi	Pali	primary	Sinh	Sinhala
+pi	Pali	secondary	Mymr	Myanmar
 pi	Pali	secondary	Deva	Devanagari
-pi	Pali	secondary	Sinh	Sinhala
 pi	Pali	secondary	Thai	Thai
+pi	Pali	secondary	Khar	Kharothi
 pis	Pijin	primary	Latn	Latin
 pko	Pökoot	primary	Latn	Latin
 pl	Polish	primary	Latn	Latin
@@ -715,11 +719,12 @@ rup	Aromanian	primary	Latn	Latin
 rw	Kinyarwanda	primary	Latn	Latin
 rwk	Rwa	primary	Latn	Latin
 ryu	Central Okinawan	primary	Kana	Katakana
-sa	Sanskrit	secondary	Deva	Devanagari
+sa	Sanskrit	primary	Deva	Devanagari
 sa	Sanskrit	secondary	Gran	Grantha
 sa	Sanskrit	secondary	Shrd	Sharada
 sa	Sanskrit	secondary	Sidd	Siddham
 sa	Sanskrit	secondary	Sinh	Sinhala
+sa	Sanskrit	secondary	Khar	Karosthi
 sad	Sandawe	primary	Latn	Latin
 saf	Safaliba	primary	Latn	Latin
 sah	Sakha	primary	Cyrl	Cyrillic


### PR DESCRIPTION
CLDR-18233

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
