### PR TITLE
CLDR-18574 Fix coverage for iso8601

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -76,7 +76,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%dateFormatItems" value="((E|d|Ed|EEEEd)|((Gy|y|yyyy|U)?(M|Md|MEd|MEEEEd|MMM|MMMd|MMMEd|MMMEEEEd|MMMM|MMMMd|MMMMEd|MMMMEEEEd))|((Gy|y|yyyy)(QQQ|QQQQ)?))"/>
 		<coverageVariable key="%dateFormatItemsAll" value="(G{0,5}(y|U){0,4}Q{0,4}(M|L){0,5}(E|c){0,5}d{0,2}(H|h){0,2}m{0,2}s{0,2}(v|z|Z){0,4})"/>
 		<coverageVariable key="%dateTimeFormatLengths" value="(full|long|medium|short)"/>
-		<coverageVariable key="%iso8601IDs" value='([^\\x{22}]*(Gy|y[MQw]|M[EdW]|Ed)[^\\x{22}]*)'/> <!-- two different date characters. Because they are ordered we can test pairs -->
+		<coverageVariable key="%iso8601IDs" value='([^\x{22}]*(Gy|y[MQw]|M[EdW]|Ed)[^\x{22}]*)'/> <!-- two different date characters. Because they are ordered we can test pairs -->
 
 		<coverageVariable key="%emTypes" value="(default|emoji|text)"/>
 		<coverageVariable key="%fullMedium" value="(full|medium)"/>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -8,6 +8,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 <!--
 	Note: For an explanation of the coverage level numbers (e.g. 80) see org/unicode/cldr/util/Level.java
+	Also, most of the attributes with regex quantifiers (?, +, *) will be possessive (without backtrack).
 -->
 <supplementalData>
 	<version number="$Revision$"/>
@@ -75,6 +76,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%dateFormatItems" value="((E|d|Ed|EEEEd)|((Gy|y|yyyy|U)?(M|Md|MEd|MEEEEd|MMM|MMMd|MMMEd|MMMEEEEd|MMMM|MMMMd|MMMMEd|MMMMEEEEd))|((Gy|y|yyyy)(QQQ|QQQQ)?))"/>
 		<coverageVariable key="%dateFormatItemsAll" value="(G{0,5}(y|U){0,4}Q{0,4}(M|L){0,5}(E|c){0,5}d{0,2}(H|h){0,2}m{0,2}s{0,2}(v|z|Z){0,4})"/>
 		<coverageVariable key="%dateTimeFormatLengths" value="(full|long|medium|short)"/>
+		<coverageVariable key="%iso8601IDs" value='([^\\x{22}]*(Gy|y[MQw]|M[EdW]|Ed)[^\\x{22}]*)'/> <!-- two different date characters. Because they are ordered we can test pairs -->
+
 		<coverageVariable key="%emTypes" value="(default|emoji|text)"/>
 		<coverageVariable key="%fullMedium" value="(full|medium)"/>
 		<coverageVariable key="%fullShort" value="(full|short)"/>
@@ -392,21 +395,21 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dayPeriods/dayPeriodContext[@type='format']/dayPeriodWidth[@type='wide']/dayPeriod[@type='(am|pm)']"/>
 
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
-		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
+		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='generic']/dateFormats/dateFormatLength[@type='%shortLong']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateFormats/dateFormatLength[@type='%fullMedium']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inTerritory="%chineseCalendarTerritories"	match="dates/calendars/calendar[@type='chinese']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inTerritory="KR"	match="dates/calendars/calendar[@type='dangi']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	inLanguage="yi" inTerritory="IL"	match="dates/calendars/calendar[@type='hebrew']/dateFormats/dateFormatLength[@type='%dateTimeFormatLengths']/dateFormat%stdPattern"/>
 
