### PR TITLE
CLDR-18229 Add tts keycap names

### DIFF
--- a/common/annotations/af.xml
+++ b/common/annotations/af.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | elektroniese geldeenheid | kriptogeld</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nul | knoppiesimbool</annotation>
+		<annotation cp="0⃣" type="tts">knoppiesimbool: 0</annotation>
 		<annotation cp="1⃣">1 | een | knoppiesimbool</annotation>
+		<annotation cp="1⃣" type="tts">knoppiesimbool: 1</annotation>
 		<annotation cp="2⃣">2 | twee | knoppiesimbool</annotation>
+		<annotation cp="2⃣" type="tts">knoppiesimbool: 2</annotation>
 		<annotation cp="3⃣">3 | drie | knoppiesimbool</annotation>
+		<annotation cp="3⃣" type="tts">knoppiesimbool: 3</annotation>
 		<annotation cp="4⃣">4 | vier | knoppiesimbool</annotation>
+		<annotation cp="4⃣" type="tts">knoppiesimbool: 4</annotation>
 		<annotation cp="5⃣">5 | vyf | knoppiesimbool</annotation>
+		<annotation cp="5⃣" type="tts">knoppiesimbool: 5</annotation>
 		<annotation cp="6⃣">6 | ses | knoppiesimbool</annotation>
+		<annotation cp="6⃣" type="tts">knoppiesimbool: 6</annotation>
 		<annotation cp="7⃣">7 | sewe | knoppiesimbool</annotation>
+		<annotation cp="7⃣" type="tts">knoppiesimbool: 7</annotation>
 		<annotation cp="8⃣">8 | agt | knoppiesimbool</annotation>
+		<annotation cp="8⃣" type="tts">knoppiesimbool: 8</annotation>
 		<annotation cp="9⃣">9 | nege | knoppiesimbool</annotation>
+		<annotation cp="9⃣" type="tts">knoppiesimbool: 9</annotation>
 		<annotation cp="¹">boskrif | boskrif-een | een</annotation>
 		<annotation cp="¹" type="tts">boskrif-een</annotation>
 		<annotation cp="²">boskrif | twee | vierkant</annotation>

--- a/common/annotations/ak.xml
+++ b/common/annotations/ak.xml
@@ -3623,15 +3623,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">bitkͻin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkͻin</annotation>
 		<annotation cp="0⃣">0 | hwee | kiikape</annotation>
+		<annotation cp="0⃣" type="tts">kiikape: 0</annotation>
 		<annotation cp="1⃣">1 | koro | kiikape</annotation>
+		<annotation cp="1⃣" type="tts">kiikape: 1</annotation>
 		<annotation cp="2⃣">2 | abien | kiikape</annotation>
+		<annotation cp="2⃣" type="tts">kiikape: 2</annotation>
 		<annotation cp="3⃣">3 | abiasa | kiikape</annotation>
+		<annotation cp="3⃣" type="tts">kiikape: 3</annotation>
 		<annotation cp="4⃣">4 | anan | kiikape</annotation>
+		<annotation cp="4⃣" type="tts">kiikape: 4</annotation>
 		<annotation cp="5⃣">5 | anum | kiikape</annotation>
+		<annotation cp="5⃣" type="tts">kiikape: 5</annotation>
 		<annotation cp="6⃣">6 | asia | kiikape</annotation>
+		<annotation cp="6⃣" type="tts">kiikape: 6</annotation>
 		<annotation cp="7⃣">7 | asuon | kiikape</annotation>
+		<annotation cp="7⃣" type="tts">kiikape: 7</annotation>
 		<annotation cp="8⃣">8 | awɔtwe | kiikape</annotation>
+		<annotation cp="8⃣" type="tts">kiikape: 8</annotation>
 		<annotation cp="9⃣">9 | akron | kiikape</annotation>
+		<annotation cp="9⃣" type="tts">kiikape: 9</annotation>
 		<annotation cp="¹">baako | supasikripite</annotation>
 		<annotation cp="¹" type="tts">supasikripite baako</annotation>
 		<annotation cp="²">mmienu | sokwɛɛde | supasikripite</annotation>

--- a/common/annotations/am.xml
+++ b/common/annotations/am.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | ቢትኮን</annotation>
 		<annotation cp="₿" type="tts">ቢትኮን</annotation>
 		<annotation cp="0⃣">0 | ባዶ | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="0⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 0</annotation>
 		<annotation cp="1⃣">1 | አንድ | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="1⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 1</annotation>
 		<annotation cp="2⃣">2 | ሁለት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="2⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 2</annotation>
 		<annotation cp="3⃣">3 | ሦስት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="3⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 3</annotation>
 		<annotation cp="4⃣">4 | አራት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="4⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 4</annotation>
 		<annotation cp="5⃣">5 | አምስት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="5⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 5</annotation>
 		<annotation cp="6⃣">6 | ስድስት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="6⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 6</annotation>
 		<annotation cp="7⃣">7 | ሰባት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="7⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 7</annotation>
 		<annotation cp="8⃣">8 | ስምንት | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="8⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 8</annotation>
 		<annotation cp="9⃣">9 | ዘጠኝ | የአብይ ሆሄ ቁልፍ ማብሪያ</annotation>
+		<annotation cp="9⃣" type="tts">የአብይ ሆሄ ቁልፍ ማብሪያ: 9</annotation>
 		<annotation cp="¹">ራስጌ ምልክት | ራስጌ ምልክት አንድ | አንድ</annotation>
 		<annotation cp="¹" type="tts">ራስጌ ምልክት አንድ</annotation>
 		<annotation cp="²">ሁለት | ራስጌ ምልክት | ራስጌ ምልክት ሁለት | ስኴርድ</annotation>

--- a/common/annotations/ar.xml
+++ b/common/annotations/ar.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | بيتكوين</annotation>
 		<annotation cp="₿" type="tts">بيتكوين</annotation>
 		<annotation cp="0⃣">0 | صفر | مفتاح</annotation>
+		<annotation cp="0⃣" type="tts">مفتاح: 0</annotation>
 		<annotation cp="1⃣">1 | واحد | مفتاح</annotation>
+		<annotation cp="1⃣" type="tts">مفتاح: 1</annotation>
 		<annotation cp="2⃣">2 | إثنان | مفتاح</annotation>
+		<annotation cp="2⃣" type="tts">مفتاح: 2</annotation>
 		<annotation cp="3⃣">3 | ثلاثة | مفتاح</annotation>
+		<annotation cp="3⃣" type="tts">مفتاح: 3</annotation>
 		<annotation cp="4⃣">4 | أربعة | مفتاح</annotation>
+		<annotation cp="4⃣" type="tts">مفتاح: 4</annotation>
 		<annotation cp="5⃣">5 | خمسة | مفتاح</annotation>
+		<annotation cp="5⃣" type="tts">مفتاح: 5</annotation>
 		<annotation cp="6⃣">6 | ستة | مفتاح</annotation>
+		<annotation cp="6⃣" type="tts">مفتاح: 6</annotation>
 		<annotation cp="7⃣">7 | سبعة | مفتاح</annotation>
+		<annotation cp="7⃣" type="tts">مفتاح: 7</annotation>
 		<annotation cp="8⃣">8 | ثمانية | مفتاح</annotation>
+		<annotation cp="8⃣" type="tts">مفتاح: 8</annotation>
 		<annotation cp="9⃣">9 | تسعة | مفتاح</annotation>
+		<annotation cp="9⃣" type="tts">مفتاح: 9</annotation>
 		<annotation cp="¹">رقم واحد علوي | علوي | واحد</annotation>
 		<annotation cp="¹" type="tts">رقم واحد علوي</annotation>
 		<annotation cp="²">اثنان | رقم اثنين علوي | علوي | مربع</annotation>

--- a/common/annotations/ar_SA.xml
+++ b/common/annotations/ar_SA.xml
@@ -15,14 +15,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🍷" draft="contributed">كأس عصير</annotation>
 		<annotation cp="🍷" type="tts">كأس عصير</annotation>
 		<annotation cp="0⃣">0 | صفر | مفتاح</annotation>
+		<annotation cp="0⃣" type="tts">مفتاح: 0</annotation>
 		<annotation cp="1⃣">1 | واحد | مفتاح</annotation>
+		<annotation cp="1⃣" type="tts">مفتاح: 1</annotation>
 		<annotation cp="2⃣">2 | إثنان | مفتاح</annotation>
+		<annotation cp="2⃣" type="tts">مفتاح: 2</annotation>
 		<annotation cp="3⃣">3 | ثلاثة | مفتاح</annotation>
+		<annotation cp="3⃣" type="tts">مفتاح: 3</annotation>
 		<annotation cp="4⃣">4 | أربعة | مفتاح</annotation>
+		<annotation cp="4⃣" type="tts">مفتاح: 4</annotation>
 		<annotation cp="5⃣">5 | خمسة | مفتاح</annotation>
+		<annotation cp="5⃣" type="tts">مفتاح: 5</annotation>
 		<annotation cp="6⃣">6 | ستة | مفتاح</annotation>
+		<annotation cp="6⃣" type="tts">مفتاح: 6</annotation>
 		<annotation cp="7⃣">7 | سبعة | مفتاح</annotation>
+		<annotation cp="7⃣" type="tts">مفتاح: 7</annotation>
 		<annotation cp="8⃣">8 | ثمانية | مفتاح</annotation>
+		<annotation cp="8⃣" type="tts">مفتاح: 8</annotation>
 		<annotation cp="9⃣">9 | تسعة | مفتاح</annotation>
+		<annotation cp="9⃣" type="tts">مفتاح: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/as.xml
+++ b/common/annotations/as.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">ৰুবল</annotation>
 		<annotation cp="₿">BTC | বিটকইন</annotation>
 		<annotation cp="₿" type="tts">বিটকইন</annotation>
+		<annotation cp="0⃣" type="tts">কীকেপ: 0</annotation>
+		<annotation cp="1⃣" type="tts">কীকেপ: 1</annotation>
+		<annotation cp="2⃣" type="tts">কীকেপ: 2</annotation>
+		<annotation cp="3⃣" type="tts">কীকেপ: 3</annotation>
+		<annotation cp="4⃣" type="tts">কীকেপ: 4</annotation>
+		<annotation cp="5⃣" type="tts">কীকেপ: 5</annotation>
+		<annotation cp="6⃣" type="tts">কীকেপ: 6</annotation>
+		<annotation cp="7⃣" type="tts">কীকেপ: 7</annotation>
+		<annotation cp="8⃣" type="tts">কীকেপ: 8</annotation>
+		<annotation cp="9⃣" type="tts">কীকেপ: 9</annotation>
 		<annotation cp="¹">এক | ছুপাৰস্ক্ৰিপ্ট</annotation>
 		<annotation cp="¹" type="tts">ছুপাৰস্ক্ৰিপ্ট এক</annotation>
 		<annotation cp="²">ছুপাৰস্ক্ৰিপ্ট | দুই | বৰ্গক্ষেত্ৰ</annotation>

--- a/common/annotations/ast.xml
+++ b/common/annotations/ast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -35,5 +35,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="💍" type="tts">aniellu</annotation>
 		<annotation cp="💎">diamante | piedra preciosa | xema | xoya</annotation>
 		<annotation cp="💎" type="tts">piedra preciosa</annotation>
+		<annotation cp="0⃣" type="tts">tecles: 0</annotation>
+		<annotation cp="1⃣" type="tts">tecles: 1</annotation>
+		<annotation cp="2⃣" type="tts">tecles: 2</annotation>
+		<annotation cp="3⃣" type="tts">tecles: 3</annotation>
+		<annotation cp="4⃣" type="tts">tecles: 4</annotation>
+		<annotation cp="5⃣" type="tts">tecles: 5</annotation>
+		<annotation cp="6⃣" type="tts">tecles: 6</annotation>
+		<annotation cp="7⃣" type="tts">tecles: 7</annotation>
+		<annotation cp="8⃣" type="tts">tecles: 8</annotation>
+		<annotation cp="9⃣" type="tts">tecles: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/az.xml
+++ b/common/annotations/az.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitkoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkoin</annotation>
 		<annotation cp="0⃣">0 | sıfır | klaviatura qapağı</annotation>
+		<annotation cp="0⃣" type="tts">klaviatura qapağı: 0</annotation>
 		<annotation cp="1⃣">1 | bir | klaviatura qapağı</annotation>
+		<annotation cp="1⃣" type="tts">klaviatura qapağı: 1</annotation>
 		<annotation cp="2⃣">2 | iki | klaviatura qapağı</annotation>
+		<annotation cp="2⃣" type="tts">klaviatura qapağı: 2</annotation>
 		<annotation cp="3⃣">3 | üç | klaviatura qapağı</annotation>
+		<annotation cp="3⃣" type="tts">klaviatura qapağı: 3</annotation>
 		<annotation cp="4⃣">4 | dörd | klaviatura qapağı</annotation>
+		<annotation cp="4⃣" type="tts">klaviatura qapağı: 4</annotation>
 		<annotation cp="5⃣">5 | beş | klaviatura qapağı</annotation>
+		<annotation cp="5⃣" type="tts">klaviatura qapağı: 5</annotation>
 		<annotation cp="6⃣">6 | altı | klaviatura qapağı</annotation>
+		<annotation cp="6⃣" type="tts">klaviatura qapağı: 6</annotation>
 		<annotation cp="7⃣">7 | yeddi | klaviatura qapağı</annotation>
+		<annotation cp="7⃣" type="tts">klaviatura qapağı: 7</annotation>
 		<annotation cp="8⃣">8 | səkkiz | klaviatura qapağı</annotation>
+		<annotation cp="8⃣" type="tts">klaviatura qapağı: 8</annotation>
 		<annotation cp="9⃣">9 | doqquz | klaviatura qapağı</annotation>
+		<annotation cp="9⃣" type="tts">klaviatura qapağı: 9</annotation>
 		<annotation cp="¹">bir | üstdə bir | üstdə yazılan</annotation>
 		<annotation cp="¹" type="tts">üstdə bir</annotation>
 		<annotation cp="²">iki | kvadrata yüksəlmiş | üstdə iki | üstdə yazılan</annotation>

--- a/common/annotations/be.xml
+++ b/common/annotations/be.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | біткойн</annotation>
 		<annotation cp="₿" type="tts">біткойн</annotation>
 		<annotation cp="0⃣">0 | нуль | Клавіша</annotation>
+		<annotation cp="0⃣" type="tts">Клавіша: 0</annotation>
 		<annotation cp="1⃣">1 | адзiн | Клавіша</annotation>
+		<annotation cp="1⃣" type="tts">Клавіша: 1</annotation>
 		<annotation cp="2⃣">2 | два | Клавіша</annotation>
+		<annotation cp="2⃣" type="tts">Клавіша: 2</annotation>
 		<annotation cp="3⃣">3 | тры | Клавіша</annotation>
+		<annotation cp="3⃣" type="tts">Клавіша: 3</annotation>
 		<annotation cp="4⃣">4 | чатыры | Клавіша</annotation>
+		<annotation cp="4⃣" type="tts">Клавіша: 4</annotation>
 		<annotation cp="5⃣">5 | пяць | Клавіша</annotation>
+		<annotation cp="5⃣" type="tts">Клавіша: 5</annotation>
 		<annotation cp="6⃣">6 | шэсць | Клавіша</annotation>
+		<annotation cp="6⃣" type="tts">Клавіша: 6</annotation>
 		<annotation cp="7⃣">7 | сем | Клавіша</annotation>
+		<annotation cp="7⃣" type="tts">Клавіша: 7</annotation>
 		<annotation cp="8⃣">8 | восем | Клавіша</annotation>
+		<annotation cp="8⃣" type="tts">Клавіша: 8</annotation>
 		<annotation cp="9⃣">9 | дзевяць | Клавіша</annotation>
+		<annotation cp="9⃣" type="tts">Клавіша: 9</annotation>
 		<annotation cp="¹">адзінка | верхні індэкс | надрадковая</annotation>
 		<annotation cp="¹" type="tts">надрадковая адзінка</annotation>
 		<annotation cp="²">верхні індэкс | двойка | надрадковая | у квадраце</annotation>

--- a/common/annotations/bg.xml
+++ b/common/annotations/bg.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | биткойн</annotation>
 		<annotation cp="₿" type="tts">биткойн</annotation>
 		<annotation cp="0⃣">0 | нула | Клавиш</annotation>
+		<annotation cp="0⃣" type="tts">Клавиш: 0</annotation>
 		<annotation cp="1⃣">1 | едно | Клавиш</annotation>
+		<annotation cp="1⃣" type="tts">Клавиш: 1</annotation>
 		<annotation cp="2⃣">2 | две | Клавиш</annotation>
+		<annotation cp="2⃣" type="tts">Клавиш: 2</annotation>
 		<annotation cp="3⃣">3 | три | Клавиш</annotation>
+		<annotation cp="3⃣" type="tts">Клавиш: 3</annotation>
 		<annotation cp="4⃣">4 | четири | Клавиш</annotation>
+		<annotation cp="4⃣" type="tts">Клавиш: 4</annotation>
 		<annotation cp="5⃣">5 | пет | Клавиш</annotation>
+		<annotation cp="5⃣" type="tts">Клавиш: 5</annotation>
 		<annotation cp="6⃣">6 | шест | Клавиш</annotation>
+		<annotation cp="6⃣" type="tts">Клавиш: 6</annotation>
 		<annotation cp="7⃣">7 | седем | Клавиш</annotation>
+		<annotation cp="7⃣" type="tts">Клавиш: 7</annotation>
 		<annotation cp="8⃣">8 | осем | Клавиш</annotation>
+		<annotation cp="8⃣" type="tts">Клавиш: 8</annotation>
 		<annotation cp="9⃣">9 | девет | Клавиш</annotation>
+		<annotation cp="9⃣" type="tts">Клавиш: 9</annotation>
 		<annotation cp="¹">горен индекс | едно | първа степен</annotation>
 		<annotation cp="¹" type="tts">първа степен</annotation>
 		<annotation cp="²">втора степен | горен индекс | две | на квадрат</annotation>

--- a/common/annotations/bn.xml
+++ b/common/annotations/bn.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | বিটকয়েন</annotation>
 		<annotation cp="₿" type="tts">বিটকয়েন</annotation>
 		<annotation cp="0⃣">0 | শূন্য | কিক্যাপ</annotation>
+		<annotation cp="0⃣" type="tts">কিক্যাপ: 0</annotation>
 		<annotation cp="1⃣">1 | এক | কিক্যাপ</annotation>
+		<annotation cp="1⃣" type="tts">কিক্যাপ: 1</annotation>
 		<annotation cp="2⃣">2 | দুই | কিক্যাপ</annotation>
+		<annotation cp="2⃣" type="tts">কিক্যাপ: 2</annotation>
 		<annotation cp="3⃣">3 | তিন | কিক্যাপ</annotation>
+		<annotation cp="3⃣" type="tts">কিক্যাপ: 3</annotation>
 		<annotation cp="4⃣">4 | চার | কিক্যাপ</annotation>
+		<annotation cp="4⃣" type="tts">কিক্যাপ: 4</annotation>
 		<annotation cp="5⃣">5 | পাঁচ | কিক্যাপ</annotation>
+		<annotation cp="5⃣" type="tts">কিক্যাপ: 5</annotation>
 		<annotation cp="6⃣">6 | ছয় | কিক্যাপ</annotation>
+		<annotation cp="6⃣" type="tts">কিক্যাপ: 6</annotation>
 		<annotation cp="7⃣">7 | সাত | কিক্যাপ</annotation>
+		<annotation cp="7⃣" type="tts">কিক্যাপ: 7</annotation>
 		<annotation cp="8⃣">8 | আট | কিক্যাপ</annotation>
+		<annotation cp="8⃣" type="tts">কিক্যাপ: 8</annotation>
 		<annotation cp="9⃣">9 | নয় | কিক্যাপ</annotation>
+		<annotation cp="9⃣" type="tts">কিক্যাপ: 9</annotation>
 		<annotation cp="¹">ওয়ান | সুপারস্ক্রিপ্ট</annotation>
 		<annotation cp="¹" type="tts">সুপারস্ক্রিপ্ট ওয়ান</annotation>
 		<annotation cp="²">দুই | বর্গাকার | সুপারস্ক্রিপ্ট | সুপারস্ক্রিপ্ট টু</annotation>

--- a/common/annotations/bs.xml
+++ b/common/annotations/bs.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nula | Kapica za tipku</annotation>
+		<annotation cp="0⃣" type="tts">Kapica za tipku: 0</annotation>
 		<annotation cp="1⃣">1 | jedan | Kapica za tipku</annotation>
+		<annotation cp="1⃣" type="tts">Kapica za tipku: 1</annotation>
 		<annotation cp="2⃣">2 | dva | Kapica za tipku</annotation>
+		<annotation cp="2⃣" type="tts">Kapica za tipku: 2</annotation>
 		<annotation cp="3⃣">3 | tri | Kapica za tipku</annotation>
+		<annotation cp="3⃣" type="tts">Kapica za tipku: 3</annotation>
 		<annotation cp="4⃣">4 | četiri | Kapica za tipku</annotation>
+		<annotation cp="4⃣" type="tts">Kapica za tipku: 4</annotation>
 		<annotation cp="5⃣">5 | pet | Kapica za tipku</annotation>
+		<annotation cp="5⃣" type="tts">Kapica za tipku: 5</annotation>
 		<annotation cp="6⃣">6 | šest | Kapica za tipku</annotation>
+		<annotation cp="6⃣" type="tts">Kapica za tipku: 6</annotation>
 		<annotation cp="7⃣">7 | sedam | Kapica za tipku</annotation>
+		<annotation cp="7⃣" type="tts">Kapica za tipku: 7</annotation>
 		<annotation cp="8⃣">8 | osam | Kapica za tipku</annotation>
+		<annotation cp="8⃣" type="tts">Kapica za tipku: 8</annotation>
 		<annotation cp="9⃣">9 | devet | Kapica za tipku</annotation>
+		<annotation cp="9⃣" type="tts">Kapica za tipku: 9</annotation>
 		<annotation cp="¹">eksponent | jedan | jedan eksponentno</annotation>
 		<annotation cp="¹" type="tts">jedan eksponentno</annotation>
 		<annotation cp="²">dva | dva eksponentno | eksponent | na kvadrat</annotation>

--- a/common/annotations/ca.xml
+++ b/common/annotations/ca.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | tecla</annotation>
+		<annotation cp="0⃣" type="tts">tecla: 0</annotation>
 		<annotation cp="1⃣">1 | u | tecla</annotation>
+		<annotation cp="1⃣" type="tts">tecla: 1</annotation>
 		<annotation cp="2⃣">2 | dos | tecla</annotation>
+		<annotation cp="2⃣" type="tts">tecla: 2</annotation>
 		<annotation cp="3⃣">3 | tres | tecla</annotation>
+		<annotation cp="3⃣" type="tts">tecla: 3</annotation>
 		<annotation cp="4⃣">4 | quatre | tecla</annotation>
+		<annotation cp="4⃣" type="tts">tecla: 4</annotation>
 		<annotation cp="5⃣">5 | cinc | tecla</annotation>
+		<annotation cp="5⃣" type="tts">tecla: 5</annotation>
 		<annotation cp="6⃣">6 | sis | tecla</annotation>
+		<annotation cp="6⃣" type="tts">tecla: 6</annotation>
 		<annotation cp="7⃣">7 | set | tecla</annotation>
+		<annotation cp="7⃣" type="tts">tecla: 7</annotation>
 		<annotation cp="8⃣">8 | vuit | tecla</annotation>
+		<annotation cp="8⃣" type="tts">tecla: 8</annotation>
 		<annotation cp="9⃣">9 | nou | tecla</annotation>
+		<annotation cp="9⃣" type="tts">tecla: 9</annotation>
 		<annotation cp="¹">superíndex | u</annotation>
 		<annotation cp="¹" type="tts">superíndex u</annotation>
 		<annotation cp="²">al quadrat | dos | superíndex</annotation>

--- a/common/annotations/ccp.xml
+++ b/common/annotations/ccp.xml
@@ -475,14 +475,24 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🏳‍🌈" draft="unconfirmed">𑄢𑄚𑄴𑄎𑄪𑄚𑄨 𑄝𑄝𑄧𑄘</annotation>
 		<annotation cp="🏳‍🌈" type="tts" draft="unconfirmed">𑄢𑄚𑄴𑄎𑄪𑄚𑄨 𑄝𑄝𑄧𑄘</annotation>
 		<annotation cp="0⃣">0 | 𑄥𑄪𑄚𑄳𑄠𑄴𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="0⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 0</annotation>
 		<annotation cp="1⃣">1 | 𑄆𑄇𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="1⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 1</annotation>
 		<annotation cp="2⃣">2 | 𑄘𑄨 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="2⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 2</annotation>
 		<annotation cp="3⃣">3 | 𑄖𑄨𑄚𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="3⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 3</annotation>
 		<annotation cp="4⃣">4 | 𑄌𑄳𑄆𑄬𑄢𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="4⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 4</annotation>
 		<annotation cp="5⃣">5 | 𑄛𑄌𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="5⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 5</annotation>
 		<annotation cp="6⃣">6 | 𑄍𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="6⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 6</annotation>
 		<annotation cp="7⃣">7 | 𑄥𑄖𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="7⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 7</annotation>
 		<annotation cp="8⃣">8 | 𑄃𑄖𑄳𑄠𑄴𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="8⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 8</annotation>
 		<annotation cp="9⃣">9 | 𑄚𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴</annotation>
+		<annotation cp="9⃣" type="tts">𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/chr.xml
+++ b/common/annotations/chr.xml
@@ -3896,15 +3896,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">BTC | ᎠᏏᎳᏕᏫᏒᎢ ᎠᏕᎳ</annotation>
 		<annotation cp="₿" type="tts">ᎠᏏᎳᏕᏫᏒᎢ ᎠᏕᎳ</annotation>
 		<annotation cp="0⃣">0 | ꮭ ꭺꮝꮧ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="0⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 0</annotation>
 		<annotation cp="1⃣">1 | ꮠꮼ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="1⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 1</annotation>
 		<annotation cp="2⃣">2 | ꮤꮅ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="2⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 2</annotation>
 		<annotation cp="3⃣">3 | ꮶꭲ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="3⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 3</annotation>
 		<annotation cp="4⃣">4 | ꮕꭹ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="4⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 4</annotation>
 		<annotation cp="5⃣">5 | ꭿꮝꭹ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="5⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 5</annotation>
 		<annotation cp="6⃣">6 | ꮡꮣꮅ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="6⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 6</annotation>
 		<annotation cp="7⃣">7 | ꭶꮅꮙꭹ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="7⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 7</annotation>
 		<annotation cp="8⃣">8 | ꮷꮑꮃ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="8⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 8</annotation>
 		<annotation cp="9⃣">9 | ꮠꮑꮃ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ</annotation>
+		<annotation cp="9⃣" type="tts">ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 9</annotation>
 		<annotation cp="¹">ᎤᏍᏗ ᎦᎸᎳᏗ | ᎤᏍᏗ ᎦᎸᎳᏗ ᏌᏊ | ᏌᏊ</annotation>
 		<annotation cp="¹" type="tts">ᎤᏍᏗ ᎦᎸᎳᏗ ᏌᏊ</annotation>
 		<annotation cp="²">ᎤᏍᏗ ᎦᎸᎳᏗ | ᎤᏍᏗ ᎦᎸᎳᏗ ᏔᎵ | ᏔᎵ</annotation>

--- a/common/annotations/cs.xml
+++ b/common/annotations/cs.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC | kryptoměna | měna</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nula | klávesa</annotation>
+		<annotation cp="0⃣" type="tts">klávesa: 0</annotation>
 		<annotation cp="1⃣">1 | jeden | klávesa</annotation>
+		<annotation cp="1⃣" type="tts">klávesa: 1</annotation>
 		<annotation cp="2⃣">2 | dva | klávesa</annotation>
+		<annotation cp="2⃣" type="tts">klávesa: 2</annotation>
 		<annotation cp="3⃣">3 | tři | klávesa</annotation>
+		<annotation cp="3⃣" type="tts">klávesa: 3</annotation>
 		<annotation cp="4⃣">4 | čtyři | klávesa</annotation>
+		<annotation cp="4⃣" type="tts">klávesa: 4</annotation>
 		<annotation cp="5⃣">5 | pět | klávesa</annotation>
+		<annotation cp="5⃣" type="tts">klávesa: 5</annotation>
 		<annotation cp="6⃣">6 | šest | klávesa</annotation>
+		<annotation cp="6⃣" type="tts">klávesa: 6</annotation>
 		<annotation cp="7⃣">7 | sedm | klávesa</annotation>
+		<annotation cp="7⃣" type="tts">klávesa: 7</annotation>
 		<annotation cp="8⃣">8 | osm | klávesa</annotation>
+		<annotation cp="8⃣" type="tts">klávesa: 8</annotation>
 		<annotation cp="9⃣">9 | devět | klávesa</annotation>
+		<annotation cp="9⃣" type="tts">klávesa: 9</annotation>
 		<annotation cp="¹">číslice jedna jako horní index | exponent | horní index | jedna | jednička | na první</annotation>
 		<annotation cp="¹" type="tts">číslice jedna jako horní index</annotation>
 		<annotation cp="²">číslice dvě jako horní index | čtvereční | dvě | dvojka | exponent | horní index | na druhou</annotation>

--- a/common/annotations/cv.xml
+++ b/common/annotations/cv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts" draft="unconfirmed">тенкӗ</annotation>
 		<annotation cp="₿" draft="unconfirmed">btc | биткоин | биткойн | бтк</annotation>
 		<annotation cp="₿" type="tts" draft="unconfirmed">биткоин</annotation>
+		<annotation cp="0⃣" type="tts">брелок: 0</annotation>
+		<annotation cp="1⃣" type="tts">брелок: 1</annotation>
+		<annotation cp="2⃣" type="tts">брелок: 2</annotation>
+		<annotation cp="3⃣" type="tts">брелок: 3</annotation>
+		<annotation cp="4⃣" type="tts">брелок: 4</annotation>
+		<annotation cp="5⃣" type="tts">брелок: 5</annotation>
+		<annotation cp="6⃣" type="tts">брелок: 6</annotation>
+		<annotation cp="7⃣" type="tts">брелок: 7</annotation>
+		<annotation cp="8⃣" type="tts">брелок: 8</annotation>
+		<annotation cp="9⃣" type="tts">брелок: 9</annotation>
 		<annotation cp="¹" draft="unconfirmed">пӗрре | строка тĕлĕнче цифри</annotation>
 		<annotation cp="¹" type="tts" draft="unconfirmed">строка тĕлĕнче цифри &quot;пӗрре&quot;</annotation>
 		<annotation cp="²" draft="unconfirmed">иккӗ | икке хăпарт | строка тĕлĕнче цифри</annotation>

