### PR TITLE
CLDR-18349 Keep scriptData when generating ConvertLanguageData

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -2474,7 +2474,7 @@ XXX Code for transations where no currency is involved
 		<scriptVariant type="subset" id='Hans' base='Hani'/> <!-- Han (Simplified variant) -->
 		<scriptVariant type="subset" id='Hant' base='Hani'/> <!-- Han (Traditional variant) -->
 	</scriptData>
- <!-- See http://unicode.org/cldr/data/diff/supplemental/territory_language_information.html for more information on territoryInfo. -->
+	<!-- See https://www.unicode.org/cldr/charts/latest/supplemental/territory_language_information.html for more information on territoryInfo. -->
 	<territoryInfo>
 		<territory type="AC" gdp="50800000" literacyPercent="99" population="940">	<!--Ascension Island-->
 			<languagePopulation type="en" populationPercent="99" references="R1020"/>	<!--English-->


### PR DESCRIPTION
ConvertLanguageData rebuilds part of the supplementalData.xml. Since the new <scriptData /> is in the middle of 2 generated sections we need to re-write the generator so it does not accidentally drop it when running the script. Long term this is only more reason to break up the supplementalData.xml - but let's plan that out first.

Can be landed in v48 or v47, no changes will affect ICU.

Code to run generator:
```
mvn package -DskipTests=true &&  java -jar tools/cldr-code/target/cldr-code.jar ConvertLanguageData
```

CLDR-18349

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
