### PR TITLE
CLDR-18205 workaround eclipse issue

### DIFF
--- a/tools/cldr-code/pom.xml
+++ b/tools/cldr-code/pom.xml
@@ -70,16 +70,9 @@
 				<directory>src/main/resources</directory>
 			</resource>
 			<resource>
-		       <directory>${project.basedir}/../..</directory>
-			   <!-- This is put here so that it can be read by CldrUtility, even outside of a jar -->
-		       <targetPath>${project.build.directory}/classes/org/unicode/cldr/util/data</targetPath>
-				<includes>
-					<include>LICENSE</include>
-				</includes>
-			</resource>
-			<resource>
-		       <directory>${project.basedir}/../..</directory>
-			   <!-- This is put here so that it shows up in the final .jar in an expected spot -->
+			   <!-- Note: the copy of the LICENSE file needs to be kept in sync with the one at the root of the repo. -->
+		       <directory>src/main/resources/org/unicode/cldr/util/data/</directory>
+			   <!-- This copies LICENSE here so that it shows up in the final .jar in an expected spot -->
 			   <!-- Note: icu4j keeps its license file at the root, /LICENSE. We won't conflict. -->
 		       <targetPath>META-INF</targetPath>
 				<includes>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CopyLicense.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CopyLicense.java
@@ -8,6 +8,10 @@ import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRTool;
 import org.unicode.cldr.util.CldrUtility;
 
+/**
+ * Note: CLDR-18205: There are two copies of LICENSE to work around Eclipse bug
+ * https://github.com/eclipse-m2e/m2e-core/issues/1912
+ */
 @CLDRTool(alias = "copylicense", description = "copy LICENSE file from root into subdirectory")
 public class CopyLicense {
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CopyLicense.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CopyLicense.java
@@ -1,0 +1,32 @@
+package org.unicode.cldr.tool;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRTool;
+import org.unicode.cldr.util.CldrUtility;
+
+@CLDRTool(alias = "copylicense", description = "copy LICENSE file from root into subdirectory")
+public class CopyLicense {
+
+    static final Path ROOT_PATH =
+            CLDRConfig.getInstance().getCldrBaseDirectory().toPath().resolve(CldrUtility.LICENSE);
+    static final Path RESOURCE_PATH =
+            CLDRConfig.getInstance()
+                    .getCldrBaseDirectory()
+                    .toPath()
+                    .resolve(
+                            "tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/"
+                                    + CldrUtility.LICENSE);
+
+    public static void main(String[] args) throws IOException {
+        System.out.println("# Copying " + ROOT_PATH + " to " + RESOURCE_PATH);
+        Files.copy(
+                ROOT_PATH,
+                RESOURCE_PATH,
+                StandardCopyOption.COPY_ATTRIBUTES,
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/LICENSE
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/LICENSE
@@ -1,0 +1,41 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2004-2025 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/tool/TestCopyLicense.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/tool/TestCopyLicense.java
@@ -8,6 +8,10 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.CldrUtility;
 
+/**
+ * Note: CLDR-18205: There are two copies of LICENSE to work around Eclipse bug
+ * https://github.com/eclipse-m2e/m2e-core/issues/1912
+ */
 public class TestCopyLicense {
     @Test
     void TestLicenseFileCopy() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/tool/TestCopyLicense.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/tool/TestCopyLicense.java
@@ -1,0 +1,37 @@
+package org.unicode.cldr.tool;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.util.CldrUtility;
+
+public class TestCopyLicense {
+    @Test
+    void TestLicenseFileCopy() {
+        String resourceLicense;
+        String rootLicense;
+        final String HELP = "Run CopyLicense";
+        try {
+            rootLicense = Files.readString(CopyLicense.ROOT_PATH);
+        } catch (Throwable t) {
+            fail("Could not read " + CopyLicense.ROOT_PATH + " !", t);
+            return;
+        }
+        try {
+            resourceLicense =
+                    CldrUtility.getUTF8Data(CldrUtility.LICENSE)
+                            .lines()
+                            .collect(Collectors.joining("\n"));
+        } catch (Throwable t) {
+            fail("Could not read " + CopyLicense.RESOURCE_PATH + " - " + HELP, t);
+            return;
+        }
+        assertArrayEquals(
+                rootLicense.split("\n"),
+                resourceLicense.split("\n"),
+                () -> "License mismatch - " + HELP);
+    }
+}


### PR DESCRIPTION
- copy LICENSE file into a secondary spot
- new tool CopyLicense that performs the copy (should it be needed) so that this can be tied into automation
- test to assert the files are the same

This is to work around the bug https://github.com/eclipse-m2e/m2e-core/issues/1912

CLDR-18205

- [X] This PR completes the ticket.

Note: I'm inclined to not bother cloning the ticket… if some year we find out it's fixed we can back out the change. The eclipse bug  <https://github.com/eclipse-m2e/m2e-core/issues/1912> is already linked in the code and the commit.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
