### PR TITLE
CLDR-18475 deps, web: remove org.json from deps, fix rtl

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
@@ -812,10 +812,6 @@ function locInfo(loc) {
   return locmap.getLocaleInfo(loc);
 }
 
-function setOverrideDir(dir) {
-  overridedir = dir;
-}
-
 /**
  * Set the dir and lang attributes for a node that represents
  * a CLDR value.
@@ -823,7 +819,7 @@ function setOverrideDir(dir) {
  * @param {Node} node DOM node
  * @param {String} loc locale
  */
-function setLang(node, loc) {
+function setLang(node, loc, overridedir) {
   var info = locInfo(loc);
 
   if (overridedir) {
@@ -979,7 +975,6 @@ export {
   localizeFlyover,
   parseStatusAction,
   setLang,
-  setOverrideDir,
   setShower,
   showLoader,
   testsToHtml,

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -177,8 +177,6 @@ function insertRowsIntoTbody(theTable, reuseTable) {
   for (let i in rowList) {
     const k = rowList[i];
     const theRow = theRows[k];
-    const dir = theRow.dir;
-    cldrSurvey.setOverrideDir(dir != null ? dir : null);
     /*
      * Don't regenerate the headings if we're re-using an existing table.
      */
@@ -809,7 +807,7 @@ function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
     const flagIcon = cldrSurvey.addIcon(cell, "s-flag");
     flagIcon.title = cldrText.get("flag_desc");
   }
-  cldrSurvey.setLang(cell);
+  cldrSurvey.setLang(cell, null, theRow.dir);
   tr.proposedcell = cell;
 
   /*
@@ -844,7 +842,7 @@ function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
 function updateRowOthersCell(tr, theRow, cell, protoButton) {
   let hadOtherItems = false;
   cldrDom.removeAllChildNodes(cell); // other
-  cldrSurvey.setLang(cell);
+  cldrSurvey.setLang(cell, null, theRow.dir);
 
   /*
    * Add the other vote info -- that is, vote info for the "Others" column.

--- a/tools/cldr-apps/pom.xml
+++ b/tools/cldr-apps/pom.xml
@@ -110,12 +110,6 @@
 			<artifactId>javax.activation</artifactId>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.json/json -->
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-		</dependency>
-
 		<!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->
 		<dependency>
 			<groupId>org.jsoup</groupId>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRConfigImpl.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/util/CLDRConfigImpl.java
@@ -10,15 +10,11 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.util.Date;
 import java.util.Enumeration;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONString;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.web.CookieSession;
 import org.unicode.cldr.web.SurveyLog;
@@ -32,7 +28,7 @@ import org.unicode.cldr.web.WebContext;
  * distinction is that it uses the "cldr.properties" file in the server root rather than environment
  * variables.
  */
-public class CLDRConfigImpl extends CLDRConfig implements JSONString {
+public class CLDRConfigImpl extends CLDRConfig {
     private static final String CODE_HASH_KEY = "CLDR_CODE_HASH";
     private static final String DATA_HASH_KEY = "CLDR_DATA_HASH";
 
@@ -438,22 +434,6 @@ public class CLDRConfigImpl extends CLDRConfig implements JSONString {
         } else {
             return null; // Setting is disallowed (silently?)
         }
-    }
-
-    @Override
-    public String toJSONString() throws JSONException {
-        return toJSONObject().toString();
-    }
-
-    public JSONObject toJSONObject() throws JSONException {
-        JSONObject ret = new JSONObject();
-
-        ret.put("CLDR_HEADER", ""); // always show these
-        for (Entry<Object, Object> e : survprops.entrySet()) {
-            ret.put(e.getKey().toString(), e.getValue().toString());
-        }
-
-        return ret;
     }
 
     @Override

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AdminPanel.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AdminPanel.java
@@ -8,12 +8,12 @@ import java.util.Map;
 import java.util.Random;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfigImpl;
 import org.unicode.cldr.util.VoteResolver;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 public class AdminPanel {
     public void getJson(

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/BallotBox.java
@@ -4,10 +4,10 @@ package org.unicode.cldr.web;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-import org.json.JSONObject;
 import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.VoteType;
 import org.unicode.cldr.web.UserRegistry.User;
+import org.unicode.cldr.web.util.JSONObject;
 
 /**
  * @author srl This is an abstract interface for allowing SurveyTool-like input to a CLDRFile. It

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ChunkyReader.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ChunkyReader.java
@@ -22,12 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONString;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Pair;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
+import org.unicode.cldr.web.util.JSONString;
 
 /**
  * This is only used by exception log readers

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ClaGithubList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ClaGithubList.java
@@ -16,6 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfigImpl;
+import org.unicode.cldr.web.util.JsonUtil;
 
 /**
  * Utility class for reading a signatures.json file This file can be downloaded from
@@ -174,7 +175,7 @@ public class ClaGithubList {
 
     /** read from a Reader */
     Map<String, SignEntry> readSigners(final Reader r) throws IOException {
-        final Gson gson = new Gson();
+        final Gson gson = JsonUtil.gson();
         Map<String, SignEntry> allSigners = new HashMap<>();
         try (final JsonReader jr = gson.newJsonReader(r); ) {
             jr.beginArray();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DBUtils.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DBUtils.java
@@ -43,9 +43,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 import org.apache.ibatis.jdbc.ScriptRunner;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.icu.dev.util.ElapsedTimer;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRConfig.Environment;
@@ -53,6 +50,9 @@ import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.StackTracker;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /** Singleton utility class for simple(r) DB access. */
 public class DBUtils {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ErrorSubtypes.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/ErrorSubtypes.java
@@ -5,9 +5,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 public class ErrorSubtypes {
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/MailSender.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/MailSender.java
@@ -29,11 +29,11 @@ import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.EmailValidator;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /** Helper class. Sends mail with a simple interface */
 public class MailSender implements Runnable {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -26,9 +26,6 @@ import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.icu.dev.util.ElapsedTimer;
 import org.unicode.cldr.test.CheckCLDR;
@@ -37,17 +34,35 @@ import org.unicode.cldr.test.CheckForCopy;
 import org.unicode.cldr.test.DisplayAndInputProcessor;
 import org.unicode.cldr.test.SubmissionLocales;
 import org.unicode.cldr.test.TestCache;
-import org.unicode.cldr.util.*;
+import org.unicode.cldr.util.CLDRConfig;
+import org.unicode.cldr.util.CLDRConfigImpl;
+import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRInfo.CandidateInfo;
 import org.unicode.cldr.util.CLDRInfo.UserInfo;
+import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.util.CoverageInfo;
+import org.unicode.cldr.util.DateTimeFormats;
+import org.unicode.cldr.util.DowngradePaths;
 import org.unicode.cldr.util.DtdData.IllegalByDtdException;
+import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.PathHeader;
+import org.unicode.cldr.util.SpecialLocales;
+import org.unicode.cldr.util.SupplementalDataInfo;
+import org.unicode.cldr.util.VoteType;
 import org.unicode.cldr.util.VoterReportStatus.ReportId;
+import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.util.XMLUploader;
+import org.unicode.cldr.util.XPathParts;
 import org.unicode.cldr.web.BallotBox.InvalidXPathException;
 import org.unicode.cldr.web.BallotBox.VoteNotAcceptedException;
 import org.unicode.cldr.web.CLDRProgressIndicator.CLDRProgressTask;
 import org.unicode.cldr.web.SurveyException.ErrorCode;
 import org.unicode.cldr.web.UserRegistry.User;
 import org.unicode.cldr.web.WebContext.HTMLDirection;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /**
  * Servlet implementation class SurveyAjax
@@ -1086,7 +1101,7 @@ public class SurveyAjax extends HttpServlet {
         }
     }
 
-    private static JSONObject createJSONLocMap(SurveyMain sm) throws JSONException {
+    static JSONObject createJSONLocMap(SurveyMain sm) throws JSONException {
         JSONObject locmap = new JSONObject();
         // locales will have info about each locale, including name
         JSONObject locales = new JSONObject();
@@ -1107,7 +1122,7 @@ public class SurveyAjax extends HttpServlet {
             locale.put("bcp47", loc.toLanguageTag());
 
             HTMLDirection dir = sm.getHTMLDirectionFor(loc);
-            if (!dir.toString().equals("ltr")) {
+            if (dir != HTMLDirection.LEFT_TO_RIGHT) {
                 locale.put("dir", dir);
             }
 
@@ -1398,7 +1413,7 @@ public class SurveyAjax extends HttpServlet {
             oldvotes.put("locale", locale);
             oldvotes.put("localeDisplayName", locale.getDisplayName());
             HTMLDirection dir = sm.getHTMLDirectionFor(locale);
-            oldvotes.put("dir", dir); // e.g., LEFT_TO_RIGHT
+            oldvotes.put("dir", dir); // e.g., "ltr"
             if (isSubmit) {
                 submitOldVotes(user, sm, locale, confirmList, newVotesTable, oldvotes);
             } else {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyBulkClosePosts.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyBulkClosePosts.java
@@ -6,10 +6,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
-import org.json.JSONException;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.Factory;
 import org.unicode.cldr.util.XMLSource;
+import org.unicode.cldr.web.util.JSONException;
 
 public class SurveyBulkClosePosts {
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyException.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyException.java
@@ -1,7 +1,7 @@
 package org.unicode.cldr.web;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /**
  * An exception class that has an err_code that the ST client understands.

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyFlaggedItems.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyFlaggedItems.java
@@ -2,8 +2,8 @@ package org.unicode.cldr.web;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import org.json.JSONException;
-import org.json.JSONObject;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 public class SurveyFlaggedItems {
     private boolean userIsTC;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForum.java
@@ -17,13 +17,13 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.icu.dev.util.ElapsedTimer;
 import org.unicode.cldr.util.*;
 import org.unicode.cldr.web.SurveyException.ErrorCode;
 import org.unicode.cldr.web.UserRegistry.User;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /** This class implements a discussion forum per language (ISO code) */
 public class SurveyForum {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForumParticipation.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyForumParticipation.java
@@ -3,8 +3,8 @@ package org.unicode.cldr.web;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Set;
-import org.json.JSONException;
 import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.web.util.JSONException;
 
 public class SurveyForumParticipation {
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyJSONWrapper.java
@@ -7,9 +7,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
@@ -18,6 +15,9 @@ import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.web.SurveyException.ErrorCode;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /**
  * Consolidate my JSONify functions here.
@@ -40,7 +40,7 @@ public final class SurveyJSONWrapper {
 
     @Override
     public String toString() {
-        return j.toString();
+        return j.toJSONString();
     }
 
     /**

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -55,9 +55,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONString;
 import org.unicode.cldr.draft.FileUtilities;
 import org.unicode.cldr.icu.dev.util.ElapsedTimer;
 import org.unicode.cldr.test.CheckCLDR;
@@ -92,6 +89,9 @@ import org.unicode.cldr.util.TimeDiff;
 import org.unicode.cldr.web.UserRegistry.User;
 import org.unicode.cldr.web.WebContext.HTMLDirection;
 import org.unicode.cldr.web.api.Summary;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
+import org.unicode.cldr.web.util.JSONString;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -3730,7 +3730,7 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
                     .put("sysload", sysload)
                     .put("memtotal", memtotal)
                     .put("memfree", memfree)
-                    .put("uptime", uptime)
+                    .put("uptime", uptime.toString())
                     .put("user", user) // allowed since User implements JSONString?
                     .put("users", users);
         }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMenus.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMenus.java
@@ -8,9 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRLocale;
@@ -22,6 +19,9 @@ import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathHeader.SectionId;
 import org.unicode.cldr.util.PathHeader.SurveyToolStatus;
 import org.unicode.cldr.web.SurveyMenus.Section.Page;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 public class SurveyMenus implements Iterable<SurveyMenus.Section> {
     PathHeader.Factory phf;

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -1,7 +1,6 @@
 package org.unicode.cldr.web;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,9 +15,10 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.json.JSONException;
 import org.unicode.cldr.util.CLDRURLS;
 import org.unicode.cldr.util.CldrUtility;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JsonUtil;
 
 public class SurveyTool extends HttpServlet {
     static final Logger logger = SurveyLog.forClass(SurveyTool.class);
@@ -240,7 +240,7 @@ public class SurveyTool extends HttpServlet {
         }
     }
 
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private static final Gson gson = JsonUtil.gson();
 
     private final class STManifest {
         public String jsfiles[];

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyVettingParticipation.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyVettingParticipation.java
@@ -11,9 +11,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.util.CLDRLocale;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleSet;
@@ -21,6 +18,9 @@ import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.web.UserRegistry.User;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 public class SurveyVettingParticipation {
     private static final int GUEST_STLEVEL = VoteResolver.Level.guest.getSTLevel();

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -10,14 +10,14 @@ import java.util.Map;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONString;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.web.UserRegistry.InfoType;
 import org.unicode.cldr.web.UserRegistry.User;
+import org.unicode.cldr.web.util.JSONArray;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
+import org.unicode.cldr.web.util.JSONString;
 
 public class UserList {
     private static final Logger logger = SurveyLog.forClass(UserList.class);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -6,6 +6,7 @@
 
 package org.unicode.cldr.web;
 
+import com.google.gson.JsonSyntaxException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -22,9 +23,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONString;
 import org.unicode.cldr.icu.dev.util.ElapsedTimer;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.util.CLDRConfig;
@@ -39,6 +37,9 @@ import org.unicode.cldr.util.VoteResolver;
 import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.util.VoteResolver.VoterInfo;
 import org.unicode.cldr.util.VoterInfoList;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
+import org.unicode.cldr.web.util.JSONString;
 
 /**
  * This class represents the list of all registered users. It contains an inner class,
@@ -493,7 +494,7 @@ public class UserRegistry {
                     .put("orgName", vrOrg().getDisplayName())
                     .put("id", id)
                     .put("claSigned", claSigned)
-                    .toString();
+                    .toJSONString();
         }
 
         public boolean canGenerateVxml() {
@@ -612,7 +613,12 @@ public class UserRegistry {
             } else if (ClaSignature.CLA_ORGS.contains(getOrganization())) {
                 return new ClaSignature(getOrganization());
             }
-            return settings().getJson(ClaSignature.CLA_KEY, ClaSignature.class);
+            try {
+                return settings().getJson(ClaSignature.CLA_KEY, ClaSignature.class);
+            } catch (JsonSyntaxException jsx) {
+                logger.log(java.util.logging.Level.SEVERE, "Could not deserialize CLA", jsx);
+                return null;
+            }
         }
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserSettings.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserSettings.java
@@ -3,7 +3,7 @@
 package org.unicode.cldr.web;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import org.unicode.cldr.web.util.JsonUtil;
 
 public abstract class UserSettings implements Comparable<UserSettings> {
     /**
@@ -93,12 +93,12 @@ public abstract class UserSettings implements Comparable<UserSettings> {
     }
 
     public void setJson(String name, Object o) {
-        final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
+        final Gson gson = JsonUtil.gson();
         set(name, gson.toJson(o));
     }
 
     public <T> T getJson(String name, Class<T> clazz) {
-        final Gson gson = new Gson();
+        final Gson gson = JsonUtil.gson();
         final String j = get(name, null);
         if (j == null || j.isBlank()) return null;
         return gson.fromJson(j, clazz);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/VettingViewerQueue.java
@@ -6,13 +6,13 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.logging.Logger;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.unicode.cldr.icu.dev.util.ElapsedTimer;
 import org.unicode.cldr.util.*;
 import org.unicode.cldr.util.TimeDiff;
 import org.unicode.cldr.web.CLDRProgressIndicator.CLDRProgressTask;
 import org.unicode.cldr.web.api.LocaleCompletion;
+import org.unicode.cldr.web.util.JSONException;
+import org.unicode.cldr.web.util.JSONObject;
 
 /**
  * @author srl

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
@@ -7,6 +7,7 @@
 //
 package org.unicode.cldr.web;
 
+import com.google.gson.annotations.SerializedName;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 import java.io.IOException;
@@ -1050,19 +1051,10 @@ public class WebContext implements Cloneable, Appendable {
      * @author srl
      */
     public enum HTMLDirection {
-        LEFT_TO_RIGHT("ltr"),
-        RIGHT_TO_LEFT("rtl");
-
-        private final String str;
-
-        HTMLDirection(String str) {
-            this.str = str;
-        }
-
-        @Override
-        public String toString() {
-            return str;
-        }
+        @SerializedName("ltr")
+        LEFT_TO_RIGHT,
+        @SerializedName("rtl")
+        RIGHT_TO_LEFT;
 
         /**
          * Convert a CLDR direction to an enum

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -33,11 +33,11 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.json.JSONException;
 import org.unicode.cldr.util.*;
 import org.unicode.cldr.web.*;
 import org.unicode.cldr.web.Dashboard.ReviewOutput;
 import org.unicode.cldr.web.VettingViewerQueue.LoadingPolicy;
+import org.unicode.cldr.web.util.JSONException;
 
 @ApplicationScoped
 @Path("/summary")

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/UserLevels.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/UserLevels.java
@@ -9,9 +9,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.json.JSONObject;
 import org.unicode.cldr.web.CookieSession;
 import org.unicode.cldr.web.UserRegistry;
+import org.unicode.cldr.web.util.JSONObject;
 
 @Path("/userlevels")
 @Tag(name = "userlevels", description = "Get the list of Survey Tool user levels")

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -17,7 +17,6 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.json.JSONArray;
 import org.unicode.cldr.test.CheckCLDR;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
@@ -34,6 +33,7 @@ import org.unicode.cldr.web.SubtypeToURLMap;
 import org.unicode.cldr.web.SurveyForum;
 import org.unicode.cldr.web.UserRegistry.ModifyDenial;
 import org.unicode.cldr.web.api.VoteAPIHelper.VoteEntry;
+import org.unicode.cldr.web.util.JSONArray;
 
 @Path("/voting")
 @Tag(name = "voting", description = "APIs for voting and retrieving vote and row data")

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONArray.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONArray.java
@@ -1,0 +1,44 @@
+package org.unicode.cldr.web.util;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class JSONArray implements JSONString {
+
+    private final List<Object> l = new LinkedList<>();
+
+    public JSONArray(Object[] value) {
+        for (final Object v : value) {
+            l.add(v);
+        }
+    }
+
+    public JSONArray() {}
+
+    public JSONArray put(Object o) {
+        l.add(o);
+        return this;
+    }
+
+    public int length() {
+        return l.size();
+    }
+
+    public JSONArray getJSONArray(int i) {
+        return (JSONArray) (l.get(i));
+    }
+
+    public int getInt(int i) {
+        return (Integer) (l.get(i));
+    }
+
+    @Override
+    public String toString() {
+        return toJSONString();
+    }
+
+    @Override
+    public String toJSONString() throws JSONException {
+        return JsonUtil.gson().toJson(l);
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONException.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONException.java
@@ -1,0 +1,6 @@
+package org.unicode.cldr.web.util;
+
+public class JSONException extends RuntimeException {
+
+    private static final long serialVersionUID = -6664351275226402713L;
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONObject.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONObject.java
@@ -1,0 +1,51 @@
+package org.unicode.cldr.web.util;
+
+import com.google.gson.Gson;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+/* shim */
+public class JSONObject implements JSONString {
+    private static final Gson gson = JsonUtil.gson();
+    private final Map<String, Object> m = new TreeMap<>();
+
+    @Override
+    public String toJSONString() throws JSONException {
+        return gson.toJson(m);
+    }
+
+    @Override
+    public String toString() {
+        return toJSONString();
+    }
+
+    public JSONObject put(String k, Object v) {
+        m.put(k, v);
+        return this;
+    }
+
+    public Object get(String string) {
+        return m.get(string);
+    }
+
+    public JSONArray getJSONArray(String string) {
+        return (JSONArray) (get(string));
+    }
+
+    public String getString(String k) {
+        return get(k).toString();
+    }
+
+    public int length() {
+        return m.size();
+    }
+
+    public boolean has(String ov) {
+        return m.containsKey(ov);
+    }
+
+    public Iterator<String> keys() {
+        return m.keySet().iterator();
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONString.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JSONString.java
@@ -1,0 +1,6 @@
+package org.unicode.cldr.web.util;
+
+/** Shim */
+public interface JSONString {
+    public String toJSONString() throws JSONException;
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JsonUtil.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/JsonUtil.java
@@ -1,0 +1,40 @@
+package org.unicode.cldr.web.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+/** utilities for JSON */
+public class JsonUtil {
+
+    private static final Gson gson =
+            new GsonBuilder()
+                    .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                    .setPrettyPrinting()
+                    .registerTypeHierarchyAdapter(
+                            JSONString.class,
+                            new TypeAdapter<JSONString>() {
+
+                                @Override
+                                public void write(JsonWriter out, JSONString value)
+                                        throws IOException {
+                                    out.jsonValue(value.toJSONString());
+                                }
+
+                                @Override
+                                public JSONString read(JsonReader in) throws IOException {
+                                    // write only
+                                    // TODO Auto-generated method stub
+                                    throw new UnsupportedOperationException(
+                                            "Unimplemented method 'read' - write only");
+                                }
+                            })
+                    .create();
+
+    public static Gson gson() {
+        return gson;
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/STRestClient.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/util/STRestClient.java
@@ -66,7 +66,7 @@ public class STRestClient {
         }
     }
 
-    static final Gson gson = new Gson();
+    static final Gson gson = JsonUtil.gson();
 
     String bearer = null;
 

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSTFactory.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestSTFactory.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,6 +40,7 @@ import org.unicode.cldr.web.BallotBox.InvalidXPathException;
 import org.unicode.cldr.web.BallotBox.VoteNotAcceptedException;
 import org.unicode.cldr.web.UserRegistry.LogoutException;
 import org.unicode.cldr.web.UserRegistry.User;
+import org.unicode.cldr.web.util.JSONObject;
 
 @NotThreadSafe
 public class TestSTFactory {
@@ -50,8 +52,8 @@ public class TestSTFactory {
 
     @BeforeAll
     public static void setup() {
-        if (TestAll.skipIfNoDb()) return;
-        TestAll.setupTestDb();
+        // if (TestAll.skipIfNoDb()) return;
+        // TestAll.setupTestDb();
     }
 
     /** validate the phase and mode */
@@ -635,6 +637,21 @@ public class TestSTFactory {
                 fail("Error - readBack's full path lost numbers= - " + fullPath2);
             }
         }
+    }
+
+    @Test
+    void testLocMapSerialization() throws SQLException {
+        // this particular test doesn't really need SQL
+        // but it's simpler to just depend on the rest of the machinery here.
+        STFactory fac = getFactory();
+        assertNotNull(fac);
+        assertNotNull(CookieSession.sm);
+        final JSONObject jo = SurveyAjax.createJSONLocMap(CookieSession.sm);
+        assertNotNull(jo);
+        final String s = jo.toString();
+        assertFalse(
+                s.contains("RIGHT_TO_LEFT"),
+                () -> "str contains RIGHT_TO_LEFT at " + s.indexOf("RIGHT_TO_LEFT"));
     }
 
     private void verifyReadOnly(CLDRFile f) {

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestWebContext.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/TestWebContext.java
@@ -1,0 +1,26 @@
+package org.unicode.cldr.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.web.WebContext.HTMLDirection;
+import org.unicode.cldr.web.util.JsonUtil;
+
+public class TestWebContext {
+
+    @Test
+    void testHtmlDir() {
+        HTMLDirection dir = HTMLDirection.RIGHT_TO_LEFT;
+        final Gson gson = JsonUtil.gson();
+        Map<String, Object> locale = new HashMap<>();
+        locale.put("dir", dir);
+        final String s = gson.toJson(locale);
+        // verify that the enum annotation is working properly
+        assertFalse(s.contains("RIGHT_TO_LEFT"), s);
+        assertTrue(s.contains("rtl"), s);
+    }
+}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -121,13 +121,6 @@
 				<version>1.2.0</version>
 			</dependency>
 
-			<!-- https://mvnrepository.com/artifact/org.json/json -->
-			<dependency>
-				<groupId>org.json</groupId>
-				<artifactId>json</artifactId>
-				<version>20231013</version>
-			</dependency>
-
 			<!-- HTTP client -->
 			<dependency>
 				<groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
CLDR-18475


- Also fixes CLDR-5839
- Drop org.json dependency completely
- Add shim objects for now to ease the transition to Gson, but no longer link against org.json
- add a standard Gson serializer object in JsonUtil.gson()

Also:

- Better handle CLA deserialization issues from prefs.
**Migration note**: this will invalidate previously signed CLAs (would only affect test data) which will get this message instead.  Now use ISO 8601 style timestamps.

> `Failed parsing 'Dec 9, 2024, 12:43:31 PM' as Date; at path $.signed`

- ST: remove setOverride() global - use an explicit override for locale directionality.
  This was causing a race condition.



ALLOW_MANY_COMMITS=true
