### PR TITLE
CLDR-18573 locmap-load-fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -308,9 +308,6 @@ jobs:
     - name: Build webdriver
       run: docker compose run -v ~/.m2/repository:/root/.m2/repository:rw --rm webdriver mvn -B test-compile
       working-directory: tools/cldr-apps
-    - name: Test with Webdriver, ignoring result due to CLDR-18613
-      run: docker compose run -v ~/.m2/repository:/root/.m2/repository:rw --rm webdriver || ( echo this may fail the first time see https://unicode-org.atlassian.net/browse/CLDR-18613 && true)
-      working-directory: tools/cldr-apps
     - name: Test with Webdriver
       # See tools/cldr-apps/README.md
       run: >

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverDashboard.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverDashboard.java
@@ -22,6 +22,8 @@ public class SurveyDriverDashboard {
         if (!s.login()) {
             return false;
         }
+        System.out.println("CLDR-18613 - try refresh to work around loading issue");
+        driver.navigate().refresh();
         final int REPETITION_COUNT = 10; // 10000;
         for (int i = 0; i < REPETITION_COUNT; i++) {
             SurveyDriverLog.println("SurveyDriverDashboard.test i = " + i);

--- a/tools/cldr-apps-webdriver/surveydriver-docker.properties
+++ b/tools/cldr-apps-webdriver/surveydriver-docker.properties
@@ -1,4 +1,4 @@
 WEBDRIVER_PASSWORD=pw-for-docker-webdriver
 SURVEYTOOL_URL=http://cldr-apps:9080
 WEBDRIVER_URL=http://selenium:4444
-TIME_OUT_SECONDS=60
+TIME_OUT_SECONDS=120

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -124,7 +124,7 @@ function haveSession() {
 }
 
 function completeStartupWithSession() {
-  // TODO: Here is where auto import should be scheduled.
+  // TODO CLDR-18681: Here is where auto import should be scheduled.
   cldrSurvey.updateStatus();
   cldrEvent.startup();
 }

--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -58,7 +58,9 @@ function run() {
   } catch (e) {
     return Promise.reject(e);
   }
-  // We load
+  // Get this ready before initial setup
+  cldrLoad.showV();
+  // We load..
   return initialSetup().then(completeStartupWithSession);
 }
 
@@ -124,7 +126,6 @@ function haveSession() {
 function completeStartupWithSession() {
   // TODO: Here is where auto import should be scheduled.
   cldrSurvey.updateStatus();
-  cldrLoad.showV();
   cldrEvent.startup();
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrLocales.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLocales.mjs
@@ -24,9 +24,9 @@ const LOCALE_REGEX = new RegExp("^[a-zA-Z0-9_]*$");
 let didValidateAll = false;
 
 async function fetchMap() {
+  // we use a simple load here, just basic fetch. no session.
   const url = getUrl();
-  return await cldrAjax
-    .doFetch(url)
+  return await fetch(url)
     .then(cldrAjax.handleFetchErrors)
     .then((r) => r.json())
     .then(setMap)
@@ -34,12 +34,9 @@ async function fetchMap() {
 }
 
 function getUrl() {
+  // We use a simple URL here, no session, just loading the locale map
   const p = new URLSearchParams();
-  p.append("what", "menus"); // cf. WHAT_GET_MENUS in SurveyAjax.java
-  // p.append("_", locale);
-  p.append("locmap", "true");
-  p.append("s", cldrStatus.getSessionId());
-  p.append("cacheKill", cldrSurvey.cacheBuster());
+  p.append("what", "locale");
   return cldrAjax.makeUrl(p);
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrLocales.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLocales.mjs
@@ -27,16 +27,14 @@ async function fetchMap() {
   // we use a simple load here, just basic fetch. no session.
   const url = getUrl();
   return await fetch(url)
-    .then(cldrAjax.handleFetchErrors)
     .then((r) => r.json())
-    .then(setMap)
-    .catch(console.error);
+    .then(setMap);
 }
 
 function getUrl() {
   // We use a simple URL here, no session, just loading the locale map
   const p = new URLSearchParams();
-  p.append("what", "locale");
+  p.append("what", "locmap");
   return cldrAjax.makeUrl(p);
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrMenu.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.mjs
@@ -125,7 +125,7 @@ function loadInitialMenusFromJson(json) {
 
   setupCoverageLevels(json);
 
-  // TODO: this should be ideally imperatively called from an upper level,
+  // TODO CLDR-18681: this should be ideally imperatively called from an upper level,
   // not called in the tail of an unrelated loader function
   cldrLoad.continueInitializing(json.canAutoImport || false);
 }

--- a/tools/cldr-apps/js/src/esm/cldrMenu.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.mjs
@@ -82,17 +82,23 @@ function makeSafe(s) {
   return s.replace(/[^-_a-zA-Z0-9]/g, "");
 }
 
-function getInitialMenusEtc() {
+async function getInitialMenusEtc() {
   const theLocale = cldrStatus.getCurrentLocale() || "root";
   const xurl = getMenusAjaxUrl(
     theLocale,
     false /* do not fetch locale map here */
   );
-  cldrLoad.myLoad(xurl, "initial menus for " + theLocale, function (json) {
-    loadInitialMenusFromJson(json);
-  });
+  await fetch(xurl)
+    .then(cldrAjax.handleFetchErrors)
+    .then((r) => r.json)
+    .then((json) => loadInitialMenusFromJson(json));
 }
 
+/**
+ * Processes initial menus.
+ * Also, schedules auto import and perhaps other items
+ * @param {Object} json
+ */
 function loadInitialMenusFromJson(json) {
   if (
     cldrStatus.getCurrentLocale() === cldrLocales.USER_LOCALE_ID &&
@@ -119,6 +125,8 @@ function loadInitialMenusFromJson(json) {
 
   setupCoverageLevels(json);
 
+  // TODO: this should be ideally imperatively called from an upper level,
+  // not called in the tail of an unrelated loader function
   cldrLoad.continueInitializing(json.canAutoImport || false);
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrMenu.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.mjs
@@ -90,7 +90,7 @@ async function getInitialMenusEtc() {
   );
   await fetch(xurl)
     .then(cldrAjax.handleFetchErrors)
-    .then((r) => r.json)
+    .then((r) => r.json())
     .then((json) => loadInitialMenusFromJson(json));
 }
 

--- a/tools/cldr-apps/js/src/esm/cldrStatus.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrStatus.mjs
@@ -233,12 +233,7 @@ function getCurrentLocale() {
 }
 
 function setCurrentLocale(loc) {
-  if (
-    cldrGui.LOAD_LOCALES_EARLY &&
-    loc &&
-    loc !== cldrLocales.USER_LOCALE_ID &&
-    !cldrLocales.isValid(loc)
-  ) {
+  if (loc && loc !== cldrLocales.USER_LOCALE_ID && !cldrLocales.isValid(loc)) {
     return;
   }
   currentLocale = loc;


### PR DESCRIPTION
CLDR-18573

- revert d078d935845292bb8df57d41116f24e5ecdd984f and #4742
- untangle loading sequence for locales, menus. improve robustness for starting

- also relates to CLDR-14409 and to the workaroudn for CLDR-18613 - increase webdriver timeout, and add a refresh  to work around CLDR-18613 to enable webdriver test to continue.  
- remove workaround retry from workflow



- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
