### PR TITLE
CLDR-18475 st: fix RTL input in input box and examples

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAddAlt.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddAlt.mjs
@@ -9,7 +9,7 @@ import * as cldrVue from "./cldrVue.mjs";
 
 import AddAlt from "../views/AddAlt.vue";
 
-function addButton(containerEl, xpstrid) {
+function addAltButton(containerEl, xpstrid) {
   try {
     const addAltWrapper = cldrVue.mount(AddAlt, containerEl);
     addAltWrapper.setXpathStringId(xpstrid);
@@ -71,4 +71,4 @@ function reloadPage() {
   cldrLoad.reloadV(); // crude
 }
 
-export { addButton, getAlts, addChosenAlt, reloadPage };
+export { addAltButton, getAlts, addChosenAlt, reloadPage };

--- a/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
@@ -31,9 +31,12 @@ function setFormIsVisible(visible, xpstrid) {
   }
 }
 
-function addButton(containerEl, xpstrid) {
+function addValueButton(containerEl, xpstrid, overrideDir) {
   try {
-    const AddValueWrapper = cldrVue.mount(AddValue, containerEl);
+    const dir = overrideDir || cldrSurvey.locInfo()?.dir;
+    const AddValueWrapper = cldrVue.mount(AddValue, containerEl, {
+      dir,
+    });
     AddValueWrapper.setXpathStringId(xpstrid);
   } catch (e) {
     console.error(
@@ -87,7 +90,7 @@ function getTrFromXpathStringId(xpstrid) {
 }
 
 export {
-  addButton,
+  addValueButton,
   getEnglish,
   getWinning,
   isFormVisible,

--- a/tools/cldr-apps/js/src/esm/cldrComponents.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrComponents.mjs
@@ -27,6 +27,7 @@ import {
   Col,
   Collapse,
   CollapsePanel,
+  ConfigProvider,
   Form,
   Input,
   List,
@@ -67,6 +68,7 @@ function setup(app) {
   app.component("a-col", Col);
   app.component("a-collapse-panel", CollapsePanel);
   app.component("a-collapse", Collapse);
+  app.component("a-config-provider", ConfigProvider);
   app.component("a-form-item", Form.Item);
   app.component("a-form", Form);
   app.component("a-input-password", Input.Password);

--- a/tools/cldr-apps/js/src/esm/cldrEvent.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEvent.mjs
@@ -76,14 +76,14 @@ function startup() {
         .closest(".d-disp,.d-item,.d-item-err,.d-item-warn")
         .find(".d-example");
       if (example) {
+        const lang = example.attr("lang");
+        const dir = example.attr("dir");
         $(this)
           .popover({
             html: true,
             placement: "top",
-            content: `<div class='d-example-popover' lang='${example.attr(
-              "lang"
-            )}' dir='${example.attr("dir")}'>
-                        ${example.html()}
+            content: `<div class='d-example-popover' lang='${lang}' dir='${dir}'>
+                ${example.html()}
             </div>`,
             dir: example.dir,
           })
@@ -95,7 +95,7 @@ function startup() {
     "mouseleave",
     ".vetting-page .d-example-img, .vetting-page .subSpan",
     function () {
-      $(this).popover("hide");
+      $(this).popover("hide"); // comment this out to keep example popup around
     }
   );
 
@@ -122,7 +122,7 @@ function startup() {
     "mouseleave",
     ".vetting-page .d-trans-hint-img, .vetting-page .subSpan",
     function () {
-      $(this).popover("hide");
+      $(this).popover("hide"); // comment this out to keep example popup around
     }
   );
   resizeSidebar();

--- a/tools/cldr-apps/js/src/esm/cldrEvent.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEvent.mjs
@@ -80,7 +80,12 @@ function startup() {
           .popover({
             html: true,
             placement: "top",
-            content: example.html(),
+            content: `<div class='d-example-popover' lang='${example.attr(
+              "lang"
+            )}' dir='${example.attr("dir")}'>
+                        ${example.html()}
+            </div>`,
+            dir: example.dir,
           })
           .popover("show");
       }

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
@@ -802,7 +802,7 @@ function appendExtraAttributes(container, theRow) {
  * @param loc optional
  * @returns locale bundle
  */
-function locInfo(loc) {
+export function locInfo(loc) {
   if (!loc) {
     loc = cldrStatus.getCurrentLocale();
   }

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
@@ -802,7 +802,7 @@ function appendExtraAttributes(container, theRow) {
  * @param loc optional
  * @returns locale bundle
  */
-export function locInfo(loc) {
+function locInfo(loc) {
   if (!loc) {
     loc = cldrStatus.getCurrentLocale();
   }
@@ -980,6 +980,7 @@ export {
   hideLoader,
   isInputBusy,
   localizeFlyover,
+  locInfo,
   parseStatusAction,
   setLang,
   setShower,

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -562,7 +562,7 @@ function reallyUpdateRow(tr, theRow) {
    */
   if (addCell) {
     cldrDom.removeAllChildNodes(addCell);
-    cldrAddValue.addButton(addCell, theRow.xpstrid);
+    cldrAddValue.addValueButton(addCell, theRow.xpstrid, theRow.dir);
   }
 
   /*
@@ -786,7 +786,7 @@ function updateRowEnglishComparisonCell(tr, theRow, cell) {
   }
   listen(null, tr, cell, null);
   if (cldrStatus.getPermissions()?.userIsTC) {
-    cldrAddAlt.addButton(cell, theRow.xpstrid);
+    cldrAddAlt.addAltButton(cell, theRow.xpstrid, theRow.dir);
   }
   cell.isSetup = true;
 }

--- a/tools/cldr-apps/js/src/esm/cldrVue.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVue.mjs
@@ -37,9 +37,9 @@ function showPanel(type, el, opts) {
  * @param {Element} el the element below which to mount it
  * @returns the application instance
  */
-function mount(component, el) {
+function mount(component, el, extraProps) {
   const fragment = document.createDocumentFragment();
-  const app = create(component).mount(fragment);
+  const app = create(component, null, extraProps).mount(fragment);
   const childEl = document.createElement("div");
   el.appendChild(childEl);
   childEl.replaceWith(fragment);

--- a/tools/cldr-apps/js/src/views/AddValue.vue
+++ b/tools/cldr-apps/js/src/views/AddValue.vue
@@ -10,6 +10,8 @@ const formTop = ref(0);
 const formIsVisible = ref(false);
 const inputToFocus = ref(null);
 
+const { dir } = defineProps(["dir"]);
+
 function setXpathStringId(id) {
   xpstrid.value = id;
 }
@@ -57,37 +59,37 @@ defineExpose({
 </script>
 
 <template>
-  <div>
-    <!-- If use a-button instead of button, form positioning fails -->
-    <button class="plus" type="button" @click="showModal">
-      ✚
-      <!-- U+271A HEAVY GREEK CROSS -->
-    </button>
-    <a-modal
-      v-model:visible="formIsVisible"
-      :closable="false"
-      :footer="null"
-      :style="{
-        position: 'sticky',
-        left: formLeft + 'px',
-        top: formTop + 'px',
-      }"
-      @ok="onSubmit"
-    >
+  <!-- If use a-button instead of button, form positioning fails -->
+  <button class="plus" type="button" @click="showModal">
+    ✚
+    <!-- U+271A HEAVY GREEK CROSS -->
+  </button>
+  <a-modal
+    v-model:visible="formIsVisible"
+    :closable="false"
+    :footer="null"
+    :style="{
+      position: 'sticky',
+      left: formLeft + 'px',
+      top: formTop + 'px',
+    }"
+    @ok="onSubmit"
+  >
+    <a-config-provider :direction="dir">
       <a-input
         v-model:value="newValue"
         placeholder="Add a translation"
         ref="inputToFocus"
         @keydown.enter="onSubmit"
       />
-      <div class="button-container">
-        <a-button @click="onEnglish">→English</a-button>
-        <a-button @click="onWinning">→Winning</a-button>
-        <a-button type="cancel" @click="onCancel">Cancel</a-button>
-        <a-button type="primary" @click="onSubmit">Submit</a-button>
-      </div>
-    </a-modal>
-  </div>
+    </a-config-provider>
+    <div class="button-container">
+      <a-button @click="onEnglish">→English</a-button>
+      <a-button @click="onWinning">→Winning</a-button>
+      <a-button type="cancel" @click="onCancel">Cancel</a-button>
+      <a-button type="primary" @click="onSubmit">Submit</a-button>
+    </div>
+  </a-modal>
 </template>
 
 <style scoped>

--- a/tools/cldr-apps/js/test/TestCldrSurvey.mjs
+++ b/tools/cldr-apps/js/test/TestCldrSurvey.mjs
@@ -92,7 +92,7 @@ describe("cldrSurvey.setLang", function () {
     expect(n.lang).to.equal("bn");
     expect(n.dir).to.equal("ltr");
   });
-  it("should be able to a node with ar language", () => {
+  it("should be able to set a node with ar language", () => {
     const n = document.createElement("span");
     expect(n).to.be.ok;
     cldrSurvey.setLang(n, "ar");
@@ -106,7 +106,7 @@ describe("cldrSurvey.setLang", function () {
     expect(n.lang).to.equal("bn");
     expect(n.dir).to.equal("ltr");
   });
-  it("should be able to a node with default ar language", () => {
+  it("should be able to set a node with default ar language", () => {
     cldrStatus.setCurrentLocale("ar");
     const n = document.createElement("span");
     expect(n).to.be.ok;
@@ -114,7 +114,7 @@ describe("cldrSurvey.setLang", function () {
     expect(n.lang).to.equal("ar");
     expect(n.dir).to.equal("rtl");
   });
-  it("should be able to a node with default bn language", () => {
+  it("should be able to set a node with default bn language", () => {
     cldrStatus.setCurrentLocale("bn");
     const n = document.createElement("span");
     expect(n).to.be.ok;
@@ -122,7 +122,7 @@ describe("cldrSurvey.setLang", function () {
     expect(n.lang).to.equal("bn");
     expect(n.dir).to.equal("ltr");
   });
-  it("should be able to a node with override ar language", () => {
+  it("should be able to set a node with override ar language", () => {
     cldrStatus.setCurrentLocale("ar");
     const n = document.createElement("span");
     expect(n).to.be.ok;
@@ -130,7 +130,7 @@ describe("cldrSurvey.setLang", function () {
     expect(n.lang).to.equal("ar");
     expect(n.dir).to.equal("ltr");
   });
-  it("should be able to a node with override bn language", () => {
+  it("should be able to set a node with override bn language", () => {
     cldrStatus.setCurrentLocale("bn");
     const n = document.createElement("span");
     expect(n).to.be.ok;

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -1968,6 +1968,11 @@ div.d-example {
     margin-top:7px;
 }
 
+/* bootstrap popover likes to force the alignment left, but we want it to follow the language */
+.popover .d-example-popover {
+	text-align: initial !important;
+}
+
 #stchanged_loc {
 	font-weight: bold;
 }


### PR DESCRIPTION
- rename cldrAddAlt.addButton and cldrAddValue.addButton to reduce my own confusion
- export cldrSurvey.locInfo
- import <a-config-provider> from ant
- add a <AddValue dir="rtl"/> prop to AddValue to support passing through the directionality
- update AddValue to use the configProvider to set directionality
- fix a typo in TestCldrSurvey
- update cldrVue.mount to pass through extra props to mounted components
- also fix RTL on examples

CLDR-18475

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

Fixed input page:
![image](https://github.com/user-attachments/assets/d9933e25-7846-444b-868d-5b6661e592bc)

Fixed example page:
<img width="759" alt="image" src="https://github.com/user-attachments/assets/a662e818-0b09-4e92-9f15-fe1f04a334b9" />