### PR TITLE
CLDR-18233 Remove language families from likely subtags

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -890,7 +890,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="zh_Bopo" to="zh_Bopo_TW"/>		<!--Chinese‧Bopomofo‧?	➡ Chinese‧Bopomofo‧Taiwan-->
 		<likelySubtag from="zh_Hanb" to="zh_Hanb_TW"/>		<!--Chinese‧Han with Bopomofo‧?	➡ Chinese‧Han with Bopomofo‧Taiwan-->
 		<likelySubtag from="zh_Hant" to="zh_Hant_TW"/>		<!--Chinese‧Traditional‧?	➡ Chinese‧Traditional‧Taiwan-->
-		<likelySubtag from="zhx" to="zhx_Nshu_CN"/>		<!--Chinese (family)‧?‧?	➡ Chinese (family)‧Nüshu‧China-->
 		<likelySubtag from="zkt" to="zkt_Kits_CN"/>		<!--Kitan‧?‧?	➡ Kitan‧Khitan small script‧China-->
 		<likelySubtag from="zlm" to="zlm_Latn_MY"/>		<!--Malay (individual language)‧?‧?	➡ Malay (individual language)‧Latin‧Malaysia-->
 		<likelySubtag from="zmi" to="zmi_Latn_MY"/>		<!--Negeri Sembilan Malay‧?‧?	➡ Negeri Sembilan Malay‧Latin‧Malaysia-->
@@ -1296,7 +1295,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Newa" to="new_Newa_NP"/>		<!--?‧Newa‧?	➡ Newari‧Newa‧Nepal-->
 		<likelySubtag from="und_Nkoo" to="man_Nkoo_GN"/>		<!--?‧N’Ko‧?	➡ Mandingo‧N’Ko‧Guinea-->
 		<likelySubtag from="und_Nkoo_ML" to="bm_Nkoo_ML"/>		<!--?‧N’Ko‧Mali	➡ Bambara‧N’Ko‧Mali-->
-		<likelySubtag from="und_Nshu" to="zhx_Nshu_CN"/>		<!--?‧Nüshu‧?	➡ Chinese (family)‧Nüshu‧China-->
 		<likelySubtag from="und_Ogam" to="sga_Ogam_IE"/>		<!--?‧Ogham‧?	➡ Old Irish‧Ogham‧Ireland-->
 		<likelySubtag from="und_Olck" to="sat_Olck_IN"/>		<!--?‧Ol Chiki‧?	➡ Santali‧Ol Chiki‧India-->
 		<likelySubtag from="und_Onao" to="unr_Onao_IN"/>		<!--?‧Ol Onal‧?	➡ Mundari‧Ol Onal‧India-->
@@ -5801,7 +5799,6 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="pps" to="pps_Latn_MX" origin="sil1"/>		<!--San Luís Temalacayuca Popoloca‧?‧?	➡ San Luís Temalacayuca Popoloca‧Latin‧Mexico-->
 		<likelySubtag from="ppt" to="ppt_Latn_PG" origin="sil1"/>		<!--Pare‧?‧?	➡ Pare‧Latin‧Papua New Guinea-->
 		<likelySubtag from="pqa" to="pqa_Latn_NG" origin="sil1"/>		<!--Pa'a‧?‧?	➡ Pa'a‧Latin‧Nigeria-->
-		<likelySubtag from="pra" to="pra_Khar_PK" origin="sil1"/>		<!--Prakrit languages‧?‧?	➡ Prakrit languages‧Kharoshthi‧Pakistan-->
 		<likelySubtag from="prc" to="prc_Arab_AF" origin="sil1"/>		<!--Parachi‧?‧?	➡ Parachi‧Arabic‧Afghanistan-->
 		<likelySubtag from="pre" to="pre_Latn_ST" origin="sil1"/>		<!--Principense‧?‧?	➡ Principense‧Latin‧São Tomé & Príncipe-->
 		<likelySubtag from="prf" to="prf_Latn_PH" origin="sil1"/>		<!--Paranan‧?‧?	➡ Paranan‧Latin‧Philippines-->

--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -347,7 +347,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="kdh" to="kdh_Latn_TG"/>		<!--Tem‧?‧?	➡ Tem‧Latin‧Togo-->
 		<likelySubtag from="kdt" to="kdt_Thai_TH"/>		<!--Kuy‧?‧?	➡ Kuy‧Thai‧Thailand-->
 		<likelySubtag from="kea" to="kea_Latn_CV"/>		<!--Kabuverdianu‧?‧?	➡ Kabuverdianu‧Latin‧Cape Verde-->
