### PR TITLE
CLDR-17014 Handle TERRITORY paths like LANGUAGE and SCRIPT

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -1158,12 +1158,6 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
                                         continue;
                                     }
                                 }
-                                String keepValue =
-                                        XMLSource.getPathsAllowingDuplicates().get(xpath);
-                                if (keepValue != null && keepValue.equals(currentValue)) {
-                                    logicDuplicate = false;
-                                    continue;
-                                }
                                 // we've now established that the values are the same
                                 String currentFullXPath = dataSource.getFullPath(xpath);
                                 String otherFullXPath = other.dataSource.getFullPath(otherXpath);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -80,8 +80,9 @@ public class ExtraPaths {
 
         Singleton() {
             pathsTemp = new TreeSet<>();
-            addPaths(NameType.SCRIPT);
             addPaths(NameType.LANGUAGE);
+            addPaths(NameType.SCRIPT);
+            addPaths(NameType.TERRITORY);
             addMetazones();
             pathsTemp.addAll(CONST_EXTRA_PATHS);
             paths = ImmutableSet.copyOf(pathsTemp); // preserves order (Sets.copyOf doesn't)
@@ -128,6 +129,27 @@ public class ExtraPaths {
                 case SCRIPT:
                     addAltPath("Hans", "stand-alone", nameType);
                     addAltPath("Hant", "stand-alone", nameType);
+                case TERRITORY:
+                    addAltPath("GB", "short", nameType);
+                    addAltPath("HK", "short", nameType);
+                    addAltPath("MO", "short", nameType);
+                    addAltPath("PS", "short", nameType);
+                    addAltPath("US", "short", nameType);
+                    addAltPath("CD", "variant", nameType);
+                    addAltPath("CG", "variant", nameType);
+                    addAltPath("CI", "variant", nameType);
+                    addAltPath("CZ", "variant", nameType);
+                    addAltPath("FK", "variant", nameType);
+                    addAltPath("TL", "variant", nameType);
+                    addAltPath("SZ", "variant", nameType);
+                    addAltPath("IO", "biot", nameType);
+                    addAltPath("IO", "chagos", nameType);
+
+                    // new alternate name
+                    addAltPath("NZ", "variant", nameType);
+                    addAltPath("TR", "variant", nameType);
+                    addAltPath("XA", "variant", nameType);
+                    addAltPath("XB", "variant", nameType);
             }
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -101,14 +101,19 @@ public class ExtraPaths {
         }
 
         private void adjustCodeSet(Set<String> codes, NameType nameType) {
-            if (nameType == NameType.LANGUAGE) {
-                codes.remove(LocaleNames.ROOT);
-                codes.addAll(
-                        List.of(
-                                "ar_001", "de_AT", "de_CH", "en_AU", "en_CA", "en_GB", "en_US",
-                                "es_419", "es_ES", "es_MX", "fa_AF", "fr_CA", "fr_CH", "frc",
-                                "hi_Latn", "lou", "nds_NL", "nl_BE", "pt_BR", "pt_PT", "ro_MD",
-                                "sw_CD", "zh_Hans", "zh_Hant"));
+            switch (nameType) {
+                case LANGUAGE:
+                    codes.remove(LocaleNames.ROOT);
+                    codes.addAll(
+                            List.of(
+                                    "ar_001", "de_AT", "de_CH", "en_AU", "en_CA", "en_GB", "en_US",
+                                    "es_419", "es_ES", "es_MX", "fa_AF", "fr_CA", "fr_CH", "frc",
+                                    "hi_Latn", "lou", "nds_NL", "nl_BE", "pt_BR", "pt_PT", "ro_MD",
+                                    "sw_CD", "zh_Hans", "zh_Hant"));
+                    break;
+                case TERRITORY:
+                    codes.addAll(List.of("XA", "XB"));
+                    break;
             }
         }
 
@@ -144,12 +149,9 @@ public class ExtraPaths {
                     addAltPath("SZ", "variant", nameType);
                     addAltPath("IO", "biot", nameType);
                     addAltPath("IO", "chagos", nameType);
-
                     // new alternate name
                     addAltPath("NZ", "variant", nameType);
                     addAltPath("TR", "variant", nameType);
-                    addAltPath("XA", "variant", nameType);
-                    addAltPath("XB", "variant", nameType);
             }
         }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -46,7 +46,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
     public static final String ROOT_ID = "root";
     public static final boolean USE_PARTS_IN_ALIAS = false;
     private static final String TRACE_INDENT = " "; // "\t"
-    private static Map<String, String> allowDuplicates = new HashMap<>();
 
     private String localeID;
     private boolean nonInheriting;
@@ -273,11 +272,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             putFullPathAtDPath(distinguishingXPath, fixedPath[0]);
         }
         return distinguishingXPath;
-    }
-
-    /** Gets those paths that allow duplicates */
-    public static Map<String, String> getPathsAllowingDuplicates() {
-        return allowDuplicates;
     }
 
     /** A listener for XML source data. */
@@ -1605,7 +1599,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             Map<String, String> zone_countries = sc.getZoneToCountry();
             List<NameType> nameTypeList =
                     List.of(
-                            NameType.TERRITORY,
                             NameType.VARIANT,
                             NameType.CURRENCY,
                             NameType.CURRENCY_SYMBOL,
@@ -1627,30 +1620,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                     addFallbackCode(nameType, code, value);
                 }
             }
