### PR TITLE
CLDR-11950 Fix Info Panel wrong-message bug in front end

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -328,7 +328,7 @@ function addSelectedItem(theRow) {
   const { language, direction } = getLanguageAndDirection();
   selectedItemWrapper.setLanguageAndDirection(language, direction);
 
-  const description = getItemDescription(item?.pClass, theRow?.inheritedLocale);
+  const description = getItemDescription(item?.pClass, theRow);
   selectedItemWrapper.setDescription(description);
 
   const { linkUrl, linkText } = getLinkUrlAndText(theRow, item);
@@ -399,7 +399,7 @@ function getLinkUrlAndText(theRow, item) {
     }
     if (xpstrid === theRow.xpstrid && loc === cldrStatus.getCurrentLocale()) {
       // following the alias would come back to the current item; no link
-      linkText = cldrText.get("noFollowAlias");
+      // and no link text either
     } else {
       linkText = cldrText.get("followAlias");
       linkUrl = "#/" + loc + "//" + xpstrid;
@@ -907,17 +907,22 @@ function createVoter(v) {
   return div;
 }
 
-function getItemDescription(itemClass, inheritedLocale) {
+function getItemDescription(itemClass, theRow) {
   /*
    * itemClass may be "winner, "alias", "fallback", "fallback_code", "fallback_root", or "loser".
    *  See getPClass in DataPage.java.*
    */
+  const inheritedLocale = theRow?.inheritedLocale;
   if (itemClass === "fallback") {
     const locName = cldrLoad.getLocaleName(inheritedLocale);
     return cldrText.sub("item_description_fallback", [locName]);
   } else if (itemClass === "alias") {
     if (inheritedLocale === cldrStatus.getCurrentLocale()) {
-      return cldrText.get("item_description_alias_same_locale");
+      return cldrText.get(
+        theRow.inheritedXpid
+          ? "item_description_alias_same_locale"
+          : "noFollowAlias"
+      );
     } else {
       const locName = cldrLoad.getLocaleName(inheritedLocale);
       return cldrText.sub("item_description_alias_diff_locale", [locName]);


### PR DESCRIPTION
-For constructed value, message should be noFollowAlias = This item is constructed from other values

-The wrong message was item_description_alias_same_locale = This item is inherited from another field in this locale

-In cldrInfo.mjs, addSelectedItem calls getItemDescription and getLinkUrlAndText

-In getItemDescription, if no inheritance path, show the message for constructed value

-In getLinkUrlAndText, if no inheritance path, there is no link URL, AND no link text; link text is ignored if there is no link URL

CLDR-11950

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
