### PR TITLE
CLDR-18437 Remove duplicate language alias

### DIFF
--- a/common/supplemental/supplementalMetadata.xml
+++ b/common/supplemental/supplementalMetadata.xml
@@ -304,7 +304,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<languageAlias type="zsm" replacement="ms" reason="macrolanguage"/> <!-- Standard Malay ⇒ Malay -->
 			<languageAlias type="zyb" replacement="za" reason="macrolanguage"/> <!-- Yongbei Zhuang ⇒ Zhuang -->
 			<languageAlias type="him" replacement="srx" reason="macrolanguage"/> <!-- Himachali ⇒ Sirmauri (= Pahari, Himachali) -->
-			<languageAlias type="mnk" replacement="man" reason="macrolanguage"/> <!-- Mandinka ⇒ Mandingo -->
 			<languageAlias type="bh" replacement="bho" reason="macrolanguage"/> <!-- Bihari ⇒ Bhojpuri -->
 			<languageAlias type="cls" replacement="sa" reason="macrolanguage"/> <!-- Classical Sanskrit ⇒ Sanskrit -->
 			<!-- Special case <languageAlias type="nb" replacement="no" reason="macrolanguage"/> <! - - Norwegian Bokmål ⇒ Norwegian -->

--- a/common/testData/localeIdentifiers/localeCanonicalization.txt
+++ b/common/testData/localeIdentifiers/localeCanonicalization.txt
@@ -290,7 +290,6 @@ mhr	;	chm
 mkd	;	mk
 mlg	;	mg
 mlt	;	mt
-mnk	;	man
 mnt	;	wnn
 mo	;	ro
 mof	;	xnt
@@ -1557,7 +1556,6 @@ mhr_Adlm_AC_fonipa	;	chm_Adlm_AC_fonipa
 mkd_Adlm_AC_fonipa	;	mk_Adlm_AC_fonipa
 mlg_Adlm_AC_fonipa	;	mg_Adlm_AC_fonipa
 mlt_Adlm_AC_fonipa	;	mt_Adlm_AC_fonipa
-mnk_Adlm_AC_fonipa	;	man_Adlm_AC_fonipa
 mnt_Adlm_AC_fonipa	;	wnn_Adlm_AC_fonipa
 mo_Adlm_AC_fonipa	;	ro_Adlm_AC_fonipa
 mof_Adlm_AC_fonipa	;	xnt_Adlm_AC_fonipa

--- a/common/validity/language.xml
+++ b/common/validity/language.xml
@@ -12,7 +12,7 @@
 <supplementalData>
 	<version number="$Revision$"/>
 	<idValidity>
-		<id type='language' idStatus='regular'>		<!-- 7963 items -->
+		<id type='language' idStatus='regular'>		<!-- 7964 items -->
 			aa aaa~i aak~l aan~q aas~x aaz
 			ab aba~j abl~z
 			aca~b acd~f ach~i ack~n acp~z
@@ -321,7 +321,7 @@
 			mk mka~c mke~z
 			ml mla~c mle~f mlh~s mlu~x mlz
 			mma~r mmt~z
-			mn mna~j mnl~s mnu~z
+			mn mna~s mnu~z
 			moa moc~e mog~k mom moo~z
 			mpa~e mpg~z
 			mqa~c mqe~z
@@ -625,7 +625,7 @@
 			mis mul
 			zxx
 		</id>
-		<id type='language' idStatus='deprecated'>		<!-- 299 items -->
+		<id type='language' idStatus='deprecated'>		<!-- 298 items -->
 			aam adp agp ais ajp ajt~u als aoh arb asd aue ayr ayx~y azj
 			baz bbz bcc bcl bgm bh bhk bic bij bjd bjq bkb blg bmy bpb btb btl bxk bxr bxx byy
 			cbe cbh cca ccq cdg cjr cka cld cls cmk cmn cnr coy cqu cug cum cwd
@@ -638,7 +638,7 @@
 			jar jeg ji jw
 			kbf kdv kgc~d kgh kgm khk kjf kmr knc kng koj kox kpp kpv krm ksa ktr kvs kwq kxe kxl kxu kzh kzj kzt
 			lak lba lbk leg lii llo lmm lmz lno lsg lvs
-			meg mgx mhh mhr mja mld mnk mnt mo mof mst mup mvm mwd mwj mwx~y myd myi myq myt
+			meg mgx mhh mhr mja mld mnt mo mof mst mup mvm mwd mwj mwx~y myd myi myq myt
 			nad nbf nbx ncp ngo nln nlr nns nnx nom noo npi nte nts nxu
 			ojg ome ory oun
 			pat pbu pbz pcr pes pgy pii plj plp plt pmc pmk pmu pnb pod ppa ppr prb prp prs pry puk puz

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -586,6 +586,7 @@ public class TestValidity extends TestFmwkPlus {
         return diff;
     }
 
+    // Shows the items in set A that are not in set B
     private <T> Set<T> showMinus(String title, LstrType lstrType, Set<T> a, Set<T> b) {
         if (a == null) {
             a = Collections.emptySet();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -141,7 +141,9 @@ public class TestValidity extends TestFmwkPlus {
                     "SLE",
                     // 2024
                     "dzd",
-                    "knn");
+                    "knn",
+                    //2025
+                    "mnk");
     static final Set<String> ALLOWED_MISSING =
             ImmutableSet.of(LocaleNames.ROOT, "POSIX", "REVISED", "SAAHO");
     static final Set<String> ALLOWED_REGULAR_TO_SPECIAL = ImmutableSet.of("Zanb", "Zinh", "Zyyy");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestValidity.java
@@ -142,7 +142,7 @@ public class TestValidity extends TestFmwkPlus {
                     // 2024
                     "dzd",
                     "knn",
-                    //2025
+                    // 2025
                     "mnk");
     static final Set<String> ALLOWED_MISSING =
             ImmutableSet.of(LocaleNames.ROOT, "POSIX", "REVISED", "SAAHO");


### PR DESCRIPTION
The Mandingo `man` macrolanguage has 7 members. Right now, in languageAlias, we show 2 default members that represent the whole of Mandingo. In reality, there should be only 1 default for each macrolanguage, so this updates the values to just 1.

Eastern Maninkakan `emk` has ~3.5million speakers but Mandinka `mnk` only has 1 million, so Eastern Maninkakan takes precedence.

CLDR-18437

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
