### PR TITLE
CLDR-18500 still show the coverage menu even if the CLA isn't signed.

### DIFF
--- a/tools/cldr-apps/js/src/views/MainHeader.vue
+++ b/tools/cldr-apps/js/src/views/MainHeader.vue
@@ -21,7 +21,7 @@
           {{ unreadAnnouncementCount }}</a
         >
       </li>
-      <li v-if="coverageLevel && !needCla">
+      <li v-if="coverageLevel">
         <label for="coverageLevel">Coverage:</label>
         <select
           id="coverageLevel"
@@ -52,11 +52,6 @@
           <option :key="n" v-for="n in voteCountMenu">{{ n }}</option>
         </select>
       </li>
-      <li>
-        <a href="https://cldr.unicode.org/translation/" target="_blank"
-          >Instructions</a
-        >
-      </li>
       <a-alert
         v-if="needCla"
         @click="showCla"
@@ -64,6 +59,11 @@
         type="error"
         show-icon
       />
+      <li>
+        <a href="https://cldr.unicode.org/translation/" target="_blank"
+          >Instructions</a
+        >
+      </li>
       <li id="st-special-header" class="specialmessage">{{ specialHeader }}</li>
       <li>
         <a


### PR DESCRIPTION
CLDR-18500

The coverage menu wasn't obscured, it was purposely hidden. Show it even if the CLA isn't signed.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/b5843312-1534-4c4f-9061-4a7b994e0c56" />


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
