### PR TITLE
CLDR-18473 Change coverage levels for some date/time formats

### DIFF
--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -8,172 +8,172 @@
 # https://cldr.unicode.org/index/cldr-spec/coverage-levels.		
 		
 		
-af ;	modern ;	Afrikaans
-ak ;	moderate ;	Akan
-am ;	modern ;	Amharic
-ar ;	modern ;	Arabic
-as ;	modern ;	Assamese
+af ;	basic ;	Afrikaans
+ak ;	basic ;	Akan
+am ;	basic ;	Amharic
+ar ;	basic ;	Arabic
+as ;	basic ;	Assamese
 ast ;	basic ;	Asturian
-az ;	modern ;	Azerbaijani
-bal_Latn ;	moderate ;	Baluchi (Latin)
-be ;	modern ;	Belarusian
-bg ;	modern ;	Bulgarian
+az ;	basic ;	Azerbaijani
+bal_Latn ;	basic ;	Baluchi (Latin)
+be ;	basic ;	Belarusian
+bg ;	basic ;	Bulgarian
 bgc ;	basic ;	Haryanvi
 bho ;	basic ;	Bhojpuri
 blo ;	basic ;	Anii
-bn ;	modern ;	Bangla
-br ;	moderate ;	Breton
+bn ;	basic ;	Bangla
+br ;	basic ;	Breton
 brx ;	basic ;	Bodo
-bs ;	modern ;	Bosnian
+bs ;	basic ;	Bosnian
 bs_Cyrl ;	basic ;	Bosnian (Cyrillic)
-ca ;	modern ;	Catalan
-ceb ;	moderate ;	Cebuano
-chr ;	modern ;	Cherokee
-cs ;	modern ;	Czech
+ca ;	basic ;	Catalan
+ceb ;	basic ;	Cebuano
+chr ;	basic ;	Cherokee
+cs ;	basic ;	Czech
 csw ;	basic ;	Swampy Cree
 cv ;	basic ;	Chuvash
-cy ;	modern ;	Welsh
-da ;	modern ;	Danish
-de ;	modern ;	German
+cy ;	basic ;	Welsh
+da ;	basic ;	Danish
+de ;	basic ;	German
 doi ;	basic ;	Dogri
-dsb ;	modern ;	Lower Sorbian
+dsb ;	basic ;	Lower Sorbian
 ee ;	basic ;	Ewe
-el ;	modern ;	Greek
+el ;	basic ;	Greek
 en ;	modern ;	English
 eo ;	basic ;	Esperanto
-es ;	modern ;	Spanish
-et ;	modern ;	Estonian
-eu ;	modern ;	Basque
-fa ;	modern ;	Persian
+es ;	basic ;	Spanish
+et ;	basic ;	Estonian
+eu ;	basic ;	Basque
+fa ;	basic ;	Persian
 ff_Adlm ;	basic ;	Fula (Adlam)
-fi ;	modern ;	Finnish
-fil ;	modern ;	Filipino
-fo ;	moderate ;	Faroese
-fr ;	modern ;	French
+fi ;	basic ;	Finnish
+fil ;	basic ;	Filipino
+fo ;	basic ;	Faroese
+fr ;	basic ;	French
 fy ;	basic ;	Western Frisian
-ga ;	modern ;	Irish
+ga ;	basic ;	Irish
 gaa ;	basic ;	Ga
-gd ;	modern ;	Scottish Gaelic
-gl ;	modern ;	Galician
-gu ;	modern ;	Gujarati
-ha ;	modern ;	Hausa
-he ;	modern ;	Hebrew
-hi ;	modern ;	Hindi
-hi_Latn ;	modern ;	Hindi [Latin]
-hr ;	modern ;	Croatian
-hsb ;	modern ;	Upper Sorbian
-hu ;	modern ;	Hungarian
-hy ;	modern ;	Armenian
-ia ;	moderate ;	Interlingua
-id ;	modern ;	Indonesian
+gd ;	basic ;	Scottish Gaelic
+gl ;	basic ;	Galician
+gu ;	basic ;	Gujarati
+ha ;	basic ;	Hausa
+he ;	basic ;	Hebrew
+hi ;	basic ;	Hindi
+hi_Latn ;	basic ;	Hindi [Latin]
+hr ;	basic ;	Croatian
+hsb ;	basic ;	Upper Sorbian
+hu ;	basic ;	Hungarian
+hy ;	basic ;	Armenian
+ia ;	basic ;	Interlingua
+id ;	basic ;	Indonesian
 ie ;	basic ;	Interlingue
