### PR TITLE
CLDR-5708 Remove misleading territories attribute from supplementalData

### DIFF
--- a/common/dtd/ldmlSupplemental.dtd
+++ b/common/dtd/ldmlSupplemental.dtd
@@ -147,6 +147,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST language territories NMTOKENS #IMPLIED >
     <!--@MATCH:set/validity/region-->
     <!--@VALUE-->
+    <!--@DEPRECATED-->
 <!ATTLIST language variants NMTOKENS #IMPLIED >
     <!--@VALUE-->
 <!ATTLIST language draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -193,7 +193,6 @@
 			<attributeValues dtds='supplementalData' elements='info' attributes='rounding' type='regex'>[0-9]+</attributeValues>
 			<attributeValues dtds='ldml' elements='key' attributes='type'>$_bcp47_keys</attributeValues>
 			<attributeValues dtds='supplementalData' elements='language' attributes='scripts' type='list'>$_script</attributeValues>
-			<attributeValues dtds='supplementalData' elements='language' attributes='territories' type='list'>$_region</attributeValues>
 			<attributeValues dtds='ldml' elements='language' attributes='type'>$localeOrDeprecated</attributeValues>
 			<attributeValues dtds='supplementalData' elements='language' attributes='variants'>$_variant</attributeValues>
 			<attributeValues dtds='supplementalData' elements='languageAlias' attributes='replacement' type='locale'/>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1277,38 +1277,27 @@ XXX Code for transations where no currency is involved
     <!-- Start of Generated Data: see https://cldr.unicode.org/development/updating-codes/update-languagescriptregion-subtags -->
 	<languageData>
 		<language type="aa" scripts="Latn"/>
-		<language type="aa" territories="DJ ET" alt="secondary"/>
 		<language type="ab" scripts="Cyrl"/>
-		<language type="ab" territories="GE" alt="secondary"/>
 		<language type="abq" scripts="Cyrl"/>
 		<language type="abr" scripts="Latn"/>
-		<language type="abr" territories="GH" alt="secondary"/>
 		<language type="ace" scripts="Latn"/>
-		<language type="ace" territories="ID" alt="secondary"/>
 		<language type="ach" scripts="Latn"/>
-		<language type="ach" territories="UG" alt="secondary"/>
 		<language type="ada" scripts="Latn"/>
-		<language type="ada" territories="GH" alt="secondary"/>
 		<language type="ady" scripts="Cyrl"/>
-		<language type="ady" territories="RU" alt="secondary"/>
 		<language type="ae" scripts="Avst"/>
 		<language type="aeb" scripts="Arab"/>
-		<language type="aeb" territories="TN" alt="secondary"/>
 		<language type="af" scripts="Latn"/>
-		<language type="af" territories="NA ZA" alt="secondary"/>
 		<language type="agq" scripts="Latn"/>
 		<language type="aii" scripts="Cyrl"/>
 		<language type="aii" scripts="Syrc" alt="secondary"/>
 		<language type="ain" scripts="Kana Latn" alt="secondary"/>
 		<language type="ak" scripts="Latn"/>
-		<language type="ak" territories="GH" alt="secondary"/>
 		<language type="akk" scripts="Xsux"/>
 		<language type="akz" scripts="Latn"/>
 		<language type="ale" scripts="Latn"/>
 		<language type="aln" scripts="Latn"/>
-		<language type="aln" territories="XK" alt="secondary"/>
 		<language type="alt" scripts="Cyrl"/>
-		<language type="am" scripts="Ethi" territories="ET"/>
+		<language type="am" scripts="Ethi"/>
 		<language type="amo" scripts="Latn"/>
 		<language type="an" scripts="Latn"/>
 		<language type="ang" scripts="Latn"/>
@@ -1316,91 +1305,63 @@ XXX Code for transations where no currency is involved
 		<language type="anp" scripts="Deva"/>
 		<language type="aoz" scripts="Latn"/>
 		<language type="apc" scripts="Arab"/>
-		<language type="apc" territories="IL JO LB PS SY TR" alt="secondary"/>
 		<language type="apd" scripts="Arab"/>
-		<language type="apd" territories="SD" alt="secondary"/>
-		<language type="ar" scripts="Arab" territories="AE BH DJ DZ EG EH ER IL IQ JO KM KW LB LY MA MR OM PS QA SA SD SO SY TD TN YE"/>
-		<language type="ar" scripts="Syrc" territories="IR SS" alt="secondary"/>
+		<language type="ar" scripts="Arab"/>
+		<language type="ar" scripts="Syrc" alt="secondary"/>
 		<language type="arc" scripts="Armi Nbat Palm" alt="secondary"/>
 		<language type="arn" scripts="Latn"/>
 		<language type="aro" scripts="Latn"/>
 		<language type="arp" scripts="Latn"/>
 		<language type="arq" scripts="Arab"/>
-		<language type="arq" territories="DZ" alt="secondary"/>
 		<language type="ars" scripts="Arab"/>
-		<language type="ars" territories="SA" alt="secondary"/>
 		<language type="arw" scripts="Latn"/>
 		<language type="ary" scripts="Arab"/>
-		<language type="ary" territories="MA" alt="secondary"/>
 		<language type="arz" scripts="Arab"/>
-		<language type="arz" territories="EG" alt="secondary"/>
 		<language type="as" scripts="Beng"/>
-		<language type="as" territories="IN" alt="secondary"/>
 		<language type="asa" scripts="Latn"/>
 		<language type="ast" scripts="Latn"/>
-		<language type="ast" territories="ES" alt="secondary"/>
 		<language type="atj" scripts="Latn"/>
 		<language type="av" scripts="Cyrl"/>
-		<language type="av" territories="RU" alt="secondary"/>
 		<language type="avk" scripts="Latn"/>
 		<language type="awa" scripts="Deva"/>
-		<language type="awa" territories="IN" alt="secondary"/>
-		<language type="ay" scripts="Latn" territories="BO"/>
-		<language type="az" scripts="Latn Arab Cyrl" territories="AZ"/>
-		<language type="az" territories="IQ IR RU" alt="secondary"/>
+		<language type="ay" scripts="Latn"/>
+		<language type="az" scripts="Latn Arab Cyrl"/>
 		<language type="ba" scripts="Cyrl"/>
-		<language type="ba" territories="RU" alt="secondary"/>
 		<language type="bal" scripts="Arab"/>
-		<language type="bal" scripts="Latn" territories="IR PK" alt="secondary"/>
+		<language type="bal" scripts="Latn" alt="secondary"/>
 		<language type="ban" scripts="Latn"/>
-		<language type="ban" scripts="Bali" territories="ID" alt="secondary"/>
+		<language type="ban" scripts="Bali" alt="secondary"/>
 		<language type="bap" scripts="Deva"/>
 		<language type="bar" scripts="Latn"/>
-		<language type="bar" territories="AT DE" alt="secondary"/>
 		<language type="bas" scripts="Latn"/>
 		<language type="bax" scripts="Bamu"/>
 		<language type="bbc" scripts="Latn"/>
-		<language type="bbc" scripts="Batk" territories="ID" alt="secondary"/>
+		<language type="bbc" scripts="Batk" alt="secondary"/>
 		<language type="bbj" scripts="Latn"/>
 		<language type="bci" scripts="Latn"/>
-		<language type="bci" territories="CI" alt="secondary"/>
-		<language type="be" scripts="Cyrl" territories="BY"/>
+		<language type="be" scripts="Cyrl"/>
 		<language type="bej" scripts="Arab"/>
-		<language type="bej" territories="SD" alt="secondary"/>
 		<language type="bem" scripts="Latn"/>
-		<language type="bem" territories="ZM" alt="secondary"/>
 		<language type="bew" scripts="Latn"/>
-		<language type="bew" territories="ID" alt="secondary"/>
 		<language type="bez" scripts="Latn"/>
-		<language type="bez" territories="TZ" alt="secondary"/>
 		<language type="bfd" scripts="Latn"/>
 		<language type="bfq" scripts="Taml"/>
 		<language type="bft" scripts="Arab"/>
 		<language type="bft" scripts="Tibt" alt="secondary"/>
 		<language type="bfy" scripts="Deva"/>
-		<language type="bg" scripts="Cyrl" territories="BG"/>
+		<language type="bg" scripts="Cyrl"/>
 		<language type="bgc" scripts="Deva"/>
-		<language type="bgc" territories="IN" alt="secondary"/>
 		<language type="bgn" scripts="Arab"/>
-		<language type="bgn" territories="PK" alt="secondary"/>
 		<language type="bgx" scripts="Grek"/>
 		<language type="bhb" scripts="Deva"/>
-		<language type="bhb" territories="IN" alt="secondary"/>
 		<language type="bhi" scripts="Deva"/>
-		<language type="bhi" territories="IN" alt="secondary"/>
 		<language type="bho" scripts="Deva"/>
-		<language type="bho" territories="IN NP" alt="secondary"/>
-		<language type="bi" scripts="Latn" territories="VU"/>
+		<language type="bi" scripts="Latn"/>
 		<language type="bik" scripts="Latn"/>
-		<language type="bik" territories="PH" alt="secondary"/>
 		<language type="bin" scripts="Latn"/>
-		<language type="bin" territories="NG" alt="secondary"/>
 		<language type="bjj" scripts="Deva"/>
-		<language type="bjj" territories="IN" alt="secondary"/>
 		<language type="bjn" scripts="Latn"/>
-		<language type="bjn" territories="ID" alt="secondary"/>
 		<language type="bjt" scripts="Latn"/>
-		<language type="bjt" territories="SN" alt="secondary"/>
 		<language type="bkm" scripts="Latn"/>
 		<language type="bku" scripts="Latn"/>
 		<language type="bku" scripts="Buhd" alt="secondary"/>
@@ -1408,25 +1369,19 @@ XXX Code for transations where no currency is involved
 		<language type="blo" scripts="Latn"/>
 		<language type="blt" scripts="Tavt"/>
 		<language type="bm" scripts="Latn Nkoo"/>
-		<language type="bm" territories="ML" alt="secondary"/>
 		<language type="bmq" scripts="Latn"/>
-		<language type="bn" scripts="Beng" territories="BD"/>
-		<language type="bn" territories="IN" alt="secondary"/>
+		<language type="bn" scripts="Beng"/>
 		<language type="bo" scripts="Tibt"/>
-		<language type="bo" territories="CN" alt="secondary"/>
 		<language type="bpy" scripts="Beng"/>
 		<language type="bqi" scripts="Arab"/>
-		<language type="bqi" territories="IR" alt="secondary"/>
 		<language type="bqv" scripts="Latn"/>
 		<language type="br" scripts="Latn"/>
 		<language type="bra" scripts="Deva"/>
 		<language type="brh" scripts="Arab"/>
