### PR TITLE
CLDR-17857 coverage for scripts, update 'bal' coverage

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -107,7 +107,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%language60_TD" value="(shu|dzg|kbl|mde|mua|sba)"/>
 		<!-- See CLDR-16673: All basic+ locales (per coverageLevels.txt) MUST have their language's name at least at level 80 (modern), except for those on exception list -->
 		<!-- Can use MinimizeRegex.java to "unpack" the compressed lists that are painful to edit -->
-		<coverageVariable key="%language80" value="(af|ak|am|ar|as|az|be|bg|bgc|bho|bn|brx|bs|ca|ceb|cs|cv|cy|da|de|doi|ee|el|en|es|et|eu|fa|fi|fil|fr|ga|gaa|gd|gl|gu|ha|he|hi|hr|hu|hy|id|ig|ii|is|it|ja|jv|ka|kk|km|kn|ko|kok|ks|ky|lo|lt|lv|mai|mi|mk|ml|mn|mni|mr|ms|my|ne|nl|nn|no|nso|om|or|pa|pcm|pl|ps|pt|raj|ro|ru|rw|sa|sat|sd|si|sk|sl|so|sq|sr|st|su|sv|sw|ta|te|tg|th|ti|tk|tn|tr|tt|uk|ur|uz|vi|wo|xh|yo|yue|zh|zu|ast|blo|br|chr|csw|dsb|eo|ff|fo|fy|hsb|ia|ie|kea|kgp|ku|kxv|lb|lij|lmo|mt|nds|nqo|oc|prg|qu|rm|sah|sc|syr|szl|to|ug|vec|vmw|xnr|yrl|za|mul|root|zxx|und)"/>
+		<coverageVariable key="%language80" value="(af|ak|am|ar|as|az|bal|be|bg|bgc|bho|bn|brx|bs|ca|ceb|cs|cv|cy|da|de|doi|ee|el|en|es|et|eu|fa|fi|fil|fr|ga|gaa|gd|gl|gu|ha|he|hi|hr|hu|hy|id|ig|ii|is|it|ja|jv|ka|kk|km|kn|ko|kok|ks|ky|lo|lt|lv|mai|mi|mk|ml|mn|mni|mr|ms|my|ne|nl|nn|no|nso|om|or|pa|pcm|pl|ps|pt|raj|ro|ru|rw|sa|sat|sd|si|sk|sl|so|sq|sr|st|su|sv|sw|ta|te|tg|th|ti|tk|tn|tr|tt|uk|ur|uz|vi|wo|xh|yo|yue|zh|zu|ast|blo|br|chr|csw|dsb|eo|ff|fo|fy|hsb|ia|ie|kea|kgp|ku|kxv|lb|lij|lmo|mt|nds|nqo|oc|prg|qu|rm|sah|sc|syr|szl|to|ug|vec|vmw|xnr|yrl|za|mul|root|zxx|und)"/>
 		<coverageVariable key="%lbTypes80" value="(strict|normal|loose)"/>
 		<coverageVariable key="%lwTypes" value="(normal|breakall|keepall|phrase)"/>
 		<coverageVariable key="%m0Types80" value="(bgn|prprname|ungegn)"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRLocale.java