-		<likelySubtag from="kek" to="kek_Latn_GT"/>		<!--Kekchí‧?‧?	➡ Kekchí‧Latin‧Guatemala-->
+		<likelySubtag from="kek" to="kek_Latn_GT"/>		<!--Qʼeqchiʼ‧?‧?	➡ Qʼeqchiʼ‧Latin‧Guatemala-->
 		<likelySubtag from="ken" to="ken_Latn_CM"/>		<!--Kenyang‧?‧?	➡ Kenyang‧Latin‧Cameroon-->
 		<likelySubtag from="kfo" to="kfo_Latn_CI"/>		<!--Koro‧?‧?	➡ Koro‧Latin‧Côte d’Ivoire-->
 		<likelySubtag from="kfr" to="kfr_Deva_IN"/>		<!--Kachhi‧?‧?	➡ Kachhi‧Devanagari‧India-->

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -5,7 +5,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.Row;
@@ -1771,7 +1770,8 @@ public class GenerateLikelySubtags {
         }
     }
 
-    // Check if the language code is a collection of languages (ISO 639-5). Otherwise its probably an individual one or maybe a macrolanguage.
+    // Check if the language code is a collection of languages (ISO 639-5). Otherwise its probably
+    // an individual one or maybe a macrolanguage.
     private static Boolean isLanguageCollection(String language) {
         return Iso639Data.getHierarchy(language) != null;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -83,13 +83,8 @@ public class GenerateLikelySubtags {
     private static final Map<String, Status> SCRIPT_CODE_TO_STATUS =
             Validity.getInstance().getCodeToStatus(LstrType.script);
 
-    private static final String TEMP_UNKNOWN_REGION = "XZ";
-
-    private static final String DEBUG_ADD_KEY = "und_Latn_ZA";
-
     private static final double MIN_UNOFFICIAL_LANGUAGE_SIZE = 10000000;
     private static final double MIN_UNOFFICIAL_LANGUAGE_PROPORTION = 0.20;
-    private static final double MIN_UNOFFICIAL_CLDR_LANGUAGE_SIZE = 100000;
 
     /** When a language is not official, scale it down. */
     private static final double UNOFFICIAL_SCALE_DOWN = 0.2;
@@ -153,8 +148,6 @@ public class GenerateLikelySubtags {
     private static boolean DEBUG;
     private static Map<String, LstrType> WATCH_PAIRS = null;
 
-    private static final boolean SHOW_OVERRIDES = true;
-
     static final Map<String, LSRSource> silData = LangTagsData.getJsonData();
 
     public static void main(String[] args) throws IOException {
@@ -217,7 +210,6 @@ public class GenerateLikelySubtags {
             throw new IllegalArgumentException();
         }
 
-        Set<String> newAdditions = new TreeSet<>();
         Set<String> newMissing = new TreeSet<>();
 
         // Check against last version
@@ -290,12 +282,6 @@ public class GenerateLikelySubtags {
         cldrContainerToLanguages.freeze();
         System.out.println("Keeping macroregions used in cldr " + cldrContainerToLanguages);
     }
-
-    private static final List<String> KEEP_TARGETS =
-            DROP_HARDCODED ? List.of() : List.of("und_Arab_PK", "und_Latn_ET");
-
-    private static final ImmutableSet<String> deprecatedISONotInLST =
-            DROP_HARDCODED ? ImmutableSet.of() : ImmutableSet.of("scc", "scr");
 
     /**
      * This is the simplest way to override, by supplying the max value. It gets a very low weight,
@@ -469,7 +455,6 @@ public class GenerateLikelySubtags {
                                 {"rhg_Arab", "rhg_Arab_MM"},
                                 {"und_Arab_MM", "rhg_Arab_MM"},
                                 {"sd_IN", "sd_Deva_IN"}, // preferred in CLDR
-                                // { "sd_Deva", "sd_Deva_IN"},
                                 {"und_Cpmn", "und_Cpmn_CY"},
                                 {"oc_ES", "oc_Latn_ES"},
                                 {"os", "os_Cyrl_GE"},
@@ -517,15 +502,6 @@ public class GenerateLikelySubtags {
         {"ko", "Kore"}, // Korean (North Korea)
         {"ko_KR", "Kore"}, // Korean (North Korea)
         {"ja", "Jpan"}, // Special script for japan
-
-        //        {"chk", "Latn"}, // Chuukese (Micronesia)
-        //        {"fil", "Latn"}, // Filipino (Philippines)"
-        //        {"pap", "Latn"}, // Papiamento (Netherlands Antilles)
-        //        {"pau", "Latn"}, // Palauan (Palau)
-        //        {"su", "Latn"}, // Sundanese (Indonesia)
-        //        {"tet", "Latn"}, // Tetum (East Timor)
-        //        {"tk", "Latn"}, // Turkmen (Turkmenistan)
-        //        {"ty", "Latn"}, // Tahitian (French Polynesia)
         // {LocaleNames.UND, "Latn"}, // Ultimate fallback
     };
 
@@ -543,21 +519,6 @@ public class GenerateLikelySubtags {
             localeToScriptCache.put(pair[0], pair[1]);
         }
     }
-
-    private static Map<String, String> FALLBACK_SCRIPTS;
-
-    static {
-        LanguageTagParser additionLtp = new LanguageTagParser();
-        Map<String, String> _FALLBACK_SCRIPTS = new TreeMap<>();
-        for (String addition : MAX_ADDITIONS) {
-            additionLtp.set(addition);
-            String lan = additionLtp.getLanguage();
-            _FALLBACK_SCRIPTS.put(lan, additionLtp.getScript());
-        }
-        FALLBACK_SCRIPTS = ImmutableMap.copyOf(_FALLBACK_SCRIPTS);
-    }
-
-    private static int errorCount;
 
     /**
      * Debugging function that returns false if the flag is false, otherwise returns true if the
@@ -679,8 +640,6 @@ public class GenerateLikelySubtags {
     private static OutputStyle OUTPUT_STYLE =
             OutputStyle.valueOf(CldrUtility.getProperty("OutputStyle", "XML", "XML").toUpperCase());
 
-    private static final String TAG_SEPARATOR = OUTPUT_STYLE == OutputStyle.C_ALT ? "-" : "_";
-
     private static final Joiner JOIN_SPACE = Joiner.on(' ');
     private static final Joiner JOIN_UBAR = Joiner.on('_');
 
@@ -728,21 +687,6 @@ public class GenerateLikelySubtags {
 
                 if (data.getOfficialStatus() == OfficialStatus.unknown) {
                     final String locale = writtenLanguage + "_" + region;
-                    //                    if (literatePopulation >= minimalLiteratePopulation) {
-                    //                        // ok, skip
-                    //                    } else if (literatePopulation >=
-                    // MIN_UNOFFICIAL_CLDR_LANGUAGE_SIZE
-                    //                            && cldrLocales.contains(locale)) {
-                    //                        // ok, skip
-                    //                    } else {
-                    //                        // if (SHOW_ADD)
-                    //                        // System.out.println("Skipping:\t" + writtenLanguage
-                    // + "\t" + region + "\t"
-                    //                        // + english.nameGetter().getName(locale)
-                    //                        // + "\t-- too small:\t" +
-                    // number.format(literatePopulation));
-                    //                        // continue;
-                    //                    }
                     order *= UNOFFICIAL_SCALE_DOWN;
                     if (watching(SHOW_POP, writtenLanguage))
                         System.out.println(
@@ -800,22 +744,6 @@ public class GenerateLikelySubtags {
             }
         }
 
-        // Old code for getting language to script, adding XZ, which converts to ZZ. Replaced by use
-        // of SIL data
-
-        //        for (Entry<String, Collection<String>> entry :
-        //                DeriveScripts.getLanguageToScript().asMap().entrySet()) {
-        //            String language = entry.getKey();
-        //            final Collection<String> values = entry.getValue();
-        //            if (values.size() != 1) {
-        //                continue; // skip, no either way
-        //            }
-        //            Set<R3<Double, String, String>> old = maxData.languages.get(language);
-        //            if (!maxData.languages.containsKey(language)) {
-        //                maxData.add(language, values.iterator().next(), TEMP_UNKNOWN_REGION, 1.0);
-        //            }
-        //        }
-
         // add others, with English default
         for (String region : otherTerritories) {
             if (!LocaleValidator.ALLOW_IN_LIKELY.isAllowed(LstrType.region, region, null, null)) {
@@ -843,10 +771,6 @@ public class GenerateLikelySubtags {
 
             String badLanguage = str.getKey();
             if (badLanguage.contains("_")) { // only single subtag
-                continue;
-            }
-
-            if (deprecatedISONotInLST.contains(badLanguage)) {
                 continue;
             }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateLikelySubtags.java
@@ -42,6 +42,7 @@ import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.Containment;
 import org.unicode.cldr.util.Counter;
 import org.unicode.cldr.util.Factory;
+import org.unicode.cldr.util.Iso639Data;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LocaleScriptInfo;
@@ -995,6 +996,10 @@ public class GenerateLikelySubtags {
                 System.out.println(JOIN_LS.join("Failure in ScriptMetaData: " + ltp, errors));
                 continue;
             }
+            if (isLanguageCollection(likelyLanguage)) {
+                // Dropping language collections
+                continue;
+            }
             final String result = likelyLanguage + "_" + script + "_" + originCountry;
             add("und_" + script, result, toMaximized, "S->LR•", LocaleOverride.KEEP_EXISTING);
             add(likelyLanguage, result, toMaximized, "L->SR•", LocaleOverride.KEEP_EXISTING);
@@ -1682,7 +1687,7 @@ public class GenerateLikelySubtags {
             for (Entry<String, LSRSource> entry : silData.entrySet()) {
                 CLDRLocale source = CLDRLocale.getInstance(entry.getKey());
                 String lang = source.getLanguage();
-                if (!fluffup.containsKey(lang)) {
+                if (!fluffup.containsKey(lang) && !isLanguageCollection(lang)) {
                     silMap.put(entry.getKey(), entry.getValue().getLsrString());
                     if (!entry.getValue().getSources().isEmpty()) {
                         silOrigins.put(entry.getKey(), entry.getValue().getSourceString());
@@ -1764,5 +1769,10 @@ public class GenerateLikelySubtags {
                                 + "  }");
             }
         }
+    }
+
+    // Check if the language code is a collection of languages (ISO 639-5). Otherwise its probably an individual one or maybe a macrolanguage.
+    private static Boolean isLanguageCollection(String language) {
+        return Iso639Data.getHierarchy(language) != null;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Iso639Data.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Iso639Data.java
@@ -34,7 +34,7 @@ public class Iso639Data {
 
     static Map<String, Scope> toScope;
 
-    static Map<String, List<String>> toHeirarchy;
+    static Map<String, List<String>> toHierarchy;
 
     static Map<String, Type> toType;
 
@@ -246,12 +246,12 @@ public class Iso639Data {
         return Scope.Individual;
     }
 
-    /** Returns the ISO 639-5 heirarchy if available, otherwise null. */
-    public static List<String> getHeirarchy(String languageSubtag) {
-        if (toHeirarchy == null) {
+    /** Returns the ISO 639-5 hierarchy if available, otherwise null. */
+    public static List<String> getHierarchy(String languageSubtag) {
+        if (toHierarchy == null) {
             getData();
         }
-        return toHeirarchy.get(languageSubtag);
+        return toHierarchy.get(languageSubtag);
     }
 
     public static Type getType(String languageSubtag) {
@@ -473,7 +473,7 @@ public class Iso639Data {
             }
             in.close();
 
-            Map<String, String> toHeirarchyTemp = new TreeMap<>();
+            Map<String, String> toHierarchyTemp = new TreeMap<>();
             in = CldrUtility.getUTF8Data("external/Iso639-5.html");
             String lastCode = null;
             int column = 0;
@@ -535,8 +535,8 @@ public class Iso639Data {
                                 lastCode = result.toString();
                                 break;
                             case 5:
-                                String old = toHeirarchyTemp.get(lastCode);
-                                toHeirarchyTemp.put(
+                                String old = toHierarchyTemp.get(lastCode);
+                                toHierarchyTemp.put(
                                         lastCode,
                                         old == null || old.length() == 0
                                                 ? result.toString().trim()
@@ -571,18 +571,18 @@ public class Iso639Data {
 
             in.close();
 
-            Pattern SPLIT_HEIRARCHY = PatternCache.get("\\s*:\\s*");
-            toHeirarchy = new TreeMap<>();
-            // for (String code : toHeirarchyTemp.keySet()) {
-            // System.out.println(code + " => " + toHeirarchyTemp.get(code));
+            Pattern SPLIT_HIERARCHY = PatternCache.get("\\s*:\\s*");
+            toHierarchy = new TreeMap<>();
+            // for (String code : toHierarchyTemp.keySet()) {
+            // System.out.println(code + " => " + toHierarchyTemp.get(code));
             // }
-            for (String code : toHeirarchyTemp.keySet()) {
-                String valueString = toHeirarchyTemp.get(code);
-                String[] values = SPLIT_HEIRARCHY.split(valueString);
+            for (String code : toHierarchyTemp.keySet()) {
+                String valueString = toHierarchyTemp.get(code);
+                String[] values = SPLIT_HIERARCHY.split(valueString);
                 for (String value : values) {
-                    if (toScope.get(value) == null && toHeirarchyTemp.get(value) == null) {
+                    if (toScope.get(value) == null && toHierarchyTemp.get(value) == null) {
                         throw new IllegalArgumentException(
-                                "Unexpected value in heirarchy:\t"
+                                "Unexpected value in hierarchy:\t"
                                         + value
                                         + "\t"
                                         + code
@@ -590,7 +590,7 @@ public class Iso639Data {
                                         + valueString);
                     }
                 }
-                toHeirarchy.put(code, Arrays.asList(values));
+                toHierarchy.put(code, Arrays.asList(values));
             }
             // System.out.println("Size:\t" + toNames.size());
 
@@ -602,7 +602,7 @@ public class Iso639Data {
             fromBiblio3 = Collections.unmodifiableMap(fromBiblio3);
             toScope = Collections.unmodifiableMap(toScope);
             toType = Collections.unmodifiableMap(toType);
-            toHeirarchy = Collections.unmodifiableMap(toHeirarchy);
+            toHierarchy = Collections.unmodifiableMap(toHierarchy);
 
             toNames.freeze();
             toRetirements.freeze();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Iso639Data.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Iso639Data.java
@@ -423,7 +423,7 @@ public class Iso639Data {
             // System.out.println("Size:\t" + toNames.size());
             in.close();
 
-            // TODO https://unicode-org.atlassian.net/browse/CLDR-18499 Find an up-to-date source 
+            // TODO https://unicode-org.atlassian.net/browse/CLDR-18499 Find an up-to-date source
             in = CldrUtility.getUTF8Data("ISO-639-2_values_8bits.txt");
             // An alpha-3 (bibliographic) code,
             // an alpha-3 (terminologic) code (when given),
@@ -466,7 +466,8 @@ public class Iso639Data {
                         toAlpha3.put(languageSubtag, alpha3);
                         fromAlpha3.put(alpha3, languageSubtag);
                     }
-                    // Warning: This is not always correct. Deprecated ISO 639-3 codes will also appear here
+                    // Warning: This is not always correct. Deprecated ISO 639-3 codes will also
+                    // appear here
                     toScope.put(languageSubtag, Scope.Collection);
                     toType.put(languageSubtag, Type.Special);
                     toNames.putAll(languageSubtag, Arrays.asList(english));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Iso639Data.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Iso639Data.java
@@ -423,6 +423,7 @@ public class Iso639Data {
             // System.out.println("Size:\t" + toNames.size());
             in.close();
 
+            // TODO https://unicode-org.atlassian.net/browse/CLDR-18499 Find an up-to-date source 
             in = CldrUtility.getUTF8Data("ISO-639-2_values_8bits.txt");
             // An alpha-3 (bibliographic) code,
             // an alpha-3 (terminologic) code (when given),
@@ -465,6 +466,7 @@ public class Iso639Data {
                         toAlpha3.put(languageSubtag, alpha3);
                         fromAlpha3.put(alpha3, languageSubtag);
                     }
+                    // Warning: This is not always correct. Deprecated ISO 639-3 codes will also appear here
                     toScope.put(languageSubtag, Scope.Collection);
                     toType.put(languageSubtag, Type.Special);
                     toNames.putAll(languageSubtag, Arrays.asList(english));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -399,10 +399,8 @@ public class LikelySubtagsTest extends TestFmwk {
         }
     }
 
-    // typically historical script that don't need to  be in likely subtags
-
-    static final Set<String> KNOWN_SCRIPTS_WITHOUT_LIKELY_SUBTAGS =
-            ImmutableSet.of("Hatr", "Cpmn", "Ougr");
+    // These historical scripts don't have a language with an ISO tag (as of 2025-04-11)
+    static final Set<String> KNOWN_SCRIPTS_WITHOUT_LIKELY_SUBTAGS = ImmutableSet.of("Cpmn", "Nshu");
 
     public void TestMissingInfoForScript() {
         VersionInfo icuUnicodeVersion = UCharacter.getUnicodeVersion();
@@ -415,19 +413,7 @@ public class LikelySubtagsTest extends TestFmwk {
                 // we minimize away und_X, when the code puts in en...US
                 continue;
             }
-            // Temporary exception for CLDR 46 Unicode 16 (CLDR-17226) because
-            // GenerateMaximalLocales is currently not usable.
-            if (script.equals("Aghb")) {
-                // The script metadata for Aghb=Caucasian_Albanian changed
-                // the likely region from Russia to Azerbaijan, and
-                // the likely language from udi=Udi to xag=Old Udi.
-                // Error: likelySubtags.xml has wrong language for script (und_Aghb).
-                // Should not be udi_Aghb_RU, but Script Metadata suggests something like:
-                // {"und_Aghb", "xag_Aghb_AZ"},
-                continue;
-            }
             Info i = ScriptMetadata.getInfo(script);
-            // System.out.println(i);
             String likelyLanguage = i.likelyLanguage;
             String originCountry = i.originCountry;
             String undScript = "und_" + script;
@@ -450,15 +436,6 @@ public class LikelySubtagsTest extends TestFmwk {
                 }
             } else if (!exceptions2.contains(likelyExpansion)
                     && !likelyExpansion.startsWith(langScript)) {
-                // if
-                // (logKnownIssue("Cldrbug:7181","Missing script metadata for "
-                // + script)
-                // && (script.equals("Tfng") || script.equals("Brah"))) {
-                // logln("Wrong likely language for script (und_" + script +
-                // "). Should not be " + likelyExpansion
-                // + ", but something like:\t " + showOverride(script,
-                // originCountry, langScript));
-                // } else {
                 errln(
                         "likelySubtags.xml has wrong language for script (und_"
                                 + script
@@ -471,10 +448,6 @@ public class LikelySubtagsTest extends TestFmwk {
                 logln("OK: " + undScript + " => " + likelyExpansion);
             }
         }
-        /**
-         * und_Bopo => zh_Bopo_TW und_Copt => cop_Copt_EG // fix 002 und_Dsrt => en_Dsrt_US // fix
-         * US
-         */
     }
 
     public String showOverride(String script, String originCountry, String langScript) {
@@ -760,10 +733,7 @@ public class LikelySubtagsTest extends TestFmwk {
         //        System.out.println("\t\t" + Joiner.on("\n\t\t").join(possibleFixes));
     }
 
-    private static final Joiner JOIN_LS = Joiner.on(CldrUtility.LINE_SEPARATOR);
-
     public void testToAttributeValidityStatus() {
-        Multimap<String, String> badFieldsToLocales = TreeMultimap.create();
         for (String s : likely.values()) {
             LanguageTagParser ltp = new LanguageTagParser().set(s);
             Set<String> errors = new LinkedHashSet<>();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -1300,7 +1300,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             }
             Scope languageScope = getScope(language, lstregLanguageInfo);
             if (languageScope == Scope.Macrolanguage) {
-                if (Iso639Data.getHeirarchy(language) != null) {
+                if (Iso639Data.getHierarchy(language) != null) {
                     continue main; // is real family
                 }
                 Set<String> replacements = replacementToReplaced.getAll(language);


### PR DESCRIPTION
I noticed there are language families in the likely subtags data when we import data from Script-Metadata and SIL. It's caused because of script imports -- which we like but in this case the families are too general. The 2 items removed are for the families `pra` Prakrit and `zhx` Chinese -- they are written in a lot of scripts and a lot of regions. It's not well-defined to say which script or region is the likely one, so I am removing the language families from the generated file.

SIL inherited this error from CLDR and is passing it back to CLDR, so this also helps prevent that erroneous feedback loop.

Note that I did this in 2 commits. The first commit deletes dead code and fixes the spelling of Hierarchy, it also updates a language name that wasn't previously updated by running the likely subtag generation script. The second commit contains the functional changes.

CLDR-18233

Script to generate XML:
```
mvn package -DskipTests=true &&  java -jar tools/cldr-code/target/cldr-code.jar GenerateLikelySubtags
```

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