-		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='(gregorian|iso8601)']/timeFormats/timeFormatLength[@type='%medLong']/timeFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/timeFormats/timeFormatLength[@type='%fullShort']/timeFormat%stdPattern"/>
+		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/timeFormats/timeFormatLength[@type='%medLong']/timeFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/timeFormats/timeFormatLength[@type='%fullShort']/timeFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="units/durationUnit[@type='(hm|ms|hms)']/durationUnitPattern"/>
 
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%stdPattern"/>
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%atTimePattern"/>
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%relativePattern"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%stdPattern"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%atTimePattern"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%relativePattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%stdPattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%atTimePattern"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/dateTimeFormatLength[@type='%dateTimeFormatLengths']/dateTimeFormat%relativePattern"/>
@@ -415,9 +418,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
 		<coverageLevel	value="comprehensive"	 	match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
 
-		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
+		<coverageLevel	value="basic"	 	    match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
-		<coverageLevel	value="comprehensive"	 	match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/availableFormats/dateFormatItem[@id='%iso8601IDs']"/>
 
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/eras/eraAbbr/era[@type='(0|1)'][@alt='variant']"/>
@@ -999,18 +1002,19 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='vaii']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='vaii']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 
-		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/appendItems/appendItem[@request='Timezone']"/>
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/appendItems/appendItem[@request='Timezone']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%timeFormatItems']"/>
 		<coverageLevel inTerritory="TH" value="modern" match="dates/calendars/calendar[@type='buddhist']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="%islamicCalendarTerritories" value="modern" match="dates/calendars/calendar[@type='islamic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="JP" value="modern" match="dates/calendars/calendar[@type='japanese']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel inTerritory="TW" value="modern" match="dates/calendars/calendar[@type='roc']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
-		<coverageLevel value="comprehensive" match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
-		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
-		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
+		
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%iso8601IDs']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatDateItems']/greatestDifference[@id='%intervalFormatGDiff']"/>
-		<coverageLevel inLanguage="(hi|zh)" value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
+		<coverageLevel inLanguage="(hi|zh)" value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel inLanguage="(hi|zh)" value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="moderate" match="dates/fields/field[@type='(year|month|week)(-short|-narrow)?']/relative[@type='(-1|0|1)']"/>
 		<coverageLevel value="moderate" match="dates/fields/field[@type='week(-short|-narrow)?']/relativePeriod"/>
@@ -1028,7 +1032,10 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="moderate" match="characters/ellipsis[@type='%ellipsisTypes']"/>
 		<coverageLevel value="moderate" match="characters/moreInformation"/>
 		<coverageLevel value="moderate" match="characters/parseLenients[@scope='%anyAttribute'][@level='%anyAttribute']/parseLenient[@sample='%anyAttribute']"/>
-		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute'][@count='%anyAttribute']"/>
+		
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute'][@count='%anyAttribute']"/>
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/availableFormats/dateFormatItem[@id='%iso8601IDs'][@count='%anyAttribute']"/>
+		
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='%contextTypes']/dayWidth[@type='short']/day[@type='%dayTypes']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dayPeriods/dayPeriodContext[@type='%anyAlphaNum']/dayPeriodWidth[@type='%allWidths']/dayPeriod[@type='%anyAlphaNum']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/eras/eraNames/era[@type='(0|1)']"/>
@@ -1102,7 +1109,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='t0'][@type='%t0Types80']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='kr'][@type='(currency|digit|punct|space|symbol)'][@scope='%A']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='kr'][@type='(currency|digit|punct|space|symbol)']"/>
-		<coverageLevel value="modern" match="dates/calendars/calendar[@type='(gregorian|iso8601)']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
+		<coverageLevel value="modern" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
+		<coverageLevel value="modern" match="dates/calendars/calendar[@type='iso8601']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%iso8601IDs']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="modern" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="modern" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%timeFormatItemsDayPer']"/>
 		<coverageLevel inLanguage="(ja|ko|vi|zh)" value="modern" match="dates/calendars/calendar[@type='chinese']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItemsAll']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Joiners.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Joiners.java
