### PR TITLE
CLDR-16765 Show un printables

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -1,0 +1,49 @@
+import * as cldrClient from "./cldrClient.mjs";
+
+let escapedCharInfo = {
+  namedInvisibleRegex: "[\\u200e\\u200f]",
+  invisibleRegex: "[\\u200e\\u200f]",
+  names: {
+    "\u200e": { name: "LRM" },
+    "\u200f": { name: "RLM" },
+  },
+};
+
+export let namedInvisible;
+export let invisible;
+
+/** recompile regex */
+function compile() {
+  namedInvisible = new RegExp(escapedCharInfo.namedInvisibleRegex, "u");
+  invisible = new RegExp(escapedCharInfo.invisibleRegex, "u");
+}
+
+compile(); // start from static info
+
+/** load the escaper's map */
+export async function load() {
+  const client = await cldrClient.getClient();
+  const { body } = await client.apis.info.getEscapedCharInfo();
+  escapedCharInfo = body;
+  compile(); // update regex
+}
+
+/**
+ * Escape any named invisible code points, if needed
+ * @param {string} str input string
+ * @returns escaped string such as `<span class="visible-mark">&lt;LRM&gt;</span>` or falsy if no escaping was needed
+ */
+export function getEscapedHtml(str) {
+  if (!str) return str;
+  if (namedInvisible.test(str)) {
+    const escaped = str.replace(namedInvisible, (o) => {
+      const e = escapedCharInfo?.names[o];
+      if (!e) return o; // could not find the entry
+      return `<span class="visible-mark" title="${e.shortName || e.name}\n ${
+        e.description || ""
+      }">${e.name}</span>`;
+    });
+    return escaped;
+  }
+  return undefined;
+}

