### PR TITLE
CLDR-17760 Add note about v48 deprecation of number symbols and format elements without numberSystem

### DIFF
--- a/docs/site/downloads/cldr-47.md
+++ b/docs/site/downloads/cldr-47.md
@@ -102,7 +102,11 @@ For a full listing, see [Delta Data](https://unicode.org/cldr/charts/dev/delta/i
 
 ## Migration
 
-- TBD
+- Number `<symbols>` elements and format elements (`<currencyFormats>`, `<decimalFormats>`, `<percentFormats>`, `<scientificFormats>`)
+  should all have a `numberSystem` attribute. In CLDR v48 such elements without a `numberSystem` attribute will be deprecated, and the
+  corresponding entries in root will be removed; these were only intended as a long-ago migration aid. See the relevant sections of the
+  LDML specification: [Number Symbols](https://www.unicode.org/reports/tr35/dev/tr35-numbers.html#Number_Symbols) and
+  [Number Formats](https://www.unicode.org/reports/tr35/dev/tr35-numbers.html#number-formats).
 
 ## Known Issues
 


### PR DESCRIPTION
CLDR-17760

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17760)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add migration note (per ticket comment) about v48 deprecation of number symbols and format elements without numberSystem, and removal of these from root.

ALLOW_MANY_COMMITS=true
