### PR TITLE
CLDR-15693 Improve CurrencyDateInfo ordering, add test for XML file ordering, fix data

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1145,11 +1145,11 @@ The printed version of ISO-4217:2001
             <currency iso4217="DEM" from="1999-09-01" to="2002-03-09"/>
             <currency iso4217="YUM" from="1994-01-24" to="1999-09-30"/><!-- Yugoslavian history. YU was renamed to CS. -->
         </region>
-        <region iso3166="YE">
-            <currency iso4217="YER" from="1990-05-22"/><!-- You might be able to say 1964-05-08 is the starting date -->
-        </region>
         <region iso3166="YD">
             <currency iso4217="YDD" from="1965-04-01" to="1996-01-01"/>
+        </region>
+        <region iso3166="YE">
+            <currency iso4217="YER" from="1990-05-22"/><!-- You might be able to say 1964-05-08 is the starting date -->
         </region>
         <region iso3166="YT">
             <currency iso4217="EUR" from="1999-01-01"/>

--- a/docs/ldml/tr35-numbers.md
+++ b/docs/ldml/tr35-numbers.md
@@ -1000,6 +1000,8 @@ That is, each `currency` element will list an interval in which it was valid. Th
 <currency iso4217="YUN" from="1994-01-01" to="1994-07-22"/>
 ```
 
+All `currency` elements with `tender="false"` should be at the end of the list for a given `region`. 
+
 The `from` element is limited by the fact that ISO 4217 does not go very far back in time, so there may be no ISO code for the previous currency.
 
 Currencies change relatively frequently. There are different types of changes:

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -4347,6 +4347,8 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 
 ### Number symbols and formats without numberSystem
 - Noted that [Number Symbols](tr35-numbers.md#Number_Symbols) and [Number Formats](tr35-numbers.md#Number_Formats) without a specific `numberSystem` attribute should not be used and will be deprecated in CLDR v48.
+### Clarified `currencyData` element ordering
+- In [Supplemental Currency Data](tr35-numbers.md#Supplemental_Currency_Data), noted that in the list of `currency` elements for a given `currencyData/region`, those with `tender="false"` should be at the end of the list.
 
 **Changes in LDML Version 46.1 (Differences from Version 46)**
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -703,8 +703,25 @@ public class SupplementalDataInfo {
 
         @Override
         public int compareTo(CurrencyDateInfo o) {
+            // Sort first by isLegalTender
+            if (isLegalTender && !o.isLegalTender) {
+                return -1;
+            }
+            if (!isLegalTender && o.isLegalTender) {
+                return 1;
+            }
+            // Note that sorting using criteria other than the above loses info, because per
+            // https://www.unicode.org/reports/tr35/tr35-numbers.html#Supplemental_Currency_Data,
+            // "The [xml file] *ordering* of the elements in the list tells us which was the
+            // primary currency during any period in time." However we do keep the further
+            // comparison steps below to preserve a unique ordering of CurrencyDateInfo items; we
+            // just make the ordering closer to the file order by sorting the dateRange newest
+            // first (CLDR-15693).
+            //
+            // Then sort by date range
             int result = dateRange.compareTo(o.dateRange);
-            if (result != 0) return result;
+            if (result != 0) return -result; // want *newest* "to" first, then newest "from"
+            // then by currency
             return currency.compareTo(o.currency);
         }
 


### PR DESCRIPTION
CLDR-15693

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-15693)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Note that per TR35 [Supplemental Currency Data](https://www.unicode.org/reports/tr35/tr35-numbers.html#Supplemental_Currency_Data), "The [xml file] *ordering* of the elements in the [currency] list tells us which was the primary currency during any period in time."

- Update TR35 to note that currency elements with tender="false" should be last in list for currencyData/region (they are never primary at any point in time).
- Order SupplementalDataInfo.CurrencyDataInfo first by isLegalTender, then by _newest_ date range first (not _older_ date range). Note that while this ordering is closer to the file ordering, it will not be identical (since we need to sort these in a unique way), so SupplementalDataInfo has never preserved info about the primary currency during any time period in the event that two currencies are legal tender during overlapping time periods.
- Add test for currencyData/region element ordering (regions must be ordered by region code, and within a region, currency elements with `tender = "false"` should be last).
- Fix supplementalData.xml currencyData to pass test (use reorder one region)


ALLOW_MANY_COMMITS=true
