### PR TITLE
CLDR-18283 add Unicode 16 FractionalUCA_blanked.txt

### DIFF
--- a/docs/ldml/tr35-collation.md
+++ b/docs/ldml/tr35-collation.md
@@ -507,6 +507,8 @@ The final table gives certain hard-coded byte values. The "trail" area is provid
 
 > 👉 **Note**: The particular primary lead bytes for Hani vs. IMPLICIT vs. TRAILING are only an example. An implementation is free to move them if it also moves the explicit TRAILING weights. This affects only a small number of explicit mappings in FractionalUCA.txt, such as for U+FFFD, U+FFFF, and the “unassigned first primary”. It is possible to use no SPECIAL bytes at all, and to use only the one primary lead byte FF for TRAILING weights.
 
+Starting with CLDR 48/Unicode 17, the root collation data files include `FractionalUCA_blanked.txt` which has the same contents as `FractionalUCA.txt` but with “blanked weights” for most non-zero collation weights. It is not useful as a _data_ file, but it is valuable for simple diffing between versions of the data, showing changes in the sort order and in the number of bytes in fractional weights.
+
 #### <a name="File_Format_UCA_Rules_txt" href="#File_Format_UCA_Rules_txt">UCA_Rules.txt</a>
 
 The format for this file uses the CLDR collation syntax, see _[Collation Tailorings](#Collation_Tailorings)_.


### PR DESCRIPTION
CLDR-18283

- [ ] This PR completes the ticket.

This file is like running blankweights.sed over FractionalUCA.txt.

FractionalUCA.txt contains all of the data for building the CLDR root collation data. Diffing it across Unicode versions is nearly unusable, because inserting any character into the sort order changes the primary weights of every following character. And the fractional byte sequence weights are subject to manual and automatic tweaks in their computation.

Therefore, for many years I have used the [blankweights.sed script](https://github.com/unicode-org/cldr/blob/main/tools/scripts/uca/blankweights.sed) to generate a modified file with “blanked weights” that preserves the sort order and the number of non-zero weights. I find diffing this file across versions valuable. See the [UCA tools docs](https://github.com/unicode-org/unicodetools/blob/main/docs/uca/index.md) for some more details.

For example:
```
FractionalUCA.txt
04C1; [62 2C, 05, 9B][, 8C, 05]	# Cyrl Lu	[2837.0020.0008][0000.0026.0002]	* CYRILLIC CAPITAL LETTER ZHE WITH BREVE

FractionalUCA_blanked.txt
04C1; [pp pp, ss, tt][, ss, tt]	# Cyrl Lu	[pppp.ssss.0008][0000.ssss.0002]	* CYRILLIC CAPITAL LETTER ZHE WITH BREVE
```

I am changing the Unicode Tools Java code to directly write FractionalUCA_blanked.txt, just like it has also already written a FractionalUCA_SHORT.txt file (which omits the inline comments with allkeys.txt weights and character types & names). It should make the UCA-CLDR update workflow easier.
- https://github.com/unicode-org/unicodetools/pull/1155

ALLOW_MANY_COMMITS=true
