### PR TITLE
CLDR-18312 json- workaround CLDRFile identity bug

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -596,10 +596,10 @@ public class Ldml2JsonConverter {
             if (cv > coverageValue) {
                 continue;
             }
-            // Discard root identity element unless the locale is root
-            // TODO: CLDR-17790 this code should not be needed.
+
+            // TODO: CLDR-17790 known issue - //ldml/identity inherits when it shouldn't.
             rootIdentityMatcher.reset(fullPath);
-            if (rootIdentityMatcher.matches() && !"root".equals(locID)) {
+            if (rootIdentityMatcher.matches() && !file.isHere(fullPath)) {
                 continue;
             }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -422,12 +422,8 @@ class LdmlConvertRules {
         "//ldml/numbers/otherNumberingSystems/finance"
     };
 
-    /**
-     * Root language id pattern should be discarded in all locales except root, even though the path
-     * will exist in a resolved CLDRFile.
-     */
-    public static final Pattern ROOT_IDENTITY_PATTERN =
-            Pattern.compile("//ldml/identity/language\\[@type=\"root\"\\]");
+    /** resolved identity should be discarded if inherited, known issue CLDR-17790 */
+    public static final Pattern ROOT_IDENTITY_PATTERN = Pattern.compile("//ldml/identity.*");
 
     /**
      * Version (coming from DTD) should be discarded everywhere. This information is now in

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -1004,4 +1004,36 @@ public class TestCLDRFile extends TestFmwk {
             }
         }
     }
+
+    public void TestInheritedIdentity() {
+        final Map<String, Set<String>> elementToPaths = new TreeMap<>();
+
+        final CLDRFile f = CLDRConfig.getInstance().getCLDRFile("hi_Latn_IN", true);
+        for (final String s : f.fullIterable()) {
+            if (s.startsWith("//ldml/identity")) {
+                final String element = XPathParts.getFrozenInstance(s).getElement(-1);
+                final Set<String> setForElement =
+                        elementToPaths.computeIfAbsent(element, (ignored) -> new TreeSet<>());
+                assertTrue(
+                        "Duplicate XPath: " + s + " in " + f.getLocaleID(), setForElement.add(s));
+                if (!f.isHere(s)) {
+                    // this path should not be inherited
+                    if (!logKnownIssue("CLDR-17790", "//ldml/identity has inherited paths")) {
+                        errln("Inherited path " + s + " in " + f.getLocaleID());
+                    }
+                }
+            }
+        }
+        for (final Set<String> set : elementToPaths.values()) {
+            if (set.size() > 1) {
+                if (!logKnownIssue(
+                        "CLDR-17790",
+                        "//ldml/identity has duplicate resolved paths for elements")) {
+                    errln(
+                            "Duplicate //ldml/identity paths: "
+                                    + String.join(" ", set.toArray(new String[0])));
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
- add a known issue on CLDR-17790
- //ldml/identity resolves (inherits) when it shouldn't, per spec
- skip //ldml/identity paths that are inherited (!isHere())

CLDR-18312


FYI @btangmu I don't change CLDRFile here but relevant to inheritance stuff

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
