### PR TITLE
CLDR-16765 use-right-regex in front end

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -10,10 +10,7 @@ const staticInfo = {
 
 /** updates content and recompiles regex */
 export function updateInfo(escapedCharInfo) {
-  const updatedRegex = escapedCharInfo.forceEscapeRegex
-    .replace(/\\ /g, " ")
-    .replace(/\\U[0]*([0-9a-fA-F]+)/g, `\\u{$1}`);
-  console.log(updatedRegex);
+  const updatedRegex = escapedCharInfo.forceEscapeRegex;
   const forceEscape = new RegExp(updatedRegex, "u");
   data = { escapedCharInfo, forceEscape };
 }

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -921,7 +921,7 @@ function addVitem(td, tr, theRow, item, newButton) {
       cldrText.get("voteInfo_baseline_desc")
     );
   }
-  checkLRmarker(choiceField, item.value);
+  checkLRmarker(choiceField, displayValue);
   if (item.votes && !isWinner) {
     if (
       item.valueHash == theRow.voteVhash &&

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
@@ -53,7 +53,7 @@ public class CharInfo {
 
     public static final class EscapedCharInfo {
         public final String forceEscapeRegex =
-                CodePointEscaper.ESCAPE_IN_SURVEYTOOL.toPattern(true);
+                CodePointEscaper.regexPattern(CodePointEscaper.ESCAPE_IN_SURVEYTOOL, "\\u{", "}");
         public final Map<String, EscapedCharEntry> names = new HashMap<>();
 
         EscapedCharInfo() {


### PR DESCRIPTION
- use new 'use right regex' function #4673
 - remove a debug printout
 - pass inherited text through the escaper, as well as translated

CLDR-16765

depends on #4673

![image](https://github.com/user-attachments/assets/c919288d-6f69-4646-bb7f-916356b31aaa)

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