-            addFallbackCode(NameType.TERRITORY, "GB", "GB", "short");
-            addFallbackCode(NameType.TERRITORY, "HK", "HK", "short");
-            addFallbackCode(NameType.TERRITORY, "MO", "MO", "short");
-            addFallbackCode(NameType.TERRITORY, "PS", "PS", "short");
-            addFallbackCode(NameType.TERRITORY, "US", "US", "short");
-
-            addFallbackCode(
-                    NameType.TERRITORY, "CD", "CD", "variant"); // add other geopolitical items
-            addFallbackCode(NameType.TERRITORY, "CG", "CG", "variant");
-            addFallbackCode(NameType.TERRITORY, "CI", "CI", "variant");
-            addFallbackCode(NameType.TERRITORY, "CZ", "CZ", "variant");
-            addFallbackCode(NameType.TERRITORY, "FK", "FK", "variant");
-            addFallbackCode(NameType.TERRITORY, "TL", "TL", "variant");
-            addFallbackCode(NameType.TERRITORY, "SZ", "SZ", "variant");
-            addFallbackCode(NameType.TERRITORY, "IO", "IO", "biot");
-            addFallbackCode(NameType.TERRITORY, "IO", "IO", "chagos");
-
-            // new alternate name
-
-            addFallbackCode(NameType.TERRITORY, "NZ", "NZ", "variant");
-            addFallbackCode(NameType.TERRITORY, "TR", "TR", "variant");
-
-            addFallbackCode(NameType.TERRITORY, "XA", "XA");
-            addFallbackCode(NameType.TERRITORY, "XB", "XB");
 
             addFallbackCode(
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/eras/eraAbbr/era[@type=\"0\"]",
@@ -1697,7 +1666,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                         typeDisplayNames[i][0]);
             }
             constructedItems.freeze();
-            allowDuplicates = Collections.unmodifiableMap(allowDuplicates);
         }
 
         private static void addFallbackCode(NameType nameType, String code, String value) {
@@ -1708,13 +1676,9 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 NameType nameType, String code, String value, String alt) {
             String fullpath = nameType.getKeyPath(code);
             String distinguishingPath = addFallbackCodeToConstructedItems(fullpath, value, alt);
-            if (nameType == NameType.SCRIPT || nameType == NameType.TERRITORY) {
-                allowDuplicates.put(distinguishingPath, code);
-            }
         }
 
-        private static void addFallbackCode(
-                String fullpath, String value, String alt) { // assumes no allowDuplicates for this
+        private static void addFallbackCode(String fullpath, String value, String alt) {
             addFallbackCodeToConstructedItems(fullpath, value, alt); // ignore unneeded return value
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -193,6 +193,8 @@ public class TestCLDRFile extends TestFmwk {
                                     || path.startsWith(
                                             "//ldml/localeDisplayNames/languages/language")
                                     || path.startsWith("//ldml/localeDisplayNames/scripts/script")
+                                    || path.startsWith(
+                                            "//ldml/localeDisplayNames/territories/territory")
                                     || path.startsWith("//ldml/numbers/currencies/currency")
                                     || path.startsWith("//ldml/personNames/sampleName")
                                     || path.contains("/availableFormats")
@@ -924,7 +926,7 @@ public class TestCLDRFile extends TestFmwk {
         }
     }
 
-    public void TestExtraPaths() {
+    public void TestExtraPathsCapitalT() { // CapitalT to distinguish from testExtraPaths above
         List<String> testCases =
                 Arrays.asList(
                         "//ldml/localeDisplayNames/languages/language[@type=\"ccp\"]",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -926,7 +926,7 @@ public class TestCLDRFile extends TestFmwk {
         }
     }
 
-    public void TestExtraPathsCapitalT() { // CapitalT to distinguish from testExtraPaths above
+    public void testExtraPaths2() {
         List<String> testCases =
                 Arrays.asList(
                         "//ldml/localeDisplayNames/languages/language[@type=\"ccp\"]",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -253,6 +253,7 @@ public class TestPaths extends TestFmwkPlus {
                 || path.contains("/caseMinimalPairs")
                 || path.contains("/genderMinimalPairs")
                 || path.contains("/sampleName")
+                || path.contains("/localeDisplayNames/territories/territory")
         //            ||
         // path.equals("//ldml/dates/timeZoneNames/zone[@type=\"Australia/Currie\"]/exemplarCity")
         //            ||

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCLDRFile.java
@@ -274,10 +274,6 @@ public class TestCLDRFile {
                                     XMLSource.ROOT_ID,
                                     "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                                     Reason.constructed),
-                            new LocaleInheritanceInfo(
-                                    XMLSource.CODE_FALLBACK_ID,
-                                    "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]",
-                                    Reason.constructed),
                             new LocaleInheritanceInfo(XMLSource.ROOT_ID, p, Reason.none),
                             new LocaleInheritanceInfo(null, p, Reason.codeFallback)),
                     pwf,
@@ -323,10 +319,6 @@ public class TestCLDRFile {
                                     XMLSource
                                             .CODE_FALLBACK_ID /* test data does not have this in root */,
                                     "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                                    Reason.constructed),
-                            new LocaleInheritanceInfo(
-                                    XMLSource.CODE_FALLBACK_ID,
-                                    "//ldml/localeDisplayNames/territories/territory[@type=\"CH\"]",
                                     Reason.constructed),
                             new LocaleInheritanceInfo(locale, p, Reason.none),
                             new LocaleInheritanceInfo(XMLSource.ROOT_ID, p, Reason.none),


### PR DESCRIPTION
-Use ExtraPaths instead of XMLSource.ResolvingSource.constructedItems

-Paths constructed in this way no longer have fallback values

-Delete getPathsAllowingDuplicates and related code, now unused

CLDR-17014

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
