### PR TITLE
CLDR-16765 unescape improvements

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -11,7 +11,7 @@ const staticInfo = {
 /** updates content and recompiles regex */
 export function updateInfo(escapedCharInfo) {
   const updatedRegex = escapedCharInfo.forceEscapeRegex;
-  const forceEscape = new RegExp(updatedRegex, "u");
+  const forceEscape = new RegExp(updatedRegex, "gu");
   data = { escapedCharInfo, forceEscape };
 }
 
@@ -20,7 +20,7 @@ updateInfo(staticInfo);
 
 export function needsEscaping(str) {
   if (!str) return false;
-  return data?.forceEscape?.test(str);
+  return !!str.match(data.forceEscape);
 }
 
 /**
@@ -38,12 +38,12 @@ export function getEscapedHtml(str) {
 
 /** get information for one char, or null */
 export function getCharInfo(str) {
-  return data?.escapedCharInfo?.names[str];
+  return data.escapedCharInfo?.names[str];
 }
 
 /** Unconditionally escape (without testing) */
 function escapeHtml(str) {
-  return str.replace(data?.forceEscape, (o) => {
+  return str.replaceAll(data.forceEscape, (o) => {
     const hexName = `U+${Number(o.codePointAt(0)).toString(16).toUpperCase()}`;
     let e = getCharInfo(o) || {};
     const name = e.name || e.shortName;

--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -41,6 +41,9 @@ export function getCharInfo(str) {
   return data.escapedCharInfo?.names[str];
 }
 
+const PREFIX = "❰";
+const SUFFIX = "❱";
+
 /** Unconditionally escape (without testing) */
 function escapeHtml(str) {
   return str.replaceAll(data.forceEscape, (o) => {
@@ -50,6 +53,6 @@ function escapeHtml(str) {
     const body = name || hexName;
     const description = e.description;
     const title = `${e.shortName || ""} ${hexName}\n${description || ""}`;
-    return `<span class="visible-mark" title="${title}">${body}</span>`;
+    return `<span class="visible-mark" title="${title}">${PREFIX}${body}${SUFFIX}</span>`;
   });
 }

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -764,7 +764,9 @@ function updateRowEnglishComparisonCell(tr, theRow, cell) {
       cldrDom.createChunk(theRow.displayName, "span", "subSpan")
     );
     // add possible <LRM>, etc escaped text to English
-    checkLRmarker(cell, theRow.displayName);
+    if (!theRow.noEscaping) {
+      checkLRmarker(cell, theRow.displayName);
+    }
   } else {
     cell.appendChild(document.createTextNode(""));
     if (!trHint) {
@@ -923,7 +925,9 @@ function addVitem(td, tr, theRow, item, newButton) {
       cldrText.get("voteInfo_baseline_desc")
     );
   }
-  checkLRmarker(choiceField, displayValue);
+  if (!theRow.noEscaping) {
+    checkLRmarker(choiceField, displayValue);
+  }
   if (item.votes && !isWinner) {
     if (
       item.valueHash == theRow.voteVhash &&

--- a/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
+++ b/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
@@ -10,8 +10,8 @@ function uplus(ch) {
 
 describe("cldrEscaper test", function () {
   describe("LRM/RLM test", function () {
-    for (const ch of ["\u200E", "\u200F", "\uFFF0"]) {
-      it(`returns true for ${uplus(ch)}`, function () {
+    for (const ch of ["\u200E", "\u200F", "\u200E", "\uFFF0", "\u200E\u200F", "\uFFF0\u200E", "e\u200E"]) {
+      it(`returns true for ${uplus(ch)}…`, function () {
         expect(cldrEscaper.needsEscaping(ch)).to.be.ok;
       });
     }
@@ -22,20 +22,23 @@ describe("cldrEscaper test", function () {
     }
   });
   describe("Escaping Test", () => {
+    const VISIBLE_MARK=/class="visible-mark"/g;
     it(`Should return undefined for a non-escapable str`, () => {
       expect(cldrEscaper.getEscapedHtml(`dd/MM/y`)).to.not.be.ok;
     });
-    it(`Should return HTML for a non-escapable str`, () => {
+    it(`Should return HTML for an escapable str`, () => {
       const html = cldrEscaper.getEscapedHtml(`dd‏/MM‏/y`); // U+200F / U+200F here
       expect(html).to.be.ok;
       expect(html).to.contain('class="visible-mark"');
       expect(html).to.contain("RLM");
+      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(2, "number of escapes");
     });
     it(`Should return hex for a unknown str`, () => {
       const html = cldrEscaper.getEscapedHtml(`\uFFF0`); // U+200F / U+200F here
       expect(html).to.be.ok;
       expect(html).to.contain('class="visible-mark"');
       expect(html).to.contain("U+FFF0");
+      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(1, "number of escapes");
     });
   });
 });

--- a/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
+++ b/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
@@ -10,7 +10,15 @@ function uplus(ch) {
 
 describe("cldrEscaper test", function () {
   describe("LRM/RLM test", function () {
-    for (const ch of ["\u200E", "\u200F", "\u200E", "\uFFF0", "\u200E\u200F", "\uFFF0\u200E", "e\u200E"]) {
+    for (const ch of [
+      "\u200E",
+      "\u200F",
+      "\u200E",
+      "\uFFF0",
+      "\u200E\u200F",
+      "\uFFF0\u200E",
+      "e\u200E",
+    ]) {
       it(`returns true for ${uplus(ch)}…`, function () {
         expect(cldrEscaper.needsEscaping(ch)).to.be.ok;
       });
@@ -22,7 +30,7 @@ describe("cldrEscaper test", function () {
     }
   });
   describe("Escaping Test", () => {
-    const VISIBLE_MARK=/class="visible-mark"/g;
+    const VISIBLE_MARK = /class="visible-mark"/g;
     it(`Should return undefined for a non-escapable str`, () => {
       expect(cldrEscaper.getEscapedHtml(`dd/MM/y`)).to.not.be.ok;
     });
@@ -31,14 +39,20 @@ describe("cldrEscaper test", function () {
       expect(html).to.be.ok;
       expect(html).to.contain('class="visible-mark"');
       expect(html).to.contain("RLM");
-      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(2, "number of escapes");
+      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(
+        2,
+        "number of escapes"
+      );
     });
     it(`Should return hex for a unknown str`, () => {
       const html = cldrEscaper.getEscapedHtml(`\uFFF0`); // U+200F / U+200F here
       expect(html).to.be.ok;
       expect(html).to.contain('class="visible-mark"');
       expect(html).to.contain("U+FFF0");
-      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(1, "number of escapes");
+      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(
+        1,
+        "number of escapes"
+      );
     });
   });
 });

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -242,6 +242,9 @@ public class VoteAPI {
             public int xpathId;
             public String xpstrid;
 
+            @Schema(description = "inhibit codepoint escaping of values")
+            public boolean noEscaping;
+
             @Schema(description = "prose description of voting outcome")
             public String voteTranscript;
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -305,6 +305,7 @@ public class VoteAPIHelper {
         row.xpathId = CookieSession.sm.xpt.getByXpath(xpath);
         row.xpstrid = XPathTable.getStringIDString(xpath);
         row.fixedCandidates = r.fixedCandidates();
+        row.noEscaping = DisplayAndInputProcessor.hasUnicodeSetValue(xpath);
         return row;
     }
 

--- a/tools/cldr-apps/src/main/webapp/css/redesign.css
+++ b/tools/cldr-apps/src/main/webapp/css/redesign.css
@@ -242,12 +242,6 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 	display: flex;
 	border: 1px solid #0FF;
 }
-.data .visible-mark::before{
-	content: '❰';
-}
-.data .visible-mark::after{
-	content: '❱';
-}
 .data .visible-mark{
 	background-color: #d9edf7;
 	border-color: #bce8f1;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -399,7 +399,7 @@ public class DisplayAndInputProcessor {
         return value;
     }
 
-    private boolean hasUnicodeSetValue(String path) {
+    public static boolean hasUnicodeSetValue(String path) {
         return path.startsWith("//ldml/characters/exemplarCharacters")
                 || path.startsWith("//ldml/characters/parseLenients");
     }


### PR DESCRIPTION
1. escape multiple chars, not just first
2. move prefix/suffix out of CSS and into plain text
3. don't escape items on the FE that DAIP already escaped on the BE


CLDR-16765

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

### Review notes

#### 1 - multiple escape

<img width="773" alt="image" src="https://github.com/user-attachments/assets/9c4a871a-b1b0-4aed-aec0-5b3860d96f35" />

#### 2 - plain text brackets

showing selected as plain text

<img width="209" alt="image" src="https://github.com/user-attachments/assets/5955215e-e4d1-4976-8511-5436d1ecd81a" />


#### 3 - no double escape

I'm a little surprised that we didn't have double escaping before for Arabic exemplars. In any event, this is suppressed now - however, I actually think the new escaping display is superior to the server-generated HTML.  Ideally we should have a _widget_ for working with exemplars on the server side. Anyway.

<img width="888" alt="image" src="https://github.com/user-attachments/assets/177ade05-75cf-4fa6-8d44-1b910f2694eb" />
