### PR TITLE
CLDR-16821 Fix Australian time zone names

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -3913,12 +3913,17 @@ annotations.
 			<regionFormat type="daylight">{0} Daylight Time</regionFormat>
 			<regionFormat type="standard">{0} Standard Time</regionFormat>
 			<fallbackFormat>{1} ({0})</fallbackFormat>
-			<zone type="Pacific/Honolulu">
-				<short>
-					<generic>HST</generic>
-					<standard>HST</standard>
-					<daylight>HDT</daylight>
-				</short>
+			<zone type="Antarctica/Macquarie">
+				<exemplarCity>Macquarie Island</exemplarCity>
+			</zone>
+			<zone type="Asia/Qostanay">
+				<exemplarCity>Kostanay</exemplarCity>
+			</zone>
+			<zone type="Asia/Saigon">
+				<exemplarCity>Ho Chi Minh City</exemplarCity>
+			</zone>
+			<zone type="Australia/Lord_Howe">
+				<exemplarCity>Lord Howe Island</exemplarCity>
 			</zone>
 			<zone type="Etc/UTC">
 				<long>
@@ -3938,17 +3943,27 @@ annotations.
 					<daylight>Irish Standard Time</daylight>
 				</long>
 			</zone>
-			<zone type="Asia/Qostanay">
-				<exemplarCity>Kostanay</exemplarCity>
+			<zone type="Indian/Christmas">
+				<exemplarCity>Christmas Island</exemplarCity>
+			</zone>
+			<zone type="Indian/Cocos">
+				<exemplarCity>Cocos Islands</exemplarCity>
 			</zone>
 			<zone type="Pacific/Easter">
 				<exemplarCity>Easter Island</exemplarCity>
 			</zone>
+			<zone type="Pacific/Honolulu">
+				<short>
+					<generic>HST</generic>
+					<standard>HST</standard>
+					<daylight>HDT</daylight>
+				</short>
+			</zone>
+			<zone type="Pacific/Norfolk">
+				<exemplarCity>Norfolk Island</exemplarCity>
+			</zone>
 			<zone type="Pacific/Wake">
 				<exemplarCity>Wake Island</exemplarCity>
-			</zone>
-			<zone type="Asia/Saigon">
-				<exemplarCity>Ho Chi Minh City</exemplarCity>
 			</zone>
 			<metazone type="Acre">
 				<long>
@@ -4128,7 +4143,7 @@ annotations.
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
-					<generic>Central Australia Time</generic>
+					<generic>Australian Central Time</generic>
 					<standard>Australian Central Standard Time</standard>
 					<daylight>Australian Central Daylight Time</daylight>
 				</long>
@@ -4142,14 +4157,14 @@ annotations.
 			</metazone>
 			<metazone type="Australia_Eastern">
 				<long>
-					<generic>Eastern Australia Time</generic>
+					<generic>Australian Eastern Time</generic>
 					<standard>Australian Eastern Standard Time</standard>
 					<daylight>Australian Eastern Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Australia_Western">
 				<long>
-					<generic>Western Australia Time</generic>
+					<generic>Australian Western Time</generic>
 					<standard>Australian Western Standard Time</standard>
 					<daylight>Australian Western Daylight Time</daylight>
 				</long>
@@ -4256,7 +4271,7 @@ annotations.
 				<long>
 					<generic>Cook Islands Time</generic>
 					<standard>Cook Islands Standard Time</standard>
-					<daylight>Cook Islands Half Summer Time</daylight>
+					<daylight>Cook Islands Summer Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cuba">

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -4968,7 +4968,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Africa_Eastern">
 				<long>
-					<standard>Eastern Africa Time</standard>
+					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Africa_Southern">
@@ -5034,9 +5034,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Arabian">
 				<long>
-					<generic>Arabia Time</generic>
-					<standard>Arabia Standard Time</standard>
-					<daylight>Arabia Daylight Time</daylight>
+					<generic>↑↑↑</generic>
+					<standard>↑↑↑</standard>
+					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Argentina">
@@ -5069,7 +5069,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
-					<generic>Australian Central Time</generic>
+					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
 				</long>
@@ -5093,7 +5093,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Australia_Eastern">
 				<long>
-					<generic>Australian Eastern Time</generic>
+					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
 				</long>
@@ -5105,7 +5105,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Australia_Western">
 				<long>
-					<generic>Australian Western Time</generic>
+					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
 				</long>
@@ -5210,9 +5210,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Cook">
 				<long>
-					<generic>Cook Island Time</generic>
-					<standard>Cook Island Standard Time</standard>
-					<daylight>Cook Island Summer Time</daylight>
+					<generic>↑↑↑</generic>
+					<standard>↑↑↑</standard>
+					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Cuba">
@@ -5345,7 +5345,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 				<short>
-					<standard>Gulf ST</standard>
+					<standard>↑↑↑</standard>
 				</short>
 			</metazone>
 			<metazone type="Guyana">
@@ -5449,7 +5449,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Korea">
 				<long>
-					<generic>Korea Time</generic>
+					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>Korean Summer Time</daylight>
 				</long>
@@ -5545,7 +5545,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>Moscow Daylight Time</daylight>
+					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Myanmar">


### PR DESCRIPTION
CLDR-16821

This adds exemplar cities for some islands, and aligns the `en` metazone names with the correct names from `en-AU`.

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
