### PR TITLE
CLDR-16665 Add documentation of 'core' type values

### DIFF
--- a/docs/site/translation.md
+++ b/docs/site/translation.md
@@ -91,7 +91,9 @@ As new locales reach Basic Coverage, their language names are added for locales 
 
 #### Core/Extensions
 
-There is a new mechanism for better menu names. When you see a **Code** with `-core` or `-extension`, please read [Locale Option Value Names](/translation/displaynames/locale-option-names-key#locale-option-value-names).
+There is a new mechanism for better menu names. When you see a **Code** with `-core` or `-extension`, please read [Locale Option Value Names](/translation/displaynames/locale-option-names-key).
+
+💡🆕 The link in the Info Panel was not pointing to [Locale Option Value Names](/translation/displaynames/locale-option-names-key); that has been fixed. There is also now a Full List of the option names on that page.
 
 #### Scripts
 

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -47,7 +47,7 @@ Here are examples of names of Options to be translated.
 ## Full List
 The following provides a full list of keys and values. You may see just a subset of the keys and/or their values, depending on your coverage level. (It does exclude the Transform options, because those are used less often.)
 
-Note that in many cases the values do not need to be translated, because the data is available elsewhere. For example, most numbering systems ar identified by their Script code. Those are indicated in the list below by all-uppercase Codes.
+Note that in many cases the values do not need to be translated, because the data is available elsewhere. For example, most numbering systems are identified by their Script code. Those are indicated in the list below by all-uppercase Codes.
 
 ### Dates
 

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -116,6 +116,7 @@ Collation type
 
 #### Ignore Symbols Sorting  (ka, colAlternate)
 Collation parameter key for alternate handling
+
 |Codes|English Name|Description|
 |-|-|-|
 |noignore, non-ignorable|Punctuation… not ignored|Variable collation elements are not reset to ignorable|
@@ -265,16 +266,7 @@ Numbering system type
 |SCRIPT_CODE-N|_translation by other CLDR data_|Any script code with numbering system|
 ### Segmentation
 
-#### Line Break Strictness  (lb)
-Line break type
-
-|Codes|English Name|Description|
-|-|-|-|
-|loose|Loose|CSS lev 3 line-break=loose|
-|normal|Normal|CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh|
-|strict|Strict|CSS level 3 line-break=strict, e.g. treat CJ as NS|
-
-#### Line Breaks In Words Setting  (lw)
+#### Line Breaks within Words  (lw)
 Line break key for CSS lev 3 word-break options
 
 |Codes|English Name|Description|
@@ -283,6 +275,15 @@ Line break key for CSS lev 3 word-break options
 |keepall|Keep all|CSS lev 3 word-break=keep-all, prohibit midword breaks except for dictionary breaks|
 |normal|Normal|CSS lev 3 word-break=normal, normal script/language behavior for midword breaks|
 |phrase|Keep in phrases|Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline|
+
+#### CJK Line Break  (lb)
+Line break type
+
+|Codes|English Name|Description|
+|-|-|-|
+|loose|Loose|CSS lev 3 line-break=loose|
+|normal|Normal|CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh|
+|strict|Strict|CSS level 3 line-break=strict, e.g. treat CJ as NS|
 
 #### Dictionary Break Exclusions  (dx)
 Scripts to exclude from dictionary break

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -8,7 +8,7 @@ Locale codes can have special variants, to indicate the use of particular calend
 
 When displayed as a menu or in certain other contexts, the name of the _key_ for the option (such as _Calendar_) is split from the names of the different _values_ for that option (such as _Buddhist, Gregorian, Japanese_, etc.). That shorter version is called the core value.
 
-So you will be asked to translate the long name (such as _Buddhist Calendar_), plus the name of each key (_Calendar_) and the name of the "core" value (_Buddhist_). This allows systems to show users of your language what all the locale options are.
+You will be asked to translate the long name (such as _Buddhist Calendar_), plus the name of each key (_Calendar_) and the name of the "core" value (_Buddhist_). This allows systems to show users of your language what all the locale options are.
 
 | Code | Name |
 | -- | -- |

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -42,7 +42,7 @@ Here are examples of names of Options to be translated.
 | Calendar | Calendar system (the European calendar is called "Gregorian"; others are the Chinese Lunar Calendar, and so on.) |
 | Collation | How text is sorted (where a language has different possible ways to sort). |
 | Currency | The default currency. (The value is any currency value, such as USD.) |
-| Numbers | The numbering system in use, such as European (0,1,2), Arabic (٠, ١, ٢ ), Devanagari ( ०,  १,  २ ). <br /> - Usually these are just derived from the name of the script.<br /> - There are some special forms, such as " Simplified Chinese Financial Numerals " or " Full Width Digits ". |
+| Numbers | The numbering system in use, such as European (0,1,2), Arabic (٠, ١, ٢ ), Devanagari ( ०,  १,  २ ). <br /> - Usually these are just derived from the name of the script.<br /> - There are some special forms, such as "Simplified Chinese Financial Numerals" or "Full Width Digits". |
 
 ## Full List
 The following provides a full list of keys and values. You may see just a subset of the keys and/or their values, depending on your coverage level. (It does exclude the Transform options, because those are lesser-used.)

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -16,7 +16,7 @@ You will be asked to translate the long name (such as _Buddhist Calendar_), plus
 | `calendar-buddhist` | Buddhistischer Kalender |
 | `calendar-buddhist-core` | Buddhistischer |
 
-The core name is typically used in menu listings or pull-downs, where the key name is used as the header, such as:
+The core name is typically used in menu listings or pull-down menus where the key name is used as the header, such as:
     - **Calendar**
         - Buddhist
         - Chinese

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -45,7 +45,7 @@ Here are examples of names of Options to be translated.
 | Numbers | The numbering system in use, such as European (0,1,2), Arabic (٠, ١, ٢ ), Devanagari ( ०,  १,  २ ). <br /> - Usually these are just derived from the name of the script.<br /> - There are some special forms, such as "Simplified Chinese Financial Numerals" or "Full Width Digits". |
 
 ## Full List
-The following provides a full list of keys and values. You may see just a subset of the keys and/or their values, depending on your coverage level. (It does exclude the Transform options, because those are lesser-used.)
+The following provides a full list of keys and values. You may see just a subset of the keys and/or their values, depending on your coverage level. (It does exclude the Transform options, because those are used less often.)
 
 Note that in many cases the values do not need to be translated, because the data is available elsewhere. For example, most numbering systems ar identified by their Script code. Those are indicated in the list below by all-uppercase Codes.
 

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -4,7 +4,7 @@ title: 'Locale Option Names'
 
 # Locale Option Names
 
-Locale codes can have special variants, to indicate the use of particular calendars, or other features. They be used to select among different options in menus, and also display which options are in effect for the user. The locale codes use a special format like `de_DE`; the names for those locales are assembled from names for language, script, region, and so on. Locale codes can also carry options, such as when users want to use native digits or ASCII digits (aka Latin digits). The full name of a locale will include those options in a short format, such as _German (Germany, Buddhist Calendar)_.
+Locale codes can have special variants, to indicate the use of particular calendars or other features. They can be used to select among different options in menus, and also display which options are in effect for the user. The locale codes use a special format like `de_DE`; the names for these locales are assembled from names for language, script, region, and so on. Locale codes can also carry options, such as when users want to use native digits or ASCII digits (aka Latin digits). The full name of a locale will include those options in a short format, such as _German (Germany, Buddhist Calendar)_.
 
 When displayed as a menu or in certain other contexts, the name of the _key_ for the option (such as _Calendar_) is split from the names of the different _values_ for that option (such as _Buddhist, Gregorian, Japanese_, etc.) That shorter version is called the core value.
 

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -53,6 +53,7 @@ Note that in many cases the values do not need to be translated, because the dat
 
 #### Calendar  (ca, calendar)
 Calendar algorithm
+
 |Codes|English Name|Description|
 |-|-|-|
 |buddhist|Buddhist|Thai Buddhist calendar|
@@ -76,12 +77,14 @@ Calendar algorithm
 
 #### First day of week  (fw)
 First day of week
+
 |Codes|English Name|Description|
 |-|-|-|
 |DAY_OF_WEEK|_translation by other CLDR data_|Any day of the week|
 
 #### Hour Cycle (12 vs 24)  (hc, hours)
 Hour cycle (12 vs 24)
+
 |Codes|English Name|Description|
 |-|-|-|
 |h11|12 (0–11)|Hour system using 0–11; 'K' in patterns|
@@ -92,6 +95,7 @@ Hour cycle (12 vs 24)
 
 #### Sort Order  (co, collation)
 Collation type
+
 |Codes|English Name|Description|
 |-|-|-|
 |compat|Compatibility|A previous version of the ordering, for compatibility|
@@ -119,6 +123,7 @@ Collation parameter key for alternate handling
 
 #### Reversed Accent Sorting  (kb, colBackwards)
 Collation parameter key for backward collation weight
+
 |Codes|English Name|Description|
 |-|-|-|
 |false, no|_translation by other CLDR data_|No backwards (the second level to be forwards)|
@@ -126,6 +131,7 @@ Collation parameter key for backward collation weight
 
 #### Case Sensitive Sorting  (kc, colCaseLevel)
 Collation parameter key for case level
+
 |Codes|English Name|Description|
 |-|-|-|
 |false, no|_translation by other CLDR data_|No special case level handling|
@@ -133,6 +139,7 @@ Collation parameter key for case level
 
 #### Uppercase/Lowercase Ordering  (kf, colCaseFirst)
 Collation parameter key for ordering by case
+
 |Codes|English Name|Description|
 |-|-|-|
 |false, no|_translation by other CLDR data_|No special case ordering|
@@ -141,6 +148,7 @@ Collation parameter key for ordering by case
 
 #### Normalized Sorting  (kk, colNormalization)
 Collation parameter key for normalization
+
 |Codes|English Name|Description|
 |-|-|-|
 |false, no|_translation by other CLDR data_|Skip normalization|
@@ -148,6 +156,7 @@ Collation parameter key for normalization
 
 #### Numeric Sorting  (kn, colNumeric)
 Collation parameter key for numeric handling
+
 |Codes|English Name|Description|
 |-|-|-|
 |false, no|_translation by other CLDR data_|No special handling for numeric ordering|
@@ -155,6 +164,7 @@ Collation parameter key for numeric handling
 
 #### Script/Block Reordering  (kr, colReorder)
 Collation reorder codes
+
 |Codes|English Name|Description|
 |-|-|-|
 |REORDER_CODE|_translation by other CLDR data_|Other collation reorder code — for script, see LDML Part 5: Collation|
@@ -166,6 +176,7 @@ Collation reorder codes
 
 #### Sorting Strength  (ks, colStrength)
 Collation parameter key for collation strength
+
 |Codes|English Name|Description|
 |-|-|-|
 |identic, identical|The identical level|The identical level|
@@ -176,6 +187,7 @@ Collation parameter key for collation strength
 
 #### Highest Ignored  (kv)
 Collation parameter key for maxVariable, the last reordering group to be affected by ka-shifted
+
 |Codes|English Name|Description|
 |-|-|-|
 |currency|Spaces, punctuation, all symbolsSpaces, punctuation ka-shifted|Spaces, punctuation and all symbols are affected by ka-shifted|
@@ -186,12 +198,14 @@ Collation parameter key for maxVariable, the last reordering group to be affecte
 
 #### Currency  (cu, currency)
 Currency type
+
 |Codes|English Name|Description|
 |-|-|-|
 |CURRENCY_CODE|_translation by other CLDR data_|Any currency code|
 
 #### Currency Format  (cf)
 Currency format
+
 |Codes|English Name|Description|
 |-|-|-|
 |account|Accounting|Accounting currency format|
@@ -200,6 +214,7 @@ Currency format
 
 #### Measurement System  (ms, measure)
 Measurement System
+
 |Codes|English Name|Description|
 |-|-|-|
 |metric|Metric|Metric System|
@@ -208,6 +223,7 @@ Measurement System
 
 #### Measurement Unit  (mu)
 Allows setting overrides for measurement units. Currently limited to quantity=temperature, and no provision for usage or size.
+
 |Codes|English Name|Description|
 |-|-|-|
 |MEASUREMENT_UNIT|_translation by other CLDR data_|Any temperature unit|
@@ -215,6 +231,7 @@ Allows setting overrides for measurement units. Currently limited to quantity=te
 
 #### Numbers  (nu, numbers)
 Numbering system type
+
 |Codes|English Name|Description|
 |-|-|-|
 |arabext|Extended Arabic-Indic|Extended Arabic-Indic digits|
@@ -250,6 +267,7 @@ Numbering system type
 
 #### Line Break Strictness  (lb)
 Line break type
+
 |Codes|English Name|Description|
 |-|-|-|
 |loose|Loose|CSS lev 3 line-break=loose|
@@ -258,6 +276,7 @@ Line break type
 
 #### Line Breaks In Words Setting  (lw)
 Line break key for CSS lev 3 word-break options
+
 |Codes|English Name|Description|
 |-|-|-|
 |breakall|Break all|CSS lev 3 word-break=break-all, allow midword breaks unless forbidden by lb setting|
@@ -267,12 +286,14 @@ Line break key for CSS lev 3 word-break options
 
 #### Dictionary Break Exclusions  (dx)
 Scripts to exclude from dictionary break
+
 |Codes|English Name|Description|
 |-|-|-|
 |SCRIPT_CODE|_translation by other CLDR data_|ISO 15924 script code|
 
 #### Sentence Break After Abbr.  (ss)
 Sentence break parameter key to control use of suppressions data
+
 |Codes|English Name|Description|
 |-|-|-|
 |none|Off|Don't use segmentation suppressions data|
@@ -281,6 +302,7 @@ Sentence break parameter key to control use of suppressions data
 
 #### Time Zone  (tz, timezone)
 Time zone
+
 |Codes|English Name|Description|
 |-|-|-|
 |TIMEZONE_CODE|_translation by other CLDR data_|Any timezone code|
@@ -288,18 +310,21 @@ Time zone
 
 #### Region For Supplemental Data  (rg)
 Alternate region for determining certain data values (e.g. default currency and units) specified by rgScope
+
 |Codes|English Name|Description|
 |-|-|-|
 |RG_KEY_VALUE|_translation by other CLDR data_|A region code from idValidity/id[type='region'][idStatus='regular'], suffixed with 'ZZZZ'|
 
 #### Region Subdivision  (sd)
 Region subdivision
+
 |Codes|English Name|Description|
 |-|-|-|
 |SUBDIVISION_CODE|_translation by other CLDR data_|Valid unicode_subdivision_subtag for the region subtag as specified in LDML, based on subdivisionContainment data in supplementalData, prefixed by the associated unicode_region_subtag|
 
 #### Emoji Presentation  (em)
 Emoji presentation style request
+
 |Codes|English Name|Description|
 |-|-|-|
 |default|Default|use the default presentation as specified in UTR #51|
@@ -308,6 +333,7 @@ Emoji presentation style request
 
 #### Locale Variant  (va)
 Common locale variant type
+
 |Codes|English Name|Description|
 |-|-|-|
 |posix|POSIX variant|POSIX style locale variant|

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -1,26 +1,14 @@
 ---
-title: 'Locale Option Names (Key)'
+title: 'Locale Option Names'
 ---
 
-# Locale Option Names (Key)
+# Locale Option Names
 
-Locales can have special variants, to indicate the use of particular calendars, or other features. They be used to select among different options in menus, and also display which options are in effect for the user.
+Locale codes can have special variants, to indicate the use of particular calendars, or other features. They be used to select among different options in menus, and also display which options are in effect for the user. The locale codes use a special format like `de_DE`; the names for those locales are assembled from names for language, script, region, and so on. Locale codes can also carry options, such as when users want to use native digits or ASCII digits (aka Latin digits). The full name of a locale will include those options in a short format, such as _German (Germany, Buddhist Calendar)_.
 
-## Locale Option Names
+When displayed as a menu or in certain other contexts, the name of the _key_ for the option (such as _Calendar_) is split from the names of the different _values_ for that option (such as _Buddhist, Gregorian, Japanese_, etc.) That shorter version is called the core value.
 
-Here are examples of names of Options to be translated.
-
-| Option | Meaning   |
-|---|---|
-| Calendar | Calendar system (the European calendar is called "Gregorian"; others are the Chinese Lunar Calendar, and so on.) |
-| Collation | How text is sorted (where a language has different possible ways to sort). |
-| Currency | The default currency. (The value is any currency value, such as USD). |
-| Numbers | The numbering system in use, such as European (0,1,2), Arabic (٠, ١, ٢ ), Devanagari ( ०,  १,  २ ). <br /> - Usually these are just derived from the name of the script.<br /> - There are some special forms, such as " Simplified Chinese Financial Numerals " or " Full Width Digits ". |
-| Private Use | Used for Private-Use options (x). |
-
-## Locale Option Value Names
-
-There are two kinds of option value names: the Long name and the Core name. The Long name includes the name of the Option while the Core name does not. Here are examples of what that can look like:
+So you will be asked to translate the long name (such as _Buddhist Calendar_), plus the name of each key (_Calendar_) and the name of the "core" value (_Buddhist_). This allows systems to show users of your language what all the locale options are.
 
 | Code | Name |
 | -- | -- |
@@ -28,11 +16,298 @@ There are two kinds of option value names: the Long name and the Core name. The 
 | `calendar-buddhist` | Buddhistischer Kalender |
 | `calendar-buddhist-core` | Buddhistischer |
 
-The core name is used in two ways: 
-- In locale names with Locale Option Pattern, like "English (Calendar: Buddhist)"
-- In menu listings or pull-downs, where the Option code is used as the header, such as:
+The core name is typically used in menu listings or pull-downs, where the key name is used as the header, such as:
     - **Calendar**
         - Buddhist
         - Chinese
         - Coptic
         - …
+     
+This avoids the repetition that you would see if the long name were used:
+    - **Calendar**
+        - Buddhist Calendar
+        - Chinese Calendar
+        - Coptic Calendar
+        - …
+
+The core name can aso be used as an alternate form of a full locale name, such as "English (UK, Calendar: Buddhist)".
+
+
+## Locale Option Names
+
+Here are examples of names of Options to be translated.
+
+| Key | Meaning   |
+|---|---|
+| Calendar | Calendar system (the European calendar is called "Gregorian"; others are the Chinese Lunar Calendar, and so on.) |
+| Collation | How text is sorted (where a language has different possible ways to sort). |
+| Currency | The default currency. (The value is any currency value, such as USD). |
+| Numbers | The numbering system in use, such as European (0,1,2), Arabic (٠, ١, ٢ ), Devanagari ( ०,  १,  २ ). <br /> - Usually these are just derived from the name of the script.<br /> - There are some special forms, such as " Simplified Chinese Financial Numerals " or " Full Width Digits ". |
+
+## Full List
+The following provides a full list of keys and values. You may see just a subset of the keys and/or their values, depending on your coverage level. (It does exclude the Transform options, because those are lesser-used.)
+
+Note that in many cases the values do not need to be translated, because the data is available elsewhere. For example, most numbering systems ar identified by their Script code. Those are indicated in the list below by all-uppercase Codes.
+
+### Dates
+
+#### Calendar  (ca, calendar)
+Calendar algorithm
+|Codes|English Name|Description|
+|-|-|-|
+|buddhist|Buddhist|Thai Buddhist calendar|
+|chinese|Chinese|Traditional Chinese calendar|
+|coptic|Coptic|Coptic calendar|
+|dangi|Dangi|Traditional Korean calendar|
+|ethioaa, ethiopic-amete-alem|Ethiopic Amete Alem|Ethiopic calendar, Amete Alem (epoch approx. 5493 B.C.E)|
+|ethiopic|Ethiopic|Ethiopic calendar, Amete Mihret (epoch approx, 8 C.E.)|
+|gregory, gregorian|Gregorian|Gregorian calendar|
+|hebrew|Hebrew|Traditional Hebrew calendar|
+|indian|Indian National|Indian calendar|
+|islamic|Hijri|Hijri calendar|
+|islamic-civil|Hijri (tabular, civil epoch)|Hijri calendar, tabular (intercalary years [2,5,7,10,13,16,18,21,24,26,29] - civil epoch)|
+|islamic-rgsa|Hijri, Saudi Arabia sighting|Hijri calendar, Saudi Arabia sighting|
+|islamic-tbla|Hijri (tabular, astronomical epoch)|Hijri calendar, tabular (intercalary years [2,5,7,10,13,16,18,21,24,26,29] - astronomical epoch)|
+|islamic-umalqura|Hijri (Umm al-Qura)|Hijri calendar, Umm al-Qura|
+|iso8601|Gregorian YMD|Gregorian calendar, but all fields in descending order: era, year, month, day, day-of-week, hour, minute, second|
+|japanese|Japanese|Japanese Imperial calendar|
+|persian|Persian|Persian calendar|
+|roc|Minguo|Republic of China calendar|
+
+#### First day of week  (fw)
+First day of week
+|Codes|English Name|Description|
+|-|-|-|
+|DAY_OF_WEEK|_translation by other CLDR data_|Any day of the week|
+
+#### Hour Cycle (12 vs 24)  (hc, hours)
+Hour cycle (12 vs 24)
+|Codes|English Name|Description|
+|-|-|-|
+|h11|12 (0–11)|Hour system using 0–11; 'K' in patterns|
+|h12|12 (1–12)|Hour system using 1–12; 'h' in patterns|
+|h23|24 (0–23)|Hour system using 0–23; 'H' in patterns|
+|h24|24 (1–24)|Hour system using 1–24; 'k' in patterns|
+### Sorting
+
+#### Sort Order  (co, collation)
+Collation type
+|Codes|English Name|Description|
+|-|-|-|
+|compat|Compatibility|A previous version of the ordering, for compatibility|
+|dict, dictionary|Dictionary|Dictionary style ordering (such as in Sinhala)|
+|ducet|Default Unicode|The default Unicode collation element table order|
+|emoji|Emoji|Recommended ordering for emoji characters|
+|eor|European rules|European ordering rules|
+|phonebk, phonebook|Phonebook|Phonebook style ordering (such as in German)|
+|phonetic|Phonetic|Phonetic ordering (sorting based on pronunciation)|
+|pinyin|Pinyin|Pinyin ordering for Latin and for CJK characters (used in Chinese)|
+|search|Search|Special collation type for string search|
+|searchjl|Korean initial consonant|Special collation type for Korean initial consonant search|
+|standard|Standard|Default ordering for each language|
+|stroke|Stroke|Pinyin ordering for Latin, stroke order for CJK characters (used in Chinese)|
+|trad, traditional|Traditional|Traditional style ordering (such as in Spanish)|
+|unihan|Radical-Stroke|Pinyin ordering for Latin, Unihan radical-stroke ordering for CJK characters (used in Chinese)|
+|zhuyin|Zhuyin|Pinyin ordering for Latin, zhuyin order for Bopomofo and CJK characters (used in Chinese)|
+
+#### Ignore Symbols Sorting  (ka, colAlternate)
+Collation parameter key for alternate handling
+|Codes|English Name|Description|
+|-|-|-|
+|noignore, non-ignorable|Punctuation… not ignored|Variable collation elements are not reset to ignorable|
+|shifted|Punctuation… ignored|Variable collation elements are reset to zero at levels one through three|
+
+#### Reversed Accent Sorting  (kb, colBackwards)
+Collation parameter key for backward collation weight
+|Codes|English Name|Description|
+|-|-|-|
+|false, no|_translation by other CLDR data_|No backwards (the second level to be forwards)|
+|true, yes|_translation by other CLDR data_|The second level to be backwards|
+
+#### Case Sensitive Sorting  (kc, colCaseLevel)
+Collation parameter key for case level
+|Codes|English Name|Description|
+|-|-|-|
+|false, no|_translation by other CLDR data_|No special case level handling|
+|true, yes|_translation by other CLDR data_|The case level is inserted in front of tertiary|
+
+#### Uppercase/Lowercase Ordering  (kf, colCaseFirst)
+Collation parameter key for ordering by case
+|Codes|English Name|Description|
+|-|-|-|
+|false, no|_translation by other CLDR data_|No special case ordering|
+|lower|Lowercase < uppercase|Lower case to be sorted before upper case|
+|upper|Uppercase < lowercase|Upper case to be sorted before lower case|
+
+#### Normalized Sorting  (kk, colNormalization)
+Collation parameter key for normalization
+|Codes|English Name|Description|
+|-|-|-|
+|false, no|_translation by other CLDR data_|Skip normalization|
+|true, yes|_translation by other CLDR data_|Convert text into Normalization Form D before calculating collation weights|
+
+#### Numeric Sorting  (kn, colNumeric)
+Collation parameter key for numeric handling
+|Codes|English Name|Description|
+|-|-|-|
+|false, no|_translation by other CLDR data_|No special handling for numeric ordering|
+|true, yes|_translation by other CLDR data_|A sequence of decimal digits is sorted at primary level with its numeric value|
+
+#### Script/Block Reordering  (kr, colReorder)
+Collation reorder codes
+|Codes|English Name|Description|
+|-|-|-|
+|REORDER_CODE|_translation by other CLDR data_|Other collation reorder code — for script, see LDML Part 5: Collation|
+|currency|Currency reordering code, see LDML Part 5: Collation|Currency reordering code, see LDML Part 5: Collation|
+|digit|Digit (number) reordering code, see LDML Part 5: Collation|Digit (number) reordering code, see LDML Part 5: Collation|
+|punct|Punctuation reordering code, see LDML Part 5: Collation|Punctuation reordering code, see LDML Part 5: Collation|
+|space|Whitespace reordering code, see LDML Part 5: Collation|Whitespace reordering code, see LDML Part 5: Collation|
+|symbol|Symbol reordering code (other than currency), see LDML Part 5: Collation|Symbol reordering code (other than currency), see LDML Part 5: Collation|
+
+#### Sorting Strength  (ks, colStrength)
+Collation parameter key for collation strength
+|Codes|English Name|Description|
+|-|-|-|
+|identic, identical|The identical level|The identical level|
+|level1, primary|The primary level|The primary level|
+|level2, secondary|The secondary level|The secondary level|
+|level3, tertiary|The tertiary level|The tertiary level|
+|level4, quaternary, quarternary|The quaternary level|The quaternary level|
+
+#### Highest Ignored  (kv)
+Collation parameter key for maxVariable, the last reordering group to be affected by ka-shifted
+|Codes|English Name|Description|
+|-|-|-|
+|currency|Spaces, punctuation, all symbolsSpaces, punctuation ka-shifted|Spaces, punctuation and all symbols are affected by ka-shifted|
+|punct|Spaces, punctuation ka-shifted|Spaces and punctuation are affected by ka-shifted (CLDR default)|
+|space|Spaces, punctuation ka-shifted|Only spaces are affected by ka-shifted|
+|symbol|Spaces, punctuation, non-currency symbols ka-shifted|Spaces, punctuation and symbols except for currency symbols are affected by ka-shifted (UCA default)|
+### Currencies
+
+#### Currency  (cu, currency)
+Currency type
+|Codes|English Name|Description|
+|-|-|-|
+|CURRENCY_CODE|_translation by other CLDR data_|Any currency code|
+
+#### Currency Format  (cf)
+Currency format
+|Codes|English Name|Description|
+|-|-|-|
+|account|Accounting|Accounting currency format|
+|standard|Standard|Standard currency format|
+### Measurement
+
+#### Measurement System  (ms, measure)
+Measurement System
+|Codes|English Name|Description|
+|-|-|-|
+|metric|Metric|Metric System|
+|uksystem, imperial|UK|UK System of measurement: feet, pints, etc.; pints are 20oz|
+|ussystem|US|US System of measurement: feet, pints, etc.; pints are 16oz|
+
+#### Measurement Unit  (mu)
+Allows setting overrides for measurement units. Currently limited to quantity=temperature, and no provision for usage or size.
+|Codes|English Name|Description|
+|-|-|-|
+|MEASUREMENT_UNIT|_translation by other CLDR data_|Any temperature unit|
+### Numbers
+
+#### Numbers  (nu, numbers)
+Numbering system type
+|Codes|English Name|Description|
+|-|-|-|
+|arabext|Extended Arabic-Indic|Extended Arabic-Indic digits|
+|armnlow|Armenian lowercase|Armenian lower case numerals — algorithmic|
+|finance|Financial|Financial numerals — may be algorithmic|
+|fullwide|Full-width|Full width digits|
+|greklow|Greek lowercase|Greek lower case numerals — algorithmic|
+|hanidays|Han-character day-of-month numbering for lunar/other traditional calendars|Han-character day-of-month numbering for lunar/other traditional calendars|
+|hanidec|Positional decimal system using Chinese number ideographs as digits|Positional decimal system using Chinese number ideographs as digits|
+|hansfin|Simplified Chinese financial|Simplified Chinese financial numerals — algorithmic|
+|hantfin|Traditional Chinese financial|Traditional Chinese financial numerals — algorithmic|
+|jpanfin|Japanese financial|Japanese financial numerals — algorithmic|
+|jpanyear|Japanese first-year Gannen numbering|Japanese first-year Gannen numbering for Japanese calendar|
+|lanatham|Tai Tham Tham (ecclesiastical)|Tai Tham Tham (ecclesiastical) digits|
+|mathbold|Mathematical bold|Mathematical bold digits|
+|mathdbl|Mathematical double-struck|Mathematical double-struck digits|
+|mathmono|Mathematical monospace|Mathematical monospace digits|
+|mathsanb|Mathematical sans-serif bold|Mathematical sans-serif bold digits|
+|mathsans|Mathematical sans-serif|Mathematical sans-serif digits|
+|mymrepka|Myanmar Eastern Pwo Karen|Myanmar Eastern Pwo Karen digits|
+|mymrpao|Myanmar Pao|Myanmar Pao digits|
+|mymrshan|Myanmar Shan|Myanmar Shan digits|
+|mymrtlng|Myanmar Tai Laing|Myanmar Tai Laing digits|
+|native|Native digits|Native digits|
+|outlined|Outlined|Legacy computing outlined digits|
+|roman|Roman uppercase|Roman upper case numerals — algorithmic|
+|romanlow|Roman lowercase|Roman lowercase numerals — algorithmic|
+|segment|Segmented|Legacy computing segmented digits|
+|tamldec|Modern Tamil|Modern Tamil decimal digits|
+|traditio, traditional|Traditional numerals|Traditional numerals — may be algorithmic|
+|SCRIPT_CODE-N|_translation by other CLDR data_|Any script code with numbering system|
+### Segmentation
+
+#### Line Break Strictness  (lb)
+Line break type
+|Codes|English Name|Description|
+|-|-|-|
+|loose|Loose|CSS lev 3 line-break=loose|
+|normal|Normal|CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh|
+|strict|Strict|CSS level 3 line-break=strict, e.g. treat CJ as NS|
+
+#### Line Breaks In Words Setting  (lw)
+Line break key for CSS lev 3 word-break options
+|Codes|English Name|Description|
+|-|-|-|
+|breakall|Break all|CSS lev 3 word-break=break-all, allow midword breaks unless forbidden by lb setting|
+|keepall|Keep all|CSS lev 3 word-break=keep-all, prohibit midword breaks except for dictionary breaks|
+|normal|Normal|CSS lev 3 word-break=normal, normal script/language behavior for midword breaks|
+|phrase|Keep in phrases|Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline|
+
+#### Dictionary Break Exclusions  (dx)
+Scripts to exclude from dictionary break
+|Codes|English Name|Description|
+|-|-|-|
+|SCRIPT_CODE|_translation by other CLDR data_|ISO 15924 script code|
+
+#### Sentence Break After Abbr.  (ss)
+Sentence break parameter key to control use of suppressions data
+|Codes|English Name|Description|
+|-|-|-|
+|none|Off|Don't use segmentation suppressions data|
+|standard|On|Use segmentation suppressions data of type standard|
+### Timezone
+
+#### Time Zone  (tz, timezone)
+Time zone
+|Codes|English Name|Description|
+|-|-|-|
+|TIMEZONE_CODE|_translation by other CLDR data_|Any timezone code|
+### Misc
+
+#### Region For Supplemental Data  (rg)
+Alternate region for determining certain data values (e.g. default currency and units) specified by rgScope
+|Codes|English Name|Description|
+|-|-|-|
+|RG_KEY_VALUE|_translation by other CLDR data_|A region code from idValidity/id[type='region'][idStatus='regular'], suffixed with 'ZZZZ'|
+
+#### Region Subdivision  (sd)
+Region subdivision
+|Codes|English Name|Description|
+|-|-|-|
+|SUBDIVISION_CODE|_translation by other CLDR data_|Valid unicode_subdivision_subtag for the region subtag as specified in LDML, based on subdivisionContainment data in supplementalData, prefixed by the associated unicode_region_subtag|
+
+#### Emoji Presentation  (em)
+Emoji presentation style request
+|Codes|English Name|Description|
+|-|-|-|
+|default|Default|use the default presentation as specified in UTR #51|
+|emoji|Emoji|use an emoji presentation for emoji characters if possible|
+|text|Text|use a text presentation for emoji characters if possible|
+
+#### Locale Variant  (va)
+Common locale variant type
+|Codes|English Name|Description|
+|-|-|-|
+|posix|POSIX variant|POSIX style locale variant|

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -41,7 +41,7 @@ Here are examples of names of Options to be translated.
 |---|---|
 | Calendar | Calendar system (the European calendar is called "Gregorian"; others are the Chinese Lunar Calendar, and so on.) |
 | Collation | How text is sorted (where a language has different possible ways to sort). |
-| Currency | The default currency. (The value is any currency value, such as USD). |
+| Currency | The default currency. (The value is any currency value, such as USD.) |
 | Numbers | The numbering system in use, such as European (0,1,2), Arabic (٠, ١, ٢ ), Devanagari ( ०,  १,  २ ). <br /> - Usually these are just derived from the name of the script.<br /> - There are some special forms, such as " Simplified Chinese Financial Numerals " or " Full Width Digits ". |
 
 ## Full List

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -51,7 +51,10 @@ Note that in many cases the values do not need to be translated, because the dat
 
 ### Dates
 
-#### Calendar  (ca, calendar)
+#### Calendar
+
+Codes: ca, calendar
+
 Calendar algorithm
 
 |Codes|English Name|Description|
@@ -75,14 +78,11 @@ Calendar algorithm
 |persian|Persian|Persian calendar|
 |roc|Minguo|Republic of China calendar|
 
-#### First day of week  (fw)
-First day of week
 
-|Codes|English Name|Description|
-|-|-|-|
-|DAY_OF_WEEK|_translation by other CLDR data_|Any day of the week|
+#### Hour Cycle
 
-#### Hour Cycle (12 vs 24)  (hc, hours)
+Codes: hc, hours
+
 Hour cycle (12 vs 24)
 
 |Codes|English Name|Description|
@@ -91,9 +91,13 @@ Hour cycle (12 vs 24)
 |h12|12 (1–12)|Hour system using 1–12; 'h' in patterns|
 |h23|24 (0–23)|Hour system using 0–23; 'H' in patterns|
 |h24|24 (1–24)|Hour system using 1–24; 'k' in patterns|
+
 ### Sorting
 
-#### Sort Order  (co, collation)
+#### Sort Order
+
+Codes: co, collation
+
 Collation type
 
 |Codes|English Name|Description|
@@ -114,7 +118,11 @@ Collation type
 |unihan|Radical-Stroke|Pinyin ordering for Latin, Unihan radical-stroke ordering for CJK characters (used in Chinese)|
 |zhuyin|Zhuyin|Pinyin ordering for Latin, zhuyin order for Bopomofo and CJK characters (used in Chinese)|
 
-#### Ignore Symbols Sorting  (ka, colAlternate)
+
+#### Ignore Symbols Sorting
+
+Codes: ka, colAlternate
+
 Collation parameter key for alternate handling
 
 |Codes|English Name|Description|
@@ -122,60 +130,38 @@ Collation parameter key for alternate handling
 |noignore, non-ignorable|Punctuation… not ignored|Variable collation elements are not reset to ignorable|
 |shifted|Punctuation… ignored|Variable collation elements are reset to zero at levels one through three|
 
-#### Reversed Accent Sorting  (kb, colBackwards)
-Collation parameter key for backward collation weight
 
-|Codes|English Name|Description|
-|-|-|-|
-|false, no|_translation by other CLDR data_|No backwards (the second level to be forwards)|
-|true, yes|_translation by other CLDR data_|The second level to be backwards|
+#### Uppercase/Lowercase Ordering
 
-#### Case Sensitive Sorting  (kc, colCaseLevel)
-Collation parameter key for case level
+Codes: kf, colCaseFirst
 
-|Codes|English Name|Description|
-|-|-|-|
-|false, no|_translation by other CLDR data_|No special case level handling|
-|true, yes|_translation by other CLDR data_|The case level is inserted in front of tertiary|
-
-#### Uppercase/Lowercase Ordering  (kf, colCaseFirst)
 Collation parameter key for ordering by case
 
 |Codes|English Name|Description|
 |-|-|-|
-|false, no|_translation by other CLDR data_|No special case ordering|
 |lower|Lowercase < uppercase|Lower case to be sorted before upper case|
 |upper|Uppercase < lowercase|Upper case to be sorted before lower case|
 
-#### Normalized Sorting  (kk, colNormalization)
-Collation parameter key for normalization
 
-|Codes|English Name|Description|
-|-|-|-|
-|false, no|_translation by other CLDR data_|Skip normalization|
-|true, yes|_translation by other CLDR data_|Convert text into Normalization Form D before calculating collation weights|
+#### Script/Block Reordering
 
-#### Numeric Sorting  (kn, colNumeric)
-Collation parameter key for numeric handling
+Codes: kr, colReorder
 
-|Codes|English Name|Description|
-|-|-|-|
-|false, no|_translation by other CLDR data_|No special handling for numeric ordering|
-|true, yes|_translation by other CLDR data_|A sequence of decimal digits is sorted at primary level with its numeric value|
-
-#### Script/Block Reordering  (kr, colReorder)
 Collation reorder codes
 
 |Codes|English Name|Description|
 |-|-|-|
-|REORDER_CODE|_translation by other CLDR data_|Other collation reorder code — for script, see LDML Part 5: Collation|
 |currency|Currency reordering code, see LDML Part 5: Collation|Currency reordering code, see LDML Part 5: Collation|
 |digit|Digit (number) reordering code, see LDML Part 5: Collation|Digit (number) reordering code, see LDML Part 5: Collation|
 |punct|Punctuation reordering code, see LDML Part 5: Collation|Punctuation reordering code, see LDML Part 5: Collation|
 |space|Whitespace reordering code, see LDML Part 5: Collation|Whitespace reordering code, see LDML Part 5: Collation|
 |symbol|Symbol reordering code (other than currency), see LDML Part 5: Collation|Symbol reordering code (other than currency), see LDML Part 5: Collation|
 
-#### Sorting Strength  (ks, colStrength)
+
+#### Sorting Strength
+
+Codes: ks, colStrength
+
 Collation parameter key for collation strength
 
 |Codes|English Name|Description|
@@ -186,7 +172,11 @@ Collation parameter key for collation strength
 |level3, tertiary|The tertiary level|The tertiary level|
 |level4, quaternary, quarternary|The quaternary level|The quaternary level|
 
-#### Highest Ignored  (kv)
+
+#### Highest Ignored
+
+Codes: kv
+
 Collation parameter key for maxVariable, the last reordering group to be affected by ka-shifted
 
 |Codes|English Name|Description|
@@ -195,25 +185,26 @@ Collation parameter key for maxVariable, the last reordering group to be affecte
 |punct|Spaces, punctuation ka-shifted|Spaces and punctuation are affected by ka-shifted (CLDR default)|
 |space|Spaces, punctuation ka-shifted|Only spaces are affected by ka-shifted|
 |symbol|Spaces, punctuation, non-currency symbols ka-shifted|Spaces, punctuation and symbols except for currency symbols are affected by ka-shifted (UCA default)|
+
 ### Currencies
 
-#### Currency  (cu, currency)
-Currency type
+#### Currency Format
 
-|Codes|English Name|Description|
-|-|-|-|
-|CURRENCY_CODE|_translation by other CLDR data_|Any currency code|
+Codes: cf
 
-#### Currency Format  (cf)
 Currency format
 
 |Codes|English Name|Description|
 |-|-|-|
 |account|Accounting|Accounting currency format|
 |standard|Standard|Standard currency format|
+
 ### Measurement
 
-#### Measurement System  (ms, measure)
+#### Measurement System
+
+Codes: ms, measure
+
 Measurement System
 
 |Codes|English Name|Description|
@@ -222,15 +213,12 @@ Measurement System
 |uksystem, imperial|UK|UK System of measurement: feet, pints, etc.; pints are 20oz|
 |ussystem|US|US System of measurement: feet, pints, etc.; pints are 16oz|
 
-#### Measurement Unit  (mu)
-Allows setting overrides for measurement units. Currently limited to quantity=temperature, and no provision for usage or size.
-
-|Codes|English Name|Description|
-|-|-|-|
-|MEASUREMENT_UNIT|_translation by other CLDR data_|Any temperature unit|
 ### Numbers
 
-#### Numbers  (nu, numbers)
+#### Numbers
+
+Codes: nu, numbers
+
 Numbering system type
 
 |Codes|English Name|Description|
@@ -262,11 +250,15 @@ Numbering system type
 |romanlow|Roman lowercase|Roman lowercase numerals — algorithmic|
 |segment|Segmented|Legacy computing segmented digits|
 |tamldec|Modern Tamil|Modern Tamil decimal digits|
-|traditio, traditional|Traditional numerals|Traditional numerals — may be algorithmic|
+|traditio, traditional|null|Traditional numerals — may be algorithmic|
 |SCRIPT_CODE-N|_translation by other CLDR data_|Any script code with numbering system|
+
 ### Segmentation
 
-#### Line Breaks within Words  (lw)
+#### Line Breaks within Words
+
+Codes: lw
+
 Line break key for CSS lev 3 word-break options
 
 |Codes|English Name|Description|
@@ -276,7 +268,11 @@ Line break key for CSS lev 3 word-break options
 |normal|Normal|CSS lev 3 word-break=normal, normal script/language behavior for midword breaks|
 |phrase|Keep in phrases|Prioritize keeping natural phrases (of multiple words) together when breaking, used in short text like title and headline|
 
-#### CJK Line Break  (lb)
+
+#### CJK Line Break
+
+Codes: lb
+
 Line break type
 
 |Codes|English Name|Description|
@@ -285,45 +281,24 @@ Line break type
 |normal|Normal|CSS level 3 line-break=normal, e.g. treat CJ as ID, break before hyphens for ja,zh|
 |strict|Strict|CSS level 3 line-break=strict, e.g. treat CJ as NS|
 
-#### Dictionary Break Exclusions  (dx)
-Scripts to exclude from dictionary break
 
-|Codes|English Name|Description|
-|-|-|-|
-|SCRIPT_CODE|_translation by other CLDR data_|ISO 15924 script code|
+#### Sentence Break After Abbr.
 
-#### Sentence Break After Abbr.  (ss)
+Codes: ss
+
 Sentence break parameter key to control use of suppressions data
 
 |Codes|English Name|Description|
 |-|-|-|
 |none|Off|Don't use segmentation suppressions data|
 |standard|On|Use segmentation suppressions data of type standard|
-### Timezone
 
-#### Time Zone  (tz, timezone)
-Time zone
-
-|Codes|English Name|Description|
-|-|-|-|
-|TIMEZONE_CODE|_translation by other CLDR data_|Any timezone code|
 ### Misc
 
-#### Region For Supplemental Data  (rg)
-Alternate region for determining certain data values (e.g. default currency and units) specified by rgScope
+#### Emoji Presentation
 
-|Codes|English Name|Description|
-|-|-|-|
-|RG_KEY_VALUE|_translation by other CLDR data_|A region code from idValidity/id[type='region'][idStatus='regular'], suffixed with 'ZZZZ'|
+Codes: em
 
-#### Region Subdivision  (sd)
-Region subdivision
-
-|Codes|English Name|Description|
-|-|-|-|
-|SUBDIVISION_CODE|_translation by other CLDR data_|Valid unicode_subdivision_subtag for the region subtag as specified in LDML, based on subdivisionContainment data in supplementalData, prefixed by the associated unicode_region_subtag|
-
-#### Emoji Presentation  (em)
 Emoji presentation style request
 
 |Codes|English Name|Description|
@@ -332,7 +307,11 @@ Emoji presentation style request
 |emoji|Emoji|use an emoji presentation for emoji characters if possible|
 |text|Text|use a text presentation for emoji characters if possible|
 
-#### Locale Variant  (va)
+
+#### Locale Variant
+
+Codes: va
+
 Common locale variant type
 
 |Codes|English Name|Description|

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -6,7 +6,7 @@ title: 'Locale Option Names'
 
 Locale codes can have special variants, to indicate the use of particular calendars or other features. They can be used to select among different options in menus, and also display which options are in effect for the user. The locale codes use a special format like `de_DE`; the names for these locales are assembled from names for language, script, region, and so on. Locale codes can also carry options, such as when users want to use native digits or ASCII digits (aka Latin digits). The full name of a locale will include those options in a short format, such as _German (Germany, Buddhist Calendar)_.
 
-When displayed as a menu or in certain other contexts, the name of the _key_ for the option (such as _Calendar_) is split from the names of the different _values_ for that option (such as _Buddhist, Gregorian, Japanese_, etc.) That shorter version is called the core value.
+When displayed as a menu or in certain other contexts, the name of the _key_ for the option (such as _Calendar_) is split from the names of the different _values_ for that option (such as _Buddhist, Gregorian, Japanese_, etc.). That shorter version is called the core value.
 
 So you will be asked to translate the long name (such as _Buddhist Calendar_), plus the name of each key (_Calendar_) and the name of the "core" value (_Buddhist_). This allows systems to show users of your language what all the locale options are.
 

--- a/docs/site/translation/displaynames/locale-option-names-key.md
+++ b/docs/site/translation/displaynames/locale-option-names-key.md
@@ -94,6 +94,8 @@ Hour cycle (12 vs 24)
 
 ### Sorting
 
+The [introduction section of the Unicode Collation Algorithm report](https://www.unicode.org/reports/tr10/#Introduction) is a good description of how collation (sorting) works in software.
+
 #### Sort Order
 
 Codes: co, collation

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
@@ -6,7 +6,7 @@ Example Entry:
 
     - `^//ldml/localeDisplayNames/types/type\[@key="fw"]\[@type="([^"]*)"]`
 
-    The name of “first day of the week is {1}”. For more information, please see [Key Names].
+    The name of “first day of the week is {1}”. For more information, please see [Locale Option Names].
 
 1. The first line beginning with `###` is a comment and can be used to describe that section. It can be blank, just `###`.
     If it begins with `ROOT` it has special placeholders.
@@ -104,110 +104,110 @@ The name of the timezone for “{0}”. Note: before translating, be sure to rea
 
 - `^//ldml/localeDisplayNames/types/type\[@key="collation"]\[@type="([^"]*)"]`
 
-The name of “{1} collation” (sorting order). For more information, please see [Key Names].
+The name of “{1} collation” (sorting order). For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="numbers"]\[@type="([^"]*)"]`
 
