### PR TITLE
CLDR-17014 Handle VARIANT paths like LANGUAGE, SCRIPT, ...

### DIFF
--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -1237,7 +1237,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<variant type="REVISED">revidert ortografi</variant>
 			<variant type="RIGIK" draft="contributed">klassisk volapük</variant>
 			<variant type="ROZAJ">resisk dialekt</variant>
-			<variant type="RUMGR">↑↑↑</variant>
 			<variant type="SAAHO">saho</variant>
 			<variant type="SCOTLAND">skotsk standard engelsk</variant>
 			<variant type="SCOUSE">scouse dialekt</variant>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -1221,8 +1221,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<variant type="KSCOR" draft="contributed">standard ortografi</variant>
 			<variant type="LAUKIKA" draft="contributed">laukika</variant>
 			<variant type="LIPAW" draft="contributed">resia med Lipovaz-dialekt</variant>
-			<variant type="LTG1929">↑↑↑</variant>
-			<variant type="LUNA1918">↑↑↑</variant>
 			<variant type="METELKO" draft="contributed">Metelko-alfabet</variant>
 			<variant type="MONOTON">monotonisk rettskriving</variant>
 			<variant type="NDYUKA">ndyuka-dialekt</variant>

--- a/common/testData/localeIdentifiers/localeDisplayName.txt
+++ b/common/testData/localeIdentifiers/localeDisplayName.txt
@@ -356,7 +356,7 @@ es-Cyrl-MX; Spaans (Cyrillies, Meksiko)
 hi-Latn; Hindi (Latyn)
 nl-BE; Nederlands (België)
 nl-Latn-BE; Nederlands (Latyn, België)
-zh-Hans-fonipa; Chinees (Vereenvoudig, FONIPA)
+zh-Hans-fonipa; Chinees (Vereenvoudig, fonipa)
 
 
 @locale=af
@@ -369,7 +369,7 @@ es-Cyrl-MX; Spaans (Cyrillies, Meksiko)
 hi-Latn; Hindi (Latyn)
 nl-BE; Vlaams
 nl-Latn-BE; Vlaams (Latyn)
-zh-Hans-fonipa; Chinees (Vereenvoudig, FONIPA)
+zh-Hans-fonipa; Chinees (Vereenvoudig, fonipa)
 
 
 @locale=am
@@ -382,7 +382,7 @@ es-Cyrl-MX; ስፓኒሽ (ሲይሪልክ፣ ሜክሲኮ)
 hi-Latn; ሕንድኛ (ላቲን)
 nl-BE; ደች (ቤልጄም)
 nl-Latn-BE; ደች (ላቲን፣ ቤልጄም)
-zh-Hans-fonipa; ቻይንኛ (ቀለል ያለ፣ FONIPA)
+zh-Hans-fonipa; ቻይንኛ (ቀለል ያለ፣ fonipa)
 
 
 @locale=am
@@ -395,7 +395,7 @@ es-Cyrl-MX; የሜክሲኮ ስፓኒሽ (ሲይሪልክ)
 hi-Latn; ሕንድኛ [ላቲን]
 nl-BE; ፍሌሚሽ
 nl-Latn-BE; ፍሌሚሽ (ላቲን)
-zh-Hans-fonipa; ቀለል ያለ ቻይንኛ (FONIPA)
+zh-Hans-fonipa; ቀለል ያለ ቻይንኛ (fonipa)
 
 
 @locale=ar
@@ -408,7 +408,7 @@ es-Cyrl-MX; الإسبانية (السيريلية، المكسيك)
 hi-Latn; الهندية (اللاتينية)
 nl-BE; الهولندية (بلجيكا)
 nl-Latn-BE; الهولندية (اللاتينية، بلجيكا)
-zh-Hans-fonipa; الصينية (المبسطة، FONIPA)
+zh-Hans-fonipa; الصينية (المبسطة، fonipa)
 
 
 @locale=ar
@@ -421,7 +421,7 @@ es-Cyrl-MX; الإسبانية المكسيكية (السيريلية)
 hi-Latn; الهندية (اللاتينية)
 nl-BE; الهولندية (بلجيكا)
 nl-Latn-BE; الهولندية (اللاتينية، بلجيكا)
-zh-Hans-fonipa; الصينية المبسطة (FONIPA)
+zh-Hans-fonipa; الصينية المبسطة (fonipa)
 
 
 @locale=as
