### PR TITLE
CLDR-18370 Prevent alt=ascii values from being exported for datetime test data

### DIFF
--- a/common/testData/datetime/datetime.json
+++ b/common/testData/datetime/datetime.json
@@ -590,7 +590,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
-    "expected": "12:00:00 AM"
+    "expected": "12:00:00 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -599,7 +599,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
-    "expected": "8:50:07 AM"
+    "expected": "8:50:07 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -608,7 +608,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
-    "expected": "12:00:00 PM"
+    "expected": "12:00:00 PM"
   },
   {
     "semanticSkeleton": "T",
@@ -618,7 +618,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
-    "expected": "12:00:00 AM"
+    "expected": "12:00:00 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -628,7 +628,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
-    "expected": "8:50:07 AM"
+    "expected": "8:50:07 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -638,7 +638,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
-    "expected": "12:00:00 PM"
+    "expected": "12:00:00 PM"
   },
   {
     "semanticSkeleton": "T",
@@ -648,7 +648,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
-    "expected": "12:00:00 AM"
+    "expected": "12:00:00 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -658,7 +658,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
-    "expected": "8:50:07 AM"
+    "expected": "8:50:07 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -668,7 +668,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
-    "expected": "12:00:00 PM"
+    "expected": "12:00:00 PM"
   },
   {
     "semanticSkeleton": "T",
@@ -678,7 +678,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
-    "expected": "12:00:00 AM"
+    "expected": "12:00:00 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -688,7 +688,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
-    "expected": "8:50:07 AM"
+    "expected": "8:50:07 AM"
   },
   {
     "semanticSkeleton": "T",
@@ -698,7 +698,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
-    "expected": "12:00:00 PM"
+    "expected": "12:00:00 PM"
   },
   {
     "semanticSkeleton": "T",

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -157,6 +157,9 @@ public class DateTimeFormats {
     /**
      * Set a CLDRFile and calendar. Must be done before calling addTable.
      *
+     * <p>Note: currently, this method will skip `alt="ascii"` elements of `dateFormatItem`. This
+     * may be configurable in the future. See CLDR-18580
+     *
      * @param file
      * @param calendarID
      * @return
@@ -167,6 +170,9 @@ public class DateTimeFormats {
 
     /**
      * Set a CLDRFile and calendar. Must be done before calling addTable.
+     *
+     * <p>Note: currently, this method will skip `alt="ascii"` elements of `dateFormatItem`. This
+     * may be configurable in the future. See CLDR-18580
      *
      * @param file
      * @param calendarID
@@ -270,6 +276,10 @@ public class DateTimeFormats {
                                         + calendarID
                                         + "\"]/dateTimeFormats/availableFormats/dateFormatItem"))) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
+            if ("ascii".equals(parts.findAttributeValue("dateFormatItem", "alt"))) {
+                // TODO(CLDR-18580): Make this configurable.
+                continue;
+            }
             String key = parts.getAttributeValue(-1, "id");
             String value = file.getStringValue(path);
             if (key.equals(DEBUG_SKELETON)) {


### PR DESCRIPTION
This PR fixes an issue that is occurring in datetime test data generation, in which `alt="ascii"` alternate data is being picked up, even though no extra configuration was set to request it. So this is undesirable yet happening by default in some cases.

[CLDR-18370](https://unicode-org.atlassian.net/browse/CLDR-18370)

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true


[CLDR-18370]: https://unicode-org.atlassian.net/browse/CLDR-18370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