@@ -4,4 +4,6 @@ import com.google.common.base.Joiner;
 
 public class Joiners {
     public static final Joiner VBAR = Joiner.on('|').useForNull("null");
+    public static final Joiner TAB = Joiner.on('\t').useForNull("null");
+    public static final Joiner COMMA_SP = Joiner.on(", ").useForNull("null");
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Joiners.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Joiners.java
@@ -1,0 +1,7 @@
+package org.unicode.cldr.util;
+
+import com.google.common.base.Joiner;
+
+public class Joiners {
+    public static final Joiner VBAR = Joiner.on('|').useForNull("null");
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Splitters.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Splitters.java
@@ -1,0 +1,7 @@
+package org.unicode.cldr.util;
+
+import com.google.common.base.Splitter;
+
+public class Splitters {
+    public static final Splitter VBAR = Splitter.on('|').trimResults();
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -1427,8 +1427,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
             Multimap<Level, PathHeader> sorted = TreeMultimap.create();
             for (String path : cldrFile) {
                 if (!path.startsWith("//ldml/dates/calendars/calendar[@type=\"iso8601\"]")
-                        || path.endsWith("/alias")
-                        || path.contains("[@type=\"standard\"]")) {
+                        || path.endsWith("/alias")) {
                     continue;
                 }
                 Level actual = coverageLevel.getLevel(path);
@@ -1461,7 +1460,10 @@ public class TestCoverageLevel extends TestFmwkPlus {
                     boolean expectedComprehensive =
                             comprehesiveElements.stream().anyMatch(x -> containing(parts, x));
                     if (!expectedComprehensive) {
-                        if (id != null) {
+                        if (path.endsWith("/pattern[@type=\"standard\"]")
+                                && !path.contains("/dateFormat[@type=\"standard\"]")) {
+                            expectedComprehensive = true;
+                        } else if (id != null) {
                             boolean keepIdS = keepIds.contains(id);
                             if (keepIdS) {
                                 keepIdSet.add(id);
@@ -1482,7 +1484,9 @@ public class TestCoverageLevel extends TestFmwkPlus {
                                         locale,
                                         ph.getPageId(),
                                         ph.getHeader(),
-                                        ph.getCode()));
+                                        ph.getCode(),
+                                        cldrFile.getStringValue(path),
+                                        path));
                     } else if (DEBUG) {
                         warnln(
                                 Joiners.TAB.join(
@@ -1491,7 +1495,8 @@ public class TestCoverageLevel extends TestFmwkPlus {
                                         locale,
                                         ph.getPageId(),
                                         ph.getHeader(),
-                                        ph.getCode()));
+                                        ph.getCode(),
+                                        cldrFile.getStringValue(path)));
                     }
                 }
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -46,6 +47,7 @@ import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.GrammarInfo;
+import org.unicode.cldr.util.Joiners;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleNames;
@@ -60,6 +62,7 @@ import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.RegexLookup;
 import org.unicode.cldr.util.RegexLookup.Finder;
+import org.unicode.cldr.util.Splitters;
 import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.CoverageVariableInfo;
@@ -1390,5 +1393,106 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 }
             }
         }