-The name of “{1} number system”. For more information, please see [Key Names].
+The name of “{1} number system”. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="roc"]`
 
-The name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”). For more information, please see [Key Names].
+The name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”). For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="([^"]*)"]\[@alt="variant"]`
 
-The alternate name of “{1} calendar”. For more information, please see [Key Names].
+The alternate name of “{1} calendar”. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="([^"]*)"]`
 
-The name of “{1} calendar”. For more information, please see [Key Names].
+The name of “{1} calendar”. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="em"]\[@type="([^"]*)"]`
 
-The name of “emoji presentation style {1}”. For more information, please see [Key Names].
+The name of “emoji presentation style {1}”. For more information, please see [Locale Option Names].
 
 ### First Day of the Week
 
 - `^//ldml/localeDisplayNames/types/type\[@key="fw"]\[@type="([^"]*)"]`
 
-The name of “first day of the week is {1}”. For more information, please see [Key Names].
+The name of “first day of the week is {1}”. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="lb"]\[@type="([^"]*)"]`
 
-The name of “{1} line break style”. For more information, please see [Key Names].
+The name of “{1} line break style”. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="([^"]*)"]\[@type="([^"]*)"]`
 
-The name of the “{2} {1}”. For more information, please see [Key Names].
+The name of the “{2} {1}”. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/keys/key\[@type="([^"]*)"]`
 
-The name of the system for “{1}”. For more information, please see [Key Names].
+The name of the system for “{1}”. For more information, please see [Locale Option Names].
 
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="collation"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of “{1} collation” (sorting order) — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “{1} collation” (sorting order) — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="numbers"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of “{1} number system” — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “{1} number system” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="roc"]\[@scope="([^"]*)"]`
 