--- a/common/annotations/cy.xml
+++ b/common/annotations/cy.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | dim | gorchudd bysell</annotation>
+		<annotation cp="0⃣" type="tts">gorchudd bysell: 0</annotation>
 		<annotation cp="1⃣">1 | un | gorchudd bysell</annotation>
+		<annotation cp="1⃣" type="tts">gorchudd bysell: 1</annotation>
 		<annotation cp="2⃣">2 | dau | gorchudd bysell</annotation>
+		<annotation cp="2⃣" type="tts">gorchudd bysell: 2</annotation>
 		<annotation cp="3⃣">3 | tri | gorchudd bysell</annotation>
+		<annotation cp="3⃣" type="tts">gorchudd bysell: 3</annotation>
 		<annotation cp="4⃣">4 | pedwar | gorchudd bysell</annotation>
+		<annotation cp="4⃣" type="tts">gorchudd bysell: 4</annotation>
 		<annotation cp="5⃣">5 | pump | gorchudd bysell</annotation>
+		<annotation cp="5⃣" type="tts">gorchudd bysell: 5</annotation>
 		<annotation cp="6⃣">6 | chwech | gorchudd bysell</annotation>
+		<annotation cp="6⃣" type="tts">gorchudd bysell: 6</annotation>
 		<annotation cp="7⃣">7 | saith | gorchudd bysell</annotation>
+		<annotation cp="7⃣" type="tts">gorchudd bysell: 7</annotation>
 		<annotation cp="8⃣">8 | wyth | gorchudd bysell</annotation>
+		<annotation cp="8⃣" type="tts">gorchudd bysell: 8</annotation>
 		<annotation cp="9⃣">9 | naw | gorchudd bysell</annotation>
+		<annotation cp="9⃣" type="tts">gorchudd bysell: 9</annotation>
 		<annotation cp="¹">un | uwchysgrifen</annotation>
 		<annotation cp="¹" type="tts">uwchysgrifen un</annotation>
 		<annotation cp="²">dau | sgwâr | uwchysgrifen</annotation>

--- a/common/annotations/de.xml
+++ b/common/annotations/de.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">Bitcoin-Zeichen | BTC</annotation>
 		<annotation cp="₿" type="tts">Bitcoin-Zeichen</annotation>
 		<annotation cp="0⃣">0 | null | Taste</annotation>
+		<annotation cp="0⃣" type="tts">Taste: 0</annotation>
 		<annotation cp="1⃣">1 | eins | Taste</annotation>
+		<annotation cp="1⃣" type="tts">Taste: 1</annotation>
 		<annotation cp="2⃣">2 | zwei | Taste</annotation>
+		<annotation cp="2⃣" type="tts">Taste: 2</annotation>
 		<annotation cp="3⃣">3 | drei | Taste</annotation>
+		<annotation cp="3⃣" type="tts">Taste: 3</annotation>
 		<annotation cp="4⃣">4 | vier | Taste</annotation>
+		<annotation cp="4⃣" type="tts">Taste: 4</annotation>
 		<annotation cp="5⃣">5 | fünf | Taste</annotation>
+		<annotation cp="5⃣" type="tts">Taste: 5</annotation>
 		<annotation cp="6⃣">6 | sechs | Taste</annotation>
+		<annotation cp="6⃣" type="tts">Taste: 6</annotation>
 		<annotation cp="7⃣">7 | sieben | Taste</annotation>
+		<annotation cp="7⃣" type="tts">Taste: 7</annotation>
 		<annotation cp="8⃣">8 | acht | Taste</annotation>
+		<annotation cp="8⃣" type="tts">Taste: 8</annotation>
 		<annotation cp="9⃣">9 | neun | Taste</annotation>
+		<annotation cp="9⃣" type="tts">Taste: 9</annotation>
 		<annotation cp="¹">Eins | hoch eins | hochgestellt | hochgestellte Eins</annotation>
 		<annotation cp="¹" type="tts">hochgestellte Eins</annotation>
 		<annotation cp="²">hoch zwei | hochgestellt | hochgestellte Zwei | im Quadrat | Quadrat | Zwei</annotation>

--- a/common/annotations/dsb.xml
+++ b/common/annotations/dsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">symbol za rubel</annotation>
 		<annotation cp="₿">bitcoin | pjenjeze | płaśeński srědk | symbol za bitcoin</annotation>
 		<annotation cp="₿" type="tts">symbol za bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">tasta: 0</annotation>
+		<annotation cp="1⃣" type="tts">tasta: 1</annotation>
+		<annotation cp="2⃣" type="tts">tasta: 2</annotation>
+		<annotation cp="3⃣" type="tts">tasta: 3</annotation>
+		<annotation cp="4⃣" type="tts">tasta: 4</annotation>
+		<annotation cp="5⃣" type="tts">tasta: 5</annotation>
+		<annotation cp="6⃣" type="tts">tasta: 6</annotation>
+		<annotation cp="7⃣" type="tts">tasta: 7</annotation>
+		<annotation cp="8⃣" type="tts">tasta: 8</annotation>
+		<annotation cp="9⃣" type="tts">tasta: 9</annotation>
 		<annotation cp="¹">cysło jaden | jadenka | wušej stajona jadenka | wušej stajone znamuško</annotation>
 		<annotation cp="¹" type="tts">wušej stajona jadenka</annotation>
 		<annotation cp="²">cysło dwa | dwójka | wušej stajona dwójka | wušej stajone znamuško</annotation>

--- a/common/annotations/el.xml
+++ b/common/annotations/el.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | μπίτκοϊν</annotation>
 		<annotation cp="₿" type="tts">μπίτκοϊν</annotation>
 		<annotation cp="0⃣">0 | μηδέν | πλήκτρο</annotation>
+		<annotation cp="0⃣" type="tts">πλήκτρο: 0</annotation>
 		<annotation cp="1⃣">1 | ένα | πλήκτρο</annotation>
+		<annotation cp="1⃣" type="tts">πλήκτρο: 1</annotation>
 		<annotation cp="2⃣">2 | δύο | πλήκτρο</annotation>
+		<annotation cp="2⃣" type="tts">πλήκτρο: 2</annotation>
 		<annotation cp="3⃣">3 | τρία | πλήκτρο</annotation>
+		<annotation cp="3⃣" type="tts">πλήκτρο: 3</annotation>
 		<annotation cp="4⃣">4 | τέσσερα | πλήκτρο</annotation>
+		<annotation cp="4⃣" type="tts">πλήκτρο: 4</annotation>
 		<annotation cp="5⃣">5 | πέντε | πλήκτρο</annotation>
+		<annotation cp="5⃣" type="tts">πλήκτρο: 5</annotation>
 		<annotation cp="6⃣">6 | έξι | πλήκτρο</annotation>
+		<annotation cp="6⃣" type="tts">πλήκτρο: 6</annotation>
 		<annotation cp="7⃣">7 | επτά | πλήκτρο</annotation>
+		<annotation cp="7⃣" type="tts">πλήκτρο: 7</annotation>
 		<annotation cp="8⃣">8 | οκτώ | πλήκτρο</annotation>
+		<annotation cp="8⃣" type="tts">πλήκτρο: 8</annotation>
 		<annotation cp="9⃣">9 | εννέα | πλήκτρο</annotation>
+		<annotation cp="9⃣" type="tts">πλήκτρο: 9</annotation>
 		<annotation cp="¹">εκθέτης | ένα</annotation>
 		<annotation cp="¹" type="tts">εκθέτης ένα</annotation>
 		<annotation cp="²">δύο | εκθέτης | στο τετράγωνο</annotation>

--- a/common/annotations/en.xml
+++ b/common/annotations/en.xml
@@ -3907,15 +3907,25 @@ annotations.
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | keycap</annotation>
+		<annotation cp="0⃣" type="tts">keycap: 0</annotation>
 		<annotation cp="1⃣">1 | one | keycap</annotation>
+		<annotation cp="1⃣" type="tts">keycap: 1</annotation>
 		<annotation cp="2⃣">2 | two | keycap</annotation>
+		<annotation cp="2⃣" type="tts">keycap: 2</annotation>
 		<annotation cp="3⃣">3 | three | keycap</annotation>
+		<annotation cp="3⃣" type="tts">keycap: 3</annotation>
 		<annotation cp="4⃣">4 | four | keycap</annotation>
+		<annotation cp="4⃣" type="tts">keycap: 4</annotation>
 		<annotation cp="5⃣">5 | five | keycap</annotation>
+		<annotation cp="5⃣" type="tts">keycap: 5</annotation>
 		<annotation cp="6⃣">6 | six | keycap</annotation>
+		<annotation cp="6⃣" type="tts">keycap: 6</annotation>
 		<annotation cp="7⃣">7 | seven | keycap</annotation>
+		<annotation cp="7⃣" type="tts">keycap: 7</annotation>
 		<annotation cp="8⃣">8 | eight | keycap</annotation>
+		<annotation cp="8⃣" type="tts">keycap: 8</annotation>
 		<annotation cp="9⃣">9 | nine | keycap</annotation>
+		<annotation cp="9⃣" type="tts">keycap: 9</annotation>
 		<annotation cp="¹">one | superscript</annotation>
 		<annotation cp="¹" type="tts">superscript one</annotation>
 		<annotation cp="²">squared | superscript | two</annotation>

--- a/common/annotations/es.xml
+++ b/common/annotations/es.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | bitcóin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcóin</annotation>
 		<annotation cp="0⃣">0 | cero | Teclas</annotation>
+		<annotation cp="0⃣" type="tts">Teclas: 0</annotation>
 		<annotation cp="1⃣">1 | uno | Teclas</annotation>
+		<annotation cp="1⃣" type="tts">Teclas: 1</annotation>
 		<annotation cp="2⃣">2 | dos | Teclas</annotation>
+		<annotation cp="2⃣" type="tts">Teclas: 2</annotation>
 		<annotation cp="3⃣">3 | tres | Teclas</annotation>
+		<annotation cp="3⃣" type="tts">Teclas: 3</annotation>
 		<annotation cp="4⃣">4 | cuatro | Teclas</annotation>
+		<annotation cp="4⃣" type="tts">Teclas: 4</annotation>
 		<annotation cp="5⃣">5 | cinco | Teclas</annotation>
+		<annotation cp="5⃣" type="tts">Teclas: 5</annotation>
 		<annotation cp="6⃣">6 | seis | Teclas</annotation>
+		<annotation cp="6⃣" type="tts">Teclas: 6</annotation>
 		<annotation cp="7⃣">7 | siete | Teclas</annotation>
+		<annotation cp="7⃣" type="tts">Teclas: 7</annotation>
 		<annotation cp="8⃣">8 | ocho | Teclas</annotation>
+		<annotation cp="8⃣" type="tts">Teclas: 8</annotation>
 		<annotation cp="9⃣">9 | nueve | Teclas</annotation>
+		<annotation cp="9⃣" type="tts">Teclas: 9</annotation>
 		<annotation cp="¹">superíndice | uno</annotation>
 		<annotation cp="¹" type="tts">uno en superíndice</annotation>
 		<annotation cp="²">al cuadrado | dos | superíndice</annotation>

--- a/common/annotations/es_419.xml
+++ b/common/annotations/es_419.xml
@@ -3899,15 +3899,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">↑↑↑</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | cero | tecla mayus</annotation>
+		<annotation cp="0⃣" type="tts">tecla mayus: 0</annotation>
 		<annotation cp="1⃣">1 | uno | tecla mayus</annotation>
+		<annotation cp="1⃣" type="tts">tecla mayus: 1</annotation>
 		<annotation cp="2⃣">2 | dos | tecla mayus</annotation>
+		<annotation cp="2⃣" type="tts">tecla mayus: 2</annotation>
 		<annotation cp="3⃣">3 | tres | tecla mayus</annotation>
+		<annotation cp="3⃣" type="tts">tecla mayus: 3</annotation>
 		<annotation cp="4⃣">4 | cuatro | tecla mayus</annotation>
+		<annotation cp="4⃣" type="tts">tecla mayus: 4</annotation>
 		<annotation cp="5⃣">5 | cinco | tecla mayus</annotation>
+		<annotation cp="5⃣" type="tts">tecla mayus: 5</annotation>
 		<annotation cp="6⃣">6 | seis | tecla mayus</annotation>
+		<annotation cp="6⃣" type="tts">tecla mayus: 6</annotation>
 		<annotation cp="7⃣">7 | siete | tecla mayus</annotation>
+		<annotation cp="7⃣" type="tts">tecla mayus: 7</annotation>
 		<annotation cp="8⃣">8 | ocho | tecla mayus</annotation>
+		<annotation cp="8⃣" type="tts">tecla mayus: 8</annotation>
 		<annotation cp="9⃣">9 | nueve | tecla mayus</annotation>
+		<annotation cp="9⃣" type="tts">tecla mayus: 9</annotation>
 		<annotation cp="¹">↑↑↑</annotation>
 		<annotation cp="¹" type="tts">↑↑↑</annotation>
 		<annotation cp="²">↑↑↑</annotation>

--- a/common/annotations/es_MX.xml
+++ b/common/annotations/es_MX.xml
@@ -3897,15 +3897,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">↑↑↑</annotation>
 		<annotation cp="0⃣">0 | cero | tecla</annotation>
+		<annotation cp="0⃣" type="tts">tecla: 0</annotation>
 		<annotation cp="1⃣">1 | uno | tecla</annotation>
+		<annotation cp="1⃣" type="tts">tecla: 1</annotation>
 		<annotation cp="2⃣">2 | dos | tecla</annotation>
+		<annotation cp="2⃣" type="tts">tecla: 2</annotation>
 		<annotation cp="3⃣">3 | tres | tecla</annotation>
+		<annotation cp="3⃣" type="tts">tecla: 3</annotation>
 		<annotation cp="4⃣">4 | cuatro | tecla</annotation>
+		<annotation cp="4⃣" type="tts">tecla: 4</annotation>
 		<annotation cp="5⃣">5 | cinco | tecla</annotation>
+		<annotation cp="5⃣" type="tts">tecla: 5</annotation>
 		<annotation cp="6⃣">6 | seis | tecla</annotation>
+		<annotation cp="6⃣" type="tts">tecla: 6</annotation>
 		<annotation cp="7⃣">7 | siete | tecla</annotation>
+		<annotation cp="7⃣" type="tts">tecla: 7</annotation>
 		<annotation cp="8⃣">8 | ocho | tecla</annotation>
+		<annotation cp="8⃣" type="tts">tecla: 8</annotation>
 		<annotation cp="9⃣">9 | nueve | tecla</annotation>
+		<annotation cp="9⃣" type="tts">tecla: 9</annotation>
 		<annotation cp="¹">↑↑↑</annotation>
 		<annotation cp="¹" type="tts">↑↑↑</annotation>
 		<annotation cp="²">↑↑↑</annotation>

--- a/common/annotations/es_US.xml
+++ b/common/annotations/es_US.xml
@@ -3897,15 +3897,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">↑↑↑</annotation>
 		<annotation cp="₿" type="tts">↑↑↑</annotation>
 		<annotation cp="0⃣">0 | cero | tecla</annotation>
+		<annotation cp="0⃣" type="tts">tecla: 0</annotation>
 		<annotation cp="1⃣">1 | uno | tecla</annotation>
+		<annotation cp="1⃣" type="tts">tecla: 1</annotation>
 		<annotation cp="2⃣">2 | dos | tecla</annotation>
+		<annotation cp="2⃣" type="tts">tecla: 2</annotation>
 		<annotation cp="3⃣">3 | tres | tecla</annotation>
+		<annotation cp="3⃣" type="tts">tecla: 3</annotation>
 		<annotation cp="4⃣">4 | cuatro | tecla</annotation>
+		<annotation cp="4⃣" type="tts">tecla: 4</annotation>
 		<annotation cp="5⃣">5 | cinco | tecla</annotation>
+		<annotation cp="5⃣" type="tts">tecla: 5</annotation>
 		<annotation cp="6⃣">6 | seis | tecla</annotation>
+		<annotation cp="6⃣" type="tts">tecla: 6</annotation>
 		<annotation cp="7⃣">7 | siete | tecla</annotation>
+		<annotation cp="7⃣" type="tts">tecla: 7</annotation>
 		<annotation cp="8⃣">8 | ocho | tecla</annotation>
+		<annotation cp="8⃣" type="tts">tecla: 8</annotation>
 		<annotation cp="9⃣">9 | nueve | tecla</annotation>
+		<annotation cp="9⃣" type="tts">tecla: 9</annotation>
 		<annotation cp="¹">↑↑↑</annotation>
 		<annotation cp="¹" type="tts">↑↑↑</annotation>
 		<annotation cp="²">↑↑↑</annotation>

--- a/common/annotations/et.xml
+++ b/common/annotations/et.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | null | klahv</annotation>
+		<annotation cp="0⃣" type="tts">klahv: 0</annotation>
 		<annotation cp="1⃣">1 | üks | klahv</annotation>
+		<annotation cp="1⃣" type="tts">klahv: 1</annotation>
 		<annotation cp="2⃣">2 | kaks | klahv</annotation>
+		<annotation cp="2⃣" type="tts">klahv: 2</annotation>
 		<annotation cp="3⃣">3 | kolm | klahv</annotation>
+		<annotation cp="3⃣" type="tts">klahv: 3</annotation>
 		<annotation cp="4⃣">4 | neli | klahv</annotation>
+		<annotation cp="4⃣" type="tts">klahv: 4</annotation>
 		<annotation cp="5⃣">5 | viis | klahv</annotation>
+		<annotation cp="5⃣" type="tts">klahv: 5</annotation>
 		<annotation cp="6⃣">6 | kuus | klahv</annotation>
+		<annotation cp="6⃣" type="tts">klahv: 6</annotation>
 		<annotation cp="7⃣">7 | seitse | klahv</annotation>
+		<annotation cp="7⃣" type="tts">klahv: 7</annotation>
 		<annotation cp="8⃣">8 | kaheksa | klahv</annotation>
+		<annotation cp="8⃣" type="tts">klahv: 8</annotation>
 		<annotation cp="9⃣">9 | üheksa | klahv</annotation>
+		<annotation cp="9⃣" type="tts">klahv: 9</annotation>
 		<annotation cp="¹">aste | astmel 1 | üks</annotation>
 		<annotation cp="¹" type="tts">astmel 1</annotation>
 		<annotation cp="²">2 | aste | astmel 2 | ruudus</annotation>

--- a/common/annotations/eu.xml
+++ b/common/annotations/eu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">errubloa</annotation>
 		<annotation cp="₿">bitcoina | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoina</annotation>
+		<annotation cp="0⃣" type="tts">Tekla: 0</annotation>
+		<annotation cp="1⃣" type="tts">Tekla: 1</annotation>
+		<annotation cp="2⃣" type="tts">Tekla: 2</annotation>
+		<annotation cp="3⃣" type="tts">Tekla: 3</annotation>
+		<annotation cp="4⃣" type="tts">Tekla: 4</annotation>
+		<annotation cp="5⃣" type="tts">Tekla: 5</annotation>
+		<annotation cp="6⃣" type="tts">Tekla: 6</annotation>
+		<annotation cp="7⃣" type="tts">Tekla: 7</annotation>
+		<annotation cp="8⃣" type="tts">Tekla: 8</annotation>
+		<annotation cp="9⃣" type="tts">Tekla: 9</annotation>
 		<annotation cp="¹">bat | goi-indize | goi-indizeko bat</annotation>
 		<annotation cp="¹" type="tts">goi-indizeko bat</annotation>
 		<annotation cp="²">bi | goi-indize | goi-indizeko bi</annotation>

--- a/common/annotations/fa.xml
+++ b/common/annotations/fa.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | بیت‌کوین</annotation>
 		<annotation cp="₿" type="tts">بیت‌کوین</annotation>
 		<annotation cp="0⃣">0 | صفر | جلد کلید</annotation>
+		<annotation cp="0⃣" type="tts">جلد کلید: 0</annotation>
 		<annotation cp="1⃣">1 | یک | جلد کلید</annotation>
+		<annotation cp="1⃣" type="tts">جلد کلید: 1</annotation>
 		<annotation cp="2⃣">2 | دو | جلد کلید</annotation>
+		<annotation cp="2⃣" type="tts">جلد کلید: 2</annotation>
 		<annotation cp="3⃣">3 | سه | جلد کلید</annotation>
+		<annotation cp="3⃣" type="tts">جلد کلید: 3</annotation>
 		<annotation cp="4⃣">4 | چهار | جلد کلید</annotation>
+		<annotation cp="4⃣" type="tts">جلد کلید: 4</annotation>
 		<annotation cp="5⃣">5 | پنج | جلد کلید</annotation>
+		<annotation cp="5⃣" type="tts">جلد کلید: 5</annotation>
 		<annotation cp="6⃣">6 | شش | جلد کلید</annotation>
+		<annotation cp="6⃣" type="tts">جلد کلید: 6</annotation>
 		<annotation cp="7⃣">7 | هفت | جلد کلید</annotation>
+		<annotation cp="7⃣" type="tts">جلد کلید: 7</annotation>
 		<annotation cp="8⃣">8 | هشت | جلد کلید</annotation>
+		<annotation cp="8⃣" type="tts">جلد کلید: 8</annotation>
 		<annotation cp="9⃣">9 | نه | جلد کلید</annotation>
+		<annotation cp="9⃣" type="tts">جلد کلید: 9</annotation>
 		<annotation cp="¹">بالانگاشت | بالانوشت | زِبَرنوشت | یک</annotation>
 		<annotation cp="¹" type="tts">یک بالانوشت</annotation>
 		<annotation cp="²">بالانگاشت | بالانوشت | توان ۲ | دو | زِبَرنوشت | عدد دو بالانگاشت</annotation>

--- a/common/annotations/ff_Adlm.xml
+++ b/common/annotations/ff_Adlm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -194,5 +194,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👓" type="tts">𞤲𞤣𞤢𞥄𞤪𞤯𞤵𞤤𞤫</annotation>
 		<annotation cp="🏧">𞤃𞤢𞥄𞤲𞤣𞤫 𞤑𞤑𞤒</annotation>
 		<annotation cp="🏧" type="tts">𞤃𞤢𞥄𞤲𞤣𞤫 𞤑𞤑𞤒</annotation>
+		<annotation cp="0⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 0</annotation>
+		<annotation cp="1⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 1</annotation>
+		<annotation cp="2⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 2</annotation>
+		<annotation cp="3⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 3</annotation>
+		<annotation cp="4⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 4</annotation>
+		<annotation cp="5⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 5</annotation>
+		<annotation cp="6⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 6</annotation>
+		<annotation cp="7⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 7</annotation>
+		<annotation cp="8⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 8</annotation>
+		<annotation cp="9⃣" type="tts">𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/fi.xml
+++ b/common/annotations/fi.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nolla | näppäin</annotation>
+		<annotation cp="0⃣" type="tts">näppäin: 0</annotation>
 		<annotation cp="1⃣">1 | yksi | näppäin</annotation>
+		<annotation cp="1⃣" type="tts">näppäin: 1</annotation>
 		<annotation cp="2⃣">2 | kaksi | näppäin</annotation>
+		<annotation cp="2⃣" type="tts">näppäin: 2</annotation>
 		<annotation cp="3⃣">3 | kolme | näppäin</annotation>
+		<annotation cp="3⃣" type="tts">näppäin: 3</annotation>
 		<annotation cp="4⃣">4 | neljä | näppäin</annotation>
+		<annotation cp="4⃣" type="tts">näppäin: 4</annotation>
 		<annotation cp="5⃣">5 | viisi | näppäin</annotation>
+		<annotation cp="5⃣" type="tts">näppäin: 5</annotation>
 		<annotation cp="6⃣">6 | kuusi | näppäin</annotation>
+		<annotation cp="6⃣" type="tts">näppäin: 6</annotation>
 		<annotation cp="7⃣">7 | seitsemän | näppäin</annotation>
+		<annotation cp="7⃣" type="tts">näppäin: 7</annotation>
 		<annotation cp="8⃣">8 | kahdeksan | näppäin</annotation>
+		<annotation cp="8⃣" type="tts">näppäin: 8</annotation>
 		<annotation cp="9⃣">9 | yhdeksän | näppäin</annotation>
+		<annotation cp="9⃣" type="tts">näppäin: 9</annotation>
 		<annotation cp="¹">yksi | yläindeksi</annotation>
 		<annotation cp="¹" type="tts">yläindeksi yksi</annotation>
 		<annotation cp="²">kaksi | neliö | yläindeksi</annotation>

--- a/common/annotations/fo.xml
+++ b/common/annotations/fo.xml
@@ -3474,15 +3474,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">bitcoin | gjaldoyra</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | null | Knappahetta</annotation>
+		<annotation cp="0⃣" type="tts">Knappahetta: 0</annotation>
 		<annotation cp="1⃣">1 | ein | Knappahetta</annotation>
+		<annotation cp="1⃣" type="tts">Knappahetta: 1</annotation>
 		<annotation cp="2⃣">2 | tveir | Knappahetta</annotation>
+		<annotation cp="2⃣" type="tts">Knappahetta: 2</annotation>
 		<annotation cp="3⃣">3 | tríggir | Knappahetta</annotation>
+		<annotation cp="3⃣" type="tts">Knappahetta: 3</annotation>
 		<annotation cp="4⃣">4 | fýre | Knappahetta</annotation>
+		<annotation cp="4⃣" type="tts">Knappahetta: 4</annotation>
 		<annotation cp="5⃣">5 | fimm | Knappahetta</annotation>
+		<annotation cp="5⃣" type="tts">Knappahetta: 5</annotation>
 		<annotation cp="6⃣">6 | seks | Knappahetta</annotation>
+		<annotation cp="6⃣" type="tts">Knappahetta: 6</annotation>
 		<annotation cp="7⃣">7 | sjey | Knappahetta</annotation>
+		<annotation cp="7⃣" type="tts">Knappahetta: 7</annotation>
 		<annotation cp="8⃣">8 | átta | Knappahetta</annotation>
+		<annotation cp="8⃣" type="tts">Knappahetta: 8</annotation>
 		<annotation cp="9⃣">9 | níggju | Knappahetta</annotation>
+		<annotation cp="9⃣" type="tts">Knappahetta: 9</annotation>
 		<annotation cp="¹">eitt | háskrift</annotation>
 		<annotation cp="¹" type="tts">háskrift eitt</annotation>
 		<annotation cp="²">ferningur | háskrift | kvadrat | tvey</annotation>

--- a/common/annotations/fr.xml
+++ b/common/annotations/fr.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zéro | touches</annotation>
+		<annotation cp="0⃣" type="tts">touches&#x202F;: 0</annotation>
 		<annotation cp="1⃣">1 | un | touches</annotation>
+		<annotation cp="1⃣" type="tts">touches&#x202F;: 1</annotation>
 		<annotation cp="2⃣">2 | deux | touches</annotation>
+		<annotation cp="2⃣" type="tts">touches&#x202F;: 2</annotation>
 		<annotation cp="3⃣">3 | trois | touches</annotation>
+		<annotation cp="3⃣" type="tts">touches&#x202F;: 3</annotation>
 		<annotation cp="4⃣">4 | quatre | touches</annotation>
+		<annotation cp="4⃣" type="tts">touches&#x202F;: 4</annotation>
 		<annotation cp="5⃣">5 | cinq | touches</annotation>
+		<annotation cp="5⃣" type="tts">touches&#x202F;: 5</annotation>
 		<annotation cp="6⃣">6 | six | touches</annotation>
+		<annotation cp="6⃣" type="tts">touches&#x202F;: 6</annotation>
 		<annotation cp="7⃣">7 | sept | touches</annotation>
+		<annotation cp="7⃣" type="tts">touches&#x202F;: 7</annotation>
 		<annotation cp="8⃣">8 | huit | touches</annotation>
+		<annotation cp="8⃣" type="tts">touches&#x202F;: 8</annotation>
 		<annotation cp="9⃣">9 | neuf | touches</annotation>
+		<annotation cp="9⃣" type="tts">touches&#x202F;: 9</annotation>
 		<annotation cp="¹">exposant | un</annotation>
 		<annotation cp="¹" type="tts">exposant un</annotation>
 		<annotation cp="²">au carré | deux | exposant</annotation>

--- a/common/annotations/fr_CA.xml
+++ b/common/annotations/fr_CA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3896,6 +3896,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">↑↑↑</annotation>
 		<annotation cp="₿">↑↑↑</annotation>
 		<annotation cp="₿" type="tts">↑↑↑</annotation>
+		<annotation cp="0⃣" type="tts">dessus de touche&#xA0;: 0</annotation>
+		<annotation cp="1⃣" type="tts">dessus de touche&#xA0;: 1</annotation>
+		<annotation cp="2⃣" type="tts">dessus de touche&#xA0;: 2</annotation>
+		<annotation cp="3⃣" type="tts">dessus de touche&#xA0;: 3</annotation>
+		<annotation cp="4⃣" type="tts">dessus de touche&#xA0;: 4</annotation>
+		<annotation cp="5⃣" type="tts">dessus de touche&#xA0;: 5</annotation>
+		<annotation cp="6⃣" type="tts">dessus de touche&#xA0;: 6</annotation>
+		<annotation cp="7⃣" type="tts">dessus de touche&#xA0;: 7</annotation>
+		<annotation cp="8⃣" type="tts">dessus de touche&#xA0;: 8</annotation>
+		<annotation cp="9⃣" type="tts">dessus de touche&#xA0;: 9</annotation>
 		<annotation cp="¹">↑↑↑</annotation>
 		<annotation cp="¹" type="tts">↑↑↑</annotation>
 		<annotation cp="²">↑↑↑</annotation>

--- a/common/annotations/ga.xml
+++ b/common/annotations/ga.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bonn giotáin | BTC</annotation>
 		<annotation cp="₿" type="tts">bonn giotáin</annotation>
 		<annotation cp="0⃣">0 | a náid | caipín eochrach</annotation>
+		<annotation cp="0⃣" type="tts">caipín eochrach: 0</annotation>
 		<annotation cp="1⃣">1 | a haon | caipín eochrach</annotation>
