### PR TITLE
CLDR-18128 Pair classical with semantic skeletons in datetime test data

### DIFF
--- a/common/testData/datetime/datetime.json
+++ b/common/testData/datetime/datetime.json
@@ -152,6 +152,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "yyMdEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -160,6 +161,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "yyMdEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -168,6 +170,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "yyMdEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -176,6 +179,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "yMMMdEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -184,6 +188,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "yMMMdEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -192,6 +197,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "yMMMdEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -200,6 +206,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "yMMMMdEEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -208,6 +215,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "yMMMMdEEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -216,6 +224,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "yMMMMdEEEE",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -224,6 +233,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GyMdEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -233,6 +243,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GyMdEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -242,6 +253,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GyMdEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -251,6 +263,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -260,6 +273,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -269,6 +283,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -278,6 +293,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -287,6 +303,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -296,6 +313,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "gregorian",
     "locale": "en",
@@ -305,6 +323,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "gregorian",
     "locale": "en",
@@ -314,6 +333,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "gregorian",
     "locale": "en",
@@ -323,6 +343,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "gregorian",
     "locale": "en",
@@ -332,6 +353,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "gregorian",
     "locale": "en",
@@ -340,6 +362,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "gregorian",
     "locale": "en",
@@ -348,6 +371,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "gregorian",
     "locale": "en",
@@ -356,6 +380,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "gregorian",
     "locale": "en",
@@ -364,6 +389,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "gregorian",
     "locale": "en",
@@ -373,6 +399,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "gregorian",
     "locale": "en",
@@ -382,6 +409,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "gregorian",
     "locale": "en",
@@ -391,6 +419,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "gregorian",
     "locale": "en",
@@ -400,6 +429,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "gregorian",
     "locale": "en",
@@ -409,6 +439,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "gregorian",
     "locale": "en",
@@ -418,6 +449,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "gregorian",
     "locale": "en",
@@ -427,6 +459,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "gregorian",
     "locale": "en",
@@ -436,6 +469,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "gregorian",
     "locale": "en",
@@ -445,6 +479,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "gregorian",
     "locale": "en",
@@ -454,6 +489,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "gregorian",
     "locale": "en",
@@ -463,6 +499,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "gregorian",
     "locale": "en",
@@ -472,6 +509,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "gregorian",
     "locale": "en",
@@ -481,6 +519,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "gregorian",
     "locale": "en",
@@ -490,6 +529,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "gregorian",
     "locale": "en",
@@ -499,6 +539,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "gregorian",
     "locale": "en",
@@ -508,6 +549,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "gregorian",
     "locale": "en",
@@ -517,6 +559,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -525,6 +568,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -533,6 +577,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -541,6 +586,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -549,6 +595,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -557,6 +604,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -565,6 +613,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -574,6 +623,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -583,6 +633,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -592,6 +643,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -601,6 +653,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -610,6 +663,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -619,6 +673,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -628,6 +683,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -637,6 +693,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "gregorian",
     "locale": "en",
@@ -646,6 +703,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "gregorian",
     "locale": "en",
@@ -655,6 +713,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "gregorian",
     "locale": "en",
@@ -664,6 +723,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "gregorian",
     "locale": "en",
