### PR TITLE
CLDR-18239 Add Kurdish variant

### DIFF
--- a/common/main/ku_SY.xml
+++ b/common/main/ku_SY.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2025 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="ku"/>
+		<territory type="SY"/>
+	</identity>
+</ldml>


### PR DESCRIPTION
(Intended for v48. Only to be merged after v47 is stable and cut from main)

Kurdish, specifically Northern Kurdish, is also spoken by many people in Syria. This adds a Syrian variant. Yes, it also uses the Latin orthography (the default for ku).

CLDR-18239

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
