### PR TITLE
CLDR-17014 Change HashMap to ConcurrentHashMap in ExtraPaths

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -1,16 +1,16 @@
 package org.unicode.cldr.util;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ExtraPaths {
 
-    private static final Map<NameType, ExtraPaths> instances = new HashMap<>();
+    private static final Map<NameType, ExtraPaths> instances = new ConcurrentHashMap<>();
 
     public static ExtraPaths getInstance(NameType nameType) {
         return instances.computeIfAbsent(nameType, ExtraPaths::new);


### PR DESCRIPTION
-ConcurrentModificationException was thrown when ExtraPaths.getInstance called computeIfAbsent during cldr-generate-json.sh

-Unable to repro the exception before making this change

CLDR-17014

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