+    }
+
+    public void testIso8601() {
+        List<String> comprehesiveElements =
+                List.of(
+                        "timeFormat",
+                        "quarters",
+                        "eras",
+                        "dayPeriods",
+                        "days",
+                        "months",
+                        "appendItems",
+                        "intervalFormatFallback");
+        // drop IDs unless they have y+M or M+d
+        List<String> raw =
+                Splitters.VBAR.splitToList(
+                        "MMMMd|MMMMW|MMMMW|yw|yw|yQQQ|yQQQQ|Gy|Gy|GyM|GyM|GyM|GyMd|GyMd|GyMd|GyMd|GyMEd|GyMEd|GyMEd|GyMEd|GyMMM|GyMMM|GyMMM|GyMMMd|GyMMMd|GyMMMd|GyMMMd|GyMMMEd|GyMMMEd|GyMMMEd|GyMMMEd|Md|Md|MEd|MEd|MMMd|MMMd|MMMEd|MMMEd|Ed|yM|yM|yMd|yMd|yMd|yMEd|yMEd|yMEd|yMMM|yMMM|yMMMd|yMMMd|yMMMd|yMMMEd|yMMMEd|yMMMEd|yMMMM|yMMMM");
+        Set<String> keepIds = ImmutableSortedSet.copyOf(raw);
+
+        Pattern okIdPattern =
+                Pattern.compile(
+                        "[^\\x{22}]*(Gy|y[MQw]|M[EdW]|Ed)[^\\x{22}]*"); // two different [GyMEd]
+        // characters. Because they
+        // are ordered we can test
+        // pairs
+
+        for (String locale : List.of("en" /*, "de"*/)) {
+            CLDRFile cldrFile = CLDRConfig.getInstance().getCldrFactory().make(locale, true);
+            CoverageLevel2 coverageLevel = CoverageLevel2.getInstance(locale);
+
+            Multimap<Level, PathHeader> sorted = TreeMultimap.create();
+            for (String path : cldrFile) {
+                if (!path.startsWith("//ldml/dates/calendars/calendar[@type=\"iso8601\"]")
+                        || path.endsWith("/alias")
+                        || path.contains("[@type=\"standard\"]")) {
+                    continue;
+                }
+                Level actual = coverageLevel.getLevel(path);
+                sorted.put(actual, PathHeader.getFactory().fromPath(path));
+            }
+            Set<String> ids = new TreeSet<>();
+            Set<String> keepIdSet = new TreeSet<>();
+            for (Entry<Level, Collection<PathHeader>> entry : sorted.asMap().entrySet()) {
+                Level level = entry.getKey();
+
+                for (PathHeader ph : entry.getValue()) {
+
+                    String path = ph.getOriginalPath();
+                    XPathParts parts = XPathParts.getFrozenInstance(path);
+
+                    // account for .../intervalFormatItem[@id="Gy"]/greatestDifference[@id="G"]
+                    // and for .../dateFormatItem[@id="Gy"]
+                    String id = parts.getAttributeValue(-2, "id");
+                    if (id == null) {
+                        id = parts.getAttributeValue(-1, "id");
+                    }
+                    if (id != null) {
+                        ids.add(id);
+                    }
+
+                    boolean expectedComprehensive =
+                            comprehesiveElements.stream().anyMatch(x -> containing(parts, x));
+                    if (!expectedComprehensive) {
+                        if (id != null) {
+                            boolean keepIdS = keepIds.contains(id);
+                            if (keepIdS) {
+                                keepIdSet.add(id);
+                            } else {
+                                expectedComprehensive = !keepIdS;
+                                boolean keepIdR = okIdPattern.matcher(id).matches();
+                                if (keepIdS != keepIdR) {
+                                    throw new IllegalArgumentException("ID mismatch: " + id);
+                                }
+                            }
+                        }
+                    }
+                    if (Level.CORE_TO_MODERN.contains(level) == expectedComprehensive) {
+                        errln(
+                                String.format(
+                                        "level:%s, locale:%s, path:%s",
+                                        level.toString(), locale, path));
+                    } else {
+                        //                        warnln(
+                        //                                String.format(
+                        //                                        "level:%s, locale:%s, path:%s",
+                        //                                        level.toString(), locale, path));
+                    }
+                }
+            }
+            if (DEBUG) {
+                System.out.println(Joiners.VBAR.join(keepIds));
+                System.out.println(Joiner.on("|").join(ids));
+                System.out.println(Joiner.on("|").join(keepIdSet));
+                System.out.println(Joiner.on("|").join(Sets.difference(ids, keepIdSet)));
+            }
+        }
+    }
+
+    private boolean containing(XPathParts parts, String x) { // separated out for debugging
+        boolean result = parts.containsElement(x);
+        return result;
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -74,6 +74,8 @@ import org.unicode.cldr.util.XPathParts;
 
 public class TestCoverageLevel extends TestFmwkPlus {
 
+    private static final boolean DEBUG = System.getProperty("TestCoverageLevel") != null;
+
     private static final boolean SHOW_LSR_DATA =
             CLDRConfig.getInstance().getProperty("SHOW_LSR_DATA", false);
 
@@ -370,8 +372,6 @@ public class TestCoverageLevel extends TestFmwkPlus {
     }
 
     static final Date NOW = new Date();
-
-    private static final boolean DEBUG = false;
 
     RegexLookup<Level> exceptions =
             RegexLookup.of(
@@ -1474,11 +1474,11 @@ public class TestCoverageLevel extends TestFmwkPlus {
                                 String.format(
                                         "level:%s, locale:%s, path:%s",
                                         level.toString(), locale, path));
-                    } else {
-                        //                        warnln(
-                        //                                String.format(
-                        //                                        "level:%s, locale:%s, path:%s",
-                        //                                        level.toString(), locale, path));
+                    } else if (DEBUG) {
+                        warnln(
+                                String.format(
+                                        "level:%s, locale:%s, path:%s",
+                                        level.toString(), locale, path));
                     }
                 }
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -58,6 +58,7 @@ import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.PathHeader;
 import org.unicode.cldr.util.PathHeader.Factory;
+import org.unicode.cldr.util.PathHeader.PageId;
 import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.RegexLookup;
@@ -1431,7 +1432,11 @@ public class TestCoverageLevel extends TestFmwkPlus {
                     continue;
                 }
                 Level actual = coverageLevel.getLevel(path);
-                sorted.put(actual, PathHeader.getFactory().fromPath(path));
+                PathHeader ph = PathHeader.getFactory().fromPath(path);
+                ph.getPageId();
+                if (ph.getPageId() != PageId.Suppress) {
+                    sorted.put(actual, ph);
+                }
             }
             Set<String> ids = new TreeSet<>();
             Set<String> keepIdSet = new TreeSet<>();