-ig ;	modern ;	Igbo
+ig ;	basic ;	Igbo
 ii ;	basic ;	Sichuan Yi
-is ;	modern ;	Icelandic
-it ;	modern ;	Italian
-ja ;	modern ;	Japanese
-jv ;	modern ;	Javanese
-ka ;	modern ;	Georgian
+is ;	basic ;	Icelandic
+it ;	basic ;	Italian
+ja ;	basic ;	Japanese
+jv ;	basic ;	Javanese
+ka ;	basic ;	Georgian
 kea ;	basic ;	Kabuverdianu
 kgp ;	basic ;	Kaingang
-kk ;	modern ;	Kazakh
-km ;	modern ;	Khmer
-kn ;	modern ;	Kannada
-ko ;	modern ;	Korean
-kok ;	modern ;	Konkani
+kk ;	basic ;	Kazakh
+km ;	basic ;	Khmer
+kn ;	basic ;	Kannada
+ko ;	basic ;	Korean
+kok ;	basic ;	Konkani
 kok_Latn ;	basic ;	Konkani (Latin)
 ks ;	basic ;	Kashmiri
 ks_Deva ;	basic ;	Kashmiri (Devanagari)
-ku ;	moderate ;	Kurdish
+ku ;	basic ;	Kurdish
 kxv ;	basic ;	Kuvi
 kxv_Deva ;	basic ;	Kuvi (Devanagari)
 kxv_Orya ;	basic ;	Kuvi (Odia)
 kxv_Telu ;	basic ;	Kuvi (Telugu)
-ky ;	modern ;	Kyrgyz
+ky ;	basic ;	Kyrgyz
 lb ;	basic ;	Luxembourgish
 lij ;	basic ;	Ligurian
 lmo ;	basic ;	Lombard
-lo ;	modern ;	Lao
-lt ;	modern ;	Lithuanian
-lv ;	modern ;	Latvian
+lo ;	basic ;	Lao
+lt ;	basic ;	Lithuanian
+lv ;	basic ;	Latvian
 mai ;	basic ;	Maithili
-mi ;	moderate ;	Māori
-mk ;	modern ;	Macedonian
-ml ;	modern ;	Malayalam
-mn ;	modern ;	Mongolian
+mi ;	basic ;	Māori
+mk ;	basic ;	Macedonian
+ml ;	basic ;	Malayalam
+mn ;	basic ;	Mongolian
 mni ;	basic ;	Manipuri
-mr ;	modern ;	Marathi
-ms ;	modern ;	Malay
+mr ;	basic ;	Marathi
+ms ;	basic ;	Malay
 mt ;	basic ;	Maltese
-my ;	modern ;	Burmese
+my ;	basic ;	Burmese
 nds ;	basic ;	Low German
-ne ;	modern ;	Nepali
-nl ;	modern ;	Dutch
+ne ;	basic ;	Nepali
+nl ;	basic ;	Dutch
 nn ;	modern ;	Norwegian Nynorsk
-no ;	modern ;	Norwegian
+no ;	basic ;	Norwegian
 nqo ;	basic ;	N’Ko
 nso ;	basic ;	Northern Sotho
 oc ;	basic ;	Occitan
 om ;	basic ;	Oromo
-or ;	modern ;	Odia
-pa ;	modern ;	Punjabi
-pcm ;	modern ;	Nigerian Pidgin
-pl ;	modern ;	Polish
-ps ;	modern ;	Pashto
-pt ;	modern ;	Portuguese
-qu ;	moderate ;	Quechua
+or ;	basic ;	Odia
+pa ;	basic ;	Punjabi
+pcm ;	basic ;	Nigerian Pidgin
+pl ;	basic ;	Polish
+ps ;	basic ;	Pashto
+pt ;	basic ;	Portuguese
+qu ;	basic ;	Quechua
 raj ;	basic ;	Rajasthani
 rm ;	basic ;	Romansh
-ro ;	modern ;	Romanian
-ru ;	modern ;	Russian
+ro ;	basic ;	Romanian
+ru ;	basic ;	Russian
 rw ;	basic ;	Kinyarwanda
 sa ;	basic ;	Sanskrit
 sah ;	basic ;	Yakut
 sat ;	basic ;	Santali
