### PR TITLE
CLDR-18351 fail better: for site and spec deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -112,9 +112,9 @@ jobs:
           rsync -cav --delete-after -e "ssh -o UserKnownHostsFile=${HOME}/.knownhosts -i ${HOME}/.key -p ${CCC_PORT}" ./_site/ ${CCC_USER}@${CCC_HOST}:spec/$(basename ${GITHUB_REF_NAME})/
           echo "::endgroup::"
           echo "Now go to https://cldr-smoke.unicode.org/spec/"$(basename ${GITHUB_REF_NAME})
-
   deploy:
-    if: github.repository == 'unicode-org/cldr' && github.event_name == 'push'
+    # only deploy from main branch of main repo
+    if: github.repository == 'unicode-org/cldr' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -18,10 +18,10 @@ on:
         paths:
         #  - "tools/scripts/tr-archive/**"
          - "docs/site/**"
-         - '.github/workflows/site.yml'
-
+         - '.github/workflows/site.yml'    
 jobs:
   cloudflare:
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     environment: cloudflare
     steps:
@@ -39,9 +39,11 @@ jobs:
     - name: Build cldr.pages.dev
       run: 'cd docs/site && jekyll build'
     - name: Pre-install Wrangler
+      if: github.event.pull_request.head.repo.full_name == 'unicode-org/cldr'
       run: npm i -g wrangler@3.x
       # see https://github.com/cloudflare/wrangler-action/issues/286
     - name: Deploy cldr.pages.dev
+      if: github.event.pull_request.head.repo.full_name == 'unicode-org/cldr'
       id: deploy
       uses: cloudflare/wrangler-action@v3
       with:
@@ -50,7 +52,7 @@ jobs:
         command: pages deploy ./_site --project-name=cldr
     - name: Add deploy comment to PR
       uses: actions/github-script@v7
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'unicode-org/cldr'
       with:
         script: |
           github.rest.issues.createComment({


### PR DESCRIPTION
- if you open a site PR from a fork for the site, give a warning instead of failing.
- if you merge to a branch that can't deploy to gh-pages, skip deploy instead of fail



CLDR-18351

- [X] This PR completes the ticket.

### Review Notes:

- [X] site: verify that a PR from a fork doesn't error (it won't label either)
- [ ] site: once merged, verify that a PR from the head fork deploys ok
- [ ] spec: once merged, verify that main deploys OK
- [ ] spec: once merged, verify that a merge to a branch no longer fails GH-pages


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
