### PR TITLE
CLDR-18647 IllegalArgumentException in ExampleGenerator

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFileOverride.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFileOverride.java
@@ -8,7 +8,12 @@ import org.unicode.cldr.util.XPathParts.Comments;
 
 public class CLDRFileOverride extends CLDRFile {
 
-    private static boolean threwException = false;
+    /**
+     * Silently ignore missing paths for the locale used for the Comparison Value column in Survey
+     * Tool. This happens for some light-speed unit paths with @case="accusative", which have values
+     * for some locales such as Amharic ("am") but not for English.
+     */
+    static final String COMPARISON_LOCALE = "en";
 
     /**
      * Overrides the values of the sourceFile. The keys of the overrides must already be in the
@@ -26,20 +31,19 @@ public class CLDRFileOverride extends CLDRFile {
      * same, since it provides for the map.
      */
     public static class XMLSourceMapOverride extends XMLSource {
-        private XMLSource delegate;
+        private final XMLSource delegate;
 
-        private Map<String, String> overrides;
+        private final Map<String, String> overrides;
 
         public XMLSourceMapOverride(XMLSource source, Map<String, String> overrides) {
             overrides.keySet().stream()
                     .forEach(
                             x -> {
                                 if (source.getValueAtDPath(x) == null) {
-                                    System.out.println(
-                                            "source.getValueAtDPath null in XMLSourceMapOverride");
-                                    if (!threwException) { // only throw once
-                                        threwException = true;
-                                        throw new IllegalArgumentException();
+                                    String loc = source.getLocaleID();
+                                    if (!COMPARISON_LOCALE.equals(loc)) {
+                                        throw new IllegalArgumentException(
+                                                "loc=" + loc + "; path=" + x);
                                     }
                                 }
                             });

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFileOverride.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFileOverride.java
@@ -8,6 +8,8 @@ import org.unicode.cldr.util.XPathParts.Comments;
 
 public class CLDRFileOverride extends CLDRFile {
 
+    private static boolean threwException = false;
+
     /**
      * Overrides the values of the sourceFile. The keys of the overrides must already be in the
      * XMLSource source
@@ -33,7 +35,12 @@ public class CLDRFileOverride extends CLDRFile {
                     .forEach(
                             x -> {
                                 if (source.getValueAtDPath(x) == null) {
-                                    throw new IllegalArgumentException();
+                                    System.out.println(
+                                            "source.getValueAtDPath null in XMLSourceMapOverride");
+                                    if (!threwException) { // only throw once
+                                        threwException = true;
+                                        throw new IllegalArgumentException();
+                                    }
                                 }
                             });
             this.overrides = overrides;

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -2063,6 +2063,12 @@ public class TestExampleGenerator extends TestFmwk {
                 "{0} licht",
                 "〖Used as a fallback in the following:〗〖❬1❭ licht⋅seconde〗〖❬1❭ licht⋅minuut〗〖❬1❭ licht⋅uur〗〖❬1❭ licht⋅dag〗〖❬1❭ licht⋅week〗〖❬1❭ licht⋅maand〗〖Compare with:〗〖❬1❭ lichtjaar〗"
             },
+            {
+                "am",
+                "//ldml/units/unitLength[@type=\"long\"]/unit[@type=\"speed-light-speed\"]/unitPattern[@count=\"other\"][@case=\"accusative\"]",
+                "{0} ብርሃን",
+                "〖Used as a fallback in the following:〗〖❬2.6❭ ብርሃን⋅ሰከንዶች〗〖❬2.6❭ ብርሃን⋅ደቂቃዎች〗〖❬2.6❭ ብርሃን⋅ሰዓቶች〗〖❬2.6❭ ብርሃን⋅ቀናት〗〖❬2.6❭ ብርሃን⋅ሳምንታት〗〖❬2.6❭ ብርሃን⋅ወራት〗〖Compare with:〗〖❬2.6❭ የብርሃን ዓመት〗"
+            },
         };
         String lastLocale = "";
         CLDRFile baseCldrFile = null;


### PR DESCRIPTION
-Do not throw exception from XMLSourceMapOverride if locale is en = COMPARISON_LOCALE

-Enlarge testLightSpeed to include locale am (Amharic) and path that threw the exception

-Make delegate and overrides final per compiler suggestion

CLDR-18647

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
