### PR TITLE
CLDR-18548 BRS 48 CLDRModify passes 2025-04-23

### DIFF
--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -432,8 +432,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</codePatterns>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[aáàâ b c ɖ eéèê ǝ{ǝ́}{ǝ̀}{ǝ̂} ɛ{ɛ́}{ɛ̀}{ɛ̂} f g {gb} h iíìî ɩ{ɩ́}{ɩ̀}{ɩ̂} j k {kp} l mḿ{m̀} nńǹ {ny} ŋ{ŋ́}{ŋ̀} {ŋm} oóòô ɔ{ɔ́}{ɔ̀}{ɔ̂} p r s {sh} t uúùû ʊ{ʊ́}{ʊ̀}{ʊ̂} w y]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[ăǎåäãā{a̰} æ ɓ ćç d ɗ ĕěëẽēḛ {ǝ̃}{ǝ̄}{ǝ̰} {ə̌} {ɛ̌}{ɛ̃}{ɛ̄}{ɛ̰} ƒ ɣ {hw} ĭǐïĩīḭ ĳ {ɩ̃}{ɩ̄}{ɩ̰} {m̌}{m̄} ňñ{n̄} {ŋw} ŏǒöõøō{o̰} œ {ɔ̌}{ɔ̃}{ɔ̄}{ɔ̰} ř šſ ß ŭǔüūṵ {̃ũ} {ʊ̌}{ʊ̃}{ʊ̄}{ʊ̰} v ʋ x {xw} ÿ ƴ z ʒ {̃ʼ}]</exemplarCharacters>
+		<exemplarCharacters>[aáàâ ǝ{ǝ́}{ǝ̀}{ǝ̂} b c ɖ eéèê ɛ{ɛ́}{ɛ̀}{ɛ̂} f g {gb} h iíìî ɩ{ɩ́}{ɩ̀}{ɩ̂} j k {kp} l mḿ{m̀} nńǹ {ny} ŋ{ŋ́}{ŋ̀} {ŋm} oóòô ɔ{ɔ́}{ɔ̀}{ɔ̂} p r s {sh} t uúùû ʊ{ʊ́}{ʊ̀}{ʊ̂} w y]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[ăǎåäãā{a̰} æ {ǝ̃}{ǝ̄}{ǝ̰} ɓ ćç d ɗ ĕěëẽēḛ {ə̌} {ɛ̌}{ɛ̃}{ɛ̄}{ɛ̰} ƒ ɣ {hw} ĭǐïĩīḭ ĳ {ɩ̃}{ɩ̄}{ɩ̰} {m̌}{m̄} ňñ{n̄} {ŋw} ŏǒöõøō{o̰} œ {ɔ̌}{ɔ̃}{ɔ̄}{ɔ̰} ř šſ ß ŭǔüūṵ {̃ũ} {ʊ̌}{ʊ̃}{ʊ̄}{ʊ̰} v ʋ x {xw} ÿ ƴ z ʒ {̃ʼ}]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[   \- ‑ , . % ‰ ‱ + 0 1 2² 3³ 4 5 6 7 8 9 {ʲᵃ} {ᵏᵃ}]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[_ \- ‐‑ – — ― , ; \: ! ? . … '‘’ ‹ › &quot;“” « » ( ) \[ \] \{ \} § @ * / \\ \&amp; # % ‰ ‱ † ‡ • ‣ ‧ ′ ″ ° &lt; = &gt; | ¦ ~]</exemplarCharacters>
 		<ellipsis type="final">↑↑↑</ellipsis>

--- a/common/main/bqi.xml
+++ b/common/main/bqi.xml
@@ -17,9 +17,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</layout>
 	<characters>
 		<!-- Using the Persian orthography -->
-		<exemplarCharacters>[ً ٍ ٌ ّ ٔ آ ا ءأؤئ ب پ ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن و هة ی]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[ـ\u200C\u200D\u200E\u200F َ ِ ُ ْ ٖ ٰ إ ك ىي]</exemplarCharacters>
-		<exemplarCharacters type="index">[آ ا ب پ ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن و ه ی]</exemplarCharacters>
+		<exemplarCharacters>[ً ٌ ٍ ّ ٔ ء آ أ ؤ ئ ا ب پ ة ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن ه و ی]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[ـ\u200C\u200D\u200E\u200F َ ُ ِ ْ ٖ ٰ إ ك ى ي]</exemplarCharacters>
+		<exemplarCharacters type="index">[آ ا ب پ ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن ه و ی]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\u200E , ٫ ٬ . % ٪ ‰ ؉ + − 0۰ 1۱ 2۲ 3۳ 4۴ 5۵ 6۶ 7۷ 8۸ 9۹]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐‑ ، ٫ ٬ ؛ \: ! ؟ . … ‹ › « » ( ) \[ \] * / \\]</exemplarCharacters>
 	</characters>

