### PR TITLE
CLDR-17014 Make ExtraPaths.getInstance synchronized

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -12,7 +12,7 @@ public class ExtraPaths {
 
     private static final Map<NameType, ExtraPaths> instances = new HashMap<>();
 
-    public static ExtraPaths getInstance(NameType nameType) {
+    public static synchronized ExtraPaths getInstance(NameType nameType) {
         return instances.computeIfAbsent(nameType, ExtraPaths::new);
     }
 


### PR DESCRIPTION
-ConcurrentModificationException was thrown when ExtraPaths.getInstance called computeIfAbsent during cldr-generate-json.sh

-Unable to repro the exception before making this change; anyway, this should prevent it

CLDR-17014

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
