### PR TITLE
CLDR-17570 Rational formatting

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -2267,12 +2267,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@VALUE-->
     <!--@DEPRECATED-->
 
-<!ELEMENT rationalFormats ( alias | ( rationalPattern*,  integerAndRationalPattern*, rationalUsage* ) ) >
+<!ELEMENT rationalFormats ( alias | ( rationalPattern*,  integerAndRationalPattern*, rationalUsage*, special* ) ) >
 <!ATTLIST rationalFormats numberSystem CDATA #IMPLIED >
     <!--@MATCH:bcp47/nu-->
 
 <!ELEMENT rationalPattern ( #PCDATA ) >
-<!ATTLIST decimalFormat draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+<!ATTLIST rationalPattern alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST rationalPattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
     
 <!ELEMENT integerAndRationalPattern ( #PCDATA ) >
@@ -2282,6 +2284,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
     
 <!ELEMENT rationalUsage ( #PCDATA ) >
+<!ATTLIST rationalUsage alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
 <!ATTLIST rationalUsage draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
     <!--@METADATA-->
 

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1963,7 +1963,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!-- ######################################################### -->
 
-<!ELEMENT numbers ( alias | ( defaultNumberingSystem*, otherNumberingSystems*, minimumGroupingDigits*, symbols*, decimalFormats*, scientificFormats*, percentFormats*, currencyFormats*, currencies?, miscPatterns*, minimalPairs*, special* ) ) >
+<!ELEMENT numbers ( alias | ( defaultNumberingSystem*, otherNumberingSystems*, minimumGroupingDigits*, symbols*, decimalFormats*, rationalFormats*, scientificFormats*, percentFormats*, currencyFormats*, currencies?, miscPatterns*, minimalPairs*, special* ) ) >
 <!ATTLIST numbers alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST numbers draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
@@ -2266,6 +2266,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST decimalFormat validSubLocales CDATA #IMPLIED >
     <!--@VALUE-->
     <!--@DEPRECATED-->
+
+<!ELEMENT rationalFormats ( alias | ( rationalPattern*,  integerAndRationalPattern*, rationalUsage* ) ) >
+<!ATTLIST rationalFormats numberSystem CDATA #IMPLIED >
+    <!--@MATCH:bcp47/nu-->
+
+<!ELEMENT rationalPattern ( #PCDATA ) >
+<!ATTLIST decimalFormat draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+    
+<!ELEMENT integerAndRationalPattern ( #PCDATA ) >
+<!ATTLIST integerAndRationalPattern alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/superSub-->
+<!ATTLIST integerAndRationalPattern draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+    
+<!ELEMENT rationalUsage ( #PCDATA ) >
+<!ATTLIST rationalUsage draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+
 
 <!ELEMENT scientificFormats ( alias | ( default*, scientificFormatLength*, special* ) ) >
 <!ATTLIST scientificFormats draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5053,6 +5053,12 @@ annotations.
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
+		<rationalFormats numberSystem="latn">
+			<rationalPattern>{0}⁄{1}</rationalPattern>
+			<integerAndRationalPattern>{0}&#x202F;{1}</integerAndRationalPattern>
+			<integerAndRationalPattern alt="superSub">{0}&#x200b;{1}</integerAndRationalPattern>
+			<rationalUsage>used</rationalUsage> <!-- unknown vs unused vs used -->
+		</rationalFormats>
 		<scientificFormats numberSystem="latn">
 			<scientificFormatLength>
 				<scientificFormat>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3931,6 +3931,243 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<decimalFormats numberSystem="wcho">
 			<alias source="locale" path="../decimalFormats[@numberSystem='latn']"/>
 		</decimalFormats>
+		<rationalFormats numberSystem="latn">
+			<rationalPattern>{0}⁄{1}</rationalPattern>
+			<integerAndRationalPattern>{0}&#x202F;{1}</integerAndRationalPattern>
+			<integerAndRationalPattern alt="superSub">{0}&#x200b;{1}</integerAndRationalPattern>
+			<rationalUsage>used</rationalUsage> <!-- unknown vs unused vs used -->
+		</rationalFormats>
+		<rationalFormats>
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="adlm">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="ahom">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="arab">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="arabext">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="bali">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="beng">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="bhks">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="brah">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="cakm">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="cham">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="deva">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="diak">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="fullwide">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="gara">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="gong">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="gonm">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="gujr">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="gukh">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="guru">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="hanidec">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="hmng">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="hmnp">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="java">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="kali">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="kawi">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="khmr">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="knda">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="krai">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="lana">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="lanatham">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="laoo">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="lepc">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="limb">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mathbold">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mathdbl">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mathmono">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mathsanb">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mathsans">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mlym">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="modi">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mong">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mroo">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mtei">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mymr">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mymrepka">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mymrpao">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mymrshan">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="mymrtlng">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="nagm">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="newa">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="nkoo">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="olck">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="onao">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="orya">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="osma">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="outlined">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="rohg">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="saur">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="segment">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="shrd">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="sind">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="sinh">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="sora">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="sund">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="sunu">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="takr">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="talu">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="tamldec">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="telu">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="thai">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="tibt">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="tirh">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="tnsa">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="vaii">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="wara">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
+		<rationalFormats numberSystem="wcho">
+			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
+		</rationalFormats>
 		<scientificFormats>
 			<alias source="locale" path="../scientificFormats[@numberSystem='latn']"/>
 		</scientificFormats>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -100,7 +100,7 @@ public enum CodePointEscaper {
             new UnicodeSet("[\\uFE0F\\U000E0020-\\U000E007F]").freeze();
 
     public static final UnicodeSet FORCE_ESCAPE =
-            new UnicodeSet("[[:DI:][:Pat_WS:][:WSpace:][:C:][:Z:]]")
+            new UnicodeSet("[[:DI:][:Pat_WS:][:WSpace:][:C:][:Z:]\u200B]")
                     .addAll(getNamedEscapes())
                     .removeAll(EMOJI_INVISIBLES)
                     .freeze();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -13,6 +13,7 @@ import java.util.TreeSet;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.unicode.cldr.util.RegexLookup.Finder;
 
 public class PathDescription {
     /** Remember to quote any [ character! */
@@ -258,7 +259,7 @@ public class PathDescription {
                     + ".\n"
 
                     /*
-                     * Warning: the longer match must come first
+                     * Warning: the longer match and more specific match must come first!
                      */
                     + "^//ldml/units/unitLength\\[@type=\"([^\"]*)\"]/compoundUnit\\[@type=\"([^\"]*)\"]/compoundUnitPattern1"
                     + RegexLookup.SEPARATOR
@@ -510,10 +511,45 @@ public class PathDescription {
                     + "Sample names for person name format examples (enter ∅∅∅ for optional unused fields). For more information, please see "
                     + CLDRURLS.PERSON_NAME_FORMATS
                     + ".\n"
-                    + "^//ldml/numbers/([a-z]*)Formats(\\[@numberSystem=\"([^\"]*)\"])?/\\1FormatLength/\\1Format\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]$"
+                    + "^//ldml/numbers/rationalFormats/rationalPattern"
                     + RegexLookup.SEPARATOR
-                    + "Special pattern used to compose {1} numbers. Note: before translating, be sure to read "
-                    + CLDRURLS.NUMBER_PATTERNS
+                    + "A pattern that is used to format a rational fraction (eg, ½), using the numerator and denominator"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats/integerAndRationalPattern\\[@alt=\"([^\"]*)\"]"
+                    + RegexLookup.SEPARATOR
+                    + "A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together; only used when the rational fraction does not start with an un-superscripted digit"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats/integerAndRationalPattern"
+                    + RegexLookup.SEPARATOR
+                    + "A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats/rationalUsage"
+                    + RegexLookup.SEPARATOR
+                    + "A value that is used to indicate the usage of rational fractions (eg, ½) in your language; only pick “unused” if it never occurs, even with text translated or transliterated from another language"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats\\[@numberSystem=\"([^\"]*)\"]/rationalPattern"
+                    + RegexLookup.SEPARATOR
+                    + "A pattern that is used to format a rational fraction (eg, ½), using the numerator and denominator"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats\\[@numberSystem=\"([^\"]*)\"]/integerAndRationalPattern\\[@alt=\"([^\"]*)\"]"
+                    + RegexLookup.SEPARATOR
+                    + "A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together; only used when the rational fraction does not start with an un-superscripted digit"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats\\[@numberSystem=\"([^\"]*)\"]/integerAndRationalPattern"
+                    + RegexLookup.SEPARATOR
+                    + "A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together"
+                    + CLDRURLS.NUMBERS_HELP
+                    + ".\n"
+                    + "^//ldml/numbers/rationalFormats\\[@numberSystem=\"([^\"]*)\"]/rationalUsage"
+                    + RegexLookup.SEPARATOR
+                    + "A value that is used to indicate the usage of rational fractions (eg, ½) in your language; only pick “unused” if it never occurs, even with text translated or transliterated from another language"
+                    + CLDRURLS.NUMBERS_HELP
                     + ".\n"
                     + "^//ldml/numbers/currencyFormats\\[@numberSystem=\"([^\"]*)\"]/currencyFormatLength/currencyFormat\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]\\[@alt=\"alphaNextToNumber\"]"
                     + RegexLookup.SEPARATOR
@@ -533,6 +569,15 @@ public class PathDescription {
                     + "^//ldml/numbers/currencyFormats/currencySpacing/([a-zA-Z]*)/([a-zA-Z]*)"
                     + RegexLookup.SEPARATOR
                     + "Special pattern used to compose currency signs ($1/$2) with numbers. Note: before translating, be sure to read "
+                    + CLDRURLS.NUMBER_PATTERNS
+                    + ".\n"
+
+                    // the following matches remaining number formats. It must go AFTER specific
+                    // ones.
+
+                    + "^//ldml/numbers/([a-z]*)Formats(\\[@numberSystem=\"([^\"]*)\"])?/\\1FormatLength/\\1Format\\[@type=\"standard\"]/pattern\\[@type=\"standard\"]$"
+                    + RegexLookup.SEPARATOR
+                    + "Special pattern used to compose {1} numbers. Note: before translating, be sure to read "
                     + CLDRURLS.NUMBER_PATTERNS
                     + ".\n"
                     + "^//ldml/listPatterns/listPattern/listPatternPart\\[@type=\"2\"]"
@@ -912,6 +957,12 @@ public class PathDescription {
     public String getRawDescription(String path, Object context) {
         status.clear();
         return pathHandling.get(path, context, pathArguments);
+    }
+
+    public String getRawDescription(
+            String path, Object context, Output<Finder> matcherFound, Set<String> failures) {
+        status.clear();
+        return pathHandling.get(path, context, pathArguments, matcherFound, failures);
     }
 
     public String getDescription(String path, String value, Object context) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/RegexLookup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/RegexLookup.java
@@ -4,6 +4,7 @@ import com.google.common.base.Splitter;
 import com.ibm.icu.text.Transform;
 import com.ibm.icu.util.Output;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -782,7 +783,7 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
     }
 
     public static Transform<String, RegexFinder> RegexFinderTransform =
-            new Transform<String, RegexFinder>() {
+            new Transform<>() {
                 @Override
                 public RegexFinder transform(String source) {
                     return new RegexFinder(source);
@@ -794,7 +795,7 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
      * //. To work better with XPaths.
      */
     public static Transform<String, RegexFinder> RegexFinderTransformPath =
-            new Transform<String, RegexFinder>() {
+            new Transform<>() {
                 @Override
                 public RegexFinder transform(String source) {
                     final String newSource = source.replace("[@", "\\[@");
@@ -808,7 +809,7 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
      * //, and ' is changed to ". To work better with XPaths.
      */
     public static Transform<String, RegexFinder> RegexFinderTransformPath2 =
-            new Transform<String, RegexFinder>() {
+            new Transform<>() {
                 @Override
                 public RegexFinder transform(String source) {
                     final String newSource = source.replace("[@", "\\[@").replace('\'', '"');
@@ -860,7 +861,7 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
             Object context,
             Output<String[]> arguments,
             Output<Finder> matcherFound,
-            List<String> failures) {
+            Collection<String> failures) {
 
         if (_lookupType == RegexLookup.LookupType.STAR_PATTERN_LOOKUP) {
             //   T ret = SPEntries.get(source, context, arguments, matcherFound);

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -181,6 +181,18 @@
 //ldml/numbers/%EFormats[@numberSystem="latn"]/%EFormatLength[@type="(short)"]/%EFormat[@type="%A"]/pattern[@type="%A"][@count="%A"] ; Numbers ; Compact Decimal Formatting ; Short Formats &numberingSystem(latn) ; &count2($6-digits-$3-$7)
 //ldml/numbers/%EFormats[@numberSystem="%A"]/%EFormatLength[@type="(short)"]/%EFormat[@type="%A"]/pattern[@type="%A"][@count="%A"] ; Numbers ; Compact Decimal Formatting (Other Numbering Systems) ; Short Formats &numberingSystem($2) ; &count2($7-digits-$4-$8) ; HIDE
 
+
+//ldml/numbers/rationalFormats/rationalPattern												; Numbers ; Number Formatting Patterns ; Rationals-Latin 				; Rational
+//ldml/numbers/rationalFormats/integerAndRationalPattern[@alt="%A"]  						; Numbers ; Number Formatting Patterns ; Rationals-Latin 				; Integer + Rational ($2)
+//ldml/numbers/rationalFormats/integerAndRationalPattern 									; Numbers ; Number Formatting Patterns ; Rationals-Latin 				; Integer + Rational
+//ldml/numbers/rationalFormats/rationalUsage  												; Numbers ; Number Formatting Patterns ; Rationals-Latin 				; Usage
+
+//ldml/numbers/rationalFormats[@numberSystem="%A"]/rationalPattern 							; Numbers ; Number Formatting Patterns ; Rationals-&numberingSystem($1)	; Rational
+//ldml/numbers/rationalFormats[@numberSystem="%A"]/integerAndRationalPattern[@alt="%A"] 	; Numbers ; Number Formatting Patterns ; Rationals-&numberingSystem($1)	; Integer + Rational ($2)
+//ldml/numbers/rationalFormats[@numberSystem="%A"]/integerAndRationalPattern 				; Numbers ; Number Formatting Patterns ; Rationals-&numberingSystem($1)	; Integer + Rational
+//ldml/numbers/rationalFormats[@numberSystem="%A"]/rationalUsage  							; Numbers ; Number Formatting Patterns ; Rationals-&numberingSystem($1)	; Usage
+
+
 ### Currencies
 
 //ldml/numbers/currencies/currency[@type="%A"]/displayName[@count="%A"]     ; Currencies ; &continentFromCurrency($1) ; &categoryFromCurrency($1) ; &count($1-name-$2)

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -253,3 +253,6 @@
 //ldml/personNames/initialPattern\[@type="initial"] ; {0}=NAME_INITIAL J
 //ldml/personNames/initialPattern\[@type="initialSequence"] ; {0}=PREVIOUS_NAME_INITIALS J.R.; {1}=ADD_NAME_INITIAL R.
 //ldml/personNames/personName\[@order="%A"]\[@length="%A"]\[@usage="%A"]\[@formality="%A"]/namePattern ; optional ; {title}=HONORIFIC Dr. ; {given}=GIVEN_NAME Bertram Wilberforce ; {given-informal}=INFORMAL_NAME Bertie ; {given2}=GIVEN_NAME_2 Henry Robert ; {surname}=SURNAME van den Wolf ; {surname-prefix}=SURNAME_PREFIX van den ; {surname-core}=SURNAME_CORE Wolf ; {surname2}=SURNAME_2 González Domingo ; {generation}=GEN_MARKER Jr ; {credentials}=ACCREDITATIONS MD DDS
+
+^//ldml/numbers/rational/rationalPattern ; {0}=NUMERATOR integer or negative integer; {1}=DENOMINATOR integer
+^//ldml/numbers/rational/integerAndRationalPattern ; {0}=INTEGER integer or negative integer; {0}=NUMERATOR integer; {1}=DENOMINATOR integer

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -254,5 +254,6 @@
 //ldml/personNames/initialPattern\[@type="initialSequence"] ; {0}=PREVIOUS_NAME_INITIALS J.R.; {1}=ADD_NAME_INITIAL R.
 //ldml/personNames/personName\[@order="%A"]\[@length="%A"]\[@usage="%A"]\[@formality="%A"]/namePattern ; optional ; {title}=HONORIFIC Dr. ; {given}=GIVEN_NAME Bertram Wilberforce ; {given-informal}=INFORMAL_NAME Bertie ; {given2}=GIVEN_NAME_2 Henry Robert ; {surname}=SURNAME van den Wolf ; {surname-prefix}=SURNAME_PREFIX van den ; {surname-core}=SURNAME_CORE Wolf ; {surname2}=SURNAME_2 González Domingo ; {generation}=GEN_MARKER Jr ; {credentials}=ACCREDITATIONS MD DDS
 
-^//ldml/numbers/rational/rationalPattern ; {0}=NUMERATOR integer or negative integer; {1}=DENOMINATOR integer
-^//ldml/numbers/rational/integerAndRationalPattern ; {0}=INTEGER integer or negative integer; {0}=NUMERATOR integer; {1}=DENOMINATOR integer
+^//ldml/numbers/rationalFormats\[@numberSystem="%A"]/rationalPattern ; {0}=NUMERATOR integer or negative integer; {1}=DENOMINATOR integer
+^//ldml/numbers/rationalFormats\[@numberSystem="%A"]/integerAndRationalPattern ; {0}=INTEGER integer or negative integer; {1}=RATIONAL formatted positive rational
+^//ldml/numbers/rationalFormats\[@numberSystem="%A"]/integerAndRationalPattern\[@alt="%A"] ; {0}=INTEGER integer or negative integer; {1}=RATIONAL formatted positive rational

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -257,3 +257,7 @@
 ^//ldml/numbers/rationalFormats\[@numberSystem="%A"]/rationalPattern ; {0}=NUMERATOR integer or negative integer; {1}=DENOMINATOR integer
 ^//ldml/numbers/rationalFormats\[@numberSystem="%A"]/integerAndRationalPattern ; {0}=INTEGER integer or negative integer; {1}=RATIONAL formatted positive rational
 ^//ldml/numbers/rationalFormats\[@numberSystem="%A"]/integerAndRationalPattern\[@alt="%A"] ; {0}=INTEGER integer or negative integer; {1}=RATIONAL formatted positive rational
+
+^//ldml/numbers/rationalFormats/rationalPattern ; {0}=NUMERATOR integer or negative integer; {1}=DENOMINATOR integer
+^//ldml/numbers/rationalFormats/integerAndRationalPattern ; {0}=INTEGER integer or negative integer; {1}=RATIONAL formatted positive rational
+^//ldml/numbers/rationalFormats/integerAndRationalPattern\[@alt="%A"] ; {0}=INTEGER integer or negative integer; {1}=RATIONAL formatted positive rational

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -9,10 +9,12 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
+import org.unicode.cldr.test.DisplayAndInputProcessor.NumericType;
 import org.unicode.cldr.test.DisplayAndInputProcessor.PathSpaceType;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.ExemplarType;
+import org.unicode.cldr.util.CodePointEscaper;
 import org.unicode.cldr.util.Factory;
 
 public class TestDisplayAndInputProcessor extends TestFmwk {
@@ -904,6 +906,27 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         dat = new KeywordCaseTestData(array, expectedArray);
         if (!dat.filtersAsExpected()) {
             errln("Resulting set differs from expected set 3");
+        }
+    }
+
+    public void TestRationals() {
+        String[][] tests = {{"{0}/{1}", "{0}⁄{1}"}, {"{0}{1}/{2}", "{0} {1}⁄{2}"}};
+        for (String[] test : tests) {
+            String rational = test[0];
+            String expected = test[1];
+            String actual =
+                    DisplayAndInputProcessor.getCanonicalPattern(
+                            rational, NumericType.RATIONAL, false);
+            String example = rational.replace("{0}", "1").replace("{1}", "2").replace("{2}", "3");
+            assertEquals(
+                    "example: "
+                            + CodePointEscaper.toEscaped(example)
+                            + ", source"
+                            + rational
+                            + ", actual"
+                            + CodePointEscaper.toEscaped(actual),
+                    expected,
+                    actual);
         }
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -2242,33 +2242,33 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "en",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"latn\"]/rationalPattern",
-                "〖1⁄2〗〖½〗〖¹⁄₂〗"
+                "〖❬1❭⁄❬2❭〗〖❬<sup>1</sup>❭⁄❬<sub>2</sub>❭〗〖❬¹❭⁄❬₂❭〗"
             },
             {
                 "en",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"latn\"]/integerAndRationalPattern",
-                "〖3❰NBTSP❱1⁄2〗〖3❰NBTSP❱½〗〖3❰NBTSP❱¹⁄₂〗"
+                "〖❬3❭❰NBTSP❱❬1⁄2❭〗〖❬3❭❰NBTSP❱❬½❭〗〖❬3❭❰NBTSP❱❬<sup>1</sup>⁄<sub>2</sub>❭〗"
             },
             {
                 "en",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"latn\"]/integerAndRationalPattern[@alt=\"superSub\"]",
-                "〖3❰WNJ❱1⁄2〗〖3❰WNJ❱½〗〖3❰WNJ❱¹⁄₂〗"
+                "〖❬3❭❰WNJ❱❬½❭〗〖❬3❭❰WNJ❱❬<sup>1</sup>⁄<sub>2</sub>❭〗"
             },
             {"en", "//ldml/numbers/rationalFormats[@numberSystem=\"latn\"]/rationalUsage", null},
             {
                 "hi",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"deva\"]/rationalPattern",
-                "〖१⁄२〗"
+                "〖❬१❭⁄❬२❭〗〖❬<sup>१</sup>❭⁄❬<sub>२</sub>❭〗"
             },
             {
                 "hi",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"deva\"]/integerAndRationalPattern",
-                "〖३❰NBTSP❱१⁄२〗"
+                "〖❬३❭❰NBTSP❱❬१⁄२❭〗〖❬३❭❰NBTSP❱❬<sup>१</sup>⁄<sub>२</sub>❭〗"
             },
             {
                 "hi",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"deva\"]/integerAndRationalPattern[@alt=\"superSub\"]",
-                "〖३❰WNJ❱१⁄२〗"
+                "〖❬३❭❰WNJ❱❬<sup>१</sup>⁄<sub>२</sub>❭〗"
             },
             {"hi", "//ldml/numbers/rationalFormats[@numberSystem=\"deva\"]/rationalUsage", null},
         };

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -166,7 +166,9 @@ public class TestExampleGenerator extends TestFmwk {
                     "//ldml/dates/calendars/calendar[@type=\"([^\"]*+)\"]/cyclicNameSets/cyclicNameSet[@type=\"([^\"]*+)\"]/cyclicNameContext[@type=\"([^\"]*+)\"]/cyclicNameWidth[@type=\"([^\"]*+)\"]/cyclicName[@type=\"([^\"]*+)\"]",
                     "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"([^\"]*+)\"]",
                     "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"([^\"]*+)\"]",
-                    "//ldml/characters/parseLenients[@scope=\"([^\"]*+)\"][@level=\"([^\"]*+)\"]/parseLenient[@sample=\"([^\"]*+)\"]");
+                    "//ldml/characters/parseLenients[@scope=\"([^\"]*+)\"][@level=\"([^\"]*+)\"]/parseLenient[@sample=\"([^\"]*+)\"]",
+                    "//ldml/numbers/rationalFormats/rationalUsage",
+                    "//ldml/numbers/rationalFormats[@numberSystem=\"([^\"]*+)\"]/rationalUsage");
 
     // Only add to above if the example should NEVER appear.
 


### PR DESCRIPTION
CLDR-17570

Add new structure for rationals; put them with the rest of the number formats (decimal, scientific, etc.).
This involved various other changes:
- root and en and dtd
- Placeholder additions
- DAIP additions
- ExampleGenerator additions
- Note that often new structure needs Checks, but this uses DAIP for two cases that would otherwise be errors.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
