### PR TITLE
CLDR-17953 Enable TC to generate VXML

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGenerateVxml.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGenerateVxml.mjs
@@ -39,7 +39,7 @@ function canGenerateVxml() {
 function viewMounted(setData) {
   callbackToSetData = setData;
   const perm = cldrStatus.getPermissions();
-  canGenerate = Boolean(perm?.userIsAdmin);
+  canGenerate = Boolean(perm?.userCanGenerateVxml);
 }
 
 function start() {

--- a/tools/cldr-apps/js/src/views/GenerateVxml.vue
+++ b/tools/cldr-apps/js/src/views/GenerateVxml.vue
@@ -84,7 +84,9 @@ defineExpose({
 </script>
 
 <template>
-  <div v-if="!hasPermission">Please log in as Admin to use this feature.</div>
+  <div v-if="!hasPermission">
+    Please log in as a user with sufficient permissions.
+  </div>
   <div v-else>
     <p v-if="status != STATUS.INIT">Generation Status: {{ status }}</p>
     <p class="buttons">

--- a/tools/cldr-apps/js/src/views/MainMenu.vue
+++ b/tools/cldr-apps/js/src/views/MainMenu.vue
@@ -2,7 +2,9 @@
   <ul>
     <template v-if="loggedIn">
       <li v-if="isAdmin"><a href="#admin///">Admin Panel</a></li>
-      <li v-if="isAdmin"><a href="#generate_vxml///">Generate VXML</a></li>
+      <li v-if="canGenerateVxml">
+        <a href="#generate_vxml///">Generate VXML</a>
+      </li>
       <!-- My Account only has border-top (section-header) if Admin Panel is shown -->
       <li v-if="isAdmin" class="section-header">My Account</li>
       <li v-else>My Account</li>
@@ -144,6 +146,7 @@ export default {
   data() {
     return {
       accountLocked: false,
+      canGenerateVxml: false,
       canImportOldVotes: false,
       canListUsers: false,
       canMonitorVetting: false,
@@ -168,20 +171,21 @@ export default {
   methods: {
     initializeData() {
       const perm = cldrStatus.getPermissions();
-      this.accountLocked = perm && perm.userIsLocked;
-      this.canImportOldVotes = perm && perm.userCanImportOldVotes;
-      this.canListUsers = !!perm?.userCanListUsers;
-      this.canMonitorVetting = !!perm?.userCanUseVettingParticipation;
-      this.canMonitorForum = perm && perm.userCanMonitorForum;
+      this.accountLocked = Boolean(perm?.userIsLocked);
+      this.canGenerateVxml = Boolean(perm?.userCanGenerateVxml);
+      this.canImportOldVotes = Boolean(perm?.userCanImportOldVotes);
+      this.canListUsers = Boolean(perm?.userCanListUsers);
+      this.canMonitorVetting = Boolean(perm?.userCanUseVettingParticipation);
+      this.canMonitorForum = Boolean(perm?.userCanMonitorForum);
       // this.canSeeStatistics will be false until there is a new implementation
-      this.canUseVettingSummary = perm && perm.userCanUseVettingSummary;
-      this.isAdmin = perm && perm.userIsAdmin;
+      this.canUseVettingSummary = Boolean(perm?.userCanUseVettingSummary);
+      this.isAdmin = Boolean(perm?.userIsAdmin);
       this.canSeeUnofficialEmail =
-        cldrStatus.getIsUnofficial() && !!perm?.userIsManager;
-      this.isTC = perm && perm.userIsTC;
+        cldrStatus.getIsUnofficial() && Boolean(perm?.userIsManager);
+      this.isTC = Boolean(perm?.userIsTC);
 
       const user = cldrStatus.getSurveyUser();
-      this.loggedIn = !!user;
+      this.loggedIn = Boolean(user);
       this.userId = user ? user.id : 0;
 
       this.org = cldrStatus.getOrganizationName();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AnnouncementData.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AnnouncementData.java
@@ -505,11 +505,11 @@ public class AnnouncementData {
             if (Announcements.AUDIENCE_EVERYONE.equals(audience)) {
                 return true;
             } else if (Announcements.AUDIENCE_VETTERS.equals(audience)) {
-                return userLevel.isVetter();
+                return userLevel.isVetterOrStronger();
             } else if (Announcements.AUDIENCE_MANAGERS.equals(audience)) {
                 return userLevel.isManagerOrStronger();
             } else if (Announcements.AUDIENCE_TC.equals(audience)) {
-                return userLevel.isTC();
+                return userLevel.isTCOrStronger();
             } else {
                 logger.severe("Unrecognized audience: " + audience);
                 return false;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/STFactory.java
@@ -422,7 +422,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
             if (ph.getSurveyToolStatus() == PathHeader.SurveyToolStatus.DEPRECATED) return false;
             if (ph.getSurveyToolStatus() == PathHeader.SurveyToolStatus.HIDE
                     || ph.getSurveyToolStatus() == PathHeader.SurveyToolStatus.READ_ONLY) {
-                if (!UserRegistry.userIsTC(user)) return false;
+                if (!UserRegistry.userIsTCOrStronger(user)) return false;
             }
 
             if (sm.getSupplementalDataInfo().getCoverageValue(xpath, locale.getBaseName())
@@ -918,7 +918,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 throws InvalidXPathException {
             if (!getPathsForFile().contains(xpath)) {
                 if (value == null
-                        && UserRegistry.userIsTC(user)
+                        && UserRegistry.userIsTCOrStronger(user)
                         && XPathTable.getAlt(xpath) != null) {
                     synchronized (this) {
                         Set<String> set = new HashSet<>(pathsForFile);
@@ -1026,7 +1026,7 @@ public class STFactory extends Factory implements BallotBoxFactory<UserRegistry.
                 }
                 ps.executeUpdate();
 
-                if (wasFlagged && UserRegistry.userIsTC(user)) {
+                if (wasFlagged && UserRegistry.userIsTCOrStronger(user)) {
                     clearFlag(conn, locale, xpathId);
                     didClearFlag = true;
                 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -207,7 +207,7 @@ public class SurveyAjax extends HttpServlet {
             } else if (what.equals(WHAT_FLAGGED)) {
                 SurveyJSONWrapper r = newJSONStatus(request, sm);
                 mySession = CookieSession.retrieve(sess);
-                new SurveyFlaggedItems(UserRegistry.userIsTC(mySession.user)).getJson(r);
+                new SurveyFlaggedItems(UserRegistry.userIsTCOrStronger(mySession.user)).getJson(r);
                 send(r, out);
             } else if (what.equals(WHAT_STATS_BYDAYUSERLOC)) {
                 String votesAfterString = SurveyMain.getVotesAfterString();
@@ -610,7 +610,7 @@ public class SurveyAjax extends HttpServlet {
                              */
                             if (mySession.user != null
                                     && mySession.user.canImportOldVotes()
-                                    && !UserRegistry.userIsTC(mySession.user)
+                                    && !UserRegistry.userIsTCOrStronger(mySession.user)
                                     && !alreadyAutoImportedVotes(mySession.user.id, "ask")) {
                                 r.put("canAutoImport", "true");
                             }
@@ -707,7 +707,7 @@ public class SurveyAjax extends HttpServlet {
                                     if (them != null
                                             && ((them.id == mySession.user.id)
                                                     || // it's me
-                                                    UserRegistry.userIsTC(mySession.user)
+                                                    UserRegistry.userIsTCOrStronger(mySession.user)
                                                     || (UserRegistry.userIsExactlyManager(
                                                                     mySession.user)
                                                             && (them.getOrganization()
@@ -877,7 +877,7 @@ public class SurveyAjax extends HttpServlet {
      * @throws SurveyException
      */
     public void assertIsTC(CookieSession mySession) throws SurveyException {
-        if (!UserRegistry.userIsTC(mySession.user)) {
+        if (!UserRegistry.userIsTCOrStronger(mySession.user)) {
             throw new SurveyException(ErrorCode.E_NO_PERMISSION);
         }
     }
@@ -1568,7 +1568,7 @@ public class SurveyAjax extends HttpServlet {
         // sort by pathheader
         Arrays.sort(rows, Comparator.comparing(o -> ((PathHeader) o.get("pathHeader"))));
 
-        boolean useWinningVotes = UserRegistry.userIsTC(user);
+        boolean useWinningVotes = UserRegistry.userIsTCOrStronger(user);
 
         /* Some variables are only used if oldvotes != null; otherwise leave them null. */
         JSONArray contested = null; // contested = losing

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
@@ -198,7 +198,7 @@ public class SurveyForum {
                             && !u.email.isEmpty()
                             && !(UserRegistry.userIsLocked(u)
                                     || UserRegistry.userIsExactlyAnonymous(u))) {
-                        if (UserRegistry.userIsVetter(u)) {
+                        if (UserRegistry.userIsVetterOrStronger(u)) {
                             cc_emails.add(u.id);
                         } else {
                             bcc_emails.add(u.id);
@@ -301,7 +301,7 @@ public class SurveyForum {
             return; // don't notify the poster of their own action
         }
         UserRegistry.User rootPoster = sm.reg.getInfo(rootPosterId);
-        if (UserRegistry.userIsTC(rootPoster)) {
+        if (UserRegistry.userIsTCOrStronger(rootPoster)) {
             cc_emails.add(rootPosterId);
         }
     }
@@ -316,7 +316,7 @@ public class SurveyForum {
      */
     private boolean userCanUsePostType(PostInfo postInfo) {
         User user = postInfo.getUser();
-        boolean isTC = UserRegistry.userIsTC(user);
+        boolean isTC = UserRegistry.userIsTCOrStronger(user);
         if (!isTC && SurveyMain.isPhaseReadonly()) {
             return false;
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -96,7 +96,7 @@ public class UserList {
                 org = null; // all
             }
         }
-        canShowLocked = UserRegistry.userIsExactlyManager(me) || UserRegistry.userIsTC(me);
+        canShowLocked = UserRegistry.userIsManagerOrStronger(me);
         showLocked = canShowLocked && ctx.prefBool(PREF_SHOWLOCKED);
         isValid = isJustMe || UserRegistry.userCanListUsers(me);
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
@@ -1440,7 +1440,7 @@ public class WebContext implements Cloneable, Appendable {
         logger.fine("Session Now=" + session + ", user=" + user);
 
         // allow in administrator or TC.
-        if (!UserRegistry.userIsTC(user)) {
+        if (!UserRegistry.userIsTCOrStronger(user)) {
             if ((user != null) && (session == null)) { // user trying to log in-
                 if (CookieSession.tooManyUsers()) {
                     System.err.println(

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Announcements.java
@@ -85,7 +85,7 @@ public class Announcements {
         if (session == null) {
             return Auth.noSessionResponse();
         }
-        if (!UserRegistry.userIsGuest(session.user)) { // userIsGuest means "is guest or stronger"
+        if (!UserRegistry.userIsGuestOrStronger(session.user)) {
             return Response.status(403, "Forbidden").build();
         }
         session.userDidAction();
@@ -223,7 +223,7 @@ public class Announcements {
         // Only TC or Admin can specify orgs other than ORGS_MINE
         if (!UserRegistry.userIsManagerOrStronger(session.user)
                 || (!ORGS_MINE.equals(request.orgs)
-                        && !UserRegistry.userIsTC(session.user))) { // userIsTC means TC or stronger
+                        && !UserRegistry.userIsTCOrStronger(session.user))) {
             return Response.status(403, "Forbidden").build();
         }
         final AnnouncementSubmissionResponse response = new AnnouncementSubmissionResponse();
@@ -331,7 +331,7 @@ public class Announcements {
         if (session == null) {
             return Auth.noSessionResponse();
         }
-        if (!UserRegistry.userIsGuest(session.user)) { // means guest or stronger
+        if (!UserRegistry.userIsGuestOrStronger(session.user)) {
             return Response.status(403, "Forbidden").build();
         }
         final CheckReadResponse response = new CheckReadResponse();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/GenerateVxml.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/GenerateVxml.java
@@ -47,7 +47,7 @@ public class GenerateVxml {
             if (cs == null) {
                 return Auth.noSessionResponse();
             }
-            if (!UserRegistry.userIsAdmin(cs.user)) {
+            if (!UserRegistry.userIsTCOrStronger(cs.user)) {
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
             if (SurveyMain.isBusted()

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -157,7 +157,7 @@ public class VoteAPIHelper {
         try {
             /** if true, hide emails. TODO: CLDR-16829 remove this parameter */
             final boolean redacted =
-                    ((mySession.user == null) || (!mySession.user.getLevel().isGuest()));
+                    ((mySession.user == null) || (!mySession.user.getLevel().isGuestOrStronger()));
             final RowResponse r = getRowsResponse(args, sm, locale, mySession, redacted);
             return Response.ok(r).build();
         } catch (Throwable t) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAlt.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/XPathAlt.java
@@ -114,7 +114,7 @@ public class XPathAlt {
             if (session == null) {
                 return Auth.noSessionResponse();
             }
-            if (!UserRegistry.userIsTC(session.user)) {
+            if (!UserRegistry.userIsTCOrStronger(session.user)) {
                 return Response.status(403, "Forbidden").build();
             }
             session.userDidAction();

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestUserLevel.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestUserLevel.java
@@ -149,16 +149,16 @@ public class TestUserLevel {
                 assertEquals(expected, UserRegistry.userIsManagerOrStronger(u), onFail);
                 break;
             case "userIsVetter":
-                assertEquals(expected, UserRegistry.userIsVetter(u), onFail);
+                assertEquals(expected, UserRegistry.userIsVetterOrStronger(u), onFail);
                 break;
             case "userIsAdmin":
                 assertEquals(expected, UserRegistry.userIsAdmin(u), onFail);
                 break;
             case "userIsTC":
-                assertEquals(expected, UserRegistry.userIsTC(u), onFail);
+                assertEquals(expected, UserRegistry.userIsTCOrStronger(u), onFail);
                 break;
             case "userIsGuest":
-                assertEquals(expected, UserRegistry.userIsGuest(u), onFail);
+                assertEquals(expected, UserRegistry.userIsGuestOrStronger(u), onFail);
                 break;
             case "userIsLocked":
                 assertEquals(expected, UserRegistry.userIsLocked(u), onFail);
@@ -288,16 +288,16 @@ public class TestUserLevel {
                 assertEquals(expected, l.isManagerOrStronger(), onFail);
                 break;
             case "userIsVetter":
-                assertEquals(expected, l.isVetter(), onFail);
+                assertEquals(expected, l.isVetterOrStronger(), onFail);
                 break;
             case "userIsAdmin":
                 assertEquals(expected, l.isAdmin(), onFail);
                 break;
             case "userIsTC":
-                assertEquals(expected, l.isTC(), onFail);
+                assertEquals(expected, l.isTCOrStronger(), onFail);
                 break;
             case "userIsGuest":
-                assertEquals(expected, l.isGuest(), onFail);
+                assertEquals(expected, l.isGuestOrStronger(), onFail);
                 break;
             case "userIsLocked":
                 assertEquals(expected, l.isLocked(), onFail);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -330,14 +330,11 @@ public class VoteResolver<T> {
                             PERMANENT_VOTES);
         }
 
-        // The following methods were moved here from UserRegistry
-        // TODO: remove this todo notice
-
         public boolean isAdmin() {
             return stlevel <= admin.stlevel;
         }
 
-        public boolean isTC() {
+        public boolean isTCOrStronger() {
             return stlevel <= tc.stlevel;
         }
 
@@ -349,11 +346,11 @@ public class VoteResolver<T> {
             return stlevel <= manager.stlevel;
         }
 
-        public boolean isVetter() {
+        public boolean isVetterOrStronger() {
             return stlevel <= vetter.stlevel;
         }
 
-        public boolean isGuest() {
+        public boolean isGuestOrStronger() {
             return stlevel <= guest.stlevel;
         }
 
@@ -372,11 +369,11 @@ public class VoteResolver<T> {
          * @param myOrg
          */
         public boolean isAdminForOrg(Organization myOrg, Organization target) {
-            return isAdmin() || ((isTC() || stlevel == manager.stlevel) && (myOrg == target));
+            return isAdmin() || (isManagerOrStronger() && (myOrg == target));
         }
 
         public boolean canImportOldVotes(CheckCLDR.Phase inPhase) {
-            return isVetter() && (inPhase == Phase.SUBMISSION);
+            return isVetterOrStronger() && (inPhase == Phase.SUBMISSION);
         }
 
         public boolean canListUsers() {
@@ -384,15 +381,15 @@ public class VoteResolver<T> {
         }
 
         public boolean canCreateUsers() {
-            return isTC() || isExactlyManager();
+            return isManagerOrStronger();
         }
 
         public boolean canEmailUsers() {
-            return isTC() || isExactlyManager();
+            return isManagerOrStronger();
         }
 
         public boolean canModifyUsers() {
-            return isTC() || isExactlyManager();
+            return isManagerOrStronger();
         }
 
         public boolean canCreateOtherOrgs() {
@@ -410,7 +407,7 @@ public class VoteResolver<T> {
                 // false here.
                 // This is probably desired!
             }
-            return isGuest();
+            return isGuestOrStronger();
         }
 
         public boolean canCreateSummarySnapshot() {
@@ -418,7 +415,7 @@ public class VoteResolver<T> {
         }
 
         public boolean canMonitorForum() {
-            return isTC() || isExactlyManager();
+            return isManagerOrStronger();
         }
 
         public boolean canSetInterestLocales() {


### PR DESCRIPTION
-Previously only Admin could use the Generate VXML option in the ☰ menu

-New Java function canGenerateVxml, new http response item userCanGenerateVxml to encapsulate this rule on the back end

-Rename Java function isTC to isTCOrStronger, for clarity, likewise for isVetter, etc.

-Remove some superfluous conditions like userIsAdmin in (userIsAdmin || userIsTCOrStronger)

-Do not exhaustively rename ...OrStronger; in particular front end and http response json still have userIsTC, etc.; renaming for front end and json will require caution and is beyond scope of this PR

-Refactor a few lines of js for consistency and to ensure boolean: Boolean(perm?.userIsLocked) instead of (perm && perm.userIsLocked)

-Comments

CLDR-17953

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
