### PR TITLE
CLDR-18375 Check time format matches region

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -50,6 +50,7 @@ import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.PreferredAndAllowedHour;
 import org.unicode.cldr.util.RegexUtilities;
+import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.XPathParts;
 
@@ -88,6 +89,9 @@ public class CheckDates extends FactoryCheckCLDR {
     private static final Pattern YEAR_FIELDS = PatternCache.get("(y|Y|u|U|r){1,5}");
 
     private static final String CALENDAR_ID_PREFIX = "/calendar[@type=\"";
+
+    private static final String TIME_FORMAT_CHECK_PATH =
+            "//ldml/dates/calendars/calendar[@type=\"gregorian\"]/timeFormats/timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]";
 
     // The following calendar symbol sets need not have distinct values
     // "/months/monthContext[@type=\"format\"]/monthWidth[@type=\"narrow\"]/month",
@@ -253,20 +257,24 @@ public class CheckDates extends FactoryCheckCLDR {
             return this; // skip paths that we don't have
         }
 
+        if (value == null) {
+            return this;
+        }
+
         if (!path.contains("/dates") || path.endsWith("/default") || path.endsWith("/alias")) {
             return this;
         }
 
         if (!accept(result)) return this;
 
+        if (TIME_FORMAT_CHECK_PATH.equals(fullPath)) {
+            checkTimeFormatMatchesRegion(value, result);
+        }
+
         String sourceLocale = getCldrFileToCheck().getSourceLocaleID(path, status);
 
         if (!path.equals(status.pathWhereFound)
                 || !sourceLocale.equals(getCldrFileToCheck().getLocaleID())) {
-            return this;
-        }
-
-        if (value == null) {
             return this;
         }
 
@@ -652,6 +660,71 @@ public class CheckDates extends FactoryCheckCLDR {
             }
         }
         return this;
+    }
+
+    private void checkTimeFormatMatchesRegion(String value, List<CheckStatus> result) {
+        DateTimePatternGenerator dtpg = DateTimePatternGenerator.getEmptyInstance();
+        Map<String /* region */, PreferredAndAllowedHour> timeData = sdi.getTimeData();
+        Map<String, String> likelySubtags = sdi.getLikelySubtags();
+        String localeID = getResolvedCldrFileToCheck().getLocaleID();
+        String jPattern = getRegionHourFormat(timeData, localeID, likelySubtags);
+        if (jPattern == null) {
+            CheckStatus item =
+                    new CheckStatus()
+                            .setCause(this)
+                            .setMainType(CheckStatus.errorType)
+                            .setSubtype(Subtype.inconsistentTimePattern)
+                            .setMessage("No hour format found");
+            result.add(item);
+            return;
+        }
+        String shortPatSkeleton = dtpg.getBaseSkeleton(value); // e.g., "ahm" or "Hm"
+        String jPatSkeleton = dtpg.getBaseSkeleton(jPattern); // e.g., "ah" or "H"
+        final char[] timeCycleChars = {'H', 'h', 'K', 'k'};
+        for (char timeCycleChar : timeCycleChars) {
+            if (jPatSkeleton.indexOf(timeCycleChar) >= 0
+                    && shortPatSkeleton.indexOf(timeCycleChar) < 0) {
+                System.out.println("Got one in checkTimeFormatMatchesRegion");
+                String message =
+                        "Time format does not match region; expected "
+                                + timeCycleChar
+                                + " in the value "
+                                + value;
+                CheckStatus item =
+                        new CheckStatus()
+                                .setCause(this)
+                                .setMainType(CheckStatus.warningType)
+                                .setSubtype(Subtype.inconsistentTimePattern)
+                                .setMessage(message);
+                result.add(item);
+                return;
+            }
+        }
+    }
+
+    private String getRegionHourFormat(
+            Map<String, PreferredAndAllowedHour> timeData,
+            String localeID,
+            Map<String, String> likelySubtags) {
+        PreferredAndAllowedHour prefAndAllowedHr = timeData.get(localeID);
+        if (prefAndAllowedHr == null) {
+            LocaleIDParser lp = new LocaleIDParser();
+            String region = lp.set(localeID).getRegion();
+            if (region == null || region.isEmpty()) {
+                String loc2 = likelySubtags.get(localeID);
+                if (loc2 != null && !loc2.isEmpty()) {
+                    region = lp.set(loc2).getRegion();
+                }
+            }
+            prefAndAllowedHr = timeData.get(region);
+            if (prefAndAllowedHr == null) {
+                prefAndAllowedHr = timeData.get(StandardCodes.NO_COUNTRY /* 001, world */);
+                if (prefAndAllowedHr == null) {
+                    return null;
+                }
+            }
+        }
+        return prefAndAllowedHr.preferred.base.name();
     }
 
     // ORDERED SET (the ordering is used in toOrder)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckDates.java
@@ -684,7 +684,6 @@ public class CheckDates extends FactoryCheckCLDR {
         for (char timeCycleChar : timeCycleChars) {
             if (jPatSkeleton.indexOf(timeCycleChar) >= 0
                     && shortPatSkeleton.indexOf(timeCycleChar) < 0) {
-                System.out.println("Got one in checkTimeFormatMatchesRegion");
                 String message =
                         "Time format does not match region; expected "
                                 + timeCycleChar
@@ -693,7 +692,7 @@ public class CheckDates extends FactoryCheckCLDR {
                 CheckStatus item =
                         new CheckStatus()
                                 .setCause(this)
-                                .setMainType(CheckStatus.warningType)
+                                .setMainType(CheckStatus.errorType)
                                 .setSubtype(Subtype.inconsistentTimePattern)
                                 .setMessage(message);
                 result.add(item);


### PR DESCRIPTION
-Add to existing checks in CheckDates

-New methods checkTimeFormatMatchesRegion, getRegionHourFormat

-Failure causes warning, not error

CLDR-18375

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
