### PR TITLE
CLDR-18258 Exclude new values from coverage

### DIFF
--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -62,6 +62,7 @@ hi ;	modern ;	Hindi
 hi_Latn ;	modern ;	Hindi [Latin]
 hr ;	modern ;	Croatian
 hsb ;	modern ;	Upper Sorbian
+ht ;	modern ;	Haitian Creole
 hu ;	modern ;	Hungarian
 hy ;	modern ;	Armenian
 ia ;	moderate ;	Interlingua
@@ -119,7 +120,6 @@ or ;	modern ;	Odia
 pa ;	modern ;	Punjabi
 pcm ;	modern ;	Nigerian Pidgin
 pl ;	modern ;	Polish
-prg ;	basic ;	Prussian
 ps ;	modern ;	Pashto
 pt ;	modern ;	Portuguese
 qu ;	moderate ;	Quechua
@@ -167,7 +167,7 @@ vi ;	modern ;	Vietnamese
 vmw ;	basic ;	Makhuwa
 wo ;	moderate ;	Wolof
 xh ;	moderate ;	Xhosa
-xnr ;	moderate ;	Kangri
+xnr ;	basic ;	Kangri
 yo ;	modern ;	Yoruba
 yrl ;	basic ;	Nheengatu
 yue ;	modern ;	Cantonese

--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -62,7 +62,6 @@ hi ;	modern ;	Hindi
 hi_Latn ;	modern ;	Hindi [Latin]
 hr ;	modern ;	Croatian
 hsb ;	modern ;	Upper Sorbian
-ht ;	modern ;	Haitian Creole
 hu ;	modern ;	Hungarian
 hy ;	modern ;	Armenian
 ia ;	moderate ;	Interlingua

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -172,6 +172,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%unitsCommonUS" value="(length-(inch|foot|yard|mile)|mass-(ounce|pound)|temperature-fahrenheit|speed-mile-per-hour)"/>
 		<coverageVariable key="%unitsEnglish" value="(length-fathom|length-furlong|mass-stone|volume-bushel|energy-british-thermal-unit)"/>
 		<coverageVariable key="%unitsNonEnglish" value="[a-z]++-(?!(furlong|fathom|stone|bushel|mile-nautical))([a-z]++([-a-z]++)?)"/>
+		<coverageVariable key="%unitsNonLightSpeed" value="[a-z]++-(?!(light-speed))"/>
 		<coverageVariable key="%unitsOther" value="(length-(picometer|light-year)|pressure-(hectopascal|inch-ofhg|millibar)|acceleration-g-force|angle-(degree|minute|second)|area-(acre|hectare|square-(foot|kilometer|meter|mile))|power-(horsepower|kilowatt|watt)|speed-meter-per-second|volume-cubic-(mile|kilometer))"/>
 		<coverageVariable key="%unitBeaufortRegions" value="(CN|DE|GB|GR|HK|MO|MT|NL|TW|US)"/>
 		<coverageVariable key="%variantTypes" value="([A-Z0-9]++)"/>
@@ -237,9 +238,30 @@ For terms of use, see http://www.unicode.org/copyright.html
 		would cause many supported locales to drop in coverage. During the next regular submission cycle, please remove these rules
 		and encourage linguists to fix these values.
 		********************* -->
+		<!-- <coverageLevel	value="modern" inLanguage="de"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/unitPattern[@count='%anyAttribute']/[@case='%anyAttribute']"/>
+		<coverageLevel	value="modern"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/unitPattern[@count='%anyAttribute']"/>
+		<coverageLevel	value="modern"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/displayName"/> -->
+		<coverageLevel	value="comprehensive"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
+
+		<!-- <coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute'][@case='%anyAttribute']"/>
+		<coverageLevel inTerritory="%unitBeaufortRegions" value="modern" match="units/unitLength[@type='%unitLengths']/unit[@type='speed-beaufort']/unitPattern[@count='%anyAttribute']"/>
+		//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+modern //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"]
+//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"] -->
 		<coverageLevel	value="comprehensive"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/unitPattern[@count='%anyAttribute']"/>
 		<coverageLevel	value="comprehensive"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/displayName"/>
 
