### PR TITLE
CLDR-18464 Fix IndexOutOfBoundsException in ExampleGenerator.handleEras

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -312,7 +312,11 @@ public class ExampleGenerator {
                             List.of(
                                     new GregorianCalendar(1989, 0, 10).getTime(),
                                     new GregorianCalendar(2019, 4, 3).getTime()));
-                    put("islamic", List.of(new GregorianCalendar(622, 6, 17).getTime()));
+                    put(
+                            "islamic",
+                            List.of(
+                                    new GregorianCalendar(622, 6, 17).getTime(),
+                                    new GregorianCalendar(622, 6, 12).getTime()));
                     put("chinese", List.of(new GregorianCalendar(-2636, 0, 03).getTime()));
                     put("hebrew", List.of(new GregorianCalendar(-3760, 9, 9).getTime()));
                     put("buddhist", List.of(new GregorianCalendar(-542, 0, 03).getTime()));


### PR DESCRIPTION
CLDR-18464

Addition of the new islamic era caused an IndexOutOfBoundsException in ExampleGenerator.handleEras, since it uses a hard-coded map to a list of sample dates for each era and it did not have an entry for the new islamic era. Fixed by adding the entry.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18464)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
