### PR TITLE
CLDR-18295 spec: fix anchors

### DIFF
--- a/docs/ldml/tr35-messageFormat.md
+++ b/docs/ldml/tr35-messageFormat.md
@@ -4300,7 +4300,7 @@ This data model might also be used to:
 
 To ensure compatibility across all platforms,
 this interchange data model is defined here using TypeScript notation.
-An equivalent JSON Schema definition [`message.json`](#message-json) is also provided,
+An equivalent JSON Schema definition [`message.json`](#messagejson) is also provided,
 for use with message data encoded as JSON or compatible formats, such as YAML.
 
 Note that while the data model description below is the canonical one,

--- a/docs/ldml/tr35-messageFormat.md
+++ b/docs/ldml/tr35-messageFormat.md
@@ -50,7 +50,6 @@ The LDML specification is divided into the following parts:
 
 ## <a name="Contents">Contents of Part 9, MessageFormat</a>
 
-* [Table of Contents](#table-of-contents)
 * [Introduction](#introduction)
   * [Conformance](#conformance)
   * [Terminology and Conventions](#terminology-and-conventions)
@@ -84,7 +83,7 @@ The LDML specification is divided into the following parts:
   * [Escape Sequences](#escape-sequences)
     * [Whitespace](#whitespace)
   * [Complete ABNF](#complete-abnf)
-* [message.abnf](#message-abnf)
+* [message.abnf](#messageabnf)
 * [Formatting](#formatting)
   * [Formatting Context](#formatting-context)
   * [Resolved Values](#resolved-values)
@@ -197,11 +196,10 @@ The LDML specification is divided into the following parts:
   * [Markup Model](#markup-model)
   * [Attribute Model](#attribute-model)
   * [Model Extensions](#model-extensions)
-  * [`message.json`](#message-json)
+  * [`message.json`](#messagejson)
 * [Appendices](#appendices)
   * [Security Considerations](#security-considerations)
   * [Acknowledgements](#acknowledgements)
-
 
 ## Introduction
 
@@ -402,7 +400,7 @@ This part of the MessageFormat specification defines the syntax for a _message_,
 along with the concepts and terminology needed when processing a _message_
 during the [formatting](#formatting) of a _message_ at runtime.
 
-The complete formal syntax of a _message_ is described by the [ABNF](#message-abnf).
+The complete formal syntax of a _message_ is described by the [ABNF](#messageabnf).
 
 #### Well-formed vs. Valid Messages
 
@@ -1382,7 +1380,7 @@ ws = SP / HTAB / CR / LF / %x3000
 
 ### Complete ABNF
 
-The grammar is formally defined in [`message.abnf`](#message-abnf)
+The grammar is formally defined in [`message.abnf`](#messageabnf)
 using the ABNF notation [[STD68](https://www.rfc-editor.org/info/std68)],
 including the modifications found in [RFC 7405](https://www.rfc-editor.org/rfc/rfc7405).
 
@@ -4088,7 +4086,7 @@ When the offset is not present, implementations SHOULD use a floating time type
 For more information, see [Working with Timezones](https://w3c.github.io/timezone).
 
 > [!IMPORTANT]
-> The [ABNF](#message-abnf) and [syntax](#syntax) of MF2
+> The [ABNF](#messageabnf) and [syntax](#syntax) of MF2
 > do not formally define date/time literals.
 > This means that a _message_ can be syntactically valid but produce
 > a _Bad Operand_ error at runtime.

--- a/tools/scripts/tr-archive/package-lock.json
+++ b/tools/scripts/tr-archive/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@not-dalia/gfm-toc": "github:not-dalia/gfm-toc#995683cdac2aa0cce1f175104eb6cce63fb99c8d",
         "anchor-js": "^5.0.0",
+        "anchor-markdown-header": "^0.7.0",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.7.0",
         "jsdom": "^22.1.0",
@@ -172,6 +173,15 @@
       "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-5.0.0.tgz",
       "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA=="
     },
+    "node_modules/anchor-markdown-header": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.7.0.tgz",
+      "integrity": "sha512-OYUgo5tYN+WipGB2R3sZUvXLpTzqSnm0b3AXRqN9Rhi2Z+uCQsFSguDDgpoSdhDrnu/aCYHFGHosdL9hbaWSHA==",
+      "dependencies": {
+        "emoji-regex": "~10.1.0",
+        "remove-markdown": "^0.5.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -279,6 +289,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg=="
     },
     "node_modules/entities": {
       "version": "4.4.0",
@@ -693,6 +708,11 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
+    "node_modules/remove-markdown": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.5.tgz",
+      "integrity": "sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g=="
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -1029,6 +1049,15 @@
       "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-5.0.0.tgz",
       "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA=="
     },
+    "anchor-markdown-header": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.7.0.tgz",
+      "integrity": "sha512-OYUgo5tYN+WipGB2R3sZUvXLpTzqSnm0b3AXRqN9Rhi2Z+uCQsFSguDDgpoSdhDrnu/aCYHFGHosdL9hbaWSHA==",
+      "requires": {
+        "emoji-regex": "~10.1.0",
+        "remove-markdown": "^0.5.0"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1115,6 +1144,11 @@
       "requires": {
         "webidl-conversions": "^7.0.0"
       }
+    },
+    "emoji-regex": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg=="
     },
     "entities": {
       "version": "4.4.0",
@@ -1414,6 +1448,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "remove-markdown": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.5.tgz",
+      "integrity": "sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g=="
     },
     "requires-port": {
       "version": "1.0.0",

--- a/tools/scripts/tr-archive/package.json
+++ b/tools/scripts/tr-archive/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@not-dalia/gfm-toc": "github:not-dalia/gfm-toc#995683cdac2aa0cce1f175104eb6cce63fb99c8d",
     "anchor-js": "^5.0.0",
+    "anchor-markdown-header": "^0.7.0",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.7.0",
     "jsdom": "^22.1.0",


### PR DESCRIPTION
- AnchorJS and GFM have different ideas about the fragment id
- find and detect those, and set for example `<h2 id="foobar">foo.bar</h2>` only where it would make a difference (to minimize impact)

this is a workaround for https://github.com/bryanbraun/anchorjs/issues/197

Also:
- Don't anchorify H1 (#) which is just the top anchor
- fix link target in tr35-messageFormat.md which would now be incorrect.

CLDR-18295

- [ ] This PR completes the ticket.

FYI @aphillips 


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
