### PR TITLE
CLDR-18251 Remove number symbols and xxxFormats without numberSystem from root,en

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -2277,7 +2277,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@DEPRECATED-->
 
 <!ELEMENT rationalFormats ( alias | ( rationalPattern*,  integerAndRationalPattern*, rationalUsage*, special* ) ) >
-<!ATTLIST rationalFormats numberSystem CDATA #IMPLIED >
+<!ATTLIST rationalFormats numberSystem CDATA #REQUIRED >
     <!--@MATCH:bcp47/nu-->
 
 <!ELEMENT rationalPattern ( #PCDATA ) >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5209,12 +5209,6 @@ annotations.
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
-		<rationalFormats>
-			<rationalPattern>{0}⁄{1}</rationalPattern>
-			<integerAndRationalPattern>{0}&#x202F;{1}</integerAndRationalPattern>
-			<integerAndRationalPattern alt="superSub">{0}&#x200b;{1}</integerAndRationalPattern>
-			<rationalUsage>sometimes</rationalUsage>
-		</rationalFormats>
 		<rationalFormats numberSystem="latn">
 			<rationalPattern>{0}⁄{1}</rationalPattern>
 			<integerAndRationalPattern>{0}&#x202F;{1}</integerAndRationalPattern>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -3426,9 +3426,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<native>latn</native>
 		</otherNumberingSystems>
 		<minimumGroupingDigits>1</minimumGroupingDigits>
-		<symbols>
-			<alias source="locale" path="../symbols[@numberSystem='latn']"/>
-		</symbols>
 		<symbols numberSystem="adlm">
 			<alias source="locale" path="../symbols[@numberSystem='latn']"/>
 		</symbols>
@@ -3696,9 +3693,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<symbols numberSystem="wcho">
 			<alias source="locale" path="../symbols[@numberSystem='latn']"/>
 		</symbols>
-		<decimalFormats>
-			<alias source="locale" path="../decimalFormats[@numberSystem='latn']"/>
-		</decimalFormats>
 		<decimalFormats numberSystem="adlm">
 			<alias source="locale" path="../decimalFormats[@numberSystem='latn']"/>
 		</decimalFormats>
@@ -3959,9 +3953,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<integerAndRationalPattern alt="superSub">{0}&#x200b;{1}</integerAndRationalPattern>
 			<rationalUsage>sometimes</rationalUsage>
 		</rationalFormats>
-		<rationalFormats>
-			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
-		</rationalFormats>
 		<rationalFormats numberSystem="adlm">
 			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
 		</rationalFormats>
@@ -4190,9 +4181,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<rationalFormats numberSystem="wcho">
 			<alias source="locale" path="../rationalFormats[@numberSystem='latn']"/>
 		</rationalFormats>
-		<scientificFormats>
-			<alias source="locale" path="../scientificFormats[@numberSystem='latn']"/>
-		</scientificFormats>
 		<scientificFormats numberSystem="adlm">
 			<alias source="locale" path="../scientificFormats[@numberSystem='latn']"/>
 		</scientificFormats>
@@ -4428,9 +4416,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<scientificFormats numberSystem="wcho">
 			<alias source="locale" path="../scientificFormats[@numberSystem='latn']"/>
 		</scientificFormats>
-		<percentFormats>
-			<alias source="locale" path="../percentFormats[@numberSystem='latn']"/>
-		</percentFormats>
 		<percentFormats numberSystem="adlm">
 			<alias source="locale" path="../percentFormats[@numberSystem='latn']"/>
 		</percentFormats>
@@ -4670,9 +4655,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<percentFormats numberSystem="wcho">
 			<alias source="locale" path="../percentFormats[@numberSystem='latn']"/>
 		</percentFormats>
-		<currencyFormats>
-			<alias source="locale" path="../currencyFormats[@numberSystem='latn']"/>
-		</currencyFormats>
 		<currencyFormats numberSystem="adlm">
 			<alias source="locale" path="../currencyFormats[@numberSystem='latn']"/>
 		</currencyFormats>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCMonetary.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCMonetary.java
@@ -45,7 +45,7 @@ public class POSIX_LCMonetary {
 
         String grouping_pattern =
                 doc.getWinningValue(
-                        "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type='standard']/pattern[@type='standard']");
+                        "//ldml/numbers/currencyFormats[@numberSystem='latn']/currencyFormatLength/currencyFormat[@type='standard']/pattern[@type='standard']");
 
         String[] monetary_formats = new String[2];
         if (grouping_pattern.indexOf(";") > 0) monetary_formats = grouping_pattern.split(";", 2);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCNumeric.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/posix/POSIX_LCNumeric.java
@@ -30,7 +30,9 @@ public class POSIX_LCNumeric {
                                 "//ldml/numbers/symbols[@numberSystem='" + numsys + "']/group"));
         String grouping_pattern =
                 doc.getWinningValue(
-                        "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type='standard']/pattern[@type='standard']");
+                        "//ldml/numbers/decimalFormats[@numberSystem='"
+                                + numsys
+                                + "']/decimalFormatLength/decimalFormat[@type='standard']/pattern[@type='standard']");
 
         grouping = POSIXUtilities.POSIXGrouping(grouping_pattern);
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CLDRTest.java
@@ -131,9 +131,9 @@ public class CLDRTest extends TestFmwk {
     /** Check to make sure that the currency formats are kosher. */
     public void TestCurrencyFormats() {
         // String decimal =
-        // "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"standard\"]/";
+        // "//ldml/numbers/decimalFormats[@numberSystem=\"latn\"]/decimalFormatLength/decimalFormat[@type=\"standard\"]/";
         // String currency =
-        // "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"standard\"]/";
+        // "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength/currencyFormat[@type=\"standard\"]/";
         for (String locale : locales) {
             boolean isPOSIX = locale.indexOf("POSIX") >= 0;
             logln("Testing: " + locale);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -938,7 +938,8 @@ public abstract class CheckCLDR implements CheckAccessor {
             illegalAnnotationCode,
             nullOrEmptyValue,
             ttsAnnotationMissing,
-            illegalCharacter;
+            illegalCharacter,
+            missingNumberingSystem;
 
             @Override
             public String toString() {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckNumbers.java
@@ -233,12 +233,39 @@ public class CheckNumbers extends FactoryCheckCLDR {
             }
         }
 
-        // quick bail from all other cases
+        // Check that symbols are for an explicit number system;
+        // note that symbols are skipped for checks after this point.
+        if (path.indexOf("/symbols") >= 0) {
+            XPathParts symbolParts = XPathParts.getFrozenInstance(path);
+            if (symbolParts.getAttributeValue(2, "numberSystem") == null) {
+                result.add(
+                        new CheckStatus()
+                                .setCause(this)
+                                .setMainType(CheckStatus.errorType)
+                                .setSubtype(Subtype.missingNumberingSystem)
+                                .setMessage(
+                                        "Symbols must have an explicit numberSystem attribute."));
+            }
+        }
+
+        // quick bail from all other cases (including symbols)
         NumericType type = NumericType.getNumericType(path);
         if (type == NumericType.NOT_NUMERIC || type == NumericType.RATIONAL) {
             return this; // skip
         }
         XPathParts parts = XPathParts.getFrozenInstance(path);
+
+        // Check that number formats are for an explicit number system.
+        String numberSystem = parts.getAttributeValue(2, "numberSystem");
+        if (numberSystem == null) {
+            result.add(
+                    new CheckStatus()
+                            .setCause(this)
+                            .setMainType(CheckStatus.errorType)
+                            .setSubtype(Subtype.missingNumberingSystem)
+                            .setMessage(
+                                    "Number formats must have an explicit numberSystem attribute."));
+        }
 
         boolean isPositive = true;
         for (String patternPart : SEMI_SPLITTER.split(value)) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleDependencies.java
@@ -8,23 +8,86 @@ public class ExampleDependencies {
             new ImmutableSetMultimap.Builder<String, String>()
                     .putAll(
                             "//ldml/characterLabels/characterLabelPattern[@type=\"*\"]",
-                            "//ldml/characterLabels/characterLabel[@type=\"*\"]")
+                            "//ldml/characterLabels/characterLabel[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/characterLabels/characterLabelPattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/characterLabels/characterLabel[@type=\"*\"]",
-                            "//ldml/characterLabels/characterLabelPattern[@type=\"*\"]")
+                            "//ldml/characterLabels/characterLabelPattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/characters/ellipsis[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/characters/exemplarCharacters",
-                            "//ldml/characters/exemplarCharacters[@type=\"*\"]")
+                            "//ldml/characters/exemplarCharacters[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/characters/exemplarCharacters[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/characters/moreInformation",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/characters/parseLenients[@scope=\"*\"][@level=\"*\"]/parseLenient[@sample=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/contextTransforms/contextTransformUsage[@type=\"*\"]/contextTransform[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/cyclicNameSets/cyclicNameSet[@type=\"*\"]/cyclicNameContext[@type=\"*\"]/cyclicNameWidth[@type=\"*\"]/cyclicName[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/datetimeSkeleton",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]")
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/appendItems/appendItem[@request=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
-                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"*\"][@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatFallback",
-                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]")
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -38,8 +101,20 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
@@ -51,8 +126,12 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/days/dayContext[@type=\"*\"]/dayWidth[@type=\"*\"]/day[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -66,8 +145,20 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
@@ -79,8 +170,12 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/days/dayContext[@type=\"*\"]/dayWidth[@type=\"*\"]/day[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -94,8 +189,20 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
@@ -107,8 +214,12 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -122,8 +233,20 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
@@ -135,8 +258,24 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/monthPatterns/monthPatternContext[@type=\"*\"]/monthPatternWidth[@type=\"*\"]/monthPattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -150,9 +289,21 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/monthPatterns/monthPatternContext[@type=\"*\"]/monthPatternWidth[@type=\"*\"]/monthPattern[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
@@ -164,8 +315,12 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -179,8 +334,20 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id=\"*\"]/greatestDifference[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dayPeriods/dayPeriodContext[@type=\"*\"]/dayPeriodWidth[@type=\"*\"]/dayPeriod[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraAbbr/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNames/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/eras/eraNarrow/era[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/months/monthContext[@type=\"*\"]/monthWidth[@type=\"*\"]/month[@type=\"*\"][@yeartype=\"*\"]",
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/quarters/quarterContext[@type=\"*\"]/quarterWidth[@type=\"*\"]/quarter[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
@@ -192,8 +359,15 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
                             "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/datetimeSkeleton",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/datetimeSkeleton[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/appendItems/appendItem[@request=\"*\"]",
@@ -206,74 +380,147 @@ public class ExampleDependencies {
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/short/standard",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/fields/field[@type=\"*\"]/displayName",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/fields/field[@type=\"*\"]/displayName[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativePeriod",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/fields/field[@type=\"*\"]/relativeTime[@type=\"*\"]/relativeTimePattern[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/fields/field[@type=\"*\"]/relative[@type=\"*\"]",
-                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]")
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/dateTimeFormatLength[@type=\"*\"]/dateTimeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/fallbackFormat",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/gmtUnknownFormat",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/gmtZeroFormat",
-                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/appendItems/appendItem[@request=\"*\"]")
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/appendItems/appendItem[@request=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/hourFormat",
                             "//ldml/dates/timeZoneNames/gmtFormat",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/daylight",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/generic",
-                            "//ldml/dates/timeZoneNames/fallbackFormat")
+                            "//ldml/dates/timeZoneNames/fallbackFormat",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/long/standard",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/short/daylight",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/short/generic",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/metazone[@type=\"*\"]/short/standard",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/regionFormat",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/regionFormat[@type=\"*\"]",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/exemplarCity",
                             "//ldml/dates/timeZoneNames/fallbackFormat",
                             "//ldml/dates/timeZoneNames/regionFormat",
-                            "//ldml/dates/timeZoneNames/regionFormat[@type=\"*\"]")
+                            "//ldml/dates/timeZoneNames/regionFormat[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/exemplarCity[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/long/daylight",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/long/standard",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/short/daylight",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/short/generic",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/dates/timeZoneNames/zone[@type=\"*\"]/short/standard",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/delimiters/alternateQuotationEnd",
                             "//ldml/delimiters/alternateQuotationStart",
                             "//ldml/delimiters/quotationEnd",
-                            "//ldml/delimiters/quotationStart")
+                            "//ldml/delimiters/quotationStart",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/delimiters/alternateQuotationStart",
                             "//ldml/delimiters/alternateQuotationEnd",
                             "//ldml/delimiters/quotationEnd",
-                            "//ldml/delimiters/quotationStart")
+                            "//ldml/delimiters/quotationStart",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/delimiters/quotationEnd",
                             "//ldml/delimiters/alternateQuotationEnd",
                             "//ldml/delimiters/alternateQuotationStart",
-                            "//ldml/delimiters/quotationStart")
+                            "//ldml/delimiters/quotationStart",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/delimiters/quotationStart",
                             "//ldml/delimiters/alternateQuotationEnd",
                             "//ldml/delimiters/alternateQuotationStart",
-                            "//ldml/delimiters/quotationEnd")
+                            "//ldml/delimiters/quotationEnd",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/layout/orientation/characterOrder",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/layout/orientation/lineOrder",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/listPatterns/listPattern/listPatternPart[@type=\"*\"]",
-                            "//ldml/listPatterns/listPattern/listPatternPart[@type=\"*\"]")
+                            "//ldml/listPatterns/listPattern/listPatternPart[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
-                            "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]")
+                            "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/codePatterns/codePattern[@type=\"*\"]",
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
@@ -281,14 +528,15 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"]",
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
-                            "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/keys/key[@type=\"*\"]",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
-                            "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
@@ -297,17 +545,19 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]")
+                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
-                            "//ldml/localeDisplayNames/languages/language[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/localeDisplayNames/languages/language[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
-                            "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
-                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]")
+                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
@@ -318,7 +568,8 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]")
+                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
@@ -329,7 +580,11 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]")
+                            "//ldml/personNames/nameOrderLocales[@order=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/localeDisplayNames/measurementSystemNames/measurementSystemName[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"]",
                             "//ldml/localeDisplayNames/languages/language[@type=\"*\"]",
@@ -338,11 +593,16 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
-                            "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"]",
-                            "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/localeDisplayNames/subdivisions/subdivision[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
                             "//ldml/characterLabels/characterLabelPattern[@type=\"*\"]",