-		<language type="brh" scripts="Latn" territories="PK" alt="secondary"/>
+		<language type="brh" scripts="Latn" alt="secondary"/>
 		<language type="brx" scripts="Deva"/>
-		<language type="brx" territories="IN" alt="secondary"/>
-		<language type="bs" scripts="Latn Cyrl" territories="BA"/>
+		<language type="bs" scripts="Latn Cyrl"/>
 		<language type="bsc" scripts="Latn"/>
-		<language type="bsc" territories="SN" alt="secondary"/>
 		<language type="bsq" scripts="Latn"/>
 		<language type="bsq" scripts="Bass" alt="secondary"/>
 		<language type="bss" scripts="Latn"/>
@@ -1434,18 +1389,15 @@ XXX Code for transations where no currency is involved
 		<language type="btv" scripts="Deva"/>
 		<language type="bua" scripts="Cyrl"/>
 		<language type="buc" scripts="Latn"/>
-		<language type="buc" territories="YT" alt="secondary"/>
 		<language type="bug" scripts="Latn"/>
-		<language type="bug" scripts="Bugi" territories="ID" alt="secondary"/>
+		<language type="bug" scripts="Bugi" alt="secondary"/>
 		<language type="bum" scripts="Latn"/>
-		<language type="bum" territories="CM" alt="secondary"/>
 		<language type="bvb" scripts="Latn"/>
 		<language type="byn" scripts="Ethi"/>
 		<language type="byv" scripts="Latn"/>
 		<language type="bze" scripts="Latn"/>
 		<language type="bzx" scripts="Latn"/>
-		<language type="ca" scripts="Latn" territories="AD"/>
-		<language type="ca" territories="ES" alt="secondary"/>
+		<language type="ca" scripts="Latn"/>
 		<language type="cad" scripts="Latn"/>
 		<language type="car" scripts="Latn"/>
 		<language type="cay" scripts="Latn"/>
@@ -1453,19 +1405,15 @@ XXX Code for transations where no currency is involved
 		<language type="ccp" scripts="Cakm Beng"/>
 		<language type="ccr" scripts="Latn"/>
 		<language type="ce" scripts="Cyrl"/>
-		<language type="ce" territories="RU" alt="secondary"/>
 		<language type="ceb" scripts="Latn"/>
-		<language type="ceb" territories="PH" alt="secondary"/>
 		<language type="cgg" scripts="Latn"/>
-		<language type="cgg" territories="UG" alt="secondary"/>
-		<language type="ch" scripts="Latn" territories="GU"/>
+		<language type="ch" scripts="Latn"/>
 		<language type="chk" scripts="Latn"/>
-		<language type="chk" territories="FM" alt="secondary"/>
 		<language type="chm" scripts="Cyrl"/>
 		<language type="chn" scripts="Latn"/>
 		<language type="cho" scripts="Latn"/>
 		<language type="chp" scripts="Latn"/>
-		<language type="chp" scripts="Cans" territories="CA" alt="secondary"/>
+		<language type="chp" scripts="Cans" alt="secondary"/>
 		<language type="chr" scripts="Cher"/>
 		<language type="chy" scripts="Latn"/>
 		<language type="cic" scripts="Latn"/>
@@ -1475,11 +1423,10 @@ XXX Code for transations where no currency is involved
 		<language type="cjm" scripts="Arab" alt="secondary"/>
 		<language type="cjs" scripts="Cyrl"/>
 		<language type="ckb" scripts="Arab"/>
-		<language type="ckb" territories="IQ IR" alt="secondary"/>
 		<language type="ckt" scripts="Cyrl"/>
 		<language type="clc" scripts="Latn"/>
 		<language type="co" scripts="Latn"/>
-		<language type="cop" scripts="Copt Arab Grek" territories="EG" alt="secondary"/>
+		<language type="cop" scripts="Copt Arab Grek" alt="secondary"/>
 		<language type="cps" scripts="Latn"/>
 		<language type="cr" scripts="Cans Latn"/>
 		<language type="crg" scripts="Latn"/>
@@ -1487,249 +1434,187 @@ XXX Code for transations where no currency is involved
 		<language type="crj" scripts="Cans"/>
 		<language type="crj" scripts="Latn" alt="secondary"/>
 		<language type="crk" scripts="Cans"/>
-		<language type="crk" territories="CA" alt="secondary"/>
 		<language type="crl" scripts="Cans"/>
 		<language type="crl" scripts="Latn" alt="secondary"/>
 		<language type="crm" scripts="Cans"/>
 		<language type="crs" scripts="Latn"/>
-		<language type="crs" territories="SC" alt="secondary"/>
-		<language type="cs" scripts="Latn" territories="CZ"/>
-		<language type="cs" territories="SK" alt="secondary"/>
+		<language type="cs" scripts="Latn"/>
 		<language type="csb" scripts="Latn"/>
-		<language type="csb" territories="PL" alt="secondary"/>
 		<language type="csw" scripts="Cans"/>
 		<language type="ctd" scripts="Latn"/>
 		<language type="cu" scripts="Cyrl"/>
 		<language type="cv" scripts="Cyrl"/>
-		<language type="cv" territories="RU" alt="secondary"/>
 		<language type="cy" scripts="Latn"/>
-		<language type="cy" territories="GB" alt="secondary"/>
-		<language type="da" scripts="Latn" territories="DK"/>
-		<language type="da" territories="DE" alt="secondary"/>
+		<language type="da" scripts="Latn"/>
 		<language type="dak" scripts="Latn"/>
 		<language type="dar" scripts="Cyrl"/>
 		<language type="dav" scripts="Latn"/>
 		<language type="dcc" scripts="Arab"/>
-		<language type="dcc" territories="IN" alt="secondary"/>
-		<language type="de" scripts="Latn" territories="AT BE CH DE LI LU"/>
-		<language type="de" scripts="Runr" territories="BR CZ DK FI FR GB HU KZ NL PL SI SK US" alt="secondary"/>
+		<language type="de" scripts="Latn"/>
+		<language type="de" scripts="Runr" alt="secondary"/>
 		<language type="del" scripts="Latn"/>
 		<language type="den" scripts="Latn"/>
-		<language type="den" scripts="Cans" territories="CA" alt="secondary"/>
+		<language type="den" scripts="Cans" alt="secondary"/>
 		<language type="dgr" scripts="Latn"/>
-		<language type="dgr" territories="CA" alt="secondary"/>
 		<language type="din" scripts="Latn"/>
 		<language type="dje" scripts="Latn"/>
-		<language type="dje" territories="NE" alt="secondary"/>
 		<language type="dng" scripts="Cyrl"/>
 		<language type="dnj" scripts="Latn"/>
-		<language type="dnj" territories="CI" alt="secondary"/>
 		<language type="doi" scripts="Deva"/>
-		<language type="doi" scripts="Arab Takr" territories="IN" alt="secondary"/>
+		<language type="doi" scripts="Arab Takr" alt="secondary"/>
 		<language type="dsb" scripts="Latn"/>
 		<language type="dtm" scripts="Latn"/>
 		<language type="dtp" scripts="Latn"/>
 		<language type="dty" scripts="Deva"/>
 		<language type="dua" scripts="Latn"/>
 		<language type="dum" scripts="Latn"/>
-		<language type="dv" scripts="Thaa" territories="MV"/>
+		<language type="dv" scripts="Thaa"/>
 		<language type="dyo" scripts="Latn"/>
-		<language type="dyo" scripts="Arab" territories="SN" alt="secondary"/>
+		<language type="dyo" scripts="Arab" alt="secondary"/>
 		<language type="dyu" scripts="Latn"/>
-		<language type="dyu" territories="BF" alt="secondary"/>
-		<language type="dz" scripts="Tibt" territories="BT"/>
+		<language type="dz" scripts="Tibt"/>
 		<language type="ebu" scripts="Latn"/>
 		<language type="ecy" scripts="Cprt"/>
 		<language type="ee" scripts="Latn"/>
-		<language type="ee" territories="GH TG" alt="secondary"/>
 		<language type="efi" scripts="Latn"/>
-		<language type="efi" territories="NG" alt="secondary"/>
 		<language type="egl" scripts="Latn"/>
 		<language type="egy" scripts="Egyp"/>
 		<language type="eka" scripts="Latn"/>
 		<language type="eky" scripts="Kali"/>
-		<language type="el" scripts="Grek" territories="CY GR"/>
-		<language type="en" scripts="Latn" territories="AG AI AS AU BB BI BM BS BW BZ CA CC CK CM CQ CX DG DM ER FJ FK FM GB GD GG GH GI GM GS GU GY HK IE IM IN IO JE JM KE KI KN KY LC LR LS MG MH MP MS MT MU MW NA NF NG NR NU NZ PG PH PK PN PR PW RW SB SC SD SG SH SL SS SX SZ TC TK TO TT TV TZ UG UM US VC VG VI VU WS ZA ZM ZW"/>
-		<language type="en" scripts="Dsrt Shaw" territories="AC AE AR AT BA BD BE BG BR CH CL CY CZ DE DK DZ EE EG ES ET FI FR GR HR HU IL IQ IT JO KZ LB LK LT LU LV MA MO MV MX MY NL PL PT RO SE SI SK TA TH TR YE" alt="secondary"/>
+		<language type="el" scripts="Grek"/>
+		<language type="en" scripts="Latn"/>
+		<language type="en" scripts="Dsrt Shaw" alt="secondary"/>
 		<language type="enm" scripts="Latn"/>
 		<language type="eo" scripts="Latn"/>
-		<language type="es" scripts="Latn" territories="AR BO CL CO CR CU DO EA EC ES GQ GT HN IC MX NI PA PE PR PY SV UY VE"/>
-		<language type="es" territories="AD BZ CA DE FR GB GI PH PT RO US" alt="secondary"/>
+		<language type="es" scripts="Latn"/>
 		<language type="esu" scripts="Latn"/>
-		<language type="et" scripts="Latn" territories="EE"/>
+		<language type="et" scripts="Latn"/>
 		<language type="ett" scripts="Ital Latn" alt="secondary"/>
 		<language type="eu" scripts="Latn"/>
-		<language type="eu" territories="ES" alt="secondary"/>
 		<language type="evn" scripts="Cyrl"/>
 		<language type="ewo" scripts="Latn"/>
 		<language type="ext" scripts="Latn"/>
-		<language type="fa" scripts="Arab" territories="AF IR"/>
-		<language type="fa" territories="PK" alt="secondary"/>
+		<language type="fa" scripts="Arab"/>
 		<language type="fan" scripts="Latn"/>
-		<language type="fan" territories="GQ" alt="secondary"/>
-		<language type="fbl" territories="PH" alt="secondary"/>
 		<language type="ff" scripts="Latn"/>