@@ -434,7 +434,7 @@ es-Cyrl-MX; স্পেনিচ (চিৰিলিক, মেক্সিক�
 hi-Latn; হিন্দী (লেটিন)
 nl-BE; ডাচ (বেলজিয়াম)
 nl-Latn-BE; ডাচ (লেটিন, বেলজিয়াম)
-zh-Hans-fonipa; চীনা (সৰলীকৃত, FONIPA)
+zh-Hans-fonipa; চীনা (সৰলীকৃত, fonipa)
 
 
 @locale=as
@@ -447,7 +447,7 @@ es-Cyrl-MX; মেক্সিকান স্পেনিচ (চিৰিল�
 hi-Latn; হিন্দী (লেটিন)
 nl-BE; ফ্লেমিচ
 nl-Latn-BE; ফ্লেমিচ (লেটিন)
-zh-Hans-fonipa; সৰলীকৃত চীনা (FONIPA)
+zh-Hans-fonipa; সৰলীকৃত চীনা (fonipa)
 
 
 @locale=az
@@ -460,7 +460,7 @@ es-Cyrl-MX; ispan (kiril, Meksika)
 hi-Latn; hind (latın)
 nl-BE; holland (Belçika)
 nl-Latn-BE; holland (latın, Belçika)
-zh-Hans-fonipa; çin (sadələşmiş, FONIPA)
+zh-Hans-fonipa; çin (sadələşmiş, fonipa)
 
 
 @locale=az
@@ -473,7 +473,7 @@ es-Cyrl-MX; Meksika ispancası (kiril)
 hi-Latn; Hindi [latın]
 nl-BE; flamand
 nl-Latn-BE; flamand (latın)
-zh-Hans-fonipa; sadələşmiş çin (FONIPA)
+zh-Hans-fonipa; sadələşmiş çin (fonipa)
 
 
 @locale=az_Latn
@@ -486,7 +486,7 @@ es-Cyrl-MX; ispan (kiril, Meksika)
 hi-Latn; hind (latın)
 nl-BE; holland (Belçika)
 nl-Latn-BE; holland (latın, Belçika)
-zh-Hans-fonipa; çin (sadələşmiş, FONIPA)
+zh-Hans-fonipa; çin (sadələşmiş, fonipa)
 
 
 @locale=az_Latn
@@ -499,7 +499,7 @@ es-Cyrl-MX; Meksika ispancası (kiril)
 hi-Latn; Hindi [latın]
 nl-BE; flamand
 nl-Latn-BE; flamand (latın)
-zh-Hans-fonipa; sadələşmiş çin (FONIPA)
+zh-Hans-fonipa; sadələşmiş çin (fonipa)
 
 
 @locale=be
@@ -512,7 +512,7 @@ es-Cyrl-MX; іспанская (кірыліца, Мексіка)
 hi-Latn; хіндзі (лацініца)
 nl-BE; нідэрландская (Бельгія)
 nl-Latn-BE; нідэрландская (лацініца, Бельгія)
-zh-Hans-fonipa; кітайская (спрошчанае кітайскае, FONIPA)
+zh-Hans-fonipa; кітайская (спрошчанае кітайскае, fonipa)
 
 
 @locale=be
@@ -525,7 +525,7 @@ es-Cyrl-MX; мексіканская іспанская (кірыліца)
 hi-Latn; хіндзі (лацініца)
 nl-BE; фламандская
 nl-Latn-BE; фламандская (лацініца)
-zh-Hans-fonipa; кітайская [спрошчаныя іерогліфы] (FONIPA)
+zh-Hans-fonipa; кітайская [спрошчаныя іерогліфы] (fonipa)
 
 
 @locale=bg
@@ -564,7 +564,7 @@ es-Cyrl-MX; স্প্যানিশ (সিরিলিক, মেক্স�
 hi-Latn; হিন্দি (ল্যাটিন)
 nl-BE; ওলন্দাজ (বেলজিয়াম)
 nl-Latn-BE; ওলন্দাজ (ল্যাটিন, বেলজিয়াম)
-zh-Hans-fonipa; চীনা (সরলীকৃত, FONIPA)
+zh-Hans-fonipa; চীনা (সরলীকৃত, fonipa)
 
 
 @locale=bn
@@ -577,7 +577,7 @@ es-Cyrl-MX; স্প্যানিশ (সিরিলিক, মেক্স�
 hi-Latn; হিন্দি (ল্যাটিন)
 nl-BE; ফ্লেমিশ
 nl-Latn-BE; ফ্লেমিশ (ল্যাটিন)
-zh-Hans-fonipa; চীনা (সরলীকৃত, FONIPA)
+zh-Hans-fonipa; চীনা (সরলীকৃত, fonipa)
 
 
 @locale=bs
@@ -668,7 +668,7 @@ es-Cyrl-MX; ᏍᏆᏂ (ᏲᏂᎢ ᏗᎪᏪᎵ, ᎠᏂᏍᏆᏂ)
 hi-Latn; ᎯᏂᏗ (ᎳᏘᏂ)
 nl-BE; ᏛᏥ (ᏇᎵᏥᎥᎻ)
 nl-Latn-BE; ᏛᏥ (ᎳᏘᏂ, ᏇᎵᏥᎥᎻ)
-zh-Hans-fonipa; ᏓᎶᏂᎨ (ᎠᎯᏗᎨ, FONIPA)
+zh-Hans-fonipa; ᏓᎶᏂᎨ (ᎠᎯᏗᎨ, fonipa)
 
 
 @locale=chr
@@ -681,7 +681,7 @@ es-Cyrl-MX; ᏍᏆᏂᏱ ᏍᏆᏂ (ᏲᏂᎢ ᏗᎪᏪᎵ)
 hi-Latn; ᎯᏂᏗ (ᎳᏘᏂ)
 nl-BE; ᏊᎵᏥᎥᎻ ᏛᏥ
 nl-Latn-BE; ᏊᎵᏥᎥᎻ ᏛᏥ (ᎳᏘᏂ)
-zh-Hans-fonipa; ᎠᎯᏗᎨ ᏓᎶᏂᎨ (FONIPA)
+zh-Hans-fonipa; ᎠᎯᏗᎨ ᏓᎶᏂᎨ (fonipa)
 
 
 @locale=cs
@@ -694,7 +694,7 @@ es-Cyrl-MX; španělština (cyrilice, Mexiko)
 hi-Latn; hindština (latinka)
 nl-BE; nizozemština (Belgie)
 nl-Latn-BE; nizozemština (latinka, Belgie)
-zh-Hans-fonipa; čínština (zjednodušené, FONIPA)
+zh-Hans-fonipa; čínština (zjednodušené, fonipa)
 
 
 @locale=cs
@@ -707,7 +707,7 @@ es-Cyrl-MX; španělština (cyrilice, Mexiko)
 hi-Latn; hindština (latinka)
 nl-BE; vlámština
 nl-Latn-BE; vlámština (latinka)
-zh-Hans-fonipa; čínština [zjednodušená] (FONIPA)
+zh-Hans-fonipa; čínština [zjednodušená] (fonipa)
 
 
 @locale=cy
@@ -798,7 +798,7 @@ es-Cyrl-MX; špańšćina (kyriliski, Mexiko)
 hi-Latn; hindišćina (łatyński)
 nl-BE; nižozemšćina (Belgiska)
 nl-Latn-BE; nižozemšćina (łatyński, Belgiska)
-zh-Hans-fonipa; chinšćina (zjadnorjone, FONIPA)
+zh-Hans-fonipa; chinšćina (zjadnorjone, fonipa)
 
 
 @locale=dsb
@@ -811,7 +811,7 @@ es-Cyrl-MX; mexikańska špańšćina (kyriliski)
 hi-Latn; hindišćina (łatyński)
 nl-BE; flamšćina
 nl-Latn-BE; flamšćina (łatyński)
-zh-Hans-fonipa; chinšćina [zjadnorjona] (FONIPA)
+zh-Hans-fonipa; chinšćina [zjadnorjona] (fonipa)
 
 
 @locale=el
@@ -1006,7 +1006,7 @@ es-Cyrl-MX; Spanish (Cyrillic, Mexico)
 hi-Latn; Hindi (Latin)
 nl-BE; Dutch (Belgium)
 nl-Latn-BE; Dutch (Latin, Belgium)
-zh-Hans-fonipa; Chinese (Pinasimple, FONIPA)
+zh-Hans-fonipa; Chinese (Pinasimple, fonipa)
 
 
 @locale=fil
@@ -1019,7 +1019,7 @@ es-Cyrl-MX; Mexican na Espanyol (Cyrillic)
 hi-Latn; Hindi (Latin)
 nl-BE; Flemish
 nl-Latn-BE; Flemish (Latin)
-zh-Hans-fonipa; Pinasimpleng Chinese (FONIPA)
+zh-Hans-fonipa; Pinasimpleng Chinese (fonipa)
 
 
 @locale=fr
@@ -1110,7 +1110,7 @@ es-Cyrl-MX; español (cirílico, México)
 hi-Latn; hindi (latino)
 nl-BE; neerlandés (Bélxica)
 nl-Latn-BE; neerlandés (latino, Bélxica)
-zh-Hans-fonipa; chinés (simplificado, FONIPA)
+zh-Hans-fonipa; chinés (simplificado, fonipa)
 
 
 @locale=gl
@@ -1123,7 +1123,7 @@ es-Cyrl-MX; español de México (cirílico)
 hi-Latn; hindi [alfabeto latino]
 nl-BE; flamengo
 nl-Latn-BE; flamengo (latino)
-zh-Hans-fonipa; chinés simplificado (FONIPA)
+zh-Hans-fonipa; chinés simplificado (fonipa)
 
 
 @locale=gu
@@ -1136,7 +1136,7 @@ es-Cyrl-MX; સ્પેનિશ (સિરિલિક, મેક્સિક�
 hi-Latn; હિન્દી (લેટિન)
 nl-BE; ડચ (બેલ્જીયમ)
 nl-Latn-BE; ડચ (લેટિન, બેલ્જીયમ)
-zh-Hans-fonipa; ચાઇનીઝ (સરળીકૃત, FONIPA)
+zh-Hans-fonipa; ચાઇનીઝ (સરળીકૃત, fonipa)
 
 
 @locale=gu
@@ -1149,7 +1149,7 @@ es-Cyrl-MX; મેક્સિકન સ્પેનિશ (સિરિલિ�
 hi-Latn; હિન્દી (લેટિન)
 nl-BE; ફ્લેમિશ
 nl-Latn-BE; ફ્લેમિશ (લેટિન)
-zh-Hans-fonipa; સરળીકૃત ચાઇનીઝ (FONIPA)
+zh-Hans-fonipa; સરળીકૃત ચાઇનીઝ (fonipa)
 
 
 @locale=ha
@@ -1162,7 +1162,7 @@ es-Cyrl-MX; Sifaniyanci (Cyrillic, Mesiko)
 hi-Latn; Harshen Hindi (Latin)
 nl-BE; Holanci (Belgiyom)
 nl-Latn-BE; Holanci (Latin, Belgiyom)
-zh-Hans-fonipa; Harshen Sinanci (Sauƙaƙaƙƙe, FONIPA)
+zh-Hans-fonipa; Harshen Sinanci (Sauƙaƙaƙƙe, fonipa)
 
 
 @locale=ha
@@ -1175,7 +1175,7 @@ es-Cyrl-MX; Sifaniyanci Mesiko (Cyrillic)
 hi-Latn; Harshen Hindi (Latin)
 nl-BE; Holanci (Belgiyom)
 nl-Latn-BE; Holanci (Latin, Belgiyom)
-zh-Hans-fonipa; Sauƙaƙaƙƙen Sinanci (FONIPA)
+zh-Hans-fonipa; Sauƙaƙaƙƙen Sinanci (fonipa)
 
 
 @locale=he
@@ -1214,7 +1214,7 @@ es-Cyrl-MX; स्पेनिश (सिरिलिक, मैक्सिक�
 hi-Latn; हिन्दी (लैटिन)
 nl-BE; डच (बेल्जियम)
 nl-Latn-BE; डच (लैटिन, बेल्जियम)
-zh-Hans-fonipa; चीनी (सरलीकृत, FONIPA)
+zh-Hans-fonipa; चीनी (सरलीकृत, fonipa)
 
 
 @locale=hi
@@ -1227,7 +1227,7 @@ es-Cyrl-MX; मैक्सिकन स्पेनिश (सिरिलि�
 hi-Latn; हिन्दी (लैटिन)
 nl-BE; फ़्लेमिश
 nl-Latn-BE; फ़्लेमिश (लैटिन)
-zh-Hans-fonipa; सरलीकृत चीनी (FONIPA)
+zh-Hans-fonipa; सरलीकृत चीनी (fonipa)
 
 
 @locale=hi_Latn
@@ -1292,7 +1292,7 @@ es-Cyrl-MX; španišćina (kyrilisce, Mexiko)
 hi-Latn; hindišćina (łaćonsce)
 nl-BE; nižozemšćina (Belgiska)
 nl-Latn-BE; nižozemšćina (łaćonsce, Belgiska)
-zh-Hans-fonipa; chinšćina (zjednorjene, FONIPA)
+zh-Hans-fonipa; chinšćina (zjednorjene, fonipa)
 
 
 @locale=hsb
@@ -1305,7 +1305,7 @@ es-Cyrl-MX; mexiska španišćina (kyrilisce)
 hi-Latn; hindišćina (łaćonsce)
 nl-BE; flamšćina
 nl-Latn-BE; flamšćina (łaćonsce)
-zh-Hans-fonipa; chinšćina [zjednorjena] (FONIPA)
+zh-Hans-fonipa; chinšćina [zjednorjena] (fonipa)
 
 
 @locale=ht
@@ -1370,7 +1370,7 @@ es-Cyrl-MX; իսպաներեն (կյուրեղագիր, Մեքսիկա)
 hi-Latn; հինդի (լատինական)
 nl-BE; հոլանդերեն (Բելգիա)
 nl-Latn-BE; հոլանդերեն (լատինական, Բելգիա)
-zh-Hans-fonipa; չինարեն (պարզեցված, FONIPA)
+zh-Hans-fonipa; չինարեն (պարզեցված, fonipa)
 
 
 @locale=hy
@@ -1383,7 +1383,7 @@ es-Cyrl-MX; մեքսիկական իսպաներեն (կյուրեղագիր)
 hi-Latn; հինդի [լատինատառ]
 nl-BE; ֆլամանդերեն
 nl-Latn-BE; ֆլամանդերեն (լատինական)
-zh-Hans-fonipa; պարզեցված չինարեն (FONIPA)
+zh-Hans-fonipa; պարզեցված չինարեն (fonipa)
 
 
 @locale=id
@@ -1422,7 +1422,7 @@ es-Cyrl-MX; Spanish (Cyrillic, Mexico)
 hi-Latn; Hindi (Latin)
 nl-BE; Dutch (Belgium)
 nl-Latn-BE; Dutch (Latin, Belgium)
-zh-Hans-fonipa; Chaịniiz (Nke dị mfe, FONIPA)
+zh-Hans-fonipa; Chaịniiz (Nke dị mfe, fonipa)
 
 
 @locale=ig
@@ -1435,7 +1435,7 @@ es-Cyrl-MX; Spanish ndị Mexico (Cyrillic)
 hi-Latn; Hindi (Latin)
 nl-BE; Flemish
 nl-Latn-BE; Flemish (Latin)
-zh-Hans-fonipa; Asụsụ Chaịniiz dị mfe (FONIPA)
+zh-Hans-fonipa; Asụsụ Chaịniiz dị mfe (fonipa)
 
 
 @locale=is
@@ -1448,7 +1448,7 @@ es-Cyrl-MX; spænska (kyrillískt, Mexíkó)
 hi-Latn; hindí (latneskt)
 nl-BE; hollenska (Belgía)
 nl-Latn-BE; hollenska (latneskt, Belgía)
-zh-Hans-fonipa; kínverska (einfaldað, FONIPA)
+zh-Hans-fonipa; kínverska (einfaldað, fonipa)
 
 
 @locale=is
@@ -1461,7 +1461,7 @@ es-Cyrl-MX; mexíkósk spænska (kyrillískt)
 hi-Latn; hindí (latneskt)
 nl-BE; flæmska
 nl-Latn-BE; flæmska (latneskt)
-zh-Hans-fonipa; kínverska [einfölduð] (FONIPA)
+zh-Hans-fonipa; kínverska [einfölduð] (fonipa)
 
 
 @locale=it
@@ -1526,7 +1526,7 @@ es-Cyrl-MX; Spanyol (Sirilik, Mèksiko)
 hi-Latn; India (Latin)
 nl-BE; Walanda (Bèlgi)
 nl-Latn-BE; Walanda (Latin, Bèlgi)
-zh-Hans-fonipa; Tyonghwa (Prasaja, FONIPA)
+zh-Hans-fonipa; Tyonghwa (Prasaja, fonipa)
 
 
 @locale=jv
@@ -1539,7 +1539,7 @@ es-Cyrl-MX; Spanyol [Meksiko] (Sirilik)
 hi-Latn; India (Latin)
 nl-BE; Flemis
 nl-Latn-BE; Flemis (Latin)
-zh-Hans-fonipa; Tyonghwa [Ringkes] (FONIPA)
+zh-Hans-fonipa; Tyonghwa [Ringkes] (fonipa)
 
 
 @locale=ka
@@ -1552,7 +1552,7 @@ es-Cyrl-MX; ესპანური (კირილიცა, მექსი�
 hi-Latn; ჰინდი (ლათინური)
 nl-BE; ნიდერლანდური (ბელგია)
 nl-Latn-BE; ნიდერლანდური (ლათინური, ბელგია)
-zh-Hans-fonipa; ჩინური (გამარტივებული, FONIPA)
+zh-Hans-fonipa; ჩინური (გამარტივებული, fonipa)
 
 
 @locale=ka
@@ -1565,7 +1565,7 @@ es-Cyrl-MX; მექსიკური ესპანური (კირი�
 hi-Latn; ჰინდი (ლათინური)
 nl-BE; ფლამანდიური
 nl-Latn-BE; ფლამანდიური (ლათინური)
-zh-Hans-fonipa; გამარტივებული ჩინური (FONIPA)
+zh-Hans-fonipa; გამარტივებული ჩინური (fonipa)
 
 
 @locale=kk
@@ -1630,7 +1630,7 @@ es-Cyrl-MX; អេស្ប៉ាញ (ស៊ីរីលីក, ម៉ិកស�
 hi-Latn; ហិណ្ឌី (ឡាតាំង)
 nl-BE; ហូឡង់ (បែលហ្ស៊ិក)
 nl-Latn-BE; ហូឡង់ (ឡាតាំង, បែលហ្ស៊ិក)
-zh-Hans-fonipa; ចិន (អក្សរ​ចិន​កាត់, FONIPA)
+zh-Hans-fonipa; ចិន (អក្សរ​ចិន​កាត់, fonipa)
 
 
 @locale=km
@@ -1643,7 +1643,7 @@ es-Cyrl-MX; អេស្ប៉ាញ (ស៊ីរីលីក, ម៉ិកស�
 hi-Latn; ហិណ្ឌី (ឡាតាំង)
 nl-BE; ផ្លាមីស
 nl-Latn-BE; ផ្លាមីស (ឡាតាំង)
-zh-Hans-fonipa; ចិន​អក្សរ​កាត់ (FONIPA)
+zh-Hans-fonipa; ចិន​អក្សរ​កាត់ (fonipa)
 
 
 @locale=kn
@@ -1656,7 +1656,7 @@ es-Cyrl-MX; ಸ್ಪ್ಯಾನಿಷ್ (ಸಿರಿಲಿಕ್, ಮೆಕ�
 hi-Latn; ಹಿಂದಿ (ಲ್ಯಾಟಿನ್)
 nl-BE; ಡಚ್ (ಬೆಲ್ಜಿಯಮ್)
 nl-Latn-BE; ಡಚ್ (ಲ್ಯಾಟಿನ್, ಬೆಲ್ಜಿಯಮ್)
-zh-Hans-fonipa; ಚೈನೀಸ್ (ಸರಳೀಕೃತ, FONIPA)
+zh-Hans-fonipa; ಚೈನೀಸ್ (ಸರಳೀಕೃತ, fonipa)
 
 
 @locale=kn
@@ -1669,7 +1669,7 @@ es-Cyrl-MX; ಮೆಕ್ಸಿಕನ್ ಸ್ಪ್ಯಾನಿಷ್ (ಸಿ�
 hi-Latn; ಹಿಂದಿ (ಲ್ಯಾಟಿನ್)
 nl-BE; ಫ್ಲೆಮಿಷ್
 nl-Latn-BE; ಫ್ಲೆಮಿಷ್ (ಲ್ಯಾಟಿನ್)
-zh-Hans-fonipa; ಸರಳೀಕೃತ ಚೈನೀಸ್ (FONIPA)
+zh-Hans-fonipa; ಸರಳೀಕೃತ ಚೈನೀಸ್ (fonipa)
 
 
 @locale=ko
@@ -1682,7 +1682,7 @@ es-Cyrl-MX; 스페인어(키릴 문자, 멕시코)
 hi-Latn; 힌디어(로마자)
 nl-BE; 네덜란드어(벨기에)
 nl-Latn-BE; 네덜란드어(로마자, 벨기에)
-zh-Hans-fonipa; 중국어(간체, FONIPA)
+zh-Hans-fonipa; 중국어(간체, fonipa)
 
 
 @locale=ko
@@ -1695,7 +1695,7 @@ es-Cyrl-MX; 스페인어(키릴 문자, 멕시코)
 hi-Latn; 힌디어(로마자)
 nl-BE; 플라망어
 nl-Latn-BE; 플라망어(로마자)
-zh-Hans-fonipa; 중국어(간체, FONIPA)
+zh-Hans-fonipa; 중국어(간체, fonipa)
 
 
 @locale=kok
@@ -1708,7 +1708,7 @@ es-Cyrl-MX; स्पॅनीश (सिरिलिक, मेक्सिक�
 hi-Latn; हिन्दी (लॅटीन)
 nl-BE; डच (बेल्जियम)
 nl-Latn-BE; डच (लॅटीन, बेल्जियम)
-zh-Hans-fonipa; चिनी (सोंपी, FONIPA)
+zh-Hans-fonipa; चिनी (सोंपी, fonipa)
 
 
 @locale=kok
@@ -1721,7 +1721,7 @@ es-Cyrl-MX; मॅक्सिकन स्पॅनीश (सिरिलि�
 hi-Latn; हिन्दी (लॅटीन)
 nl-BE; फ्लेमिश
 nl-Latn-BE; फ्लेमिश (लॅटीन)
-zh-Hans-fonipa; सोंपी चिनी (FONIPA)
+zh-Hans-fonipa; सोंपी चिनी (fonipa)
 
 
 @locale=kok_Deva
@@ -1734,7 +1734,7 @@ es-Cyrl-MX; स्पॅनीश (सिरिलिक, मेक्सिक�
 hi-Latn; हिन्दी (लॅटीन)
 nl-BE; डच (बेल्जियम)
 nl-Latn-BE; डच (लॅटीन, बेल्जियम)
-zh-Hans-fonipa; चिनी (सोंपी, FONIPA)
+zh-Hans-fonipa; चिनी (सोंपी, fonipa)
 
 
 @locale=kok_Deva
@@ -1747,7 +1747,7 @@ es-Cyrl-MX; मॅक्सिकन स्पॅनीश (सिरिलि�
 hi-Latn; हिन्दी (लॅटीन)
 nl-BE; फ्लेमिश
 nl-Latn-BE; फ्लेमिश (लॅटीन)
-zh-Hans-fonipa; सोंपी चिनी (FONIPA)
+zh-Hans-fonipa; सोंपी चिनी (fonipa)
 
 
 @locale=ky
@@ -1760,7 +1760,7 @@ es-Cyrl-MX; испанча (Кирилл, Мексика)
 hi-Latn; хиндиче (Латын)
 nl-BE; голландча (Бельгия)
 nl-Latn-BE; голландча (Латын, Бельгия)
-zh-Hans-fonipa; кытайча (Жөнөкөйлөштүрүлгөн, FONIPA)
+zh-Hans-fonipa; кытайча (Жөнөкөйлөштүрүлгөн, fonipa)
 
 
 @locale=ky
@@ -1773,7 +1773,7 @@ es-Cyrl-MX; испанча (Кирилл, Мексика)
 hi-Latn; хиндиче (Латын)
 nl-BE; фламандча
 nl-Latn-BE; фламандча (Латын)
-zh-Hans-fonipa; кытайча [жөнөкөйлөштүрүлгөн] (FONIPA)
+zh-Hans-fonipa; кытайча [жөнөкөйлөштүрүлгөн] (fonipa)
 
 
 @locale=lo
@@ -1864,7 +1864,7 @@ es-Cyrl-MX; шпански (кирилско писмо, Мексико)
 hi-Latn; хинди (латинично писмо)
 nl-BE; холандски (Белгија)
 nl-Latn-BE; холандски (латинично писмо, Белгија)
-zh-Hans-fonipa; кинески (поедноставено, FONIPA)
+zh-Hans-fonipa; кинески (поедноставено, fonipa)
 
 
 @locale=mk
@@ -1877,7 +1877,7 @@ es-Cyrl-MX; мексикански шпански (кирилско писмо)
 hi-Latn; хинди (латинично писмо)
 nl-BE; фламански
 nl-Latn-BE; фламански (латинично писмо)
-zh-Hans-fonipa; поедноставен кинески (FONIPA)
+zh-Hans-fonipa; поедноставен кинески (fonipa)
 
 
 @locale=ml
@@ -1916,7 +1916,7 @@ es-Cyrl-MX; испани (кирилл, Мексик)
 hi-Latn; хинди (латин)
 nl-BE; нидерланд (Бельги)
 nl-Latn-BE; нидерланд (латин, Бельги)
-zh-Hans-fonipa; хятад (хялбаршуулсан, FONIPA)
+zh-Hans-fonipa; хятад (хялбаршуулсан, fonipa)
 
 
 @locale=mn
@@ -1929,7 +1929,7 @@ es-Cyrl-MX; испани хэл [Мексик] (кирилл)
 hi-Latn; хинди (латин)
 nl-BE; фламанд
 nl-Latn-BE; фламанд (латин)
-zh-Hans-fonipa; хялбаршуулсан хятад (FONIPA)
+zh-Hans-fonipa; хялбаршуулсан хятад (fonipa)
 
 
 @locale=mr
@@ -1942,7 +1942,7 @@ es-Cyrl-MX; स्पॅनिश (सीरिलिक, मेक्सिक�
 hi-Latn; हिंदी (लॅटिन)
 nl-BE; डच (बेल्जियम)
 nl-Latn-BE; डच (लॅटिन, बेल्जियम)
-zh-Hans-fonipa; चीनी (सरलीकृत, FONIPA)
+zh-Hans-fonipa; चीनी (सरलीकृत, fonipa)
 
 
 @locale=mr
@@ -1955,7 +1955,7 @@ es-Cyrl-MX; मेक्सिकन स्पॅनिश (सीरिलि�
 hi-Latn; हिंदी (लॅटिन)
 nl-BE; फ्लेमिश
 nl-Latn-BE; फ्लेमिश (लॅटिन)
-zh-Hans-fonipa; सरलीकृत चीनी (FONIPA)
+zh-Hans-fonipa; सरलीकृत चीनी (fonipa)
 
 
 @locale=ms
@@ -2046,7 +2046,7 @@ es-Cyrl-MX; स्पेनी (सिरिलिक, मेक्सिको)
 hi-Latn; हिन्दी (ल्याटिन)
 nl-BE; डच (बेल्जियम)
 nl-Latn-BE; डच (ल्याटिन, बेल्जियम)
-zh-Hans-fonipa; चिनियाँ (सरलिकृत चिनियाँ, FONIPA)
+zh-Hans-fonipa; चिनियाँ (सरलिकृत चिनियाँ, fonipa)
 
 
 @locale=ne
@@ -2059,7 +2059,7 @@ es-Cyrl-MX; मेक्सिकन स्पेनी (सिरिलिक)
 hi-Latn; हिन्दी (ल्याटिन)
 nl-BE; फ्लेमिस
 nl-Latn-BE; फ्लेमिस (ल्याटिन)
-zh-Hans-fonipa; सरलिकृत चिनियाँ (FONIPA)
+zh-Hans-fonipa; सरलिकृत चिनियाँ (fonipa)
 
 
 @locale=nl
@@ -2150,7 +2150,7 @@ es-Cyrl-MX; ସ୍ପାନିସ୍‌ (ସିରିଲିକ୍, ମେକ୍�
 hi-Latn; ହିନ୍ଦୀ (ଲାଟିନ୍)
 nl-BE; ଡଚ୍ (ବେଲଜିୟମ୍)
 nl-Latn-BE; ଡଚ୍ (ଲାଟିନ୍, ବେଲଜିୟମ୍)
-zh-Hans-fonipa; ଚାଇନିଜ୍‌ (ସରଳୀକୃତ, FONIPA)
+zh-Hans-fonipa; ଚାଇନିଜ୍‌ (ସରଳୀକୃତ, fonipa)
 
 
 @locale=or
@@ -2163,7 +2163,7 @@ es-Cyrl-MX; ମେକ୍ସିକାନ ସ୍ପାନିସ୍‌ (ସିର�
 hi-Latn; ହିନ୍ଦୀ (ଲାଟିନ୍)
 nl-BE; ଫ୍ଲେମିଶ୍
 nl-Latn-BE; ଫ୍ଲେମିଶ୍ (ଲାଟିନ୍)
-zh-Hans-fonipa; ସରଳୀକୃତ ଚାଇନିଜ (FONIPA)
+zh-Hans-fonipa; ସରଳୀକୃତ ଚାଇନିଜ (fonipa)
 
 
 @locale=pa
@@ -2176,7 +2176,7 @@ es-Cyrl-MX; ਸਪੇਨੀ (ਸਿਰਿਲਿਕ, ਮੈਕਸੀਕੋ)
 hi-Latn; ਹਿੰਦੀ (ਲਾਤੀਨੀ)
 nl-BE; ਡੱਚ (ਬੈਲਜੀਅਮ)
 nl-Latn-BE; ਡੱਚ (ਲਾਤੀਨੀ, ਬੈਲਜੀਅਮ)
-zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, FONIPA)
+zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, fonipa)
 
 
 @locale=pa
@@ -2189,7 +2189,7 @@ es-Cyrl-MX; ਸਪੇਨੀ (ਸਿਰਿਲਿਕ, ਮੈਕਸੀਕੋ)
 hi-Latn; ਹਿੰਦੀ (ਲਾਤੀਨੀ)
 nl-BE; ਫਲੈਮਿਸ਼
 nl-Latn-BE; ਫਲੈਮਿਸ਼ (ਲਾਤੀਨੀ)
-zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, FONIPA)
+zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, fonipa)
 
 
 @locale=pa_Guru
@@ -2202,7 +2202,7 @@ es-Cyrl-MX; ਸਪੇਨੀ (ਸਿਰਿਲਿਕ, ਮੈਕਸੀਕੋ)
 hi-Latn; ਹਿੰਦੀ (ਲਾਤੀਨੀ)
 nl-BE; ਡੱਚ (ਬੈਲਜੀਅਮ)
 nl-Latn-BE; ਡੱਚ (ਲਾਤੀਨੀ, ਬੈਲਜੀਅਮ)
-zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, FONIPA)
+zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, fonipa)
 
 
 @locale=pa_Guru
@@ -2215,7 +2215,7 @@ es-Cyrl-MX; ਸਪੇਨੀ (ਸਿਰਿਲਿਕ, ਮੈਕਸੀਕੋ)
 hi-Latn; ਹਿੰਦੀ (ਲਾਤੀਨੀ)
 nl-BE; ਫਲੈਮਿਸ਼
 nl-Latn-BE; ਫਲੈਮਿਸ਼ (ਲਾਤੀਨੀ)
-zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, FONIPA)
+zh-Hans-fonipa; ਚੀਨੀ (ਸਰਲ, fonipa)
 
 
 @locale=pcm
@@ -2228,7 +2228,7 @@ es-Cyrl-MX; Spánish Lángwej (Sírílik, Mẹ́ksíko)
 hi-Latn; Híndi Lángwej (Látin)
 nl-BE; Dọch Lángwej (Bẹ́ljọm)
 nl-Latn-BE; Dọch Lángwej (Látin, Bẹ́ljọm)
-zh-Hans-fonipa; Mandarín Chainíz Lángwej (Ízí Chainíz Lángwej, FONIPA)
+zh-Hans-fonipa; Mandarín Chainíz Lángwej (Ízí Chainíz Lángwej, fonipa)
 
 
 @locale=pcm
@@ -2241,7 +2241,7 @@ es-Cyrl-MX; Mẹ́ksiko Spánish (Sírílik)
 hi-Latn; Híndi [Látin]
 nl-BE; Flẹ́mish Lángwej
 nl-Latn-BE; Flẹ́mish Lángwej (Látin)
-zh-Hans-fonipa; Mandarín Chainíz Lángwej (Ízí Chainíz Lángwej, FONIPA)
+zh-Hans-fonipa; Mandarín Chainíz Lángwej (Ízí Chainíz Lángwej, fonipa)
 
 
 @locale=pl
@@ -2280,7 +2280,7 @@ es-Cyrl-MX; هسپانوي (سیریلیک, میکسیکو)
 hi-Latn; هندي (لاتين/لاتيني)
 nl-BE; هالېنډي (بیلجیم)
 nl-Latn-BE; هالېنډي (لاتين/لاتيني, بیلجیم)
-zh-Hans-fonipa; چیني (ساده شوی, FONIPA)
+zh-Hans-fonipa; چیني (ساده شوی, fonipa)
 
 
 @locale=ps
@@ -2293,7 +2293,7 @@ es-Cyrl-MX; ميکسيکي هسپانوي (سیریلیک)
 hi-Latn; هندي [لاتيني]
 nl-BE; فلېمېشي
 nl-Latn-BE; فلېمېشي (لاتين/لاتيني)
-zh-Hans-fonipa; چیني (ساده شوی, FONIPA)
+zh-Hans-fonipa; چیني (ساده شوی, fonipa)
 
 
 @locale=pt
@@ -2358,7 +2358,7 @@ es-Cyrl-MX; es (Cyrl, MX)
 hi-Latn; hi (Latn)
 nl-BE; nl (BE)
 nl-Latn-BE; nl (Latn, BE)
-zh-Hans-fonipa; zh (Hans, FONIPA)
+zh-Hans-fonipa; zh (Hans, fonipa)
 
 
 @locale=root
@@ -2371,7 +2371,7 @@ es-Cyrl-MX; es (Cyrl, MX)
 hi-Latn; hi (Latn)
 nl-BE; nl (BE)
 nl-Latn-BE; nl (Latn, BE)
-zh-Hans-fonipa; zh (Hans, FONIPA)
+zh-Hans-fonipa; zh (Hans, fonipa)
 
 
 @locale=ru
@@ -2410,7 +2410,7 @@ es-Cyrl-MX; هسپانوي (سيريلي, ميڪسيڪو)
 hi-Latn; هندي (لاطيني)
 nl-BE; ڊچ (بيلجيم)
 nl-Latn-BE; ڊچ (لاطيني, بيلجيم)
-zh-Hans-fonipa; چيني (سادي, FONIPA)
+zh-Hans-fonipa; چيني (سادي, fonipa)
 
 
 @locale=sd
@@ -2423,7 +2423,7 @@ es-Cyrl-MX; ميڪسيڪين اسپيني (سيريلي)
 hi-Latn; هندي (لاطيني)
 nl-BE; فليمش
 nl-Latn-BE; فليمش (لاطيني)
-zh-Hans-fonipa; چيني (سادي, FONIPA)
+zh-Hans-fonipa; چيني (سادي, fonipa)
 
 
 @locale=sd_Arab
@@ -2436,7 +2436,7 @@ es-Cyrl-MX; هسپانوي (سيريلي, ميڪسيڪو)
 hi-Latn; هندي (لاطيني)
 nl-BE; ڊچ (بيلجيم)
 nl-Latn-BE; ڊچ (لاطيني, بيلجيم)
-zh-Hans-fonipa; چيني (سادي, FONIPA)
+zh-Hans-fonipa; چيني (سادي, fonipa)
 
 
 @locale=sd_Arab
@@ -2449,7 +2449,7 @@ es-Cyrl-MX; ميڪسيڪين اسپيني (سيريلي)
 hi-Latn; هندي (لاطيني)
 nl-BE; فليمش
 nl-Latn-BE; فليمش (لاطيني)
-zh-Hans-fonipa; چيني (سادي, FONIPA)
+zh-Hans-fonipa; چيني (سادي, fonipa)
 
 
 @locale=si
@@ -2462,7 +2462,7 @@ es-Cyrl-MX; ස්පාඤ්ඤ (සිරිලික්, මෙක්සි�
 hi-Latn; හින්දි (ලතින්)
 nl-BE; ලන්දේසි (බෙල්ජියම)
 nl-Latn-BE; ලන්දේසි (ලතින්, බෙල්ජියම)
-zh-Hans-fonipa; චීන (සුළුකළ, FONIPA)
+zh-Hans-fonipa; චීන (සුළුකළ, fonipa)
 
 
 @locale=si
@@ -2475,7 +2475,7 @@ es-Cyrl-MX; මෙක්සිකානු ස්පාඤ්ඤ (සිරි�
 hi-Latn; හින්දි (ලතින්)
 nl-BE; ෆ්ලෙමිශ්
 nl-Latn-BE; ෆ්ලෙමිශ් (ලතින්)
-zh-Hans-fonipa; සරල චීන (FONIPA)
+zh-Hans-fonipa; සරල චීන (fonipa)
 
 
 @locale=sk
@@ -2488,7 +2488,7 @@ es-Cyrl-MX; španielčina (cyrilika, Mexiko)
 hi-Latn; hindčina (latinka)
 nl-BE; holandčina (Belgicko)
 nl-Latn-BE; holandčina (latinka, Belgicko)
-zh-Hans-fonipa; čínština (zjednodušené, FONIPA)
+zh-Hans-fonipa; čínština (zjednodušené, fonipa)
 
 
 @locale=sk
@@ -2501,7 +2501,7 @@ es-Cyrl-MX; španielčina [mexická] (cyrilika)
 hi-Latn; hindčina (latinka)
 nl-BE; flámčina
 nl-Latn-BE; flámčina (latinka)
-zh-Hans-fonipa; čínština [zjednodušená] (FONIPA)
+zh-Hans-fonipa; čínština [zjednodušená] (fonipa)
 
 
 @locale=sl
@@ -2540,7 +2540,7 @@ es-Cyrl-MX; Isbaanish (Siriylik, Meksiko)
 hi-Latn; Hindi (Laatiin)
 nl-BE; Holandays (Biljam)
 nl-Latn-BE; Holandays (Laatiin, Biljam)
-zh-Hans-fonipa; Shinees (La fududeeyay, FONIPA)
+zh-Hans-fonipa; Shinees (La fududeeyay, fonipa)
 
 
 @locale=so
@@ -2553,7 +2553,7 @@ es-Cyrl-MX; Isbaanishka Mexico (Siriylik)
 hi-Latn; Hindi [Latin]
 nl-BE; Af faleemi
 nl-Latn-BE; Af faleemi (Laatiin)
-zh-Hans-fonipa; Shiinaha Rasmiga ah (FONIPA)
+zh-Hans-fonipa; Shiinaha Rasmiga ah (fonipa)
 
 
 @locale=sq
@@ -2566,7 +2566,7 @@ es-Cyrl-MX; spanjisht (cirilik, Meksikë)
 hi-Latn; indisht (latin)
 nl-BE; holandisht (Belgjikë)
 nl-Latn-BE; holandisht (latin, Belgjikë)
-zh-Hans-fonipa; kinezisht (i thjeshtuar, FONIPA)
+zh-Hans-fonipa; kinezisht (i thjeshtuar, fonipa)
 
 
 @locale=sq
@@ -2579,7 +2579,7 @@ es-Cyrl-MX; spanjishte meksikane (cirilik)
 hi-Latn; hindisht [latine]
 nl-BE; flamandisht
 nl-Latn-BE; flamandisht (latin)
-zh-Hans-fonipa; kinezishte e thjeshtuar (FONIPA)
+zh-Hans-fonipa; kinezishte e thjeshtuar (fonipa)
 
 
 @locale=sr
@@ -2696,7 +2696,7 @@ es-Cyrl-MX; Kihispania (Kisiriliki, Meksiko)
 hi-Latn; Kihindi (Kilatini)
 nl-BE; Kiholanzi (Ubelgiji)
 nl-Latn-BE; Kiholanzi (Kilatini, Ubelgiji)
-zh-Hans-fonipa; Kichina (Rahisi, FONIPA)
+zh-Hans-fonipa; Kichina (Rahisi, fonipa)
 
 
 @locale=sw
@@ -2709,7 +2709,7 @@ es-Cyrl-MX; Kihispania (Kisiriliki, Meksiko)
 hi-Latn; Kihindi (Kilatini)
 nl-BE; Kiflemi
 nl-Latn-BE; Kiflemi (Kilatini)
-zh-Hans-fonipa; Kichina [Kilichorahisishwa] (FONIPA)
+zh-Hans-fonipa; Kichina [Kilichorahisishwa] (fonipa)
 
 
 @locale=ta
@@ -2722,7 +2722,7 @@ es-Cyrl-MX; ஸ்பானிஷ் (சிரிலிக், மெக்ச�
 hi-Latn; இந்தி (லத்தின்)
 nl-BE; டச்சு (பெல்ஜியம்)
 nl-Latn-BE; டச்சு (லத்தின், பெல்ஜியம்)
-zh-Hans-fonipa; சீனம் (எளிதாக்கப்பட்டது, FONIPA)
+zh-Hans-fonipa; சீனம் (எளிதாக்கப்பட்டது, fonipa)
 
 
 @locale=ta
@@ -2735,7 +2735,7 @@ es-Cyrl-MX; மெக்ஸிகன் ஸ்பானிஷ் (சிரி�
 hi-Latn; இந்தி (லத்தின்)
 nl-BE; ஃப்லெமிஷ்
 nl-Latn-BE; ஃப்லெமிஷ் (லத்தின்)
-zh-Hans-fonipa; எளிதாக்கப்பட்ட சீனம் (FONIPA)
+zh-Hans-fonipa; எளிதாக்கப்பட்ட சீனம் (fonipa)
 
 
 @locale=te
@@ -2748,7 +2748,7 @@ es-Cyrl-MX; స్పానిష్ (సిరిలిక్, మెక్స�
 hi-Latn; హిందీ (లాటిన్)
 nl-BE; డచ్ (బెల్జియం)
 nl-Latn-BE; డచ్ (లాటిన్, బెల్జియం)
-zh-Hans-fonipa; చైనీస్ (సరళీకృతం, FONIPA)
+zh-Hans-fonipa; చైనీస్ (సరళీకృతం, fonipa)
 
 
 @locale=te
@@ -2761,7 +2761,7 @@ es-Cyrl-MX; మెక్సికన్ స్పానిష్ (సిరి�
 hi-Latn; హిందీ (లాటిన్)
 nl-BE; ఫ్లెమిష్
 nl-Latn-BE; ఫ్లెమిష్ (లాటిన్)
-zh-Hans-fonipa; సరళీకృత చైనీస్ (FONIPA)
+zh-Hans-fonipa; సరళీకృత చైనీస్ (fonipa)
 
 
 @locale=th
@@ -2800,7 +2800,7 @@ es-Cyrl-MX; ስጳንኛ (ቋንቋ ሲሪል፣ ሜክሲኮ)
 hi-Latn; ሂንዲ (ላቲን)
 nl-BE; ዳች (ቤልጅዩም)
 nl-Latn-BE; ዳች (ላቲን፣ ቤልጅዩም)
-zh-Hans-fonipa; ቻይንኛ (ዝተቐለለ፣ FONIPA)
+zh-Hans-fonipa; ቻይንኛ (ዝተቐለለ፣ fonipa)
 
 
 @locale=ti
@@ -2813,7 +2813,7 @@ es-Cyrl-MX; ስጳንኛ (ቋንቋ ሲሪል፣ ሜክሲኮ)
 hi-Latn; ሂንዲ (ላቲን)
 nl-BE; ፍላሚሽ
 nl-Latn-BE; ፍላሚሽ (ላቲን)
-zh-Hans-fonipa; ቀሊል ቻይንኛ (FONIPA)
+zh-Hans-fonipa; ቀሊል ቻይንኛ (fonipa)
 
 
 @locale=tk
@@ -2826,7 +2826,7 @@ es-Cyrl-MX; ispan dili (Kiril elipbiýi, Meksika)
 hi-Latn; hindi dili (Latyn elipbiýi)
 nl-BE; niderland dili (Belgiýa)
 nl-Latn-BE; niderland dili (Latyn elipbiýi, Belgiýa)
-zh-Hans-fonipa; hytaý dili (Ýönekeýleşdirilen, FONIPA)
+zh-Hans-fonipa; hytaý dili (Ýönekeýleşdirilen, fonipa)
 
 
 @locale=tk
@@ -2839,7 +2839,7 @@ es-Cyrl-MX; ispan dili (Kiril elipbiýi, Meksika)
 hi-Latn; hindi dili (Latyn elipbiýi)
 nl-BE; flamand dili
 nl-Latn-BE; flamand dili (Latyn elipbiýi)
-zh-Hans-fonipa; ýönekeýleşdirilen hytaý dili (FONIPA)
+zh-Hans-fonipa; ýönekeýleşdirilen hytaý dili (fonipa)
 
 
 @locale=tr
@@ -2904,7 +2904,7 @@ es-Cyrl-MX; ہسپانوی (سیریلک،میکسیکو)
 hi-Latn; ہندی (لاطینی)
 nl-BE; ڈچ (بیلجیم)
 nl-Latn-BE; ڈچ (لاطینی،بیلجیم)
-zh-Hans-fonipa; چینی (آسان،FONIPA)
+zh-Hans-fonipa; چینی (آسان،fonipa)
 
 
 @locale=ur
@@ -2917,7 +2917,7 @@ es-Cyrl-MX; میکسیکن ہسپانوی (سیریلک)
 hi-Latn; ہندی (لاطینی)
 nl-BE; فلیمِش
 nl-Latn-BE; فلیمِش (لاطینی)
-zh-Hans-fonipa; چینی [آسان کردہ] (FONIPA)
+zh-Hans-fonipa; چینی [آسان کردہ] (fonipa)
 
 
 @locale=uz
@@ -2930,7 +2930,7 @@ es-Cyrl-MX; ispancha (kirill, Meksika)
 hi-Latn; hind (lotin)
 nl-BE; niderland (Belgiya)
 nl-Latn-BE; niderland (lotin, Belgiya)
-zh-Hans-fonipa; xitoy (soddalashgan, FONIPA)
+zh-Hans-fonipa; xitoy (soddalashgan, fonipa)
 
 
 @locale=uz
@@ -2943,7 +2943,7 @@ es-Cyrl-MX; ispan [Meksika] (kirill)
 hi-Latn; hind (lotin)
 nl-BE; flamand
 nl-Latn-BE; flamand (lotin)
-zh-Hans-fonipa; xitoy [soddalashgan] (FONIPA)
+zh-Hans-fonipa; xitoy [soddalashgan] (fonipa)
 
 
 @locale=uz_Latn
@@ -2956,7 +2956,7 @@ es-Cyrl-MX; ispancha (kirill, Meksika)
 hi-Latn; hind (lotin)
 nl-BE; niderland (Belgiya)
 nl-Latn-BE; niderland (lotin, Belgiya)
-zh-Hans-fonipa; xitoy (soddalashgan, FONIPA)
+zh-Hans-fonipa; xitoy (soddalashgan, fonipa)
 
 
 @locale=uz_Latn
@@ -2969,7 +2969,7 @@ es-Cyrl-MX; ispan [Meksika] (kirill)
 hi-Latn; hind (lotin)
 nl-BE; flamand
 nl-Latn-BE; flamand (lotin)
-zh-Hans-fonipa; xitoy [soddalashgan] (FONIPA)
+zh-Hans-fonipa; xitoy [soddalashgan] (fonipa)
 
 
 @locale=vi
@@ -3008,7 +3008,7 @@ es-Cyrl-MX; Èdè Sípáníìṣì (èdè ilẹ̀ Rọ́ṣíà, Mesiko)
 hi-Latn; Èdè Híńdì (Èdè Látìn)
 nl-BE; Èdè Dọ́ọ̀ṣì (Bégíọ́mù)
 nl-Latn-BE; Èdè Dọ́ọ̀ṣì (Èdè Látìn, Bégíọ́mù)
-zh-Hans-fonipa; Edè Ṣáínà (tí wọ́n mú rọrùn., FONIPA)
+zh-Hans-fonipa; Edè Ṣáínà (tí wọ́n mú rọrùn., fonipa)
 
 
 @locale=yo
@@ -3021,7 +3021,7 @@ es-Cyrl-MX; Èdè Sípáníìṣì [orílẹ̀-èdè Mẹ́síkò] (èdè ilẹ�
 hi-Latn; Èdè Híndì [Látìnì]
 nl-BE; Èdè Flemiṣi
 nl-Latn-BE; Èdè Flemiṣi (Èdè Látìn)
-zh-Hans-fonipa; Ẹdè Ṣáínà Onírọ̀rùn (FONIPA)
+zh-Hans-fonipa; Ẹdè Ṣáínà Onírọ̀rùn (fonipa)
 
 
 @locale=yue

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -83,6 +83,7 @@ public class ExtraPaths {
             addPaths(NameType.LANGUAGE);
             addPaths(NameType.SCRIPT);
             addPaths(NameType.TERRITORY);
+            addPaths(NameType.VARIANT);
             addMetazones();
             pathsTemp.addAll(CONST_EXTRA_PATHS);
             paths = ImmutableSet.copyOf(pathsTemp); // preserves order (Sets.copyOf doesn't)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -1598,11 +1598,7 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             Map<String, Set<String>> countries_zoneSet = sc.getCountryToZoneSet();
             Map<String, String> zone_countries = sc.getZoneToCountry();
             List<NameType> nameTypeList =
-                    List.of(
-                            NameType.VARIANT,
-                            NameType.CURRENCY,
-                            NameType.CURRENCY_SYMBOL,
-                            NameType.TZ_EXEMPLAR);
+                    List.of(NameType.CURRENCY, NameType.CURRENCY_SYMBOL, NameType.TZ_EXEMPLAR);
             for (NameType nameType : nameTypeList) {
                 StandardCodes.CodeType codeType = nameType.toCodeType();
                 Set<String> codes = sc.getGoodAvailableCodes(codeType);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -195,6 +195,7 @@ public class TestCLDRFile extends TestFmwk {
                                     || path.startsWith("//ldml/localeDisplayNames/scripts/script")
                                     || path.startsWith(
                                             "//ldml/localeDisplayNames/territories/territory")
+                                    || path.startsWith("//ldml/localeDisplayNames/variants/variant")
                                     || path.startsWith("//ldml/numbers/currencies/currency")
                                     || path.startsWith("//ldml/personNames/sampleName")
                                     || path.contains("/availableFormats")

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -254,6 +254,7 @@ public class TestPaths extends TestFmwkPlus {
                 || path.contains("/genderMinimalPairs")
                 || path.contains("/sampleName")
                 || path.contains("/localeDisplayNames/territories/territory")
+                || path.contains("/localeDisplayNames/variants/variant")
         //            ||
         // path.equals("//ldml/dates/timeZoneNames/zone[@type=\"Australia/Currie\"]/exemplarCity")
         //            ||

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -254,7 +254,6 @@ public class TestPaths extends TestFmwkPlus {
                 || path.contains("/genderMinimalPairs")
                 || path.contains("/sampleName")
                 || path.contains("/localeDisplayNames/territories/territory")
-                || path.contains("/localeDisplayNames/variants/variant")
         //            ||
         // path.equals("//ldml/dates/timeZoneNames/zone[@type=\"Australia/Currie\"]/exemplarCity")
         //            ||


### PR DESCRIPTION
-Use ExtraPaths instead of XMLSource.ResolvingSource.constructedItems

-Paths constructed in this way no longer have fallback values

-Revise test data localeDisplayName.txt to expect fonipa instead of FONIPA

-Remove three paths from common/main/no.xml that had INHERITANCE_MARKER for paths that had no value to inherit

CLDR-17014

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
