### PR TITLE
CLDR-18381 Add kek_GT locale

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -312,6 +312,7 @@ annotations.
 			<language type="kcg">Tyap</language>
 			<language type="kde">Makonde</language>
 			<language type="kea">Kabuverdianu</language>
+			<language type="kek">Qʼeqchiʼ</language>
 			<language type="ken">Kenyang</language>
 			<language type="kfo">Koro</language>
 			<language type="kg">Kongo</language>

--- a/common/main/kek.xml
+++ b/common/main/kek.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2025 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="kek"/>
+	</identity>
+	<localeDisplayNames>
+		<languages>
+			<language type="kek">Qʼeqchiʼ</language>
+		</languages>
+	</localeDisplayNames>
+	<layout>
+		<orientation>
+			<characterOrder>↑↑↑</characterOrder>
+			<lineOrder>↑↑↑</lineOrder>
+		</orientation>
+	</layout>
+	<characters>
+		<exemplarCharacters>[a {aa} {bʼ} c {ch} {ch’} e {ee} h i {ii} j k {k’} l m n o {oo} p q {q’} r s t {t’} {tz} {tz’} u {uu} w x y]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[d f g v z]</exemplarCharacters>
+		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[“” ’ , . ! ? \: \- … ( ) ; \[ \] \{ \} /]</exemplarCharacters>
+	</characters>
+</ldml>

--- a/common/main/kek_GT.xml
+++ b/common/main/kek_GT.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
+<!-- Copyright © 1991-2025 Unicode, Inc.
+For terms of use, see http://www.unicode.org/copyright.html
+SPDX-License-Identifier: Unicode-3.0
+CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
+-->
+<ldml>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="kek"/>
+		<territory type="GT"/>
+	</identity>
+</ldml>

--- a/common/supplemental/attributeValueValidity.xml
+++ b/common/supplemental/attributeValueValidity.xml
@@ -74,7 +74,7 @@
 				 haw hnj ht
 				 ii io iu
 				 jbo jgo jmc
-				 kaa kab kaj kam kcg kde ken khq ki kkj kl kln kpe ksb ksf ksh kw
+				 kaa kab kaj kam kcg kde kek ken khq ki kkj kl kln kpe ksb ksf ksh kw
 				 la lag lg lkt lld ln lrc ltg lu luo luy lzz
 				 mas mdf mer mfe mhn mg mgh mgo mic moh mua mus myv mzn
 				 naq nb nd nmg nnh nr nso nus nv ny nyn om

--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -1893,7 +1893,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 			hsb_DE ht_HT hu_HU hy_AM
 			ia_001 id_ID ie_EE ife_TG ig_NG ii_CN io_001 is_IS it_IT iu_CA iu_Latn_CA
 			ja_JP jbo_001 jgo_CM jmc_TZ jv_ID
-			ka_GE kaa_Cyrl kaa_Cyrl_UZ kaa_Latn_UZ kab_DZ kaj_NG kam_KE kcg_NG kde_TZ kea_CV ken_CM kgp_BR
+			ka_GE kaa_Cyrl kaa_Cyrl_UZ kaa_Latn_UZ kab_DZ kaj_NG kam_KE kcg_NG kde_TZ kea_CV kek_GT ken_CM kgp_BR
 			khq_ML ki_KE
 			kk_Arab_CN kk_Cyrl kk_Cyrl_KZ
 			kkj_CM kl_GL kln_KE km_KH kn_IN ko_KR kok_Deva kok_Deva_IN kok_Latn_IN kpe_LR ks_Arab

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -197,8 +197,8 @@ public class DisplayAndInputProcessor {
     public static final Set<String> LANGUAGES_USING_MODIFIER_APOSTROPHE =
             new HashSet<>(
                     Arrays.asList(
-                            "br", "bss", "cad", "cic", "cch", "gn", "ha", "ha_Latn", "lkt", "mgo",
-                            "mic", "moh", "mus", "nnh", "qu", "quc", "uk", "uz", "uz_Latn"));
+                            "br", "bss", "cad", "cic", "cch", "gn", "ha", "ha_Latn", "kek", "lkt",
+                            "mgo", "mic", "moh", "mus", "nnh", "qu", "quc", "uk", "uz", "uz_Latn"));
 
     // Ş ş Ţ ţ  =>  Ș ș Ț ț
     private static final char[][] ROMANIAN_CONVERSIONS = {


### PR DESCRIPTION
Adds a new locale, per CLDR-18381

There are some outstanding questions on orthography.

Also I'll update language's population in a separate diff updating the data from the full Guatemalan census: https://github.com/unicode-org/cldr/pull/4474

CLDR-18381

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
