### PR TITLE
CLDR-18294 Add unit test for inheriting null, and fix two items in xml

### DIFF
--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -1028,7 +1028,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<variant type="FONNAPA" draft="unconfirmed">Hurup Pengucapan Amrik Lor</variant>
 			<variant type="FONUPA" draft="unconfirmed">Hurup Pengucapan Ural</variant>
 			<variant type="FONXSAMP" draft="unconfirmed">Hurup Pengucapan X-SAMPA</variant>
-			<variant type="GALLO">↑↑↑</variant>
 			<variant type="GASCON" draft="unconfirmed">Gaskon</variant>
 			<variant type="GRCLASS" draft="unconfirmed">Èjaan Oksitan Klasik</variant>
 			<variant type="GRITAL" draft="unconfirmed">Èjaan Oksitan Keitalian</variant>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -1272,7 +1272,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<variant type="SAAHO">↑↑↑</variant>
 			<variant type="SCOTLAND">↑↑↑</variant>
 			<variant type="SCOUSE">↑↑↑</variant>
-			<variant type="SIMPLE">↑↑↑</variant>
 			<variant type="SOLBA">↑↑↑</variant>
 			<variant type="SOTAV">↑↑↑</variant>
 			<variant type="TARASK">↑↑↑</variant>


### PR DESCRIPTION
-Combine the test with TestCheckCLDR to avoid another cycle through factory.getAvailable

-New method checkNullWithInheritanceMark

-Skip and log known issue for paths not in LANGUAGE/SCRIPT/TERRITORY/VARIANT

CLDR-18294

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
