### PR TITLE
CLDR-14409 remove a spurious 'doc' line

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyTool.java
@@ -196,7 +196,6 @@ public class SurveyTool extends HttpServlet {
                         + "  console.error(e);\n"
                         + "  document.getElementById('st-run-gui').innerHTML = '<h1>&#x26A0; Error: Could not load CLDR ST GUI. Try reloading?</h1> <pre>'"
                         + " + e + '</pre>\\n<hr />\\n<pre>' + (e.stack||'') + '</pre>';\n"
-                        + "  doc"
                         + "}\n"
                         + "try {\n"
                         + "  cldrBundle.runGui()\n"


### PR DESCRIPTION
CLDR-14409

this has been broken for A Long Time

but, stRunGuiErr() has a typo in it producing an error message on the console - masking the original real error.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