@@ -1471,14 +1476,22 @@ public class TestCoverageLevel extends TestFmwkPlus {
                     }
                     if (Level.CORE_TO_MODERN.contains(level) == expectedComprehensive) {
                         errln(
-                                String.format(
-                                        "level:%s, locale:%s, path:%s",
-                                        level.toString(), locale, path));
+                                Joiners.TAB.join(
+                                        "",
+                                        level.toString(),
+                                        locale,
+                                        ph.getPageId(),
+                                        ph.getHeader(),
+                                        ph.getCode()));
                     } else if (DEBUG) {
                         warnln(
-                                String.format(
-                                        "level:%s, locale:%s, path:%s",
-                                        level.toString(), locale, path));
+                                Joiners.TAB.join(
+                                        "",
+                                        level.toString(),
+                                        locale,
+                                        ph.getPageId(),
+                                        ph.getHeader(),
+                                        ph.getCode()));
                     }
                 }
             }


### PR DESCRIPTION
CLDR-18574

This narrows the coverage of iso8601 to only date patterns. For available and interval formats, that is tested by making sure that the `id` value matches a regular expression that contains 2 "date" pattern characters. That uses the line:
```
<coverageVariable key="%iso8601IDs" value='([^\\x{22}]*(Gy|y[MQw]|M[EdW]|Ed)[^\\x{22}]*)'/>
<!-- two different date characters. Because they are ordered we can test pairs -->
```
The regex has the optional non " characters before and after, and sees if there are certain pairs, like Gy or Md. That is, it excludes singleton date characters like value='d', because ordering does not matter for them.

Adds a test, and a couple of GP utility classes.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