-		<language type="ff" scripts="Adlm" territories="CM GN SN" alt="secondary"/>
+		<language type="ff" scripts="Adlm" alt="secondary"/>
 		<language type="ffm" scripts="Latn"/>
-		<language type="ffm" territories="ML" alt="secondary"/>
-		<language type="fi" scripts="Latn" territories="FI"/>
-		<language type="fi" territories="EE SE" alt="secondary"/>
+		<language type="fi" scripts="Latn"/>
 		<language type="fia" scripts="Arab"/>
-		<language type="fil" scripts="Latn" territories="PH"/>
-		<language type="fil" scripts="Tglg" territories="US" alt="secondary"/>
+		<language type="fil" scripts="Latn"/>
+		<language type="fil" scripts="Tglg" alt="secondary"/>
 		<language type="fit" scripts="Latn"/>
-		<language type="fj" scripts="Latn" territories="FJ"/>
-		<language type="fo" scripts="Latn" territories="FO"/>
+		<language type="fj" scripts="Latn"/>
+		<language type="fo" scripts="Latn"/>
 		<language type="fon" scripts="Latn"/>
-		<language type="fon" territories="BJ" alt="secondary"/>
-		<language type="fr" scripts="Latn" territories="BE BF BI BJ BL CA CD CF CG CH CI CM DJ DZ FR GA GF GN GP GQ HT KM LU MA MC MF MG ML MQ MU NC NE PF PM RE RW SC SN TD TG TN VU WF YT"/>
-		<language type="fr" scripts="Dupl" territories="AT DE GB IT LB NL PT RO ST SY TF US" alt="secondary"/>
+		<language type="fr" scripts="Latn"/>
+		<language type="fr" scripts="Dupl" alt="secondary"/>
 		<language type="frc" scripts="Latn"/>
 		<language type="frm" scripts="Latn"/>
 		<language type="fro" scripts="Latn"/>
 		<language type="frp" scripts="Latn"/>
 		<language type="frr" scripts="Latn"/>
-		<language type="frr" territories="DE" alt="secondary"/>
 		<language type="frs" scripts="Latn"/>
 		<language type="fud" scripts="Latn"/>
-		<language type="fud" territories="WF" alt="secondary"/>
 		<language type="fuq" scripts="Latn"/>
-		<language type="fuq" territories="NE" alt="secondary"/>
 		<language type="fur" scripts="Latn"/>
 		<language type="fuv" scripts="Latn"/>
-		<language type="fuv" territories="NG" alt="secondary"/>
 		<language type="fvr" scripts="Latn"/>
-		<language type="fvr" territories="SD" alt="secondary"/>
 		<language type="fy" scripts="Latn"/>
-		<language type="fy" territories="NL" alt="secondary"/>
-		<language type="ga" scripts="Latn" territories="IE"/>
-		<language type="ga" territories="GB" alt="secondary"/>
+		<language type="ga" scripts="Latn"/>
 		<language type="gaa" scripts="Latn"/>
-		<language type="gaa" territories="GH" alt="secondary"/>
 		<language type="gag" scripts="Latn"/>
 		<language type="gag" scripts="Cyrl" alt="secondary"/>
 		<language type="gan" scripts="Hans"/>
-		<language type="gan" territories="CN" alt="secondary"/>
 		<language type="gay" scripts="Latn"/>
 		<language type="gba" scripts="Latn"/>
 		<language type="gbm" scripts="Deva"/>
-		<language type="gbm" territories="IN" alt="secondary"/>
 		<language type="gbz" scripts="Arab"/>
 		<language type="gcr" scripts="Latn"/>
-		<language type="gcr" territories="GF" alt="secondary"/>
 		<language type="gd" scripts="Latn"/>
-		<language type="gd" territories="GB" alt="secondary"/>
 		<language type="gez" scripts="Ethi"/>
-		<language type="gil" scripts="Latn" territories="KI"/>
+		<language type="gil" scripts="Latn"/>
 		<language type="gjk" scripts="Arab"/>
 		<language type="gju" scripts="Arab"/>
 		<language type="gl" scripts="Latn"/>
-		<language type="gl" territories="ES" alt="secondary"/>
 		<language type="gld" scripts="Cyrl"/>
 		<language type="glk" scripts="Arab"/>
-		<language type="glk" territories="IR" alt="secondary"/>
 		<language type="gmh" scripts="Latn"/>
 		<language type="gmy" scripts="Linb"/>
-		<language type="gn" scripts="Latn" territories="PY"/>
+		<language type="gn" scripts="Latn"/>
 		<language type="goh" scripts="Latn"/>
 		<language type="gon" scripts="Deva Telu"/>
-		<language type="gon" territories="IN" alt="secondary"/>
 		<language type="gor" scripts="Latn"/>
-		<language type="gor" territories="ID" alt="secondary"/>
 		<language type="gos" scripts="Latn"/>
 		<language type="got" scripts="Goth"/>
 		<language type="grb" scripts="Latn"/>
 		<language type="grc" scripts="Grek"/>
 		<language type="grt" scripts="Beng"/>
-		<language type="gsw" scripts="Latn" territories="CH LI"/>
-		<language type="gsw" territories="DE" alt="secondary"/>
+		<language type="gsw" scripts="Latn"/>
 		<language type="gu" scripts="Gujr"/>
-		<language type="gu" territories="GB IN" alt="secondary"/>
 		<language type="gub" scripts="Latn"/>
 		<language type="guc" scripts="Latn"/>
 		<language type="gur" scripts="Latn"/>
-		<language type="gur" territories="GH" alt="secondary"/>
 		<language type="guz" scripts="Latn"/>
-		<language type="guz" territories="KE" alt="secondary"/>
-		<language type="gv" scripts="Latn" territories="IM"/>
+		<language type="gv" scripts="Latn"/>
 		<language type="gvr" scripts="Deva"/>
 		<language type="gwi" scripts="Latn"/>
-		<language type="gwi" territories="CA" alt="secondary"/>
 		<language type="ha" scripts="Latn Arab"/>
-		<language type="ha" territories="NE NG" alt="secondary"/>
 		<language type="hai" scripts="Latn"/>
-		<language type="hak" scripts="Hans Hant" territories="TW"/>
-		<language type="hak" territories="CN" alt="secondary"/>
+		<language type="hak" scripts="Hans Hant"/>
 		<language type="haw" scripts="Latn"/>
-		<language type="haw" territories="US" alt="secondary"/>
 		<language type="haz" scripts="Arab"/>
-		<language type="haz" territories="AF" alt="secondary"/>
-		<language type="he" scripts="Hebr" territories="IL"/>
-		<language type="hi" scripts="Deva" territories="IN"/>
-		<language type="hi" scripts="Latn Mahj" territories="FJ IN ZA" alt="secondary"/>
-		<language type="hif" scripts="Deva Latn" territories="FJ"/>
+		<language type="he" scripts="Hebr"/>
+		<language type="hi" scripts="Deva"/>
+		<language type="hi" scripts="Latn Mahj" alt="secondary"/>
+		<language type="hif" scripts="Deva Latn"/>
 		<language type="hil" scripts="Latn"/>
-		<language type="hil" territories="PH" alt="secondary"/>
 		<language type="hit" scripts="Xsux"/>
 		<language type="hmd" scripts="Plrd"/>
 		<language type="hmn" scripts="Latn"/>
 		<language type="hmn" scripts="Hmng" alt="secondary"/>
 		<language type="hnd" scripts="Arab"/>
-		<language type="hnd" territories="PK" alt="secondary"/>
 		<language type="hne" scripts="Deva"/>
-		<language type="hne" territories="IN" alt="secondary"/>
 		<language type="hnj" scripts="Laoo"/>
 		<language type="hnn" scripts="Latn"/>
 		<language type="hnn" scripts="Hano" alt="secondary"/>
 		<language type="hno" scripts="Arab"/>
-		<language type="hno" territories="PK" alt="secondary"/>
-		<language type="ho" scripts="Latn" territories="PG"/>
+		<language type="ho" scripts="Latn"/>
 		<language type="hoc" scripts="Deva"/>
-		<language type="hoc" scripts="Wara" territories="IN" alt="secondary"/>
+		<language type="hoc" scripts="Wara" alt="secondary"/>
 		<language type="hoj" scripts="Deva"/>
-		<language type="hoj" territories="IN" alt="secondary"/>
 		<language type="hop" scripts="Latn"/>
-		<language type="hr" scripts="Latn" territories="BA HR"/>
-		<language type="hr" territories="AT RS SI" alt="secondary"/>
+		<language type="hr" scripts="Latn"/>
 		<language type="hsb" scripts="Latn"/>
 		<language type="hsn" scripts="Hans"/>
-		<language type="hsn" territories="CN" alt="secondary"/>
-		<language type="ht" scripts="Latn" territories="HT"/>
-		<language type="hu" scripts="Latn" territories="HU"/>
-		<language type="hu" territories="AT RO RS" alt="secondary"/>
+		<language type="ht" scripts="Latn"/>
+		<language type="hu" scripts="Latn"/>
 		<language type="hup" scripts="Latn"/>
 		<language type="hur" scripts="Latn"/>
-		<language type="hy" scripts="Armn" territories="AM"/>
-		<language type="hy" territories="RU" alt="secondary"/>
+		<language type="hy" scripts="Armn"/>
 		<language type="hz" scripts="Latn"/>
 		<language type="ia" scripts="Latn"/>
 		<language type="iba" scripts="Latn"/>
 		<language type="ibb" scripts="Latn"/>
-		<language type="ibb" territories="NG" alt="secondary"/>
-		<language type="id" scripts="Latn" territories="ID"/>
+		<language type="id" scripts="Latn"/>
 		<language type="id" scripts="Arab" alt="secondary"/>
 		<language type="ie" scripts="Latn"/>
 		<language type="ife" scripts="Latn"/>
 		<language type="ig" scripts="Latn"/>
-		<language type="ig" territories="NG" alt="secondary"/>
 		<language type="ii" scripts="Yiii"/>
-		<language type="ii" scripts="Latn" territories="CN" alt="secondary"/>
+		<language type="ii" scripts="Latn" alt="secondary"/>
 		<language type="ik" scripts="Latn"/>
 		<language type="ikt" scripts="Latn"/>
 		<language type="ilo" scripts="Latn"/>
-		<language type="ilo" territories="PH" alt="secondary"/>
 		<language type="inh" scripts="Cyrl"/>
-		<language type="inh" scripts="Arab Latn" territories="RU" alt="secondary"/>
+		<language type="inh" scripts="Arab Latn" alt="secondary"/>
 		<language type="io" scripts="Latn"/>