--- a/common/main/bqi.xml
+++ b/common/main/bqi.xml
@@ -15,7 +15,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<characterOrder>right-to-left</characterOrder>
 		</orientation>
 	</layout>
-	<characters> <!-- Using the Persian orthography-->
+	<characters>
+		<!-- Using the Persian orthography -->
 		<exemplarCharacters>[ً ٍ ٌ ّ ٔ آ ا ءأؤئ ب پ ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن و هة ی]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[ـ\u200C\u200D\u200E\u200F َ ِ ُ ْ ٖ ٰ إ ك ىي]</exemplarCharacters>
 		<exemplarCharacters type="index">[آ ا ب پ ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن و ه ی]</exemplarCharacters>

--- a/common/main/bua.xml
+++ b/common/main/bua.xml
@@ -11,8 +11,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="bua"/>
 	</identity>
 	<characters>
-		<exemplarCharacters>[а б в г д е ё ж з и й к л м н о ө п р с т у ү ф х һ ц ч ш щ ъ ы ь э ю я]</exemplarCharacters>
+		<exemplarCharacters>[а б в г д её ж з и й к л м н о ө п р с т у ү ф х һ ц ч ш щ ъ ы ь э ю я]</exemplarCharacters>
 		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
-		<exemplarCharacters type="punctuation">[ \- ‐ ‑ – — , ; \: ! ? . … ' ‘ ‚ \&quot; “ „ « » ( ) \[ \] \{ \} § @ * / \&amp; #]</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[\- ‐‑ – — , ; \: ! ? . … '‘‚ &quot;“„ « » ( ) \[ \] \{ \} § @ * / \&amp; #]</exemplarCharacters>
 	</characters>
 </ldml>

--- a/common/main/bua.xml
+++ b/common/main/bua.xml
@@ -6,13 +6,13 @@ SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <ldml>
-    <identity>
-        <version number="$Revision$"/>
-        <language type="bua"/>
-    </identity>
-    <characters>
-        <exemplarCharacters>[а б в г д е ё ж з и й к л м н о ө п р с т у ү ф х һ ц ч ш щ ъ ы ь э ю я]</exemplarCharacters>
-        <exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
-        <exemplarCharacters type="punctuation">[ \- ‐ ‑ – — , ; \: ! ? . … ' ‘ ‚ \&quot; “ „ « » ( ) \[ \] \{ \} § @ * / \&amp; #]</exemplarCharacters>
-    </characters>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="bua"/>
+	</identity>
+	<characters>
+		<exemplarCharacters>[а б в г д е ё ж з и й к л м н о ө п р с т у ү ф х һ ц ч ш щ ъ ы ь э ю я]</exemplarCharacters>
+		<exemplarCharacters type="numbers">↑↑↑</exemplarCharacters>
+		<exemplarCharacters type="punctuation">[ \- ‐ ‑ – — , ; \: ! ? . … ' ‘ ‚ \&quot; “ „ « » ( ) \[ \] \{ \} § @ * / \&amp; #]</exemplarCharacters>
+	</characters>
 </ldml>

--- a/common/main/bua_RU.xml
+++ b/common/main/bua_RU.xml
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
 -->
 <ldml>
-    <identity>
-        <version number="$Revision$"/>
-        <language type="bua"/>
-        <territory type="RU"/>
-    </identity>
+	<identity>
+		<version number="$Revision$"/>
+		<language type="bua"/>
+		<territory type="RU"/>
+	</identity>
 </ldml>

--- a/common/main/ku_Arab.xml
+++ b/common/main/ku_Arab.xml
@@ -17,11 +17,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<lineOrder>top-to-bottom</lineOrder>
 		</orientation>
 	</layout>
-    <characters>
+	<characters>
 		<exemplarCharacters>[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ه ە و ۆ ی ێ]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[\u200C\u200D\u200E\u200F ً ٌ ٍ َ ُ ِ ّ ْ ء آ أ ؤ إ ة ث ذ ص ض ط ظ ك ھ ى ي]</exemplarCharacters>
 		<exemplarCharacters type="index" draft="unconfirmed">[ئ ا ب پ ت ج چ ح خ د ر ز ڕ ژ س ش ع غ ف ڤ ق ک گ ل ڵ م ن ه ە و ۆ ی ێ]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\u200E\u200F \- ‑ , ٫ ٬ . % ٪ ‰ ؉ + 0٠ 1١ 2٢ 3٣ 4٤ 5٥ 6٦ 7٧ 8٨ 9٩]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐‑ , ، ؛ \: ! ؟ . … ‘’ ‹ › &quot;“” « » ( ) \[ \] \{ \} ﴿ * / • −]</exemplarCharacters>
-    </characters>
+	</characters>
 </ldml>

--- a/common/main/sgs.xml
+++ b/common/main/sgs.xml
@@ -11,10 +11,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="sgs"/>
 	</identity>
 	<characters>
-		<exemplarCharacters>[aā b c č d eē ė{ė\u0304} f g h iī j k l m n oō p r s š t uū v z ž]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[{a\u0304} {ch} {dz} {dž} {e\u0304} {i\u0304} {o\u0304} {u\u0304}]</exemplarCharacters>
-		<exemplarCharacters type="index">[AĀ B C Č D EĒ Ė{Ė\u0304} F G H IĪ J K L M N OŌ P R S Š T UŪ V Z Ž]</exemplarCharacters>
-		<exemplarCharacters type="numbers">[  , % ‰ + − 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
+		<exemplarCharacters>[aā b cč d eė{ė̄}ē f g h iī j k l m n oō p r sš t uū v zž]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[{ā}ā {ch} {dz}{dž} {ē}ē {ī}ī {ō}ō {ū}ū]</exemplarCharacters>
+		<exemplarCharacters type="index">[AĀ B CČ D EĖ{Ė̄}Ē F G H IĪ J K L M N OŌ P R SŠ T UŪ V ZŽ]</exemplarCharacters>
+		<exemplarCharacters type="numbers">[, % ‰ + − 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐‑ – — , ; \: ! ? . … “„ ( ) \[ \] \{ \}]</exemplarCharacters>
 	</characters>
 	<delimiters>

--- a/common/main/sgs.xml
+++ b/common/main/sgs.xml
@@ -12,7 +12,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</identity>
 	<characters>
 		<exemplarCharacters>[aā b cč d eė{ė̄}ē f g h iī j k l m n oō p r sš t uū v zž]</exemplarCharacters>
-		<exemplarCharacters type="auxiliary">[{ā}ā {ch} {dz}{dž} {ē}ē {ī}ī {ō}ō {ū}ū]</exemplarCharacters>
+		<exemplarCharacters type="auxiliary">[{ch} {dz}{dž}]</exemplarCharacters>
 		<exemplarCharacters type="index">[AĀ B CČ D EĖ{Ė̄}Ē F G H IĪ J K L M N OŌ P R SŠ T UŪ V ZŽ]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[, % ‰ + − 0 1 2 3 4 5 6 7 8 9]</exemplarCharacters>
 		<exemplarCharacters type="punctuation">[\- ‐‑ – — , ; \: ! ? . … “„ ( ) \[ \] \{ \}]</exemplarCharacters>


### PR DESCRIPTION
CLDR-18548

- [x] This PR completes the ticket.

I decided to go ahead and do the CLDRModify passes since they cleaned up some recent DDL locale updates:
- the no-options pass fixed formatting (spaces->tabs, comments) for `bqi bua_RU bua ku_Arab`
- the -fP pass reordered/reformatted exemplar sets for `blo bqi bua sgs`

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