+		<annotation cp="1⃣" type="tts">caipín eochrach: 1</annotation>
 		<annotation cp="2⃣">2 | a dó | caipín eochrach</annotation>
+		<annotation cp="2⃣" type="tts">caipín eochrach: 2</annotation>
 		<annotation cp="3⃣">3 | a trí | caipín eochrach</annotation>
+		<annotation cp="3⃣" type="tts">caipín eochrach: 3</annotation>
 		<annotation cp="4⃣">4 | a ceathair | caipín eochrach</annotation>
+		<annotation cp="4⃣" type="tts">caipín eochrach: 4</annotation>
 		<annotation cp="5⃣">5 | a cúig | caipín eochrach</annotation>
+		<annotation cp="5⃣" type="tts">caipín eochrach: 5</annotation>
 		<annotation cp="6⃣">6 | a sé | caipín eochrach</annotation>
+		<annotation cp="6⃣" type="tts">caipín eochrach: 6</annotation>
 		<annotation cp="7⃣">7 | a seacht | caipín eochrach</annotation>
+		<annotation cp="7⃣" type="tts">caipín eochrach: 7</annotation>
 		<annotation cp="8⃣">8 | a hocht | caipín eochrach</annotation>
+		<annotation cp="8⃣" type="tts">caipín eochrach: 8</annotation>
 		<annotation cp="9⃣">9 | a naoi | caipín eochrach</annotation>
+		<annotation cp="9⃣" type="tts">caipín eochrach: 9</annotation>
 		<annotation cp="¹">aon forscríofa</annotation>
 		<annotation cp="¹" type="tts">aon forscríofa</annotation>
 		<annotation cp="²">cearnaithe | dó forscríofa</annotation>

--- a/common/annotations/gd.xml
+++ b/common/annotations/gd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">rùbal</annotation>
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">còmhdachadh iuchrach: 0</annotation>
+		<annotation cp="1⃣" type="tts">còmhdachadh iuchrach: 1</annotation>
+		<annotation cp="2⃣" type="tts">còmhdachadh iuchrach: 2</annotation>
+		<annotation cp="3⃣" type="tts">còmhdachadh iuchrach: 3</annotation>
+		<annotation cp="4⃣" type="tts">còmhdachadh iuchrach: 4</annotation>
+		<annotation cp="5⃣" type="tts">còmhdachadh iuchrach: 5</annotation>
+		<annotation cp="6⃣" type="tts">còmhdachadh iuchrach: 6</annotation>
+		<annotation cp="7⃣" type="tts">còmhdachadh iuchrach: 7</annotation>
+		<annotation cp="8⃣" type="tts">còmhdachadh iuchrach: 8</annotation>
+		<annotation cp="9⃣" type="tts">còmhdachadh iuchrach: 9</annotation>
 		<annotation cp="¹">a h-aon os-sgrìobhte | aon | os-sgrìobhte</annotation>
 		<annotation cp="¹" type="tts">a h-aon os-sgrìobhte</annotation>
 		<annotation cp="²">a dhà os-sgrìobhte | ceàrnagach | ceàrnagaichte | dà | os-sgrìobhte</annotation>

--- a/common/annotations/gl.xml
+++ b/common/annotations/gl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">rublo</annotation>
 		<annotation cp="₿">BTC | criptomoeda</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">tecla: 0</annotation>
+		<annotation cp="1⃣" type="tts">tecla: 1</annotation>
+		<annotation cp="2⃣" type="tts">tecla: 2</annotation>
+		<annotation cp="3⃣" type="tts">tecla: 3</annotation>
+		<annotation cp="4⃣" type="tts">tecla: 4</annotation>
+		<annotation cp="5⃣" type="tts">tecla: 5</annotation>
+		<annotation cp="6⃣" type="tts">tecla: 6</annotation>
+		<annotation cp="7⃣" type="tts">tecla: 7</annotation>
+		<annotation cp="8⃣" type="tts">tecla: 8</annotation>
+		<annotation cp="9⃣" type="tts">tecla: 9</annotation>
 		<annotation cp="¹">1 | superíndice</annotation>
 		<annotation cp="¹" type="tts">un en superíndice</annotation>
 		<annotation cp="²">2 | cadrado | superíndice</annotation>

--- a/common/annotations/gu.xml
+++ b/common/annotations/gu.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | બિટકોઇન</annotation>
 		<annotation cp="₿" type="tts">બિટકોઇન</annotation>
 		<annotation cp="0⃣">0 | શૂન્ય | કીકેપ</annotation>
+		<annotation cp="0⃣" type="tts">કીકેપ: 0</annotation>
 		<annotation cp="1⃣">1 | એક | કીકેપ</annotation>
+		<annotation cp="1⃣" type="tts">કીકેપ: 1</annotation>
 		<annotation cp="2⃣">2 | બે | કીકેપ</annotation>
+		<annotation cp="2⃣" type="tts">કીકેપ: 2</annotation>
 		<annotation cp="3⃣">3 | ત્રણ | કીકેપ</annotation>
+		<annotation cp="3⃣" type="tts">કીકેપ: 3</annotation>
 		<annotation cp="4⃣">4 | ચાર | કીકેપ</annotation>
+		<annotation cp="4⃣" type="tts">કીકેપ: 4</annotation>
 		<annotation cp="5⃣">5 | પાંચ | કીકેપ</annotation>
+		<annotation cp="5⃣" type="tts">કીકેપ: 5</annotation>
 		<annotation cp="6⃣">6 | છ | કીકેપ</annotation>
+		<annotation cp="6⃣" type="tts">કીકેપ: 6</annotation>
 		<annotation cp="7⃣">7 | સાત | કીકેપ</annotation>
+		<annotation cp="7⃣" type="tts">કીકેપ: 7</annotation>
 		<annotation cp="8⃣">8 | આઠ | કીકેપ</annotation>
+		<annotation cp="8⃣" type="tts">કીકેપ: 8</annotation>
 		<annotation cp="9⃣">9 | નવ | કીકેપ</annotation>
+		<annotation cp="9⃣" type="tts">કીકેપ: 9</annotation>
 		<annotation cp="¹">એક | સુપરસ્ક્રિપ્ટ</annotation>
 		<annotation cp="¹" type="tts">સુપરસ્ક્રિપ્ટ એક</annotation>
 		<annotation cp="²">બે | સુપરસ્ક્રિપ્ટ | સ્ક્વેર્ડ</annotation>

--- a/common/annotations/ha.xml
+++ b/common/annotations/ha.xml
@@ -3896,15 +3896,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">alamar bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">alamar bitcoin</annotation>
 		<annotation cp="0⃣">0 | sifili | maɓalli na musamman</annotation>
+		<annotation cp="0⃣" type="tts">maɓalli na musamman: 0</annotation>
 		<annotation cp="1⃣">1 | daya | maɓalli na musamman</annotation>
+		<annotation cp="1⃣" type="tts">maɓalli na musamman: 1</annotation>
 		<annotation cp="2⃣">2 | biyu | maɓalli na musamman</annotation>
+		<annotation cp="2⃣" type="tts">maɓalli na musamman: 2</annotation>
 		<annotation cp="3⃣">3 | uku | maɓalli na musamman</annotation>
+		<annotation cp="3⃣" type="tts">maɓalli na musamman: 3</annotation>
 		<annotation cp="4⃣">4 | hudu | maɓalli na musamman</annotation>
+		<annotation cp="4⃣" type="tts">maɓalli na musamman: 4</annotation>
 		<annotation cp="5⃣">5 | biyar | maɓalli na musamman</annotation>
+		<annotation cp="5⃣" type="tts">maɓalli na musamman: 5</annotation>
 		<annotation cp="6⃣">6 | shida | maɓalli na musamman</annotation>
+		<annotation cp="6⃣" type="tts">maɓalli na musamman: 6</annotation>
 		<annotation cp="7⃣">7 | bakwai | maɓalli na musamman</annotation>
+		<annotation cp="7⃣" type="tts">maɓalli na musamman: 7</annotation>
 		<annotation cp="8⃣">8 | takwas | maɓalli na musamman</annotation>
+		<annotation cp="8⃣" type="tts">maɓalli na musamman: 8</annotation>
 		<annotation cp="9⃣">9 | tara | maɓalli na musamman</annotation>
+		<annotation cp="9⃣" type="tts">maɓalli na musamman: 9</annotation>
 		<annotation cp="¹">ɗaya | ɗaya mai rubutun sama | rubutun sama</annotation>
 		<annotation cp="¹" type="tts">ɗaya mai rubutun sama</annotation>
 		<annotation cp="²">biyu | biyu rubutun sama | mai murabbaʼi | rubutun sama</annotation>

--- a/common/annotations/he.xml
+++ b/common/annotations/he.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | ביטקוין</annotation>
 		<annotation cp="₿" type="tts">ביטקוין</annotation>
 		<annotation cp="0⃣">0 | אפס | מקש</annotation>
+		<annotation cp="0⃣" type="tts">מקש: 0</annotation>
 		<annotation cp="1⃣">1 | אחת | מקש</annotation>
+		<annotation cp="1⃣" type="tts">מקש: 1</annotation>
 		<annotation cp="2⃣">2 | שתיים | מקש</annotation>
+		<annotation cp="2⃣" type="tts">מקש: 2</annotation>
 		<annotation cp="3⃣">3 | שלוש | מקש</annotation>
+		<annotation cp="3⃣" type="tts">מקש: 3</annotation>
 		<annotation cp="4⃣">4 | ארבע | מקש</annotation>
+		<annotation cp="4⃣" type="tts">מקש: 4</annotation>
 		<annotation cp="5⃣">5 | חמש | מקש</annotation>
+		<annotation cp="5⃣" type="tts">מקש: 5</annotation>
 		<annotation cp="6⃣">6 | שש | מקש</annotation>
+		<annotation cp="6⃣" type="tts">מקש: 6</annotation>
 		<annotation cp="7⃣">7 | שבע | מקש</annotation>
+		<annotation cp="7⃣" type="tts">מקש: 7</annotation>
 		<annotation cp="8⃣">8 | שמונה | מקש</annotation>
+		<annotation cp="8⃣" type="tts">מקש: 8</annotation>
 		<annotation cp="9⃣">9 | תשע | מקש</annotation>
+		<annotation cp="9⃣" type="tts">מקש: 9</annotation>
 		<annotation cp="¹">אחת | הספרה אחת בכתב עילי | הערה | כתב עילי | מוקטן</annotation>
 		<annotation cp="¹" type="tts">הספרה אחת בכתב עילי</annotation>
 		<annotation cp="²">בריבוע | הספרה שתיים בכתב עילי | הערה | כתב עילי | מוקטן | שתיים</annotation>

--- a/common/annotations/hi.xml
+++ b/common/annotations/hi.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">बिटकॉइन | बीटीसी</annotation>
 		<annotation cp="₿" type="tts">बिटकॉइन</annotation>
 		<annotation cp="0⃣">0 | शून्य | कीकैप</annotation>
+		<annotation cp="0⃣" type="tts">कीकैप: 0</annotation>
 		<annotation cp="1⃣">1 | एक | कीकैप</annotation>
+		<annotation cp="1⃣" type="tts">कीकैप: 1</annotation>
 		<annotation cp="2⃣">2 | दो | कीकैप</annotation>
+		<annotation cp="2⃣" type="tts">कीकैप: 2</annotation>
 		<annotation cp="3⃣">3 | तीन | कीकैप</annotation>
+		<annotation cp="3⃣" type="tts">कीकैप: 3</annotation>
 		<annotation cp="4⃣">4 | चार | कीकैप</annotation>
+		<annotation cp="4⃣" type="tts">कीकैप: 4</annotation>
 		<annotation cp="5⃣">5 | पाँच | कीकैप</annotation>
+		<annotation cp="5⃣" type="tts">कीकैप: 5</annotation>
 		<annotation cp="6⃣">6 | छह | कीकैप</annotation>
+		<annotation cp="6⃣" type="tts">कीकैप: 6</annotation>
 		<annotation cp="7⃣">7 | सात | कीकैप</annotation>
+		<annotation cp="7⃣" type="tts">कीकैप: 7</annotation>
 		<annotation cp="8⃣">8 | आठ | कीकैप</annotation>
+		<annotation cp="8⃣" type="tts">कीकैप: 8</annotation>
 		<annotation cp="9⃣">9 | नौ | कीकैप</annotation>
+		<annotation cp="9⃣" type="tts">कीकैप: 9</annotation>
 		<annotation cp="¹">एक | सुपरस्क्रिप्ट</annotation>
 		<annotation cp="¹" type="tts">सुपरस्क्रिप्ट एक</annotation>
 		<annotation cp="²">चौकोर | दो | सुपरस्क्रिप्ट</annotation>

--- a/common/annotations/hr.xml
+++ b/common/annotations/hr.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nula | tipka</annotation>
+		<annotation cp="0⃣" type="tts">tipka: 0</annotation>
 		<annotation cp="1⃣">1 | jedan | tipka</annotation>
+		<annotation cp="1⃣" type="tts">tipka: 1</annotation>
 		<annotation cp="2⃣">2 | dva | tipka</annotation>
+		<annotation cp="2⃣" type="tts">tipka: 2</annotation>
 		<annotation cp="3⃣">3 | tri | tipka</annotation>
+		<annotation cp="3⃣" type="tts">tipka: 3</annotation>
 		<annotation cp="4⃣">4 | četiri | tipka</annotation>
+		<annotation cp="4⃣" type="tts">tipka: 4</annotation>
 		<annotation cp="5⃣">5 | pet | tipka</annotation>
+		<annotation cp="5⃣" type="tts">tipka: 5</annotation>
 		<annotation cp="6⃣">6 | šest | tipka</annotation>
+		<annotation cp="6⃣" type="tts">tipka: 6</annotation>
 		<annotation cp="7⃣">7 | sedam | tipka</annotation>
+		<annotation cp="7⃣" type="tts">tipka: 7</annotation>
 		<annotation cp="8⃣">8 | osam | tipka</annotation>
+		<annotation cp="8⃣" type="tts">tipka: 8</annotation>
 		<annotation cp="9⃣">9 | devet | tipka</annotation>
+		<annotation cp="9⃣" type="tts">tipka: 9</annotation>
 		<annotation cp="¹">1 | eksponent</annotation>
 		<annotation cp="¹" type="tts">eksponent 1</annotation>
 		<annotation cp="²">2 | eksponent | kvadratni</annotation>

--- a/common/annotations/hsb.xml
+++ b/common/annotations/hsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">symbol za rubl</annotation>
 		<annotation cp="₿">bitcoin | měna | płaćenski srědk | symbol za bitcoin</annotation>
 		<annotation cp="₿" type="tts">symbol za bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">tłóčatko: 0</annotation>
+		<annotation cp="1⃣" type="tts">tłóčatko: 1</annotation>
+		<annotation cp="2⃣" type="tts">tłóčatko: 2</annotation>
+		<annotation cp="3⃣" type="tts">tłóčatko: 3</annotation>
+		<annotation cp="4⃣" type="tts">tłóčatko: 4</annotation>
+		<annotation cp="5⃣" type="tts">tłóčatko: 5</annotation>
+		<annotation cp="6⃣" type="tts">tłóčatko: 6</annotation>
+		<annotation cp="7⃣" type="tts">tłóčatko: 7</annotation>
+		<annotation cp="8⃣" type="tts">tłóčatko: 8</annotation>
+		<annotation cp="9⃣" type="tts">tłóčatko: 9</annotation>
 		<annotation cp="¹">čisło jedyn | jedynka | jedynka jako powyšene znamješko | powyšene znamješko</annotation>
 		<annotation cp="¹" type="tts">jedynka jako powyšene znamješko</annotation>
 		<annotation cp="²">čisło dwaj | dwójka | dwójka jako powyšene znamješko | powyšene znamješko</annotation>

--- a/common/annotations/hu.xml
+++ b/common/annotations/hu.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nulla | gombfej</annotation>
+		<annotation cp="0⃣" type="tts">gombfej: 0</annotation>
 		<annotation cp="1⃣">1 | egy | gombfej</annotation>
+		<annotation cp="1⃣" type="tts">gombfej: 1</annotation>
 		<annotation cp="2⃣">2 | kettő | gombfej</annotation>
+		<annotation cp="2⃣" type="tts">gombfej: 2</annotation>
 		<annotation cp="3⃣">3 | három | gombfej</annotation>
+		<annotation cp="3⃣" type="tts">gombfej: 3</annotation>
 		<annotation cp="4⃣">4 | négy | gombfej</annotation>
+		<annotation cp="4⃣" type="tts">gombfej: 4</annotation>
 		<annotation cp="5⃣">5 | öt | gombfej</annotation>
+		<annotation cp="5⃣" type="tts">gombfej: 5</annotation>
 		<annotation cp="6⃣">6 | hat | gombfej</annotation>
+		<annotation cp="6⃣" type="tts">gombfej: 6</annotation>
 		<annotation cp="7⃣">7 | hét | gombfej</annotation>
+		<annotation cp="7⃣" type="tts">gombfej: 7</annotation>
 		<annotation cp="8⃣">8 | nyolc | gombfej</annotation>
+		<annotation cp="8⃣" type="tts">gombfej: 8</annotation>
 		<annotation cp="9⃣">9 | kilenc | gombfej</annotation>
+		<annotation cp="9⃣" type="tts">gombfej: 9</annotation>
 		<annotation cp="¹">egyes | egyes felső index | felső index</annotation>
 		<annotation cp="¹" type="tts">egyes felső index</annotation>
 		<annotation cp="²">felső index | kettes | kettes felső index | négyzeten</annotation>

--- a/common/annotations/hy.xml
+++ b/common/annotations/hy.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">բիթկոին</annotation>
 		<annotation cp="₿" type="tts">բիթկոին</annotation>
 		<annotation cp="0⃣">0 | զրո | ստեղն</annotation>
+		<annotation cp="0⃣" type="tts">ստեղն․ 0</annotation>
 		<annotation cp="1⃣">1 | մեկ | ստեղն</annotation>
+		<annotation cp="1⃣" type="tts">ստեղն․ 1</annotation>
 		<annotation cp="2⃣">2 | երկու | ստեղն</annotation>
+		<annotation cp="2⃣" type="tts">ստեղն․ 2</annotation>
 		<annotation cp="3⃣">3 | երեք | ստեղն</annotation>
+		<annotation cp="3⃣" type="tts">ստեղն․ 3</annotation>
 		<annotation cp="4⃣">4 | չորս | ստեղն</annotation>
+		<annotation cp="4⃣" type="tts">ստեղն․ 4</annotation>
 		<annotation cp="5⃣">5 | հինգ | ստեղն</annotation>
+		<annotation cp="5⃣" type="tts">ստեղն․ 5</annotation>
 		<annotation cp="6⃣">6 | վեց | ստեղն</annotation>
+		<annotation cp="6⃣" type="tts">ստեղն․ 6</annotation>
 		<annotation cp="7⃣">7 | յոթ | ստեղն</annotation>
+		<annotation cp="7⃣" type="tts">ստեղն․ 7</annotation>
 		<annotation cp="8⃣">8 | ութ | ստեղն</annotation>
+		<annotation cp="8⃣" type="tts">ստեղն․ 8</annotation>
 		<annotation cp="9⃣">9 | ինը | ստեղն</annotation>
+		<annotation cp="9⃣" type="tts">ստեղն․ 9</annotation>
 		<annotation cp="¹">մեկ | վերգիր</annotation>
 		<annotation cp="¹" type="tts">վերգիր մեկ</annotation>
 		<annotation cp="²">երկու | վերգիր | քառակուսի</annotation>

--- a/common/annotations/ia.xml
+++ b/common/annotations/ia.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -161,5 +161,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🏳‍🌈" type="tts">bandiera iride</annotation>
 		<annotation cp="🏴‍☠">bandiera de pirata | cranio | ossos | piliage | pirata | tresor</annotation>
 		<annotation cp="🏴‍☠" type="tts">bandiera de pirata</annotation>
+		<annotation cp="0⃣" type="tts">clave: 0</annotation>
+		<annotation cp="1⃣" type="tts">clave: 1</annotation>
+		<annotation cp="2⃣" type="tts">clave: 2</annotation>
+		<annotation cp="3⃣" type="tts">clave: 3</annotation>
+		<annotation cp="4⃣" type="tts">clave: 4</annotation>
+		<annotation cp="5⃣" type="tts">clave: 5</annotation>
+		<annotation cp="6⃣" type="tts">clave: 6</annotation>
+		<annotation cp="7⃣" type="tts">clave: 7</annotation>
+		<annotation cp="8⃣" type="tts">clave: 8</annotation>
+		<annotation cp="9⃣" type="tts">clave: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/is.xml
+++ b/common/annotations/is.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | núll | takki</annotation>
+		<annotation cp="0⃣" type="tts">takki: 0</annotation>
 		<annotation cp="1⃣">1 | einn | takki</annotation>
+		<annotation cp="1⃣" type="tts">takki: 1</annotation>
 		<annotation cp="2⃣">2 | tveir | takki</annotation>
+		<annotation cp="2⃣" type="tts">takki: 2</annotation>
 		<annotation cp="3⃣">3 | þrír | takki</annotation>
+		<annotation cp="3⃣" type="tts">takki: 3</annotation>
 		<annotation cp="4⃣">4 | fjórir | takki</annotation>
+		<annotation cp="4⃣" type="tts">takki: 4</annotation>
 		<annotation cp="5⃣">5 | fimm | takki</annotation>
+		<annotation cp="5⃣" type="tts">takki: 5</annotation>
 		<annotation cp="6⃣">6 | sex | takki</annotation>
+		<annotation cp="6⃣" type="tts">takki: 6</annotation>
 		<annotation cp="7⃣">7 | sjó | takki</annotation>
+		<annotation cp="7⃣" type="tts">takki: 7</annotation>
 		<annotation cp="8⃣">8 | átta | takki</annotation>
+		<annotation cp="8⃣" type="tts">takki: 8</annotation>
 		<annotation cp="9⃣">9 | níu | takki</annotation>
+		<annotation cp="9⃣" type="tts">takki: 9</annotation>
 		<annotation cp="¹">brjóstletur | einn</annotation>
 		<annotation cp="¹" type="tts">brjóstletur einn</annotation>
 		<annotation cp="²">brjóstletur | í öðru veldi | tveir</annotation>

--- a/common/annotations/it.xml
+++ b/common/annotations/it.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | tasto</annotation>
+		<annotation cp="0⃣" type="tts">tasto: 0</annotation>
 		<annotation cp="1⃣">1 | uno | tasto</annotation>
+		<annotation cp="1⃣" type="tts">tasto: 1</annotation>
 		<annotation cp="2⃣">2 | due | tasto</annotation>
+		<annotation cp="2⃣" type="tts">tasto: 2</annotation>
 		<annotation cp="3⃣">3 | tre | tasto</annotation>
+		<annotation cp="3⃣" type="tts">tasto: 3</annotation>
 		<annotation cp="4⃣">4 | quattro | tasto</annotation>
+		<annotation cp="4⃣" type="tts">tasto: 4</annotation>
 		<annotation cp="5⃣">5 | cinque | tasto</annotation>
+		<annotation cp="5⃣" type="tts">tasto: 5</annotation>
 		<annotation cp="6⃣">6 | sei | tasto</annotation>
+		<annotation cp="6⃣" type="tts">tasto: 6</annotation>
 		<annotation cp="7⃣">7 | sette | tasto</annotation>
+		<annotation cp="7⃣" type="tts">tasto: 7</annotation>
 		<annotation cp="8⃣">8 | otto | tasto</annotation>
+		<annotation cp="8⃣" type="tts">tasto: 8</annotation>
 		<annotation cp="9⃣">9 | nove | tasto</annotation>
+		<annotation cp="9⃣" type="tts">tasto: 9</annotation>
 		<annotation cp="¹">apice | numero uno in apice | uno</annotation>
 		<annotation cp="¹" type="tts">numero uno in apice</annotation>
 		<annotation cp="²">apice | due | numero due in apice | valore al quadrato</annotation>

--- a/common/annotations/ja.xml
+++ b/common/annotations/ja.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | ビットコイン | 仮想通貨 | 通貨</annotation>
 		<annotation cp="₿" type="tts">ビットコイン</annotation>
 		<annotation cp="0⃣">0 | 〇 | 囲み数字</annotation>
+		<annotation cp="0⃣" type="tts">囲み数字: 0</annotation>
 		<annotation cp="1⃣">1 | 一 | 囲み数字</annotation>
+		<annotation cp="1⃣" type="tts">囲み数字: 1</annotation>
 		<annotation cp="2⃣">2 | 二 | 囲み数字</annotation>
+		<annotation cp="2⃣" type="tts">囲み数字: 2</annotation>
 		<annotation cp="3⃣">3 | 三 | 囲み数字</annotation>
+		<annotation cp="3⃣" type="tts">囲み数字: 3</annotation>
 		<annotation cp="4⃣">4 | 四 | 囲み数字</annotation>
+		<annotation cp="4⃣" type="tts">囲み数字: 4</annotation>
 		<annotation cp="5⃣">5 | 五 | 囲み数字</annotation>
+		<annotation cp="5⃣" type="tts">囲み数字: 5</annotation>
 		<annotation cp="6⃣">6 | 六 | 囲み数字</annotation>
+		<annotation cp="6⃣" type="tts">囲み数字: 6</annotation>
 		<annotation cp="7⃣">7 | 七 | 囲み数字</annotation>
+		<annotation cp="7⃣" type="tts">囲み数字: 7</annotation>
 		<annotation cp="8⃣">8 | 八 | 囲み数字</annotation>
+		<annotation cp="8⃣" type="tts">囲み数字: 8</annotation>
 		<annotation cp="9⃣">9 | 九 | 囲み数字</annotation>
+		<annotation cp="9⃣" type="tts">囲み数字: 9</annotation>
 		<annotation cp="¹">1 | 上付き1 | 添え字</annotation>
 		<annotation cp="¹" type="tts">上付き1</annotation>
 		<annotation cp="²">2 | 2乗 | 上付き2 | 添え字</annotation>

--- a/common/annotations/ka.xml
+++ b/common/annotations/ka.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | ბიტკოინი | კრიპტოვალუტა</annotation>
 		<annotation cp="₿" type="tts">ბიტკოინი</annotation>
 		<annotation cp="0⃣">0 | ნული | კლავიში</annotation>
+		<annotation cp="0⃣" type="tts">კლავიში: 0</annotation>
 		<annotation cp="1⃣">1 | ერთი | კლავიში</annotation>
+		<annotation cp="1⃣" type="tts">კლავიში: 1</annotation>
 		<annotation cp="2⃣">2 | ორი | კლავიში</annotation>
+		<annotation cp="2⃣" type="tts">კლავიში: 2</annotation>
 		<annotation cp="3⃣">3 | სამი | კლავიში</annotation>
+		<annotation cp="3⃣" type="tts">კლავიში: 3</annotation>
 		<annotation cp="4⃣">4 | ოთხი | კლავიში</annotation>
+		<annotation cp="4⃣" type="tts">კლავიში: 4</annotation>
 		<annotation cp="5⃣">5 | ხუთი | კლავიში</annotation>
+		<annotation cp="5⃣" type="tts">კლავიში: 5</annotation>
 		<annotation cp="6⃣">6 | ექვსი | კლავიში</annotation>
+		<annotation cp="6⃣" type="tts">კლავიში: 6</annotation>
 		<annotation cp="7⃣">7 | შვიდი | კლავიში</annotation>
+		<annotation cp="7⃣" type="tts">კლავიში: 7</annotation>
 		<annotation cp="8⃣">8 | რვა | კლავიში</annotation>
+		<annotation cp="8⃣" type="tts">კლავიში: 8</annotation>
 		<annotation cp="9⃣">9 | ცხრა | კლავიში</annotation>
+		<annotation cp="9⃣" type="tts">კლავიში: 9</annotation>
 		<annotation cp="¹">ერთი | ერთიანი ზედა ინდექსში | ზედა ინდექსი</annotation>
 		<annotation cp="¹" type="tts">ერთიანი ზედა ინდექსში</annotation>
 		<annotation cp="²">ზედა ინდექსი | კვადრატული | ორი | ორიანი ზედა ინდექსში</annotation>

--- a/common/annotations/kk.xml
+++ b/common/annotations/kk.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | биткоин</annotation>
 		<annotation cp="₿" type="tts">биткоин</annotation>
 		<annotation cp="0⃣">0 | нөл | перне</annotation>
+		<annotation cp="0⃣" type="tts">перне: 0</annotation>
 		<annotation cp="1⃣">1 | бір | перне</annotation>
+		<annotation cp="1⃣" type="tts">перне: 1</annotation>
 		<annotation cp="2⃣">2 | екі | перне</annotation>
+		<annotation cp="2⃣" type="tts">перне: 2</annotation>
 		<annotation cp="3⃣">3 | үш | перне</annotation>
+		<annotation cp="3⃣" type="tts">перне: 3</annotation>
 		<annotation cp="4⃣">4 | төрт | перне</annotation>
+		<annotation cp="4⃣" type="tts">перне: 4</annotation>
 		<annotation cp="5⃣">5 | бес | перне</annotation>
+		<annotation cp="5⃣" type="tts">перне: 5</annotation>
 		<annotation cp="6⃣">6 | алты | перне</annotation>
+		<annotation cp="6⃣" type="tts">перне: 6</annotation>
 		<annotation cp="7⃣">7 | жеті | перне</annotation>
+		<annotation cp="7⃣" type="tts">перне: 7</annotation>
 		<annotation cp="8⃣">8 | сегіз | перне</annotation>
+		<annotation cp="8⃣" type="tts">перне: 8</annotation>
 		<annotation cp="9⃣">9 | тоғыз | перне</annotation>
+		<annotation cp="9⃣" type="tts">перне: 9</annotation>
 		<annotation cp="¹">бір | үстіңгі бір индексі | үстіңгі индекс</annotation>
 		<annotation cp="¹" type="tts">үстіңгі бір индексі</annotation>
 		<annotation cp="²">екі | квадрат | үстіңгі екі индексі | үстіңгі индекс</annotation>

--- a/common/annotations/kk_Arab.xml
+++ b/common/annotations/kk_Arab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3896,6 +3896,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts" draft="unconfirmed">ءرۋبىل</annotation>
 		<annotation cp="₿" draft="unconfirmed">بيتكوين</annotation>
 		<annotation cp="₿" type="tts" draft="unconfirmed">بيتكوين</annotation>
