### PR TITLE
CLDR-16439 zone alias South_Pole was moved to McMurdo, so remove it from Auckland

### DIFF
--- a/common/bcp47/timezone.xml
+++ b/common/bcp47/timezone.xml
@@ -305,7 +305,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="npktm" description="Kathmandu, Nepal" alias="Asia/Katmandu Asia/Kathmandu" iana="Asia/Kathmandu"/>
             <type name="nrinu" description="Nauru" alias="Pacific/Nauru"/>
             <type name="nuiue" description="Niue" alias="Pacific/Niue"/>
-            <type name="nzakl" description="Auckland, New Zealand" alias="Pacific/Auckland Antarctica/South_Pole NZ"/>
+            <type name="nzakl" description="Auckland, New Zealand" alias="Pacific/Auckland NZ"/>
             <type name="nzcht" description="Chatham Islands, New Zealand" alias="Pacific/Chatham NZ-CHAT"/>
             <type name="ommct" description="Muscat, Oman" alias="Asia/Muscat"/>
             <type name="papty" description="Panama" alias="America/Panama EST"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBCP47.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestBCP47.java
@@ -349,6 +349,14 @@ public class TestBCP47 extends TestFmwk {
             if (BOGUS_TZIDS.contains(tzid)) {
                 continue;
             }
+            if (tzid.equals("Antarctica/South_Pole")) {
+                // This non-canonical alias was moved from one zone to another per CLDR-16439;
+                // skip test until we have an ICU updated to reflect this.
+                logKnownIssue(
+                        "CLDR-18361",
+                        "BRS 48 task, update ICU4J libs for CLDR after 48m1 integration to ICU");
+                continue;
+            }
             String bcp47Id = aliasToId.get(tzid);
             if (!assertNotNull(tzid, bcp47Id)) {
                 missingAliases.add(tzid);


### PR DESCRIPTION
CLDR-16439

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-16439)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

PR [#4535](https://github.com/unicode-org/cldr/pull/4535) added the secondary zone alias South_Pole for McMurdo, but did not remove it from its previous entry for Auckland. That caused a serious problem in the timezoneTypes array generated for ICU which tries to map legacy zone IDs to modern one; it was trying to map South_Pole to 2 different IDs, so the resource could not be read and all mapping of BCP47 keys and types was broken. So this PR removes the old alias. I will also file a ticket for a unit test to check this sort of thing.

ALLOW_MANY_COMMITS=true