-The _core_ name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”) — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”) — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of “{1} calendar” — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “{1} calendar” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="em"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of “emoji presentation style {1}” — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “emoji presentation style {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="fw"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of “first day of the week is {1}” — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “first day of the week is {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="lb"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of “{1} line break style” — **without the key name**. For more information, please see [Key Names].
+The _core_ name of “{1} line break style” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
 - `^//ldml/localeDisplayNames/types/type\[@key="([^"]*)"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
 
-The _core_ name of the “{2} {1}” — **without the key name**. For more information, please see [Key Names].
+The _core_ name of the “{2} {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 
 ###
@@ -1104,7 +1104,7 @@ All links should be https://cldr.unicode.org/translation/
 [Date Time Patterns]: https://cldr.unicode.org/translation/date-time/date-time-patterns
 [Exemplar Characters]: https://cldr.unicode.org/translation/core-data/exemplars
 [Grammatical Inflection]: https://cldr.unicode.org/translation/grammatical-inflection
-[Key Names]: https://cldr.unicode.org/translation/displaynames/countryregion-territory-names#geopolitically-sensitive-names
+[Locale Option Names]: https://cldr.unicode.org/translation/displaynames/locale-option-names-key
 [Language Names]: https://cldr.unicode.org/translation/displaynames/languagelocale-names
 [Lists]: https://cldr.unicode.org/translation/miscellaneous-displaying-lists
 [Locale Patterns]: https://cldr.unicode.org/translation/displaynames/languagelocale-name-patterns


### PR DESCRIPTION
CLDR-16665

This is adding information about the different locale key-type values, to help people translate them. 

This draws upon the data in https://github.com/unicode-org/cldr/tree/main/common/bcp47, mostly the descriptions. After viewing in context, I think we need to make various clarifications and fixes (like not starting the description with "CSS lev 3 ..."). 

I'd like to do those in a later PR, however.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
