### PR TITLE
CLDR-18561 hora peninsular

### DIFF
--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -4031,6 +4031,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Europe/Madrid">
+				<long>
+					<generic>hora peninsular</generic>
+				</long>
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Africa/Addis_Ababa">

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -3432,6 +3432,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Europe/Madrid">
+				<long>
+					<generic>∅∅∅</generic>
+				</long>
 				<exemplarCity>↑↑↑</exemplarCity>
 			</zone>
 			<zone type="Africa/Addis_Ababa">

--- a/common/main/es_GQ.xml
+++ b/common/main/es_GQ.xml
@@ -11,6 +11,15 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<language type="es"/>
 		<territory type="GQ"/>
 	</identity>
+	<dates>
+		<timeZoneNames>
+			<zone type="Europe/Madrid">
+				<long>
+					<generic>∅∅∅</generic>
+				</long>
+			</zone>
+		</timeZoneNames>
+	</dates>
 	<numbers>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>

--- a/common/main/es_PH.xml
+++ b/common/main/es_PH.xml
@@ -42,6 +42,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</timeFormats>
 			</calendar>
 		</calendars>
+		<timeZoneNames>
+			<zone type="Europe/Madrid">
+				<long>
+					<generic>∅∅∅</generic>
+				</long>
+			</zone>
+		</timeZoneNames>
 	</dates>
 	<numbers>
 		<currencies>


### PR DESCRIPTION
CLDR-18561

- [x] This PR completes the ticket.

Adds "hora peninsular" to es, es_ES (Spain), es_EA (Ceuta & Melilla), es_IC (Canaries).

ALLOW_MANY_COMMITS=true