+		<annotation cp="0⃣" type="tts">پەرنە: 0</annotation>
+		<annotation cp="1⃣" type="tts">پەرنە: 1</annotation>
+		<annotation cp="2⃣" type="tts">پەرنە: 2</annotation>
+		<annotation cp="3⃣" type="tts">پەرنە: 3</annotation>
+		<annotation cp="4⃣" type="tts">پەرنە: 4</annotation>
+		<annotation cp="5⃣" type="tts">پەرنە: 5</annotation>
+		<annotation cp="6⃣" type="tts">پەرنە: 6</annotation>
+		<annotation cp="7⃣" type="tts">پەرنە: 7</annotation>
+		<annotation cp="8⃣" type="tts">پەرنە: 8</annotation>
+		<annotation cp="9⃣" type="tts">پەرنە: 9</annotation>
 		<annotation cp="¹" draft="unconfirmed">ءبىر | ۇستىڭگى ءبىر يندەكسى | ۇستىڭگى يندەكس</annotation>
 		<annotation cp="¹" type="tts" draft="unconfirmed">ۇستىڭگى ءبىر يندەكسى</annotation>
 		<annotation cp="²" draft="unconfirmed">كۆادرات | ەكى | ۇستىڭگى ەكى يندەكسى | ۇستىڭگى يندەكس</annotation>

--- a/common/annotations/km.xml
+++ b/common/annotations/km.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">ប៊ីតខញ | សញ្ញាប៊ីតខញ</annotation>
 		<annotation cp="₿" type="tts">ប៊ីតខញ</annotation>
 		<annotation cp="0⃣">0 | សូន្យ | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="0⃣" type="tts">គម្របគ្រាប់ចុច: 0</annotation>
 		<annotation cp="1⃣">1 | មួយ | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="1⃣" type="tts">គម្របគ្រាប់ចុច: 1</annotation>
 		<annotation cp="2⃣">2 | ពីរ | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="2⃣" type="tts">គម្របគ្រាប់ចុច: 2</annotation>
 		<annotation cp="3⃣">3 | បី | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="3⃣" type="tts">គម្របគ្រាប់ចុច: 3</annotation>
 		<annotation cp="4⃣">4 | បួន | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="4⃣" type="tts">គម្របគ្រាប់ចុច: 4</annotation>
 		<annotation cp="5⃣">5 | ប្រាំ | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="5⃣" type="tts">គម្របគ្រាប់ចុច: 5</annotation>
 		<annotation cp="6⃣">6 | ប្រាំមួយ | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="6⃣" type="tts">គម្របគ្រាប់ចុច: 6</annotation>
 		<annotation cp="7⃣">7 | ប្រាំពីរ | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="7⃣" type="tts">គម្របគ្រាប់ចុច: 7</annotation>
 		<annotation cp="8⃣">8 | ប្រាំបី | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="8⃣" type="tts">គម្របគ្រាប់ចុច: 8</annotation>
 		<annotation cp="9⃣">9 | ប្រាំបួន | គម្របគ្រាប់ចុច</annotation>
+		<annotation cp="9⃣" type="tts">គម្របគ្រាប់ចុច: 9</annotation>
 		<annotation cp="¹">តូចនៅលើ | លេខមួយ | លេខមួយតូចនៅលើ</annotation>
 		<annotation cp="¹" type="tts">លេខមួយតូចនៅលើ</annotation>
 		<annotation cp="²">ការ៉េ | តូចនៅលើ | លេខពីរ | លេខពីរតូចនៅលើ</annotation>

--- a/common/annotations/kn.xml
+++ b/common/annotations/kn.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">ಬಿಟಿಸಿ | ಬಿಟ್‌ಕಾಯಿನ್‌</annotation>
 		<annotation cp="₿" type="tts">ಬಿಟ್‌ಕಾಯಿನ್‌</annotation>
 		<annotation cp="0⃣">0 | ಶೂನ್ಯ | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="0⃣" type="tts">ಕೀಕ್ಯಾಪ್: 0</annotation>
 		<annotation cp="1⃣">1 | ಒಂದು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="1⃣" type="tts">ಕೀಕ್ಯಾಪ್: 1</annotation>
 		<annotation cp="2⃣">2 | ಎರಡು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="2⃣" type="tts">ಕೀಕ್ಯಾಪ್: 2</annotation>
 		<annotation cp="3⃣">3 | ಮೂರು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="3⃣" type="tts">ಕೀಕ್ಯಾಪ್: 3</annotation>
 		<annotation cp="4⃣">4 | ನಾಲ್ಕು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="4⃣" type="tts">ಕೀಕ್ಯಾಪ್: 4</annotation>
 		<annotation cp="5⃣">5 | ಐದು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="5⃣" type="tts">ಕೀಕ್ಯಾಪ್: 5</annotation>
 		<annotation cp="6⃣">6 | ಆರು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="6⃣" type="tts">ಕೀಕ್ಯಾಪ್: 6</annotation>
 		<annotation cp="7⃣">7 | ಏಳು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="7⃣" type="tts">ಕೀಕ್ಯಾಪ್: 7</annotation>
 		<annotation cp="8⃣">8 | ಎಂಟು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="8⃣" type="tts">ಕೀಕ್ಯಾಪ್: 8</annotation>
 		<annotation cp="9⃣">9 | ಒಂಭತ್ತು | ಕೀಕ್ಯಾಪ್</annotation>
+		<annotation cp="9⃣" type="tts">ಕೀಕ್ಯಾಪ್: 9</annotation>
 		<annotation cp="¹">ಒಂದು | ಘಾತ</annotation>
 		<annotation cp="¹" type="tts">ಘಾತ ಒಂದು</annotation>
 		<annotation cp="²">ಎರಡು | ಘಾತ | ವರ್ಗ</annotation>

--- a/common/annotations/ko.xml
+++ b/common/annotations/ko.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | 비트코인</annotation>
 		<annotation cp="₿" type="tts">비트코인</annotation>
 		<annotation cp="0⃣">0 | 공 | 키 캡</annotation>
+		<annotation cp="0⃣" type="tts">키 캡: 0</annotation>
 		<annotation cp="1⃣">1 | 일 | 키 캡</annotation>
+		<annotation cp="1⃣" type="tts">키 캡: 1</annotation>
 		<annotation cp="2⃣">2 | 이 | 키 캡</annotation>
+		<annotation cp="2⃣" type="tts">키 캡: 2</annotation>
 		<annotation cp="3⃣">3 | 삼 | 키 캡</annotation>
+		<annotation cp="3⃣" type="tts">키 캡: 3</annotation>
 		<annotation cp="4⃣">4 | 사 | 키 캡</annotation>
+		<annotation cp="4⃣" type="tts">키 캡: 4</annotation>
 		<annotation cp="5⃣">5 | 오 | 키 캡</annotation>
+		<annotation cp="5⃣" type="tts">키 캡: 5</annotation>
 		<annotation cp="6⃣">6 | 육 | 키 캡</annotation>
+		<annotation cp="6⃣" type="tts">키 캡: 6</annotation>
 		<annotation cp="7⃣">7 | 칠 | 키 캡</annotation>
+		<annotation cp="7⃣" type="tts">키 캡: 7</annotation>
 		<annotation cp="8⃣">8 | 팔 | 키 캡</annotation>
+		<annotation cp="8⃣" type="tts">키 캡: 8</annotation>
 		<annotation cp="9⃣">9 | 구 | 키 캡</annotation>
+		<annotation cp="9⃣" type="tts">키 캡: 9</annotation>
 		<annotation cp="¹">1 | 1승 | 승</annotation>
 		<annotation cp="¹" type="tts">1승</annotation>
 		<annotation cp="²">2 | 2승 | 승 | 제곱</annotation>

--- a/common/annotations/kok.xml
+++ b/common/annotations/kok.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">रुबल (रशियेचें नाणे)</annotation>
 		<annotation cp="₿">बिटकॉयन</annotation>
 		<annotation cp="₿" type="tts">बिटकॉयन</annotation>
+		<annotation cp="0⃣" type="tts">कीकॅप: 0</annotation>
+		<annotation cp="1⃣" type="tts">कीकॅप: 1</annotation>
+		<annotation cp="2⃣" type="tts">कीकॅप: 2</annotation>
+		<annotation cp="3⃣" type="tts">कीकॅप: 3</annotation>
+		<annotation cp="4⃣" type="tts">कीकॅप: 4</annotation>
+		<annotation cp="5⃣" type="tts">कीकॅप: 5</annotation>
+		<annotation cp="6⃣" type="tts">कीकॅप: 6</annotation>
+		<annotation cp="7⃣" type="tts">कीकॅप: 7</annotation>
+		<annotation cp="8⃣" type="tts">कीकॅप: 8</annotation>
+		<annotation cp="9⃣" type="tts">कीकॅप: 9</annotation>
 		<annotation cp="¹">एक | सुपरस्क्रिप्ट</annotation>
 		<annotation cp="¹" type="tts">सुपरस्क्रिप्ट एक</annotation>
 		<annotation cp="²">दोन | समकोनी | सुपरस्क्रिप्ट</annotation>

--- a/common/annotations/ky.xml
+++ b/common/annotations/ky.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | биткоин</annotation>
 		<annotation cp="₿" type="tts">биткоин</annotation>
 		<annotation cp="0⃣">0 | нөл | клавиатура калпакчасы</annotation>
+		<annotation cp="0⃣" type="tts">клавиатура калпакчасы: 0</annotation>
 		<annotation cp="1⃣">1 | бир | клавиатура калпакчасы</annotation>
+		<annotation cp="1⃣" type="tts">клавиатура калпакчасы: 1</annotation>
 		<annotation cp="2⃣">2 | эки | клавиатура калпакчасы</annotation>
+		<annotation cp="2⃣" type="tts">клавиатура калпакчасы: 2</annotation>
 		<annotation cp="3⃣">3 | үч | клавиатура калпакчасы</annotation>
+		<annotation cp="3⃣" type="tts">клавиатура калпакчасы: 3</annotation>
 		<annotation cp="4⃣">4 | төрт | клавиатура калпакчасы</annotation>
+		<annotation cp="4⃣" type="tts">клавиатура калпакчасы: 4</annotation>
 		<annotation cp="5⃣">5 | беш | клавиатура калпакчасы</annotation>
+		<annotation cp="5⃣" type="tts">клавиатура калпакчасы: 5</annotation>
 		<annotation cp="6⃣">6 | алты | клавиатура калпакчасы</annotation>
+		<annotation cp="6⃣" type="tts">клавиатура калпакчасы: 6</annotation>
 		<annotation cp="7⃣">7 | жети | клавиатура калпакчасы</annotation>
+		<annotation cp="7⃣" type="tts">клавиатура калпакчасы: 7</annotation>
 		<annotation cp="8⃣">8 | сегиз | клавиатура калпакчасы</annotation>
+		<annotation cp="8⃣" type="tts">клавиатура калпакчасы: 8</annotation>
 		<annotation cp="9⃣">9 | тогуз | клавиатура калпакчасы</annotation>
+		<annotation cp="9⃣" type="tts">клавиатура калпакчасы: 9</annotation>
 		<annotation cp="¹">жогоруда бир жазуусу</annotation>
 		<annotation cp="¹" type="tts">жогоруда бир жазуусу</annotation>
 		<annotation cp="²">жогоруда эки жазуусу</annotation>

--- a/common/annotations/lij.xml
+++ b/common/annotations/lij.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3029,6 +3029,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts" draft="unconfirmed">rublo</annotation>
 		<annotation cp="₿" draft="unconfirmed">bitcoin</annotation>
 		<annotation cp="₿" type="tts" draft="unconfirmed">bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">tasto: 0</annotation>
+		<annotation cp="1⃣" type="tts">tasto: 1</annotation>
+		<annotation cp="2⃣" type="tts">tasto: 2</annotation>
+		<annotation cp="3⃣" type="tts">tasto: 3</annotation>
+		<annotation cp="4⃣" type="tts">tasto: 4</annotation>
+		<annotation cp="5⃣" type="tts">tasto: 5</annotation>
+		<annotation cp="6⃣" type="tts">tasto: 6</annotation>
+		<annotation cp="7⃣" type="tts">tasto: 7</annotation>
+		<annotation cp="8⃣" type="tts">tasto: 8</annotation>
+		<annotation cp="9⃣" type="tts">tasto: 9</annotation>
 		<annotation cp="¹" draft="unconfirmed">un in testa</annotation>
 		<annotation cp="¹" type="tts" draft="unconfirmed">un in testa</annotation>
 		<annotation cp="²" draft="unconfirmed">doî in testa</annotation>

--- a/common/annotations/lo.xml
+++ b/common/annotations/lo.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">ບິດຄອຍ</annotation>
 		<annotation cp="₿" type="tts">ບິດຄອຍ</annotation>
 		<annotation cp="0⃣">0 | ศูนย์ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="0⃣" type="tts">ແປ້ນແຄັບ: 0</annotation>
 		<annotation cp="1⃣">1 | ໜຶ່ງ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="1⃣" type="tts">ແປ້ນແຄັບ: 1</annotation>
 		<annotation cp="2⃣">2 | ສອງ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="2⃣" type="tts">ແປ້ນແຄັບ: 2</annotation>
 		<annotation cp="3⃣">3 | ສາມ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="3⃣" type="tts">ແປ້ນແຄັບ: 3</annotation>
 		<annotation cp="4⃣">4 | ສີ່ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="4⃣" type="tts">ແປ້ນແຄັບ: 4</annotation>
 		<annotation cp="5⃣">5 | ຫ້າ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="5⃣" type="tts">ແປ້ນແຄັບ: 5</annotation>
 		<annotation cp="6⃣">6 | ຫົກ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="6⃣" type="tts">ແປ້ນແຄັບ: 6</annotation>
 		<annotation cp="7⃣">7 | ເຈັດ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="7⃣" type="tts">ແປ້ນແຄັບ: 7</annotation>
 		<annotation cp="8⃣">8 | ແປດ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="8⃣" type="tts">ແປ້ນແຄັບ: 8</annotation>
 		<annotation cp="9⃣">9 | ເກົ້າ | ແປ້ນແຄັບ</annotation>
+		<annotation cp="9⃣" type="tts">ແປ້ນແຄັບ: 9</annotation>
 		<annotation cp="¹">ກຳລັງ | ກຳລັງໜຶ່ງ | ໜຶ່ງ</annotation>
 		<annotation cp="¹" type="tts">ກຳລັງໜຶ່ງ</annotation>
 		<annotation cp="²">ກຳລັງ | ກຳລັງສອງ | ສອງ | ຍົກກຳລັງ</annotation>

--- a/common/annotations/lt.xml
+++ b/common/annotations/lt.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitkoino ženklas | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkoino ženklas</annotation>
 		<annotation cp="0⃣">0 | nulis | mygtukas</annotation>
+		<annotation cp="0⃣" type="tts">mygtukas: 0</annotation>
 		<annotation cp="1⃣">1 | vienas | mygtukas</annotation>
+		<annotation cp="1⃣" type="tts">mygtukas: 1</annotation>
 		<annotation cp="2⃣">2 | du | mygtukas</annotation>
+		<annotation cp="2⃣" type="tts">mygtukas: 2</annotation>
 		<annotation cp="3⃣">3 | trys | mygtukas</annotation>
+		<annotation cp="3⃣" type="tts">mygtukas: 3</annotation>
 		<annotation cp="4⃣">4 | keturi | mygtukas</annotation>
+		<annotation cp="4⃣" type="tts">mygtukas: 4</annotation>
 		<annotation cp="5⃣">5 | penki | mygtukas</annotation>
+		<annotation cp="5⃣" type="tts">mygtukas: 5</annotation>
 		<annotation cp="6⃣">6 | šeši | mygtukas</annotation>
+		<annotation cp="6⃣" type="tts">mygtukas: 6</annotation>
 		<annotation cp="7⃣">7 | septyni | mygtukas</annotation>
+		<annotation cp="7⃣" type="tts">mygtukas: 7</annotation>
 		<annotation cp="8⃣">8 | aštuoni | mygtukas</annotation>
+		<annotation cp="8⃣" type="tts">mygtukas: 8</annotation>
 		<annotation cp="9⃣">9 | devyni | mygtukas</annotation>
+		<annotation cp="9⃣" type="tts">mygtukas: 9</annotation>
 		<annotation cp="¹">vienetas | vienetas viršutiniame indekse | viršutinis indeksas</annotation>
 		<annotation cp="¹" type="tts">vienetas viršutiniame indekse</annotation>
 		<annotation cp="²">du | dvejetas | dvejetas viršutiniame indekse | kvadratu | viršutinis indeksas</annotation>

--- a/common/annotations/lv.xml
+++ b/common/annotations/lv.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitmonēta | BTC</annotation>
 		<annotation cp="₿" type="tts">bitmonēta</annotation>
 		<annotation cp="0⃣">0 | nulle | taustiņš</annotation>
+		<annotation cp="0⃣" type="tts">taustiņš: 0</annotation>
 		<annotation cp="1⃣">1 | viens | taustiņš</annotation>
+		<annotation cp="1⃣" type="tts">taustiņš: 1</annotation>
 		<annotation cp="2⃣">2 | divi | taustiņš</annotation>
+		<annotation cp="2⃣" type="tts">taustiņš: 2</annotation>
 		<annotation cp="3⃣">3 | trīs | taustiņš</annotation>
+		<annotation cp="3⃣" type="tts">taustiņš: 3</annotation>
 		<annotation cp="4⃣">4 | četri | taustiņš</annotation>
+		<annotation cp="4⃣" type="tts">taustiņš: 4</annotation>
 		<annotation cp="5⃣">5 | pieci | taustiņš</annotation>
+		<annotation cp="5⃣" type="tts">taustiņš: 5</annotation>
 		<annotation cp="6⃣">6 | seši | taustiņš</annotation>
+		<annotation cp="6⃣" type="tts">taustiņš: 6</annotation>
 		<annotation cp="7⃣">7 | septiņi | taustiņš</annotation>
+		<annotation cp="7⃣" type="tts">taustiņš: 7</annotation>
 		<annotation cp="8⃣">8 | astoņi | taustiņš</annotation>
+		<annotation cp="8⃣" type="tts">taustiņš: 8</annotation>
 		<annotation cp="9⃣">9 | deviņi | taustiņš</annotation>
+		<annotation cp="9⃣" type="tts">taustiņš: 9</annotation>
 		<annotation cp="¹">augšraksts | viens | viens augšrakstā</annotation>
 		<annotation cp="¹" type="tts">viens augšrakstā</annotation>
 		<annotation cp="²">augšraksts | divi | divi augšrakstā | kvadrātā</annotation>

--- a/common/annotations/mi.xml
+++ b/common/annotations/mi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2543,5 +2543,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🏳" type="tts">kara mā</annotation>
 		<annotation cp="🏳‍🌈">kahukura | kara kahukura</annotation>
 		<annotation cp="🏳‍🌈" type="tts">kara kahukura</annotation>
+		<annotation cp="0⃣" type="tts">uhi pātuhi: 0</annotation>
+		<annotation cp="1⃣" type="tts">uhi pātuhi: 1</annotation>
+		<annotation cp="2⃣" type="tts">uhi pātuhi: 2</annotation>
+		<annotation cp="3⃣" type="tts">uhi pātuhi: 3</annotation>
+		<annotation cp="4⃣" type="tts">uhi pātuhi: 4</annotation>
+		<annotation cp="5⃣" type="tts">uhi pātuhi: 5</annotation>
+		<annotation cp="6⃣" type="tts">uhi pātuhi: 6</annotation>
+		<annotation cp="7⃣" type="tts">uhi pātuhi: 7</annotation>
+		<annotation cp="8⃣" type="tts">uhi pātuhi: 8</annotation>
+		<annotation cp="9⃣" type="tts">uhi pātuhi: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/mk.xml
+++ b/common/annotations/mk.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">[BTC] | биткоин</annotation>
 		<annotation cp="₿" type="tts">биткоин</annotation>
 		<annotation cp="0⃣">0 | нула | копче</annotation>
+		<annotation cp="0⃣" type="tts">копче: 0</annotation>
 		<annotation cp="1⃣">1 | еден | копче</annotation>
+		<annotation cp="1⃣" type="tts">копче: 1</annotation>
 		<annotation cp="2⃣">2 | два | копче</annotation>
+		<annotation cp="2⃣" type="tts">копче: 2</annotation>
 		<annotation cp="3⃣">3 | три | копче</annotation>
+		<annotation cp="3⃣" type="tts">копче: 3</annotation>
 		<annotation cp="4⃣">4 | четири | копче</annotation>
+		<annotation cp="4⃣" type="tts">копче: 4</annotation>
 		<annotation cp="5⃣">5 | пет | копче</annotation>
+		<annotation cp="5⃣" type="tts">копче: 5</annotation>
 		<annotation cp="6⃣">6 | шест | копче</annotation>
+		<annotation cp="6⃣" type="tts">копче: 6</annotation>
 		<annotation cp="7⃣">7 | седум | копче</annotation>
+		<annotation cp="7⃣" type="tts">копче: 7</annotation>
 		<annotation cp="8⃣">8 | осум | копче</annotation>
+		<annotation cp="8⃣" type="tts">копче: 8</annotation>
 		<annotation cp="9⃣">9 | девет | копче</annotation>
+		<annotation cp="9⃣" type="tts">копче: 9</annotation>
 		<annotation cp="¹">1 | експонент</annotation>
 		<annotation cp="¹" type="tts">експонент 1</annotation>
 		<annotation cp="²">2 | експонент | квадратни</annotation>

--- a/common/annotations/ml.xml
+++ b/common/annotations/ml.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">ബിറ്റ്‌കോയിൻ</annotation>
 		<annotation cp="₿" type="tts">ബിറ്റ്‌കോയിൻ</annotation>
 		<annotation cp="0⃣">0 | പൂജ്യം | കീക്യാപ്പ്</annotation>
+		<annotation cp="0⃣" type="tts">കീക്യാപ്പ്: 0</annotation>
 		<annotation cp="1⃣">1 | ഒന്ന് | കീക്യാപ്പ്</annotation>
+		<annotation cp="1⃣" type="tts">കീക്യാപ്പ്: 1</annotation>
 		<annotation cp="2⃣">2 | രണ്ട് | കീക്യാപ്പ്</annotation>
+		<annotation cp="2⃣" type="tts">കീക്യാപ്പ്: 2</annotation>
 		<annotation cp="3⃣">3 | മൂന്ന് | കീക്യാപ്പ്</annotation>
+		<annotation cp="3⃣" type="tts">കീക്യാപ്പ്: 3</annotation>
 		<annotation cp="4⃣">4 | നാല് | കീക്യാപ്പ്</annotation>
+		<annotation cp="4⃣" type="tts">കീക്യാപ്പ്: 4</annotation>
 		<annotation cp="5⃣">5 | അഞ്ച് | കീക്യാപ്പ്</annotation>
+		<annotation cp="5⃣" type="tts">കീക്യാപ്പ്: 5</annotation>
 		<annotation cp="6⃣">6 | ആറ് | കീക്യാപ്പ്</annotation>
+		<annotation cp="6⃣" type="tts">കീക്യാപ്പ്: 6</annotation>
 		<annotation cp="7⃣">7 | ഏഴ് | കീക്യാപ്പ്</annotation>
+		<annotation cp="7⃣" type="tts">കീക്യാപ്പ്: 7</annotation>
 		<annotation cp="8⃣">8 | എട്ട് | കീക്യാപ്പ്</annotation>
+		<annotation cp="8⃣" type="tts">കീക്യാപ്പ്: 8</annotation>
 		<annotation cp="9⃣">9 | ഒമ്പത് | കീക്യാപ്പ്</annotation>
+		<annotation cp="9⃣" type="tts">കീക്യാപ്പ്: 9</annotation>
 		<annotation cp="¹">ഒന്ന് | സൂപ്പർസ്ക്രിപ്റ്റ്</annotation>
 		<annotation cp="¹" type="tts">സൂപ്പർസ്ക്രിപ്റ്റ് ഒന്ന്</annotation>
 		<annotation cp="²">രണ്ട് | വർഗ്ഗമൂലം | സൂപ്പർസ്ക്രിപ്റ്റ്</annotation>

--- a/common/annotations/mn.xml
+++ b/common/annotations/mn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">рубль</annotation>
 		<annotation cp="₿">BTC | биткойн</annotation>
 		<annotation cp="₿" type="tts">биткойн</annotation>
+		<annotation cp="0⃣" type="tts">түлхүүрийн гэр: 0</annotation>
+		<annotation cp="1⃣" type="tts">түлхүүрийн гэр: 1</annotation>
+		<annotation cp="2⃣" type="tts">түлхүүрийн гэр: 2</annotation>
+		<annotation cp="3⃣" type="tts">түлхүүрийн гэр: 3</annotation>
+		<annotation cp="4⃣" type="tts">түлхүүрийн гэр: 4</annotation>
+		<annotation cp="5⃣" type="tts">түлхүүрийн гэр: 5</annotation>
+		<annotation cp="6⃣" type="tts">түлхүүрийн гэр: 6</annotation>
+		<annotation cp="7⃣" type="tts">түлхүүрийн гэр: 7</annotation>
+		<annotation cp="8⃣" type="tts">түлхүүрийн гэр: 8</annotation>
+		<annotation cp="9⃣" type="tts">түлхүүрийн гэр: 9</annotation>
 		<annotation cp="¹">зэрэг | нэг | нэгийн зэрэг</annotation>
 		<annotation cp="¹" type="tts">нэгийн зэрэг</annotation>
 		<annotation cp="²">квадрат | хоёрын зэрэг</annotation>

--- a/common/annotations/mr.xml
+++ b/common/annotations/mr.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | बिटकॉईन</annotation>
 		<annotation cp="₿" type="tts">बिटकॉईन</annotation>
 		<annotation cp="0⃣">0 | शून्य | कीकॅप</annotation>
+		<annotation cp="0⃣" type="tts">कीकॅप: 0</annotation>
 		<annotation cp="1⃣">1 | एक | कीकॅप</annotation>
+		<annotation cp="1⃣" type="tts">कीकॅप: 1</annotation>
 		<annotation cp="2⃣">2 | दोन | कीकॅप</annotation>
+		<annotation cp="2⃣" type="tts">कीकॅप: 2</annotation>
 		<annotation cp="3⃣">3 | तीन | कीकॅप</annotation>
+		<annotation cp="3⃣" type="tts">कीकॅप: 3</annotation>
 		<annotation cp="4⃣">4 | चार | कीकॅप</annotation>
+		<annotation cp="4⃣" type="tts">कीकॅप: 4</annotation>
 		<annotation cp="5⃣">5 | पाच | कीकॅप</annotation>
+		<annotation cp="5⃣" type="tts">कीकॅप: 5</annotation>
 		<annotation cp="6⃣">6 | सहा | कीकॅप</annotation>
+		<annotation cp="6⃣" type="tts">कीकॅप: 6</annotation>
 		<annotation cp="7⃣">7 | सात | कीकॅप</annotation>
+		<annotation cp="7⃣" type="tts">कीकॅप: 7</annotation>
 		<annotation cp="8⃣">8 | आठ | कीकॅप</annotation>
+		<annotation cp="8⃣" type="tts">कीकॅप: 8</annotation>
 		<annotation cp="9⃣">9 | नऊ | कीकॅप</annotation>
+		<annotation cp="9⃣" type="tts">कीकॅप: 9</annotation>
 		<annotation cp="¹">एक | सुपरस्क्रिप्ट</annotation>
 		<annotation cp="¹" type="tts">सुपरस्क्रिप्ट एक</annotation>
 		<annotation cp="²">दोन | वर्ग | सुपरस्क्रिप्ट</annotation>

--- a/common/annotations/ms.xml
+++ b/common/annotations/ms.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | kosong | butang kekunci</annotation>
+		<annotation cp="0⃣" type="tts">butang kekunci: 0</annotation>
 		<annotation cp="1⃣">1 | satu | butang kekunci</annotation>
+		<annotation cp="1⃣" type="tts">butang kekunci: 1</annotation>
 		<annotation cp="2⃣">2 | dua | butang kekunci</annotation>
+		<annotation cp="2⃣" type="tts">butang kekunci: 2</annotation>
 		<annotation cp="3⃣">3 | tiga | butang kekunci</annotation>
+		<annotation cp="3⃣" type="tts">butang kekunci: 3</annotation>
 		<annotation cp="4⃣">4 | empat | butang kekunci</annotation>
+		<annotation cp="4⃣" type="tts">butang kekunci: 4</annotation>
 		<annotation cp="5⃣">5 | lima | butang kekunci</annotation>
+		<annotation cp="5⃣" type="tts">butang kekunci: 5</annotation>
 		<annotation cp="6⃣">6 | enam | butang kekunci</annotation>
+		<annotation cp="6⃣" type="tts">butang kekunci: 6</annotation>
 		<annotation cp="7⃣">7 | tujuh | butang kekunci</annotation>
+		<annotation cp="7⃣" type="tts">butang kekunci: 7</annotation>
 		<annotation cp="8⃣">8 | lapan | butang kekunci</annotation>
+		<annotation cp="8⃣" type="tts">butang kekunci: 8</annotation>
 		<annotation cp="9⃣">9 | sembilan | butang kekunci</annotation>
+		<annotation cp="9⃣" type="tts">butang kekunci: 9</annotation>
 		<annotation cp="¹">nombor satu superskrip | satu | superskrip</annotation>
 		<annotation cp="¹" type="tts">nombor satu superskrip</annotation>
 		<annotation cp="²">dua | kuasa dua | nombor dua superskrip | superskrip</annotation>

--- a/common/annotations/my.xml
+++ b/common/annotations/my.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">ဘစ်ကွိုင် | ဘီတီစီ</annotation>
 		<annotation cp="₿" type="tts">ဘစ်ကွိုင်</annotation>
 		<annotation cp="0⃣">0 | သုည | ခလုတ်</annotation>
+		<annotation cp="0⃣" type="tts">ခလုတ် − 0</annotation>
 		<annotation cp="1⃣">1 | တစ် | ခလုတ်</annotation>
+		<annotation cp="1⃣" type="tts">ခလုတ် − 1</annotation>
 		<annotation cp="2⃣">2 | နှစ် | ခလုတ်</annotation>
+		<annotation cp="2⃣" type="tts">ခလုတ် − 2</annotation>
 		<annotation cp="3⃣">3 | သုံး | ခလုတ်</annotation>