-		<language type="is" scripts="Latn" territories="IS"/>
-		<language type="it" scripts="Latn" territories="CH IT SM VA"/>
-		<language type="it" territories="DE FR HR MT US" alt="secondary"/>
+		<language type="is" scripts="Latn"/>
+		<language type="it" scripts="Latn"/>
 		<language type="iu" scripts="Cans Latn"/>
-		<language type="iu" territories="CA" alt="secondary"/>
 		<language type="izh" scripts="Latn"/>
-		<language type="ja" scripts="Jpan" territories="JP"/>
+		<language type="ja" scripts="Jpan"/>
 		<language type="jam" scripts="Latn"/>
-		<language type="jam" territories="JM" alt="secondary"/>
 		<language type="jbo" scripts="Latn"/>
 		<language type="jgo" scripts="Latn"/>
 		<language type="jmc" scripts="Latn"/>
@@ -1738,359 +1623,264 @@ XXX Code for transations where no currency is involved
 		<language type="jrb" scripts="Hebr"/>
 		<language type="jut" scripts="Latn"/>
 		<language type="jv" scripts="Latn"/>
-		<language type="jv" scripts="Java" territories="ID" alt="secondary"/>
-		<language type="ka" scripts="Geor" territories="GE"/>
+		<language type="jv" scripts="Java" alt="secondary"/>
+		<language type="ka" scripts="Geor"/>
 		<language type="kaa" scripts="Cyrl Latn"/>
 		<language type="kab" scripts="Latn"/>
-		<language type="kab" territories="DZ" alt="secondary"/>
 		<language type="kac" scripts="Latn"/>
 		<language type="kaj" scripts="Latn"/>
 		<language type="kam" scripts="Latn"/>
-		<language type="kam" territories="KE" alt="secondary"/>
 		<language type="kao" scripts="Latn"/>
 		<language type="kaw" scripts="Bali"/>
 		<language type="kaw" scripts="Java Kawi" alt="secondary"/>
 		<language type="kbd" scripts="Cyrl"/>
-		<language type="kbd" territories="RU" alt="secondary"/>
 		<language type="kca" scripts="Cyrl"/>
 		<language type="kcg" scripts="Latn"/>
 		<language type="kck" scripts="Latn"/>
 		<language type="kde" scripts="Latn"/>
-		<language type="kde" territories="TZ" alt="secondary"/>
 		<language type="kdt" scripts="Thai"/>
 		<language type="kea" scripts="Latn"/>
-		<language type="kea" territories="CV" alt="secondary"/>
 		<language type="ken" scripts="Latn"/>
 		<language type="kfo" scripts="Latn"/>
 		<language type="kfr" scripts="Deva"/>
-		<language type="kfr" territories="IN" alt="secondary"/>
 		<language type="kfy" scripts="Deva"/>
-		<language type="kfy" territories="IN" alt="secondary"/>
 		<language type="kg" scripts="Latn"/>
-		<language type="kg" territories="CD" alt="secondary"/>
 		<language type="kge" scripts="Latn"/>
 		<language type="kgp" scripts="Latn"/>
 		<language type="kha" scripts="Latn"/>
-		<language type="kha" scripts="Beng" territories="IN" alt="secondary"/>
+		<language type="kha" scripts="Beng" alt="secondary"/>
 		<language type="khb" scripts="Talu"/>
 		<language type="khn" scripts="Deva"/>
-		<language type="khn" territories="IN" alt="secondary"/>
 		<language type="khq" scripts="Latn"/>
 		<language type="kht" scripts="Mymr"/>
 		<language type="khw" scripts="Arab"/>
 		<language type="ki" scripts="Latn"/>
-		<language type="ki" territories="KE" alt="secondary"/>
 		<language type="kiu" scripts="Latn"/>
 		<language type="kj" scripts="Latn"/>
-		<language type="kj" territories="NA" alt="secondary"/>
 		<language type="kjg" scripts="Laoo"/>
 		<language type="kjg" scripts="Latn" alt="secondary"/>
 		<language type="kjh" scripts="Cyrl"/>
-		<language type="kk" scripts="Cyrl Arab" territories="KZ"/>
-		<language type="kk" territories="CN" alt="secondary"/>
+		<language type="kk" scripts="Cyrl Arab"/>
 		<language type="kkj" scripts="Latn"/>
-		<language type="kl" scripts="Latn" territories="GL"/>
-		<language type="kl" territories="DK" alt="secondary"/>
+		<language type="kl" scripts="Latn"/>
 		<language type="kln" scripts="Latn"/>
-		<language type="kln" territories="KE" alt="secondary"/>
-		<language type="km" scripts="Khmr" territories="KH"/>
+		<language type="km" scripts="Khmr"/>
 		<language type="kmb" scripts="Latn"/>
-		<language type="kmb" territories="AO" alt="secondary"/>
 		<language type="kn" scripts="Knda"/>
-		<language type="kn" territories="IN" alt="secondary"/>
 		<language type="knf" scripts="Latn"/>
-		<language type="knf" territories="SN" alt="secondary"/>
 		<language type="knn" scripts="Deva"/>
-		<language type="knn" territories="IN" alt="secondary"/>
-		<language type="ko" scripts="Kore" territories="KP KR"/>
-		<language type="ko" territories="CN US" alt="secondary"/>
+		<language type="ko" scripts="Kore"/>
 		<language type="koi" scripts="Cyrl"/>
-		<language type="koi" territories="RU" alt="secondary"/>
 		<language type="kok" scripts="Deva Latn"/>
-		<language type="kok" territories="IN" alt="secondary"/>
 		<language type="kos" scripts="Latn"/>
 		<language type="kpe" scripts="Latn"/>
-		<language type="kpe" territories="LR" alt="secondary"/>
 		<language type="kpy" scripts="Cyrl"/>
 		<language type="kr" scripts="Latn"/>
 		<language type="krc" scripts="Cyrl"/>
-		<language type="krc" territories="RU" alt="secondary"/>
 		<language type="kri" scripts="Latn"/>
-		<language type="kri" territories="SL" alt="secondary"/>
 		<language type="krj" scripts="Latn"/>
 		<language type="krl" scripts="Latn"/>
 		<language type="kro" scripts="Latn"/>
 		<language type="kru" scripts="Deva"/>
-		<language type="kru" territories="IN" alt="secondary"/>
 		<language type="ks" scripts="Arab Deva"/>
-		<language type="ks" territories="IN" alt="secondary"/>
 		<language type="ksb" scripts="Latn"/>
-		<language type="ksb" territories="TZ" alt="secondary"/>
 		<language type="ksf" scripts="Latn"/>
 		<language type="ksh" scripts="Latn"/>
 		<language type="ku" scripts="Latn Arab Cyrl"/>
-		<language type="ku" territories="SY TR" alt="secondary"/>
 		<language type="kum" scripts="Cyrl"/>
-		<language type="kum" territories="RU" alt="secondary"/>
 		<language type="kut" scripts="Latn"/>
 		<language type="kv" scripts="Cyrl"/>
-		<language type="kv" scripts="Perm" territories="RU" alt="secondary"/>
+		<language type="kv" scripts="Perm" alt="secondary"/>
 		<language type="kvr" scripts="Latn"/>
 		<language type="kvx" scripts="Arab"/>
 		<language type="kw" scripts="Latn"/>
 		<language type="kwk" scripts="Latn"/>
 		<language type="kxm" scripts="Thai"/>
-		<language type="kxm" territories="TH" alt="secondary"/>
 		<language type="kxp" scripts="Arab"/>
 		<language type="kxv" scripts="Latn"/>
 		<language type="kxv" scripts="Deva Orya Telu" alt="secondary"/>
-		<language type="ky" scripts="Cyrl Arab Latn" territories="KG"/>
+		<language type="ky" scripts="Cyrl Arab Latn"/>
 		<language type="kyu" scripts="Kali"/>
 		<language type="la" scripts="Latn"/>
-		<language type="la" territories="VA" alt="secondary"/>
 		<language type="lab" scripts="Lina"/>
 		<language type="lad" scripts="Hebr"/>
 		<language type="lag" scripts="Latn"/>
 		<language type="lah" scripts="Arab"/>
-		<language type="lah" territories="PK" alt="secondary"/>
 		<language type="laj" scripts="Latn"/>
-		<language type="laj" territories="UG" alt="secondary"/>
 		<language type="lam" scripts="Latn"/>
-		<language type="lb" scripts="Latn" territories="LU"/>
+		<language type="lb" scripts="Latn"/>
 		<language type="lbe" scripts="Cyrl"/>
-		<language type="lbe" territories="RU" alt="secondary"/>
 		<language type="lbw" scripts="Latn"/>
 		<language type="lcp" scripts="Thai"/>
 		<language type="len" scripts="Latn"/>
 		<language type="lep" scripts="Lepc"/>
 		<language type="lez" scripts="Cyrl"/>
-		<language type="lez" scripts="Aghb" territories="RU" alt="secondary"/>
+		<language type="lez" scripts="Aghb" alt="secondary"/>
 		<language type="lfn" scripts="Latn Cyrl" alt="secondary"/>
 		<language type="lg" scripts="Latn"/>
-		<language type="lg" territories="UG" alt="secondary"/>
 		<language type="li" scripts="Latn"/>
 		<language type="lif" scripts="Deva Limb"/>
 		<language type="lij" scripts="Latn"/>
 		<language type="lil" scripts="Latn"/>
-		<language type="lir" territories="LR" alt="secondary"/>
 		<language type="lis" scripts="Lisu"/>
 		<language type="liv" scripts="Latn"/>
 		<language type="ljp" scripts="Latn"/>
-		<language type="ljp" territories="ID" alt="secondary"/>
 		<language type="lki" scripts="Arab"/>
 		<language type="lkt" scripts="Latn"/>
 		<language type="lld" scripts="Latn"/>
 		<language type="lmn" scripts="Telu"/>
-		<language type="lmn" territories="IN" alt="secondary"/>
 		<language type="lmo" scripts="Latn"/>
-		<language type="lmo" territories="IT" alt="secondary"/>
 		<language type="ln" scripts="Latn"/>
-		<language type="ln" territories="CD" alt="secondary"/>
-		<language type="lo" scripts="Laoo" territories="LA"/>
+		<language type="lo" scripts="Laoo"/>
 		<language type="lol" scripts="Latn"/>
 		<language type="loz" scripts="Latn"/>
-		<language type="loz" territories="ZM" alt="secondary"/>
 		<language type="lrc" scripts="Arab"/>
-		<language type="lrc" territories="IR" alt="secondary"/>
-		<language type="lt" scripts="Latn" territories="LT"/>
-		<language type="lt" territories="PL" alt="secondary"/>
+		<language type="lt" scripts="Latn"/>
 		<language type="ltg" scripts="Latn"/>
 		<language type="lu" scripts="Latn"/>
