### PR TITLE
CLDR-11874 json: output subdivisions to the correct spot

### DIFF
--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_subdivisions.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/JSON_config_subdivisions.txt
@@ -4,7 +4,7 @@
 package=subdivisions ; packageDesc=Translated versions of locale display name elements: subdivisions.
 
 # mapping paths to sections
-section=subdivisions ; path=//cldr/subdivisions/[^/]++/localeDisplayNames/subdivisions/.* ; package=subdivisions
+section=subdivisions ; path=//cldr/subdivisions/localeDisplayNames/subdivisions/.* ; package=subdivisions
 
 # Depedencies
 dependency=core ; package=subdivisions


### PR DESCRIPTION
- the configuration wasn't updated after an internal path change, so the files were in the wrong place

CLDR-11874

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
