### PR TITLE
CLDR-18492 BRS: update currency

### DIFF
--- a/docs/site/development/updating-codes/update-currency-codes.md
+++ b/docs/site/development/updating-codes/update-currency-codes.md
@@ -2,58 +2,60 @@
 title: Update Currency Codes
 ---
 
-# Update Currency Codes
-
-- Go to https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=currency-codes
-- Take the link for "Current Currency and Funds": ["List one (XML)"](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml)
+- Go to [SIX Financial Data Standards]
+- Take the link for "Current Currency and Funds": [List one XML]
 - Save the page as {cldr}/tools/cldr\-code/src/main/resources/org/unicode/cldr/util/data/dl\_iso\_table\_a1\.xml
-- Take the link for "Historic denominations": "[List three (XML)](https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-three.xml)"
+- Take the link for "Historic denominations": [List three XML]
 - Save the page as {cldr}/tools/cldr\-code/src/main/resources/org/unicode/cldr/util/data/dl\_iso\_table\_a3\.xml
 - **Use git diff to sanity check the two XML files against the old, and check them in.**
-    - **"git diff \-w" is helpful to ignore whitespace. If there are only whitespace changes, there's no need to check them in.**
-- **Check the** [**ISO amendments**](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=amendments) **to get changes that will happen during the current cycle.**
-    - Example: https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl_currency_iso_amendment_170.pdf
-    - It appears right now like there is no good way to collect all the amendments that are applicable, except to change "170" in the above link by incrementing until error \#404 results. So:
-    - *Review all amendments that are dated after the previous update , and patch the XML files and the* ```supplementalData.xml``` *as below.*
-    - *Record the last number viewed in the URL above.*
-    - *(There is a "download all amendments" link now that has a spreadsheet summary.)*
-    - **Record the version: See** [**Updating External Metadata**](/development/updating-codes/external-version-metadata)
-    - If there are no diffs in the two iso tables, and no relevant changes in the amendments, you are done.
-    - Run ```CountItems -Dmethod=generateCurrencyItems``` to generate the new currency list.
-        - If any currency is missing from ISO4217\.txt, the program will throw an exception and will print a list of items at the end that need to be added to the ISO4217\.txt file. Add as described below.
-        - Once the necessary codes are added to ISO4217\.txt, repeat the CountItems \-Dmethod\=generateCurrencyItems until it runs cleanly.
-        - If any country changes the use of a currency, verify that there is a corresponding entry in SupplementalData
-        - Since ISO doesn't publish the exact date change (usually just a month), you may need to do some additional research to see if you can determine the exact date when a new currency becomes active, or when an old currency becomes inactive. If you can't find the exact date, use the last day of the month ISO publishes for an old currency expiring.
-        - For new stuff, see below.
-    - Adding a currency:
-        - Make sure the new code exists in common/bcp47/currency.xml. The currency code should be in lower case, and make sure the "since" release corresponds to the next release of CLDR that will publish using this data.
-        - In SupplementalData:
-        - If it has unusual rounding or number of digits, add to:
-            - \<fractions\>
-            - \<info iso4217\="ADP" digits\="0" rounding\="0"/\>
-            - ...
-        - For each country in which it comes into use, add a line for when it becomes valid
-            - \<region iso3166\="TR"\>
-            - \<currency iso4217\="TRY" from\="2005\-01\-01"/\>
-        - Add the code to the file java/org/unicode/cldr/util/data/ISO4217\.txt. This is important, since it is used to get the valid codes for the survey tool.
-            - Example:
-                - currency \| TRY \| new Turkish Lira \| TR \| TURKEY \| C
-            - Mark the old code in java/org/unicode/cldr/util/data/ISO4217\.txt as deprecated.
-                - currency \| TRL \| Old Turkish Lira \| TR \| TURKEY \| O
-    - Changing currency.
-        - If the currency goes out of use in a country, then add the last day of use, such as:
-            - \<region iso3166\="TR"\>
-            - \<currency iso4217\="TRL" from\="1922\-11\-01"/\>
-            - \=\>
-            - \<region iso3166\="TR"\>
-            - \<currency iso4217\="TRL" from\="1922\-11\-01" to\="2005\-12\-31"/\>
-        - Edit common/main/en.xml to add the new names (or change old ones) based on the descriptions.
-            - If there is a collision between a new and old name, the old one typically changes to the currency name with the date range
-                - "currency\_name (1983\-2003\)".
-    - Check in your changes
-        - common/bcp47/currency.xml
-        - tools/java/org/unicode/cldr/util/data/ISO4217\.txt
-        - common/main/en.xml
-        - common/supplemental/supplementalData.xml
-- ***Note: We no longer maintain the list of currency in supplementalMetadata.xml (***[***\#4298***](http://unicode.org/cldr/trac/ticket/4298)***). The list is currently maintained by bcp47/currency.xml. We need to move the code used for checking list of ISO currency (and its numeric code mapping) currently in ICU tools repository (http://source.icu-project.org/repos/icu/tools/trunk/currency/).***
+  - **"git diff \-w" is helpful to ignore whitespace. If there are only whitespace changes, there's no need to check them in.**
+- **Check the** [ISO amendments] **to get changes that will happen during the current cycle.**
+- Example: <https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-176.pdf>
+- It appears right now like there is no good way to collect all the amendments that are applicable, except to change "176" in the above link by incrementing until error \#404 results. So:
+- *Review all amendments that are dated after the previous update , and patch the XML files and the* ```supplementalData.xml``` *as below.*
+- *Record the last number viewed in the URL above.*
+- *(There is a "download all amendments" link now that has a spreadsheet summary.)*
+- If there are no diffs in the two iso tables, and no relevant changes in the amendments, you are done.
+- Run ```CountItems -Dmethod=generateCurrencyItems``` to generate the new currency list.
+  - If any currency is missing from ISO4217\.txt, the program will throw an exception and will print a list of items at the end that need to be added to the ISO4217\.txt file. Add as described below.
+  - Once the necessary codes are added to ISO4217\.txt, repeat the CountItems \-Dmethod\=generateCurrencyItems until it runs cleanly.
+  - If any country changes the use of a currency, verify that there is a corresponding entry in SupplementalData
+  - Since ISO doesn't publish the exact date change (usually just a month), you may need to do some additional research to see if you can determine the exact date when a new currency becomes active, or when an old currency becomes inactive. If you can't find the exact date, use the last day of the month ISO publishes for an old currency expiring.
+  - For new stuff, see below.
+- Adding a currency:
+  - Make sure the new code exists in common/bcp47/currency.xml. The currency code should be in lower case, and make sure the "since" release corresponds to the next release of CLDR that will publish using this data.
+  - In SupplementalData:
+  - If it has unusual rounding or number of digits, add to:
+    - \<fractions\>
+    - \<info iso4217\="ADP" digits\="0" rounding\="0"/\>
+    - ...
+  - For each country in which it comes into use, add a line for when it becomes valid
+    - \<region iso3166\="TR"\>
+    - \<currency iso4217\="TRY" from\="2005\-01\-01"/\>
+  - Add the code to the file java/org/unicode/cldr/util/data/ISO4217\.txt. This is important, since it is used to get the valid codes for the survey tool.
+    - Example:
+      - currency \| TRY \| new Turkish Lira \| TR \| TURKEY \| C
+    - Mark the old code in java/org/unicode/cldr/util/data/ISO4217\.txt as deprecated.
+      - currency \| TRL \| Old Turkish Lira \| TR \| TURKEY \| O
+- Changing currency.
+  - If the currency goes out of use in a country, then add the last day of use, such as:
+    - \<region iso3166\="TR"\>
+    - \<currency iso4217\="TRL" from\="1922\-11\-01"/\>
+    - \=\>
+    - \<region iso3166\="TR"\>
+    - \<currency iso4217\="TRL" from\="1922\-11\-01" to\="2005\-12\-31"/\>
+  - Edit common/main/en.xml to add the new names (or change old ones) based on the descriptions.
+    - If there is a collision between a new and old name, the old one typically changes to the currency name with the date range
+      - "currency\_name (1983\-2003\)".
+- Check in your changes
+  - common/bcp47/currency.xml
+  - tools/java/org/unicode/cldr/util/data/ISO4217\.txt
+  - common/main/en.xml
+  - common/supplemental/supplementalData.xml
 
+Note: the list of currencies is in `bcp47/currency.xml` There is also an ICU tool in <https://github.com/unicode-org/icu/tree/main/tools/currency> which (according to an earlier version of this document) should move to CLDR.
+
+[SIX Financial Data Standards]: https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=currency-codes
+[List one XML]: https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml
+[List three XML]: https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-three.xml
+[ISO amendments]: https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=amendments

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateConstants.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateConstants.java
@@ -1,6 +1,10 @@
 package org.unicode.cldr.util;
 
+import com.ibm.icu.util.Calendar;
+import com.ibm.icu.util.GregorianCalendar;
+import com.ibm.icu.util.TimeZone;
 import java.util.Date;
+import java.util.Locale;
 
 /** Some date related constants */
 public class DateConstants {
@@ -13,6 +17,14 @@ public class DateConstants {
     public static final long MILLIS_PER_DAY = MILLIS_PER_HOUR * 24;
     public static final long MILLIS_PER_MONTH = MILLIS_PER_DAY * 30;
 
+    private static final Date getRecentHistory(Date d) {
+        Calendar gc = GregorianCalendar.getInstance(TimeZone.GMT_ZONE, Locale.ENGLISH);
+        gc.clear();
+        gc.setTime(d);
+        gc.set(Calendar.MONTH, -8); // 8 months prior
+        return gc.getTime();
+    }
+
     /** A date a little less than 8 months ago. */
-    public static final Date RECENT_HISTORY = new Date(NOW.getTime() - (MILLIS_PER_MONTH * 8));
+    public static final Date RECENT_HISTORY = getRecentHistory(NOW);
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2024-06-25">
+<ISO_4217 Pblshd="2025-03-31">
 	<CcyTbl>
 		<CcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -426,16 +426,9 @@
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
-			<CtryNm>CUBA</CtryNm>
-			<CcyNm>Peso Convertible</CcyNm>
-			<Ccy>CUC</Ccy>
-			<CcyNbr>931</CcyNbr>
-			<CcyMnrUnts>2</CcyMnrUnts>
-		</CcyNtry>
-		<CcyNtry>
 			<CtryNm>CURAÇAO</CtryNm>
-			<CcyNm>Netherlands Antillean Guilder</CcyNm>
-			<Ccy>ANG</Ccy>
+			<CcyNm>Caribbean Guilder</CcyNm>
+			<Ccy>XCG</Ccy>
 			<CcyNbr>532</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
@@ -1502,8 +1495,8 @@
 		</CcyNtry>
 		<CcyNtry>
 			<CtryNm>SINT MAARTEN (DUTCH PART)</CtryNm>
-			<CcyNm>Netherlands Antillean Guilder</CcyNm>
-			<Ccy>ANG</Ccy>
+			<CcyNm>Caribbean Guilder</CcyNm>
+			<Ccy>XCG</Ccy>
 			<CcyNbr>532</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2024-09-01">
+<ISO_4217 Pblshd="2025-03-31">
 	<HstrcCcyTbl>
 		<HstrcCcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -260,6 +260,20 @@
 			<CcyNbr>191</CcyNbr>
 			<WthdrwlDt>2023-01</WthdrwlDt>
 		</HstrcCcyNtry>
+		<HstrcCcyNtry>
+			<CtryNm>CUBA</CtryNm>
+			<CcyNm>Peso Convertible</CcyNm>
+			<Ccy>CUC</Ccy>
+			<CcyNbr>931</CcyNbr>
+			<WthdrwlDt>2021-06</WthdrwlDt>
+		</HstrcCcyNtry>
+		<HstrcCcyNtry>
+			<CtryNm>CURAÇAO</CtryNm>
+			<CcyNm>Netherlands Antillean Guilder</CcyNm>
+			<Ccy>ANG</Ccy>
+			<CcyNbr>532</CcyNbr>
+			<WthdrwlDt>2025-03</WthdrwlDt>
+		</HstrcCcyNtry>		
 		<HstrcCcyNtry>
 			<CtryNm>CYPRUS</CtryNm>
 			<CcyNm>Cyprus Pound</CcyNm>
@@ -807,6 +821,13 @@
 			<WthdrwlDt>2023-12</WthdrwlDt>
 		</HstrcCcyNtry>
 		<HstrcCcyNtry>
+			<CtryNm>SINT MAARTEN (DUTCH PART)</CtryNm>
+			<CcyNm>Netherlands Antillean Guilder</CcyNm>
+			<Ccy>ANG</Ccy>
+			<CcyNbr>532</CcyNbr>
+			<WthdrwlDt>2025-03</WthdrwlDt>
+		</HstrcCcyNtry>
+		<HstrcCcyNtry>
 			<CtryNm>SLOVAKIA</CtryNm>
 			<CcyNm>Slovak Koruna</CcyNm>
 			<Ccy>SKK</Ccy>
@@ -1130,7 +1151,7 @@
 		</HstrcCcyNtry>
 		<HstrcCcyNtry>
 			<CtryNm>ZIMBABWE</CtryNm>
-			<CcyNm>Zimbabwe Dollar</CcyNm>
+			<CcyNm>Zimbabwe Dollar</CcyNm>
 			<Ccy>ZWL</Ccy>
 			<CcyNbr>932</CcyNbr>
 			<WthdrwlDt>2024-09</WthdrwlDt>


### PR DESCRIPTION
CLDR-18492

- update ISO 4217
- improve site (slightly)
- fix currency test so that recently-withdrawn currencies process OK.  This makes CLDR-17397 not be an issue. ISO moves currencies directly to historical even if they are still tender.

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