-sc ;	moderate ;	Sardinian
-sd ;	modern ;	Sindhi
+sc ;	basic ;	Sardinian
+sd ;	basic ;	Sindhi
 sd_Deva ;	basic ;	Sindhi (Devanagari)
-si ;	modern ;	Sinhala
-sk ;	modern ;	Slovak
-sl ;	modern ;	Slovenian
-so ;	modern ;	Somali
-sq ;	modern ;	Albanian
-sr ;	modern ;	Serbian
-sr_Latn ;	modern ;	Serbian (Latin)
+si ;	basic ;	Sinhala
+sk ;	basic ;	Slovak
+sl ;	basic ;	Slovenian
+so ;	basic ;	Somali
+sq ;	basic ;	Albanian
+sr ;	basic ;	Serbian
+sr_Latn ;	basic ;	Serbian (Latin)
 st ;	basic ;	Southern Sotho
 su ;	basic ;	Sundanese
-sv ;	modern ;	Swedish
-sw ;	modern ;	Swahili
+sv ;	basic ;	Swedish
+sw ;	basic ;	Swahili
 syr ;	basic ;	Syriac
 szl ;	basic ;	Silesian
-ta ;	modern ;	Tamil
-te ;	modern ;	Telugu
-tg ;	moderate ;	Tajik
-th ;	modern ;	Thai
-ti ;	modern ;	Tigrinya
-tk ;	modern ;	Turkmen
+ta ;	basic ;	Tamil
+te ;	basic ;	Telugu
+tg ;	basic ;	Tajik
+th ;	basic ;	Thai
+ti ;	basic ;	Tigrinya
+tk ;	basic ;	Turkmen
 tn ;	basic ;	Tswana
 to ;	basic ;	Tongan
-tr ;	modern ;	Turkish
-tt ;	moderate ;	Tatar
+tr ;	basic ;	Turkish
+tt ;	basic ;	Tatar
 ug ;	basic ;	Uyghur
-uk ;	modern ;	Ukrainian
-ur ;	modern ;	Urdu
-uz ;	modern ;	Uzbek
+uk ;	basic ;	Ukrainian
+ur ;	basic ;	Urdu
+uz ;	basic ;	Uzbek
 uz_Cyrl ;	basic ;	Uzbek (Cyrillic)
-vec ;	moderate ;	Venetian
-vi ;	modern ;	Vietnamese
+vec ;	basic ;	Venetian
+vi ;	basic ;	Vietnamese
 vmw ;	basic ;	Makhuwa
-wo ;	moderate ;	Wolof
-xh ;	moderate ;	Xhosa
+wo ;	basic ;	Wolof
+xh ;	basic ;	Xhosa
 xnr ;	basic ;	Kangri
-yo ;	modern ;	Yoruba
+yo ;	basic ;	Yoruba
 yrl ;	basic ;	Nheengatu
-yue ;	modern ;	Cantonese
-yue_Hans ;	modern ;	Cantonese (Simplified)
+yue ;	basic ;	Cantonese
+yue_Hans ;	basic ;	Cantonese (Simplified)
 za ;	basic ;	Zhuang
-zh ;	modern ;	Chinese
-zh_Hant ;	modern ;	Traditional Chinese
-zu ;	modern ;	Zulu
+zh ;	basic ;	Chinese
+zh_Hant ;	basic ;	Traditional Chinese
+zu ;	basic ;	Zulu
 		
 #EOF		

--- a/common/properties/coverageLevels.txt
+++ b/common/properties/coverageLevels.txt
@@ -8,172 +8,172 @@
 # https://cldr.unicode.org/index/cldr-spec/coverage-levels.		
 		
 		
-af ;	basic ;	Afrikaans
-ak ;	basic ;	Akan
-am ;	basic ;	Amharic
-ar ;	basic ;	Arabic
-as ;	basic ;	Assamese
+af ;	modern ;	Afrikaans
+ak ;	moderate ;	Akan
+am ;	modern ;	Amharic
+ar ;	modern ;	Arabic
+as ;	modern ;	Assamese
 ast ;	basic ;	Asturian
-az ;	basic ;	Azerbaijani
-bal_Latn ;	basic ;	Baluchi (Latin)
-be ;	basic ;	Belarusian
-bg ;	basic ;	Bulgarian
+az ;	modern ;	Azerbaijani
+bal_Latn ;	moderate ;	Baluchi (Latin)
+be ;	modern ;	Belarusian
+bg ;	modern ;	Bulgarian
 bgc ;	basic ;	Haryanvi
 bho ;	basic ;	Bhojpuri
 blo ;	basic ;	Anii
