### PR TITLE
CLDR-13310 test that ar and children have explicit defaultNumberingSystem entry

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAll.java
@@ -192,6 +192,7 @@ public class TestAll extends TestGroup {
                     "org.unicode.cldr.unittest.TestCasingInfo",
                     "org.unicode.cldr.unittest.TestCheckAltOnly",
                     "org.unicode.cldr.unittest.TestCheckCLDR",
+                    "org.unicode.cldr.unittest.TestCheckNumbers",
                     "org.unicode.cldr.unittest.TestComparisonBuilder",
                     "org.unicode.cldr.unittest.TestCoverageLevel",
                     "org.unicode.cldr.unittest.TestDTDAttributes",

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckNumbers.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckNumbers.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.unittest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
@@ -11,9 +12,13 @@ import org.unicode.cldr.test.CheckNumbers;
 import org.unicode.cldr.unittest.TestXMLSource.DummyXMLSource;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XMLSource;
 
 public class TestCheckNumbers extends TestFmwkPlus {
+
+    static CLDRConfig testInfo = CLDRConfig.getInstance();
 
     public static void main(String[] args) {
         new TestCheckNumbers().run(args);
@@ -66,6 +71,26 @@ public class TestCheckNumbers extends TestFmwkPlus {
                 assertEquals("errorType", Type.Error, err.getType());
                 Subtype exp = err.getSubtype();
                 assertEquals("errorSubType", expectedSubtype, err.getSubtype());
+            }
+        }
+    }
+
+    public void TestDefaultNumberingSystemInArAndChildren() {
+        Factory cldrFactory = testInfo.getCldrFactory();
+        SupplementalDataInfo sdi = SupplementalDataInfo.getInstance();
+        Set<String> defaultContentLocales = sdi.getDefaultContentLocales();
+        for (String locale : cldrFactory.getAvailable()) {
+            if (locale.equals("ar")
+                    || (locale.startsWith("ar_") && !defaultContentLocales.contains(locale))) {
+                CLDRFile cldrFile = cldrFactory.make(locale, false);
+                String defaultNumberSys =
+                        cldrFile.getStringValue("//ldml/numbers/defaultNumberingSystem");
+                if (defaultNumberSys == null) {
+                    errln(
+                            "Missing explicit defaultNumberingSystem entry in "
+                                    + locale
+                                    + ", see other ar_*");
+                }
             }
         }
     }


### PR DESCRIPTION
CLDR-13310

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-13310)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

- Add TestCheckNumbers to TestAll(); TestCheckNumbers was originally added in PR #490 for [CLDR-11045](https://unicode-org.atlassian.net/browse/CLDR-11045) "Add no-placeholder compact data back to CLDR"
- In TestCheckNumbers, add a test that `ar` and its children (except the default content locale) have explicit defaultNumberingSystem entries, since for the time being we are still supporting the possibility of having `ar` support either `latn` or `arab` as default (clients can choose)

ALLOW_MANY_COMMITS=true


[CLDR-11045]: https://unicode-org.atlassian.net/browse/CLDR-11045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