-		<language type="lu" territories="CD" alt="secondary"/>
 		<language type="lua" scripts="Latn"/>
-		<language type="lua" territories="CD" alt="secondary"/>
 		<language type="lui" scripts="Latn"/>
 		<language type="lun" scripts="Latn"/>
 		<language type="luo" scripts="Latn"/>
-		<language type="luo" territories="KE" alt="secondary"/>
 		<language type="lus" scripts="Beng"/>
 		<language type="lut" scripts="Latn"/>
 		<language type="luy" scripts="Latn"/>
-		<language type="luy" territories="KE" alt="secondary"/>
 		<language type="luz" scripts="Arab"/>
-		<language type="luz" territories="IR" alt="secondary"/>
-		<language type="lv" scripts="Latn" territories="LV"/>
+		<language type="lv" scripts="Latn"/>
 		<language type="lwl" scripts="Thai"/>
 		<language type="lzh" scripts="Hant"/>
 		<language type="lzz" scripts="Latn"/>
 		<language type="lzz" scripts="Geor" alt="secondary"/>
 		<language type="mad" scripts="Latn"/>
-		<language type="mad" territories="ID" alt="secondary"/>
 		<language type="maf" scripts="Latn"/>
 		<language type="mag" scripts="Deva"/>
-		<language type="mag" territories="IN" alt="secondary"/>
 		<language type="mai" scripts="Deva"/>
-		<language type="mai" scripts="Tirh" territories="IN NP" alt="secondary"/>
+		<language type="mai" scripts="Tirh" alt="secondary"/>
 		<language type="mak" scripts="Latn"/>
-		<language type="mak" scripts="Bugi" territories="ID" alt="secondary"/>
+		<language type="mak" scripts="Bugi" alt="secondary"/>
 		<language type="man" scripts="Latn Nkoo"/>
-		<language type="man" territories="GM GN" alt="secondary"/>
 		<language type="mas" scripts="Latn"/>
 		<language type="maz" scripts="Latn"/>
 		<language type="mdf" scripts="Cyrl"/>
-		<language type="mdf" territories="RU" alt="secondary"/>
 		<language type="mdh" scripts="Latn"/>
-		<language type="mdh" territories="PH" alt="secondary"/>
 		<language type="mdr" scripts="Latn"/>
 		<language type="mdr" scripts="Bugi" alt="secondary"/>
 		<language type="mdt" scripts="Latn"/>
 		<language type="men" scripts="Latn"/>
-		<language type="men" scripts="Mend" territories="SL" alt="secondary"/>
+		<language type="men" scripts="Mend" alt="secondary"/>
 		<language type="mer" scripts="Latn"/>
-		<language type="mer" territories="KE" alt="secondary"/>
-		<language type="mey" territories="SN" alt="secondary"/>
 		<language type="mfa" scripts="Arab"/>
-		<language type="mfa" territories="TH" alt="secondary"/>
 		<language type="mfe" scripts="Latn"/>
-		<language type="mfe" territories="MU" alt="secondary"/>
 		<language type="mfv" scripts="Latn"/>
-		<language type="mfv" territories="SN" alt="secondary"/>
-		<language type="mg" scripts="Latn" territories="MG"/>
+		<language type="mg" scripts="Latn"/>
 		<language type="mgh" scripts="Latn"/>
-		<language type="mgh" territories="MZ" alt="secondary"/>
 		<language type="mgo" scripts="Latn"/>
 		<language type="mgp" scripts="Deva"/>
 		<language type="mgy" scripts="Latn"/>
-		<language type="mh" scripts="Latn" territories="MH"/>
+		<language type="mh" scripts="Latn"/>
 		<language type="mhn" scripts="Latn"/>
-		<language type="mi" scripts="Latn" territories="NZ"/>
+		<language type="mi" scripts="Latn"/>
 		<language type="mic" scripts="Latn"/>
 		<language type="min" scripts="Latn"/>
-		<language type="min" territories="ID" alt="secondary"/>
-		<language type="mk" scripts="Cyrl" territories="MK"/>
+		<language type="mk" scripts="Cyrl"/>
 		<language type="ml" scripts="Mlym"/>
-		<language type="ml" territories="IN" alt="secondary"/>
 		<language type="mls" scripts="Latn"/>
-		<language type="mn" scripts="Cyrl" territories="MN"/>
-		<language type="mn" scripts="Mong Phag" territories="CN" alt="secondary"/>
+		<language type="mn" scripts="Cyrl"/>
+		<language type="mn" scripts="Mong Phag" alt="secondary"/>
 		<language type="mnc" scripts="Mong"/>
 		<language type="mni" scripts="Beng"/>
-		<language type="mni" scripts="Mtei" territories="IN" alt="secondary"/>
+		<language type="mni" scripts="Mtei" alt="secondary"/>
 		<language type="mns" scripts="Cyrl"/>
 		<language type="mnw" scripts="Mymr"/>
 		<language type="moe" scripts="Latn"/>
 		<language type="moh" scripts="Latn"/>
 		<language type="mos" scripts="Latn"/>
-		<language type="mos" territories="BF" alt="secondary"/>
 		<language type="mr" scripts="Deva"/>
-		<language type="mr" scripts="Modi" territories="IN" alt="secondary"/>
+		<language type="mr" scripts="Modi" alt="secondary"/>
 		<language type="mrd" scripts="Deva"/>
 		<language type="mrj" scripts="Cyrl"/>
 		<language type="mro" scripts="Latn"/>
 		<language type="mro" scripts="Mroo" alt="secondary"/>
-		<language type="ms" scripts="Latn Arab" territories="BN MY SG"/>
-		<language type="ms" territories="CC ID" alt="secondary"/>
-		<language type="mt" scripts="Latn" territories="MT"/>
+		<language type="ms" scripts="Latn Arab"/>
+		<language type="mt" scripts="Latn"/>
 		<language type="mtr" scripts="Deva"/>
-		<language type="mtr" territories="IN" alt="secondary"/>
 		<language type="mua" scripts="Latn"/>
 		<language type="mus" scripts="Latn"/>
 		<language type="mvy" scripts="Arab"/>
 		<language type="mwk" scripts="Latn"/>
-		<language type="mwk" territories="ML" alt="secondary"/>
 		<language type="mwl" scripts="Latn"/>
 		<language type="mwr" scripts="Deva"/>
-		<language type="mwr" territories="IN" alt="secondary"/>
 		<language type="mwv" scripts="Latn"/>
 		<language type="mxc" scripts="Latn"/>
-		<language type="mxc" territories="ZW" alt="secondary"/>
-		<language type="my" scripts="Mymr" territories="MM"/>
+		<language type="my" scripts="Mymr"/>
 		<language type="myv" scripts="Cyrl"/>
-		<language type="myv" territories="RU" alt="secondary"/>
 		<language type="myx" scripts="Latn"/>
-		<language type="myx" territories="UG" alt="secondary"/>
 		<language type="myz" scripts="Mand"/>
 		<language type="mzn" scripts="Arab"/>
-		<language type="mzn" territories="IR" alt="secondary"/>
-		<language type="na" scripts="Latn" territories="NR"/>
-		<language type="nan" scripts="Hans Hant" territories="TW"/>
-		<language type="nan" territories="CN" alt="secondary"/>
+		<language type="na" scripts="Latn"/>
+		<language type="nan" scripts="Hans Hant"/>
 		<language type="nap" scripts="Latn"/>
 		<language type="naq" scripts="Latn"/>
-		<language type="nb" scripts="Latn" territories="NO SJ"/>
+		<language type="nb" scripts="Latn"/>
 		<language type="nch" scripts="Latn"/>
-		<language type="nd" scripts="Latn" territories="ZW"/>
+		<language type="nd" scripts="Latn"/>
 		<language type="ndc" scripts="Latn"/>
-		<language type="ndc" territories="MZ ZW" alt="secondary"/>
 		<language type="nds" scripts="Latn"/>
-		<language type="nds" territories="DE NL" alt="secondary"/>
-		<language type="ne" scripts="Deva" territories="NP"/>
-		<language type="ne" territories="IN" alt="secondary"/>
+		<language type="ne" scripts="Deva"/>
 		<language type="new" scripts="Deva"/>
-		<language type="new" territories="NP" alt="secondary"/>
 		<language type="ng" scripts="Latn"/>
-		<language type="ng" territories="NA" alt="secondary"/>
 		<language type="ngl" scripts="Latn"/>
-		<language type="ngl" territories="MZ" alt="secondary"/>
 		<language type="nhe" scripts="Latn"/>
 		<language type="nhw" scripts="Latn"/>
 		<language type="nia" scripts="Latn"/>
 		<language type="nij" scripts="Latn"/>
-		<language type="nij" territories="ID" alt="secondary"/>
-		<language type="niu" scripts="Latn" territories="NU"/>
+		<language type="niu" scripts="Latn"/>
 		<language type="njo" scripts="Latn"/>
-		<language type="nl" scripts="Latn" territories="AW BE BQ CW NL SR SX"/>
-		<language type="nl" territories="DE" alt="secondary"/>
+		<language type="nl" scripts="Latn"/>
 		<language type="nmg" scripts="Latn"/>
-		<language type="nn" scripts="Latn" territories="NO"/>
+		<language type="nn" scripts="Latn"/>
 		<language type="nnh" scripts="Latn"/>
-		<language type="no" scripts="Latn" territories="NO"/>
-		<language type="no" territories="BV" alt="secondary"/>
+		<language type="no" scripts="Latn"/>
 		<language type="nod" scripts="Lana"/>
-		<language type="nod" territories="TH" alt="secondary"/>
 		<language type="noe" scripts="Deva"/>
-		<language type="noe" territories="IN" alt="secondary"/>
 		<language type="nog" scripts="Cyrl"/>
 		<language type="non" scripts="Runr"/>
 		<language type="nov" scripts="Latn"/>
 		<language type="nqo" scripts="Nkoo"/>
 		<language type="nr" scripts="Latn"/>
-		<language type="nr" territories="ZA" alt="secondary"/>
 		<language type="nsk" scripts="Cans"/>
 		<language type="nsk" scripts="Latn" alt="secondary"/>
 		<language type="nso" scripts="Latn"/>
-		<language type="nso" territories="ZA" alt="secondary"/>
 		<language type="nus" scripts="Latn"/>
 		<language type="nv" scripts="Latn"/>
 		<language type="nxq" scripts="Latn"/>
-		<language type="ny" scripts="Latn" territories="MW"/>
-		<language type="ny" territories="ZM" alt="secondary"/>
+		<language type="ny" scripts="Latn"/>
 		<language type="nym" scripts="Latn"/>
