### PR TITLE
CLDR-17857 automatically check English against last release version

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CalculatedCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CalculatedCoverageLevels.java
@@ -77,7 +77,8 @@ public class CalculatedCoverageLevels {
         }
     }
 
-    static CalculatedCoverageLevels forVersion(VersionInfo v) throws IOException {
+    /** Read from a prior version - see CheckoutArchive */
+    public static CalculatedCoverageLevels forVersion(VersionInfo v) throws IOException {
         return fromFile(ToolConstants.getBaseDirectory(v) + "/common/");
     }
 


### PR DESCRIPTION
- error if an English translation is missing for a locale which has reached basic in the previous released version

CLDR-17857

- [X] This PR completes the ticket.

Note: no items are failing now, but I was able to get a simulated failure by locally modifying v47 data:

```
    TestMissingInfoForLanguage {
      Error: (LikelySubtagsTest.java:362) Missing English translation for: suz which was at basic in 47.0.0.0
    } (0.236s) FAILED (1 failure(s))
```



<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
