### PR TITLE
CLDR-18356 deps: remove duplicate org.json

### DIFF
--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -52,11 +52,6 @@
 			<version>4.4.1</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-		</dependency>
-
 		<!-- test -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -70,7 +65,6 @@
 			<version>${assertj-version}</version>
 			<scope>test</scope>
 		</dependency>
-
 
 		<!-- icu -->
 		<dependency>


### PR DESCRIPTION
- ref  2cbc7bcbb3db092b5b93d458444fc9ab7742d0a5 (#4506)
- seems org.json was already present

CLDR-18356

- [ ] This PR completes the ticket.

Well, I guess I added org.json to maven a long time ago- just didn't delete the source from the tree.

ALLOW_MANY_COMMITS=true