+		<annotation cp="3⃣" type="tts">ခလုတ် − 3</annotation>
 		<annotation cp="4⃣">4 | လေး | ခလုတ်</annotation>
+		<annotation cp="4⃣" type="tts">ခလုတ် − 4</annotation>
 		<annotation cp="5⃣">5 | ငါး | ခလုတ်</annotation>
+		<annotation cp="5⃣" type="tts">ခလုတ် − 5</annotation>
 		<annotation cp="6⃣">6 | ခြောက် | ခလုတ်</annotation>
+		<annotation cp="6⃣" type="tts">ခလုတ် − 6</annotation>
 		<annotation cp="7⃣">7 | ခုနှစ် | ခလုတ်</annotation>
+		<annotation cp="7⃣" type="tts">ခလုတ် − 7</annotation>
 		<annotation cp="8⃣">8 | ရှစ် | ခလုတ်</annotation>
+		<annotation cp="8⃣" type="tts">ခလုတ် − 8</annotation>
 		<annotation cp="9⃣">9 | ကိုး | ခလုတ်</annotation>
+		<annotation cp="9⃣" type="tts">ခလုတ် − 9</annotation>
 		<annotation cp="¹">၁ | နှစ်ထပ်ကိန်း</annotation>
 		<annotation cp="¹" type="tts">နှစ်ထပ်ကိန်း ၁</annotation>
 		<annotation cp="²">၂ | နှစ်ထပ်ကိန်း</annotation>

--- a/common/annotations/ne.xml
+++ b/common/annotations/ne.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">बिटक्‍वाइन | बिटिसी</annotation>
 		<annotation cp="₿" type="tts">बिटक्‍वाइन</annotation>
 		<annotation cp="0⃣">0 | शुन्य | किक्याप</annotation>
+		<annotation cp="0⃣" type="tts">किक्याप: 0</annotation>
 		<annotation cp="1⃣">1 | एक | किक्याप</annotation>
+		<annotation cp="1⃣" type="tts">किक्याप: 1</annotation>
 		<annotation cp="2⃣">2 | दुई | किक्याप</annotation>
+		<annotation cp="2⃣" type="tts">किक्याप: 2</annotation>
 		<annotation cp="3⃣">3 | तिन | किक्याप</annotation>
+		<annotation cp="3⃣" type="tts">किक्याप: 3</annotation>
 		<annotation cp="4⃣">4 | चार | किक्याप</annotation>
+		<annotation cp="4⃣" type="tts">किक्याप: 4</annotation>
 		<annotation cp="5⃣">5 | पाँच | किक्याप</annotation>
+		<annotation cp="5⃣" type="tts">किक्याप: 5</annotation>
 		<annotation cp="6⃣">6 | छ | किक्याप</annotation>
+		<annotation cp="6⃣" type="tts">किक्याप: 6</annotation>
 		<annotation cp="7⃣">7 | सात | किक्याप</annotation>
+		<annotation cp="7⃣" type="tts">किक्याप: 7</annotation>
 		<annotation cp="8⃣">8 | आठ | किक्याप</annotation>
+		<annotation cp="8⃣" type="tts">किक्याप: 8</annotation>
 		<annotation cp="9⃣">9 | नौ | किक्याप</annotation>
+		<annotation cp="9⃣" type="tts">किक्याप: 9</annotation>
 		<annotation cp="¹">एक | सुपरस्क्रिप्ट | सुपरस्क्रिप्टको एक</annotation>
 		<annotation cp="¹" type="tts">सुपरस्क्रिप्टको एक</annotation>
 		<annotation cp="²">दुई | वर्ग | सुपरस्क्रिप्ट | सुपरस्क्रिप्टको दुई</annotation>

--- a/common/annotations/nl.xml
+++ b/common/annotations/nl.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nul | toets</annotation>
+		<annotation cp="0⃣" type="tts">toets: 0</annotation>
 		<annotation cp="1⃣">1 | een | toets</annotation>
+		<annotation cp="1⃣" type="tts">toets: 1</annotation>
 		<annotation cp="2⃣">2 | twee | toets</annotation>
+		<annotation cp="2⃣" type="tts">toets: 2</annotation>
 		<annotation cp="3⃣">3 | drie | toets</annotation>
+		<annotation cp="3⃣" type="tts">toets: 3</annotation>
 		<annotation cp="4⃣">4 | vier | toets</annotation>
+		<annotation cp="4⃣" type="tts">toets: 4</annotation>
 		<annotation cp="5⃣">5 | vijf | toets</annotation>
+		<annotation cp="5⃣" type="tts">toets: 5</annotation>
 		<annotation cp="6⃣">6 | zes | toets</annotation>
+		<annotation cp="6⃣" type="tts">toets: 6</annotation>
 		<annotation cp="7⃣">7 | zeven | toets</annotation>
+		<annotation cp="7⃣" type="tts">toets: 7</annotation>
 		<annotation cp="8⃣">8 | acht | toets</annotation>
+		<annotation cp="8⃣" type="tts">toets: 8</annotation>
 		<annotation cp="9⃣">9 | negen | toets</annotation>
+		<annotation cp="9⃣" type="tts">toets: 9</annotation>
 		<annotation cp="¹">één | superscript</annotation>
 		<annotation cp="¹" type="tts">superscript één</annotation>
 		<annotation cp="²">in het kwadraat | superscript | twee</annotation>

--- a/common/annotations/nn.xml
+++ b/common/annotations/nn.xml
@@ -3896,15 +3896,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">↑↑↑</annotation>
 		<annotation cp="₿" type="tts">↑↑↑</annotation>
 		<annotation cp="0⃣">0 | null | tastar</annotation>
+		<annotation cp="0⃣" type="tts">tastar: 0</annotation>
 		<annotation cp="1⃣">1 | éin | tastar</annotation>
+		<annotation cp="1⃣" type="tts">tastar: 1</annotation>
 		<annotation cp="2⃣">2 | to | tastar</annotation>
+		<annotation cp="2⃣" type="tts">tastar: 2</annotation>
 		<annotation cp="3⃣">3 | tre | tastar</annotation>
+		<annotation cp="3⃣" type="tts">tastar: 3</annotation>
 		<annotation cp="4⃣">4 | fire | tastar</annotation>
+		<annotation cp="4⃣" type="tts">tastar: 4</annotation>
 		<annotation cp="5⃣">5 | fem | tastar</annotation>
+		<annotation cp="5⃣" type="tts">tastar: 5</annotation>
 		<annotation cp="6⃣">6 | seks | tastar</annotation>
+		<annotation cp="6⃣" type="tts">tastar: 6</annotation>
 		<annotation cp="7⃣">7 | sju | tastar</annotation>
+		<annotation cp="7⃣" type="tts">tastar: 7</annotation>
 		<annotation cp="8⃣">8 | åtte | tastar</annotation>
+		<annotation cp="8⃣" type="tts">tastar: 8</annotation>
 		<annotation cp="9⃣">9 | ni | tastar</annotation>
+		<annotation cp="9⃣" type="tts">tastar: 9</annotation>
 		<annotation cp="¹">ein | første | heva | heva eittal | i første | opphøgd</annotation>
 		<annotation cp="¹" type="tts">heva eittal</annotation>
 		<annotation cp="²">andre | heva | heva total | kvadrat | opphøgd | to</annotation>

--- a/common/annotations/no.xml
+++ b/common/annotations/no.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC | kryptovaluta | valuta</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | null | taster</annotation>
+		<annotation cp="0⃣" type="tts">taster: 0</annotation>
 		<annotation cp="1⃣">1 | én | taster</annotation>
+		<annotation cp="1⃣" type="tts">taster: 1</annotation>
 		<annotation cp="2⃣">2 | to | taster</annotation>
+		<annotation cp="2⃣" type="tts">taster: 2</annotation>
 		<annotation cp="3⃣">3 | tre | taster</annotation>
+		<annotation cp="3⃣" type="tts">taster: 3</annotation>
 		<annotation cp="4⃣">4 | fire | taster</annotation>
+		<annotation cp="4⃣" type="tts">taster: 4</annotation>
 		<annotation cp="5⃣">5 | fem | taster</annotation>
+		<annotation cp="5⃣" type="tts">taster: 5</annotation>
 		<annotation cp="6⃣">6 | seks | taster</annotation>
+		<annotation cp="6⃣" type="tts">taster: 6</annotation>
 		<annotation cp="7⃣">7 | sju | taster</annotation>
+		<annotation cp="7⃣" type="tts">taster: 7</annotation>
 		<annotation cp="8⃣">8 | åtte | taster</annotation>
+		<annotation cp="8⃣" type="tts">taster: 8</annotation>
 		<annotation cp="9⃣">9 | ni | taster</annotation>
+		<annotation cp="9⃣" type="tts">taster: 9</annotation>
 		<annotation cp="¹">en | hevet | hevet ettall | i første | opphøyd i første</annotation>
 		<annotation cp="¹" type="tts">hevet ettall</annotation>
 		<annotation cp="²">hevet | hevet totall | i andre | kvadrat | opphøyd i andre | to</annotation>

--- a/common/annotations/or.xml
+++ b/common/annotations/or.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">ରୁବେଲ୍‌</annotation>
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 0</annotation>
+		<annotation cp="1⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 1</annotation>
+		<annotation cp="2⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 2</annotation>
+		<annotation cp="3⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 3</annotation>
+		<annotation cp="4⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 4</annotation>
+		<annotation cp="5⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 5</annotation>
+		<annotation cp="6⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 6</annotation>
+		<annotation cp="7⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 7</annotation>
+		<annotation cp="8⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 8</annotation>
+		<annotation cp="9⃣" type="tts">କୀକ୍ୟାପ୍&#x200D;: 9</annotation>
 		<annotation cp="¹">ଏକ | ସୁପରସ୍କ୍ରିପ୍ଟ</annotation>
 		<annotation cp="¹" type="tts">ସୁପରସ୍କ୍ରିପ୍ଟ ଏକ</annotation>
 		<annotation cp="²">ଦୁଇ | ବର୍ଗ | ସୁପରସ୍କ୍ରିପ୍ଟ</annotation>

--- a/common/annotations/pa.xml
+++ b/common/annotations/pa.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | ਬਿਟਕੌਇਨ</annotation>
 		<annotation cp="₿" type="tts">ਬਿਟਕੌਇਨ</annotation>
 		<annotation cp="0⃣">0 | ਸਿਫਰ | ਕੀਕੈਪ</annotation>
+		<annotation cp="0⃣" type="tts">ਕੀਕੈਪ: 0</annotation>
 		<annotation cp="1⃣">1 | ਇੱਕ | ਕੀਕੈਪ</annotation>
+		<annotation cp="1⃣" type="tts">ਕੀਕੈਪ: 1</annotation>
 		<annotation cp="2⃣">2 | ਦੋ | ਕੀਕੈਪ</annotation>
+		<annotation cp="2⃣" type="tts">ਕੀਕੈਪ: 2</annotation>
 		<annotation cp="3⃣">3 | ਤਿੰਨ | ਕੀਕੈਪ</annotation>
+		<annotation cp="3⃣" type="tts">ਕੀਕੈਪ: 3</annotation>
 		<annotation cp="4⃣">4 | ਚਾਰ | ਕੀਕੈਪ</annotation>
+		<annotation cp="4⃣" type="tts">ਕੀਕੈਪ: 4</annotation>
 		<annotation cp="5⃣">5 | ਪੰਜ | ਕੀਕੈਪ</annotation>
+		<annotation cp="5⃣" type="tts">ਕੀਕੈਪ: 5</annotation>
 		<annotation cp="6⃣">6 | ਛੇ | ਕੀਕੈਪ</annotation>
+		<annotation cp="6⃣" type="tts">ਕੀਕੈਪ: 6</annotation>
 		<annotation cp="7⃣">7 | ਸੱਤ | ਕੀਕੈਪ</annotation>
+		<annotation cp="7⃣" type="tts">ਕੀਕੈਪ: 7</annotation>
 		<annotation cp="8⃣">8 | ਅੱਠ | ਕੀਕੈਪ</annotation>
+		<annotation cp="8⃣" type="tts">ਕੀਕੈਪ: 8</annotation>
 		<annotation cp="9⃣">9 | ਨੌਂ | ਕੀਕੈਪ</annotation>
+		<annotation cp="9⃣" type="tts">ਕੀਕੈਪ: 9</annotation>
 		<annotation cp="¹">ਇੱਕ | ਸੁਪਰਸਕ੍ਰਿਪਟ</annotation>
 		<annotation cp="¹" type="tts">ਸੁਪਰਸਕ੍ਰਿਪਟ ਇੱਕ</annotation>
 		<annotation cp="²">ਸੁਪਰਸਕ੍ਰਿਪਟ | ਦੋ | ਵਰਗ</annotation>

--- a/common/annotations/pcm.xml
+++ b/common/annotations/pcm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">Rúbul</annotation>
 		<annotation cp="₿">Bítkọ́in | BTC | BTK</annotation>
 		<annotation cp="₿" type="tts">Bítkọ́in</annotation>
+		<annotation cp="0⃣" type="tts">Kíkap: 0</annotation>
+		<annotation cp="1⃣" type="tts">Kíkap: 1</annotation>
+		<annotation cp="2⃣" type="tts">Kíkap: 2</annotation>
+		<annotation cp="3⃣" type="tts">Kíkap: 3</annotation>
+		<annotation cp="4⃣" type="tts">Kíkap: 4</annotation>
+		<annotation cp="5⃣" type="tts">Kíkap: 5</annotation>
+		<annotation cp="6⃣" type="tts">Kíkap: 6</annotation>
+		<annotation cp="7⃣" type="tts">Kíkap: 7</annotation>
+		<annotation cp="8⃣" type="tts">Kíkap: 8</annotation>
+		<annotation cp="9⃣" type="tts">Kíkap: 9</annotation>
 		<annotation cp="¹">Supaskript | Supaskrípt Wọn | Wọn</annotation>
 		<annotation cp="¹" type="tts">Supaskrípt Wọn</annotation>
 		<annotation cp="²">Skwea | Supaskript | Supaskrípt Tuu | Tuu</annotation>

--- a/common/annotations/pl.xml
+++ b/common/annotations/pl.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | klawisz</annotation>
+		<annotation cp="0⃣" type="tts">klawisz: 0</annotation>
 		<annotation cp="1⃣">1 | jeden | klawisz</annotation>
+		<annotation cp="1⃣" type="tts">klawisz: 1</annotation>
 		<annotation cp="2⃣">2 | dwa | klawisz</annotation>
+		<annotation cp="2⃣" type="tts">klawisz: 2</annotation>
 		<annotation cp="3⃣">3 | trzy | klawisz</annotation>
+		<annotation cp="3⃣" type="tts">klawisz: 3</annotation>
 		<annotation cp="4⃣">4 | cztery | klawisz</annotation>
+		<annotation cp="4⃣" type="tts">klawisz: 4</annotation>
 		<annotation cp="5⃣">5 | pięć | klawisz</annotation>
+		<annotation cp="5⃣" type="tts">klawisz: 5</annotation>
 		<annotation cp="6⃣">6 | sześć | klawisz</annotation>
+		<annotation cp="6⃣" type="tts">klawisz: 6</annotation>
 		<annotation cp="7⃣">7 | siedem | klawisz</annotation>
+		<annotation cp="7⃣" type="tts">klawisz: 7</annotation>
 		<annotation cp="8⃣">8 | osiem | klawisz</annotation>
+		<annotation cp="8⃣" type="tts">klawisz: 8</annotation>
 		<annotation cp="9⃣">9 | dziewięć | klawisz</annotation>
+		<annotation cp="9⃣" type="tts">klawisz: 9</annotation>
 		<annotation cp="¹">indeks górny | jeden | jeden w indeksie górnym</annotation>
 		<annotation cp="¹" type="tts">jeden w indeksie górnym</annotation>
 		<annotation cp="²">dwa | dwa w indeksie górnym | indeks górny | kwadrat</annotation>

--- a/common/annotations/ps.xml
+++ b/common/annotations/ps.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">روبل</annotation>
 		<annotation cp="₿">BTC | بټ سکه</annotation>
 		<annotation cp="₿" type="tts">بټ سکه</annotation>
+		<annotation cp="0⃣" type="tts">کیکیپ: 0</annotation>
+		<annotation cp="1⃣" type="tts">کیکیپ: 1</annotation>
+		<annotation cp="2⃣" type="tts">کیکیپ: 2</annotation>
+		<annotation cp="3⃣" type="tts">کیکیپ: 3</annotation>
+		<annotation cp="4⃣" type="tts">کیکیپ: 4</annotation>
+		<annotation cp="5⃣" type="tts">کیکیپ: 5</annotation>
+		<annotation cp="6⃣" type="tts">کیکیپ: 6</annotation>
+		<annotation cp="7⃣" type="tts">کیکیپ: 7</annotation>
+		<annotation cp="8⃣" type="tts">کیکیپ: 8</annotation>
+		<annotation cp="9⃣" type="tts">کیکیپ: 9</annotation>
 		<annotation cp="¹">بالانوشت | یو</annotation>
 		<annotation cp="¹" type="tts">یو بالانوشت</annotation>
 		<annotation cp="²">بالانوشت | څلوریځ | دوه</annotation>

--- a/common/annotations/pt.xml
+++ b/common/annotations/pt.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | tecla</annotation>
+		<annotation cp="0⃣" type="tts">tecla: 0</annotation>
 		<annotation cp="1⃣">1 | um | tecla</annotation>
+		<annotation cp="1⃣" type="tts">tecla: 1</annotation>
 		<annotation cp="2⃣">2 | dois | tecla</annotation>
+		<annotation cp="2⃣" type="tts">tecla: 2</annotation>
 		<annotation cp="3⃣">3 | três | tecla</annotation>
+		<annotation cp="3⃣" type="tts">tecla: 3</annotation>
 		<annotation cp="4⃣">4 | quatro | tecla</annotation>
+		<annotation cp="4⃣" type="tts">tecla: 4</annotation>
 		<annotation cp="5⃣">5 | cinco | tecla</annotation>
+		<annotation cp="5⃣" type="tts">tecla: 5</annotation>
 		<annotation cp="6⃣">6 | seis | tecla</annotation>
+		<annotation cp="6⃣" type="tts">tecla: 6</annotation>
 		<annotation cp="7⃣">7 | sete | tecla</annotation>
+		<annotation cp="7⃣" type="tts">tecla: 7</annotation>
 		<annotation cp="8⃣">8 | oito | tecla</annotation>
+		<annotation cp="8⃣" type="tts">tecla: 8</annotation>
 		<annotation cp="9⃣">9 | nove | tecla</annotation>
+		<annotation cp="9⃣" type="tts">tecla: 9</annotation>
 		<annotation cp="¹">número | sobrescrito | um</annotation>
 		<annotation cp="¹" type="tts">número um sobrescrito</annotation>
 		<annotation cp="²">dois | número | quadrado | sobrescrito</annotation>

--- a/common/annotations/rhg.xml
+++ b/common/annotations/rhg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1019,5 +1019,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🫛" type="tts">𐴏𐴥𐴡𐴛</annotation>
 		<annotation cp="🍄‍🟫">𐴈𐴡𐴃𐴢 𐴌𐴡𐴚𐴝 𐴀𐴟𐴓 | 𐴈𐴡𐴃𐴢 𐴌𐴡𐴚𐴝 𐴀𐴟𐴓 - 𐴈𐴥𐴝𐴕𐴝 - 𐴓𐴝𐴓 𐴀𐴟𐴓 - 𐴑𐴟𐴊𐴟𐴌𐴡𐴃𐴞 - 𐴃𐴡𐴌𐴈𐴝𐴌𐴞</annotation>
 		<annotation cp="🍄‍🟫" type="tts">𐴈𐴡𐴃𐴢 𐴌𐴡𐴚𐴝 𐴀𐴟𐴓</annotation>
+		<annotation cp="0⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 0</annotation>
+		<annotation cp="1⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 1</annotation>
+		<annotation cp="2⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 2</annotation>
+		<annotation cp="3⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 3</annotation>
+		<annotation cp="4⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 4</annotation>
+		<annotation cp="5⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 5</annotation>
+		<annotation cp="6⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 6</annotation>
+		<annotation cp="7⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 7</annotation>
+		<annotation cp="8⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 8</annotation>
+		<annotation cp="9⃣" type="tts">𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/ro.xml
+++ b/common/annotations/ro.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | tastă</annotation>
+		<annotation cp="0⃣" type="tts">tastă: 0</annotation>
 		<annotation cp="1⃣">1 | unu | tastă</annotation>
+		<annotation cp="1⃣" type="tts">tastă: 1</annotation>
 		<annotation cp="2⃣">2 | doi | tastă</annotation>
+		<annotation cp="2⃣" type="tts">tastă: 2</annotation>
 		<annotation cp="3⃣">3 | trei | tastă</annotation>
+		<annotation cp="3⃣" type="tts">tastă: 3</annotation>
 		<annotation cp="4⃣">4 | patru | tastă</annotation>
+		<annotation cp="4⃣" type="tts">tastă: 4</annotation>
 		<annotation cp="5⃣">5 | cinci | tastă</annotation>
+		<annotation cp="5⃣" type="tts">tastă: 5</annotation>
 		<annotation cp="6⃣">6 | şase | tastă</annotation>
+		<annotation cp="6⃣" type="tts">tastă: 6</annotation>
 		<annotation cp="7⃣">7 | şapte | tastă</annotation>
+		<annotation cp="7⃣" type="tts">tastă: 7</annotation>
 		<annotation cp="8⃣">8 | opt | tastă</annotation>
+		<annotation cp="8⃣" type="tts">tastă: 8</annotation>
 		<annotation cp="9⃣">9 | nouă | tastă</annotation>
+		<annotation cp="9⃣" type="tts">tastă: 9</annotation>
 		<annotation cp="¹">exponent | unu</annotation>
 		<annotation cp="¹" type="tts">exponent unu</annotation>
 		<annotation cp="²">doi | exponent | la pătrat</annotation>

--- a/common/annotations/root.xml
+++ b/common/annotations/root.xml
@@ -3914,6 +3914,26 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">E13-112</annotation>
 		<annotation cp="₿">E13.1-189</annotation>
 		<annotation cp="₿" type="tts">E13.1-189</annotation>
+		<annotation cp="0⃣">E17-100</annotation>
+		<annotation cp="0⃣" type="tts">E17-100</annotation>
+		<annotation cp="1⃣">E17-101</annotation>
+		<annotation cp="1⃣" type="tts">E17-101</annotation>
+		<annotation cp="2⃣">E17-102</annotation>
+		<annotation cp="2⃣" type="tts">E17-102</annotation>
+		<annotation cp="3⃣">E17-103</annotation>
+		<annotation cp="3⃣" type="tts">E17-103</annotation>
+		<annotation cp="4⃣">E17-104</annotation>
+		<annotation cp="4⃣" type="tts">E17-104</annotation>
+		<annotation cp="5⃣">E17-105</annotation>
+		<annotation cp="5⃣" type="tts">E17-105</annotation>
+		<annotation cp="6⃣">E17-106</annotation>
+		<annotation cp="6⃣" type="tts">E17-106</annotation>
+		<annotation cp="7⃣">E17-107</annotation>
+		<annotation cp="7⃣" type="tts">E17-107</annotation>
+		<annotation cp="8⃣">E17-108</annotation>
+		<annotation cp="8⃣" type="tts">E17-108</annotation>
+		<annotation cp="9⃣">E17-109</annotation>
+		<annotation cp="9⃣" type="tts">E17-109</annotation>
 		<annotation cp="¹">E13-135</annotation>
 		<annotation cp="¹" type="tts">E13-135</annotation>
 		<annotation cp="²">E13-136</annotation>
@@ -3943,15 +3963,5 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫪" type="tts">E17-001</annotation>
 		<annotation cp="🫯">E17-002</annotation> <!-- 1FAEF: fight cloud -->
 		<annotation cp="🫯" type="tts">E17-002</annotation>
-		<annotation cp="0⃣">E17-100</annotation>
-		<annotation cp="1⃣">E17-101</annotation>
-		<annotation cp="2⃣">E17-102</annotation>
-		<annotation cp="3⃣">E17-103</annotation>
-		<annotation cp="4⃣">E17-104</annotation>
-		<annotation cp="5⃣">E17-105</annotation>
-		<annotation cp="6⃣">E17-106</annotation>
-		<annotation cp="7⃣">E17-107</annotation>
-		<annotation cp="8⃣">E17-108</annotation>
-		<annotation cp="9⃣">E17-109</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/ru.xml
+++ b/common/annotations/ru.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">btc | биткоин | биткойн | бтк</annotation>
 		<annotation cp="₿" type="tts">биткоин</annotation>
 		<annotation cp="0⃣">0 | ноль | клавиши</annotation>
+		<annotation cp="0⃣" type="tts">клавиши: 0</annotation>
 		<annotation cp="1⃣">1 | один | клавиши</annotation>
+		<annotation cp="1⃣" type="tts">клавиши: 1</annotation>
 		<annotation cp="2⃣">2 | два | клавиши</annotation>
+		<annotation cp="2⃣" type="tts">клавиши: 2</annotation>
 		<annotation cp="3⃣">3 | три | клавиши</annotation>
+		<annotation cp="3⃣" type="tts">клавиши: 3</annotation>
 		<annotation cp="4⃣">4 | четыре | клавиши</annotation>
+		<annotation cp="4⃣" type="tts">клавиши: 4</annotation>
 		<annotation cp="5⃣">5 | пять | клавиши</annotation>
+		<annotation cp="5⃣" type="tts">клавиши: 5</annotation>
 		<annotation cp="6⃣">6 | шесть | клавиши</annotation>
+		<annotation cp="6⃣" type="tts">клавиши: 6</annotation>
 		<annotation cp="7⃣">7 | семь | клавиши</annotation>
+		<annotation cp="7⃣" type="tts">клавиши: 7</annotation>
 		<annotation cp="8⃣">8 | восемь | клавиши</annotation>
+		<annotation cp="8⃣" type="tts">клавиши: 8</annotation>
 		<annotation cp="9⃣">9 | девять | клавиши</annotation>
+		<annotation cp="9⃣" type="tts">клавиши: 9</annotation>
 		<annotation cp="¹">надстрочная цифра один | надстрочный | один | степень</annotation>
 		<annotation cp="¹" type="tts">надстрочная цифра один</annotation>
 		<annotation cp="²">в квадрате | два | квадрат | надстрочная цифра два | надстрочный | степень</annotation>

--- a/common/annotations/sat.xml
+++ b/common/annotations/sat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -630,5 +630,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🏴" type="tts" draft="unconfirmed">ᱦᱮᱸᱫᱮ ᱪᱤᱨ</annotation>
 		<annotation cp="🏳" draft="unconfirmed">ᱯᱩᱸᱰ ᱪᱤᱨ</annotation>
 		<annotation cp="🏳" type="tts" draft="unconfirmed">ᱯᱩᱸᱰ ᱪᱤᱨ</annotation>
+		<annotation cp="0⃣" type="tts">ᱠᱤᱠᱮᱯ: 0</annotation>
+		<annotation cp="1⃣" type="tts">ᱠᱤᱠᱮᱯ: 1</annotation>
+		<annotation cp="2⃣" type="tts">ᱠᱤᱠᱮᱯ: 2</annotation>
+		<annotation cp="3⃣" type="tts">ᱠᱤᱠᱮᱯ: 3</annotation>
+		<annotation cp="4⃣" type="tts">ᱠᱤᱠᱮᱯ: 4</annotation>
+		<annotation cp="5⃣" type="tts">ᱠᱤᱠᱮᱯ: 5</annotation>
+		<annotation cp="6⃣" type="tts">ᱠᱤᱠᱮᱯ: 6</annotation>
+		<annotation cp="7⃣" type="tts">ᱠᱤᱠᱮᱯ: 7</annotation>
+		<annotation cp="8⃣" type="tts">ᱠᱤᱠᱮᱯ: 8</annotation>
+		<annotation cp="9⃣" type="tts">ᱠᱤᱠᱮᱯ: 9</annotation>
 	</annotations>
 </ldml>

--- a/common/annotations/sc.xml
+++ b/common/annotations/sc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2243,6 +2243,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">rublu</annotation>
 		<annotation cp="₿">bitcoin | BTC | criptovaluta</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">tecla: 0</annotation>
+		<annotation cp="1⃣" type="tts">tecla: 1</annotation>
+		<annotation cp="2⃣" type="tts">tecla: 2</annotation>
+		<annotation cp="3⃣" type="tts">tecla: 3</annotation>
+		<annotation cp="4⃣" type="tts">tecla: 4</annotation>
+		<annotation cp="5⃣" type="tts">tecla: 5</annotation>
+		<annotation cp="6⃣" type="tts">tecla: 6</annotation>
+		<annotation cp="7⃣" type="tts">tecla: 7</annotation>
+		<annotation cp="8⃣" type="tts">tecla: 8</annotation>
+		<annotation cp="9⃣" type="tts">tecla: 9</annotation>
 		<annotation cp="¹">àpitze | nùmeru unu in àpitze | punta | unu</annotation>
 		<annotation cp="¹" type="tts">nùmeru unu in àpitze</annotation>
 		<annotation cp="²">a su cuadradu | àpitze | duos | nùmeru duos in àpitze | punta | valore cuardadu</annotation>

--- a/common/annotations/sd.xml
+++ b/common/annotations/sd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">ربل</annotation>
 		<annotation cp="₿">BTC | بٽ ڪوائن</annotation>
 		<annotation cp="₿" type="tts">بٽ ڪوائن</annotation>
+		<annotation cp="0⃣" type="tts">ڪي ڪيپ: 0</annotation>
+		<annotation cp="1⃣" type="tts">ڪي ڪيپ: 1</annotation>
+		<annotation cp="2⃣" type="tts">ڪي ڪيپ: 2</annotation>
+		<annotation cp="3⃣" type="tts">ڪي ڪيپ: 3</annotation>
+		<annotation cp="4⃣" type="tts">ڪي ڪيپ: 4</annotation>
+		<annotation cp="5⃣" type="tts">ڪي ڪيپ: 5</annotation>
+		<annotation cp="6⃣" type="tts">ڪي ڪيپ: 6</annotation>
+		<annotation cp="7⃣" type="tts">ڪي ڪيپ: 7</annotation>
+		<annotation cp="8⃣" type="tts">ڪي ڪيپ: 8</annotation>
+		<annotation cp="9⃣" type="tts">ڪي ڪيپ: 9</annotation>
 		<annotation cp="¹">سپر اسڪرپٽ | سپر اسڪرپٽ ون | ون</annotation>
 		<annotation cp="¹" type="tts">سپر اسڪرپٽ ون</annotation>
 		<annotation cp="²">ٽو | چورس | سپر اسڪرپٽ | سپر اسڪرپٽ ٽو</annotation>

