### PR TITLE
CLDR-18664 ui: fix emoji 404

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -70,7 +70,6 @@ import org.unicode.cldr.util.GrammarInfo.GrammaticalScope;
 import org.unicode.cldr.util.GrammarInfo.GrammaticalTarget;
 import org.unicode.cldr.util.ICUServiceBuilder;
 import org.unicode.cldr.util.LanguageTagParser;
-import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.NameGetter;
 import org.unicode.cldr.util.NameType;
 import org.unicode.cldr.util.Pair;
@@ -3823,21 +3822,25 @@ public class ExampleGenerator {
 
         // now get the description
 
-        Level level = CONFIG.getCoverageInfo().getCoverageLevel(xpath, cldrFile.getLocaleID());
+        // Level level = CONFIG.getCoverageInfo().getCoverageLevel(xpath, cldrFile.getLocaleID());
         String description = pathDescription.getDescription(xpath, value, null);
         if (description == null || description.equals("SKIP")) {
             return null;
         }
-        int start = 0;
         StringBuilder buffer = new StringBuilder(description);
         if (AnnotationUtil.pathIsAnnotation(xpath)) {
-            XPathParts emoji = XPathParts.getFrozenInstance(xpath);
-            String cp = emoji.getAttributeValue(-1, "cp");
-            String minimal = Utility.hex(cp).replace(',', '_').toLowerCase(Locale.ROOT);
-            buffer.append(
-                    "<br><img height='64px' width='auto' src='images/emoji/emoji_"
-                            + minimal
-                            + ".png'>");
+            final String cp = AnnotationUtil.getEmojiFromXPath(xpath);
+            final String hex = Utility.hex(cp, 4, " U+");
+            if (AnnotationUtil.haveEmojiImageFile(cp)) {
+                final String fn = AnnotationUtil.calculateEmojiImageFilename(cp);
+                buffer.append(
+                        "\n\n<br><img class='emojiImage' height='64px' width='auto' src='images/emoji/"
+                                + fn
+                                + "'"
+                                + " title='U+"
+                                + hex
+                                + "'>\n");
+            } // else no image available
         }
         return buffer.toString();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/AnnotationUtil.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/AnnotationUtil.java
@@ -1,8 +1,14 @@
 package org.unicode.cldr.util;
 
+import com.ibm.icu.impl.Utility;
+import java.io.File;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class AnnotationUtil {
+    private static final String APPS_EMOJI_DIRECTORY =
+            CLDRPaths.BASE_DIRECTORY + "/tools/cldr-apps/src/main/webapp/images/emoji";
+
     private static final String PATH_PREFIX = "//ldml/annotations/annotation";
 
     private static final Pattern BAD_EMOJI = Pattern.compile("E\\d+(\\.\\d+)?-\\d+");
@@ -19,5 +25,39 @@ public class AnnotationUtil {
 
     public static boolean pathIsAnnotation(String path) {
         return path.startsWith(PATH_PREFIX);
+    }
+
+    public static String removeEmojiVariationSelector(String emoji) {
+        String noVs = emoji.replace(Emoji.EMOJI_VARIANT, "");
+        return noVs;
+    }
+
+    public static String calculateEmojiImageFilename(String emoji) {
+        String noVs = AnnotationUtil.removeEmojiVariationSelector(emoji);
+        // example: emoji_1f1e7_1f1ec.png
+        String fileName = "emoji_" + Utility.hex(noVs, 4, "_").toLowerCase(Locale.ENGLISH) + ".png";
+        return fileName;
+    }
+
+    public static boolean isRightFacingFilename(String fileName) {
+        return fileName.endsWith("_200d_27a1.png");
+    }
+
+    public static String getEnglishAnnotationName(String emoji) {
+        String noVs = AnnotationUtil.removeEmojiVariationSelector(emoji);
+        final Factory factoryAnnotations =
+                SimpleFactory.make(CLDRPaths.ANNOTATIONS_DIRECTORY, ".*");
+        final CLDRFile enAnnotations = factoryAnnotations.make("en", false);
+        final String name =
+                enAnnotations.getStringValue(
+                        "//ldml/annotations/annotation[@cp=\"" + noVs + "\"][@type=\"tts\"]");
+        return name;
+    }
+
+    public static File getEmojiImageFile(String emoji) {
+        String noVs = AnnotationUtil.removeEmojiVariationSelector(emoji);
+        String fileName = AnnotationUtil.calculateEmojiImageFilename(noVs);
+        File file = new File(APPS_EMOJI_DIRECTORY, fileName);
+        return file;
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -14,7 +14,6 @@ import com.ibm.icu.impl.UnicodeMap;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.UnicodeSet;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,7 +23,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -52,8 +50,6 @@ import org.unicode.cldr.util.XMLFileReader;
 import org.unicode.cldr.util.XPathParts;
 
 public class TestAnnotations extends TestFmwkPlus {
-    private static final String APPS_EMOJI_DIRECTORY =
-            CLDRPaths.BASE_DIRECTORY + "/tools/cldr-apps/src/main/webapp/images/emoji";
     private static final boolean DEBUG = false;
     private static final boolean TEST_ONLY_ENGLISH_UNIQUENESS = false;
 
@@ -375,34 +371,6 @@ public class TestAnnotations extends TestFmwkPlus {
                     annotationPathsExpected,
                     annotationPaths,
                     Collections.<String>emptySet());
-        }
-    }
-
-    public void testEmojiImages() {
-        if (CLDRPaths.ANNOTATIONS_DIRECTORY.contains("cldr-staging/production/")) {
-            return; // don't bother checking production for this: the images are only in main, not
-            // production
-        }
-        Factory factoryAnnotations = SimpleFactory.make(CLDRPaths.ANNOTATIONS_DIRECTORY, ".*");
-        CLDRFile enAnnotations = factoryAnnotations.make("en", false);
-
-        String emojiImageDir = APPS_EMOJI_DIRECTORY;
-        for (String emoji : Emoji.getNonConstructed()) {
-            String noVs = emoji.replace(Emoji.EMOJI_VARIANT, "");
-
-            // example: emoji_1f1e7_1f1ec.png
-            String fileName =
-                    "emoji_" + Utility.hex(noVs, 4, "_").toLowerCase(Locale.ENGLISH) + ".png";
-            File file = new File(emojiImageDir, fileName);
-
-            if (!file.exists() && !fileName.endsWith("_200d_27a1.png")) {
-                String name =
-                        enAnnotations.getStringValue(
-                                "//ldml/annotations/annotation[@cp=\""
-                                        + noVs
-                                        + "\"][@type=\"tts\"]");
-                errln(fileName + " missing; " + name);
-            }
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestAnnotationUtil.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestAnnotationUtil.java
@@ -1,0 +1,31 @@
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.unicode.cldr.util.AnnotationUtil;
+import org.unicode.cldr.util.CLDRPaths;
+import org.unicode.cldr.util.Emoji;
+
+public class TestAnnotationUtil {
+
+    @Test
+    public void testEmojiImages() {
+        assumeFalse(CLDRPaths.ANNOTATIONS_DIRECTORY.contains("cldr-staging/production/"));
+        // don't bother checking production for this: the images are only in main, not
+        // production
+
+        for (String emoji : Emoji.getNonConstructed()) {
+            File file = AnnotationUtil.getEmojiImageFile(emoji);
+            if (AnnotationUtil.isRightFacingFilename(file.getName())) {
+                continue;
+            }
+            assertTrue(
+                    file.exists(),
+                    () ->
+                            file.getName()
+                                    + " missing; "
+                                    + AnnotationUtil.getEnglishAnnotationName(emoji));
+        }
+    }
+}

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestAnnotationUtil.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestAnnotationUtil.java
@@ -1,11 +1,11 @@
+package org.unicode.cldr.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.File;
 import org.junit.jupiter.api.Test;
-import org.unicode.cldr.util.AnnotationUtil;
-import org.unicode.cldr.util.CLDRPaths;
-import org.unicode.cldr.util.Emoji;
 
 public class TestAnnotationUtil {
 
@@ -26,6 +26,27 @@ public class TestAnnotationUtil {
                             file.getName()
                                     + " missing; "
                                     + AnnotationUtil.getEnglishAnnotationName(emoji));
+        }
+    }
+
+    @Test
+    public void testEmojiImagesVsPaths() {
+        for (final String xpath :
+                CLDRConfig.getInstance().getAnnotationsFactory().make("en", false).fullIterable()) {
+            if (AnnotationUtil.pathIsAnnotation(xpath)) {
+                final String cp = AnnotationUtil.getEmojiFromXPath(xpath);
+                final File file = AnnotationUtil.getEmojiImageFile(cp);
+                final boolean expectedExists = AnnotationUtil.haveEmojiImageFile(cp);
+                final boolean actuallyExists = file.exists();
+                assertEquals(
+                        expectedExists,
+                        actuallyExists,
+                        () ->
+                                "cache (expected) vs actual (disk) differ for "
+                                        + file.getAbsolutePath()
+                                        + " for "
+                                        + xpath);
+            }
         }
     }
 }


### PR DESCRIPTION
- also, fix an issue where the PathDescription markdown ran into the emoji sample image
- add U+xxxx hex escape as title on the emoji image
- refactor and test AnnotationUtil

CLDR-18664

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
