### PR TITLE
CLDR-18507 BRS48 Update ICU4J version in CLDR to 78.0.1-SNAPSHOT

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,7 +23,7 @@
 			SNAPSHOT for the ICU version that we want, so this should only need updating
 			when the ICU version changes e.g. from 74.0.1, to 74.1, to 75.0.1, then to 75.1.
 			You can use github actions in icu to manually push the latest SNAPSHOT version. -->
-		<icu4j.version>77.1-SNAPSHOT</icu4j.version>
+		<icu4j.version>78.0.1-SNAPSHOT</icu4j.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.3.1</maven-surefire-plugin-version>
 		<assertj-version>3.26.3</assertj-version>


### PR DESCRIPTION
CLDR-18507

- [x] This PR completes the ticket.

Update icu4j.version in tools/pom.xml to 78.0.1-SNAPSHOT. I purposely waited to do this until CLDR 48 m1 was integrated to ICU and an icu4j libs artifact with those changes was published; that way the CLDR tests can actually check that this new ICU4J version works with CLDR (we can only have the CI run tests with a new ICU4J when the version actually changes in the CLDR pom.xml).

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18507)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