@@ -13,6 +13,7 @@ import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import org.unicode.cldr.tool.LikelySubtags;
 
 /**
  * This class implements a CLDR UTS#35 compliant locale. It differs from ICU and Java locales in
@@ -707,5 +708,16 @@ public final class CLDRLocale implements Comparable<CLDRLocale> {
 
     public String getRegion() {
         return getCountry();
+    }
+
+    private String getMaximalLocaleString() {
+        return new LikelySubtags().maximize(getBaseName());
+    }
+
+    /** get the maximized version of this locale or null if not set */
+    public CLDRLocale getMaximal() {
+        final String max = getMaximalLocaleString();
+        if (max == null) return null;
+        return getInstance(max);
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -10,28 +11,23 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.MultipleFailuresError;
 import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.CoverageLevel2;
+import org.unicode.cldr.testutil.TestWithKnownIssues;
 import org.unicode.cldr.tool.ToolConstants;
-import org.unicode.cldr.util.StandardCodes.CodeType;
 
-public class TestCoverageLevel2 {
+public class TestCoverageLevel2 extends TestWithKnownIssues {
 
     final int ITERATIONS = 100000; // keep this low for normal testing
 
-    private static SupplementalDataInfo sdi;
-
-    @BeforeAll
-    private static void setup() {
-        sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
-        CoverageLevel2 c = CoverageLevel2.getInstance(sdi, "fr_CA");
-    }
-
     @Test
     public void TestCoveragePerf() {
+        final SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
         for (int i = 0; i < ITERATIONS; i++) {
             CoverageLevel2 c = CoverageLevel2.getInstance(sdi, "fr_CA");
             assertEquals(
@@ -42,69 +38,208 @@ public class TestCoverageLevel2 {
     }
 
     @Test
-    public void TestPriorBasicLanguage() throws IOException {
-        // Fail if the language name is at above this level
-        final Level failIfAbove = Level.MODERN;
-
+    public void TestPriorBasicCoverage() throws IOException {
         // we need the CLDR Archive dir for this.
         assumeTrue(TestCLDRPaths.canUseArchiveDirectory());
 
         // Previous CLDR version
         final VersionInfo prev = ToolConstants.previousVersion();
+
         // read coverageLevels.txt from the *previous* version
         final CalculatedCoverageLevels prevCovLevel = CalculatedCoverageLevels.forVersion(prev);
-        // Our xpath: the language leaf
-        final XPathParts xpp =
-                XPathParts.getFrozenInstance("//ldml/localeDisplayNames/languages/language")
-                        .cloneAsThawed();
-        // CLDR English File
-        final CLDRFile english = CLDRConfig.getInstance().getEnglish();
-
-        // Result: locales not in en.xml
-        final Set<String> notInEnglish = new TreeSet<>();
-        // Result: locales not in coverage
-        final Set<String> notInCoverage = new TreeSet<>();
 
         final Set<String> localesToCheck =
                 SupplementalDataInfo.getInstance().getLanguageTcOrBasic();
+
         final Map<String, CoverageLevel2> covs = new HashMap<>();
 
+        final SupplementalDataInfo sdi = CLDRConfig.getInstance().getSupplementalDataInfo();
         for (final String lang : localesToCheck) {
             covs.put(lang, CoverageLevel2.getInstance(sdi, lang));
         }
 
-        for (final String lang : StandardCodes.make().getAvailableCodes(CodeType.language)) {
-            if (prevCovLevel.isLocaleAtLeastBasic(lang)) {
-                xpp.setAttribute(-1, LDMLConstants.TYPE, lang);
-                final String xpath = xpp.toString();
+        // CLDR English File
+        final CLDRFile english = CLDRConfig.getInstance().getEnglish();
 
-                if (!english.isHere(xpath.toString())) {
-                    // fail if not in English
-                    notInEnglish.add(lang);
-                }
+        Assertions.assertAll(
+                () -> checkLanguageCoverage(prevCovLevel, covs, english),
+                () -> checkScriptCoverage(prevCovLevel, covs, english),
+                // region coverage elsewhere?
+                () -> checkVariantCoverage(prevCovLevel, covs, english));
+    }
 
-                if (covs.values().stream()
-                        .anyMatch((cov) -> cov.getLevel(xpath.toString()).isAbove(failIfAbove))) {
-                    // fail if level > failIfAbove for any of those locales
-                    notInCoverage.add(lang);
-                }
+    private void checkLanguageCoverage(
+            final CalculatedCoverageLevels prevCovLevel,
+            final Map<String, CoverageLevel2> covs,
+            final CLDRFile english)
+            throws MultipleFailuresError {
+
+        // configuration
+        final Level failIfAbove = Level.MODERN;
+        final String XPATH = "//ldml/localeDisplayNames/languages/language";
+
+        // all languages of previous coverage levels at basic+
+        final Set<String> typesAtBasic =
+                prevCovLevel.levels.keySet().stream()
+                        .filter(l -> prevCovLevel.isLocaleAtLeastBasic(l))
+                        .map(l -> CLDRLocale.getInstance(l).getLanguage())
+                        .collect(Collectors.toSet());
+
+        assertMissingCoverage(covs, english, failIfAbove, XPATH, typesAtBasic);
+    }
+
+    private void checkScriptCoverage(
+            final CalculatedCoverageLevels prevCovLevel,
+            final Map<String, CoverageLevel2> covs,
+            final CLDRFile english)
+            throws MultipleFailuresError {
+
+        // configuration
+        final Level failIfAbove = Level.MODERN;
+        final String XPATH = "//ldml/localeDisplayNames/scripts/script";
+
+        // all scripts of previous coverage levels at basic+
+        final Set<String> typesAtBasic =
+                prevCovLevel.levels.keySet().stream()
+                        .filter(l -> prevCovLevel.isLocaleAtLeastBasic(l))
+                        .map(l -> CLDRLocale.getInstance(l))
+                        .map(
+                                l -> {
+                                    final CLDRLocale max = l.getMaximal();
+                                    assertNotNull(max, () -> "Max locale for " + l);
+                                    final String script = max.getScript();
+                                    assertNotNull(
+                                            script,
+                                            () -> "Script for " + max + " which is max for " + l);
+                                    return script;
+                                })
+                        .collect(Collectors.toSet());
+
+        assertMissingCoverage(covs, english, failIfAbove, XPATH, typesAtBasic);
+    }
+
+    private void checkVariantCoverage(
+            final CalculatedCoverageLevels prevCovLevel,
+            final Map<String, CoverageLevel2> covs,
+            final CLDRFile english)
+            throws MultipleFailuresError {
+
+        // configuration
+        final Level failIfAbove = Level.MODERN;
+        final String XPATH = "//ldml/localeDisplayNames/variants/variant";
+
+        // We need all locales for looking for variants
+        final Set<CLDRLocale> allLocales =
+                CLDRConfig.getInstance().getFullCldrFactory().getAvailableCLDRLocales();
+
+        // get all of the "raw" locales mentioned in coverage
+        final Set<CLDRLocale> localesAtBasic =
+                prevCovLevel.levels.keySet().stream()
+                        .filter(l -> prevCovLevel.isLocaleAtLeastBasic(l))
+                        .map(l -> CLDRLocale.getInstance(l))
+                        .collect(Collectors.toSet());
+
+        final Set<CLDRLocale> localesWithVariant =
+                allLocales.stream()
+                        .filter(l -> !l.getVariant().isEmpty())
+                        .collect(Collectors.toSet());
+        final Set<CLDRLocale> variantLocalesInCoverage =
+                localesWithVariant.stream()
+                        .filter(l -> localesAtBasic.stream().anyMatch(p -> l.childOf(p)))
+                        .collect(Collectors.toSet());
+        final Set<String> typesAtBasic =
+                variantLocalesInCoverage.stream()
+                        .map(l -> l.getVariant())
+                        .collect(Collectors.toSet());
+
+        assertMissingCoverage(covs, english, failIfAbove, XPATH, typesAtBasic);
+    }
+
+    /**
+     * Given types (script code, etc) at basic, check coverage and English inclusion.
+     *
+     * @param XPath in question - this will be mutated.
+     */
+    private void assertMissingCoverage(
+            final Map<String, CoverageLevel2> covs,
+            final CLDRFile english,
+            final Level failIfAbove,
+            final String xpath,
+            final Set<String> typesAtBasic)
+            throws MultipleFailuresError {
+        // Our xpath: the leaf node
+        final XPathParts xpp = XPathParts.getFrozenInstance(xpath).cloneAsThawed();
+
+        // Result: types not in en.xml
+        final Set<String> notInEnglish = new TreeSet<>();
+        // Result: types not in coverage
+        final Set<String> notInCoverage = new TreeSet<>();
+
+        collectMissingTypes(
+                covs, english, failIfAbove, xpp, notInEnglish, notInCoverage, typesAtBasic);
+
+        assertMissingCoverage(failIfAbove, notInEnglish, notInCoverage, xpp);
+    }
+
+    /**
+     * Given types (script code, etc) at basic, check coverage and English inclusion.
+     *
+     * @param xpath XPath in question - this will be mutated.
+     */
+    private void collectMissingTypes(
+            final Map<String, CoverageLevel2> covs,
+            final CLDRFile english,
+            final Level failIfAbove,
+            final XPathParts xpp,
+            final Set<String> notInEnglish,
+            final Set<String> notInCoverage,
+            final Set<String> typesAtBasic) {
+        for (final String type : typesAtBasic) {
+            xpp.setAttribute(-1, LDMLConstants.TYPE, type);
+            final String xpath = xpp.toString();
+
+            if (!english.isHere(xpath)) {
+                // fail if not in English
+                notInEnglish.add(type);
+            }
+
+            if (covs.values().stream()
+                    .anyMatch((cov) -> cov.getLevel(xpath).isAbove(failIfAbove))) {
+                // fail if level > failIfAbove for any of those locales
+                notInCoverage.add(type);
             }
         }
+    }
 
+    /** Bring the bad news (if any). Reporting factored out here. */
+    private void assertMissingCoverage(
+            final Level failIfAbove,
+            final Set<String> notInEnglish,
+            final Set<String> notInCoverage,
+            final XPathParts xpp)
+            throws MultipleFailuresError {
+        // given xpp is  scripts/script or languages/language, etc.
+        final String plural = xpp.getElement(-2); // the plural form of what we're looking for
         Assertions.assertAll(
                 () ->
                         assertTrue(
                                 notInEnglish.isEmpty(),
                                 () ->
-                                        "en.xml is missing translations for these languages' names:"
-                                                + notInEnglish.toString()),
-                () ->
-                        assertTrue(
-                                notInCoverage.isEmpty(),
-                                () ->
-                                        "coverageLevels.xml has a coverage level >"
-                                                + failIfAbove
-                                                + " for these language's names:"
-                                                + notInCoverage.toString()));
+                                        String.format(
+                                                "en.xml missing these %s: %s",
+                                                plural, notInEnglish.toString())),
+                () -> {
+                    final Supplier<String> formatter =
+                            () ->
+                                    String.format(
+                                            "coverageLevels.xml has level > %s for these %s: %s",
+                                            failIfAbove, plural, notInCoverage.toString());
+                    if (!notInCoverage.isEmpty() && plural.equals("variants")) {
+                        if (logKnownIssue("CLDR-18480", formatter.get())) {
+                            return;
+                        }
+                    }
+                    assertTrue(notInCoverage.isEmpty(), formatter);
+                });
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCoverageLevel2.java
@@ -18,10 +18,9 @@ import org.junit.jupiter.api.Test;
 import org.opentest4j.MultipleFailuresError;
 import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.test.CoverageLevel2;
-import org.unicode.cldr.testutil.TestWithKnownIssues;
 import org.unicode.cldr.tool.ToolConstants;
 
-public class TestCoverageLevel2 extends TestWithKnownIssues {
+public class TestCoverageLevel2 {
 
     final int ITERATIONS = 100000; // keep this low for normal testing
 
@@ -235,9 +234,12 @@ public class TestCoverageLevel2 extends TestWithKnownIssues {
                                             "coverageLevels.xml has level > %s for these %s: %s",
                                             failIfAbove, plural, notInCoverage.toString());
                     if (!notInCoverage.isEmpty() && plural.equals("variants")) {
-                        if (logKnownIssue("CLDR-18480", formatter.get())) {
-                            return;
-                        }
+                        // TODO CLDR-18481 need logKnownIssue in JUnit
+                        // if (logKnownIssue("CLDR-18480", formatter.get())) {
+                        //     return;
+                        // }
+                        System.err.println("CLDR-18400: known issue: " + formatter.get());
+                        return;
                     }
                     assertTrue(notInCoverage.isEmpty(), formatter);
                 });


### PR DESCRIPTION
CLDR-17857

- add `bal` to modern
- update test which had missed bal before
- also, test that all Basic lang's scripts are in modern
- add CLDRLocale.toMaximal
- add check for variants - with a known issue CLDR-18480

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
