### PR TITLE
CLDR-18401 SBRSv48: Delete spec TOC entries for Modifications section

### DIFF
--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -220,19 +220,6 @@ The LDML specification is divided into the following parts:
 * [References](#References)
 * [Acknowledgments](#Acknowledgments)
 * [Modifications](#Modifications)
-  * [Locale identifiers](#locale-identifiers)
-    * [Changes in LDML Version 46.1](#changes-in-ldml-version-461)
-  * [Number symbols and formats without numberSystem](#number-symbols-and-formats-without-numbersystem)
-  * [Clarified `currencyData` element ordering](#clarified-currencydata-element-ordering)
-  * [Semantic Datetime Skeletons](#semantic-datetime-skeletons)
-  * [[Timezones](tr35-dates.md#Using_Time_Zone_Names)](#timezonestr35-datesmdusingtimezonenames)
-  * [[Unit Identifiers](tr35-general.md#Unit_Identifiers)](#unit-identifierstr35-generalmdunitidentifiers)
-    * [Changes in LDML Version 46.1](#changes-in-ldml-version-461)
-  * [[DTD Annotations](https://cldr.unicode.org/development/dtd_annotations)](#dtd-annotationshttpscldrunicodeorgdevelopmentdtdannotations)
-  * [[Inheritance](https://unicode.org/reports/tr35/dev/tr35.html#inheritance-marker)](#inheritancehttpsunicodeorgreportstr35devtr35htmlinheritance-marker)
-  * [Improvements to Keyboard Transforms](#improvements-to-keyboard-transforms)
-  * [[MessageFormat](tr35-messageFormat.md#Contents)](#messageformattr35-messageformatmdcontents)
-    * [Changes in LDML Version 46.1](#changes-in-ldml-version-461)
 
 ## <a name="Introduction" href="#Introduction">Introduction</a>
 


### PR DESCRIPTION
CLDR-18401

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18401)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

Among other things, the previous PR for this ticket - [#4481](https://github.com/unicode-org/cldr/pull/4481) - deleted most of the body of the Modifications section of tr35, consisting of entries relevant for CLDR 46.1 and 47. However, it did not delete the TOC entries for those items in the body of the Modification section; this PR completes the job by deleting the corresponding TOC entries.

ALLOW_MANY_COMMITS=true