@@ -358,11 +618,13 @@ public class ExampleDependencies {
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
                             "//ldml/localeDisplayNames/scripts/script[@type=\"*\"]",
-                            "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/localeDisplayNames/scripts/script[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/localeDisplayNames/territories/territory[@type=\"*\"]",
-                            "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/localeDisplayNames/territories/territory[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/localeDisplayNames/types/type[@key=\"*\"][@type=\"*\"]",
                             "//ldml/delimiters/alternateQuotationEnd",
@@ -371,51 +633,51 @@ public class ExampleDependencies {
                             "//ldml/delimiters/quotationStart",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern",
                             "//ldml/localeDisplayNames/localeDisplayPattern/localePattern",
-                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator")
+                            "//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/localeDisplayNames/types/type[@key=\"*\"][@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/localeDisplayNames/variants/variant[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/localeDisplayNames/variants/variant[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/decimal",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]")
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]")
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]")
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/group",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/grouping",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
@@ -426,90 +688,85 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]")
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]")
-                    .putAll(
-                            "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/currencyMatch",
-                            "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyPatternAppendISO",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencySpacing/afterCurrency/currencyMatch",
+                            "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -519,51 +776,41 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/insertBetween",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencySpacing/afterCurrency/insertBetween",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -573,51 +820,41 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/surroundingMatch",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencySpacing/afterCurrency/surroundingMatch",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -627,51 +864,41 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/currencyMatch",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencySpacing/beforeCurrency/currencyMatch",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -681,51 +908,41 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/insertBetween",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencySpacing/beforeCurrency/insertBetween",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -735,51 +952,41 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/surroundingMatch",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencySpacing/beforeCurrency/surroundingMatch",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -789,26 +996,26 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]")
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
+                            "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -817,6 +1024,9 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/perUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
+                    .putAll(
+                            "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/defaultNumberingSystem",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -830,32 +1040,17 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
+                            "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -865,73 +1060,101 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
+                            "//ldml/numbers/defaultNumberingSystem[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
-                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign")
+                            "//ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
+                            "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/minimumGroupingDigits",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/otherNumberingSystems/finance",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/otherNumberingSystems/native",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/otherNumberingSystems/traditional",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
-                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent")
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/approximatelySign")
-                    .putAll("//ldml/numbers/symbols/percentSign", "//ldml/numbers/symbols/perMille")
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/currencyDecimal",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -946,46 +1169,36 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1000,45 +1213,35 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1048,50 +1251,43 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .putAll(
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1106,45 +1302,35 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1153,52 +1339,45 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/perUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
+                    .putAll(
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/infinity",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1213,46 +1392,36 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1267,45 +1436,35 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1320,46 +1479,36 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1374,45 +1523,35 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1427,45 +1566,35 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/plusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1480,45 +1609,35 @@ public class ExampleDependencies {
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/displayName[@count=\"*\"]",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol",
                             "//ldml/numbers/currencies/currency[@type=\"*\"]/symbol[@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
-                            "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
-                            "//ldml/numbers/currencyFormats/unitPattern[@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/currencyFormatLength[@type=\"*\"]/currencyFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"][@alt=\"*\"]",
                             "//ldml/numbers/currencyFormats[@numberSystem=\"*\"]/unitPattern[@count=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/decimalFormats/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/decimalFormats[@numberSystem=\"*\"]/decimalFormatLength[@type=\"*\"]/decimalFormat[@type=\"*\"]/pattern[@type=\"*\"][@count=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\"*\"]",
                             "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\"*\"]",
+                            "//ldml/numbers/minimumGroupingDigits",
                             "//ldml/numbers/miscPatterns[@numberSystem=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
                             "//ldml/numbers/percentFormats[@numberSystem=\"*\"]/percentFormatLength/percentFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/integerAndRationalPattern[@alt=\"*\"]",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalPattern",
+                            "//ldml/numbers/rationalFormats[@numberSystem=\"*\"]/rationalUsage",
                             "//ldml/numbers/scientificFormats[@numberSystem=\"*\"]/scientificFormatLength/scientificFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/numbers/symbols/approximatelySign",
-                            "//ldml/numbers/symbols/decimal",
-                            "//ldml/numbers/symbols/exponential",
-                            "//ldml/numbers/symbols/group",
-                            "//ldml/numbers/symbols/minusSign",
-                            "//ldml/numbers/symbols/perMille",
-                            "//ldml/numbers/symbols/percentSign",
-                            "//ldml/numbers/symbols/plusSign",
-                            "//ldml/numbers/symbols/superscriptingExponent",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/approximatelySign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/decimal[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/exponential",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/group",
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/group[@alt=\"*\"]",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/minusSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/perMille",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/percentSign",
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1527,6 +1646,9 @@ public class ExampleDependencies {
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/perUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
+                    .putAll(
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/superscriptingExponent",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/numbers/symbols[@numberSystem=\"*\"]/timeSeparator",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateFormats/dateFormatLength[@type=\"*\"]/dateFormat[@type=\"*\"]/pattern[@type=\"*\"]",
@@ -1535,7 +1657,11 @@ public class ExampleDependencies {
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"*\"][@alt=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\"*\"][@count=\"*\"]",
                             "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"]",
-                            "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]")
+                            "//ldml/dates/calendars/calendar[@type=\"*\"]/timeFormats/timeFormatLength[@type=\"*\"]/timeFormat[@type=\"*\"]/pattern[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/numbers/symbols[@numberSystem=\"*\"]/timeSeparator[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/personNames/foreignSpaceReplacement",
                             "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
@@ -1561,18 +1687,78 @@ public class ExampleDependencies {
                             "//ldml/personNames/sampleName[@item=\"*\"]/nameField[@type=\"*\"]",
                             "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
+                            "//ldml/posix/messages/nostr",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/posix/messages/yesstr",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/typographicNames/axisName[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/typographicNames/featureName[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/typographicNames/featureName[@type=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/typographicNames/styleName[@type=\"*\"][@subtype=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/typographicNames/styleName[@type=\"*\"][@subtype=\"*\"][@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/durationUnit[@type=\"*\"]/durationUnitPattern[@alt=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@gender=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@gender=\"*\"][@case=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/unitPrefixPattern",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/coordinateUnit/coordinateUnitPattern[@type=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/coordinateUnit/displayName",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/displayName",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/unitPrefixPattern")
                     .putAll(
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/gender",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
-                            "//ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"*\"]")
+                            "//ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
+                    .putAll(
+                            "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/perUnitPattern",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern")
                     .putAll(
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/listPatterns/listPattern[@type=\"*\"]/listPatternPart[@type=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/genderMinimalPairs[@gender=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/compoundUnit[@type=\"*\"]/compoundUnitPattern1[@count=\"*\"][@case=\"*\"]",
@@ -1582,6 +1768,7 @@ public class ExampleDependencies {
                     .putAll(
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]",
                             "//ldml/numbers/minimalPairs/caseMinimalPairs[@case=\"*\"]",
+                            "//ldml/personNames/personName[@order=\"*\"][@length=\"*\"][@usage=\"*\"][@formality=\"*\"]/namePattern",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"]",
                             "//ldml/units/unitLength[@type=\"*\"]/unit[@type=\"*\"]/unitPattern[@count=\"*\"][@case=\"*\"]")
                     .build();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2345,7 +2345,8 @@ public class ExampleGenerator {
     private String getUnitPattern(String unitType, final boolean isCurrency, Count count) {
         return cldrFile.getStringValue(
                 isCurrency
-                        ? "//ldml/numbers/currencyFormats/unitPattern" + countAttribute(count)
+                        ? "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/unitPattern"
+                                + countAttribute(count)
                         : "//ldml/units/unit[@type=\""
                                 + unitType
                                 + "\"]/unitPattern"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/FlexibleDateFromCLDR.java
@@ -136,7 +136,7 @@ class FlexibleDateFromCLDR {
      * @param fullPath
      */
     public void checkFlexibles(String path, String value, String fullPath) {
-        if (path.indexOf("numbers/symbols/decimal") >= 0) {
+        if (path.indexOf("numbers/symbols[@numberSystem=\"latn\"]/decimal") >= 0) {
             gen.setDecimal(value);
             return;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/TestMisc.java
@@ -178,7 +178,7 @@ public class TestMisc {
         ExampleGenerator eg = new ExampleGenerator(englishFile, englishFile);
         System.out.println(
                 eg.getHelpHtml(
-                        "//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat[@type=\"standard\"]/pattern[@type=\"standard\"][@draft=\"provisional\"]",
+                        "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength/currencyFormat[@type=\"standard\"]/pattern[@type=\"standard\"][@draft=\"provisional\"]",
                         ""));
         System.out.println(eg.getHelpHtml("/exemplarCharacters", ""));
         System.out.println(eg.getHelpHtml("/calendar/pattern", ""));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -707,7 +707,7 @@ public class ICUServiceBuilder {
             return (DecimalFormat) result.clone();
         }
 
-        String pattern = kind == PATTERN ? key1 : getPattern(key1, kind);
+        String pattern = kind == PATTERN ? key1 : getPattern(key1, kind, numberSystem);
 
         DecimalFormatSymbols symbols = _getDecimalFormatSymbols(numberSystem);
         /*
@@ -868,8 +868,8 @@ public class ICUServiceBuilder {
         }
 
         // currently constants
-        // symbols.setPadEscape(cldrFile.getWinningValueWithBailey("//ldml/numbers/symbols/xxx"));
-        // symbols.setSignificantDigit(cldrFile.getWinningValueWithBailey("//ldml/numbers/symbols/patternDigit"));
+        // symbols.setPadEscape(cldrFile.getWinningValueWithBailey("//ldml/numbers/symbols[@numberSystem=\"latn\"]/xxx"));
+        // symbols.setSignificantDigit(cldrFile.getWinningValueWithBailey("//ldml/numbers/symbols[@numberSystem=\"latn\"]/patternDigit"));
 
         symbols.setDecimalSeparator(getSymbolCharacter("decimal", numberSystem));
         // symbols.setDigit(getSymbolCharacter("patternDigit", numberSystem));
@@ -901,7 +901,8 @@ public class ICUServiceBuilder {
             symbols.setMonetaryGroupingSeparator(symbols.getGroupingSeparator());
         }
 
-        String prefix = "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/";
+        String prefix =
+                "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencySpacing/beforeCurrency/";
         beforeCurrencyMatch =
                 new UnicodeSet(cldrFile.getWinningValueWithBailey(prefix + "currencyMatch"))
                         .freeze();
@@ -909,7 +910,8 @@ public class ICUServiceBuilder {
                 new UnicodeSet(cldrFile.getWinningValueWithBailey(prefix + "surroundingMatch"))
                         .freeze();
         beforeInsertBetween = cldrFile.getWinningValueWithBailey(prefix + "insertBetween");
-        prefix = "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/";
+        prefix =
+                "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencySpacing/afterCurrency/";
         afterCurrencyMatch =
                 new UnicodeSet(cldrFile.getWinningValueWithBailey(prefix + "currencyMatch"))
                         .freeze();
@@ -960,15 +962,21 @@ public class ICUServiceBuilder {
     UnicodeSet afterSurroundingMatch;
     String afterInsertBetween;
 
-    private String getPattern(String key1, int isCurrency) {
+    private String getPattern(String key1, int isCurrency, String numberSystem) {
         String prefix = "//ldml/numbers/";
         String type = key1;
         if (isCurrency == CURRENCY) type = "currency";
         else if (key1.equals("integer")) type = "decimal";
+        if (numberSystem == null) {
+            numberSystem =
+                    cldrFile.getWinningValueWithBailey("//ldml/numbers/defaultNumberingSystem");
+        }
         String path =
                 prefix
                         + type
-                        + "Formats/"
+                        + "Formats[@numberSystem=\""
+                        + numberSystem
+                        + "\"]/"
                         + type
                         + "FormatLength/"
                         + type

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -212,11 +212,6 @@ public class PathDescription {
                     + "Specifies the vertical direction of text in the language. Valid values are \"top-to-bottom\" or \"bottom-to-top\". For more information, see "
                     + CLDRURLS.UNITS_MISC_HELP
                     + ".\n"
-                    + "^//ldml/numbers/symbols/(\\w++)"
-                    + RegexLookup.SEPARATOR
-                    + "The {1} symbol used in the localized form of numbers. Note: before translating, be sure to read "
-                    + CLDRURLS.NUMBERS_HELP
-                    + ".\n"
                     + "^//ldml/numbers/symbols\\[@numberSystem=\"([a-z]*)\"]/(\\w++)"
                     + RegexLookup.SEPARATOR
                     + "The {2} symbol used in the {1} numbering system. NOTE: especially for the decimal and grouping symbol, before translating, be sure to read "
@@ -386,9 +381,9 @@ public class PathDescription {
                     + "[ICU Syntax] Special pattern used to compose duration units. Note: before translating, be sure to read "
                     + CLDRURLS.PLURALS_HELP
                     + ".\n"
-                    + "^//ldml/numbers/decimalFormats/decimalFormatLength\\[@type=\"([^\"]*)\"]/decimalFormat\\[@type=\"([^\"]*)\"]/pattern\\[@type=\"([^\"]*)\"]"
+                    + "^//ldml/numbers/decimalFormats\\[@numberSystem=\"([^\"]*)\"]/decimalFormatLength\\[@type=\"([^\"]*)\"]/decimalFormat\\[@type=\"([^\"]*)\"]/pattern\\[@type=\"([^\"]*)\"]"
                     + RegexLookup.SEPARATOR
-                    + "Special pattern used for a short version of numbers with the same number of digits as {3}. Note: before translating, be sure to read "
+                    + "Special pattern used for a short version of numbers with the same number of digits as {4}. Note: before translating, be sure to read "
                     + CLDRURLS.NUMBERS_SHORT
                     + ".\n"
                     + "^//ldml/numbers/currencyFormats\\[@numberSystem=\"([^\"]*)\"]/currencyFormatLength\\[@type=\"short\"]/currencyFormat\\[@type=\"standard\"]/pattern\\[@type=\"(\\d+)\"]\\[@count=\"([^\"]+)\"]"
@@ -406,11 +401,6 @@ public class PathDescription {
                     + "Special decimal pattern used to obtain the long plural forms of numbers with the same number of digits as {2}. See "
                     + CLDRURLS.NUMBERS_PLURAL
                     + " for details.\n"
-                    + "^//ldml/numbers/currencyFormats/currencyPatternAppendISO"
-                    + RegexLookup.SEPARATOR
-                    + "Pattern used to combine a regular currency format with an ISO 4217 code (¤¤). For more information, please see "
-                    + CLDRURLS.NUMBER_PATTERNS
-                    + ".\n"
                     + "^//ldml/numbers/currencyFormats\\[@numberSystem=\"([^\"]*)\"]/currencyPatternAppendISO"
                     + RegexLookup.SEPARATOR
                     + "Pattern used to combine a regular currency format with an ISO 4217 code (¤¤). For more information, please see "
@@ -553,9 +543,9 @@ public class PathDescription {
                     + "Special pattern used to compose currency values for accounting purposes. Note: before translating, be sure to read "
                     + CLDRURLS.NUMBER_PATTERNS
                     + ".\n"
-                    + "^//ldml/numbers/currencyFormats/currencySpacing/([a-zA-Z]*)/([a-zA-Z]*)"
+                    + "^//ldml/numbers/currencyFormats\\[@numberSystem=\"([^\"]*)\"]/currencySpacing/([a-zA-Z]*)/([a-zA-Z]*)"
                     + RegexLookup.SEPARATOR
-                    + "Special pattern used to compose currency signs ($1/$2) with numbers. Note: before translating, be sure to read "
+                    + "Special pattern used to compose currency signs ($2/$3) with numbers. Note: before translating, be sure to read "
                     + CLDRURLS.NUMBER_PATTERNS
                     + ".\n"
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/xmbSkip.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/xmbSkip.txt
@@ -14,7 +14,7 @@
 
 ^//ldml/characters/exemplarCharacters\[@type="currency"] ;   SKIP
 
-^//ldml/numbers/currencyFormats/currencySpacing ; SKIP
+^//ldml/numbers/currencyFormats\[@numberSystem="latn"]/currencySpacing ; SKIP
 ^//ldml/numbers/defaultNumberingSystem ; SKIP
 ^//ldml/references ; SKIP
 
@@ -40,7 +40,7 @@
 
 # Skip for now, since we can't handle well:
 ^//ldml/numbers/currencies/currency\[@type="([^"]*)"]/displayName\[@count="([^"]*)"] ; SKIP
-^//ldml/numbers/currencyFormats/unitPattern\[@count="([^"]*)"]  ;   SKIP
+^//ldml/numbers/currencyFormatss\[@numberSystem="latn"]/unitPattern\[@count="([^"]*)"]  ;   SKIP
 
 # /calendar.*/dayPeriod.*\@alt   ;   SKIP
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -203,9 +203,7 @@
 ^//ldml/characterLabels/characterLabelPattern\[@type="%A"][@count="%A"] ; {0}=COUNT 3
 ^//ldml/characterLabels/characterLabelPattern\[@type="%A"] ; {0}=CATEGORY_TYPE animal or nature
 
-^//ldml/numbers/currencyFormats/unitPattern ; {0}=NUMBER 3; {1}=CURRENCY_NAME Dollars
 ^//ldml/numbers/currencyFormats\[@numberSystem="%A"]/unitPattern ; {0}=NUMBER 3; {1}=CURRENCY_NAME Dollars
-^//ldml/numbers/currencyFormats/currencyPatternAppendISO ; {0}=CURRENCY_FORMAT ¤#,##0.00
 ^//ldml/numbers/currencyFormats\[@numberSystem="%A"]/currencyPatternAppendISO ; {0}=CURRENCY_FORMAT ¤#,##0.00
 
 ^//ldml/numbers/miscPatterns\[@numberSystem="%A"]/pattern\[@type=\"range\"] ; {0}=START_NUMBER 3 ; {1}=END_NUMBER 5
@@ -240,8 +238,6 @@
 
 ^//ldml/units/unitLength\[@type="%L"]/unit\[@type="%A"]/unitPattern\[@count="\w+"] ; locale ; {0}=NUMBER_OF_UNITS 3
 ^//ldml/units/unitLength\[@type="%L"]/unit\[@type="%A"]/perUnitPattern ; {0}=NUMBER_OF_UNITS 3
-
-# ^//ldml/numbers/currencyFormats/unitPattern\[@count="(%A)"]  ;  {0}=NUMBER 3 ; {1}=UNIT hour(s)
 
 ^//ldml/characters/ellipsis\[@type="final"] ; {0}=FIRST_PART_OF_TEXT very long na
 ^//ldml/characters/ellipsis\[@type="initial"] ; {0}=LAST_PART_OF_TEXT ry long name

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/prettyPath.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/prettyPath.txt
@@ -156,7 +156,6 @@ $element=[a-zA-Z0-9]+;
 '/numbers/currencies/currency[@type="' ($avalue) '"]/' ($element) '[@type="' ($avalue) '"]' > '0-names|currency|' $1 ':' $2 '-' $3;
 '/numbers/currencies/currency[@type="' ($avalue) '"]/' ($element) > '0-names|currency|' $1 ':' $2;
 
-'/numbers/symbols/' (.*) > '2-number|symbol|' $1;
 '/numbers/symbols[@numberSystem="latn"]/' (.*) > '2-number|symbol|' $1;
 '/numbers/symbols[@numberSystem="' ($avalue) '"]/' (.*) > '2-number|symbol|' $2 '-' $1;
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAliases.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAliases.java
@@ -49,7 +49,7 @@ public class TestAliases extends TestFmwk {
         String[][] testCases = {
             {
                 "en",
-                "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"short\"]/currencyFormat[@type=\"standard\"]/pattern[@type=\"1000\"][@count=\"one\"]",
+                "//ldml/numbers/currencyFormats[@numberSystem=\"adlm\"]/currencyFormatLength[@type=\"short\"]/currencyFormat[@type=\"standard\"]/pattern[@type=\"1000\"][@count=\"one\"]",
                 "en",
                 "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength[@type=\"short\"]/currencyFormat[@type=\"standard\"]/pattern[@type=\"1000\"][@count=\"one\"]"
             },

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -560,18 +560,18 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
                         "ፊደል",
                         PathSpaceType.allowNbsp),
                 new PathSpaceData(
-                        "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/insertBetween",
+                        "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencySpacing/beforeCurrency/insertBetween",
                         "\u00A0  ding \u00A0\u00A0 dong \u00A0",
                         "ding\u00A0dong",
                         PathSpaceType.allowNbsp),
                 new PathSpaceData(
-                        "//ldml/numbers/symbols/nan",
+                        "//ldml/numbers/symbols[@numberSystem=\"latn\"]/nan",
                         "\u00A0  HA   HU \u00A0",
                         "HA\u00A0HU",
                         PathSpaceType.allowNbsp),
 
                 // removed temporarily per CLDR-16210
-                // new PathSpaceData("//ldml/numbers/symbols/nan",
+                // new PathSpaceData("//ldml/numbers/symbols[@numberSystem=\"latn\"]/nan",
                 //    "\u202F  BA \u202F  BU \u202F", "BA\u00A0BU", PathSpaceType.allowNbsp),
 
                 new PathSpaceData(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -148,9 +148,6 @@ public class TestExampleGenerator extends TestFmwk {
                     "//ldml/numbers/currencies/currency[@type=\"([^\"]*+)\"]/displayName",
                     "//ldml/localeDisplayNames/measurementSystemNames/measurementSystemName[@type=\"([^\"]*+)\"]",
                     // old format
-                    "//ldml/numbers/symbols/infinity",
-                    "//ldml/numbers/symbols/list",
-                    "//ldml/numbers/symbols/nan",
                     "//ldml/posix/messages/nostr",
                     "//ldml/posix/messages/yesstr",
                     "//ldml/contextTransforms/contextTransformUsage[@type=\"([^\"]*+)\"]/contextTransform[@type=\"([^\"]*+)\"]",
@@ -180,13 +177,6 @@ public class TestExampleGenerator extends TestFmwk {
      */
     static final Set<String> TEMPORARY_EXCLUDED_EXAMPLES =
             ImmutableSet.of(
-                    "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/currencyMatch",
-                    "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/surroundingMatch",
-                    "//ldml/numbers/currencyFormats/currencySpacing/beforeCurrency/insertBetween",
-                    "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/currencyMatch",
-                    "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/surroundingMatch",
-                    "//ldml/numbers/currencyFormats/currencySpacing/afterCurrency/insertBetween",
-                    "//ldml/numbers/currencyFormats/currencyPatternAppendISO", // TODO see
                     // CLDR-14831
                     "//ldml/numbers/currencyFormats[@numberSystem=\"([^\"]*+)\"]/currencySpacing/beforeCurrency/currencyMatch",
                     "//ldml/numbers/currencyFormats[@numberSystem=\"([^\"]*+)\"]/currencySpacing/beforeCurrency/surroundingMatch",
@@ -216,7 +206,6 @@ public class TestExampleGenerator extends TestFmwk {
                     "//ldml/dates/timeZoneNames/gmtZeroFormat",
                     "//ldml/dates/timeZoneNames/gmtUnknownFormat",
                     "//ldml/numbers/minimumGroupingDigits",
-                    "//ldml/numbers/symbols/timeSeparator",
                     "//ldml/numbers/symbols[@numberSystem=\"([^\"]*+)\"]/timeSeparator",
                     "//ldml/units/unitLength[@type=\"([^\"]*+)\"]/unit[@type=\"([^\"]*+)\"]/displayName",
                     "//ldml/units/unitLength[@type=\"([^\"]*+)\"]/unit[@type=\"([^\"]*+)\"]/perUnitPattern",
@@ -1202,7 +1191,7 @@ public class TestExampleGenerator extends TestFmwk {
      */
     public void TestExampleGeneratorConsistency() throws IOException {
         final String EVIL_PATH =
-                "//ldml/numbers/currencyFormats/currencyFormatLength[@type=\"short\"]/currencyFormat[@type=\"standard\"]/pattern[@type=\"10000\"][@count=\"one\"]";
+                "//ldml/numbers/currencyFormats[@numberSystem=\"latn\"]/currencyFormatLength[@type=\"short\"]/currencyFormat[@type=\"standard\"]/pattern[@type=\"10000\"][@count=\"one\"]";
         final String SPECIAL_PATH = "//ldml/numbers/currencies/currency[@type=\"EUR\"]/symbol";
         final String EXPECTED_TO_CONTAIN = "456,79";
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1594,7 +1594,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                 // TODO 17397: remove isKnownIssue and the if around errln when the logknown issue
                 // goes away.
                 final boolean skipKnownIssue =
-                        currency.equals("ANG")
+                        currency.equals("XCG")
                                 && isoCountries.isEmpty()
                                 && cldrCountries.equals(Set.of("CW", "SX"))
                                 && logKnownIssue("CLDR-17397", "Mismatched codes " + cldrCountries);

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/TestCoverageLevel.txt
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/TestCoverageLevel.txt
@@ -20,12 +20,12 @@
 ^//ldml/layout/orientation ; 10
 ^//ldml/localeDisplayNames/transformNames/transformName\[@type=".*"] ; 60
 ^//ldml/numbers/currencies/currency\[@type=".*"]/symbol\[@alt=".*"] ; 40
-^//ldml/numbers/currencyFormats/currencyFormatLength/currencyFormat\[@type=".*"]/pattern\[@type=".*"] ; 20
-^//ldml/numbers/decimalFormats/decimalFormatLength\[@type=".*"]/decimalFormat\[@type=".*"]/pattern\[@type=".*"] ; 40
-^//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat\[@type=".*"]/pattern\[@type=".*"] ; 20
+^//ldml/numbers/currencyFormats\[@numberSystem="latn"]/currencyFormatLength/currencyFormat\[@type=".*"]/pattern\[@type=".*"] ; 20
+^//ldml/numbers/decimalFormats\[@numberSystem="latn"]/decimalFormatLength\[@type=".*"]/decimalFormat\[@type=".*"]/pattern\[@type=".*"] ; 40
+^//ldml/numbers/decimalFormats\[@numberSystem="latn"]/decimalFormatLength/decimalFormat\[@type=".*"]/pattern\[@type=".*"] ; 20
 ^//ldml/numbers/defaultNumberingSystem ; 20
-^//ldml/numbers/symbols/nativeZeroDigit ; 100
-^//ldml/numbers/symbols/patternDigit ; 100
+^//ldml/numbers/symbols\[@numberSystem="latn"]/nativeZeroDigit ; 100
+^//ldml/numbers/symbols\[@numberSystem="latn"]/patternDigit ; 100
 
 ^//ldml/dates/calendars/calendar\[@type=".*"]/dateFormats/dateFormatLength\[@type="(long|short)"]/dateFormat\[@type=".*"]/pattern\[@type=".*"]; 20
 ^//ldml/dates/calendars/calendar\[@type=".*"]/dateTimeFormats/intervalFormats/intervalFormatItem\[@id=".*"]/greatestDifference\[@id=".*"] ; 40

--- a/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/TestExamples.txt
+++ b/tools/cldr-code/src/test/resources/org/unicode/cldr/unittest/TestExamples.txt
@@ -26,13 +26,9 @@
 //ldml/numbers/currencies/currency[@type="%A"]/symbol 	; example
 //ldml/numbers/currencyFormats[@numberSystem="%A"]/currencyFormatLength/currencyFormat[@type="%A"]/pattern[@type="%A"]    	; example
 //ldml/numbers/currencyFormats[@numberSystem="%A"]/unitPattern[@count="%A"] 	; example
-//ldml/numbers/decimalFormats/decimalFormatLength/decimalFormat[@type="%A"]/pattern[@type="%A"] 	; example
-//ldml/numbers/decimalFormats/decimalFormatLength[@type="%A"]/decimalFormat[@type="%A"]/pattern[@type="%A"]   	; example
 //ldml/numbers/decimalFormats[@numberSystem="%A"]/decimalFormatLength/decimalFormat[@type="%A"]/pattern[@type="%A"]   	; example
 //ldml/numbers/decimalFormats[@numberSystem="%A"]/decimalFormatLength[@type="%A"]/decimalFormat[@type="%A"]/pattern[@type="%A"] 	; example
 //ldml/numbers/defaultNumberingSystem   	; example
 //ldml/numbers/otherNumberingSystems/native 	; example
-//ldml/numbers/percentFormats/percentFormatLength/percentFormat[@type="%A"]/pattern[@type="%A"] 	; example
 //ldml/numbers/percentFormats[@numberSystem="%A"]/percentFormatLength/percentFormat[@type="%A"]/pattern[@type="%A"]   	; example
-//ldml/numbers/scientificFormats/scientificFormatLength/scientificFormat[@type="%A"]/pattern[@type="%A"]    	; example
 //ldml/numbers/scientificFormats[@numberSystem="%A"]/scientificFormatLength/scientificFormat[@type="%A"]/pattern[@type="%A"]  	; example


### PR DESCRIPTION
CLDR-18251

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18251)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

The goal here is to finish eliminating use of `symbols` and `xxxFormats` elements without a numberSystem attribute. There were removed from locale data (except for root) in 47, but other changes are needed here.

- ldml.dtd:
    - For the recently added (for 48) `rationalFormats` element, make the `numberSystem` attribute #REQUIRED instead of #IMPLIED.
    - For the older `symbols` and `decimalFormats`/`scientificFormats`/`percentFormats`/`currencyFormats`, the `numberSystem` attribute is #IMPLIED and we cannot change that without breaking backward compatibility. I do not know how to deprecate the **_absence_** of an #IMPLIED element however.
- en.xml: Remove the recently added (for 48) `rationalFormats` without a `numberSystem` attribute, these should not have been added; we have the `rationalFormats` with `numberSystem="latn"`
- root.xml: Remove the  `symbols` and `xxxFormats` elements without a numberSystem attribute. 
- CheckNumbers.java/CheckCLDR.java: Add a test that we don't have `symbols` and `xxxFormats` elements without a numberSystem attribute.  While it should not be possible to enter such via the Survey Tool, it could be viae.g. a bulk upload, so we need the test.
- Many other test and resource files: Eliminate or fix cases in which paths for symbols or xxxFormats elements did not have a numberSystem attribute. Of note, this included the following:
    - Regenerated ExampleDependencies.java which did eliminate cases with the problematic paths, but also added many missing cases for other things like PersonNames. This may not have been updated for a while.
    - ICUServiceBuilder.java needs to be improved to use the correct numberSystem for number formats.
- Because the preferred currency for CW and SX changed as of 2025-Mar-31, I had to change the logKnownIssue test skip (for CLDR-17397) in TestSupplementalInfo.java.

ALLOW_MANY_COMMITS=true
