### PR TITLE
CLDR-18486 publish Jira updater

### DIFF
--- a/tools/scripts/jira-updater/.gitignore
+++ b/tools/scripts/jira-updater/.gitignore
@@ -1,1 +1,3 @@
 /node_modules
+/LICENSE
+/CONTRIBUTING.md

--- a/tools/scripts/jira-updater/README.md
+++ b/tools/scripts/jira-updater/README.md
@@ -16,8 +16,8 @@ optional, JIRA_FIELD will override the field name from "Merged"
 
 ## LICENSE
 
-Copyright © 2025 Unicode, Inc.
-For terms of use, see <http://www.unicode.org/copyright.html>
-SPDX-License-Identifier: Unicode-3.0
+Copyright © 2004-2025 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.
 
-see [LICENSE](../../../LICENSE)
+A CLA is required to contribute to this project - please refer to the [CONTRIBUTING.md](./CONTRIBUTING.md) file (or start a Pull Request) for more information.
+
+The contents of this repository are governed by the Unicode [Terms of Use](https://www.unicode.org/copyright.html) and are released under [LICENSE](./LICENSE).

--- a/tools/scripts/jira-updater/package.json
+++ b/tools/scripts/jira-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicode-org/jira-updater",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "update-jira.mjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -23,5 +23,10 @@
   "private": false,
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/unicode-org/cldr.git",
+    "directory": "tools/scripts/jira-updater"
   }
 }

--- a/tools/scripts/jira-updater/package.json
+++ b/tools/scripts/jira-updater/package.json
@@ -1,16 +1,27 @@
 {
   "name": "@unicode-org/jira-updater",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "update-jira.mjs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepack": "cp ../../../LICENSE ../../../CONTRIBUTING.md ."
+  },
+  "bin": {
+    "cldr-jira-updater": "update-jira.mjs"
   },
   "keywords": [],
   "author": "Steven R. Loomis <srloomis@unicode.org>",
   "license": "Unicode-3.0",
   "description": "",
-  "private": true,
   "dependencies": {
     "jira.js": "^4.1.0"
+  },
+  "files": [
+    "LICENSE",
+    "CONTRIBUTING.md"
+  ],
+  "private": false,
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/tools/scripts/jira-updater/update-jira.mjs
+++ b/tools/scripts/jira-updater/update-jira.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Copyright © 2025 Unicode, Inc.
  * For terms of use, see http://www.unicode.org/copyright.html


### PR DESCRIPTION
CLDR-18486

no impact on CLDR.

Update the jira updater so that it can be pushed to npm separately (readme, etc)

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
