### PR TITLE
CLDR-18423 st: search: improvements to search and tests

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSearch.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSearch.mjs
@@ -79,7 +79,7 @@ class SearchClient {
     const client = await this.client;
     const { body } = await client.apis.search.newSearch(
       {
-        locale: cldrStatus.getCurrentLocale(), // TODO: || 'und'?
+        locale: cldrStatus.getCurrentLocale() || "en", // search in English if not specified.
       },
       {
         requestBody: {

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSearchManager.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSearchManager.java
@@ -1,12 +1,19 @@
 package org.unicode.cldr.web;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.web.SearchManager.SearchRequest;
@@ -14,14 +21,114 @@ import org.unicode.cldr.web.SearchManager.SearchResponse;
 import org.unicode.cldr.web.SearchManager.SearchResult;
 
 public class TestSearchManager {
+    private static SearchManager mgr;
+
+    @BeforeAll
+    private static void setup() {
+        mgr = SearchManager.forFactory(CLDRConfig.getInstance().getCldrFactory());
+    }
+
+    @AfterAll
+    private static void teardown() throws IOException {
+        mgr.close();
+    }
+
     @Test
     void TestMaltese() throws InterruptedException {
-        // Create a SearchManager over disk files
-        SearchManager mgr = SearchManager.forFactory(CLDRConfig.getInstance().getCldrFactory());
-        assertNotNull(mgr);
+        final String XPATH =
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"3\"]";
+        final String searchText = "Marzu";
+        final String locale = "mt";
 
-        SearchRequest request = new SearchRequest("Marzu");
-        final SearchResponse r0 = mgr.newSearch(request, "mt");
+        testOneSearchResult(XPATH, searchText, locale, locale);
+    }
+
+    @Test
+    void TestEnglish() throws InterruptedException {
+        final String XPATH =
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"3\"]";
+        final String searchText = "March";
+        final String locale = "en";
+
+        // should be found in English
+        assertAll(
+                () -> testOneSearchResult(XPATH, searchText, "en", locale),
+                // should be found even if we try in a different locale
+                () -> testOneSearchResult(XPATH, searchText, "mt", locale));
+    }
+
+    @Test
+    void TestCode() throws InterruptedException {
+        final String XPATH = "//ldml/localeDisplayNames/scripts/script[@type=\"Gujr\"]";
+        final String searchText = "Gujr";
+        final String locale = "ar";
+        assertAll(
+                "looking for " + searchText + " in " + locale,
+                () ->
+                        testOneSearchResult(
+                                XPATH,
+                                searchText,
+                                locale,
+                                locale,
+                                "code: " + searchText), // should match in the locale
+                () ->
+                        testOneSearchResult(
+                                XPATH,
+                                searchText.substring(0, 3),
+                                locale,
+                                locale,
+                                "code: " + searchText) // should match with a partial string
+                );
+    }
+
+    @Test
+    void TestKorean() throws InterruptedException {
+        final String XPATH =
+                "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"3\"]";
+        final String searchText = "3월";
+        final String locale = "ko";
+
+        assertAll(
+                () -> testOneSearchResult(XPATH, searchText, locale, locale),
+                () -> testNoResult("3월3월", "ko"));
+    }
+
+    private void testOneSearchResult(
+            final String XPATH,
+            final String searchText,
+            final String locale,
+            final String resultLocale)
+            throws InterruptedException {
+        testOneSearchResult(XPATH, searchText, locale, resultLocale, searchText);
+    }
+
+    private void testOneSearchResult(
+            final String XPATH,
+            final String searchText,
+            final String locale,
+            final String resultLocale,
+            final String expectContext)
+            throws InterruptedException {
+        final Set<SearchResult> r =
+                ImmutableSet.of(new SearchResult(XPATH, expectContext, resultLocale));
+
+        testSearchResult(searchText, locale, r);
+    }
+
+    private void testNoResult(final String searchText, final String locale)
+            throws InterruptedException {
+        testSearchResult(searchText, locale, Collections.emptySet());
+    }
+
+    private void testSearchResult(
+            final String searchText, final String locale, Set<SearchResult> expected)
+            throws InterruptedException {
+        // Create a SearchManager over disk files
+        assertNotNull(mgr);
+        final String searchContext = searchText + " in " + locale;
+
+        SearchRequest request = new SearchRequest(searchText);
+        final SearchResponse r0 = mgr.newSearch(request, locale);
         assertNotNull(r0);
         assertNotNull(r0.token);
         // can't assume it has not already completed.
@@ -37,26 +144,46 @@ public class TestSearchManager {
             // OK, no longer ongoing
             assertTrue(r1.isComplete);
             assertFalse(r1.isOngoing);
-            SearchResult[] results = r1.getResults();
-            assertNotNull(results);
-            assertTrue(results.length >= 1, () -> "Expected >=1 result, got " + results.length);
-            int foundFormat = 0;
-            for (final SearchResult result : results) {
-                if (result.xpstrid.equals("1c7bd76a22b7472f")) {
-                    foundFormat++;
-                    assertEquals(
-                            result.xpath,
-                            "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"3\"]");
-                    assertEquals(result.xpstrid, "1c7bd76a22b7472f");
-                    assertEquals(result.locale, "mt");
-                    assertEquals(result.context, request.value);
-                } else {
-                    assertNotEquals(
-                            result.xpath,
-                            "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/months/monthContext[@type=\"format\"]/monthWidth[@type=\"wide\"]/month[@type=\"3\"]");
+            assertNotNull(r1.getResults());
+            final Set<SearchResult> results = new TreeSet<SearchResult>();
+            for (final SearchResult result : r1.getResults()) {
+                results.add(result);
+            }
+            if (expected.isEmpty()) {
+                assertEquals(
+                        0,
+                        results.size(),
+                        () -> "Expected no results looking for " + searchContext);
+            } else {
+                assertTrue(
+                        results.size() >= 1,
+                        () ->
+                                "Expected >=1 result, got "
+                                        + results.size()
+                                        + " looking for "
+                                        + searchContext);
+                for (final SearchResult result : expected) {
+                    assertTrue(
+                            results.contains(result),
+                            () ->
+                                    "Did not find result "
+                                            + result
+                                            + " looking for "
+                                            + searchContext
+                                            + " - matches= "
+                                            + results);
                 }
             }
-            assertEquals(1, foundFormat, "Expect to find exactly 1 xpath 1c7bd76a22b7472f");
+
+            // if there's only one, do an exact comparison
+            if (results.size() == 1 && expected.size() == 1) {
+                final SearchResult expectedResult = expected.iterator().next();
+                final SearchResult foundResult = results.iterator().next();
+                assertEquals(expectedResult.xpath, foundResult.xpath);
+                assertEquals(expectedResult.xpstrid, foundResult.xpstrid);
+                assertEquals(expectedResult.locale, foundResult.locale);
+                assertEquals(expectedResult.context, foundResult.context);
+            }
 
             // delete the query
             assertTrue(mgr.deleteSearch(r1.token));
@@ -66,7 +193,11 @@ public class TestSearchManager {
             return;
         }
         throw new RuntimeException(
-                "Patience exceeded for query " + r0.token + " - did not complete in time.");
+                "Patience exceeded for query "
+                        + r0.token
+                        + " - "
+                        + searchContext
+                        + " - did not complete in time.");
     }
 
     @Test


### PR DESCRIPTION
Add new searches
- search by code
- search by parent locale
- search by xpath

Also:
- if the user is in say a top page, pass in 'en' as the current locale- this will let them search the 'baseline' content. Prevents error when searching from the main page.

Behind the scenes:
- refactor for testability
- update tests

CLDR-18423

Yes it should be using a search collator..

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
