### PR TITLE
CLDR-17760 Also fix number symbols without numberSystem; update spec accordingly

### DIFF
--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -4661,9 +4661,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<native>beng</native>
 		</otherNumberingSystems>
 		<minimumGroupingDigits>↑↑↑</minimumGroupingDigits>
-		<symbols>
-			<timeSeparator draft="unconfirmed">.</timeSeparator>
-		</symbols>
 		<symbols numberSystem="beng">
 			<decimal>↑↑↑</decimal>
 			<group>↑↑↑</group>
@@ -4689,6 +4686,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<perMille>↑↑↑</perMille>
 			<infinity>↑↑↑</infinity>
 			<nan>↑↑↑</nan>
+			<timeSeparator draft="unconfirmed">.</timeSeparator>
 		</symbols>
 		<decimalFormats numberSystem="beng">
 			<decimalFormatLength>

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -260,7 +260,7 @@ The available number symbols are as follows:
 Example:
 
 ```xml
-<symbols>
+<symbols numberSystem="latn>
     <decimal>.</decimal>
     <group>,</group>
     <list>;</list>
@@ -281,7 +281,7 @@ Example:
 ```xml
 <!ATTLIST symbols numberSystem CDATA #IMPLIED >
 ```
-The `numberSystem` attribute is used to specify that the given number symbols are to be used when the given numbering system is active. Number symbols can only be defined for numbering systems of the "numeric" type, since any special symbols required for an algorithmic numbering system should be specified by the RBNF formatting rules used for that numbering system. By default, number symbols without a specific `numberSystem` attribute are assumed to be used for the "latn" numbering system, which is western (ASCII) digits. Locales that specify a numbering system other than "latn" as the default should also specify number formatting symbols that are appropriate for use within the context of the given numbering system. For example, a locale that uses the Arabic-Indic digits as its default would likely use an Arabic comma for the grouping separator rather than the ASCII comma.
+The `numberSystem` attribute is used to specify that the given number symbols are to be used when the given numbering system is active. Number symbols can only be defined for numbering systems of the "numeric" type, since any special symbols required for an algorithmic numbering system should be specified by the RBNF formatting rules used for that numbering system. By default, number symbols without a specific `numberSystem` attribute are assumed to be used for the "latn" numbering system, which is western (ASCII) digits; however, number symbols without a specific `numberSystem` attribute should not be used and will be deprecated in CLDR v48. Locales that specify a numbering system other than "latn" as the default should also specify number formatting symbols that are appropriate for use within the context of the given numbering system. For example, a locale that uses the Arabic-Indic digits as its default would likely use an Arabic comma for the grouping separator rather than the ASCII comma.
 For more information on numbering systems and their definitions, see _[Section 1: Numbering Systems](#Numbering_Systems)_.
 
 ### <a name="Number_Formats" href="#Number_Formats">Number Formats</a>
@@ -314,7 +314,7 @@ Different formats are provided for different contexts, as follows:
 Example:
 
 ```xml
-<decimalFormats>
+<decimalFormats numberSystem="latn">
   <decimalFormatLength type="long">
     <decimalFormat>
       <pattern>#,##0.###</pattern>
@@ -322,7 +322,7 @@ Example:
   </decimalFormatLength>
 </decimalFormats>
 
-<scientificFormats>
+<scientificFormats numberSystem="latn">
   <default type="long"/>
   <scientificFormatLength type="long">
     <scientificFormat>
@@ -336,7 +336,7 @@ Example:
   </scientificFormatLength>
 </scientificFormats>
 
-<percentFormats>
+<percentFormats numberSystem="latn">
   <percentFormatLength type="long">
     <percentFormat>
       <pattern>#,##0%</pattern>
@@ -349,7 +349,7 @@ Example:
 <!ATTLIST symbols numberSystem CDATA #IMPLIED >
 ```
 
-The `numberSystem` attribute is used to specify that the given number formatting pattern(s) are to be used when the given numbering system is active. By default, number formatting patterns without a specific `numberSystem` attribute are assumed to be used for the "latn" numbering system, which is western (ASCII) digits. Locales that specify a numbering system other than "latn" as the default should also specify number formatting patterns that are appropriate for use within the context of the given numbering system.
+The `numberSystem` attribute is used to specify that the given number formatting pattern(s) are to be used when the given numbering system is active. By default, number formatting patterns without a specific `numberSystem` attribute are assumed to be used for the "latn" numbering system, which is western (ASCII) digits; however, number formatting patterns without a specific `numberSystem` attribute should not be used and will be deprecated in CLDR v48. Locales that specify a numbering system other than "latn" as the default should also specify number formatting patterns that are appropriate for use within the context of the given numbering system.
 For more information on numbering systems and their definitions, see _[Section 1: Numbering Systems](#Numbering_Systems)_.
 
 #### <a name="Compact_Number_Formats" href="#Compact_Number_Formats">Compact Number Formats</a>

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -220,13 +220,8 @@ The LDML specification is divided into the following parts:
 * [References](#References)
 * [Acknowledgments](#Acknowledgments)
 * [Modifications](#Modifications)
-  * [Conformance Modifications](#conformance-modifications)
-  * [Locale Identifiers and Inheritance Modifications](#locale-identifiers-and-inheritance-modifications)
-  * [Message Format Modifications](#message-format-modifications)
-  * [Date Modifications](#date-modifications)
-  * [Units Modifications](#units-modifications)
-  * [Collation Data Changes](#collation-data-changes)
-  * [Misc. Modifications](#misc.-modifications)
+  * [Number symbols and formats without numberSystem](#number-symbols-and-formats-without-numbersystem)
+  * [Well-formed identifiers](#well-formed-identifiers)
 
 ## <a name="Introduction" href="#Introduction">Introduction</a>
 
@@ -4348,6 +4343,11 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ## <a name="Modifications" href="#Modifications">Modifications</a>
 
+**Changes in LDML Version 47 (Differences from Version 46.1)**
+
+### Number symbols and formats without numberSystem
+- Noted that [Number Symbols](tr35-numbers.md#Number_Symbols) and [Number Formats](tr35-numbers.md#Number_Formats) without a specific `numberSystem` attribute should not be used and will be deprecated in CLDR v48.
+
 **Changes in LDML Version 46.1 (Differences from Version 46)**
 
 ### Well-formed identifiers
@@ -4358,7 +4358,7 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
     - Change the constraints into either well-formedness constraints or validity constraints.
     - Add validity constraints for base-component.
     - Reformat the EBNF to avoid using HTML tables.
-- Updated the [Unit_Preferences](tr35-info.html#Unit_Preferences) to provide well-formedness and validity definitions.
+- Updated the [Unit_Preferences](tr35-info.md#Unit_Preferences) to provide well-formedness and validity definitions.
 
 
 Note that small changes such as typos and link fixes are not listed above.


### PR DESCRIPTION
CLDR-17760

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

In addition to number format elements without a numberSystem attribute (PRs [#4292](https://github.com/unicode-org/cldr/pull/4292), [#4306](https://github.com/unicode-org/cldr/pull/4306)), we also need to clean up number symbols without a numberSystem attribute. And we need to update the spec for both so the examples do include a numberSystem attribute, and mention the such elements without a numberSystem attribute should not be used and will be deprecated.

ALLOW_MANY_COMMITS=true
