### PR TITLE
CLDR-18265 BRS update currency codes

### DIFF
--- a/docs/site/development/updating-codes/update-currency-codes.md
+++ b/docs/site/development/updating-codes/update-currency-codes.md
@@ -5,12 +5,10 @@ title: Update Currency Codes
 # Update Currency Codes
 
 - Go to https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=currency-codes
-- Take the link for "Current Currency and Funds": ["List one (XML)"](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/lists/list_one.xml)
+- Take the link for "Current Currency and Funds": ["List one (XML)"](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml)
 - Save the page as {cldr}/tools/cldr\-code/src/main/resources/org/unicode/cldr/util/data/dl\_iso\_table\_a1\.xml
-- ```curl 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list_one.xml' > tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml```
-- Take the link for "Historic denominations": "[List three (XML)](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/lists/list_three.xml)"
+- Take the link for "Historic denominations": "[List three (XML)](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-three.xml)"
 - Save the page as {cldr}/tools/cldr\-code/src/main/resources/org/unicode/cldr/util/data/dl\_iso\_table\_a3\.xml
-- ```curl 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list_three.xml' > tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml```
 - **Use git diff to sanity check the two XML files against the old, and check them in.**
     - **"git diff \-w" is helpful to ignore whitespace. If there are only whitespace changes, there's no need to check them in.**
 - **Check the** [**ISO amendments**](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=amendments) **to get changes that will happen during the current cycle.**

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
@@ -1877,13 +1877,6 @@
 		</CcyNtry>
 		<CcyNtry>
 			<CtryNm>ZIMBABWE</CtryNm>
-			<CcyNm>Zimbabwe Dollar</CcyNm>
-			<Ccy>ZWL</Ccy>
-			<CcyNbr>932</CcyNbr>
-			<CcyMnrUnts>2</CcyMnrUnts>
-		</CcyNtry>
-		<CcyNtry>
-			<CtryNm>ZIMBABWE</CtryNm>
 			<CcyNm>Zimbabwe Gold</CcyNm>
 			<Ccy>ZWG</Ccy>
 			<CcyNbr>924</CcyNbr>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2024-01-01">
+<ISO_4217 Pblshd="2024-09-01">
 	<HstrcCcyTbl>
 		<HstrcCcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -1127,6 +1127,13 @@
 			<Ccy>ZWR</Ccy>
 			<CcyNbr>935</CcyNbr>
 			<WthdrwlDt>2009-06</WthdrwlDt>
+		</HstrcCcyNtry>
+		<HstrcCcyNtry>
+			<CtryNm>ZIMBABWE</CtryNm>
+			<CcyNm>Zimbabwe Dollar</CcyNm>
+			<Ccy>ZWL</Ccy>
+			<CcyNbr>932</CcyNbr>
+			<WthdrwlDt>2024-09</WthdrwlDt>
 		</HstrcCcyNtry>
 		<HstrcCcyNtry>
 			<CtryNm>ZZ01_Gold-Franc</CtryNm>


### PR DESCRIPTION
- update URLs
- drop wget instructions, just adds noise
- updated currency codes - no change other than ZWL now in historic.

CLDR-18265

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
