### PR TITLE
CLDR-17925 da short inch-ofhg, use U+2033 not U+201C

### DIFF
--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -9557,9 +9557,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<unitPattern count="other">↑↑↑</unitPattern>
 			</unit>
 			<unit type="pressure-inch-ofhg">
-				<displayName>“ Hg</displayName>
-				<unitPattern count="one">{0} “ Hg</unitPattern>
-				<unitPattern count="other">{0} “ Hg</unitPattern>
+				<displayName>″ Hg</displayName>
+				<unitPattern count="one">{0} ″ Hg</unitPattern>
+				<unitPattern count="other">{0} ″ Hg</unitPattern>
 			</unit>
 			<unit type="pressure-bar">
 				<displayName>↑↑↑</displayName>


### PR DESCRIPTION
CLDR-17925

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-17925)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

da, short inch-ofhg should use U+2033 (double prime) as already used in narrow inch-ofhg, not U+201C (left double quotation)

ALLOW_MANY_COMMITS=true
