### PR TITLE
CLDR-18471 map `zh_min*`, `zh_pinyin` and a few `und_*` tags to better targets

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -526,19 +526,25 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="i_default" replacement="en_x_i_default" reason="legacy"/> <!-- irregular bcp47 code -->
 			<languageAlias type="i_enochian" replacement="und_x_i_enochian" reason="legacy"/> <!-- irregular bcp47 code -->
 			<languageAlias type="i_mingo" replacement="see_x_i_mingo" reason="legacy"/> <!-- irregular bcp47 code -->
-			<languageAlias type="zh_min" replacement="nan_x_zh_min" reason="legacy"/> <!-- irregular bcp47 code -->
+			<languageAlias type="zh_min" replacement="zh" reason="legacy"/> <!-- irregular bcp47 code. allowed targets: cdo, cpx, czo, mnp, nan -->
+			<languageAlias type="zh_min_bei" replacement="mnp" reason="legacy"/> <!-- Min Bei Chinese -->
+			<languageAlias type="zh_min_dong" replacement="cdo" reason="legacy"/> <!-- Min Dong Chinese -->
+			<languageAlias type="zh_min_zhong" replacement="czo" reason="legacy"/> <!-- Min Zhong Chinese -->
+			<languageAlias type="zh_min_puxian" replacement="cpx" reason="legacy"/> <!-- Pu-Xian Chinese -->
+			<languageAlias type="zh_pinyin" replacement="zh_Latn_pinyin" reason="legacy"/> <!-- Pinyin romanization -->
+			<languageAlias type="und_pinyin" replacement="zh_Latn_pinyin" reason="legacy"/> <!-- Pinyin romanization -->
 
 			<languageAlias type="und_aaland" replacement="und_AX" reason="deprecated"/>
 			<languageAlias type="hy_arevmda" replacement="hyw" reason="deprecated"/>
-			<languageAlias type="und_arevmda" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_arevela" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_lojban" replacement="und" reason="deprecated"/>
+			<languageAlias type="und_arevmda" replacement="hyw" reason="deprecated"/> <!-- Western Armenian -->
+			<languageAlias type="und_arevela" replacement="hy" reason="deprecated"/> <!-- Eastern Armenian -->
+			<languageAlias type="und_lojban" replacement="jbo" reason="deprecated"/> <!-- art-lojban -->
 			<languageAlias type="und_saaho" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_bokmal" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_nynorsk" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_hakka" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_xiang" replacement="und" reason="deprecated"/>
-			<languageAlias type="und_hepburn_heploc" replacement="und_alalc97" reason="deprecated"/>
+			<languageAlias type="und_bokmal" replacement="no" reason="deprecated"/> <!-- nb == Norwegian Bokmål -->
+			<languageAlias type="und_nynorsk" replacement="nn" reason="deprecated"/> <!-- no-nyn -->
+			<languageAlias type="und_hakka" replacement="hak" reason="deprecated"/> <!-- Hakka Chinese -->
+			<languageAlias type="und_xiang" replacement="hsn" reason="deprecated"/> <!-- Xiang Chinese -->
+			<languageAlias type="und_hepburn_heploc" replacement="ja_alalc97" reason="deprecated"/> <!-- Prefix: ja-Latn-hepburn -->
 
 			<!-- more deprecated 2024-03-19 -->
 			<languageAlias type="ajp" replacement="apc" reason="deprecated"/> <!-- South Levantine Arabic ⇒ Levantine Arabic -->


### PR DESCRIPTION
CLDR-18471

- [ ] This PR completes the ticket.

`zh_min*` and `*_pinyin` were altered for backwards compatibility, a step more than the current [language-subtag-registry] (https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)

(more details at CLDR-18471)
<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
