### PR TITLE
CLDR-17570 Fix a warning on rationals

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,2 @@
+/fixedcandidates/
+/org/

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,0 @@
-/fixedcandidates/
-/org/

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5212,7 +5212,7 @@ annotations.
 		<rationalFormats numberSystem="latn">
 			<rationalPattern>{0}⁄{1}</rationalPattern>
 			<integerAndRationalPattern>{0}&#x202F;{1}</integerAndRationalPattern>
-			<integerAndRationalPattern alt="superSub">{0}&#x200b;{1}</integerAndRationalPattern>
+			<integerAndRationalPattern alt="superSub">{0}&#x2060;{1}</integerAndRationalPattern>
 			<rationalUsage>sometimes</rationalUsage>
 		</rationalFormats>
 		<scientificFormats numberSystem="latn">

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3950,7 +3950,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<rationalFormats numberSystem="latn">
 			<rationalPattern>{0}⁄{1}</rationalPattern>
 			<integerAndRationalPattern>{0}&#x202F;{1}</integerAndRationalPattern>
-			<integerAndRationalPattern alt="superSub">{0}&#x200b;{1}</integerAndRationalPattern>
+			<integerAndRationalPattern alt="superSub">{0}&#x2060;{1}</integerAndRationalPattern>
 			<rationalUsage>sometimes</rationalUsage>
 		</rationalFormats>
 		<rationalFormats numberSystem="adlm">

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -55,7 +55,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
             new UnicodeSet("[\\u061C\\u200E\\u200F]").freeze();
 
     public static final UnicodeSet ILLEGAL_RTL_CONTROLS =
-            new UnicodeSet("[\\u202A-\\u202E\\u2066-\\u2069]");
+            new UnicodeSet("[\\u202A-\\u202E\\u2066-\\u2069]").freeze();
 
     public static final UnicodeSet LB_JOIN_CONTROLS = new UnicodeSet("[\\u200B\\u2060]").freeze();
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForExemplars.java
@@ -51,12 +51,15 @@ import org.unicode.cldr.util.XMLSource;
 import org.unicode.cldr.util.XPathParts;
 
 public class CheckForExemplars extends FactoryCheckCLDR {
-    private static final UnicodeSet RTL_CONTROLS = new UnicodeSet("[\\u061C\\u200E\\u200F]");
+    public static final UnicodeSet RTL_CONTROLS =
+            new UnicodeSet("[\\u061C\\u200E\\u200F]").freeze();
 
-    private static final UnicodeSet ILLEGAL_RTL_CONTROLS =
+    public static final UnicodeSet ILLEGAL_RTL_CONTROLS =
             new UnicodeSet("[\\u202A-\\u202E\\u2066-\\u2069]");
 
-    private static final UnicodeSet RTL = new UnicodeSet("[[:bc=AL:][:bc=R:]]");
+    public static final UnicodeSet LB_JOIN_CONTROLS = new UnicodeSet("[\\u200B\\u2060]").freeze();
+
+    public static final UnicodeSet RTL = new UnicodeSet("[[:bc=AL:][:bc=R:]]").freeze();
 
     private static final String STAND_IN = "#";
 
@@ -264,7 +267,7 @@ public class CheckForExemplars extends FactoryCheckCLDR {
             exemplars.add(STAND_IN);
         }
 
-        exemplars.addAll(CheckExemplars.AlwaysOK).freeze();
+        exemplars.addAll(CheckExemplars.AlwaysOK).addAll(LB_JOIN_CONTROLS).freeze();
         exemplarsPlusAscii = new UnicodeSet(exemplars).addAll(ASCII).freeze();
 
         skip = false;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -20,15 +20,19 @@ public enum CodePointEscaper {
     TAB(9, "tab"),
     LF(0xA, "line feed"),
     CR(0xD, "carriage return"),
+
+    // Spaces
     SP(0x20, "space", "ASCII space"),
     TSP(0x2009, "thin space", "Aka ‘narrow space’"),
-    NBSP(0xA0, "no-break space", "Same as space, but doesn’t line wrap."),
 
+    // No-break versions
+    NBSP(0xA0, "no-break space", "Same as space, but doesn’t line wrap."),
     NBTSP(
             0x202F,
             "no-break thin space",
             "Same as thin space, but doesn’t line wrap. Aka 'narrow no-break space'"),
 
+    // Line Break control
     WNJ(
             0x200B,
             "allow line wrap after, aka ZWSP",
@@ -73,6 +77,13 @@ public enum CodePointEscaper {
     ESCS('❰', "escape start", "heavy open angle bracket"),
     ESCE('❱', "escape end", "heavy close angle bracket");
 
+    // Alternates: Thin vs Narrow, order of NB vs those
+    public static final CodePointEscaper NSP = TSP;
+    public static final CodePointEscaper NBNSP = NBTSP;
+    public static final CodePointEscaper NNBSP = NBTSP;
+    public static final CodePointEscaper TNBSP = NBTSP;
+    public static final CodePointEscaper ZWSP = WNJ;
+
     public static final char RANGE_SYNTAX = (char) RANGE.getCodePoint();
     public static final char ESCAPE_START = (char) ESCS.getCodePoint();
     public static final char ESCAPE_END = (char) ESCE.getCodePoint();
@@ -100,7 +111,7 @@ public enum CodePointEscaper {
             new UnicodeSet("[\\uFE0F\\U000E0020-\\U000E007F]").freeze();
 
     public static final UnicodeSet FORCE_ESCAPE =
-            new UnicodeSet("[[:DI:][:Pat_WS:][:WSpace:][:C:][:Z:]\u200B]")
+            new UnicodeSet("[[:DI:][:Pat_WS:][:WSpace:][:C:][:Z:]\u200B\u2060]")
                     .addAll(getNamedEscapes())
                     .removeAll(EMOJI_INVISIBLES)
                     .freeze();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -2309,7 +2309,7 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "en",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"latn\"]/integerAndRationalPattern[@alt=\"superSub\"]",
-                "〖❬3❭❰WNJ❱❬½❭〗〖❬3❭❰WNJ❱❬<sup>1</sup>⁄<sub>2</sub>❭〗"
+                "〖❬3❭❰WJ❱❬½❭〗〖❬3❭❰WJ❱❬<sup>1</sup>⁄<sub>2</sub>❭〗"
             },
             {"en", "//ldml/numbers/rationalFormats[@numberSystem=\"latn\"]/rationalUsage", null},
             {
@@ -2325,7 +2325,7 @@ public class TestExampleGenerator extends TestFmwk {
             {
                 "hi",
                 "//ldml/numbers/rationalFormats[@numberSystem=\"deva\"]/integerAndRationalPattern[@alt=\"superSub\"]",
-                "〖❬३❭❰WNJ❱❬<sup>१</sup>⁄<sub>२</sub>❭〗"
+                "〖❬३❭❰WJ❱❬<sup>१</sup>⁄<sub>२</sub>❭〗"
             },
             {"hi", "//ldml/numbers/rationalFormats[@numberSystem=\"deva\"]/rationalUsage", null},
         };


### PR DESCRIPTION
CLDR-17570

- [ ] This PR completes the ticket.
Fixed a warning on \u200b. But then noticed that some other things needed fixing.

- Need to use WJ (2060) instead, to avoid linebreaks within 3½.
- Needed to _not_ warn on either WJ or ZWSP.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
