### PR TITLE
CLDR-18294 Avoid null Bailey values for paths with INHERITANCE_MARKER

### DIFF
--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -7745,9 +7745,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>Phnum Pénh</exemplarCity>
 			</zone>
-			<zone type="Pacific/Enderbury">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -2697,7 +2697,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
@@ -4100,7 +4099,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -2535,7 +2535,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
@@ -2839,7 +2838,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yM">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yMEd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yMMMd">↑↑↑</dateFormatItem>

--- a/common/main/gaa.xml
+++ b/common/main/gaa.xml
@@ -1681,9 +1681,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Enderbury">
-				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kiritimati">
 				<exemplarCity draft="unconfirmed">↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -3175,9 +3175,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Enderbury">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -1782,7 +1782,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>
@@ -2495,7 +2494,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="UMMM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="UMMMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyy">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd">↑↑↑</dateFormatItem>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -1959,7 +1959,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="UMMM" draft="contributed">MMM U</dateFormatItem>
 						<dateFormatItem id="UMMMd" draft="contributed">d MMM U</dateFormatItem>
 						<dateFormatItem id="y" draft="contributed">↑↑↑</dateFormatItem>
-						<dateFormatItem id="yMd" draft="contributed">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyy" draft="contributed">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyM" draft="contributed">↑↑↑</dateFormatItem>
 						<dateFormatItem id="yyyyMd" draft="contributed">↑↑↑</dateFormatItem>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -2949,9 +2949,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<zone type="Asia/Phnom_Penh">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
-			<zone type="Pacific/Enderbury">
-				<exemplarCity>↑↑↑</exemplarCity>
-			</zone>
 			<zone type="Pacific/Kanton">
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -1590,6 +1590,15 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
             {"zhuyin", "collation"}
         };
 
+        // Start, reference: https://unicode-org.atlassian.net/browse/CLDR-18294
+        // These codes are exceptional in the sense that adding code-fallback for them is expected
+        // to be temporary for v47, and different handling will be implemented in v48.
+        private static final String[] exceptionalLanguageTypes = {"gaa", "luo", "vai"};
+        private static final String[] exceptionalScriptTypes = {
+            "Ahom", "Arab", "Bali", "Cham", "Jamo", "Modi", "Newa", "Thai", "Toto"
+        };
+        // End, reference: https://unicode-org.atlassian.net/browse/CLDR-18294
+
         private static final boolean SKIP_SINGLEZONES = false;
         private static XMLSource constructedItems = new SimpleXMLSource(CODE_FALLBACK_ID);
 
@@ -1616,6 +1625,17 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                     addFallbackCode(nameType, code, value);
                 }
             }
+
+            // Start, reference: https://unicode-org.atlassian.net/browse/CLDR-18294
+            for (String code : exceptionalLanguageTypes) {
+                constructedItems.putValueAtPath(NameType.LANGUAGE.getKeyPath(code), code);
+            }
+            for (String code : exceptionalScriptTypes) {
+                constructedItems.putValueAtPath(NameType.SCRIPT.getKeyPath(code), code);
+            }
+            constructedItems.putValueAtPath(
+                    "//ldml/dates/timeZoneNames/metazone[@type=\"Acre\"]/long/generic", "Acre");
+            // End, reference: https://unicode-org.atlassian.net/browse/CLDR-18294
 
             addFallbackCode(
                     "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/eras/eraAbbr/era[@type=\"0\"]",


### PR DESCRIPTION
-Remove some paths with INHERITANCE_MARKER in XML for eight locales

-Restore code-fallback in XMLSource.java, maybe temporarily, for some paths

-Code comments reference this ticket for follow up in v48

CLDR-18294

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