-		<language type="nym" territories="TZ" alt="secondary"/>
 		<language type="nyn" scripts="Latn"/>
-		<language type="nyn" territories="UG" alt="secondary"/>
 		<language type="nyo" scripts="Latn"/>
 		<language type="nzi" scripts="Latn"/>
 		<language type="oc" scripts="Latn"/>
-		<language type="oc" territories="ES FR" alt="secondary"/>
 		<language type="oj" scripts="Cans"/>
 		<language type="oj" scripts="Latn" alt="secondary"/>
 		<language type="ojs" scripts="Cans"/>
 		<language type="ojw" scripts="Latn"/>
 		<language type="oka" scripts="Latn"/>
 		<language type="om" scripts="Latn"/>
-		<language type="om" scripts="Ethi" territories="ET" alt="secondary"/>
+		<language type="om" scripts="Ethi" alt="secondary"/>
 		<language type="or" scripts="Orya"/>
-		<language type="or" territories="IN" alt="secondary"/>
 		<language type="os" scripts="Cyrl"/>
-		<language type="os" territories="GE" alt="secondary"/>
 		<language type="osa" scripts="Osge"/>
 		<language type="osa" scripts="Latn" alt="secondary"/>
 		<language type="osc" scripts="Ital Latn" alt="secondary"/>
 		<language type="otk" scripts="Orkh"/>
 		<language type="pa" scripts="Guru Arab"/>
-		<language type="pa" territories="CA GB IN PK" alt="secondary"/>
 		<language type="pag" scripts="Latn"/>
-		<language type="pag" territories="PH" alt="secondary"/>
 		<language type="pal" scripts="Phli Phlp" alt="secondary"/>
 		<language type="pam" scripts="Latn"/>
-		<language type="pam" territories="PH" alt="secondary"/>
-		<language type="pap" scripts="Latn" territories="AW CW"/>
-		<language type="pap" territories="BQ" alt="secondary"/>
-		<language type="pau" scripts="Latn" territories="PW"/>
+		<language type="pap" scripts="Latn"/>
+		<language type="pau" scripts="Latn"/>
 		<language type="pcd" scripts="Latn"/>
 		<language type="pcm" scripts="Latn"/>
-		<language type="pcm" territories="NG" alt="secondary"/>
 		<language type="pdc" scripts="Latn"/>
 		<language type="pdt" scripts="Latn"/>
 		<language type="peo" scripts="Xpeo"/>
@@ -2099,295 +1889,223 @@ XXX Code for transations where no currency is involved
 		<language type="pi" scripts="Mymr"/>
 		<language type="pi" scripts="Sinh Deva Thai" alt="secondary"/>
 		<language type="pis" scripts="Latn"/>
-		<language type="pis" territories="SB" alt="secondary"/>
 		<language type="pko" scripts="Latn"/>
-		<language type="pl" scripts="Latn" territories="PL"/>
-		<language type="pl" territories="GB" alt="secondary"/>
+		<language type="pl" scripts="Latn"/>
 		<language type="pms" scripts="Latn"/>
 		<language type="pnt" scripts="Grek"/>
 		<language type="pnt" scripts="Cyrl Latn" alt="secondary"/>
 		<language type="pon" scripts="Latn"/>
-		<language type="pon" territories="FM" alt="secondary"/>
 		<language type="ppl" scripts="Latn"/>
 		<language type="pqm" scripts="Latn"/>
 		<language type="prd" scripts="Arab"/>
 		<language type="prg" scripts="Latn"/>
 		<language type="pro" scripts="Latn"/>
-		<language type="ps" scripts="Arab" territories="AF"/>
-		<language type="ps" territories="PK" alt="secondary"/>
-		<language type="pt" scripts="Latn" territories="AO BR CV GQ GW MO MZ PT ST TL"/>
+		<language type="ps" scripts="Arab"/>
+		<language type="pt" scripts="Latn"/>
 		<language type="puu" scripts="Latn"/>
-		<language type="qu" scripts="Latn" territories="BO EC PE"/>
+		<language type="qu" scripts="Latn"/>
 		<language type="quc" scripts="Latn"/>
-		<language type="quc" territories="GT" alt="secondary"/>
 		<language type="qug" scripts="Latn"/>
-		<language type="qug" territories="EC" alt="secondary"/>
 		<language type="raj" scripts="Deva"/>
-		<language type="raj" territories="IN" alt="secondary"/>
 		<language type="rap" scripts="Latn"/>
 		<language type="rar" scripts="Latn"/>
 		<language type="rcf" scripts="Latn"/>
-		<language type="rcf" territories="RE" alt="secondary"/>
 		<language type="rej" scripts="Latn"/>
-		<language type="rej" scripts="Rjng" territories="ID" alt="secondary"/>
+		<language type="rej" scripts="Rjng" alt="secondary"/>
 		<language type="rgn" scripts="Latn"/>
 		<language type="rhg" scripts="Rohg"/>
 		<language type="rhg" scripts="Arab Latn" alt="secondary"/>
 		<language type="ria" scripts="Latn"/>
 		<language type="rif" scripts="Latn Tfng"/>
-		<language type="rif" territories="MA" alt="secondary"/>
 		<language type="rjs" scripts="Deva"/>
 		<language type="rkt" scripts="Beng"/>
-		<language type="rkt" territories="BD IN" alt="secondary"/>
 		<language type="rm" scripts="Latn"/>
-		<language type="rm" territories="CH" alt="secondary"/>
 		<language type="rmf" scripts="Latn"/>
 		<language type="rmo" scripts="Latn"/>
 		<language type="rmt" scripts="Arab"/>
-		<language type="rmt" territories="IR" alt="secondary"/>
 		<language type="rmu" scripts="Latn"/>
-		<language type="rn" scripts="Latn" territories="BI"/>
+		<language type="rn" scripts="Latn"/>
 		<language type="rng" scripts="Latn"/>
-		<language type="rng" territories="MZ" alt="secondary"/>
-		<language type="ro" scripts="Latn" territories="MD RO"/>
-		<language type="ro" scripts="Cyrl" territories="RS" alt="secondary"/>
+		<language type="ro" scripts="Latn"/>
+		<language type="ro" scripts="Cyrl" alt="secondary"/>
 		<language type="rob" scripts="Latn"/>
 		<language type="rof" scripts="Latn"/>
 		<language type="rom" scripts="Latn"/>
 		<language type="rom" scripts="Cyrl" alt="secondary"/>
 		<language type="rtm" scripts="Latn"/>
-		<language type="ru" scripts="Cyrl" territories="BY KG KZ RU UA"/>
-		<language type="ru" territories="BG DE EE IL LT LV PL SJ TJ UZ" alt="secondary"/>
+		<language type="ru" scripts="Cyrl"/>
 		<language type="rue" scripts="Cyrl"/>
 		<language type="rug" scripts="Latn"/>
 		<language type="rup" scripts="Latn"/>
-		<language type="rw" scripts="Latn" territories="RW"/>
-		<language type="rw" territories="UG" alt="secondary"/>
+		<language type="rw" scripts="Latn"/>
 		<language type="rwk" scripts="Latn"/>
 		<language type="ryu" scripts="Kana"/>
-		<language type="sa" scripts="Deva Gran Shrd Sidd Sinh" territories="IN" alt="secondary"/>
+		<language type="sa" scripts="Deva Gran Shrd Sidd Sinh" alt="secondary"/>
 		<language type="sad" scripts="Latn"/>
 		<language type="saf" scripts="Latn"/>
 		<language type="sah" scripts="Cyrl"/>
-		<language type="sah" territories="RU" alt="secondary"/>
 		<language type="sam" scripts="Samr Hebr" alt="secondary"/>
 		<language type="saq" scripts="Latn"/>
 		<language type="sas" scripts="Latn"/>
-		<language type="sas" territories="ID" alt="secondary"/>
 		<language type="sat" scripts="Olck"/>
-		<language type="sat" scripts="Beng Deva Latn Orya" territories="IN" alt="secondary"/>
-		<language type="sav" territories="SN" alt="secondary"/>
+		<language type="sat" scripts="Beng Deva Latn Orya" alt="secondary"/>
 		<language type="saz" scripts="Saur"/>
 		<language type="sbp" scripts="Latn"/>
 		<language type="sc" scripts="Latn"/>
-		<language type="sc" territories="IT" alt="secondary"/>
 		<language type="sck" scripts="Deva"/>
-		<language type="sck" territories="IN" alt="secondary"/>
 		<language type="scn" scripts="Latn"/>
 		<language type="sco" scripts="Latn"/>
-		<language type="sco" territories="GB" alt="secondary"/>
 		<language type="scs" scripts="Latn"/>
 		<language type="sd" scripts="Arab Deva"/>
-		<language type="sd" scripts="Khoj Sind" territories="IN PK" alt="secondary"/>
+		<language type="sd" scripts="Khoj Sind" alt="secondary"/>
 		<language type="sdc" scripts="Latn"/>
 		<language type="sdh" scripts="Arab"/>
-		<language type="sdh" territories="IR" alt="secondary"/>
 		<language type="se" scripts="Latn"/>
-		<language type="se" scripts="Cyrl" territories="NO" alt="secondary"/>
+		<language type="se" scripts="Cyrl" alt="secondary"/>
 		<language type="see" scripts="Latn"/>
 		<language type="sef" scripts="Latn"/>
-		<language type="sef" territories="CI" alt="secondary"/>
 		<language type="seh" scripts="Latn"/>
-		<language type="seh" territories="MZ" alt="secondary"/>
 		<language type="sei" scripts="Latn"/>
 		<language type="sel" scripts="Cyrl"/>
 		<language type="ses" scripts="Latn"/>
-		<language type="sg" scripts="Latn" territories="CF"/>
+		<language type="sg" scripts="Latn"/>
 		<language type="sga" scripts="Latn"/>
 		<language type="sga" scripts="Ogam" alt="secondary"/>
 		<language type="sgs" scripts="Latn"/>
 		<language type="shi" scripts="Tfng Latn Arab"/>
-		<language type="shi" territories="MA" alt="secondary"/>
 		<language type="shn" scripts="Mymr"/>
-		<language type="shn" territories="MM" alt="secondary"/>
-		<language type="si" scripts="Sinh" territories="LK"/>
+		<language type="si" scripts="Sinh"/>
 		<language type="sid" scripts="Latn"/>
-		<language type="sid" territories="ET" alt="secondary"/>
-		<language type="sk" scripts="Latn" territories="SK"/>
-		<language type="sk" territories="CZ RS" alt="secondary"/>
+		<language type="sk" scripts="Latn"/>
 		<language type="skr" scripts="Arab"/>
