### PR TITLE
CLDR-18423 st: search box shouldn't fail if not logged in

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/SearchAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/SearchAPI.java
@@ -79,7 +79,7 @@ public class SearchAPI {
             @RequestBody(required = true) SearchRequest request) {
         final CookieSession mySession = Auth.getSession(session);
         // User must be logged in to use query function
-        if (mySession == null || mySession.user == null) {
+        if (mySession == null) {
             return Auth.noSessionResponse();
         }
 
@@ -115,7 +115,7 @@ public class SearchAPI {
             @PathParam("token") String token, @HeaderParam(Auth.SESSION_HEADER) String session) {
         final CookieSession mySession = Auth.getSession(session);
         // User must be logged in to use query function
-        if (mySession == null || mySession.user == null) {
+        if (mySession == null) {
             return Auth.noSessionResponse();
         }
 
@@ -140,7 +140,7 @@ public class SearchAPI {
             @PathParam("token") String token, @HeaderParam(Auth.SESSION_HEADER) String session) {
         final CookieSession mySession = Auth.getSession(session);
         // User must be logged in to use query function
-        if (mySession == null || mySession.user == null) {
+        if (mySession == null) {
             return Auth.noSessionResponse();
         }
 


### PR DESCRIPTION
- the search API was behind a check for a valid logged in user. this is probably not necessary.
- remove the check for now.

Note. this doesn't make any improvements, just unbreaks the search panel.

Another note: a _session_ is still required.  So you can't just hit a certain URL and cause a search to happen, it has to be a browser user (or someone sophisticated enough to use the REST API)

CLDR-18423

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
