### PR TITLE
CLDR-16524 spec v47: change the Revision line to just link to Modifications

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -13,7 +13,7 @@
 |Latest Proposed Update|<a href="https://www.unicode.org/reports/tr35/proposed.html">https://www.unicode.org/reports/tr35/proposed.html</a></td></tr>
 |Namespace|<a href="https://www.unicode.org/cldr/">https://www.unicode.org/cldr/</a>|
 |DTDs|<a href="https://www.unicode.org/cldr/dtd/47/">https://www.unicode.org/cldr/dtd/47/</a>|
-|Revision|<a href="#Modifications">75</a>|
+|Change History|[Modifications](#modifications)|
 
 ### _Summary_
 


### PR DESCRIPTION
CLDR-16524

I don't think this line needs a version number, the user can click on Modifications and see the entire history (starting with changes since the prev version).

Also, the current version is still in the "this version" URL if needed.

<img width="377" alt="image" src="https://github.com/user-attachments/assets/bb90095b-5d27-42d5-8a0d-114fd2286eab" />


- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