-bn ;	basic ;	Bangla
-br ;	basic ;	Breton
+bn ;	modern ;	Bangla
+br ;	moderate ;	Breton
 brx ;	basic ;	Bodo
-bs ;	basic ;	Bosnian
+bs ;	modern ;	Bosnian
 bs_Cyrl ;	basic ;	Bosnian (Cyrillic)
-ca ;	basic ;	Catalan
-ceb ;	basic ;	Cebuano
-chr ;	basic ;	Cherokee
-cs ;	basic ;	Czech
+ca ;	modern ;	Catalan
+ceb ;	moderate ;	Cebuano
+chr ;	modern ;	Cherokee
+cs ;	modern ;	Czech
 csw ;	basic ;	Swampy Cree
 cv ;	basic ;	Chuvash
-cy ;	basic ;	Welsh
-da ;	basic ;	Danish
-de ;	basic ;	German
+cy ;	modern ;	Welsh
+da ;	modern ;	Danish
+de ;	modern ;	German
 doi ;	basic ;	Dogri
-dsb ;	basic ;	Lower Sorbian
+dsb ;	modern ;	Lower Sorbian
 ee ;	basic ;	Ewe
-el ;	basic ;	Greek
+el ;	modern ;	Greek
 en ;	modern ;	English
 eo ;	basic ;	Esperanto
-es ;	basic ;	Spanish
-et ;	basic ;	Estonian
-eu ;	basic ;	Basque
-fa ;	basic ;	Persian
+es ;	modern ;	Spanish
+et ;	modern ;	Estonian
+eu ;	modern ;	Basque
+fa ;	modern ;	Persian
 ff_Adlm ;	basic ;	Fula (Adlam)
-fi ;	basic ;	Finnish
-fil ;	basic ;	Filipino
-fo ;	basic ;	Faroese
-fr ;	basic ;	French
+fi ;	modern ;	Finnish
+fil ;	modern ;	Filipino
+fo ;	moderate ;	Faroese
+fr ;	modern ;	French
 fy ;	basic ;	Western Frisian
-ga ;	basic ;	Irish
+ga ;	modern ;	Irish
 gaa ;	basic ;	Ga
-gd ;	basic ;	Scottish Gaelic
-gl ;	basic ;	Galician
-gu ;	basic ;	Gujarati
-ha ;	basic ;	Hausa
-he ;	basic ;	Hebrew
-hi ;	basic ;	Hindi
-hi_Latn ;	basic ;	Hindi [Latin]
-hr ;	basic ;	Croatian
-hsb ;	basic ;	Upper Sorbian
-hu ;	basic ;	Hungarian
-hy ;	basic ;	Armenian
-ia ;	basic ;	Interlingua
-id ;	basic ;	Indonesian
+gd ;	modern ;	Scottish Gaelic
+gl ;	modern ;	Galician
+gu ;	modern ;	Gujarati
+ha ;	modern ;	Hausa
+he ;	modern ;	Hebrew
+hi ;	modern ;	Hindi
+hi_Latn ;	modern ;	Hindi [Latin]
+hr ;	modern ;	Croatian
+hsb ;	modern ;	Upper Sorbian
+hu ;	modern ;	Hungarian
+hy ;	modern ;	Armenian
+ia ;	moderate ;	Interlingua
+id ;	modern ;	Indonesian
 ie ;	basic ;	Interlingue
-ig ;	basic ;	Igbo
+ig ;	modern ;	Igbo
 ii ;	basic ;	Sichuan Yi
-is ;	basic ;	Icelandic
-it ;	basic ;	Italian
-ja ;	basic ;	Japanese
-jv ;	basic ;	Javanese
-ka ;	basic ;	Georgian
+is ;	modern ;	Icelandic
+it ;	modern ;	Italian
+ja ;	modern ;	Japanese
+jv ;	modern ;	Javanese
+ka ;	modern ;	Georgian
 kea ;	basic ;	Kabuverdianu
 kgp ;	basic ;	Kaingang