--- a/common/annotations/si.xml
+++ b/common/annotations/si.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">රූබල්</annotation>
 		<annotation cp="₿">බිට්කොයින් | බීටීසී</annotation>
 		<annotation cp="₿" type="tts">බිට්කොයින්</annotation>
+		<annotation cp="0⃣" type="tts">පියන: 0</annotation>
+		<annotation cp="1⃣" type="tts">පියන: 1</annotation>
+		<annotation cp="2⃣" type="tts">පියන: 2</annotation>
+		<annotation cp="3⃣" type="tts">පියන: 3</annotation>
+		<annotation cp="4⃣" type="tts">පියන: 4</annotation>
+		<annotation cp="5⃣" type="tts">පියන: 5</annotation>
+		<annotation cp="6⃣" type="tts">පියන: 6</annotation>
+		<annotation cp="7⃣" type="tts">පියන: 7</annotation>
+		<annotation cp="8⃣" type="tts">පියන: 8</annotation>
+		<annotation cp="9⃣" type="tts">පියන: 9</annotation>
 		<annotation cp="¹">උඩකුර | එක</annotation>
 		<annotation cp="¹" type="tts">උඩකුර එක</annotation>
 		<annotation cp="²">උඩකුර | දෙක | වර්ගායිත</annotation>

--- a/common/annotations/sk.xml
+++ b/common/annotations/sk.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | nula | kláves</annotation>
+		<annotation cp="0⃣" type="tts">kláves: 0</annotation>
 		<annotation cp="1⃣">1 | jeden | kláves</annotation>
+		<annotation cp="1⃣" type="tts">kláves: 1</annotation>
 		<annotation cp="2⃣">2 | dva | kláves</annotation>
+		<annotation cp="2⃣" type="tts">kláves: 2</annotation>
 		<annotation cp="3⃣">3 | tri | kláves</annotation>
+		<annotation cp="3⃣" type="tts">kláves: 3</annotation>
 		<annotation cp="4⃣">4 | štyri | kláves</annotation>
+		<annotation cp="4⃣" type="tts">kláves: 4</annotation>
 		<annotation cp="5⃣">5 | päť | kláves</annotation>
+		<annotation cp="5⃣" type="tts">kláves: 5</annotation>
 		<annotation cp="6⃣">6 | šesť | kláves</annotation>
+		<annotation cp="6⃣" type="tts">kláves: 6</annotation>
 		<annotation cp="7⃣">7 | sedem | kláves</annotation>
+		<annotation cp="7⃣" type="tts">kláves: 7</annotation>
 		<annotation cp="8⃣">8 | osem | kláves</annotation>
+		<annotation cp="8⃣" type="tts">kláves: 8</annotation>
 		<annotation cp="9⃣">9 | deväť | kláves</annotation>
+		<annotation cp="9⃣" type="tts">kláves: 9</annotation>
 		<annotation cp="¹">horný index | jedna | jedna horný index</annotation>
 		<annotation cp="¹" type="tts">jedna horný index</annotation>
 		<annotation cp="²">dva | dva horný index | horný index | na druhú</annotation>

--- a/common/annotations/so.xml
+++ b/common/annotations/so.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">cutub lacageedka raashiya</annotation>
 		<annotation cp="₿">bitkoyn | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkoyn</annotation>
+		<annotation cp="0⃣" type="tts">daboolka furaha: 0</annotation>
+		<annotation cp="1⃣" type="tts">daboolka furaha: 1</annotation>
+		<annotation cp="2⃣" type="tts">daboolka furaha: 2</annotation>
+		<annotation cp="3⃣" type="tts">daboolka furaha: 3</annotation>
+		<annotation cp="4⃣" type="tts">daboolka furaha: 4</annotation>
+		<annotation cp="5⃣" type="tts">daboolka furaha: 5</annotation>
+		<annotation cp="6⃣" type="tts">daboolka furaha: 6</annotation>
+		<annotation cp="7⃣" type="tts">daboolka furaha: 7</annotation>
+		<annotation cp="8⃣" type="tts">daboolka furaha: 8</annotation>
+		<annotation cp="9⃣" type="tts">daboolka furaha: 9</annotation>
 		<annotation cp="¹">calaamada koobaad | mid | qoraalka sare</annotation>
 		<annotation cp="¹" type="tts">calaamada koobaad</annotation>
 		<annotation cp="²">calaamada labaad | laba | laba jibbaaran | qoraalka sare</annotation>

--- a/common/annotations/sq.xml
+++ b/common/annotations/sq.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | zero | tast</annotation>
+		<annotation cp="0⃣" type="tts">tast: 0</annotation>
 		<annotation cp="1⃣">1 | një | tast</annotation>
+		<annotation cp="1⃣" type="tts">tast: 1</annotation>
 		<annotation cp="2⃣">2 | dy | tast</annotation>
+		<annotation cp="2⃣" type="tts">tast: 2</annotation>
 		<annotation cp="3⃣">3 | tre | tast</annotation>
+		<annotation cp="3⃣" type="tts">tast: 3</annotation>
 		<annotation cp="4⃣">4 | katër | tast</annotation>
+		<annotation cp="4⃣" type="tts">tast: 4</annotation>
 		<annotation cp="5⃣">5 | pesë | tast</annotation>
+		<annotation cp="5⃣" type="tts">tast: 5</annotation>
 		<annotation cp="6⃣">6 | gjashtë | tast</annotation>
+		<annotation cp="6⃣" type="tts">tast: 6</annotation>
 		<annotation cp="7⃣">7 | shtatë | tast</annotation>
+		<annotation cp="7⃣" type="tts">tast: 7</annotation>
 		<annotation cp="8⃣">8 | tetë | tast</annotation>
+		<annotation cp="8⃣" type="tts">tast: 8</annotation>
 		<annotation cp="9⃣">9 | nëntë | tast</annotation>
+		<annotation cp="9⃣" type="tts">tast: 9</annotation>
 		<annotation cp="¹">një | një me superskript | superskript</annotation>
 		<annotation cp="¹" type="tts">një me superskript</annotation>
 		<annotation cp="²">dy | dy me superskript | rrënjë katrore | superskript</annotation>

--- a/common/annotations/sr.xml
+++ b/common/annotations/sr.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | биткоин</annotation>
 		<annotation cp="₿" type="tts">биткоин</annotation>
 		<annotation cp="0⃣">0 | нула | тастер</annotation>
+		<annotation cp="0⃣" type="tts">тастер: 0</annotation>
 		<annotation cp="1⃣">1 | један | тастер</annotation>
+		<annotation cp="1⃣" type="tts">тастер: 1</annotation>
 		<annotation cp="2⃣">2 | два | тастер</annotation>
+		<annotation cp="2⃣" type="tts">тастер: 2</annotation>
 		<annotation cp="3⃣">3 | три | тастер</annotation>
+		<annotation cp="3⃣" type="tts">тастер: 3</annotation>
 		<annotation cp="4⃣">4 | четири | тастер</annotation>
+		<annotation cp="4⃣" type="tts">тастер: 4</annotation>
 		<annotation cp="5⃣">5 | пет | тастер</annotation>
+		<annotation cp="5⃣" type="tts">тастер: 5</annotation>
 		<annotation cp="6⃣">6 | шест | тастер</annotation>
+		<annotation cp="6⃣" type="tts">тастер: 6</annotation>
 		<annotation cp="7⃣">7 | седам | тастер</annotation>
+		<annotation cp="7⃣" type="tts">тастер: 7</annotation>
 		<annotation cp="8⃣">8 | осам | тастер</annotation>
+		<annotation cp="8⃣" type="tts">тастер: 8</annotation>
 		<annotation cp="9⃣">9 | девет | тастер</annotation>
+		<annotation cp="9⃣" type="tts">тастер: 9</annotation>
 		<annotation cp="¹">1 | експонент</annotation>
 		<annotation cp="¹" type="tts">експонент 1</annotation>
 		<annotation cp="²">2 | експонент | квадратни</annotation>

--- a/common/annotations/sr_Cyrl.xml
+++ b/common/annotations/sr_Cyrl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -11,4 +11,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="sr"/>
 		<script type="Cyrl"/>
 	</identity>
+	<annotations>
+		<annotation cp="0⃣" type="tts">тастер: 0</annotation>
+		<annotation cp="1⃣" type="tts">тастер: 1</annotation>
+		<annotation cp="2⃣" type="tts">тастер: 2</annotation>
+		<annotation cp="3⃣" type="tts">тастер: 3</annotation>
+		<annotation cp="4⃣" type="tts">тастер: 4</annotation>
+		<annotation cp="5⃣" type="tts">тастер: 5</annotation>
+		<annotation cp="6⃣" type="tts">тастер: 6</annotation>
+		<annotation cp="7⃣" type="tts">тастер: 7</annotation>
+		<annotation cp="8⃣" type="tts">тастер: 8</annotation>
+		<annotation cp="9⃣" type="tts">тастер: 9</annotation>
+	</annotations>
 </ldml>

--- a/common/annotations/sr_Latn.xml
+++ b/common/annotations/sr_Latn.xml
@@ -3897,15 +3897,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">bitkoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkoin</annotation>
 		<annotation cp="0⃣">0 | nula | taster</annotation>
+		<annotation cp="0⃣" type="tts">taster: 0</annotation>
 		<annotation cp="1⃣">1 | jedan | taster</annotation>
+		<annotation cp="1⃣" type="tts">taster: 1</annotation>
 		<annotation cp="2⃣">2 | dva | taster</annotation>
+		<annotation cp="2⃣" type="tts">taster: 2</annotation>
 		<annotation cp="3⃣">3 | tri | taster</annotation>
+		<annotation cp="3⃣" type="tts">taster: 3</annotation>
 		<annotation cp="4⃣">4 | četiri | taster</annotation>
+		<annotation cp="4⃣" type="tts">taster: 4</annotation>
 		<annotation cp="5⃣">5 | pet | taster</annotation>
+		<annotation cp="5⃣" type="tts">taster: 5</annotation>
 		<annotation cp="6⃣">6 | šest | taster</annotation>
+		<annotation cp="6⃣" type="tts">taster: 6</annotation>
 		<annotation cp="7⃣">7 | sedam | taster</annotation>
+		<annotation cp="7⃣" type="tts">taster: 7</annotation>
 		<annotation cp="8⃣">8 | osam | taster</annotation>
+		<annotation cp="8⃣" type="tts">taster: 8</annotation>
 		<annotation cp="9⃣">9 | devet | taster</annotation>
+		<annotation cp="9⃣" type="tts">taster: 9</annotation>
 		<annotation cp="¹">1 | eksponent</annotation>
 		<annotation cp="¹" type="tts">eksponent 1</annotation>
 		<annotation cp="²">2 | eksponent | kvadratni</annotation>

--- a/common/annotations/sw.xml
+++ b/common/annotations/sw.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | sifuri | kitufe</annotation>
+		<annotation cp="0⃣" type="tts">kitufe: 0</annotation>
 		<annotation cp="1⃣">1 | moja | kitufe</annotation>
+		<annotation cp="1⃣" type="tts">kitufe: 1</annotation>
 		<annotation cp="2⃣">2 | mbili | kitufe</annotation>
+		<annotation cp="2⃣" type="tts">kitufe: 2</annotation>
 		<annotation cp="3⃣">3 | tatu | kitufe</annotation>
+		<annotation cp="3⃣" type="tts">kitufe: 3</annotation>
 		<annotation cp="4⃣">4 | nne | kitufe</annotation>
+		<annotation cp="4⃣" type="tts">kitufe: 4</annotation>
 		<annotation cp="5⃣">5 | tano | kitufe</annotation>
+		<annotation cp="5⃣" type="tts">kitufe: 5</annotation>
 		<annotation cp="6⃣">6 | sita | kitufe</annotation>
+		<annotation cp="6⃣" type="tts">kitufe: 6</annotation>
 		<annotation cp="7⃣">7 | saba | kitufe</annotation>
+		<annotation cp="7⃣" type="tts">kitufe: 7</annotation>
 		<annotation cp="8⃣">8 | nane | kitufe</annotation>
+		<annotation cp="8⃣" type="tts">kitufe: 8</annotation>
 		<annotation cp="9⃣">9 | tisa | kitufe</annotation>
+		<annotation cp="9⃣" type="tts">kitufe: 9</annotation>
 		<annotation cp="¹">herufijuu | moja | weka moja juu</annotation>
 		<annotation cp="¹" type="tts">weka moja juu</annotation>
 		<annotation cp="²">herufijuu | mbili | mraba | weka mbili juu</annotation>

--- a/common/annotations/ta.xml
+++ b/common/annotations/ta.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">பி.டி.சி | பிட்காயின்</annotation>
 		<annotation cp="₿" type="tts">பிட்காயின்</annotation>
 		<annotation cp="0⃣">0 | பூஜ்யம் | விசை</annotation>
+		<annotation cp="0⃣" type="tts">விசை: 0</annotation>
 		<annotation cp="1⃣">1 | ஒன்று | விசை</annotation>
+		<annotation cp="1⃣" type="tts">விசை: 1</annotation>
 		<annotation cp="2⃣">2 | இரண்டு | விசை</annotation>
+		<annotation cp="2⃣" type="tts">விசை: 2</annotation>
 		<annotation cp="3⃣">3 | மூன்று | விசை</annotation>
+		<annotation cp="3⃣" type="tts">விசை: 3</annotation>
 		<annotation cp="4⃣">4 | நான்கு | விசை</annotation>
+		<annotation cp="4⃣" type="tts">விசை: 4</annotation>
 		<annotation cp="5⃣">5 | ஐந்து | விசை</annotation>
+		<annotation cp="5⃣" type="tts">விசை: 5</annotation>
 		<annotation cp="6⃣">6 | ஆறு | விசை</annotation>
+		<annotation cp="6⃣" type="tts">விசை: 6</annotation>
 		<annotation cp="7⃣">7 | ஏழு | விசை</annotation>
+		<annotation cp="7⃣" type="tts">விசை: 7</annotation>
 		<annotation cp="8⃣">8 | எட்டு | விசை</annotation>
+		<annotation cp="8⃣" type="tts">விசை: 8</annotation>
 		<annotation cp="9⃣">9 | ஒன்பது | விசை</annotation>
+		<annotation cp="9⃣" type="tts">விசை: 9</annotation>
 		<annotation cp="¹">ஒன்று | மேல் ஒட்டு | மேல் ஒட்டு எண் ஒன்று</annotation>
 		<annotation cp="¹" type="tts">மேல் ஒட்டு எண் ஒன்று</annotation>
 		<annotation cp="²">இரண்டு | மேல் ஒட்டு | மேல் ஒட்டு எண் இரண்டு | வர்க்கம்</annotation>

--- a/common/annotations/te.xml
+++ b/common/annotations/te.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">బిటిసి | బిట్‌కాయిన్</annotation>
 		<annotation cp="₿" type="tts">బిట్‌కాయిన్</annotation>
 		<annotation cp="0⃣">0 | సున్న | కీక్యాప్</annotation>
+		<annotation cp="0⃣" type="tts">కీక్యాప్: 0</annotation>
 		<annotation cp="1⃣">1 | ఒకటి | కీక్యాప్</annotation>
+		<annotation cp="1⃣" type="tts">కీక్యాప్: 1</annotation>
 		<annotation cp="2⃣">2 | రెండు | కీక్యాప్</annotation>
+		<annotation cp="2⃣" type="tts">కీక్యాప్: 2</annotation>
 		<annotation cp="3⃣">3 | మూడు | కీక్యాప్</annotation>
+		<annotation cp="3⃣" type="tts">కీక్యాప్: 3</annotation>
 		<annotation cp="4⃣">4 | నాలుగు | కీక్యాప్</annotation>
+		<annotation cp="4⃣" type="tts">కీక్యాప్: 4</annotation>
 		<annotation cp="5⃣">5 | ఐదు | కీక్యాప్</annotation>
+		<annotation cp="5⃣" type="tts">కీక్యాప్: 5</annotation>
 		<annotation cp="6⃣">6 | ఆరు | కీక్యాప్</annotation>
+		<annotation cp="6⃣" type="tts">కీక్యాప్: 6</annotation>
 		<annotation cp="7⃣">7 | ఏడు | కీక్యాప్</annotation>
+		<annotation cp="7⃣" type="tts">కీక్యాప్: 7</annotation>
 		<annotation cp="8⃣">8 | ఎనిమిది | కీక్యాప్</annotation>
+		<annotation cp="8⃣" type="tts">కీక్యాప్: 8</annotation>
 		<annotation cp="9⃣">9 | తొమ్మిది | కీక్యాప్</annotation>
+		<annotation cp="9⃣" type="tts">కీక్యాప్: 9</annotation>
 		<annotation cp="¹">ఒకటి | సూపర్ స్క్రిప్ట్ | సూపర్ స్క్రిప్ట్ ఒకటి</annotation>
 		<annotation cp="¹" type="tts">సూపర్ స్క్రిప్ట్ ఒకటి</annotation>
 		<annotation cp="²">రెండు | సూపర్ స్క్రిప్ట్ | సూపర్ స్క్రిప్ట్ రెండు | స్క్వేర్డ్</annotation>

--- a/common/annotations/th.xml
+++ b/common/annotations/th.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">เงินดิจิทัลบิตคอยน์ | บิตคอยน์</annotation>
 		<annotation cp="₿" type="tts">บิตคอยน์</annotation>
 		<annotation cp="0⃣">0 | ศูนย์ | ปุ่มกดเลข</annotation>
+		<annotation cp="0⃣" type="tts">ปุ่มกดเลข: 0</annotation>
 		<annotation cp="1⃣">1 | หนึ่ง | ปุ่มกดเลข</annotation>
+		<annotation cp="1⃣" type="tts">ปุ่มกดเลข: 1</annotation>
 		<annotation cp="2⃣">2 | สอง | ปุ่มกดเลข</annotation>
+		<annotation cp="2⃣" type="tts">ปุ่มกดเลข: 2</annotation>
 		<annotation cp="3⃣">3 | สาม | ปุ่มกดเลข</annotation>
+		<annotation cp="3⃣" type="tts">ปุ่มกดเลข: 3</annotation>
 		<annotation cp="4⃣">4 | สี่ | ปุ่มกดเลข</annotation>
+		<annotation cp="4⃣" type="tts">ปุ่มกดเลข: 4</annotation>
 		<annotation cp="5⃣">5 | ห้า | ปุ่มกดเลข</annotation>
+		<annotation cp="5⃣" type="tts">ปุ่มกดเลข: 5</annotation>
 		<annotation cp="6⃣">6 | หก | ปุ่มกดเลข</annotation>
+		<annotation cp="6⃣" type="tts">ปุ่มกดเลข: 6</annotation>
 		<annotation cp="7⃣">7 | เจ็ด | ปุ่มกดเลข</annotation>
+		<annotation cp="7⃣" type="tts">ปุ่มกดเลข: 7</annotation>
 		<annotation cp="8⃣">8 | แปด | ปุ่มกดเลข</annotation>
+		<annotation cp="8⃣" type="tts">ปุ่มกดเลข: 8</annotation>
 		<annotation cp="9⃣">9 | เก้า | ปุ่มกดเลข</annotation>
+		<annotation cp="9⃣" type="tts">ปุ่มกดเลข: 9</annotation>
 		<annotation cp="¹">ตัวยกเลขหนึ่ง | หนึ่ง</annotation>
 		<annotation cp="¹" type="tts">ตัวยกเลขหนึ่ง</annotation>
 		<annotation cp="²">ตัวยก | ตัวยกเลขสอง | ยกกำลังสอง | สอง</annotation>

--- a/common/annotations/ti.xml
+++ b/common/annotations/ti.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">ሩብለ</annotation>
 		<annotation cp="₿">BTC | ቢትኮይን</annotation>
 		<annotation cp="₿" type="tts">ቢትኮይን</annotation>
+		<annotation cp="0⃣" type="tts">ዝምልከት ቁልፊ፦ 0</annotation>
+		<annotation cp="1⃣" type="tts">ዝምልከት ቁልፊ፦ 1</annotation>
+		<annotation cp="2⃣" type="tts">ዝምልከት ቁልፊ፦ 2</annotation>
+		<annotation cp="3⃣" type="tts">ዝምልከት ቁልፊ፦ 3</annotation>
+		<annotation cp="4⃣" type="tts">ዝምልከት ቁልፊ፦ 4</annotation>
+		<annotation cp="5⃣" type="tts">ዝምልከት ቁልፊ፦ 5</annotation>
+		<annotation cp="6⃣" type="tts">ዝምልከት ቁልፊ፦ 6</annotation>
+		<annotation cp="7⃣" type="tts">ዝምልከት ቁልፊ፦ 7</annotation>
+		<annotation cp="8⃣" type="tts">ዝምልከት ቁልፊ፦ 8</annotation>
+		<annotation cp="9⃣" type="tts">ዝምልከት ቁልፊ፦ 9</annotation>
 		<annotation cp="¹">ልዕለ-ውራቕ | ሓደ</annotation>
 		<annotation cp="¹" type="tts">ልዕለ-ውራቕ ሓደ</annotation>
 		<annotation cp="²">ልዕለ-ውራቕ | ትርብዒት | ክልተ</annotation>

--- a/common/annotations/tk.xml
+++ b/common/annotations/tk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">rubl</annotation>
 		<annotation cp="₿">bitkoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkoin</annotation>
+		<annotation cp="0⃣" type="tts">klawiş gapagy: 0</annotation>
+		<annotation cp="1⃣" type="tts">klawiş gapagy: 1</annotation>
+		<annotation cp="2⃣" type="tts">klawiş gapagy: 2</annotation>
+		<annotation cp="3⃣" type="tts">klawiş gapagy: 3</annotation>
+		<annotation cp="4⃣" type="tts">klawiş gapagy: 4</annotation>
+		<annotation cp="5⃣" type="tts">klawiş gapagy: 5</annotation>
+		<annotation cp="6⃣" type="tts">klawiş gapagy: 6</annotation>
+		<annotation cp="7⃣" type="tts">klawiş gapagy: 7</annotation>
+		<annotation cp="8⃣" type="tts">klawiş gapagy: 8</annotation>
+		<annotation cp="9⃣" type="tts">klawiş gapagy: 9</annotation>
 		<annotation cp="¹">bir | ýokary indeks | ýokary indeks bir</annotation>
 		<annotation cp="¹" type="tts">ýokary indeks bir</annotation>
 		<annotation cp="²">iki | kwadratda | ýokary indeks | ýokary indeks iki</annotation>

--- a/common/annotations/to.xml
+++ b/common/annotations/to.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3893,6 +3893,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">lupi fakalūsia</annotation>
 		<annotation cp="₿">fakapulipuli | makapiti | paʻanga</annotation>
 		<annotation cp="₿" type="tts">makapiti</annotation>
+		<annotation cp="0⃣" type="tts">tatā foʻi kī: 0</annotation>
+		<annotation cp="1⃣" type="tts">tatā foʻi kī: 1</annotation>
+		<annotation cp="2⃣" type="tts">tatā foʻi kī: 2</annotation>
+		<annotation cp="3⃣" type="tts">tatā foʻi kī: 3</annotation>
+		<annotation cp="4⃣" type="tts">tatā foʻi kī: 4</annotation>
+		<annotation cp="5⃣" type="tts">tatā foʻi kī: 5</annotation>
+		<annotation cp="6⃣" type="tts">tatā foʻi kī: 6</annotation>
+		<annotation cp="7⃣" type="tts">tatā foʻi kī: 7</annotation>
+		<annotation cp="8⃣" type="tts">tatā foʻi kī: 8</annotation>
+		<annotation cp="9⃣" type="tts">tatā foʻi kī: 9</annotation>
 		<annotation cp="¹">fakaʻilonga | hake | taha</annotation>
 		<annotation cp="¹" type="tts">taha hake</annotation>
 		<annotation cp="²">fakaʻilonga | hake | ua</annotation>

--- a/common/annotations/tr.xml
+++ b/common/annotations/tr.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | sıfır | tuş</annotation>
+		<annotation cp="0⃣" type="tts">tuş: 0</annotation>
 		<annotation cp="1⃣">1 | bir | tuş</annotation>
+		<annotation cp="1⃣" type="tts">tuş: 1</annotation>
 		<annotation cp="2⃣">2 | iki | tuş</annotation>
+		<annotation cp="2⃣" type="tts">tuş: 2</annotation>
 		<annotation cp="3⃣">3 | üç | tuş</annotation>
+		<annotation cp="3⃣" type="tts">tuş: 3</annotation>
 		<annotation cp="4⃣">4 | dört | tuş</annotation>
+		<annotation cp="4⃣" type="tts">tuş: 4</annotation>
 		<annotation cp="5⃣">5 | beş | tuş</annotation>
+		<annotation cp="5⃣" type="tts">tuş: 5</annotation>
 		<annotation cp="6⃣">6 | altı | tuş</annotation>
+		<annotation cp="6⃣" type="tts">tuş: 6</annotation>
 		<annotation cp="7⃣">7 | yedi | tuş</annotation>
+		<annotation cp="7⃣" type="tts">tuş: 7</annotation>
 		<annotation cp="8⃣">8 | sekiz | tuş</annotation>
+		<annotation cp="8⃣" type="tts">tuş: 8</annotation>
 		<annotation cp="9⃣">9 | dokuz | tuş</annotation>
+		<annotation cp="9⃣" type="tts">tuş: 9</annotation>
 		<annotation cp="¹">bir | üs bir | üst bir simgesi | üst simge</annotation>
 		<annotation cp="¹" type="tts">üs bir</annotation>
 		<annotation cp="²">iki | karesi alınmış | üs iki | üst iki simgesi | üst simge</annotation>

--- a/common/annotations/uk.xml
+++ b/common/annotations/uk.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | біткоїн</annotation>
 		<annotation cp="₿" type="tts">біткоїн</annotation>
 		<annotation cp="0⃣">0 | нуль | клавіша</annotation>
+		<annotation cp="0⃣" type="tts">клавіша: 0</annotation>
 		<annotation cp="1⃣">1 | один | клавіша</annotation>
+		<annotation cp="1⃣" type="tts">клавіша: 1</annotation>
 		<annotation cp="2⃣">2 | два | клавіша</annotation>
+		<annotation cp="2⃣" type="tts">клавіша: 2</annotation>
 		<annotation cp="3⃣">3 | три | клавіша</annotation>
+		<annotation cp="3⃣" type="tts">клавіша: 3</annotation>
 		<annotation cp="4⃣">4 | чотири | клавіша</annotation>
+		<annotation cp="4⃣" type="tts">клавіша: 4</annotation>
 		<annotation cp="5⃣">5 | пʼять | клавіша</annotation>
+		<annotation cp="5⃣" type="tts">клавіша: 5</annotation>
 		<annotation cp="6⃣">6 | шість | клавіша</annotation>
+		<annotation cp="6⃣" type="tts">клавіша: 6</annotation>
 		<annotation cp="7⃣">7 | сім | клавіша</annotation>
+		<annotation cp="7⃣" type="tts">клавіша: 7</annotation>
 		<annotation cp="8⃣">8 | вісім | клавіша</annotation>
+		<annotation cp="8⃣" type="tts">клавіша: 8</annotation>
 		<annotation cp="9⃣">9 | девʼять | клавіша</annotation>
+		<annotation cp="9⃣" type="tts">клавіша: 9</annotation>
 		<annotation cp="¹">верхній індекс | верхній регістр | надрядкова одиниця | одиниця</annotation>
 		<annotation cp="¹" type="tts">надрядкова одиниця</annotation>
 		<annotation cp="²">верхній індекс | верхній регістр | два | двійка | надрядкова двійка | у квадраті</annotation>

--- a/common/annotations/ur.xml
+++ b/common/annotations/ur.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">روبل</annotation>
 		<annotation cp="₿">BTC | بِٹ کوائن</annotation>
 		<annotation cp="₿" type="tts">بِٹ کوائن</annotation>
+		<annotation cp="0⃣" type="tts">کی کیپ: 0</annotation>
+		<annotation cp="1⃣" type="tts">کی کیپ: 1</annotation>
+		<annotation cp="2⃣" type="tts">کی کیپ: 2</annotation>
+		<annotation cp="3⃣" type="tts">کی کیپ: 3</annotation>
+		<annotation cp="4⃣" type="tts">کی کیپ: 4</annotation>
+		<annotation cp="5⃣" type="tts">کی کیپ: 5</annotation>
+		<annotation cp="6⃣" type="tts">کی کیپ: 6</annotation>
+		<annotation cp="7⃣" type="tts">کی کیپ: 7</annotation>
+		<annotation cp="8⃣" type="tts">کی کیپ: 8</annotation>
+		<annotation cp="9⃣" type="tts">کی کیپ: 9</annotation>
 		<annotation cp="¹">ایک | سپر اسکرپٹ ایک | سپراسکرپٹ</annotation>
 		<annotation cp="¹" type="tts">سپر اسکرپٹ ایک</annotation>
 		<annotation cp="²">دو | سپر اسکرپٹ دو | سپراسکرپٹ | مربع</annotation>

--- a/common/annotations/uz.xml
+++ b/common/annotations/uz.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitkoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitkoin</annotation>
 		<annotation cp="0⃣">0 | nol | tugma qalpog‘i</annotation>
+		<annotation cp="0⃣" type="tts">tugma qalpog‘i: 0</annotation>
 		<annotation cp="1⃣">1 | bir | tugma qalpog‘i</annotation>
+		<annotation cp="1⃣" type="tts">tugma qalpog‘i: 1</annotation>
 		<annotation cp="2⃣">2 | ikki | tugma qalpog‘i</annotation>
+		<annotation cp="2⃣" type="tts">tugma qalpog‘i: 2</annotation>
 		<annotation cp="3⃣">3 | uch | tugma qalpog‘i</annotation>
+		<annotation cp="3⃣" type="tts">tugma qalpog‘i: 3</annotation>
 		<annotation cp="4⃣">4 | toʻrt | tugma qalpog‘i</annotation>
+		<annotation cp="4⃣" type="tts">tugma qalpog‘i: 4</annotation>
 		<annotation cp="5⃣">5 | besh | tugma qalpog‘i</annotation>