@@ -823,6 +883,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -831,6 +892,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -839,6 +901,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -847,6 +910,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -855,6 +919,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -863,6 +928,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -871,6 +937,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -879,6 +946,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -887,6 +955,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -895,6 +964,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -904,6 +974,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -913,6 +984,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -922,6 +994,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -931,6 +1004,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -940,6 +1014,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -949,6 +1024,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -958,6 +1034,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -967,6 +1044,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -976,6 +1054,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -985,6 +1064,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -994,6 +1074,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1003,6 +1084,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1011,6 +1093,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1019,6 +1102,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1027,6 +1111,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1035,6 +1120,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1044,6 +1130,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1053,6 +1140,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1062,6 +1150,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1071,6 +1160,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1080,6 +1170,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1089,6 +1180,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1098,6 +1190,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1107,6 +1200,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1116,6 +1210,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1125,6 +1220,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1134,6 +1230,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1143,6 +1240,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1152,6 +1250,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1161,6 +1260,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1170,6 +1270,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1179,6 +1280,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1188,6 +1290,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1196,6 +1299,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1204,6 +1308,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1212,6 +1317,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1220,6 +1326,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1228,6 +1335,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1236,6 +1344,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1245,6 +1354,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1254,6 +1364,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1263,6 +1374,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1272,6 +1384,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1281,6 +1394,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1290,6 +1404,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1299,6 +1414,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1308,6 +1424,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1317,6 +1434,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1326,6 +1444,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1335,6 +1454,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
@@ -1494,6 +1614,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "yyMdEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1502,6 +1623,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "yyMdEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1510,6 +1632,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "yyMdEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1518,6 +1641,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "yMMMdEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1526,6 +1650,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "yMMMdEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1534,6 +1659,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "yMMMdEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1542,6 +1668,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "yMMMMdEEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1550,6 +1677,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "yMMMMdEEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1558,6 +1686,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "yMMMMdEEEE",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1566,6 +1695,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GyMdEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1575,6 +1705,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GyMdEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1584,6 +1715,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GyMdEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1593,6 +1725,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1602,6 +1735,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1611,6 +1745,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1620,6 +1755,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1629,6 +1765,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1638,6 +1775,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1647,6 +1785,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1656,6 +1795,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1665,6 +1805,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1674,6 +1815,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1682,6 +1824,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1690,6 +1833,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1698,6 +1842,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1706,6 +1851,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1715,6 +1861,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1724,6 +1871,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1733,6 +1881,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1742,6 +1891,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1751,6 +1901,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1760,6 +1911,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1769,6 +1921,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1778,6 +1931,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1787,6 +1941,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1796,6 +1951,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1805,6 +1961,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1814,6 +1971,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1823,6 +1981,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1832,6 +1991,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1841,6 +2001,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1850,6 +2011,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1859,6 +2021,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1867,6 +2030,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1875,6 +2039,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1883,6 +2048,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1891,6 +2057,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1899,6 +2066,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1907,6 +2075,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1916,6 +2085,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1925,6 +2095,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1934,6 +2105,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1943,6 +2115,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1952,6 +2125,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1961,6 +2135,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1970,6 +2145,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1979,6 +2155,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1988,6 +2165,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -1997,6 +2175,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -2006,6 +2185,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "buddhist",
     "locale": "th-TH",