-kk ;	basic ;	Kazakh
-km ;	basic ;	Khmer
-kn ;	basic ;	Kannada
-ko ;	basic ;	Korean
-kok ;	basic ;	Konkani
+kk ;	modern ;	Kazakh
+km ;	modern ;	Khmer
+kn ;	modern ;	Kannada
+ko ;	modern ;	Korean
+kok ;	modern ;	Konkani
 kok_Latn ;	basic ;	Konkani (Latin)
 ks ;	basic ;	Kashmiri
 ks_Deva ;	basic ;	Kashmiri (Devanagari)
-ku ;	basic ;	Kurdish
+ku ;	moderate ;	Kurdish
 kxv ;	basic ;	Kuvi
 kxv_Deva ;	basic ;	Kuvi (Devanagari)
 kxv_Orya ;	basic ;	Kuvi (Odia)
 kxv_Telu ;	basic ;	Kuvi (Telugu)
-ky ;	basic ;	Kyrgyz
+ky ;	modern ;	Kyrgyz
 lb ;	basic ;	Luxembourgish
 lij ;	basic ;	Ligurian
 lmo ;	basic ;	Lombard
-lo ;	basic ;	Lao
-lt ;	basic ;	Lithuanian
-lv ;	basic ;	Latvian
+lo ;	modern ;	Lao
+lt ;	modern ;	Lithuanian
+lv ;	modern ;	Latvian
 mai ;	basic ;	Maithili
-mi ;	basic ;	Māori
-mk ;	basic ;	Macedonian
-ml ;	basic ;	Malayalam
-mn ;	basic ;	Mongolian
+mi ;	moderate ;	Māori
+mk ;	modern ;	Macedonian
+ml ;	modern ;	Malayalam
+mn ;	modern ;	Mongolian
 mni ;	basic ;	Manipuri
-mr ;	basic ;	Marathi
-ms ;	basic ;	Malay
+mr ;	modern ;	Marathi
+ms ;	modern ;	Malay
 mt ;	basic ;	Maltese
-my ;	basic ;	Burmese
+my ;	modern ;	Burmese
 nds ;	basic ;	Low German
-ne ;	basic ;	Nepali
-nl ;	basic ;	Dutch
+ne ;	modern ;	Nepali
+nl ;	modern ;	Dutch
 nn ;	modern ;	Norwegian Nynorsk
-no ;	basic ;	Norwegian
+no ;	modern ;	Norwegian
 nqo ;	basic ;	N’Ko
 nso ;	basic ;	Northern Sotho
 oc ;	basic ;	Occitan
 om ;	basic ;	Oromo
-or ;	basic ;	Odia
-pa ;	basic ;	Punjabi
-pcm ;	basic ;	Nigerian Pidgin
-pl ;	basic ;	Polish
-ps ;	basic ;	Pashto
-pt ;	basic ;	Portuguese
-qu ;	basic ;	Quechua
+or ;	modern ;	Odia
+pa ;	modern ;	Punjabi
+pcm ;	modern ;	Nigerian Pidgin
+pl ;	modern ;	Polish
+ps ;	modern ;	Pashto
+pt ;	modern ;	Portuguese
+qu ;	moderate ;	Quechua
 raj ;	basic ;	Rajasthani
 rm ;	basic ;	Romansh
-ro ;	basic ;	Romanian
-ru ;	basic ;	Russian
+ro ;	modern ;	Romanian
+ru ;	modern ;	Russian
 rw ;	basic ;	Kinyarwanda
 sa ;	basic ;	Sanskrit
 sah ;	basic ;	Yakut
 sat ;	basic ;	Santali
-sc ;	basic ;	Sardinian
-sd ;	basic ;	Sindhi
+sc ;	moderate ;	Sardinian
+sd ;	modern ;	Sindhi
 sd_Deva ;	basic ;	Sindhi (Devanagari)
-si ;	basic ;	Sinhala
-sk ;	basic ;	Slovak
-sl ;	basic ;	Slovenian
-so ;	basic ;	Somali
-sq ;	basic ;	Albanian
-sr ;	basic ;	Serbian
-sr_Latn ;	basic ;	Serbian (Latin)
+si ;	modern ;	Sinhala
+sk ;	modern ;	Slovak
+sl ;	modern ;	Slovenian
+so ;	modern ;	Somali
+sq ;	modern ;	Albanian
+sr ;	modern ;	Serbian
+sr_Latn ;	modern ;	Serbian (Latin)
 st ;	basic ;	Southern Sotho
 su ;	basic ;	Sundanese
