### PR TITLE
CLDR-18573 Revert early locale-loading for now

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -19,6 +19,8 @@ import * as cldrVue from "./cldrVue.mjs";
 
 import MainHeader from "../views/MainHeader.vue";
 
+const LOAD_LOCALES_EARLY = false;
+
 const GUI_DEBUG = true;
 
 const runGuiId = "st-run-gui";
@@ -68,9 +70,11 @@ async function initialSetup() {
     ensureSession(),
     cldrEscaperLoader.updateEscaperFromServer(),
   ]);
-  // fetchMap requires a session, must load after ensureSession
-  await cldrLocales.fetchMap();
-  // Note: could possibly fetch initial menus here rather than later
+  if (LOAD_LOCALES_EARLY) {
+    // fetchMap requires a session, must load after ensureSession
+    await cldrLocales.fetchMap();
+    // Note: could possibly fetch initial menus here rather than later
+  }
 }
 
 async function ensureSession() {
@@ -449,6 +453,7 @@ function refreshCounterVetting() {
 }
 
 export {
+  LOAD_LOCALES_EARLY,
   refreshCounterVetting,
   run,
   setToptitleVisibility,


### PR DESCRIPTION
-Revert some changes from PR 4707 by making them contingent on boolean cldrGui.LOAD_LOCALES_EARLY, false for now

CLDR-18573

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
