### PR TITLE
CLDR-18376 Inheritance data: preliminary refactoring on server side

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -357,8 +357,7 @@ public class VoteAPIHelper {
         c.example = i.getExample();
         c.history = i.getHistory();
         c.isBaselineValue = i.isBaselineValue();
-        c.pClass =
-                i.getPClass(); // it might be better to pass underlying values (not CSS class) to FE
+        c.pClass = i.getCandidateStatus().toString();
         c.rawValue = i.getValue();
         c.tests = getConvertedTests(i.getTests());
         c.value = i.getProcessedValue();


### PR DESCRIPTION
-New enum CandidateStatus, replace String pClass on back end

-Rename getPClass to getCandidateStatus

-Still named pClass in the http response json and the front end

-Remove function getInheritedLocale, which was only called privately and had only one calling function

-Comments; removed some comments on the back end that assumed too much about the front end and might no longer be accurate

CLDR-18376

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
