### PR TITLE
CLDR-18308 Restore LICENSE copyright to 2025, update README/spec date/status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ UNICODE LICENSE V3
 
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright © 2004-2024 Unicode, Inc.
+Copyright © 2004-2025 Unicode, Inc.
 
 NOTICE TO USER: Carefully read the following legal agreement. BY
 DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ For current CLDR release information, see [cldr.unicode.org](https://cldr.unicod
 
 ## Status
 
-Update: 2025-01-07
+Update: 2025-02-12
 
 <!-- [inapplicable lines are commented out.]-->
-**Note:**  CLDR 47 is in development and not recommended for use at this stage.
+<!--**Note:**  CLDR 47 is in development and not recommended for use at this stage.-->
 <!--**Note:**  This is the milestone 1 version of CLDR 47, intended for those wishing to do pre-release testing. It is not recommended for production use.-->
-<!--**Note:** This is a preliminary version of CLDR 47, intended for those wishing to do pre-release testing. It is not recommended for production use.-->
+**Note:** This is a preliminary version of CLDR 47, intended for those wishing to do pre-release testing. It is not recommended for production use.
 <!-- **Note:**  This is a pre-release candidate version of CLDR 47, intended for testing. It is not recommended for production use. -->
 <!--This is the final release version of CLDR 47.-->
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|47 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35.md#Acknowledgments">other CLDR committee members</a>|
-|Date|2025-01-07|
+|Date|2025-02-11|
 |This Version|<a href="https://www.unicode.org/reports/tr35/tr35-75/tr35.html">https://www.unicode.org/reports/tr35/tr35-75/tr35.html</a>|
 |Previous Version|<a href="https://www.unicode.org/reports/tr35/tr35-74/tr35.html">https://www.unicode.org/reports/tr35/tr35-74/tr35.html</a>|
 |Latest Version|<a href="https://www.unicode.org/reports/tr35/">https://www.unicode.org/reports/tr35/</a>|


### PR DESCRIPTION
CLDR-18308

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18308)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

- Per recent discussion in ICU, LICENSE copyright end year should be 2025 after all. Reverts one of the changes in PR #4289
- Also update README status & date, and update spec date to date of last change.

ALLOW_MANY_COMMITS=true