+		<annotation cp="5⃣" type="tts">tugma qalpog‘i: 5</annotation>
 		<annotation cp="6⃣">6 | olti | tugma qalpog‘i</annotation>
+		<annotation cp="6⃣" type="tts">tugma qalpog‘i: 6</annotation>
 		<annotation cp="7⃣">7 | yetti | tugma qalpog‘i</annotation>
+		<annotation cp="7⃣" type="tts">tugma qalpog‘i: 7</annotation>
 		<annotation cp="8⃣">8 | sakkiz | tugma qalpog‘i</annotation>
+		<annotation cp="8⃣" type="tts">tugma qalpog‘i: 8</annotation>
 		<annotation cp="9⃣">9 | toʻqqiz | tugma qalpog‘i</annotation>
+		<annotation cp="9⃣" type="tts">tugma qalpog‘i: 9</annotation>
 		<annotation cp="¹">bir soni | satr ustidagi | satr ustidagi bir soni</annotation>
 		<annotation cp="¹" type="tts">satr ustidagi bir soni</annotation>
 		<annotation cp="²">ikki soni | kvadrat belgisi | satr ustida | satr ustidagi ikki soni</annotation>

--- a/common/annotations/vi.xml
+++ b/common/annotations/vi.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">bitcoin | BTC</annotation>
 		<annotation cp="₿" type="tts">bitcoin</annotation>
 		<annotation cp="0⃣">0 | không | mũ phím</annotation>
+		<annotation cp="0⃣" type="tts">mũ phím: 0</annotation>
 		<annotation cp="1⃣">1 | một | mũ phím</annotation>
+		<annotation cp="1⃣" type="tts">mũ phím: 1</annotation>
 		<annotation cp="2⃣">2 | hai | mũ phím</annotation>
+		<annotation cp="2⃣" type="tts">mũ phím: 2</annotation>
 		<annotation cp="3⃣">3 | ba | mũ phím</annotation>
+		<annotation cp="3⃣" type="tts">mũ phím: 3</annotation>
 		<annotation cp="4⃣">4 | bốn | mũ phím</annotation>
+		<annotation cp="4⃣" type="tts">mũ phím: 4</annotation>
 		<annotation cp="5⃣">5 | năm | mũ phím</annotation>
+		<annotation cp="5⃣" type="tts">mũ phím: 5</annotation>
 		<annotation cp="6⃣">6 | sáu | mũ phím</annotation>
+		<annotation cp="6⃣" type="tts">mũ phím: 6</annotation>
 		<annotation cp="7⃣">7 | bảy | mũ phím</annotation>
+		<annotation cp="7⃣" type="tts">mũ phím: 7</annotation>
 		<annotation cp="8⃣">8 | tám | mũ phím</annotation>
+		<annotation cp="8⃣" type="tts">mũ phím: 8</annotation>
 		<annotation cp="9⃣">9 | chín | mũ phím</annotation>
+		<annotation cp="9⃣" type="tts">mũ phím: 9</annotation>
 		<annotation cp="¹">một | mũ</annotation>
 		<annotation cp="¹" type="tts">mũ một</annotation>
 		<annotation cp="²">bình phương | hai | mũ hai | số mũ</annotation>

--- a/common/annotations/yo.xml
+++ b/common/annotations/yo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3895,6 +3895,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₽" type="tts">rúbù</annotation>
 		<annotation cp="₿">Bítikoin | bítikọ́inì | BTC</annotation>
 		<annotation cp="₿" type="tts">bítikọ́inì</annotation>
+		<annotation cp="0⃣" type="tts">Keyacap: 0</annotation>
+		<annotation cp="1⃣" type="tts">Keyacap: 1</annotation>
+		<annotation cp="2⃣" type="tts">Keyacap: 2</annotation>
+		<annotation cp="3⃣" type="tts">Keyacap: 3</annotation>
+		<annotation cp="4⃣" type="tts">Keyacap: 4</annotation>
+		<annotation cp="5⃣" type="tts">Keyacap: 5</annotation>
+		<annotation cp="6⃣" type="tts">Keyacap: 6</annotation>
+		<annotation cp="7⃣" type="tts">Keyacap: 7</annotation>
+		<annotation cp="8⃣" type="tts">Keyacap: 8</annotation>
+		<annotation cp="9⃣" type="tts">Keyacap: 9</annotation>
 		<annotation cp="¹">iwe nla | iwe nla kan | kan</annotation>
 		<annotation cp="¹" type="tts">iwe nla kan</annotation>
 		<annotation cp="²">iwe nla | iwe nla méjì | mejì | sikuwe</annotation>

--- a/common/annotations/yue.xml
+++ b/common/annotations/yue.xml
@@ -3896,15 +3896,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">比特幣</annotation>
 		<annotation cp="₿" type="tts">比特幣</annotation>
 		<annotation cp="0⃣">0 | 零 | 鍵帽</annotation>
+		<annotation cp="0⃣" type="tts">鍵帽: 0</annotation>
 		<annotation cp="1⃣">1 | 一 | 鍵帽</annotation>
+		<annotation cp="1⃣" type="tts">鍵帽: 1</annotation>
 		<annotation cp="2⃣">2 | 二 | 鍵帽</annotation>
+		<annotation cp="2⃣" type="tts">鍵帽: 2</annotation>
 		<annotation cp="3⃣">3 | 三 | 鍵帽</annotation>
+		<annotation cp="3⃣" type="tts">鍵帽: 3</annotation>
 		<annotation cp="4⃣">4 | 四 | 鍵帽</annotation>
+		<annotation cp="4⃣" type="tts">鍵帽: 4</annotation>
 		<annotation cp="5⃣">5 | 五 | 鍵帽</annotation>
+		<annotation cp="5⃣" type="tts">鍵帽: 5</annotation>
 		<annotation cp="6⃣">6 | 六 | 鍵帽</annotation>
+		<annotation cp="6⃣" type="tts">鍵帽: 6</annotation>
 		<annotation cp="7⃣">7 | 七 | 鍵帽</annotation>
+		<annotation cp="7⃣" type="tts">鍵帽: 7</annotation>
 		<annotation cp="8⃣">8 | 八 | 鍵帽</annotation>
+		<annotation cp="8⃣" type="tts">鍵帽: 8</annotation>
 		<annotation cp="9⃣">9 | 九 | 鍵帽</annotation>
+		<annotation cp="9⃣" type="tts">鍵帽: 9</annotation>
 		<annotation cp="¹">一 | 上標 | 上標一</annotation>
 		<annotation cp="¹" type="tts">上標一</annotation>
 		<annotation cp="²">上標 | 上標二 | 二 | 二次方</annotation>

--- a/common/annotations/yue_Hans.xml
+++ b/common/annotations/yue_Hans.xml
@@ -3897,15 +3897,25 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="₿">比特币</annotation>
 		<annotation cp="₿" type="tts">比特币</annotation>
 		<annotation cp="0⃣">0 | 零 | 键帽</annotation>
+		<annotation cp="0⃣" type="tts">键帽: 0</annotation>
 		<annotation cp="1⃣">1 | 一 | 键帽</annotation>
+		<annotation cp="1⃣" type="tts">键帽: 1</annotation>
 		<annotation cp="2⃣">2 | 二 | 键帽</annotation>
+		<annotation cp="2⃣" type="tts">键帽: 2</annotation>
 		<annotation cp="3⃣">3 | 三 | 键帽</annotation>
+		<annotation cp="3⃣" type="tts">键帽: 3</annotation>
 		<annotation cp="4⃣">4 | 四 | 键帽</annotation>
+		<annotation cp="4⃣" type="tts">键帽: 4</annotation>
 		<annotation cp="5⃣">5 | 五 | 键帽</annotation>
+		<annotation cp="5⃣" type="tts">键帽: 5</annotation>
 		<annotation cp="6⃣">6 | 六 | 键帽</annotation>
+		<annotation cp="6⃣" type="tts">键帽: 6</annotation>
 		<annotation cp="7⃣">7 | 七 | 键帽</annotation>
+		<annotation cp="7⃣" type="tts">键帽: 7</annotation>
 		<annotation cp="8⃣">8 | 八 | 键帽</annotation>
+		<annotation cp="8⃣" type="tts">键帽: 8</annotation>
 		<annotation cp="9⃣">9 | 九 | 键帽</annotation>
+		<annotation cp="9⃣" type="tts">键帽: 9</annotation>
 		<annotation cp="¹">一 | 上标 | 上标一</annotation>
 		<annotation cp="¹" type="tts">上标一</annotation>
 		<annotation cp="²">上标 | 上标二 | 二 | 二次方</annotation>

--- a/common/annotations/zh.xml
+++ b/common/annotations/zh.xml
@@ -3898,15 +3898,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">BTC | 比特币</annotation>
 		<annotation cp="₿" type="tts">比特币</annotation>
 		<annotation cp="0⃣">0 | 〇 | 按键</annotation>
+		<annotation cp="0⃣" type="tts">按键: 0</annotation>
 		<annotation cp="1⃣">1 | 一 | 按键</annotation>
+		<annotation cp="1⃣" type="tts">按键: 1</annotation>
 		<annotation cp="2⃣">2 | 二 | 按键</annotation>
+		<annotation cp="2⃣" type="tts">按键: 2</annotation>
 		<annotation cp="3⃣">3 | 三 | 按键</annotation>
+		<annotation cp="3⃣" type="tts">按键: 3</annotation>
 		<annotation cp="4⃣">4 | 四 | 按键</annotation>
+		<annotation cp="4⃣" type="tts">按键: 4</annotation>
 		<annotation cp="5⃣">5 | 五 | 按键</annotation>
+		<annotation cp="5⃣" type="tts">按键: 5</annotation>
 		<annotation cp="6⃣">6 | 六 | 按键</annotation>
+		<annotation cp="6⃣" type="tts">按键: 6</annotation>
 		<annotation cp="7⃣">7 | 七 | 按键</annotation>
+		<annotation cp="7⃣" type="tts">按键: 7</annotation>
 		<annotation cp="8⃣">8 | 八 | 按键</annotation>
+		<annotation cp="8⃣" type="tts">按键: 8</annotation>
 		<annotation cp="9⃣">9 | 九 | 按键</annotation>
+		<annotation cp="9⃣" type="tts">按键: 9</annotation>
 		<annotation cp="¹">1 | 上标 | 上标1</annotation>
 		<annotation cp="¹" type="tts">上标1</annotation>
 		<annotation cp="²">2 | 上标 | 上标2 | 平方</annotation>

--- a/common/annotations/zh_Hant.xml
+++ b/common/annotations/zh_Hant.xml
@@ -3899,15 +3899,25 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₿">比特幣</annotation>
 		<annotation cp="₿" type="tts">比特幣</annotation>
 		<annotation cp="0⃣">0 | 〇 | 按鍵</annotation>
+		<annotation cp="0⃣" type="tts">按鍵：0</annotation>
 		<annotation cp="1⃣">1 | 一 | 按鍵</annotation>
+		<annotation cp="1⃣" type="tts">按鍵：1</annotation>
 		<annotation cp="2⃣">2 | 二 | 按鍵</annotation>
+		<annotation cp="2⃣" type="tts">按鍵：2</annotation>
 		<annotation cp="3⃣">3 | 三 | 按鍵</annotation>
+		<annotation cp="3⃣" type="tts">按鍵：3</annotation>
 		<annotation cp="4⃣">4 | 四 | 按鍵</annotation>
+		<annotation cp="4⃣" type="tts">按鍵：4</annotation>
 		<annotation cp="5⃣">5 | 五 | 按鍵</annotation>
+		<annotation cp="5⃣" type="tts">按鍵：5</annotation>
 		<annotation cp="6⃣">6 | 六 | 按鍵</annotation>
+		<annotation cp="6⃣" type="tts">按鍵：6</annotation>
 		<annotation cp="7⃣">7 | 七 | 按鍵</annotation>
+		<annotation cp="7⃣" type="tts">按鍵：7</annotation>
 		<annotation cp="8⃣">8 | 八 | 按鍵</annotation>
+		<annotation cp="8⃣" type="tts">按鍵：8</annotation>
 		<annotation cp="9⃣">9 | 九 | 按鍵</annotation>
+		<annotation cp="9⃣" type="tts">按鍵：9</annotation>
 		<annotation cp="¹">1 | 上標 | 上標數字 1</annotation>
 		<annotation cp="¹" type="tts">上標數字 1</annotation>
 		<annotation cp="²">2 | 上標 | 上標數字 2 | 平方</annotation>

--- a/common/annotations/zu.xml
+++ b/common/annotations/zu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2024 Unicode, Inc.
+<!-- Copyright © 1991-2025 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3897,6 +3897,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="₽" type="tts">i-ruble</annotation>
 		<annotation cp="₿">i-bitcoin | i-BTC</annotation>
 		<annotation cp="₿" type="tts">i-bitcoin</annotation>
+		<annotation cp="0⃣" type="tts">i-keycap: 0</annotation>
+		<annotation cp="1⃣" type="tts">i-keycap: 1</annotation>
+		<annotation cp="2⃣" type="tts">i-keycap: 2</annotation>
+		<annotation cp="3⃣" type="tts">i-keycap: 3</annotation>
+		<annotation cp="4⃣" type="tts">i-keycap: 4</annotation>
+		<annotation cp="5⃣" type="tts">i-keycap: 5</annotation>
+		<annotation cp="6⃣" type="tts">i-keycap: 6</annotation>
+		<annotation cp="7⃣" type="tts">i-keycap: 7</annotation>
+		<annotation cp="8⃣" type="tts">i-keycap: 8</annotation>
+		<annotation cp="9⃣" type="tts">i-keycap: 9</annotation>
 		<annotation cp="¹">i-one | i-superscript one | superscript</annotation>
 		<annotation cp="¹" type="tts">i-superscript one</annotation>
 		<annotation cp="²">i-squared | i-superscript two | superscript | two</annotation>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
@@ -1,5 +1,6 @@
 package org.unicode.cldr.tool;
 
+import com.google.common.collect.ImmutableSortedSet;
 import com.ibm.icu.impl.Relation;
 import com.ibm.icu.impl.UnicodeRegex;
 import com.ibm.icu.text.Transliterator;
@@ -240,7 +241,7 @@ public class SearchXml {
                             + DiffInfo.DiffInfoHeader
                             + "\n#\tValue\tOtherValue\tPath");
         }