@@ -2165,6 +2345,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2173,6 +2354,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2181,6 +2363,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2189,6 +2372,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2197,6 +2381,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2205,6 +2390,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2213,6 +2399,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMdEEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2221,6 +2408,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMdEEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2229,6 +2417,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMdEEEE",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2237,6 +2426,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2246,6 +2436,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2255,6 +2446,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "GGGGGyMdEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2264,6 +2456,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2273,6 +2466,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2282,6 +2476,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "GyMMMdEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2291,6 +2486,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2300,6 +2496,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2309,6 +2506,7 @@
   {
     "semanticSkeleton": "YMDE",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "GyMMMdEEEE",
     "yearStyle": "with_era",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2318,6 +2516,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2327,6 +2526,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "zzzz",
     "zoneStyle": "specific",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2336,6 +2536,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2345,6 +2546,7 @@
   {
     "semanticSkeleton": "Z",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "VVVV",
     "zoneStyle": "location",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2353,6 +2555,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2361,6 +2564,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "vvvv",
     "zoneStyle": "generic",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2369,6 +2573,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2377,6 +2582,7 @@
   },
   {
     "semanticSkeleton": "Z",
+    "classicalSkeleton": "O",
     "zoneStyle": "offset",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2386,6 +2592,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2395,6 +2602,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsz",
     "zoneStyle": "specific",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2404,6 +2612,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2413,6 +2622,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsz",
     "zoneStyle": "specific",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2422,6 +2632,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2431,6 +2642,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2440,6 +2652,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2449,6 +2662,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsVVVV",
     "zoneStyle": "location",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2458,6 +2672,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2467,6 +2682,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "Mdjmsv",
     "zoneStyle": "generic",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2476,6 +2692,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2485,6 +2702,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsv",
     "zoneStyle": "generic",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2494,6 +2712,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2503,6 +2722,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "MdjmsO",
     "zoneStyle": "offset",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2512,6 +2732,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2521,6 +2742,7 @@
   {
     "semanticSkeleton": "MDTZ",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "MMMdjmsO",
     "zoneStyle": "offset",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2530,6 +2752,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2538,6 +2761,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2546,6 +2770,7 @@
   {
     "semanticSkeleton": "M",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "LLLL",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2554,6 +2779,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2562,6 +2788,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2570,6 +2797,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "jms",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2578,6 +2806,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2587,6 +2816,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2596,6 +2826,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "short",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2605,6 +2836,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2614,6 +2846,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2623,6 +2856,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "medium",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2632,6 +2866,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2641,6 +2876,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2650,6 +2886,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "hms",
     "hourCycle": "H12",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2659,6 +2896,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2668,6 +2906,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "japanese",
     "locale": "ja-JP",
@@ -2677,6 +2916,7 @@
   {
     "semanticSkeleton": "T",
     "semanticSkeletonLength": "long",
+    "classicalSkeleton": "Hms",
     "hourCycle": "H23",
     "calendar": "japanese",
     "locale": "ja-JP",

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
@@ -819,6 +819,9 @@ public class GenerateDateTimeTestData {
 
     static class TestCase {
         TestCaseInput testCaseInput;
+        String classicalSkeleton; // Should only be non-null when semantic skeleton non-null.
+        // This exists to allow existing ICU & other i18n impls to format
+        // until they add support for formatting using semantic skeletons.
         String expected;
     }
 
@@ -1088,6 +1091,7 @@ public class GenerateDateTimeTestData {
                             localeCldrFile,
                             testCaseInput.fieldStyleCombo,
                             calendarStr);
+            // compute the expected
             // TODO: fix CLDR DateTimeFormats constructor to use CLDRFile to get the dateTimeFormat
             //   glue pattern rather than use ICU to get it
             DateTimeFormats formats = new DateTimeFormats().set(localeCldrFile, calendarStr);
@@ -1101,6 +1105,7 @@ public class GenerateDateTimeTestData {
 
             TestCase result = new TestCase();
             result.testCaseInput = testCaseInput;
+            result.classicalSkeleton = skeleton;
             result.expected = formattedDateTime;
 
             return result;
@@ -1206,6 +1211,7 @@ public class GenerateDateTimeTestData {
         String timeLength = null;
         String semanticSkeleton = null;
         String semanticSkeletonLength = null;
+        String classicalSkeleton = null;
         String dateTimeFormatType = null;
         String hourCycle = null;
         String zoneStyle = null;
@@ -1235,6 +1241,7 @@ public class GenerateDateTimeTestData {
                 Optional.ofNullable(testCase.testCaseInput.fieldStyleCombo.semanticSkeletonLength)
                         .map(SemanticSkeletonLength::getLabel)
                         .orElse(null);
+        result.classicalSkeleton = testCase.classicalSkeleton;
         result.dateTimeFormatType =
                 Optional.ofNullable(testCase.testCaseInput.fieldStyleCombo.dateTimeFormatType)
                         .map(DateTimeFormatType::getLabel)


### PR DESCRIPTION
CLDR-18128

This PR is another update to the datetime test data generation that support semantic skeletons, introduced in #4313. (A previous recent followup update PR was #4341)

The purpose of this PR's update is to include the "classical" skeleton string in test cases whenever the semantic skeleton is used as input. The reason is that i18n implementations like ICU don't have support for such a new concept as semantic skeletons. However, they can still format regular "classical" skeletons in order to execute the test case and verify the expected formatted output string is correct.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