+    <!-- TestCoverageCompleteness {
+      Error: (TestCoverageLevel.java:729) Comprehensive & no exception for path =>      //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+      Error: (TestCoverageLevel.java:729) Comprehensive & no exception for path =>      //ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/displayName
+      Error: (TestCoverageLevel.java:729) Comprehensive & no exception for path =>      //ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"]
+      Error: (TestCoverageLevel.java:729) Comprehensive & no exception for path =>      //ldml/units/unitLength[@type="short"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+      Error: (TestCoverageLevel.java:729) Comprehensive & no exception for path =>      //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/displayName
+      Error: (TestCoverageLevel.java:729) Comprehensive & no exception for path =>      //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]
+	   Error: (TestCoverageLevel.java:849) de (0) Broken Logical Grouping: comprehensive => [//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]]
+      Error: (TestCoverageLevel.java:849) pl (0) Broken Logical Grouping: modern => [//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="accusative"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"][@case="genitive"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="accusative"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"][@case="genitive"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="accusative"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"][@case="genitive"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="accusative"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"][@case="genitive"]]
+      Error: (TestCoverageLevel.java:849) pl (0) Broken Logical Grouping: comprehensive => [//ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="few"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="many"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="one"], //ldml/units/unitLength[@type="long"]/unit[@type="speed-light-speed"]/unitPattern[@count="other"]]
+    } (1.309s) FAILED (4 failure(s)) -->
 		<!-- *********************
 		Modified Basic rules (v41)
 		These contain a mixture of basic and moderate.

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -68,8 +68,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%currency40" value="(BRL|CNY|EUR|GBP|INR|JPY|RUB|USD)"/>
 		<coverageVariable key="%currency60" value="(AUD|CAD|CHF|DKK|HKD|IDR|KRW|MXN|NOK|PLN|SAR|SEK|THB|TRY|TWD|ZAR)"/>
 		<coverageVariable key="%currency60_EU" value="(CZK|HUF)"/>
-		<coverageVariable key="%currency80" value="(AED|AFN|ALL|AMD|ANG|AOA|ARS|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BSD|BTN|BWP|BYN|BZD|CDF|CLP|CNH|COP|CRC|CUC|CUP|CVE|CZK|DJF|DOP|DZD|EGP|ERN|ETB|FJD|FKP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HNL|HRK|HTG|HUF|ILS|IQD|IRR|ISK|JMD|JOD|KES|KGS|KHR|KMF|KPW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MYR|MZN|NAD|NGN|NIO|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PYG|QAR|RON|RSD|RWF|SBD|SCR|SDG|SGD|SHP|SL[EL]|SOS|SRD|SSP|STN|SYP|SZL|TJS|TMT|TND|TOP|TTD|TZS|UAH|UGX|UYU|UZS|VES|VND|VUV|WST|XCD|XAF|XOF|XPF|YER|ZMW|ZWG)"/>
-		<coverageVariable key="%currency100" value="(AFA|ADP|ALK|AO[KNR]|AR[ALMP]|ATS|AZM|BA[DN]|BE[CFL]|BG[LM]|BGO|BO[LPV]|BR[BCENRZ]|BUK|BY[BR]|CH[EW]|CL[EF]|CNX|COU|CS[DK]|CYP|DDM|DEM|EC[SV]|EEK|ES[ABP]|FIM|FRF|GEK|GHC|GNS|GQE|GRD|GW[EP]|HRD|IEP|IL[PR]|ISJ|ITL|KR[HO]|LT[LT]|LU[CFL]|LV[LR]|MAF|MCF|MDC|MGF|MKN|MLF|MRO|MT[LP]|MVP|MX[PV]|MZ[EM]|NIC|NLG|PE[IS]|PLZ|PTE|RHD|ROL|RUR|SD[DP]|SIT|SKK|SRG|STD|SUR|SVC|TJR|TMM|TPE|TRL|UAK|UGS|US[NS]|UY[IPW]|VE[BF]|VNN|XA[GU]|XB[ABCD]|XDR|XEU|XF[OU]|XP[DT]|XRE|XSU|XTS|XUA|YDD|YU[DMNR]|ZAL|ZMK|ZR[NZ]|ZW[DLR])"/>
+		<!-- Restore ZWG to currency80 in next submission cycle https://unicode-org.atlassian.net/browse/CLDR-18258 -->
+		<coverageVariable key="%currency80" value="(AED|AFN|ALL|AMD|ANG|AOA|ARS|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BSD|BTN|BWP|BYN|BZD|CDF|CLP|CNH|COP|CRC|CUC|CUP|CVE|CZK|DJF|DOP|DZD|EGP|ERN|ETB|FJD|FKP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HNL|HRK|HTG|HUF|ILS|IQD|IRR|ISK|JMD|JOD|KES|KGS|KHR|KMF|KPW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MYR|MZN|NAD|NGN|NIO|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PYG|QAR|RON|RSD|RWF|SBD|SCR|SDG|SGD|SHP|SL[EL]|SOS|SRD|SSP|STN|SYP|SZL|TJS|TMT|TND|TOP|TTD|TZS|UAH|UGX|UYU|UZS|VES|VND|VUV|WST|XCD|XAF|XOF|XPF|YER|ZMW)"/>
+		<coverageVariable key="%currency100" value="(AFA|ADP|ALK|AO[KNR]|AR[ALMP]|ATS|AZM|BA[DN]|BE[CFL]|BG[LM]|BGO|BO[LPV]|BR[BCENRZ]|BUK|BY[BR]|CH[EW]|CL[EF]|CNX|COU|CS[DK]|CYP|DDM|DEM|EC[SV]|EEK|ES[ABP]|FIM|FRF|GEK|GHC|GNS|GQE|GRD|GW[EP]|HRD|IEP|IL[PR]|ISJ|ITL|KR[HO]|LT[LT]|LU[CFL]|LV[LR]|MAF|MCF|MDC|MGF|MKN|MLF|MRO|MT[LP]|MVP|MX[PV]|MZ[EM]|NIC|NLG|PE[IS]|PLZ|PTE|RHD|ROL|RUR|SD[DP]|SIT|SKK|SRG|STD|SUR|SVC|TJR|TMM|TPE|TRL|UAK|UGS|US[NS]|UY[IPW]|VE[BF]|VNN|XA[GU]|XB[ABCD]|XDR|XEU|XF[OU]|XP[DT]|XRE|XSU|XTS|XUA|YDD|YU[DMNR]|ZAL|ZMK|ZR[NZ]|ZW[DLRG])"/>
 		<coverageVariable key="%cyclicNameTypes" value="([1-9]?[0-9])"/>
 		<coverageVariable key="%d0Types80" value="(ascii|fwidth|hwidth|lower|title|upper)"/>
 		<coverageVariable key="%dateFormatItems" value="((E|d|Ed|EEEEd)|((Gy|y|yyyy|U)?(M|Md|MEd|MEEEEd|MMM|MMMd|MMMEd|MMMEEEEd|MMMM|MMMMd|MMMMEd|MMMMEEEEd))|((Gy|y|yyyy)(QQQ|QQQQ)?))"/>
@@ -227,6 +228,17 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="core" match="characters/exemplarCharacters[@type='%coreExemplarTypes']"/>
 
 		<coverageLevel value="moderate" match="characters/exemplarCharacters[@type='%anyAlphaNum']"/>
+
+
+		<!-- *********************
+		Temporary overrides for https://unicode-org.atlassian.net/browse/CLDR-18258
+
+		These overrides help us ignore values that were added not during a submission cycle. If interpreted normally, it
+		would cause many supported locales to drop in coverage. During the next regular submission cycle, please remove these rules
+		and encourage linguists to fix these values.
+		********************* -->
+		<coverageLevel	value="comprehensive"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/unitPattern[@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	match="units/unitLength[@type='%unitLengths']/unit[@type='speed-light-speed']/displayName"/>
 
 		<!-- *********************
 		Modified Basic rules (v41)
@@ -520,65 +532,73 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	match="numbers/decimalFormats[@numberSystem='latn']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
 		<!-- non-latn default number systems, standard formats for decimal/currency/percent/etc also at basic per TC 2024-05-08 -->
-		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+
+		<!-- *********************
+		Most comprehensive levels are temporary overrides for https://unicode-org.atlassian.net/browse/CLDR-18258
+
+		These overrides help us ignore values that were added not during a submission cycle. If interpreted normally, it
+		would cause many supported locales to drop in coverage. During the next regular submission cycle, please remove these rules
+		and encourage linguists to fix these values. The 4 values should be moderate / basic / modern / moderate.
+		********************* -->
+		<coverageLevel	value="comprehensive"	inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%adlmDefaultScripts" match="numbers/currencyFormats[@numberSystem='adlm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%arabDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arab']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%arabextDefaultLanguages" inScript="Arab" match="numbers/currencyFormats[@numberSystem='arabext']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%bengDefaultScripts"	match="numbers/currencyFormats[@numberSystem='beng']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%cakmDefaultScripts"	match="numbers/currencyFormats[@numberSystem='cakm']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%devaDefaultLanguages" inScript="Deva" match="numbers/currencyFormats[@numberSystem='deva']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%hmnpDefaultScripts"	match="numbers/currencyFormats[@numberSystem='hmnp']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%mteiDefaultScripts"	match="numbers/currencyFormats[@numberSystem='mtei']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%mymrDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='mymr']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%nkooDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='nkoo']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inScript="%olckDefaultScripts"	match="numbers/currencyFormats[@numberSystem='olck']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 
-		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength/currencyFormat%stdPattern[@alt='%anyAttribute']"/>
 		<coverageLevel	value="basic"		inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength/currencyFormat%stdPattern"/>
-		<coverageLevel	value="modern"	    inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
-		<coverageLevel	value="moderate"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	    inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute'][@alt='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	inLanguage="%tibtDefaultLanguages"	match="numbers/currencyFormats[@numberSystem='tibt']/currencyFormatLength[@type='short']/currencyFormat[@type='standard']/pattern[@type='%compactDecimalTypes'][@count='%anyAttribute']"/>
 	
 		<coverageLevel	value="moderate"	inScript="%adlmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='adlm']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 		<coverageLevel	value="basic"		inScript="%adlmDefaultScripts"	match="numbers/decimalFormats[@numberSystem='adlm']/decimalFormatLength/decimalFormat%stdPattern"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -67,6 +67,10 @@ import org.unicode.cldr.util.TempPrintWriter;
 import org.unicode.cldr.util.VettingViewer;
 import org.unicode.cldr.util.VettingViewer.MissingStatus;
 
+/**
+ * This produces the cldr-staging file charts/47/supplemental/locale_coverage.html eg.
+ * https://www.unicode.org/cldr/charts/47/supplemental/locale_coverage.html
+ */
 public class ShowLocaleCoverage {
 
     private static final String TSV_BASE =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/StandardCodes.java
@@ -448,7 +448,9 @@ public class StandardCodes {
         }
         // see if there is a parent
         String originalLocale = desiredLocale;
+        String originalLanguage = CLDRLocale.toLanguageTag(originalLocale);
         while (desiredLocale != null) {
+
             Level status = locale_status.get(desiredLocale);
             if (status != null && status != Level.UNDETERMINED) {
                 coverageType.value =
@@ -457,7 +459,17 @@ public class StandardCodes {
                                 : LocaleCoverageType.parent;
                 return status;
             }
+
             desiredLocale = LocaleIDParser.getParent(desiredLocale);
+
+            // Unless the parent locale jumps languages, then don't continue (unless its norwegian,
+            // then its fine)
+            if (desiredLocale != null) {
+                String desiredLanguage = CLDRLocale.toLanguageTag(desiredLocale);
+                if (desiredLanguage != originalLanguage && !desiredLanguage.equals("no")) {
+                    desiredLocale = null;
+                }
+            }
         }
         Level status = locale_status.get(ALL_LOCALES);
         if (status != null && status != Level.UNDETERMINED) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1428,6 +1428,12 @@ public class VettingViewer<T> {
          */
         ALIASED,
 
+        /**
+         * The value is not from a different path -- but it is from a different locale
+         * specification, eg. from `fr` instead of `ht`.
+         */
+        FROM_RELATED_LANGUAGE,
+
         /** See ABSENT */
         MISSING_OK,
 
@@ -1467,6 +1473,11 @@ public class VettingViewer<T> {
                         path, status, false); // does not skip inheritance marker
 
         boolean isAliased = !path.equals(status.pathWhereFound);
+
+        boolean isSourceLocaleDifferent =
+                !sourceLocale.equals(sourceLocaleID)
+                        && !sourceLocale.equals(
+                                "no") /* Norwegian has multiple ISO codes even though its practically the same locale */;
         if (DEBUG) {
             if (path.equals("//ldml/characterLabels/characterLabelPattern[@type=\"subscript\"]")) {
                 int debug = 0;
@@ -1508,7 +1519,11 @@ public class VettingViewer<T> {
                                 ? MissingStatus.ROOT_OK
                                 : isParentRoot ? MissingStatus.ABSENT : MissingStatus.ALIASED;
             } else if (!isAliased) {
-                result = MissingStatus.PRESENT;
+                if (isSourceLocaleDifferent) {
+                    result = MissingStatus.FROM_RELATED_LANGUAGE;
+                } else {
+                    result = MissingStatus.PRESENT;
+                }
             } else if (isParentRoot) { // We handle ALIASED specially, depending on whether the
                 // parent is root or not.
                 result =
@@ -1678,6 +1693,7 @@ public class VettingViewer<T> {
 
             switch (missingStatus) {
                 case ABSENT:
+                case FROM_RELATED_LANGUAGE:
                     missingCounter.add(level, 1);
                     if (missingPaths != null) {
                         missingPaths.put(missingStatus, path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -229,8 +229,9 @@ public class TestCLDRFile extends TestFmwk {
                 final CLDRFile cldrFile = fullCldrFactory.make(locale, true);
                 Set<String> sorted2 = new TreeSet<>(cldrFile.getExtraPaths());
                 for (String path : sorted2) {
-                    if (path.contains("speed-beaufort")) {
+                    if (path.contains("speed-beaufort") || path.contains("speed-light-speed")) {
                         continue; // special case
+                        // Light-speed should eventually be restored but for now is ignored for https://unicode-org.atlassian.net/browse/CLDR-18258
                     }
                     if (path.contains("/gender")
                             || path.contains("@gender")

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -231,7 +231,8 @@ public class TestCLDRFile extends TestFmwk {
                 for (String path : sorted2) {
                     if (path.contains("speed-beaufort") || path.contains("speed-light-speed")) {
                         continue; // special case
-                        // Light-speed should eventually be restored but for now is ignored for https://unicode-org.atlassian.net/browse/CLDR-18258
+                        // Light-speed should eventually be restored but for now is ignored for
+                        // https://unicode-org.atlassian.net/browse/CLDR-18258
                     }
                     if (path.contains("/gender")
                             || path.contains("@gender")

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -721,6 +721,9 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 if ("narrow".equals(xpp.findAttributeValue("unitLength", "type"))
                         || path.endsWith("/compoundUnitPattern1")) {
                     continue;
+                } else if (path.contains("light-speed")) {
+                    // Temporary overrides for https://unicode-org.atlassian.net/browse/CLDR-18258
+                    continue;
                 }
             } else if (xpp.contains("posix")) {
                 continue;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLevel.java
@@ -103,7 +103,8 @@ public class TestLevel {
                 code.equals("ZWL") && CLDRFile.GEN_VERSION.equals("46"),
                 "Skipping ZWL for CLDR 46");
         assumeFalse(
-                code.equals("ZWG") && (CLDRFile.GEN_VERSION.equals("46") || CLDRFile.GEN_VERSION.equals("47")),
+                code.equals("ZWG")
+                        && (CLDRFile.GEN_VERSION.equals("46") || CLDRFile.GEN_VERSION.equals("47")),
                 "Skipping ZWG for CLDR 46 & 47");
         assertTrue(
                 expect.isAtLeast(l),

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestLevel.java
@@ -103,8 +103,8 @@ public class TestLevel {
                 code.equals("ZWL") && CLDRFile.GEN_VERSION.equals("46"),
                 "Skipping ZWL for CLDR 46");
         assumeFalse(
-                code.equals("ZWG") && CLDRFile.GEN_VERSION.equals("46"),
-                "Skipping ZWG for CLDR 46");
+                code.equals("ZWG") && (CLDRFile.GEN_VERSION.equals("46") || CLDRFile.GEN_VERSION.equals("47")),
+                "Skipping ZWG for CLDR 46 & 47");
         assertTrue(
                 expect.isAtLeast(l),
                 () ->


### PR DESCRIPTION
These values were added to CLDR in between submission cycles and it would be unfair to drop locale coverage if the languages did not support them. I'm not happy with the styling of all of my code here -- I'm happy to respond to suggestions.

Thereby, we're temporarily overriding their coverage as "comprehensive". All other coverage level changes are for other reasons ~~(and Haitian Creole has a separate ticket to fix it)~~. You can see changes to charts in this PR https://github.com/unicode-org/cldr-staging/pull/168 Some changes to charts are from other PRs, but the ones keeping coverage level at a good level are there.

While I was here I also had put in the fix for the ticket on Haitian Creole (https://unicode-org.atlassian.net/browse/CLDR-18105) -- because tests are failing since it thought Haitian Creole is a modern locale and thereby it should have translations in other languages (which we don't have yet because its new). So commit #3 does that change.

CLDR-18258

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
