### PR TITLE
CLDR-18319 kbd: bnf: update bnf for transform ranges

### DIFF
--- a/docs/ldml/tr35-keyboards.md
+++ b/docs/ldml/tr35-keyboards.md
@@ -2507,6 +2507,7 @@ set-member
          ::= text-char
            | char-range
            | match-marker
+           | escaped-codepoint
 char-range
          ::= range-edge '-' range-edge
 range-edge

--- a/keyboards/abnf/transform-from-required.abnf
+++ b/keyboards/abnf/transform-from-required.abnf
@@ -85,7 +85,7 @@ fixed-class-char = "s" / "S" / "t" / "r" / "n" / "f" / "v" / backslash / "$" / "
 
 set-class = "[" set-negator set-members "]"
 set-members = set-member *(set-member)
-set-member = text-char / char-range / match-marker
+set-member = text-char / char-range / match-marker / escaped-codepoint
 char-range = range-edge "-" range-edge
 range-edge = escaped-codepoint / range-char
 set-negator = "^" / ""


### PR DESCRIPTION
- Single escaped points in a range such as `<transform from="[\u{127}]"/>` were not supported, but they are present in the spec.

- For example, `[a-z]` or `[a-\u{127}]` or `[\u{61}-z]` are all supported, just not `[\u{61}]` (and by extension, `[a-z\u{127}]` is not supported by the current BNF).

- this PR fixes the EBNF / ABNF to allow a single escaped codepoint to be a member of the character classes.  

CLDR-18319

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
