### PR TITLE
CLDR-18240 Check for null baileyValue in VoteResolver

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -604,7 +604,7 @@ public class VoteResolver<T> {
         private final Map<Organization, T> orgToAdd = new EnumMap<>(Organization.class);
 
         private T baileyValue;
-        private boolean baileySet; // was the bailey value set
+        private boolean baileySet; // was the bailey value set (possibly to null)
 
         OrganizationToValueAndVote() {
             for (Organization org : Organization.values()) {
@@ -1011,16 +1011,15 @@ public class VoteResolver<T> {
      * Get the bailey value (what the inherited value would be if there were no explicit value) for
      * this VoteResolver.
      *
-     * <p>Throw an exception if !baileySet.
+     * <p>Throw an exception if !baileySet, in order to detect programming errors where
+     * getBaileyValue might be called before setBaileyValue.
      *
-     * @return the bailey value.
-     *     <p>Called by STFactory.PerLocaleData.getResolverInternal in the special circumstance
-     *     where getWinningValue has returned INHERITANCE_MARKER.
+     * @return the bailey value (which may be null).
      */
-    public T getBaileyValue() {
+    private T getBaileyValue() {
         if (!organizationToValueAndVote.baileySet) {
             throw new IllegalArgumentException(
-                    "setBaileyValue must be called before getBaileyValue");
+                    "setBaileyValue must be called before getBaileyValue (even if the value is null)");
         }
         return organizationToValueAndVote.baileyValue;
     }
@@ -1029,8 +1028,11 @@ public class VoteResolver<T> {
      * Set the Bailey value (what the inherited value would be if there were no explicit value).
      * This value is used in handling any CldrUtility.INHERITANCE_MARKER. This value must be set
      * <i>before</i> adding values. Usually by calling CLDRFile.getBaileyValue().
+     *
+     * @param baileyValue the value to be set, or null
      */
     public void setBaileyValue(T baileyValue) {
+        // baileySet gets true here, even if baileyValue is null
         organizationToValueAndVote.baileySet = true;
         organizationToValueAndVote.baileyValue = baileyValue;
     }
@@ -1208,7 +1210,7 @@ public class VoteResolver<T> {
 
         /*
          * If there are no (unconflicted) votes, return baseline (trunk) if not null,
-         * else INHERITANCE_MARKER if baileySet, else NO_WINNING_VALUE.
+         * else INHERITANCE_MARKER if baileyValue isn't null, else NO_WINNING_VALUE.
          * Avoid setting winningValue to null. VoteResolver should be fully in charge of vote resolution.
          */
         if (sortedValues.size() == 0) {
@@ -1219,7 +1221,7 @@ public class VoteResolver<T> {
                         "Winning Value: '%s' with status '%s' because there were no unconflicted votes.",
                         winningValue, winningStatus);
                 // Declare the winner here, because we're about to return from the function
-            } else if (organizationToValueAndVote.baileySet) {
+            } else if (getBaileyValue() != null) {
                 setWinningValue((T) CldrUtility.INHERITANCE_MARKER);
                 winningStatus = Status.missing;
                 annotateTranscript(
@@ -1343,11 +1345,10 @@ public class VoteResolver<T> {
      */
     private boolean combineInheritanceWithBaileyForVoting(
             Set<T> sortedValues, HashMap<T, Long> voteCount) {
-        if (organizationToValueAndVote.baileySet == false
-                || organizationToValueAndVote.baileyValue == null) {
+        T hardValue = getBaileyValue();
+        if (hardValue == null) {
             return false;
         }
-        T hardValue = organizationToValueAndVote.baileyValue;
         T softValue = (T) CldrUtility.INHERITANCE_MARKER;
         /*
          * Check containsKey before get, to avoid NullPointerException.
@@ -1875,8 +1876,8 @@ public class VoteResolver<T> {
     public String toString() {
         return "{"
                 + "bailey: "
-                + (organizationToValueAndVote.baileySet
-                        ? ("“" + organizationToValueAndVote.baileyValue + "” ")
+                + (organizationToValueAndVote.baileyValue != null
+                        ? ("“" + getBaileyValue() + "” ")
                         : "none ")
                 + "baseline: {"
                 + baselineValue
@@ -2159,9 +2160,9 @@ public class VoteResolver<T> {
         return orgVote == null
                 || orgVote.equals(value)
                 || (CldrUtility.INHERITANCE_MARKER.equals(value)
-                        && orgVote.equals(organizationToValueAndVote.baileyValue))
+                        && orgVote.equals(getBaileyValue()))
                 || (CldrUtility.INHERITANCE_MARKER.equals(orgVote)
-                        && value.equals(organizationToValueAndVote.baileyValue));
+                        && value.equals(getBaileyValue()));
     }
 
     /**


### PR DESCRIPTION
-In resolveVotes, do not return INHERITANCE_MARKER if baileyValue is null

-Do not misinterpret the boolean baileySet as implying baileyValue is not null

-Always call getBaileyValue instead of reading baileyValue directly, to enforce the requirement that setBaileyValue must be called before getBaileyValue

-Make VoteResolver.getBaileyValue private; it was not called by other classes

-Comments; clarify that baileySet may be true even if baileyValue is false; it only indicates that setBaileyValue was called

CLDR-18240

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