-        for (File file : src.listFiles()) {
+        for (File file : ImmutableSortedSet.copyOf(src.listFiles())) {
             if (recursive && file.isDirectory()) {
                 processDirectory(file);
                 continue;
@@ -569,15 +570,15 @@ public class SearchXml {
                                 : new_values.iterator().next();
 
         System.out.println(
-                fileParent
-                        + ";\tlocale="
+                // fileParent  + ";\t" +
+                "locale="
                         + fileWithoutSuffix
                         + ";\taction="
                         + configOption
                         + (match_value == null ? "" : ";\tvalue=" + escape(match_value))
                         + (match_path == null ? "" : ";\tpath=" + match_path)
-                        + (values2 == null ? "" : ";\tnew_value=" + escape(values2))
                         + (new_path == null ? "" : ";\tnew_path=" + new_path)
+                        + (values2 == null ? "" : ";\tnew_value=" + escape(values2))
                         + (otherValues == null ? "" : ";\tother_value=" + otherValues));
     }
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,961 +1,1092 @@
 #Locale	Action=add;	Path	Value
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nul | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | een | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | twee | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | drie | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | vier | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | vyf | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ses | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sewe | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | agt | knoppiesimbool
-locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nege | knoppiesimbool
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | hwee | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | koro | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | abien | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | abiasa | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | anan | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | anum | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | asia | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | asuon | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | awɔtwe | kiikape
-locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | akron | kiikape
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ባዶ | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | አንድ | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ሁለት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ሦስት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | አራት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | አምስት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ስድስት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ሰባት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ስምንት | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ዘጠኝ | የአብይ ሆሄ ቁልፍ ማብሪያ
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | صفر | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | واحد | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | إثنان | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ثلاثة | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | أربعة | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | خمسة | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ستة | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | سبعة | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ثمانية | مفتاح
-locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | تسعة | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | صفر | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | واحد | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | إثنان | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ثلاثة | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | أربعة | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | خمسة | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ستة | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | سبعة | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ثمانية | مفتاح
-locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | تسعة | مفتاح
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | sıfır | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | bir | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | iki | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | üç | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | dörd | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | beş | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | altı | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | yeddi | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | səkkiz | klaviatura qapağı
-locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | doqquz | klaviatura qapağı
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нуль | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | адзiн | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | два | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | тры | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | чатыры | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | пяць | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | шэсць | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | сем | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | восем | Клавіша
-locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | дзевяць | Клавіша
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нула | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | едно | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | две | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | три | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | четири | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | пет | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | шест | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | седем | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | осем | Клавиш
-locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | девет | Клавиш
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | শূন্য | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | এক | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | দুই | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | তিন | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | চার | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | পাঁচ | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ছয় | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | সাত | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | আট | কিক্যাপ
-locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | নয় | কিক্যাপ
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nula | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | jedan | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dva | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tri | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | četiri | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pet | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šest | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sedam | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osam | Kapica za tipku
-locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | devet | Kapica za tipku
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | u | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dos | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tres | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | quatre | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinc | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sis | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | set | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | vuit | tecla
-locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nou | tecla
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 𑄥𑄪𑄚𑄳𑄠𑄴𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 𑄆𑄇𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 𑄘𑄨 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 𑄖𑄨𑄚𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 𑄌𑄳𑄆𑄬𑄢𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 𑄛𑄌𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 𑄍𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 𑄥𑄖𑄴 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 𑄃𑄖𑄳𑄠𑄴𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 𑄚𑄧 | 𑄇𑄨𑄇𑄳𑄠𑄛𑄴
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ꮭ ꭺꮝꮧ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ꮠꮼ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ꮤꮅ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ꮶꭲ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ꮕꭹ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ꭿꮝꭹ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ꮡꮣꮅ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ꭶꮅꮙꭹ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ꮷꮑꮃ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ꮠꮑꮃ | ᎠᏚᎢᏍᏘᎠᎵᏚᎶ
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nula | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | jeden | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dva | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tři | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | čtyři | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pět | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šest | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sedm | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osm | klávesa
-locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | devět | klávesa
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | dim | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | un | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dau | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tri | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | pedwar | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pump | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | chwech | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | saith | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | wyth | gorchudd bysell
-locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | naw | gorchudd bysell
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nul | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | et | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | to | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | fire | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fem | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seks | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | syv | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | otte | keycap
-locale=da;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ni | keycap
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | eins | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | zwei | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | drei | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | vier | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fünf | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sechs | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sieben | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | acht | Taste
-locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | neun | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | eins | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | zwei | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | drei | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | vier | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fünf | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sechs | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sieben | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | acht | Taste
-locale=de_CH;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | neun | Taste
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | μηδέν | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ένα | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | δύο | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | τρία | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | τέσσερα | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | πέντε | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | έξι | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | επτά | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | οκτώ | πλήκτρο
-locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | εννέα | πλήκτρο
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | one | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | two | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | three | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | four | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | five | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | six | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | seven | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | eight | keycap
-locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nine | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | one | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | two | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | three | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | four | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | five | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | six | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | seven | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | eight | keycap
-locale=en_001;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nine | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | one | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | two | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | three | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | four | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | five | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | six | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | seven | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | eight | keycap
-locale=en_IN;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nine | keycap
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | cero | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | uno | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dos | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tres | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | cuatro | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinco | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seis | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | siete | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ocho | Teclas
-locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nueve | Teclas
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | cero | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | uno | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dos | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tres | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | cuatro | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinco | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seis | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | siete | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ocho | tecla mayus
-locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nueve | tecla mayus
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | cero | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | uno | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dos | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tres | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | cuatro | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinco | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seis | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | siete | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ocho | tecla
-locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nueve | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | cero | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | uno | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dos | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tres | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | cuatro | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinco | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seis | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | siete | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ocho | tecla
-locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nueve | tecla
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | üks | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | kaks | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | kolm | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | neli | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | viis | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | kuus | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | seitse | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | kaheksa | klahv
-locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | üheksa | klahv
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | صفر | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | یک | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | دو | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | سه | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | چهار | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | پنج | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | شش | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | هفت | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | هشت | جلد کلید
-locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | نه | جلد کلید
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ɓolum | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | goʼo | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ɗiɗi | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tati | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | nawi | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | jowi | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | jeegoʼo | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | jeeɗiɗi | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | jeetati | keycap
-locale=ff;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | jeenawi | keycap
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nolla | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | yksi | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | kaksi | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | kolme | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | neljä | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | viisi | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | kuusi | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | seitsemän | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | kahdeksan | näppäin
-locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | yhdeksän | näppäin
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | walâ | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | isá | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dalawá | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tatló | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ápat | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | limá | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | anim | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | pitó | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | waló | keycap
-locale=fil;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | siyám | keycap
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ein | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | tveir | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tríggir | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | fýre | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fimm | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seks | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sjey | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | átta | Knappahetta
-locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | níggju | Knappahetta
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zéro | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | un | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | deux | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | trois | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | quatre | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinq | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | six | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sept | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | huit | touches
-locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | neuf | touches
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | a náid | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | a haon | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | a dó | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | a trí | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | a ceathair | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | a cúig | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | a sé | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | a seacht | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | a hocht | caipín eochrach
-locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | a naoi | caipín eochrach
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | શૂન્ય | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | એક | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | બે | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ત્રણ | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ચાર | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | પાંચ | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | છ | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | સાત | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | આઠ | કીકેપ
-locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | નવ | કીકેપ
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | sifili | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | daya | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | biyu | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | uku | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | hudu | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | biyar | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | shida | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | bakwai | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | takwas | maɓalli na musamman
-locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | tara | maɓalli na musamman
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | אפס | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | אחת | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | שתיים | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | שלוש | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ארבע | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | חמש | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | שש | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | שבע | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | שמונה | מקש
-locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | תשע | מקש
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | शून्य | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | एक | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | दो | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | तीन | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | चार | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | पाँच | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | छह | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | सात | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | आठ | कीकैप
-locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | नौ | कीकैप
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nula | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | jedan | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dva | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tri | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | četiri | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pet | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šest | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sedam | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osam | tipka
-locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | devet | tipka
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nulla | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | egy | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | kettő | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | három | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | négy | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | öt | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | hat | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | hét | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | nyolc | gombfej
-locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | kilenc | gombfej
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | զրո | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | մեկ | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | երկու | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | երեք | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | չորս | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | հինգ | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | վեց | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | յոթ | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ութ | ստեղն
-locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ինը | ստեղն
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nol | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | satu | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dua | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tiga | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | empat | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | lima | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | enam | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | tujuh | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | delapan | keycap
-locale=id;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | sembilan | keycap
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | núll | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | einn | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | tveir | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | þrír | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | fjórir | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fimm | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sex | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sjó | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | átta | takki
-locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | níu | takki
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | uno | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | due | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | quattro | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinque | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sei | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sette | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | otto | tasto
-locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nove | tasto
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 〇 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 一 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 二 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 三 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 四 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 五 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 六 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 七 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 八 | 囲み数字
-locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 九 | 囲み数字
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ნული | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ერთი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ორი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | სამი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ოთხი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ხუთი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ექვსი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | შვიდი | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | რვა | კლავიში
-locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ცხრა | კლავიში
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нөл | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | бір | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | екі | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | үш | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | төрт | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | бес | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | алты | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | жеті | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | сегіз | перне
-locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | тоғыз | перне
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nuulu | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ataaseq | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | marluk | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | pingasut | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | sisamat | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | tallimat | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | arfinillit | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | arfineq-marluk | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | arfineq-pingasut | keycap
-locale=kl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | arfineq-sisamat | keycap
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | សូន្យ | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | មួយ | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ពីរ | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | បី | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | បួន | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ប្រាំ | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ប្រាំមួយ | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ប្រាំពីរ | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ប្រាំបី | គម្របគ្រាប់ចុច
-locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ប្រាំបួន | គម្របគ្រាប់ចុច
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ಶೂನ್ಯ | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ಒಂದು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ಎರಡು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ಮೂರು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ನಾಲ್ಕು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ಐದು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ಆರು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ಏಳು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ಎಂಟು | ಕೀಕ್ಯಾಪ್
-locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ಒಂಭತ್ತು | ಕೀಕ್ಯಾಪ್
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 공 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 일 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 이 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 삼 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 사 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 오 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 육 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 칠 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 팔 | 키 캡
-locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 구 | 키 캡
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нөл | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | бир | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | эки | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | үч | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | төрт | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | беш | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | алты | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | жети | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | сегиз | клавиатура калпакчасы
-locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | тогуз | клавиатура калпакчасы
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | eent | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | zwee | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | dräi | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | véier | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fënnef | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sechs | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | siwen | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | aacht | keycap
-locale=lb;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | néng | keycap
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ศูนย์ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ໜຶ່ງ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ສອງ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ສາມ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ສີ່ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ຫ້າ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ຫົກ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ເຈັດ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ແປດ | ແປ້ນແຄັບ
-locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ເກົ້າ | ແປ້ນແຄັບ
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nulis | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | vienas | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | du | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | trys | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | keturi | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | penki | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šeši | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | septyni | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | aštuoni | mygtukas
-locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | devyni | mygtukas
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nulle | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | viens | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | divi | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | trīs | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | četri | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pieci | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seši | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | septiņi | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | astoņi | taustiņš
-locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | deviņi | taustiņš
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нула | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | еден | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | два | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | три | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | четири | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | пет | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | шест | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | седум | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | осум | копче
-locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | девет | копче
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | പൂജ്യം | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ഒന്ന് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | രണ്ട് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | മൂന്ന് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | നാല് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | അഞ്ച് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ആറ് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ഏഴ് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | എട്ട് | കീക്യാപ്പ്
-locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ഒമ്പത് | കീക്യാപ്പ്
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | शून्य | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | एक | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | दोन | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | तीन | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | चार | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | पाच | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | सहा | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | सात | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | आठ | कीकॅप
-locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | नऊ | कीकॅप
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | kosong | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | satu | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dua | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tiga | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | empat | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | lima | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | enam | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | tujuh | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | lapan | butang kekunci
-locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | sembilan | butang kekunci
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | żero | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | wieħed | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | tnejn | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tlieta | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | erbgħa | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ħamsa | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sitta | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sebgħa | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | tmienja | keycap
-locale=mt;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | disgħa | keycap
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | သုည | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | တစ် | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | နှစ် | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | သုံး | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | လေး | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ငါး | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ခြောက် | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ခုနှစ် | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ရှစ် | ခလုတ်
-locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ကိုး | ခလုတ်
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | शुन्य | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | एक | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | दुई | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | तिन | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | चार | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | पाँच | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | छ | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | सात | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | आठ | किक्याप
-locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | नौ | किक्याप
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nul | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | een | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | twee | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | drie | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | vier | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | vijf | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | zes | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | zeven | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | acht | toets
-locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | negen | toets
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | éin | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | to | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | fire | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fem | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seks | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sju | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | åtte | tastar
-locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ni | tastar
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | null | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | én | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | to | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | fire | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fem | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seks | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sju | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | åtte | taster
-locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ni | taster
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zeeroo | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | tokko | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | lama | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | sadii | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | afur | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | shan | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | jaha | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | torba | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | saddet | keycap
-locale=om;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | sagal | keycap
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ਸਿਫਰ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ਇੱਕ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ਦੋ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ਤਿੰਨ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | ਚਾਰ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ਪੰਜ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ਛੇ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ਸੱਤ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ਅੱਠ | ਕੀਕੈਪ
-locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ਨੌਂ | ਕੀਕੈਪ
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | jeden | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dwa | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | trzy | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | cztery | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pięć | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sześć | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | siedem | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osiem | klawisz
-locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | dziewięć | klawisz
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | um | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dois | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | três | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | quatro | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinco | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seis | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sete | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | oito | tecla
-locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nove | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | um | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dois | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | três | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | quatro | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinco | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | seis | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sete | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | oito | tecla
-locale=pt_PT;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nove | tecla
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | chusaq | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | huk | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | iskay | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | kinsa | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | tawa | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | phisqa | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | suqta | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | qanchis | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | pusaq | keycap
-locale=qu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | isqun | keycap
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | unu | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | doi | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | trei | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | patru | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | cinci | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | şase | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | şapte | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | opt | tastă
-locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nouă | tastă
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 0 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 1 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 2 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 3 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 4 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 5 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 6 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 7 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 8 | keycap
-locale=root;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 9 | keycap
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ноль | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | один | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | два | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | три | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | четыре | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | пять | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | шесть | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | семь | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | восемь | клавиши
-locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | девять | клавиши
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nula | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | jeden | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dva | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tri | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | štyri | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | päť | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šesť | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sedem | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osem | kláves
-locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | deväť | kláves
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nič | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ena | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dva | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tri | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | štiri | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pet | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šest | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sedem | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osem | keycap
-locale=sl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | devet | keycap
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | një | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dy | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | katër | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pesë | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | gjashtë | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | shtatë | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | tetë | tast
-locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nëntë | tast
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нула | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | један | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | два | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | три | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | четири | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | пет | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | шест | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | седам | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | осам | тастер
-locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | девет | тастер
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nula | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | jedan | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dva | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tri | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | četiri | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | pet | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | šest | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sedam | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | osam | taster
-locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | devet | taster
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nol | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | hiji | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | dua | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tilu | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | opat | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | lima | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | genep | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | tujuh | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | dalapan | keycap
-locale=su;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | salapan | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | noll | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ett | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | två | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | fyra | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | fem | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sex | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sju | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | åtta | keycap
-locale=sv;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nio | keycap
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | sifuri | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | moja | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | mbili | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tatu | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | nne | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | tano | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sita | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | saba | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | nane | kitufe
-locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | tisa | kitufe
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | பூஜ்யம் | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ஒன்று | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | இரண்டு | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | மூன்று | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | நான்கு | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ஐந்து | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ஆறு | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ஏழு | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | எட்டு | விசை
-locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | ஒன்பது | விசை
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | సున్న | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | ఒకటి | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | రెండు | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | మూడు | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | నాలుగు | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ఐదు | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | ఆరు | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | ఏడు | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | ఎనిమిది | కీక్యాప్
-locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | తొమ్మిది | కీక్యాప్
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | ศูนย์ | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | หนึ่ง | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | สอง | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | สาม | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | สี่ | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | ห้า | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | หก | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | เจ็ด | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | แปด | ปุ่มกดเลข
-locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | เก้า | ปุ่มกดเลข
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | sıfır | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | bir | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | iki | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | üç | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | dört | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | beş | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | altı | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | yedi | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | sekiz | tuş
-locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | dokuz | tuş
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | нуль | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | один | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | два | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | три | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | чотири | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | пʼять | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | шість | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | сім | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | вісім | клавіша
-locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | девʼять | клавіша
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | nol | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | bir | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | ikki | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | uch | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | toʻrt | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | besh | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | olti | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | yetti | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | sakkiz | tugma qalpog‘i
-locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | toʻqqiz | tugma qalpog‘i
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | zero | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | uno | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | do | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | tre | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | cuatro | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | sincue | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sie | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | sete | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | oto | keycap
-locale=vec;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | nove | keycap
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | không | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | một | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | hai | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | ba | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | bốn | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | năm | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | sáu | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | bảy | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | tám | mũ phím
-locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | chín | mũ phím
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 零 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 一 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 二 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 三 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 四 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 五 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 六 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 七 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 八 | 鍵帽
-locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 九 | 鍵帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 零 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 一 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 二 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 三 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 四 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 五 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 六 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 七 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 八 | 键帽
-locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 九 | 键帽
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 〇 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 一 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 二 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 三 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 四 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 五 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 六 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 七 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 八 | 按键
-locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 九 | 按键
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 〇 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 一 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 二 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 三 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 四 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 五 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 六 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 七 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 八 | 按鍵
-locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 九 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"];	new_value=0 | 零 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"];	new_value=1 | 一 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"];	new_value=2 | 二 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"];	new_value=3 | 三 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"];	new_value=4 | 四 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"];	new_value=5 | 五 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"];	new_value=6 | 六 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"];	new_value=7 | 七 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"];	new_value=8 | 八 | 按鍵
-locale=zh_Hant_HK;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"];	new_value=9 | 九 | 按鍵
+# Note: SearchXML will produce this format
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=knoppiesimbool: 0
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=knoppiesimbool: 1
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=knoppiesimbool: 2
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=knoppiesimbool: 3
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=knoppiesimbool: 4
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=knoppiesimbool: 5
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=knoppiesimbool: 6
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=knoppiesimbool: 7
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=knoppiesimbool: 8
+locale=af;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=knoppiesimbool: 9
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=kiikape: 0
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=kiikape: 1
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=kiikape: 2
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=kiikape: 3
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=kiikape: 4
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=kiikape: 5
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=kiikape: 6
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=kiikape: 7
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=kiikape: 8
+locale=ak;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=kiikape: 9
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 0
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 1
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 2
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 3
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 4
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 5
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 6
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 7
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 8
+locale=am;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=የአብይ ሆሄ ቁልፍ ማብሪያ: 9
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=مفتاح: 0
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=مفتاح: 1
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=مفتاح: 2
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=مفتاح: 3
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=مفتاح: 4
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=مفتاح: 5
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=مفتاح: 6
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=مفتاح: 7
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=مفتاح: 8
+locale=ar;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=مفتاح: 9
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=مفتاح: 0
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=مفتاح: 1
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=مفتاح: 2
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=مفتاح: 3
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=مفتاح: 4
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=مفتاح: 5
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=مفتاح: 6
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=مفتاح: 7
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=مفتاح: 8
+locale=ar_SA;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=مفتاح: 9
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=কীকেপ: 0
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=কীকেপ: 1
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=কীকেপ: 2
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=কীকেপ: 3
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=কীকেপ: 4
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=কীকেপ: 5
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=কীকেপ: 6
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=কীকেপ: 7
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=কীকেপ: 8
+locale=as;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=কীকেপ: 9
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecles: 0
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecles: 1
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecles: 2
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecles: 3
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecles: 4
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecles: 5
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecles: 6
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecles: 7
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecles: 8
+locale=ast;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecles: 9
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=klaviatura qapağı: 0
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=klaviatura qapağı: 1
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=klaviatura qapağı: 2
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=klaviatura qapağı: 3
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=klaviatura qapağı: 4
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=klaviatura qapağı: 5
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=klaviatura qapağı: 6
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=klaviatura qapağı: 7
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=klaviatura qapağı: 8
+locale=az;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=klaviatura qapağı: 9
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Клавіша: 0
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Клавіша: 1
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Клавіша: 2
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Клавіша: 3
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Клавіша: 4
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Клавіша: 5
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Клавіша: 6
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Клавіша: 7
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Клавіша: 8
+locale=be;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Клавіша: 9
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Клавиш: 0
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Клавиш: 1
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Клавиш: 2
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Клавиш: 3
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Клавиш: 4
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Клавиш: 5
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Клавиш: 6
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Клавиш: 7
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Клавиш: 8
+locale=bg;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Клавиш: 9
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=কিক্যাপ: 0
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=কিক্যাপ: 1
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=কিক্যাপ: 2
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=কিক্যাপ: 3
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=কিক্যাপ: 4
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=কিক্যাপ: 5
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=কিক্যাপ: 6
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=কিক্যাপ: 7
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=কিক্যাপ: 8
+locale=bn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=কিক্যাপ: 9
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Kapica za tipku: 0
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Kapica za tipku: 1
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Kapica za tipku: 2
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Kapica za tipku: 3
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Kapica za tipku: 4
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Kapica za tipku: 5
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Kapica za tipku: 6
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Kapica za tipku: 7
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Kapica za tipku: 8
+locale=bs;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Kapica za tipku: 9
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla: 0
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla: 1
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla: 2
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla: 3
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla: 4
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla: 5
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla: 6
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla: 7
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla: 8
+locale=ca;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla: 9
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 0
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 1
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 2
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 3
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 4
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 5
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 6
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 7
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 8
+locale=ccp;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=𑄇𑄨𑄇𑄳𑄠𑄛𑄴: 9
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 0
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 1
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 2
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 3
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 4
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 5
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 6
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 7
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 8
+locale=chr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ᎠᏚᎢᏍᏘᎠᎵᏚᎶ: 9
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=klávesa: 0
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=klávesa: 1
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=klávesa: 2
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=klávesa: 3
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=klávesa: 4
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=klávesa: 5
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=klávesa: 6
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=klávesa: 7
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=klávesa: 8
+locale=cs;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=klávesa: 9
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=брелок: 0
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=брелок: 1
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=брелок: 2
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=брелок: 3
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=брелок: 4
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=брелок: 5
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=брелок: 6
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=брелок: 7
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=брелок: 8
+locale=cv;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=брелок: 9
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=gorchudd bysell: 0
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=gorchudd bysell: 1
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=gorchudd bysell: 2
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=gorchudd bysell: 3
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=gorchudd bysell: 4
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=gorchudd bysell: 5
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=gorchudd bysell: 6
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=gorchudd bysell: 7
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=gorchudd bysell: 8
+locale=cy;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=gorchudd bysell: 9
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Taste: 0
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Taste: 1
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Taste: 2
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Taste: 3
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Taste: 4
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Taste: 5
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Taste: 6
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Taste: 7
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Taste: 8
+locale=de;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Taste: 9
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tasta: 0
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tasta: 1
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tasta: 2
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tasta: 3
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tasta: 4
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tasta: 5
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tasta: 6
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tasta: 7
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tasta: 8
+locale=dsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tasta: 9
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=πλήκτρο: 0
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=πλήκτρο: 1
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=πλήκτρο: 2
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=πλήκτρο: 3
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=πλήκτρο: 4
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=πλήκτρο: 5
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=πλήκτρο: 6
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=πλήκτρο: 7
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=πλήκτρο: 8
+locale=el;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=πλήκτρο: 9
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=keycap: 0
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=keycap: 1
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=keycap: 2
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=keycap: 3
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=keycap: 4
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=keycap: 5
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=keycap: 6
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=keycap: 7
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=keycap: 8
+locale=en;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=keycap: 9
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Teclas: 0
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Teclas: 1
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Teclas: 2
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Teclas: 3
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Teclas: 4
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Teclas: 5
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Teclas: 6
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Teclas: 7
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Teclas: 8
+locale=es;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Teclas: 9
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla mayus: 0
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla mayus: 1
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla mayus: 2
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla mayus: 3
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla mayus: 4
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla mayus: 5
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla mayus: 6
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla mayus: 7
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla mayus: 8
+locale=es_419;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla mayus: 9
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla: 0
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla: 1
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla: 2
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla: 3
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla: 4
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla: 5
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla: 6
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla: 7
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla: 8
+locale=es_MX;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla: 9
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla: 0
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla: 1
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla: 2
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla: 3
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla: 4
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla: 5
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla: 6
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla: 7
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla: 8
+locale=es_US;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla: 9
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=klahv: 0
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=klahv: 1
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=klahv: 2
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=klahv: 3
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=klahv: 4
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=klahv: 5
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=klahv: 6
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=klahv: 7
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=klahv: 8
+locale=et;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=klahv: 9
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Tekla: 0
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Tekla: 1
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Tekla: 2
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Tekla: 3
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Tekla: 4
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Tekla: 5
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Tekla: 6
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Tekla: 7
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Tekla: 8
+locale=eu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Tekla: 9
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=جلد کلید: 0
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=جلد کلید: 1
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=جلد کلید: 2
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=جلد کلید: 3
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=جلد کلید: 4
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=جلد کلید: 5
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=جلد کلید: 6
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=جلد کلید: 7
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=جلد کلید: 8
+locale=fa;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=جلد کلید: 9
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 0
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 1
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 2
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 3
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 4
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 5
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 6
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 7
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 8
+locale=ff_Adlm;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=𞤊𞤫𞤣𞤭𞤲𞤭𞤪𞤣𞤫: 9
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=näppäin: 0
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=näppäin: 1
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=näppäin: 2
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=näppäin: 3
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=näppäin: 4
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=näppäin: 5
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=näppäin: 6
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=näppäin: 7
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=näppäin: 8
+locale=fi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=näppäin: 9
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Knappahetta: 0
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Knappahetta: 1
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Knappahetta: 2
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Knappahetta: 3
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Knappahetta: 4
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Knappahetta: 5
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Knappahetta: 6
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Knappahetta: 7
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Knappahetta: 8
+locale=fo;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Knappahetta: 9
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=touches\x{202F}: 0
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=touches\x{202F}: 1
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=touches\x{202F}: 2
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=touches\x{202F}: 3
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=touches\x{202F}: 4
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=touches\x{202F}: 5
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=touches\x{202F}: 6
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=touches\x{202F}: 7
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=touches\x{202F}: 8
+locale=fr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=touches\x{202F}: 9
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 0
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 1
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 2
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 3
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 4
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 5
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 6
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 7
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 8
+locale=fr_CA;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=dessus de touche\x{A0}: 9
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=caipín eochrach: 0
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=caipín eochrach: 1
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=caipín eochrach: 2
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=caipín eochrach: 3
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=caipín eochrach: 4
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=caipín eochrach: 5
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=caipín eochrach: 6
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=caipín eochrach: 7
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=caipín eochrach: 8
+locale=ga;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=caipín eochrach: 9
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 0
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 1
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 2
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 3
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 4
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 5
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 6
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 7
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 8
+locale=gd;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=còmhdachadh iuchrach: 9
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla: 0
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla: 1
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla: 2
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla: 3
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla: 4
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla: 5
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla: 6
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla: 7
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla: 8
+locale=gl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla: 9
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=કીકેપ: 0
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=કીકેપ: 1
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=કીકેપ: 2
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=કીકેપ: 3
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=કીકેપ: 4
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=કીકેપ: 5
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=કીકેપ: 6
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=કીકેપ: 7
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=કીકેપ: 8
+locale=gu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=કીકેપ: 9
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=maɓalli na musamman: 0
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=maɓalli na musamman: 1
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=maɓalli na musamman: 2
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=maɓalli na musamman: 3
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=maɓalli na musamman: 4
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=maɓalli na musamman: 5
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=maɓalli na musamman: 6
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=maɓalli na musamman: 7
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=maɓalli na musamman: 8
+locale=ha;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=maɓalli na musamman: 9
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=מקש: 0
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=מקש: 1
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=מקש: 2
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=מקש: 3
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=מקש: 4
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=מקש: 5
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=מקש: 6
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=מקש: 7
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=מקש: 8
+locale=he;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=מקש: 9
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=कीकैप: 0
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=कीकैप: 1
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=कीकैप: 2
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=कीकैप: 3
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=कीकैप: 4
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=कीकैप: 5
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=कीकैप: 6
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=कीकैप: 7
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=कीकैप: 8
+locale=hi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=कीकैप: 9
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tipka: 0
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tipka: 1
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tipka: 2
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tipka: 3
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tipka: 4
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tipka: 5
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tipka: 6
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tipka: 7
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tipka: 8
+locale=hr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tipka: 9
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tłóčatko: 0
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tłóčatko: 1
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tłóčatko: 2
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tłóčatko: 3
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tłóčatko: 4
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tłóčatko: 5
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tłóčatko: 6
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tłóčatko: 7
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tłóčatko: 8
+locale=hsb;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tłóčatko: 9
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=gombfej: 0
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=gombfej: 1
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=gombfej: 2
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=gombfej: 3
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=gombfej: 4
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=gombfej: 5
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=gombfej: 6
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=gombfej: 7
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=gombfej: 8
+locale=hu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=gombfej: 9
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ստեղն․ 0
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ստեղն․ 1
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ստեղն․ 2
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ստեղն․ 3
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ստեղն․ 4
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ստեղն․ 5
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ստեղն․ 6
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ստեղն․ 7
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ստեղն․ 8
+locale=hy;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ստեղն․ 9
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=clave: 0
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=clave: 1
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=clave: 2
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=clave: 3
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=clave: 4
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=clave: 5
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=clave: 6
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=clave: 7
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=clave: 8
+locale=ia;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=clave: 9
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=takki: 0
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=takki: 1
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=takki: 2
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=takki: 3
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=takki: 4
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=takki: 5
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=takki: 6
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=takki: 7
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=takki: 8
+locale=is;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=takki: 9
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tasto: 0
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tasto: 1
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tasto: 2
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tasto: 3
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tasto: 4
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tasto: 5
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tasto: 6
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tasto: 7
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tasto: 8
+locale=it;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tasto: 9
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=囲み数字: 0
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=囲み数字: 1
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=囲み数字: 2
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=囲み数字: 3
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=囲み数字: 4
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=囲み数字: 5
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=囲み数字: 6
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=囲み数字: 7
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=囲み数字: 8
+locale=ja;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=囲み数字: 9
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=კლავიში: 0
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=კლავიში: 1
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=კლავიში: 2
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=კლავიში: 3
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=კლავიში: 4
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=კლავიში: 5
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=კლავიში: 6
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=კლავიში: 7
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=კლავიში: 8
+locale=ka;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=კლავიში: 9
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=перне: 0
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=перне: 1
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=перне: 2
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=перне: 3
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=перне: 4
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=перне: 5
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=перне: 6
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=перне: 7
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=перне: 8
+locale=kk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=перне: 9
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=پەرنە: 0
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=پەرنە: 1
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=پەرنە: 2
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=پەرنە: 3
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=پەرنە: 4
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=پەرنە: 5
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=پەرنە: 6
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=پەرنە: 7
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=پەرنە: 8
+locale=kk_Arab;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=پەرنە: 9
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 0
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 1
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 2
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 3
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 4
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 5
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 6
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 7
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 8
+locale=km;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=គម្របគ្រាប់ចុច: 9
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 0
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 1
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 2
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 3
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 4
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 5
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 6
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 7
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 8
+locale=kn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ಕೀಕ್ಯಾಪ್: 9
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=키 캡: 0
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=키 캡: 1
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=키 캡: 2
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=키 캡: 3
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=키 캡: 4
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=키 캡: 5
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=키 캡: 6
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=키 캡: 7
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=키 캡: 8
+locale=ko;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=키 캡: 9
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=कीकॅप: 0
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=कीकॅप: 1
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=कीकॅप: 2
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=कीकॅप: 3
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=कीकॅप: 4
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=कीकॅप: 5
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=कीकॅप: 6
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=कीकॅप: 7
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=कीकॅप: 8
+locale=kok;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=कीकॅप: 9
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 0
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 1
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 2
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 3
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 4
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 5
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 6
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 7
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 8
+locale=ky;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=клавиатура калпакчасы: 9
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tasto: 0
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tasto: 1
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tasto: 2
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tasto: 3
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tasto: 4
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tasto: 5
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tasto: 6
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tasto: 7
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tasto: 8
+locale=lij;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tasto: 9
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 0
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 1
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 2
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 3
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 4
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 5
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 6
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 7
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 8
+locale=lo;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ແປ້ນແຄັບ: 9
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=mygtukas: 0
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=mygtukas: 1
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=mygtukas: 2
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=mygtukas: 3
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=mygtukas: 4
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=mygtukas: 5
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=mygtukas: 6
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=mygtukas: 7
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=mygtukas: 8
+locale=lt;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=mygtukas: 9
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=taustiņš: 0
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=taustiņš: 1
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=taustiņš: 2
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=taustiņš: 3
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=taustiņš: 4
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=taustiņš: 5
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=taustiņš: 6
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=taustiņš: 7
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=taustiņš: 8
+locale=lv;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=taustiņš: 9
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=uhi pātuhi: 0
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=uhi pātuhi: 1
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=uhi pātuhi: 2
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=uhi pātuhi: 3
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=uhi pātuhi: 4
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=uhi pātuhi: 5
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=uhi pātuhi: 6
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=uhi pātuhi: 7
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=uhi pātuhi: 8
+locale=mi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=uhi pātuhi: 9
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=копче: 0
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=копче: 1
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=копче: 2
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=копче: 3
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=копче: 4
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=копче: 5
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=копче: 6
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=копче: 7
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=копче: 8
+locale=mk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=копче: 9
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 0
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 1
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 2
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 3
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 4
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 5
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 6
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 7
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 8
+locale=ml;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=കീക്യാപ്പ്: 9
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 0
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 1
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 2
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 3
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 4
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 5
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 6
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 7
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 8
+locale=mn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=түлхүүрийн гэр: 9
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=कीकॅप: 0
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=कीकॅप: 1
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=कीकॅप: 2
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=कीकॅप: 3
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=कीकॅप: 4
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=कीकॅप: 5
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=कीकॅप: 6
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=कीकॅप: 7
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=कीकॅप: 8
+locale=mr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=कीकॅप: 9
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=butang kekunci: 0
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=butang kekunci: 1
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=butang kekunci: 2
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=butang kekunci: 3
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=butang kekunci: 4
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=butang kekunci: 5
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=butang kekunci: 6
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=butang kekunci: 7
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=butang kekunci: 8
+locale=ms;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=butang kekunci: 9
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ခလုတ် − 0
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ခလုတ် − 1
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ခလုတ် − 2
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ခလုတ် − 3
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ခလုတ် − 4
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ခလုတ် − 5
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ခလုတ် − 6
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ခလုတ် − 7
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ခလုတ် − 8
+locale=my;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ခလုတ် − 9
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=किक्याप: 0
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=किक्याप: 1
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=किक्याप: 2
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=किक्याप: 3
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=किक्याप: 4
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=किक्याप: 5
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=किक्याप: 6
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=किक्याप: 7
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=किक्याप: 8
+locale=ne;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=किक्याप: 9
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=toets: 0
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=toets: 1
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=toets: 2
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=toets: 3
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=toets: 4
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=toets: 5
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=toets: 6
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=toets: 7
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=toets: 8
+locale=nl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=toets: 9
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tastar: 0
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tastar: 1
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tastar: 2
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tastar: 3
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tastar: 4
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tastar: 5
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tastar: 6
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tastar: 7
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tastar: 8
+locale=nn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tastar: 9
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=taster: 0
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=taster: 1
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=taster: 2
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=taster: 3
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=taster: 4
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=taster: 5
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=taster: 6
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=taster: 7
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=taster: 8
+locale=no;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=taster: 9
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 0
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 1
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 2
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 3
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 4
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 5
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 6
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 7
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 8
+locale=or;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=କୀକ୍ୟାପ୍\x{200D}: 9
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 0
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 1
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 2
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 3
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 4
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 5
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 6
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 7
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 8
+locale=pa;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ਕੀਕੈਪ: 9
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Kíkap: 0
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Kíkap: 1
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Kíkap: 2
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Kíkap: 3
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Kíkap: 4
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Kíkap: 5
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Kíkap: 6
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Kíkap: 7
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Kíkap: 8
+locale=pcm;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Kíkap: 9
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=klawisz: 0
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=klawisz: 1
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=klawisz: 2
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=klawisz: 3
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=klawisz: 4
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=klawisz: 5
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=klawisz: 6
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=klawisz: 7
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=klawisz: 8
+locale=pl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=klawisz: 9
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=کیکیپ: 0
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=کیکیپ: 1
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=کیکیپ: 2
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=کیکیپ: 3
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=کیکیپ: 4
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=کیکیپ: 5
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=کیکیپ: 6
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=کیکیپ: 7
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=کیکیپ: 8
+locale=ps;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=کیکیپ: 9
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla: 0
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla: 1
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla: 2
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla: 3
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla: 4
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla: 5
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla: 6
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla: 7
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla: 8
+locale=pt;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla: 9
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 0
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 1
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 2
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 3
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 4
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 5
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 6
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 7
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 8
+locale=rhg;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=𐴑𐴞𐴑𐴤𐴠𐴂𐴢: 9
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tastă: 0
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tastă: 1
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tastă: 2
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tastă: 3
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tastă: 4
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tastă: 5
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tastă: 6
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tastă: 7
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tastă: 8
+locale=ro;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tastă: 9
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=клавиши: 0
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=клавиши: 1
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=клавиши: 2
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=клавиши: 3
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=клавиши: 4
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=клавиши: 5
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=клавиши: 6
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=клавиши: 7
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=клавиши: 8
+locale=ru;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=клавиши: 9
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 0
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 1
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 2
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 3
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 4
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 5
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 6
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 7
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 8
+locale=sat;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ᱠᱤᱠᱮᱯ: 9
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tecla: 0
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tecla: 1
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tecla: 2
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tecla: 3
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tecla: 4
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tecla: 5
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tecla: 6
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tecla: 7
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tecla: 8
+locale=sc;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tecla: 9
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ڪي ڪيپ: 0
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ڪي ڪيپ: 1
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ڪي ڪيپ: 2
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ڪي ڪيپ: 3
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ڪي ڪيپ: 4
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ڪي ڪيپ: 5
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ڪي ڪيپ: 6
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ڪي ڪيپ: 7
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ڪي ڪيپ: 8
+locale=sd;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ڪي ڪيپ: 9
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=පියන: 0
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=පියන: 1
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=පියන: 2
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=පියන: 3
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=පියන: 4
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=පියන: 5
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=පියන: 6
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=පියන: 7
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=පියන: 8
+locale=si;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=පියන: 9
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=kláves: 0
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=kláves: 1
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=kláves: 2
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=kláves: 3
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=kláves: 4
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=kláves: 5
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=kláves: 6
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=kláves: 7
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=kláves: 8
+locale=sk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=kláves: 9
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=daboolka furaha: 0
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=daboolka furaha: 1
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=daboolka furaha: 2
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=daboolka furaha: 3
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=daboolka furaha: 4
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=daboolka furaha: 5
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=daboolka furaha: 6
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=daboolka furaha: 7
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=daboolka furaha: 8
+locale=so;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=daboolka furaha: 9
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tast: 0
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tast: 1
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tast: 2
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tast: 3
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tast: 4
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tast: 5
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tast: 6
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tast: 7
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tast: 8
+locale=sq;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tast: 9
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=тастер: 0
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=тастер: 1
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=тастер: 2
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=тастер: 3
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=тастер: 4
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=тастер: 5
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=тастер: 6
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=тастер: 7
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=тастер: 8
+locale=sr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=тастер: 9
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=тастер: 0
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=тастер: 1
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=тастер: 2
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=тастер: 3
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=тастер: 4
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=тастер: 5
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=тастер: 6
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=тастер: 7
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=тастер: 8
+locale=sr_Cyrl;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=тастер: 9
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=taster: 0
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=taster: 1
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=taster: 2
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=taster: 3
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=taster: 4
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=taster: 5
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=taster: 6
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=taster: 7
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=taster: 8
+locale=sr_Latn;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=taster: 9
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=kitufe: 0
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=kitufe: 1
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=kitufe: 2
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=kitufe: 3
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=kitufe: 4
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=kitufe: 5
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=kitufe: 6
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=kitufe: 7
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=kitufe: 8
+locale=sw;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=kitufe: 9
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=விசை: 0
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=விசை: 1
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=விசை: 2
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=விசை: 3
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=விசை: 4
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=விசை: 5
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=விசை: 6
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=விசை: 7
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=விசை: 8
+locale=ta;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=விசை: 9
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=కీక్యాప్: 0
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=కీక్యాప్: 1
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=కీక్యాప్: 2
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=కీక్యాప్: 3
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=కీక్యాప్: 4
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=కీక్యాప్: 5
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=కీక్యాప్: 6
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=కీక్యాప్: 7
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=కీక్యాప్: 8
+locale=te;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=కీక్యాప్: 9
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 0
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 1
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 2
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 3
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 4
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 5
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 6
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 7
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 8
+locale=th;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ปุ่มกดเลข: 9
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 0
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 1
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 2
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 3
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 4
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 5
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 6
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 7
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 8
+locale=ti;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=ዝምልከት ቁልፊ፦ 9
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=klawiş gapagy: 0
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=klawiş gapagy: 1
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=klawiş gapagy: 2
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=klawiş gapagy: 3
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=klawiş gapagy: 4
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=klawiş gapagy: 5
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=klawiş gapagy: 6
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=klawiş gapagy: 7
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=klawiş gapagy: 8
+locale=tk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=klawiş gapagy: 9
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tatā foʻi kī: 0
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tatā foʻi kī: 1
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tatā foʻi kī: 2
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tatā foʻi kī: 3
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tatā foʻi kī: 4
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tatā foʻi kī: 5
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tatā foʻi kī: 6
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tatā foʻi kī: 7
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tatā foʻi kī: 8
+locale=to;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tatā foʻi kī: 9
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tuş: 0
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tuş: 1
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tuş: 2
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tuş: 3
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tuş: 4
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tuş: 5
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tuş: 6
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tuş: 7
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tuş: 8
+locale=tr;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tuş: 9
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=клавіша: 0
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=клавіша: 1
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=клавіша: 2
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=клавіша: 3
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=клавіша: 4
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=клавіша: 5
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=клавіша: 6
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=клавіша: 7
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=клавіша: 8
+locale=uk;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=клавіша: 9
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=کی کیپ: 0
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=کی کیپ: 1
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=کی کیپ: 2
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=کی کیپ: 3
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=کی کیپ: 4
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=کی کیپ: 5
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=کی کیپ: 6
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=کی کیپ: 7
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=کی کیپ: 8
+locale=ur;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=کی کیپ: 9
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=tugma qalpog‘i: 0
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=tugma qalpog‘i: 1
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=tugma qalpog‘i: 2
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=tugma qalpog‘i: 3
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=tugma qalpog‘i: 4
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=tugma qalpog‘i: 5
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=tugma qalpog‘i: 6
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=tugma qalpog‘i: 7
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=tugma qalpog‘i: 8
+locale=uz;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=tugma qalpog‘i: 9
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=mũ phím: 0
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=mũ phím: 1
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=mũ phím: 2
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=mũ phím: 3
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=mũ phím: 4
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=mũ phím: 5
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=mũ phím: 6
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=mũ phím: 7
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=mũ phím: 8
+locale=vi;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=mũ phím: 9
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=Keyacap: 0
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=Keyacap: 1
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=Keyacap: 2
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=Keyacap: 3
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=Keyacap: 4
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=Keyacap: 5
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=Keyacap: 6
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=Keyacap: 7
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=Keyacap: 8
+locale=yo;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=Keyacap: 9
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=鍵帽: 0
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=鍵帽: 1
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=鍵帽: 2
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=鍵帽: 3
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=鍵帽: 4
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=鍵帽: 5
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=鍵帽: 6
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=鍵帽: 7
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=鍵帽: 8
+locale=yue;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=鍵帽: 9
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=键帽: 0
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=键帽: 1
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=键帽: 2
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=键帽: 3
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=键帽: 4
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=键帽: 5
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=键帽: 6
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=键帽: 7
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=键帽: 8
+locale=yue_Hans;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=键帽: 9
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=按键: 0
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=按键: 1
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=按键: 2
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=按键: 3
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=按键: 4
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=按键: 5
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=按键: 6
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=按键: 7
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=按键: 8
+locale=zh;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=按键: 9
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=按鍵：0
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=按鍵：1
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=按鍵：2
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=按鍵：3
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=按鍵：4
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=按鍵：5
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=按鍵：6
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=按鍵：7
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=按鍵：8
+locale=zh_Hant;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=按鍵：9
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="0⃣"][@type="tts"];	new_value=i-keycap: 0
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="1⃣"][@type="tts"];	new_value=i-keycap: 1
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="2⃣"][@type="tts"];	new_value=i-keycap: 2
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="3⃣"][@type="tts"];	new_value=i-keycap: 3
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="4⃣"][@type="tts"];	new_value=i-keycap: 4
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="5⃣"][@type="tts"];	new_value=i-keycap: 5
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="6⃣"][@type="tts"];	new_value=i-keycap: 6
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="7⃣"][@type="tts"];	new_value=i-keycap: 7
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="8⃣"][@type="tts"];	new_value=i-keycap: 8
+locale=zu;	action=add;	new_path=//ldml/annotations/annotation[@cp="9⃣"][@type="tts"];	new_value=i-keycap: 9


### PR DESCRIPTION
CLDR-18229

The tts forms were missing, so added them. Also added to root, so that other locales can add to them.

Minor tool changes.

Note for the future: these are the easiest kinds of changes to make:

Ran SearchXML with options:

* -p\\d\\u20E3.*tts
* -s/Users/markdavis/github/cldr/common/annotationsDerived

(needed refinement in the -p regular expression to get exactly the right paths)

Paste generated lines into modify_config.txt

(sometimes the data needs fixing; a spreadsheet is easiest, since the lines are tabbed)

Ran CLDRModify with options:

* -fk
* -s/Users/markdavis/github/cldr/common/annotations

Spot-checked the result, then copied the altered files into the right directory

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
