### PR TITLE
CLDR-16715 Match Classical Chinese with Traditional Han writing

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -441,7 +441,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="luz" to="luz_Arab_IR"/>		<!--Southern Luri‧?‧?	➡ Southern Luri‧Arabic‧Iran-->
 		<likelySubtag from="lv" to="lv_Latn_LV"/>		<!--Latvian‧?‧?	➡ Latvian‧Latin‧Latvia-->
 		<likelySubtag from="lwl" to="lwl_Thai_TH"/>		<!--Eastern Lawa‧?‧?	➡ Eastern Lawa‧Thai‧Thailand-->
-		<likelySubtag from="lzh" to="lzh_Hans_CN"/>		<!--Literary Chinese‧?‧?	➡ Literary Chinese‧Simplified‧China-->
+		<likelySubtag from="lzh" to="lzh_Hant_CN"/>		<!--Literary Chinese‧?‧?	➡ Literary Chinese‧Traditional‧China-->
 		<likelySubtag from="lzz" to="lzz_Latn_TR"/>		<!--Laz‧?‧?	➡ Laz‧Latin‧Türkiye-->
 		<likelySubtag from="lzz_GE" to="lzz_Geor_GE"/>		<!--Laz‧?‧Georgia	➡ Laz‧Georgian‧Georgia-->
 		<likelySubtag from="lzz_Geor" to="lzz_Geor_GE"/>		<!--Laz‧Georgian‧?	➡ Laz‧Georgian‧Georgia-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1906,7 +1906,7 @@ XXX Code for transations where no currency is involved
 		<language type="luz" territories="IR" alt="secondary"/>
 		<language type="lv" scripts="Latn" territories="LV"/>
 		<language type="lwl" scripts="Thai"/>
-		<language type="lzh" scripts="Hans"/>
+		<language type="lzh" scripts="Hant"/>
 		<language type="lzz" scripts="Latn"/>
 		<language type="lzz" scripts="Geor" alt="secondary"/>
 		<language type="mad" scripts="Latn"/>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -508,7 +508,7 @@ luy	Luyia	primary	Latn	Latin
 luz	Southern Luri	primary	Arab	Arabic
 lv	Latvian	primary	Latn	Latin
 lwl	Eastern Lawa	primary	Thai	Thai
-lzh	Literary Chinese	primary	Hans	Simplified
+lzh	Literary Chinese	primary	Hant	Traditional
 lzz	Laz	primary	Latn	Latin
 lzz	Laz	secondary	Geor	Georgian
 mad	Madurese	primary	Latn	Latin


### PR DESCRIPTION
The Classical Chinese [lzh] language is the standardized form of Chinese that arose around the start of the Common Era (potentially as early as 5th Century BCE). It is marked as ending in common usage by the May Fourth Movement in 1919 -- it was replaced with vernacular Chinese [zh & it's constituents].

The majority of its duration coincides with Traditional Han writing [Hant]. While many writings were in the earlier scripts, the vast majority of corpora are in Traditional script.  The printed form in which "Traditional Han writing [Hant]" now most often occurs arose in the Song dynasty starting in the 10th century CE.

The ending of common usage of Classical Chinese was 37 years before the advent of Simplified Chinese (1956). Since, for historic languages, we match their writing system to the largest corpora, we should fix this and match it to Traditional Han writing.

CLDR-16715

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