--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -1,7 +1,7 @@
 let data = null;
 
 const staticInfo = {
-  forceEscapeRegex: "[\\u200e\\u200f]",
+  forceEscapeRegex: "[\\u200e\\u200f\\uFFF0]",
   names: {
     "\u200e": { name: "LRM" },
     "\u200f": { name: "RLM" },
@@ -10,7 +10,11 @@ const staticInfo = {
 
 /** updates content and recompiles regex */
 export function updateInfo(escapedCharInfo) {
-  const forceEscape = new RegExp(escapedCharInfo.forceEscapeRegex, "u");
+  const updatedRegex = escapedCharInfo.forceEscapeRegex
+    .replace(/\\ /g, " ")
+    .replace(/\\U[0]*([0-9a-fA-F]+)/g, `\\u{$1}`);
+  console.log(updatedRegex);
+  const forceEscape = new RegExp(updatedRegex, "u");
   data = { escapedCharInfo, forceEscape };
 }
 
@@ -43,8 +47,9 @@ export function getCharInfo(str) {
 /** Unconditionally escape (without testing) */
 function escapeHtml(str) {
   return str.replace(data?.forceEscape, (o) => {
-    const e = getCharInfo(o);
-    if (!e) return o; // could not find the entry
+    const e = getCharInfo(o) || {
+      name: `U+${Number(o.codePointAt(0)).toString(16).toUpperCase()}`,
+    };
     return `<span class="visible-mark" title="${e.shortName || e.name}\n ${
       e.description || ""
     }">${e.name}</span>`;

--- a/tools/cldr-apps/js/src/esm/cldrEscaperLoader.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaperLoader.mjs
@@ -1,0 +1,9 @@
+import * as cldrEscaper from "./cldrEscaper.mjs";
+import * as cldrClient from "./cldrClient.mjs";
+
+/** load the escaper's map from the server */
+export async function updateEscaperFromServer() {
+  const client = await cldrClient.getClient();
+  const { body } = await client.apis.info.getEscapedCharInfo();
+  cldrEscaper.updateInfo(body); // update regex
+}

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -3,7 +3,7 @@
  */
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrDashContext from "./cldrDashContext.mjs";
-import * as cldrEscaper from "./cldrEscaper.mjs";
+import * as cldrEscaperLoader from "./cldrEscaperLoader.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrForum from "./cldrForum.mjs";
 import * as cldrInfo from "./cldrInfo.mjs";
@@ -65,7 +65,7 @@ async function initialSetup() {
   await Promise.all([
     ensureSession(), // that we have a session
     // any other things can go here
-    cldrEscaper.load(),
+    cldrEscaperLoader.load(),
     // TODO: locale map
     // TOOD: initial menus
   ]);

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -65,7 +65,7 @@ async function initialSetup() {
   await Promise.all([
     ensureSession(), // that we have a session
     // any other things can go here
-    cldrEscaperLoader.load(),
+    cldrEscaperLoader.updateEscaperFromServer(),
     // TODO: locale map
     // TOOD: initial menus
   ]);

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -3,6 +3,7 @@
  */
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrDashContext from "./cldrDashContext.mjs";
+import * as cldrEscaper from "./cldrEscaper.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrForum from "./cldrForum.mjs";
 import * as cldrInfo from "./cldrInfo.mjs";
@@ -55,7 +56,19 @@ function run() {
   } catch (e) {
     return Promise.reject(e);
   }
-  return ensureSession().then(completeStartupWithSession);
+  // We load
+  return initialSetup().then(completeStartupWithSession);
+}
+
+/** Hook for loading all things we want loaded - locales, menus, etc */
+async function initialSetup() {
+  await Promise.all([
+    ensureSession(), // that we have a session
+    // any other things can go here
+    cldrEscaper.load(),
+    // TODO: locale map
+    // TOOD: initial menus
+  ]);
 }
 
 async function ensureSession() {

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -14,6 +14,7 @@ import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrCoverage from "./cldrCoverage.mjs";
 import * as cldrDashContext from "./cldrDashContext.mjs";
 import * as cldrDom from "./cldrDom.mjs";
+import * as cldrEscaper from "./cldrEscaper.mjs";
 import * as cldrEvent from "./cldrEvent.mjs";
 import * as cldrGui from "./cldrGui.mjs";
 import * as cldrInfo from "./cldrInfo.mjs";
@@ -1010,13 +1011,11 @@ function showItemInfoFn(theRow, item) {
  */
 function checkLRmarker(field, value) {
   if (value) {
-    if (value.indexOf("\u200E") > -1 || value.indexOf("\u200F") > -1) {
-      value = value
-        .replace(/\u200E/g, '<span class="visible-mark">&lt;LRM&gt;</span>')
-        .replace(/\u200F/g, '<span class="visible-mark">&lt;RLM&gt;</span>');
+    const escapedValue = cldrEscaper.getEscapedHtml(value);
+    if (escapedValue) {
       const lrm = document.createElement("div");
       lrm.className = "lrmarker-container";
-      lrm.innerHTML = value;
+      lrm.innerHTML = escapedValue;
       field.appendChild(lrm);
     }
   }

--- a/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
+++ b/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import mocha from "mocha";
+
+import * as cldrEscaper from "../../src/esm/cldrEscaper.mjs";
+
+function uplus(ch) {
+  if (!ch) return ch;
+  return "U+" + Number(ch.codePointAt(0)).toString(16);
+}
+
+describe("cldrEscaper test", function () {
+  describe("LRM/RLM test", function () {
+    for (const ch of ["\u200E", "\u200F"]) {
+      it(`returns true for ${uplus(ch)}`, function () {
+        expect(cldrEscaper.needsEscaping(ch)).to.be.ok;
+      });
+    }
+    for (const ch of [undefined, false, null, " ", "X"]) {
+      it(`returns false for ${uplus(ch)}`, function () {
+        expect(cldrEscaper.needsEscaping(ch)).to.not.be.ok;
+      });
+    }
+  });
+  describe("Escaping Test", () => {
+    it(`Should return undefined for a non-escapable str`, () => {
+      expect(cldrEscaper.getEscapedHtml(`dd/MM/y`)).to.not.be.ok;
+    });
+    it(`Should return HTML for a non-escapable str`, () => {
+      const html = cldrEscaper.getEscapedHtml(`dd‏/MM‏/y`); // U+200F / U+200F here
+      expect(html).to.be.ok;
+      expect(html).to.contain('class="visible-mark"');
+      expect(html).to.contain("RLM");
+    });
+  });
+});

--- a/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
+++ b/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
@@ -10,7 +10,7 @@ function uplus(ch) {
 
 describe("cldrEscaper test", function () {
   describe("LRM/RLM test", function () {
-    for (const ch of ["\u200E", "\u200F"]) {
+    for (const ch of ["\u200E", "\u200F", "\uFFF0"]) {
       it(`returns true for ${uplus(ch)}`, function () {
         expect(cldrEscaper.needsEscaping(ch)).to.be.ok;
       });
@@ -30,6 +30,12 @@ describe("cldrEscaper test", function () {
       expect(html).to.be.ok;
       expect(html).to.contain('class="visible-mark"');
       expect(html).to.contain("RLM");
+    });
+    it(`Should return hex for a unknown str`, () => {
+      const html = cldrEscaper.getEscapedHtml(`\uFFF0`); // U+200F / U+200F here
+      expect(html).to.be.ok;
+      expect(html).to.contain('class="visible-mark"');
+      expect(html).to.contain("U+FFF0");
     });
   });
 });

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
@@ -1,0 +1,68 @@
+package org.unicode.cldr.web.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.unicode.cldr.util.CodePointEscaper;
+
+@Path("/info/chars")
+@Tag(name = "info", description = "General Information")
+public class CharInfo {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Get Escaping Map",
+            description = "This returns a list of escapable characters")
+    @APIResponses(
+            value = {
+                @APIResponse(
+                        responseCode = "200",
+                        description = "Results of Character request",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = EscapedCharInfo.class))),
+            })
+    public Response getEscapedCharInfo() {
+        return Response.ok(EscapedCharInfo.INSTANCE).build();
+    }
+
+    /** unpacks the enum into a struct */
+    public static final class EscapedCharEntry {
+        public final String name;
+        public final String shortName;
+        public final String description;
+
+        public EscapedCharEntry(final CodePointEscaper c) {
+            name = c.name();
+            shortName = c.getShortName();
+            description = c.getDescription();
+        }
+    }
+
+    public static final class EscapedCharInfo {
+        public final String invisibleRegex = CodePointEscaper.INVISIBLES.toPattern(true);
+        public final String namedInvisibleRegex = CodePointEscaper.NAMED_INVISIBLES.toPattern(true);
+        public final Map<String, EscapedCharEntry> names = new HashMap<>();
+
+        EscapedCharInfo() {
+            for (final CodePointEscaper c : CodePointEscaper.values()) {
+                names.put(c.getString(), new EscapedCharEntry(c));
+            }
+        }
+
+        /** Constant data, so a singleton is fine */
+        public static final EscapedCharInfo INSTANCE = new EscapedCharInfo();
+    }
+}

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
@@ -52,8 +52,7 @@ public class CharInfo {
     }
 
     public static final class EscapedCharInfo {
-        public final String invisibleRegex = CodePointEscaper.INVISIBLES.toPattern(true);
-        public final String namedInvisibleRegex = CodePointEscaper.NAMED_INVISIBLES.toPattern(true);
+        public final String forceEscapeRegex = CodePointEscaper.FORCE_ESCAPE.toPattern(true);
         public final Map<String, EscapedCharEntry> names = new HashMap<>();
 
         EscapedCharInfo() {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
@@ -52,7 +52,8 @@ public class CharInfo {
     }
 
     public static final class EscapedCharInfo {
-        public final String forceEscapeRegex = CodePointEscaper.FORCE_ESCAPE.toPattern(true);
+        public final String forceEscapeRegex =
+                CodePointEscaper.ESCAPE_IN_SURVEYTOOL.toPattern(true);
         public final Map<String, EscapedCharEntry> names = new HashMap<>();
 
         EscapedCharInfo() {

--- a/tools/cldr-apps/src/main/webapp/css/redesign.css
+++ b/tools/cldr-apps/src/main/webapp/css/redesign.css
@@ -242,6 +242,12 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 	display: flex;
 	border: 1px solid #0FF;
 }
+.data .visible-mark::before{
+	content: '<';
+}
+.data .visible-mark::after{
+	content: '>';
+}
 .data .visible-mark{
 	background-color: #d9edf7;
 	border-color: #bce8f1;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -116,6 +116,10 @@ public enum CodePointEscaper {
                     .removeAll(EMOJI_INVISIBLES)
                     .freeze();
 
+    /** set to be escaped in the surveytool */
+    public static final UnicodeSet ESCAPE_IN_SURVEYTOOL =
+            FORCE_ESCAPE.cloneAsThawed().remove(SP.getCodePoint()).freeze();
+
     public static final UnicodeSet NON_SPACING = new UnicodeSet("[[:Mn:][:Me:]]").freeze();
 
     public static final UnicodeSet FORCE_ESCAPE_WITH_NONSPACING =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -110,18 +110,6 @@ public enum CodePointEscaper {
     public static final UnicodeSet EMOJI_INVISIBLES =
             new UnicodeSet("[\\uFE0F\\U000E0020-\\U000E007F]").freeze();
 
-    /** Includes unassigned, surrogate, noncharacters. Some Cf are visibles! */
-    public static final UnicodeSet INVISIBLES =
-            new UnicodeSet(
-                    "[[:Cc:][:Cn:][:Z:][:Cs:][:Co:][[:Cf:]-[\\u0600-\\u0605\\u06dd\\u070f\\u0890-\\u0891\\u08e2\\U000110BD\\U000110CD]]]");
-
-    /** Invisibles we have a name for */
-    public static final UnicodeSet NAMED_INVISIBLES =
-            INVISIBLES
-                    .retainAll(CodePointEscaper.getNamedEscapes())
-                    .remove(SP.getCodePoint()) // don't need to include space
-                    .freeze();
-
     public static final UnicodeSet FORCE_ESCAPE =
             new UnicodeSet("[[:DI:][:Pat_WS:][:WSpace:][:C:][:Z:]\u200B\u2060]")
                     .addAll(getNamedEscapes())

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -110,6 +110,18 @@ public enum CodePointEscaper {
     public static final UnicodeSet EMOJI_INVISIBLES =
             new UnicodeSet("[\\uFE0F\\U000E0020-\\U000E007F]").freeze();
 
+    /** Includes unassigned, surrogate, noncharacters. Some Cf are visibles! */
+    public static final UnicodeSet INVISIBLES =
+            new UnicodeSet(
+                    "[[:Cc:][:Cn:][:Z:][:Cs:][:Co:][[:Cf:]-[\\u0600-\\u0605\\u06dd\\u070f\\u0890-\\u0891\\u08e2\\U000110BD\\U000110CD]]]");
+
+    /** Invisibles we have a name for */
+    public static final UnicodeSet NAMED_INVISIBLES =
+            INVISIBLES
+                    .retainAll(CodePointEscaper.getNamedEscapes())
+                    .remove(SP.getCodePoint()) // don't need to include space
+                    .freeze();
+
     public static final UnicodeSet FORCE_ESCAPE =
             new UnicodeSet("[[:DI:][:Pat_WS:][:WSpace:][:C:][:Z:]\u200B\u2060]")
                     .addAll(getNamedEscapes())
@@ -254,7 +266,7 @@ public enum CodePointEscaper {
     private static final String HAS_NAME = " ≡ ";
 
     public static String toExample(int codePoint) {
-        CodePointEscaper cpe = _fromCodePoint.get(codePoint);
+        CodePointEscaper cpe = forCodePoint(codePoint);
         if (cpe == null) { // hex
             final String name = UCharacter.getExtendedName(codePoint);
             return codePointToEscaped(codePoint)
@@ -265,6 +277,14 @@ public enum CodePointEscaper {
                     + HAS_NAME
                     + cpe.shortName; // TODO show hover with cpe.description
         }
+    }
+
+    static CodePointEscaper forCodePoint(int codePoint) {
+        return _fromCodePoint.get(codePoint);
+    }
+
+    static CodePointEscaper forCodePoint(String str) {
+        return forCodePoint(str.codePointAt(0));
     }
 
     /**

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCodePointEscaper.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCodePointEscaper.java
@@ -1,0 +1,29 @@
+package org.unicode.cldr.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @see org.unicode.cldr.unittest.UnicodeSetPrettyPrinterTest
+ */
+public class TestCodePointEscaper {
+    @Test
+    void testNsms() {
+        // System.out.println("Invisibles: " + CodePointEscaper.INVISIBLES.toPattern(true));
+        // System.out.println("Named Invisibles " + CodePointEscaper.NAMED_INVISIBLES);
+        // can uncomment this to check they are actually invisible!
+        // System.out.print("Here they are: ->");
+        // CodePointEscaper.NAMED_INVISIBLES.forEach(s -> System.out.print(s));
+        // System.out.println("<--");
+
+        // Make sure all of them are … named!
+        CodePointEscaper.NAMED_INVISIBLES.forEach(
+                s ->
+                        assertNotNull(
+                                CodePointEscaper.forCodePoint(s),
+                                () ->
+                                        "No named invisible for U+"
+                                                + Integer.toString(s.codePointAt(0))));
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCodePointEscaper.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestCodePointEscaper.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.util;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,21 +10,12 @@ import org.junit.jupiter.api.Test;
  */
 public class TestCodePointEscaper {
     @Test
-    void testNsms() {
-        // System.out.println("Invisibles: " + CodePointEscaper.INVISIBLES.toPattern(true));
-        // System.out.println("Named Invisibles " + CodePointEscaper.NAMED_INVISIBLES);
-        // can uncomment this to check they are actually invisible!
-        // System.out.print("Here they are: ->");
-        // CodePointEscaper.NAMED_INVISIBLES.forEach(s -> System.out.print(s));
-        // System.out.println("<--");
-
-        // Make sure all of them are … named!
-        CodePointEscaper.NAMED_INVISIBLES.forEach(
-                s ->
-                        assertNotNull(
-                                CodePointEscaper.forCodePoint(s),
-                                () ->
-                                        "No named invisible for U+"
-                                                + Integer.toString(s.codePointAt(0))));
+    void testForEach() {
+        for (final CodePointEscaper e : CodePointEscaper.values()) {
+            assertEquals(e, CodePointEscaper.forCodePoint(e.getString()));
+            assertTrue(
+                    CodePointEscaper.FORCE_ESCAPE.contains(e.getCodePoint()),
+                    () -> "For " + e.name());
+        }
     }
 }


### PR DESCRIPTION
- move <> into CSS before/after for visible-mark
- rewire startup sequence a little- could pre-load some things in parallel
- new mechanism cldrEscaper

CLDR-16765

- [ ] This PR completes the ticket.

For now, only _named_ invisibles (except SPACE U+0020!) are shown. But this mechanism could show all invisibles, substituting U+ numbers or something.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
![image_720](https://github.com/user-attachments/assets/e1442522-d75c-4eb8-b854-ae2e57e32922)

<img width="470" alt="image" src="https://github.com/user-attachments/assets/c3161787-7ce3-4ba1-baf4-13377bdcfaaa" />