-sv ;	basic ;	Swedish
-sw ;	basic ;	Swahili
+sv ;	modern ;	Swedish
+sw ;	modern ;	Swahili
 syr ;	basic ;	Syriac
 szl ;	basic ;	Silesian
-ta ;	basic ;	Tamil
-te ;	basic ;	Telugu
-tg ;	basic ;	Tajik
-th ;	basic ;	Thai
-ti ;	basic ;	Tigrinya
-tk ;	basic ;	Turkmen
+ta ;	modern ;	Tamil
+te ;	modern ;	Telugu
+tg ;	moderate ;	Tajik
+th ;	modern ;	Thai
+ti ;	modern ;	Tigrinya
+tk ;	modern ;	Turkmen
 tn ;	basic ;	Tswana
 to ;	basic ;	Tongan
-tr ;	basic ;	Turkish
-tt ;	basic ;	Tatar
+tr ;	modern ;	Turkish
+tt ;	moderate ;	Tatar
 ug ;	basic ;	Uyghur
-uk ;	basic ;	Ukrainian
-ur ;	basic ;	Urdu
-uz ;	basic ;	Uzbek
+uk ;	modern ;	Ukrainian
+ur ;	modern ;	Urdu
+uz ;	modern ;	Uzbek
 uz_Cyrl ;	basic ;	Uzbek (Cyrillic)
-vec ;	basic ;	Venetian
-vi ;	basic ;	Vietnamese
+vec ;	moderate ;	Venetian
+vi ;	modern ;	Vietnamese
 vmw ;	basic ;	Makhuwa
-wo ;	basic ;	Wolof
-xh ;	basic ;	Xhosa
+wo ;	moderate ;	Wolof
+xh ;	moderate ;	Xhosa
 xnr ;	basic ;	Kangri
-yo ;	basic ;	Yoruba
+yo ;	modern ;	Yoruba
 yrl ;	basic ;	Nheengatu
-yue ;	basic ;	Cantonese
-yue_Hans ;	basic ;	Cantonese (Simplified)
+yue ;	modern ;	Cantonese
+yue_Hans ;	modern ;	Cantonese (Simplified)
 za ;	basic ;	Zhuang
-zh ;	basic ;	Chinese
-zh_Hant ;	basic ;	Traditional Chinese
-zu ;	basic ;	Zulu
+zh ;	modern ;	Chinese
+zh_Hant ;	modern ;	Traditional Chinese
+zu ;	modern ;	Zulu
 		
 #EOF		

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -384,8 +384,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dayPeriods/dayPeriodContext[@type='format']/dayPeriodWidth[@type='wide']/dayPeriod[@type='(am|pm)']"/>
 
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
-		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
+		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='generic']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inTerritory="%chineseCalendarTerritories"	match="dates/calendars/calendar[@type='chinese']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
@@ -404,10 +404,12 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%relativePattern"/>
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(generic|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
+		<coverageLevel	value="comprehensive"	 	match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
+		<coverageLevel	value="comprehensive"	 	match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
 
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)'][@alt='variant']"/>
@@ -431,10 +433,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/fallbackFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtZeroFormat"/>
-		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/gmtUnknownFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/hourFormat"/>
 		<coverageLevel	value="basic"	 	match="dates/timeZoneNames/metazone[@type='GMT']/long/standard"/>
 
+		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/gmtUnknownFormat"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/UTC']/long/standard"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='Etc/Unknown']/exemplarCity"/>
 		<coverageLevel	value="moderate"	 	match="dates/timeZoneNames/zone[@type='${Target-TimeZones}']/exemplarCity"/>
@@ -980,6 +982,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inTerritory="%islamicCalendarTerritories" value="modern" match="dates/calendars/calendar[@type='islamic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="JP" value="modern" match="dates/calendars/calendar[@type='japanese']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="TW" value="modern" match="dates/calendars/calendar[@type='roc']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
+		<coverageLevel value="comprehensive" match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>


### PR DESCRIPTION
Updated the coverage levels for items that were previously added to basic, causing coverage levels to significantly drop. GMT Unknown Format is now moderate (causing most locales to be moderate, not modern), and the ISO 8601 formats that used to be basic are now comprehensive. There may be other ISO 8601 coverages to alter as well.

```
mvn package -DskipTests=true && java -jar tools/cldr-code/target/cldr-code.jar GenerateAllCharts
```

CLDR-18473

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
