### PR TITLE
CLDR-18138 kbd: fix DTD error for <import base>

### DIFF
--- a/keyboards/dtd/ldmlKeyboard3.dtd
+++ b/keyboards/dtd/ldmlKeyboard3.dtd
@@ -20,7 +20,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ELEMENT import EMPTY >
 <!ATTLIST import path CDATA #REQUIRED >
     <!--@MATCH:any-->
-<!ATTLIST import base (cldr) #IMPLIED >
+<!ATTLIST import base NMTOKEN #IMPLIED >
+    <!--@MATCH:literal/cldr-->
 
 <!ELEMENT locales ( locale* ) >
 

--- a/keyboards/dtd/ldmlKeyboard3.xsd
+++ b/keyboards/dtd/ldmlKeyboard3.xsd
@@ -50,15 +50,10 @@ Note: DTD @-annotations are not currently converted to .xsd. For full CLDR file 
   <xs:element name="import">
     <xs:complexType>
       <xs:attribute name="path" use="required"/>
-      <xs:attribute name="base">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="cldr"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
+      <xs:attribute name="base" type="xs:NMTOKEN"/>
     </xs:complexType>
   </xs:element>
+  
   
   <xs:element name="locales">
     <xs:complexType>


### PR DESCRIPTION
- DTD incorrectly had an implied value of 'cldr'
- No spec change needed.

CLDR-18138

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
