### PR TITLE
CLDR-18469 Change long alt names for zh_Hans and zh_Hant

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -705,10 +705,10 @@ annotations.
 			<language type="zh" alt="long">Mandarin Chinese</language>
 			<language type="zh" alt="menu">Chinese, Mandarin</language>
 			<language type="zh_Hans">Simplified Chinese</language>
-			<language type="zh_Hans" alt="long">Simplified Mandarin Chinese</language>
+			<language type="zh_Hans" alt="long">Mandarin Chinese (Simplified)</language>
 			<language type="zh_Hans" alt="menu">Chinese, Mandarin (Simplified)</language>
 			<language type="zh_Hant">Traditional Chinese</language>
-			<language type="zh_Hant" alt="long">Traditional Mandarin Chinese</language>
+			<language type="zh_Hant" alt="long">Mandarin Chinese (Traditional)</language>
 			<language type="zh_Hant" alt="menu">Chinese, Mandarin (Traditional)</language>
 			<language type="zu">Zulu</language>
 			<language type="zun">Zuni</language>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -228,6 +228,7 @@ annotations.
 			<language type="gaa">Ga</language>
 			<language type="gag">Gagauz</language>
 			<language type="gan">Gan Chinese</language>
+			<language type="gan" alt="menu">Chinese, Gan</language>
 			<language type="gay">Gayo</language>
 			<language type="gba">Gbaya</language>
 			<language type="gbz">Zoroastrian Dari</language>
@@ -254,6 +255,7 @@ annotations.
 			<language type="ha">Hausa</language>
 			<language type="hai">Haida</language>
 			<language type="hak">Hakka Chinese</language>
+			<language type="hak" alt="menu">Chinese, Hakka</language>
 			<language type="haw">Hawaiian</language>
 			<language type="hax">Southern Haida</language>
 			<language type="he">Hebrew</language>
@@ -269,6 +271,7 @@ annotations.
 			<language type="hr">Croatian</language>
 			<language type="hsb">Upper Sorbian</language>
 			<language type="hsn">Xiang Chinese</language>
+			<language type="hsn" alt="menu">Chinese, Xiang</language>
 			<language type="ht">Haitian Creole</language>
 			<language type="hu">Hungarian</language>
 			<language type="hup">Hupa</language>
@@ -388,6 +391,7 @@ annotations.
 			<language type="luy">Luyia</language>
 			<language type="lv">Latvian</language>
 			<language type="lzh">Literary Chinese</language>
+			<language type="lzh" alt="menu">Chinese, Literary</language>
 			<language type="lzz">Laz</language>
 			<language type="mad">Madurese</language>
 			<language type="maf">Mafa</language>
@@ -437,6 +441,7 @@ annotations.
 			<language type="mzn">Mazanderani</language>
 			<language type="na">Nauru</language>
 			<language type="nan">Min Nan Chinese</language>
+			<language type="nan" alt="menu">Chinese, Min Nan</language>
 			<language type="nap">Neapolitan</language>
 			<language type="naq">Nama</language>
 			<language type="nb">Norwegian Bokmål</language>
@@ -675,6 +680,7 @@ annotations.
 			<language type="wbp">Warlpiri</language>
 			<language type="wo">Wolof</language>
 			<language type="wuu">Wu Chinese</language>
+			<language type="wuu" alt="menu">Chinese, Wu</language>
 			<language type="xal">Kalmyk</language>
 			<language type="xh">Xhosa</language>
 			<language type="xmf">Mingrelian</language>
@@ -700,8 +706,10 @@ annotations.
 			<language type="zh" alt="menu">Chinese, Mandarin</language>
 			<language type="zh_Hans">Simplified Chinese</language>
 			<language type="zh_Hans" alt="long">Simplified Mandarin Chinese</language>
+			<language type="zh_Hans" alt="menu">Chinese, Mandarin (Simplified)</language>
 			<language type="zh_Hant">Traditional Chinese</language>
 			<language type="zh_Hant" alt="long">Traditional Mandarin Chinese</language>
+			<language type="zh_Hant" alt="menu">Chinese, Mandarin (Traditional)</language>
 			<language type="zu">Zulu</language>
 			<language type="zun">Zuni</language>
 			<language type="zxx">No linguistic content</language>


### PR DESCRIPTION
CLDR-18469

- [ ] This PR completes the ticket.

matching Mark's suggestion in CLDR-11834,
following the style of
>English // en if alone
>English (UK)
>English (US) // en if there is another region mentioned for en in the list

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
