### PR TITLE
CLDR-18518 abstracts: work around CORS, improve logging on ui

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -16,7 +16,7 @@ import * as cldrVue from "./cldrVue.mjs";
 
 import MainHeader from "../views/MainHeader.vue";
 
-const GUI_DEBUG = true;
+const GUI_DEBUG = false;
 
 const runGuiId = "st-run-gui";
 
@@ -53,6 +53,7 @@ function run() {
     cldrProgress.insertWidget("CompletionSpan");
     cldrInfo.initialize("ItemInfoContainer", "MainContentPane", "open-right");
   } catch (e) {
+    cldrNotify.logException(e, `Initial load`);
     return Promise.reject(e);
   }
   return ensureSession().then(completeStartupWithSession);
@@ -94,7 +95,8 @@ function loginCallback(logintoken) {
   }
 }
 
-function loginFailure() {
+function loginFailure(e) {
+  cldrNotify.logException(e, `SurveyTool did not create a session`);
   throw new Error("SurveyTool did not create a session. Try back later.");
 }
 
@@ -134,9 +136,6 @@ function insertHeader() {
     const gui = document.getElementById(runGuiId);
     mainHeaderWrapper = cldrVue.mountAsFirstChild(MainHeader, gui);
   } catch (e) {
-    console.error(
-      "Error mounting main header vue " + e.message + " / " + e.name
-    );
     cldrNotify.exception(e, "while loading MainHeader");
   }
 }

--- a/tools/cldr-apps/js/src/esm/cldrLoad.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLoad.mjs
@@ -957,22 +957,15 @@ function trimNull(x) {
  */
 function myLoad(url, message, handler, postData, headers) {
   const otime = new Date().getTime();
-  console.log("MyLoad: " + url + " for " + message);
   const errorHandler = function (err, request) {
-    console.log("Error: " + err);
-    cldrNotify.error(`Could not fetch ${message}`, `Error: ${err.toString()}`);
+    cldrNotify.exception(err, `Fetching ${message}`);
     handler(null);
   };
   const loadHandler = function (json) {
-    console.log(
-      "        " + url + " loaded in " + (new Date().getTime() - otime) + "ms"
-    );
     try {
       handler(json);
     } catch (e) {
-      console.log(
-        "Error in ajax post [" + message + "]  " + e.message + " / " + e.name
-      );
+      cldrNotify.logException(e, "Error in ajax post [" + message + "]");
       cldrRetry.handleDisconnect(
         "Exception while loading: " +
           message +

--- a/tools/cldr-apps/js/src/esm/cldrNotify.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrNotify.mjs
@@ -51,6 +51,14 @@ function open(message, description, onClick) {
   });
 }
 
+function logInfo(message, description) {
+  if (hasDataDog) {
+    datadogLogs.logger.info(message, { description });
+  } else {
+    console.log(message);
+  }
+}
+
 /**
  * Display a warning notification
  *
@@ -58,14 +66,26 @@ function open(message, description, onClick) {
  * @param {String} description the more detailed description
  */
 function warning(message, description) {
-  if (hasDataDog) {
-    datadogLogs.logger.warn(message, { description });
-  }
+  logWarning(message, description);
   notification.warning({
     message: message,
     description: description,
     duration: MEDIUM_DURATION,
   });
+}
+
+/**
+ * Log a warning
+ *
+ * @param {String} message the title
+ * @param {String} description the more detailed description
+ */
+function logWarning(message, description) {
+  if (hasDataDog) {
+    datadogLogs.logger.warn(message, { description });
+  } else {
+    console.warn(message);
+  }
 }
 
 /**
@@ -75,9 +95,7 @@ function warning(message, description) {
  * @param {String} description the more detailed description
  */
 function error(message, description) {
-  if (hasDataDog) {
-    datadogLogs.logger.error(message, { description });
-  }
+  logError(message, description);
   notification.error({
     message: message,
     description: description,
@@ -86,12 +104,24 @@ function error(message, description) {
 }
 
 /**
+ * Log an error
+ *
+ * @param {String} message the title
+ * @param {String} description the more detailed description
+ */
+function logError(message, description) {
+  if (hasDataDog) {
+    datadogLogs.logger.error(message, { description });
+  } else {
+    console.error(message);
+  }
+}
+
+/**
  * Display an error notification, and when the user closes it, call the callback function
  */
 function errorWithCallback(message, description, callback) {
-  if (hasDataDog) {
-    datadogLogs.logger.error(message, { description });
-  }
+  logError(message, description);
   notification.error({
     message: message,
     description: description,
@@ -101,12 +131,22 @@ function errorWithCallback(message, description, callback) {
 }
 
 /**
- * Display an error notification for an exception
+ * Log and Display an error notification for an exception
  *
  * @param {Object|String} e the Error that was thrown and caught
  * @param {String} context a description of where it was caught
  */
 function exception(e, context) {
+  e = logException(e, context);
+  notification.error({
+    message: "Internal error: " + e.name + " " + context,
+    description: e.message,
+    duration: NO_TIMEOUT,
+  });
+}
+
+/** Just log an exception */
+function logException(e, context) {
   if (typeof e === "string") {
     e = {
       name: "",
@@ -116,11 +156,9 @@ function exception(e, context) {
   if (hasDataDog) {
     datadogLogs.logger.error(context, {}, e);
   }
-  notification.error({
-    message: "Internal error: " + e.name + " " + context,
-    description: e.message,
-    duration: NO_TIMEOUT,
-  });
+  console.error(e.message + " " + context);
+  console.error(e); // log with stack trace
+  return e;
 }
 
 /**
@@ -150,4 +188,15 @@ function openWithHtml(message, description) {
   }
 }
 
-export { error, errorWithCallback, exception, open, openWithHtml, warning };
+export {
+  error,
+  errorWithCallback,
+  exception,
+  logError,
+  logException,
+  logInfo,
+  logWarning,
+  open,
+  openWithHtml,
+  warning,
+};

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AbstractCacheManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AbstractCacheManager.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.time.Instant;
 import java.util.logging.Logger;
 import org.apache.jena.sparql.lang.sparql_11.ParseException;
+import org.unicode.cldr.icu.LDMLConstants;
 import org.unicode.cldr.rdf.AbstractCache;
 import org.unicode.cldr.rdf.MapAll;
 import org.unicode.cldr.util.CLDRCacheDir;
@@ -25,7 +26,15 @@ class AbstractCacheManager {
             return null;
         }
 
-        return cache.get(xpath);
+        String response = cache.get(xpath);
+        if (response == null && xpath.contains(LDMLConstants.ALT)) {
+            // try with alt removed
+            final String removed = XPathTable.removeAlt(xpath);
+            if (!removed.equals(xpath)) {
+                response = cache.get(removed);
+            }
+        }
+        return response;
     }
 
     public boolean setup = false;


### PR DESCRIPTION
CLDR-18518

- [X] This PR completes the ticket.


  - example, az-short https://st.unicode.org/cldr-apps/v#/ab/Languages_A_D/700f7be0e77ae39b had no abstract but az did
  - fix the error message on deferHelp (dbPedia extract)
  - add logError, logException, logInfo, logWarning to cldrNotify for low level datadog logging without showing a message popup (these will go to datadog)
  - cleanup some noise in initial gui load and ajax load (Browser debugger panel for network shows better information here anyway)
  - workaround CORS issue with dbpedia by adding the hostname of the request to the query, this way the cache is individual for, say, smoketest vs. production (vs local) - otherwise they aren't shareable.

ALLOW_MANY_COMMITS=true