-		<language type="skr" territories="PK" alt="secondary"/>
-		<language type="sl" scripts="Latn" territories="SI"/>
-		<language type="sl" territories="AT" alt="secondary"/>
+		<language type="sl" scripts="Latn"/>
 		<language type="sli" scripts="Latn"/>
 		<language type="sly" scripts="Latn"/>
-		<language type="sm" scripts="Latn" territories="AS WS"/>
-		<language type="sm" territories="TK" alt="secondary"/>
+		<language type="sm" scripts="Latn"/>
 		<language type="sma" scripts="Latn"/>
 		<language type="smj" scripts="Latn"/>
 		<language type="smn" scripts="Latn"/>
 		<language type="smp" scripts="Samr"/>
 		<language type="sms" scripts="Latn"/>
-		<language type="sms" territories="FI" alt="secondary"/>
-		<language type="sn" scripts="Latn" territories="ZW"/>
+		<language type="sn" scripts="Latn"/>
 		<language type="snf" scripts="Latn"/>
-		<language type="snf" territories="SN" alt="secondary"/>
 		<language type="snk" scripts="Latn"/>
-		<language type="snk" territories="ML" alt="secondary"/>
-		<language type="so" scripts="Latn" territories="SO"/>
-		<language type="so" scripts="Arab Osma" territories="DJ ET" alt="secondary"/>
+		<language type="so" scripts="Latn"/>
+		<language type="so" scripts="Arab Osma" alt="secondary"/>
 		<language type="sou" scripts="Thai"/>
-		<language type="sou" territories="TH" alt="secondary"/>
-		<language type="sq" scripts="Latn" territories="AL XK"/>
-		<language type="sq" scripts="Elba" territories="MK RS" alt="secondary"/>
-		<language type="sr" scripts="Cyrl Latn" territories="BA ME RS XK"/>
+		<language type="sq" scripts="Latn"/>
+		<language type="sq" scripts="Elba" alt="secondary"/>
+		<language type="sr" scripts="Cyrl Latn"/>
 		<language type="srb" scripts="Latn"/>
 		<language type="srb" scripts="Sora" alt="secondary"/>
 		<language type="srn" scripts="Latn"/>
-		<language type="srn" territories="SR" alt="secondary"/>
 		<language type="srr" scripts="Latn"/>
-		<language type="srr" territories="SN" alt="secondary"/>
 		<language type="srx" scripts="Deva"/>
-		<language type="ss" scripts="Latn" territories="SZ"/>
-		<language type="ss" territories="ZA" alt="secondary"/>
+		<language type="ss" scripts="Latn"/>
 		<language type="ssy" scripts="Latn"/>
-		<language type="st" scripts="Latn" territories="LS"/>
-		<language type="st" territories="ZA" alt="secondary"/>
+		<language type="st" scripts="Latn"/>
 		<language type="stq" scripts="Latn"/>
 		<language type="su" scripts="Latn"/>
-		<language type="su" scripts="Sund" territories="ID" alt="secondary"/>
+		<language type="su" scripts="Sund" alt="secondary"/>
 		<language type="suk" scripts="Latn"/>
-		<language type="suk" territories="TZ" alt="secondary"/>
 		<language type="sus" scripts="Latn"/>
-		<language type="sus" scripts="Arab" territories="GN" alt="secondary"/>
-		<language type="sv" scripts="Latn" territories="AX FI SE"/>
-		<language type="sw" scripts="Latn" territories="KE TZ UG"/>
-		<language type="sw" territories="CD" alt="secondary"/>
+		<language type="sus" scripts="Arab" alt="secondary"/>
+		<language type="sv" scripts="Latn"/>
+		<language type="sw" scripts="Latn"/>
 		<language type="swb" scripts="Arab"/>
-		<language type="swb" scripts="Latn" territories="YT" alt="secondary"/>
+		<language type="swb" scripts="Latn" alt="secondary"/>
 		<language type="swg" scripts="Latn"/>
 		<language type="swv" scripts="Deva"/>
-		<language type="swv" territories="IN" alt="secondary"/>
 		<language type="sxn" scripts="Latn"/>
 		<language type="syi" scripts="Latn"/>
 		<language type="syl" scripts="Beng"/>
-		<language type="syl" scripts="Sylo" territories="BD" alt="secondary"/>
+		<language type="syl" scripts="Sylo" alt="secondary"/>
 		<language type="syr" scripts="Syrc"/>
 		<language type="szl" scripts="Latn"/>
-		<language type="ta" scripts="Taml" territories="LK SG"/>
-		<language type="ta" territories="GB IN MY" alt="secondary"/>
+		<language type="ta" scripts="Taml"/>
 		<language type="tab" scripts="Cyrl"/>
 		<language type="taj" scripts="Deva"/>
 		<language type="taj" scripts="Tibt" alt="secondary"/>
 		<language type="tbw" scripts="Latn"/>
 		<language type="tbw" scripts="Tagb" alt="secondary"/>
 		<language type="tcy" scripts="Knda"/>
-		<language type="tcy" territories="IN" alt="secondary"/>
 		<language type="tdd" scripts="Tale"/>
 		<language type="tdg" scripts="Deva"/>
 		<language type="tdg" scripts="Tibt" alt="secondary"/>
 		<language type="tdh" scripts="Deva"/>
 		<language type="te" scripts="Telu"/>
-		<language type="te" territories="IN" alt="secondary"/>
 		<language type="tem" scripts="Latn"/>
-		<language type="tem" territories="SL" alt="secondary"/>
 		<language type="teo" scripts="Latn"/>
-		<language type="teo" territories="UG" alt="secondary"/>
 		<language type="ter" scripts="Latn"/>
-		<language type="tet" scripts="Latn" territories="TL"/>
-		<language type="tg" scripts="Cyrl Arab Latn" territories="TJ"/>
-		<language type="th" scripts="Thai" territories="TH"/>
+		<language type="tet" scripts="Latn"/>
+		<language type="tg" scripts="Cyrl Arab Latn"/>
+		<language type="th" scripts="Thai"/>
 		<language type="thl" scripts="Deva"/>
 		<language type="thq" scripts="Deva"/>
 		<language type="thr" scripts="Deva"/>
-		<language type="ti" scripts="Ethi" territories="ER"/>
-		<language type="ti" territories="ET" alt="secondary"/>
+		<language type="ti" scripts="Ethi"/>
 		<language type="tig" scripts="Ethi"/>
-		<language type="tig" territories="ER" alt="secondary"/>
 		<language type="tiv" scripts="Latn"/>
-		<language type="tiv" territories="NG" alt="secondary"/>
-		<language type="tk" scripts="Latn Arab Cyrl" territories="TM"/>
-		<language type="tk" territories="AF IR" alt="secondary"/>
-		<language type="tkl" scripts="Latn" territories="TK"/>
+		<language type="tk" scripts="Latn Arab Cyrl"/>
+		<language type="tkl" scripts="Latn"/>
 		<language type="tkr" scripts="Latn"/>
 		<language type="tkr" scripts="Cyrl" alt="secondary"/>
 		<language type="tkt" scripts="Deva"/>
 		<language type="tli" scripts="Latn"/>
 		<language type="tly" scripts="Latn"/>
-		<language type="tly" scripts="Arab Cyrl" territories="AZ" alt="secondary"/>
+		<language type="tly" scripts="Arab Cyrl" alt="secondary"/>
 		<language type="tmh" scripts="Latn"/>
-		<language type="tmh" territories="NE" alt="secondary"/>
-		<language type="tn" scripts="Latn" territories="BW"/>
-		<language type="tn" territories="ZA" alt="secondary"/>
+		<language type="tn" scripts="Latn"/>
 		<language type="tnr" scripts="Latn"/>
-		<language type="tnr" territories="SN" alt="secondary"/>
-		<language type="to" scripts="Latn" territories="TO"/>
+		<language type="to" scripts="Latn"/>
 		<language type="tog" scripts="Latn"/>
-		<language type="toi" territories="ZM" alt="secondary"/>
 		<language type="tok" scripts="Latn"/>
-		<language type="tpi" scripts="Latn" territories="PG"/>
-		<language type="tr" scripts="Latn" territories="CY TR"/>
-		<language type="tr" scripts="Arab" territories="DE" alt="secondary"/>
+		<language type="tpi" scripts="Latn"/>
+		<language type="tr" scripts="Latn"/>
+		<language type="tr" scripts="Arab" alt="secondary"/>
 		<language type="tru" scripts="Latn"/>
 		<language type="tru" scripts="Syrc" alt="secondary"/>
 		<language type="trv" scripts="Latn"/>
 		<language type="trw" scripts="Arab"/>
 		<language type="ts" scripts="Latn"/>
-		<language type="ts" territories="MZ ZA" alt="secondary"/>
 		<language type="tsd" scripts="Grek"/>
 		<language type="tsg" scripts="Latn"/>
-		<language type="tsg" territories="PH" alt="secondary"/>
 		<language type="tsi" scripts="Latn"/>
 		<language type="tsj" scripts="Tibt"/>
 		<language type="tt" scripts="Cyrl"/>
-		<language type="tt" territories="RU" alt="secondary"/>
 		<language type="ttj" scripts="Latn"/>
 		<language type="tts" scripts="Thai"/>
-		<language type="tts" territories="TH" alt="secondary"/>
 		<language type="ttt" scripts="Latn"/>
 		<language type="ttt" scripts="Arab Cyrl" alt="secondary"/>
 		<language type="tum" scripts="Latn"/>
-		<language type="tum" territories="MW" alt="secondary"/>
-		<language type="tvl" scripts="Latn" territories="TV"/>
+		<language type="tvl" scripts="Latn"/>
 		<language type="twq" scripts="Latn"/>
-		<language type="ty" scripts="Latn" territories="PF"/>
+		<language type="ty" scripts="Latn"/>
 		<language type="tyv" scripts="Cyrl"/>
-		<language type="tyv" territories="RU" alt="secondary"/>
-		<language type="tzm" scripts="Latn Tfng" territories="MA"/>
+		<language type="tzm" scripts="Latn Tfng"/>
 		<language type="ude" scripts="Cyrl"/>
 		<language type="udm" scripts="Cyrl"/>
-		<language type="udm" scripts="Latn" territories="RU" alt="secondary"/>
+		<language type="udm" scripts="Latn" alt="secondary"/>
 		<language type="ug" scripts="Arab Cyrl"/>
-		<language type="ug" scripts="Latn" territories="CN" alt="secondary"/>
+		<language type="ug" scripts="Latn" alt="secondary"/>
 		<language type="uga" scripts="Ugar"/>
-		<language type="uk" scripts="Cyrl" territories="UA"/>
-		<language type="uk" territories="RS" alt="secondary"/>
+		<language type="uk" scripts="Cyrl"/>
 		<language type="uli" scripts="Latn"/>
 		<language type="umb" scripts="Latn"/>
