### PR TITLE
CLDR-18475 dashboard fix: file/tab names were wrong

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDashData.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDashData.mjs
@@ -16,7 +16,7 @@ class DashData {
    *
    * @returns the new DashData object
    */
-  constructor() {
+  constructor(locale, coverageLevel) {
     this.entries = []; // array of DashEntry objects
     this.cats = new Set(); // set of category names, such as "Error"
     this.catSize = {}; // number of entries in each category
@@ -24,6 +24,8 @@ class DashData {
     // An object whose keys are xpstrid (xpath hex IDs like "db7b4f2df0427e4"), and whose values are DashEntry objects
     this.pathIndex = {};
     this.hiddenObject = null;
+    this.locale = locale;
+    this.coverageLevel = coverageLevel;
   }
 
   addEntriesFromJson(notifications) {
@@ -265,7 +267,7 @@ function doFetch(callback, opts) {
     .doFetch(url)
     .then(cldrAjax.handleFetchErrors)
     .then((data) => data.json())
-    .then(setData)
+    .then((json) => setData(json, locale))
     .catch((err) => {
       const msg = "Error loading Dashboard data: " + err;
       console.error(msg);
@@ -307,17 +309,17 @@ function getFetchError() {
  *
  * @return the modified/reorganized data as a DashData object
  */
-function setData(json) {
+function setData(json, locale) {
   cldrProgress.updateVoterCompletion(json);
-  const newData = convertData(json);
+  const newData = convertData(json, locale);
   if (viewSetDataCallback) {
     viewSetDataCallback(newData);
   }
   return newData;
 }
 
-function convertData(json) {
-  const newData = new DashData();
+function convertData(json, locale) {
+  const newData = new DashData(locale, json.coverageLevel);
   newData.setHidden(json.hidden);
   newData.addEntriesFromJson(json.notifications);
   return newData;
@@ -448,7 +450,7 @@ async function downloadXlsx(data, locale, cb) {
       }
     }
     const xpath = await getXpath();
-    const url = `https://st.unicode.org/cldr-apps/v#/${e.locale}/${e.page}/${e.xpstrid}`;
+    const url = `https://st.unicode.org/cldr-apps/v#/${locale}/${e.page}/${e.xpstrid}`;
     const cats = Array.from(e.cats).join(", ");
     ws_data.push([
       cats,


### PR DESCRIPTION
Not sure where this regressed, but this fixes three issues:

1. XLSX download file name was always for example Dash_es_default.xlsx (default instead of es.moderate)
2. XLSX tab name was also es.default instead of es.moderate, ex
3. URL broken internally, https://st.unicode.org/cldr-apps/v#/undefined/T_NAmerica/77b7368701e0333e instead of /es/…  (undefined instead of locale)

CLDR-18475

this was under CLDR-18475 because I originally thought it was a JSON issue, but it's not.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
