### PR TITLE
CLDR-9774 Enable test for missing/extra English names for BCP47 keys/types

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBCP47.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBCP47.java
@@ -78,9 +78,6 @@ public class TestBCP47 extends TestFmwk {
     }
 
     public void TestEnglishKeyTranslations() {
-        logKnownIssue(
-                "cldr7631",
-                "Using just warnings for now, until issues are resolved. Change WARNING/ERROR when removing this.");
         ChainedMap.M3<String, String, String> foundEnglish =
                 ChainedMap.of(
                         new TreeMap<String, Object>(), new TreeMap<String, Object>(), String.class);
@@ -103,14 +100,11 @@ public class TestBCP47 extends TestFmwk {
                     if (keyTrans != null) {
                         engKey = keyAlias;
                         foundEnglish.put(engKey, "", keyTrans);
-                        msg(
+                        warnln(
                                 "Type for English 'key' translation is "
                                         + engKey
                                         + ", while bcp47 is "
-                                        + bcp47Key,
-                                WARNING,
-                                true,
-                                true);
+                                        + bcp47Key);
                         break;
                     }
                 }
@@ -125,17 +119,14 @@ public class TestBCP47 extends TestFmwk {
                                 Collections.<String>emptySet(),
                                 keyTrans));
             } else {
-                msg(
+                errln(
                         showData(
                                 bcp47Key,
                                 "",
                                 SUPPLEMENTAL_DATA_INFO.getBcp47Descriptions().get(keyRow),
                                 keyAliases,
                                 Collections.<String>emptySet(),
-                                "MISSING"),
-                        ERROR,
-                        true,
-                        true);
+                                "MISSING"));
             }
             if (bcp47Key.equals("tz")) {
                 continue;
@@ -156,8 +147,8 @@ public class TestBCP47 extends TestFmwk {
             final String type = extra.get1();
             final String trans = extra.get2();
             if (foundEnglish.get(key, type) == null) {
-                if (key.equals("x")) {
-                    msg(
+                if (key.equals("x") || key.equals("t")) {
+                    logln(
                             "OK Extra English: "
                                     + showData(
                                             key,
@@ -165,12 +156,12 @@ public class TestBCP47 extends TestFmwk {
                                             "MISSING",
                                             Collections.<String>emptySet(),
                                             Collections.<String>emptySet(),
-                                            trans),
-                            LOG,
-                            true,
-                            true);
+                                            trans));
+                } else if (type.equals("big5han") || type.equals("gb2312han")) {
+                    logKnownIssue(
+                            "CLDR-18307", "Remove English names for deprecated collation types");
                 } else {
-                    msg(
+                    errln(
                             "*Extra English: "
                                     + showData(
                                             key,
@@ -178,10 +169,7 @@ public class TestBCP47 extends TestFmwk {
                                             "MISSING",
                                             Collections.<String>emptySet(),
                                             Collections.<String>emptySet(),
-                                            trans),
-                            ERROR,
-                            true,
-                            true);
+                                            trans));
                 }
             }
         }
@@ -223,7 +211,7 @@ public class TestBCP47 extends TestFmwk {
                 if (trans != null) {
                     engType = typeAlias;
                     foundEnglish.put(engKey, engType, trans);
-                    msg(
+                    warnln(
                             "Type for English 'key+type' translation is "
                                     + engKey
                                     + "+"
@@ -231,10 +219,7 @@ public class TestBCP47 extends TestFmwk {
                                     + ", while bcp47 is "
                                     + bcp47Key
                                     + "+"
-                                    + bcp47Type,
-                            WARNING,
-                            true,
-                            true);
+                                    + bcp47Type);
                     break;
                 }
             }
@@ -260,17 +245,14 @@ public class TestBCP47 extends TestFmwk {
                             typeAliases,
                             trans));
         } else {
-            msg(
+            errln(
                     showData(
                             bcp47Key,
                             bcp47Type,
                             SUPPLEMENTAL_DATA_INFO.getBcp47Descriptions().get(row),
                             keyAliases,
                             typeAliases,
-                            "MISSING"),
-                    ERROR,
-                    true,
-                    true);
+                            "MISSING"));
         }
     }
 


### PR DESCRIPTION
CLDR-9774

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-9774)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Start using the test to check for missing or extra English display names for relevant BCP47 keys and types. Most of this was already in unittest/TestBCP47.java, but the tests there were not being run until I added them to TestAll() in PR [#4358](https://github.com/unicode-org/cldr/pull/4358). Then for this PR I just had to switch to using normal error logging, and add some test skips (one marked with a logKnownIssue).

Tested this by temporarily adding some new entries in common/bcp47 files without translations in English and verifying that the test caught them.

ALLOW_MANY_COMMITS=true
