### PR TITLE
CLDR-15388 check annotations for empty values or keyword entry without name (tts) entry

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckAnnotations.java
@@ -1,27 +1,73 @@
 package org.unicode.cldr.test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.LocaleIDParser;
 import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.XPathParts;
 
 public class CheckAnnotations extends CheckCLDR {
     private static final Pattern ANNOTATION_PATH = Pattern.compile("//ldml/annotations/.*");
 
+    // Skip tts test for these locale/cp combinations unti
+    // https://unicode-org.atlassian.net/browse/CLDR-18329 is fixed
+    private static final Map<String, Set<String>> entriesLackingTts = new HashMap<>();
+
+    static {
+        //                    locID                                            cp= values to skip
+        entriesLackingTts.put("ak", new HashSet<>(Arrays.asList(new String[] {"🪀"})));
+        entriesLackingTts.put("br", new HashSet<>(Arrays.asList(new String[] {"'"})));
+        entriesLackingTts.put("ccp", new HashSet<>(Arrays.asList(new String[] {"🥪"})));
+        entriesLackingTts.put(
+                "ha",
+                new HashSet<>(Arrays.asList(new String[] {"👨‍🦯", "👨‍🦼", "👩‍🦯", "👩‍🦼"})));
+        entriesLackingTts.put(
+                "kab",
+                new HashSet<>(
+                        Arrays.asList(
+                                new String[] {"⚙", "🀄", "🌤", "🎀", "💊", "💲", "🖲", "🚀"})));
+        entriesLackingTts.put("om", null); // all entries lack tts version
+        entriesLackingTts.put("qu", new HashSet<>(Arrays.asList(new String[] {"✒"})));
+        entriesLackingTts.put(
+                "sat",
+                new HashSet<>(
+                        Arrays.asList(
+                                new String[] {
+                                    "🍐", "🍑", "🍒", "🍓", "🐠", "🐡", "🐨", "🐳", "🐹", "👞",
+                                    "💥", "🤽‍♂", "🥐", "🥸", "🦈"
+                                })));
+    }
+    ;
+
     @Override
     public CheckCLDR handleCheck(
             String path, String fullPath, String value, Options options, List<CheckStatus> result) {
-        if (value == null) {
-            return this;
-        } else if (!ANNOTATION_PATH.matcher(path).matches()
-                || !getCldrFileToCheck().isNotRoot(path)) {
+        if (!ANNOTATION_PATH.matcher(path).matches()) return this;
+        if (!accept(result)) return this;
+
+        // check whether annotation is empty
+        if (value == null || value.isEmpty()) {
+            result.add(
+                    new CheckStatus()
+                            .setCause(this)
+                            .setMainType(CheckStatus.errorType)
+                            .setSubtype(Subtype.nullOrEmptyValue)
+                            .setMessage("The annotation may not be empty"));
             return this;
         }
-        if (!accept(result)) return this;
+        CLDRFile file = getCldrFileToCheck();
         final String ecode = hasAnnotationECode(value);
 
-        if (ecode != null) {
+        // check whether annotation value is E-code
+        if (ecode != null && file.isNotRoot(path)) {
             result.add(
                     new CheckStatus()
                             .setCause(this)
@@ -31,6 +77,42 @@ public class CheckAnnotations extends CheckCLDR {
                                     "The annotation must be a translation and not contain the E… code from root, or anything like it. ({0})",
                                     ecode));
         }
+
+        // check whether name (tts) entry corresponding to keyword entry is missing in top-level
+        // locales
+        String localeID = file.getLocaleID();
+        String parent = LocaleIDParser.getParent(localeID);
+        boolean isTopLevel = (parent == null) || parent.equals("root");
+        if (!path.contains("[@type=\"tts\"]") && isTopLevel) {
+            // this is a keyword path in top-level locale, check that corresponding tts path is
+            // present
+            XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed();
+            String ttsPath = parts.addAttribute("type", "tts").toString();
+            String ttsValue = file.getWinningValue(ttsPath);
+            boolean ttsMissing =
+                    ttsValue == null
+                            || ttsValue.isEmpty()
+                            || (file.isNotRoot(path)
+                                    && ecode == null
+                                    && hasAnnotationECode(ttsValue) != null);
+            if (ttsMissing && entriesLackingTts.keySet().contains(localeID)) {
+                String cpValue = parts.findAttributeValue("annotation", "cp");
+                Set<String> cpEntriesLackingTts = entriesLackingTts.get(localeID);
+                if (cpEntriesLackingTts == null || cpEntriesLackingTts.contains(cpValue)) {
+                    ttsMissing = !ttsMissing; // skip the error report, already have CLDR-18329
+                }
+            }
+            if (ttsMissing) {
+                result.add(
+                        new CheckStatus()
+                                .setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.ttsAnnotationMissing)
+                                .setMessage(
+                                        "Have keywords but missing the corresponding name (tts) entry"));
+            }
+        }
+
         return this;
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -936,6 +936,8 @@ public abstract class CheckCLDR implements CheckAccessor {
             shortDateFieldInconsistentLength,
             illegalParameterValue,
             illegalAnnotationCode,
+            nullOrEmptyValue,
+            ttsAnnotationMissing,
             illegalCharacter;
 
             @Override


### PR DESCRIPTION
CLDR-15388

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-15388)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Add a consoleCheck test (so vetters will see it) in CheckAnnotations that:
- Annotation entries do not have empty values (`<annotation cp=".."></annotation>` or `<annotation cp=".."/>`).
- If there is a keyword entry for a given emoji/symbol, there should also be a tts (name) entry.

This found many missing tts errors, about which I have filed [CLDR-18329](https://unicode-org.atlassian.net/browse/CLDR-18329). In the meantime, I added a skip for these known error cases so that CI tests will pass (I did not use logKnownIssue, as far as I know we cannot do that in consoleCheck tests, not sure what would happen in Survey Tool)

ALLOW_MANY_COMMITS=true


[CLDR-18329]: https://unicode-org.atlassian.net/browse/CLDR-18329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