-		<language type="umb" territories="AO" alt="secondary"/>
-		<language type="und" territories="AQ CP HM" alt="secondary"/>
 		<language type="unr" scripts="Beng Deva"/>
-		<language type="unr" territories="IN" alt="secondary"/>
 		<language type="unx" scripts="Beng Deva"/>
-		<language type="ur" scripts="Arab" territories="PK"/>
-		<language type="ur" territories="GB IN" alt="secondary"/>
-		<language type="uz" scripts="Latn Cyrl Arab" territories="UZ"/>
-		<language type="uz" territories="AF" alt="secondary"/>
+		<language type="ur" scripts="Arab"/>
+		<language type="uz" scripts="Latn Cyrl Arab"/>
 		<language type="vai" scripts="Vaii Latn"/>
 		<language type="ve" scripts="Latn"/>
-		<language type="ve" territories="ZA" alt="secondary"/>
 		<language type="vec" scripts="Latn"/>
-		<language type="vec" territories="BR HR IT SI" alt="secondary"/>
 		<language type="vep" scripts="Latn"/>
-		<language type="vi" scripts="Latn" territories="VN"/>
-		<language type="vi" scripts="Hani" territories="US" alt="secondary"/>
+		<language type="vi" scripts="Latn"/>
+		<language type="vi" scripts="Hani" alt="secondary"/>
 		<language type="vic" scripts="Latn"/>
 		<language type="vls" scripts="Latn"/>
-		<language type="vls" territories="BE" alt="secondary"/>
 		<language type="vmf" scripts="Latn"/>
-		<language type="vmf" territories="DE" alt="secondary"/>
 		<language type="vmw" scripts="Latn"/>
-		<language type="vmw" territories="MZ" alt="secondary"/>
 		<language type="vo" scripts="Latn"/>
 		<language type="vot" scripts="Latn"/>
 		<language type="vro" scripts="Latn"/>
@@ -2395,29 +2113,21 @@ XXX Code for transations where no currency is involved
 		<language type="wa" scripts="Latn"/>
 		<language type="wae" scripts="Latn"/>
 		<language type="wal" scripts="Ethi"/>
-		<language type="wal" territories="ET" alt="secondary"/>
 		<language type="war" scripts="Latn"/>
-		<language type="war" territories="PH" alt="secondary"/>
 		<language type="was" scripts="Latn"/>
 		<language type="wbp" scripts="Latn"/>
 		<language type="wbq" scripts="Telu"/>
-		<language type="wbq" territories="IN" alt="secondary"/>
 		<language type="wbr" scripts="Deva"/>
-		<language type="wbr" territories="IN" alt="secondary"/>
 		<language type="wls" scripts="Latn"/>
-		<language type="wls" territories="WF" alt="secondary"/>
-		<language type="wni" scripts="Arab" territories="KM"/>
-		<language type="wo" scripts="Latn" territories="SN"/>
+		<language type="wni" scripts="Arab"/>
+		<language type="wo" scripts="Latn"/>
 		<language type="wo" scripts="Arab" alt="secondary"/>
 		<language type="wtm" scripts="Deva"/>
-		<language type="wtm" territories="IN" alt="secondary"/>
 		<language type="wuu" scripts="Hans"/>
-		<language type="wuu" territories="CN" alt="secondary"/>
 		<language type="xal" scripts="Cyrl"/>
 		<language type="xav" scripts="Latn"/>
 		<language type="xcr" scripts="Cari"/>
 		<language type="xh" scripts="Latn"/>
-		<language type="xh" territories="ZA" alt="secondary"/>
 		<language type="xlc" scripts="Lyci"/>
 		<language type="xld" scripts="Lydi"/>
 		<language type="xmf" scripts="Geor"/>
@@ -2425,9 +2135,7 @@ XXX Code for transations where no currency is involved
 		<language type="xmr" scripts="Merc"/>
 		<language type="xna" scripts="Narb"/>
 		<language type="xnr" scripts="Deva"/>
-		<language type="xnr" territories="IN" alt="secondary"/>
 		<language type="xog" scripts="Latn"/>
-		<language type="xog" territories="UG" alt="secondary"/>
 		<language type="xpr" scripts="Prti"/>
 		<language type="xsa" scripts="Sarb"/>
 		<language type="xsr" scripts="Deva"/>
@@ -2437,29 +2145,25 @@ XXX Code for transations where no currency is involved
 		<language type="yav" scripts="Latn"/>
 		<language type="ybb" scripts="Latn"/>
 		<language type="yi" scripts="Hebr"/>
-		<language type="yo" scripts="Latn" territories="NG"/>
+		<language type="yo" scripts="Latn"/>
 		<language type="yrk" scripts="Cyrl"/>
 		<language type="yrl" scripts="Latn"/>
 		<language type="yua" scripts="Latn"/>
-		<language type="yue" scripts="Hant Hans" territories="MO"/>
-		<language type="yue" territories="CN HK" alt="secondary"/>
+		<language type="yue" scripts="Hant Hans"/>
 		<language type="za" scripts="Latn"/>
-		<language type="za" scripts="Hans" territories="CN" alt="secondary"/>
+		<language type="za" scripts="Hans" alt="secondary"/>
 		<language type="zag" scripts="Latn"/>
 		<language type="zap" scripts="Latn"/>
-		<language type="zdj" scripts="Arab" territories="KM"/>
+		<language type="zdj" scripts="Arab"/>
 		<language type="zea" scripts="Latn"/>
 		<language type="zen" scripts="Tfng"/>
 		<language type="zgh" scripts="Tfng"/>
-		<language type="zgh" territories="MA" alt="secondary"/>
-		<language type="zh" scripts="Hans Hant" territories="CN HK MO SG TW"/>
-		<language type="zh" scripts="Bopo Latn Phag" territories="CA ID MY TH US VN" alt="secondary"/>
+		<language type="zh" scripts="Hans Hant"/>
+		<language type="zh" scripts="Bopo Latn Phag" alt="secondary"/>
 		<language type="zmi" scripts="Latn"/>
 		<language type="zu" scripts="Latn"/>
-		<language type="zu" territories="ZA" alt="secondary"/>
 		<language type="zun" scripts="Latn"/>
 		<language type="zza" scripts="Latn"/>
-		<language type="zza" territories="TR" alt="secondary"/>
 	</languageData>
 	<scriptData>
 		<scriptVariant type="compound" id='Hanb' base='Hani Bopo'/> <!-- Han with Bopomofo (alias for Han + Bopomofo) -->

--- a/docs/site/downloads/cldr-48.md
+++ b/docs/site/downloads/cldr-48.md
@@ -63,7 +63,7 @@ See the [Modifications section](https://www.unicode.org/reports/tr35/proposed.ht
 
 ### DTD Changes
 
-- TBD
+- `territories` attribute of `languageData` in [`supplementalData.xml`](https://github.com/unicode-org/cldr/blob/main/common/supplemental/supplementalData.xml) removed. While it was a nice proxy to count the most important territories for each language, it was not clear and it was ripe for mis-understanding. ([CLDR-5708][])
 
 For a full listing, see [Delta DTDs](https://unicode.org/cldr/charts/dev/supplemental/dtd_deltas.html).
 
@@ -151,6 +151,7 @@ in particular, see [Exhibit 1](https://unicode.org/copyright.html#Exhibit1).
 
 For web pages with different views of CLDR data, see [http://cldr.unicode.org/index/charts](/index/charts).
 
+[CLDR-5708]: https://unicode-org.atlassian.net/browse/CLDR-5708
 [CLDR-18087]: https://unicode-org.atlassian.net/browse/CLDR-18087
 [CLDR-18219]: https://unicode-org.atlassian.net/browse/CLDR-18219
 [CLDR-18275]: https://unicode-org.atlassian.net/browse/CLDR-18275

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -464,7 +464,7 @@ public class ConvertLanguageData {
             }
 
             for (BasicLanguageData bld : newData.values()) {
-                if (bld.getTerritories().size() > 0 || bld.getScripts().size() > 0) {
+                if (bld.getScripts().size() > 0) {
                     out.println(bld.toString(languageSubtag));
                 }
             }
@@ -639,20 +639,6 @@ public class ConvertLanguageData {
                                     0,
                                     false)
                             + "\"");
-        }
-
-        Set<String> inPopulationButNotBasic = new TreeSet<>(populationOver20);
-        inPopulationButNotBasic.removeAll(basicCombos);
-        for (Iterator<String> it = inPopulationButNotBasic.iterator(); it.hasNext(); ) {
-            String locale = it.next();
-            if (locale.endsWith("_ZZ")) {
-                it.remove();
-            }
-        }
-        for (String locale : inPopulationButNotBasic) {
-            BadItem.WARNING.show(
-                    "In Population>20% but not Basic Data",
-                    locale + " " + getLanguageName(locale), localeToRowData.get(locale).toString());
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -333,6 +333,7 @@ public class SupplementalDataInfo {
 
         private Map<String, Integer> scriptsByPopulation = new TreeMap<>();
 
+        // TODO CLDR-18087 completely remove territories
         private Set<String> territories = Collections.emptySet();
 
         public Type getType() {
@@ -422,10 +423,6 @@ public class SupplementalDataInfo {
                     + (scripts.size() == 0
                             ? ""
                             : " scripts=\"" + CldrUtility.join(sortedScripts, " ") + "\"")
-                    // TODO (CLDR-5708) remove territory data
-                    + (territories.size() == 0
-                            ? ""
-                            : " territories=\"" + CldrUtility.join(territories, " ") + "\"")
                     + (type == Type.primary ? "" : " alt=\"" + type + "\"")
                     + "/>";
         }
@@ -435,7 +432,6 @@ public class SupplementalDataInfo {
             return "["
                     + type
                     + (scripts.isEmpty() ? "" : "; scripts=" + Joiner.on(" ").join(scripts))
-                    + (scripts.isEmpty() ? "" : "; territories=" + Joiner.on(" ").join(territories))
                     + "]";
         }
 


### PR DESCRIPTION
supplementalData.xml lists the top territories for languages under the `<languageData>` area -- however it's not clear and it's best for people to consume the data from `<territoryInfo>` directly.

This quickly removes the territory information -- but there is additional cleanup to do. I just wanted to get this simple change out there to see how many breaks.

CLDR-5708

- [x] This PR completes the ticket.

Scripts ran
```
mvn package -DskipTests=true &&  java -jar tools/cldr-code/target/cldr-code.jar ConvertLanguageData &&  java -jar tools/cldr-code/target/cldr-code.jar GenerateLikelySubtags &&  java -jar tools/cldr-code/target/cldr-code.jar GenerateTestData
```

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
