### PR TITLE
CLDR-18340 MessageFormat v47 change list

### DIFF
--- a/docs/ldml/tr35-messageFormat.md
+++ b/docs/ldml/tr35-messageFormat.md
@@ -50,7 +50,6 @@ The LDML specification is divided into the following parts:
 
 ## <a name="Contents">Contents of Part 9, MessageFormat</a>
 
-* [Table of Contents](#table-of-contents)
 * [Introduction](#introduction)
   * [Conformance](#conformance)
   * [Terminology and Conventions](#terminology-and-conventions)
@@ -84,7 +83,7 @@ The LDML specification is divided into the following parts:
   * [Escape Sequences](#escape-sequences)
     * [Whitespace](#whitespace)
   * [Complete ABNF](#complete-abnf)
-* [message.abnf](#message-abnf)
+* [message.abnf](#messageabnf)
 * [Formatting](#formatting)
   * [Formatting Context](#formatting-context)
   * [Resolved Values](#resolved-values)
@@ -197,11 +196,10 @@ The LDML specification is divided into the following parts:
   * [Markup Model](#markup-model)
   * [Attribute Model](#attribute-model)
   * [Model Extensions](#model-extensions)
-  * [`message.json`](#message-json)
+  * [`message.json`](#messagejson)
 * [Appendices](#appendices)
   * [Security Considerations](#security-considerations)
   * [Acknowledgements](#acknowledgements)
-
 
 ## Introduction
 

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -119,6 +119,7 @@ The LDML specification is divided into the following parts:
     * [Lateral Inheritance](#Lateral_Inheritance)
       * Table: [Count Fallback: normal](#Count_Fallback_normal)
       * Table: [Count Fallback: currency](#Count_Fallback_currency)
+    * [Inheritance Marker](#inheritance-marker)
     * [Parent Locales](#Parent_Locales)
     * [Region-Priority Inheritance](#Region_Priority_Inheritance)
   * [Inheritance and Validity](#Inheritance_and_Validity)
@@ -164,7 +165,6 @@ The LDML specification is divided into the following parts:
     * [Ordering](#Ordering)
     * [Comments](#Comments)
   * [DTD Annotations](#DTD_Annotations)
-    * [Attribute Value Constraints](#match_expressions)
 * [Property Data](#Property_Data)
   * [Script Metadata](#Script_Metadata)
   * [Extended Pictographic](#Extended_Pictographic)
@@ -223,6 +223,11 @@ The LDML specification is divided into the following parts:
   * [Number symbols and formats without numberSystem](#number-symbols-and-formats-without-numbersystem)
   * [Clarified `currencyData` element ordering](#clarified-currencydata-element-ordering)
   * [Semantic Datetime Skeletons](#semantic-datetime-skeletons)
+  * [[Timezones](tr35-dates.md#Using_Time_Zone_Names)](#timezonestr35-datesmdusingtimezonenames)
+  * [[Unit Identifiers](tr35-general.md#Unit_Identifiers)](#unit-identifierstr35-generalmdunitidentifiers)
+  * [[DTD Annotations](https://cldr.unicode.org/development/dtd_annotations)](#dtd-annotationshttpscldrunicodeorgdevelopmentdtdannotations)
+  * [[Inheritance](https://unicode.org/reports/tr35/dev/tr35.html#inheritance-marker)](#inheritancehttpsunicodeorgreportstr35devtr35htmlinheritance-marker)
+  * [[MessageFormat](tr35-messageFormat.md#Contents)](#messageformattr35-messageformatmdcontents)
   * [Improvements to Keyboard Transforms](#improvements-to-keyboard-transforms)
   * [Well-formed identifiers](#well-formed-identifiers)
 
@@ -4342,20 +4347,20 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 - Added a [Time Precision](tr35-dates#Time_Precision) option, replacing the discrete time field sets.
 - Updated the algorithm for mapping to standard skeletons.
 
-### [Timezones](https://unicode.org/reports/tr35/tr35-dates.html#Using_Time_Zone_Names)  
+### [Timezones](tr35-dates.md#Using_Time_Zone_Names)  
 * Added **Specific location format**  
 * Added to clauses in formatting timezones  
     * What to do if the canonicalization fails  
     * How to determine location formats (generic or specific)  
     * When to fall back to the specific location format
    
-### [Unit Identifiers](tr35-general.html#Unit_Identifiers)
+### [Unit Identifiers](tr35-general.md#Unit_Identifiers)
 * Modified the EBNF  
     * Deprecated use of unit\_constants  in the numerator of units  
     * Limited unit\_constants to 8 characters  
     * Clarified the normalized form of units.  
 * Modified the process of formatting to handle unit\_constants  
-* [Unit Preferences Overrides](tr35-info.html#Unit_Preferences_Overrides)
+* [Unit Preferences Overrides](tr35-info.md#Unit_Preferences_Overrides)
   * Clarified the process of deriving the region for overrides
  
 ### [DTD Annotations](https://cldr.unicode.org/development/dtd_annotations)
@@ -4365,8 +4370,31 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
 ### [Inheritance](https://unicode.org/reports/tr35/dev/tr35.html#inheritance-marker)
 * Documented the use of Inheritance Marker (↑↑↑) in the CLDR repository
 
-### [MessageFormat](tr35-messageFormat.html#Contents)
-_TBD: Note: we should also add below to the differences in 46.1; can get from release notes for 46.1_
+### [MessageFormat](tr35-messageFormat.md#Contents)
+- Made MessageFormat stable and made the stability policy normative.
+- Added or clarified terminology:
+  - Linked all terminology in the MessageFormat section to the term's definition.
+  - Defined _option value_, _literal key_, _string value_, and _digit size option_ formally. Other definitions were defined or modified for clarity.
+  - Replaced the concept of a "function registry" with default functions and `u:` namespace functions and options.
+  - Changed the data model to be called the "Interchange Data Model"
+- Modified portions of the syntax (ABNF)
+  - Removed `number-literal` from the ABNF and moved its definition to the _default functions_ for numeric formatting.
+  - Changed (expanded) the range of characters allowed in an unquoted literal and simplified syntax character set definitions.
+- Revised the _Default Bidi Strategy_.
+- Enabled functions to know whether an _option value_ was set using a literal or a variable, which is necessary for some function's selection mechanism (see below).
+- Updated the _default functions_:
+  - Only three _default functions_ are stable: `:string`, `:number`, and `:integer`. Other functions are Draft.
+  - Some options have been removed, modified, or made optional.
+  - The `select` option on `:number` and `:integer` functions now accepts only literal values.
+  - Removed the `style` `percent` from `:number` and `:integer` pending future standardization.
+  - The `u:` namespace options `u:id` and `u:dir` are optional; `u:locale` is Draft.
+- Clarified how to include the character "*" in a key.
+
+In addition, the following changes were made in v46.1:
+- Removed all of the reserved and private use syntax constructs, simplifying the grammar.
+- Changed the structure of the `.match` (selector) to require use of `.local` or `.input` declarations. This is a breaking change for existing messages.
+- Added support for bidirectional isolates and marks, and clarified whitespace handling to better enable messages that contain right-to-left and mixed direction identifiers and text.
+
 
 ### Improvements to Keyboard Transforms
 - Added rigorous EBNF definition of transform syntax to [Transform Grammar](tr35-keyboards.md#transform-grammar).

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -4390,9 +4390,10 @@ Other contributors to CLDR are listed on the [CLDR Project Page](https://www.uni
   - The `u:` namespace options `u:id` and `u:dir` are optional; `u:locale` is Draft.
 - Clarified how to include the character "*" in a key.
 
-In addition, the following changes were made in v46.1:
+#### Changes in LDML Version 46.1 (Differences from Version 46)
+
 - Removed all of the reserved and private use syntax constructs, simplifying the grammar.
-- Changed the structure of the `.match` (selector) to require use of `.local` or `.input` declarations. This is a breaking change for existing messages.
+- Changed the structure of the `.match` (selector) to require use of `.local` or `.input` declarations.
 - Added support for bidirectional isolates and marks, and clarified whitespace handling to better enable messages that contain right-to-left and mixed direction identifiers and text.
 
 

--- a/docs/site/downloads/cldr-47.md
+++ b/docs/site/downloads/cldr-47.md
@@ -64,6 +64,30 @@ The following are the most significant changes to the specification (LDML).
 - Don't produce "Unknown City Time" for VVV and VVVV, use localized offset format instead [CLDR-18237](https://unicode-org.atlassian.net/browse/CLDR-18237)
 - **TBD** (including Message Format, Part 9)
 
+
+- Made MessageFormat stable and made the stability policy normative. This includes the following changes:
+  - Added or clarified terminology
+    - Defined option value, literal key, string value, and digit size option formally.
+    - Replaced the concept of a "function registry" with default functions and u: namespace functions and options.
+    - Changed the data model to be called the "Interchange Data Model"
+  - Modified portions of the syntax (ABNF)
+    - Removed number-literal from the ABNF and moved its definition to the default functions for numeric formatting.
+    - Changed (expanded) the range of characters allowed in an unquoted literal and simplified syntax character set definitions.
+  - Revised the Default Bidi Strategy.
+  - Enabled functions to know whether an option value was set using a literal or a variable, which is necessary for some function's selection mechanism (see below).
+  - Updated the default functions:
+    - Only three default functions are stable: :string, :number, and :integer. Other functions are Draft.
+    - Some options have been removed, modified, or made optional.
+    - The select option on :number and :integer functions now accepts only literal values.
+    - Removed the style percent from :number and :integer pending future standardization.
+    - The u: namespace options u:id and u:dir are optional; u:locale is Draft.
+  - Clarified how to include the character "*" in a key.
+  - In addition, the following changes were made in v46.1:
+    - Removed all of the reserved and private use syntax constructs, simplifying the grammar.
+    - Changed the structure of the .match (selector) to require use of .local or .input declarations. This is a breaking change for existing messages.
+    - Added support for bidirectional isolates and marks, and clarified whitespace handling to better enable messages that contain right-to-left and mixed direction identifiers and text.
+
+
 There are many more changes that are important to implementations, such as changes to certain identifier syntax and various algorithms.
 See the [Modifications section](https://www.unicode.org/reports/tr35/proposed.html#Modifications) of the specification for details.
 

--- a/docs/site/downloads/cldr-47.md
+++ b/docs/site/downloads/cldr-47.md
@@ -84,7 +84,7 @@ The following are the most significant changes to the specification (LDML).
   - Clarified how to include the character "*" in a key.
   - In addition, the following changes were made in v46.1:
     - Removed all of the reserved and private use syntax constructs, simplifying the grammar.
-    - Changed the structure of the .match (selector) to require use of .local or .input declarations. This is a breaking change for existing messages.
+    - Changed the structure of the .match (selector) to require use of .local or .input declarations.
     - Added support for bidirectional isolates and marks, and clarified whitespace handling to better enable messages that contain right-to-left and mixed direction identifiers and text.
 
 


### PR DESCRIPTION
CLDR-18340

Adds changes in v47 for MessageFormat to the spec and to the downloads page. Other changes in this PR appear to have come from syncing my fork to main?

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
