### PR TITLE
CLDR-18692 Fix DAIP annotation delimiters

### DIFF
--- a/common/annotations/ja.xml
+++ b/common/annotations/ja.xml
@@ -1697,7 +1697,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🧑‍🧒‍🧒" type="tts">家族: 大人一人と子供二人</annotation>
 		<annotation cp="👣" draft="contributed">裸足 | 足 | 足あと</annotation>
 		<annotation cp="👣" type="tts">足あと</annotation>
-		<annotation cp="🫆">指紋｜鑑識｜生体認証｜セキュリティ</annotation>
+		<annotation cp="🫆">セキュリティ | 指紋 | 生体認証 | 鑑識</annotation>
 		<annotation cp="🫆" type="tts">指紋</annotation>
 		<annotation cp="🦰">赤毛 | 赤毛の人 | 赤茶</annotation>
 		<annotation cp="🦰" type="tts">赤毛</annotation>
@@ -2023,7 +2023,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🪺" type="tts">鳥の卵と巣</annotation>
 		<annotation cp="🍄">きのこ | キノコ | マッシュルーム | 毒 | 菌類 | 野菜</annotation>
 		<annotation cp="🍄" type="tts">キノコ</annotation>
-		<annotation cp="🪾">不毛｜干ばつ｜葉のない木｜冬</annotation>
+		<annotation cp="🪾">不毛 | 冬 | 干ばつ | 葉のない木</annotation>
 		<annotation cp="🪾" type="tts">枯れ木</annotation>
 		<annotation cp="🍇">グレープ | ぶどう | ブドウ | 果物</annotation>
 		<annotation cp="🍇" type="tts">ぶどう</annotation>
@@ -2101,7 +2101,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🫛" type="tts">エンドウ豆</annotation>
 		<annotation cp="🍄‍🟫">きのこ | キノコ | しいたけ | トリュフ | ブラウンマッシュルーム | ポートベロー | マッシュルーム | 椎茸 | 茸 | 菌類</annotation>
 		<annotation cp="🍄‍🟫" type="tts">きのこ</annotation>
-		<annotation cp="🫜">ビーツ｜庭｜根｜カブ｜野菜</annotation>
+		<annotation cp="🫜">カブ | ビーツ | 庭 | 根 | 野菜</annotation>
 		<annotation cp="🫜" type="tts">根菜</annotation>
 		<annotation cp="🍞">パン | ベーカリー | 小麦 | 食パン</annotation>
 		<annotation cp="🍞" type="tts">食パン</annotation>
@@ -3697,7 +3697,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="®" type="tts">登録商標マーク</annotation>
 		<annotation cp="™">TMマーク | トレードマーク | 商標 | 商標マーク | 記号</annotation>
 		<annotation cp="™" type="tts">商標マーク</annotation>
-		<annotation cp="🫟">しぶき｜ペンキ｜飛沫｜飛び散り｜スプラッシュ</annotation>
+		<annotation cp="🫟">しぶき | スプラッシュ | ペンキ | 飛び散り | 飛沫</annotation>
 		<annotation cp="🫟" type="tts">飛び散ったペンキ</annotation>
 		<annotation cp="🔠">ABCD | アルファベット | ローマ字 | 入力 | 大文字 | 英大文字の入力 | 英字</annotation>
 		<annotation cp="🔠" type="tts">英大文字の入力</annotation>

--- a/common/annotations/mn.xml
+++ b/common/annotations/mn.xml
@@ -949,7 +949,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🤖" type="tts">робот царай</annotation>
 		<annotation cp="😺">ам | амаа ангайгаад инээж байгаа | амаа ангайгаад инээж байгаа муур | ангайх | инээсэн | муур | царай</annotation>
 		<annotation cp="😺" type="tts">амаа ангайгаад инээж байгаа муур</annotation>
-		<annotation cp="😸">инээх | муур | нүд | нүдээрээ инээж байгаа ︱царай | нүдээрээ инээж байгаа муур</annotation>
+		<annotation cp="😸">инээх | муур | нүд | нүдээрээ инээж байгаа | нүдээрээ инээж байгаа муур | царай</annotation>
 		<annotation cp="😸" type="tts">нүдээрээ инээж байгаа муур</annotation>
 		<annotation cp="😹">баярлах | муур | нулимс | нулимсаа гартал инээж байгаа муур | царай</annotation>
 		<annotation cp="😹" type="tts">нулимсаа гартал инээж байгаа муур</annotation>
@@ -1829,7 +1829,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="🐼" type="tts">хулсны баавгайны толгой</annotation>
 		<annotation cp="🦥">залхуу | залхууч | удаан</annotation>
 		<annotation cp="🦥" type="tts">залхууч</annotation>
-		<annotation cp="🦦">загас барих ︱ хөгжилтэй | халиу</annotation>
+		<annotation cp="🦦">загас барих | халиу | хөгжилтэй</annotation>
 		<annotation cp="🦦" type="tts">халиу</annotation>
 		<annotation cp="🦨">өмхий | өмхий хүрнэ | өмхий хүрэн</annotation>
 		<annotation cp="🦨" type="tts">өмхий хүрнэ</annotation>
@@ -2921,7 +2921,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<annotation cp="👗" type="tts">даашинз</annotation>
 		<annotation cp="👘">кимоно | хувцас</annotation>
 		<annotation cp="👘" type="tts">кимоно</annotation>
-		<annotation cp="🥻">саарий | хувцас ︱ даашинз</annotation>
+		<annotation cp="🥻">даашинз | саарий | хувцас</annotation>
 		<annotation cp="🥻" type="tts">саарий</annotation>
 		<annotation cp="🩱">усны үргэлж хувцас | усны хувцас</annotation>
 		<annotation cp="🩱" type="tts">усны үргэлж хувцас</annotation>

--- a/common/annotations/yue.xml
+++ b/common/annotations/yue.xml
@@ -1441,9 +1441,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦸‍♀" type="tts">女超人</annotation>
 		<annotation cp="🦹">壞人 | 犯罪 | 超人 | 超級壞人 | 邪惡</annotation>
 		<annotation cp="🦹" type="tts">超級壞人</annotation>
-		<annotation cp="🦹‍♂">壞人 | 犯罪 | 超人 | 超級男壞人 | 邪惡｜男</annotation>
+		<annotation cp="🦹‍♂">壞人 | 犯罪 | 男 | 超人 | 超級男壞人 | 邪惡</annotation>
 		<annotation cp="🦹‍♂" type="tts">超級男壞人</annotation>
-		<annotation cp="🦹‍♀">壞人 | 犯罪 | 超人 | 超級女壞人 | 邪惡｜女</annotation>
+		<annotation cp="🦹‍♀">壞人 | 女 | 犯罪 | 超人 | 超級女壞人 | 邪惡</annotation>
 		<annotation cp="🦹‍♀" type="tts">超級女壞人</annotation>
 		<annotation cp="🧙">女巫 | 巫婆 | 巫師 | 男巫</annotation>
 		<annotation cp="🧙" type="tts">巫師</annotation>
@@ -1673,7 +1673,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👬" type="tts">兩個男人拖手</annotation>
 		<annotation cp="💏">吻 | 夫婦</annotation>
 		<annotation cp="💏" type="tts">吻</annotation>
-		<annotation cp="💑">夫婦｜愛 | 夫婦同心</annotation>
+		<annotation cp="💑">夫婦 | 夫婦同心 | 愛</annotation>
 		<annotation cp="💑" type="tts">夫婦同心</annotation>
 		<annotation cp="🗣">剪影 | 臉 | 講 | 講野 | 講野嘅頭 | 頭</annotation>
 		<annotation cp="🗣" type="tts">講野嘅頭</annotation>

--- a/common/annotations/yue_Hans.xml
+++ b/common/annotations/yue_Hans.xml
@@ -942,7 +942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👻" type="tts">鬼</annotation>
 		<annotation cp="👽">外星 | 外星人 | 幻想 | 怪物 | 生物 | 童话故事 | 脸 | 飞碟</annotation>
 		<annotation cp="👽" type="tts">外星人</annotation>
-		<annotation cp="👾">外星 | 外星人｜生物 | 外星怪物 | 幻想 | 怪物 | 童话故事 | 脸 | 飞碟</annotation>
+		<annotation cp="👾">外星 | 外星人 | 外星怪物 | 幻想 | 怪物 | 生物 | 童话故事 | 脸 | 飞碟</annotation>
 		<annotation cp="👾" type="tts">外星怪物</annotation>
 		<annotation cp="🤖">怪物 | 机械人 | 机械人脸 | 脸</annotation>
 		<annotation cp="🤖" type="tts">机械人脸</annotation>
@@ -1442,9 +1442,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🦸‍♀" type="tts">女超人</annotation>
 		<annotation cp="🦹">坏人 | 犯罪 | 超人 | 超级坏人 | 邪恶</annotation>
 		<annotation cp="🦹" type="tts">超级坏人</annotation>
-		<annotation cp="🦹‍♂">坏人 | 犯罪 | 超人 | 超级男坏人 | 邪恶｜男</annotation>
+		<annotation cp="🦹‍♂">坏人 | 犯罪 | 男 | 超人 | 超级男坏人 | 邪恶</annotation>
 		<annotation cp="🦹‍♂" type="tts">超级男坏人</annotation>
-		<annotation cp="🦹‍♀">坏人 | 犯罪 | 超人 | 超级女坏人 | 邪恶｜女</annotation>
+		<annotation cp="🦹‍♀">坏人 | 女 | 犯罪 | 超人 | 超级女坏人 | 邪恶</annotation>
 		<annotation cp="🦹‍♀" type="tts">超级女坏人</annotation>
 		<annotation cp="🧙">女巫 | 巫婆 | 巫师 | 男巫</annotation>
 		<annotation cp="🧙" type="tts">巫师</annotation>
@@ -1674,7 +1674,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👬" type="tts">两个男人拖手</annotation>
 		<annotation cp="💏">吻 | 夫妇</annotation>
 		<annotation cp="💏" type="tts">吻</annotation>
-		<annotation cp="💑">夫妇｜爱 | 夫妇同心</annotation>
+		<annotation cp="💑">夫妇 | 夫妇同心 | 爱</annotation>
 		<annotation cp="💑" type="tts">夫妇同心</annotation>
 		<annotation cp="🗣">剪影 | 头 | 脸 | 讲 | 讲野 | 讲野嘅头</annotation>
 		<annotation cp="🗣" type="tts">讲野嘅头</annotation>

--- a/common/annotations/zh_Hant_HK.xml
+++ b/common/annotations/zh_Hant_HK.xml
@@ -1234,9 +1234,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="💁‍♀">女人 | 攤開手 | 攤開手嘅女人 | 貼士</annotation>
 		<annotation cp="💁‍♀" type="tts">攤開手嘅女人</annotation>
 		<annotation cp="🙋">hi | me | 交俾我 | 哈囉 | 問題 | 我 | 我OK | 我知 | 我知道 | 手 | 有問題 | 舉手 | 舉起一隻手 | 開心</annotation>
-		<annotation cp="🙋" type="tts">舉起一隻手</annotation>
 		<annotation cp="🙋‍♂">hi | 人物 | 哈囉 | 問題 | 喂 | 嗨 | 姿勢 | 我 | 我知道 | 手 | 手勢 | 男人 | 男士 | 男性 | 發問 | 舉手 | 舉手的男士 | 舉起一隻手 | 開心</annotation>
-		<annotation cp="🙋‍♂" type="tts">開心</annotation>
+		<annotation cp="🙋‍♂" type="tts">開心嘅女人舉起一隻手</annotation>
 		<annotation cp="🙋‍♀">hi | 哈囉 | 女人 | 舉起一隻手 | 開心 | 開心嘅女人舉起一隻手</annotation>
 		<annotation cp="🙋‍♀" type="tts">開心嘅女人舉起一隻手</annotation>
 		<annotation cp="🧏">人物 | 殘障 | 無障礙 | 耳朵 | 耳聾 | 聆聽 | 聽 | 聽力 | 聽障人士 | 聾</annotation>

--- a/common/annotations/zh_Hant_HK.xml
+++ b/common/annotations/zh_Hant_HK.xml
@@ -1236,8 +1236,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙋">hi | me | 交俾我 | 哈囉 | 問題 | 我 | 我OK | 我知 | 我知道 | 手 | 有問題 | 舉手 | 舉起一隻手 | 開心</annotation>
 		<annotation cp="🙋‍♂">hi | 人物 | 哈囉 | 問題 | 喂 | 嗨 | 姿勢 | 我 | 我知道 | 手 | 手勢 | 男人 | 男士 | 男性 | 發問 | 舉手 | 舉手的男士 | 舉起一隻手 | 開心</annotation>
 		<annotation cp="🙋‍♂" type="tts">開心嘅女人舉起一隻手</annotation>
-		<annotation cp="🙋‍♀">hi | 哈囉 | 女人 | 舉起一隻手 | 開心 | 開心嘅女人舉起一隻手</annotation>
-		<annotation cp="🙋‍♀" type="tts">開心嘅女人舉起一隻手</annotation>
 		<annotation cp="🧏">人物 | 殘障 | 無障礙 | 耳朵 | 耳聾 | 聆聽 | 聽 | 聽力 | 聽障人士 | 聾</annotation>
 		<annotation cp="🧏" type="tts">↑↑↑</annotation>
 		<annotation cp="🧏‍♂">男 | 聽障 | 聽障男人</annotation>

--- a/common/annotations/zh_Hant_HK.xml
+++ b/common/annotations/zh_Hant_HK.xml
@@ -913,8 +913,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="😩" type="tts">面露疲憊</annotation>
 		<annotation cp="😫">乞嗤 | 乞嚏 | 哎呀 | 唉 | 噴嚏 | 小睡 | 悲傷 | 感覺 | 打乞嗤 | 打乞嚏 | 打噴嚏 | 疲倦 | 臉孔</annotation>
 		<annotation cp="😫" type="tts">↑↑↑</annotation>
-		<annotation cp="🥱">zzz | 呵欠 | 呵欠｜打喊露｜打呵欠｜打呵欠嘅樣 | 小睡 | 悶 | 想訓覺｜打呵欠 | 打喊露 | 是但 | 晚安 | 無聊 | 疲倦 | 疲勞 | 睡眠 | 睡覺 | 累 | 臉孔 | 訓覺 | 隨便</annotation>
-		<annotation cp="🥱" type="tts">呵欠｜打喊露｜打呵欠｜打呵欠嘅樣</annotation>
+		<annotation cp="🥱">zzz | 呵欠 | 小睡 | 悶 | 想訓覺 | 打呵欠 | 打呵欠嘅樣 | 打喊露 | 是但 | 晚安 | 無聊 | 疲倦 | 疲勞 | 睡眠 | 睡覺 | 累 | 臉孔 | 訓覺 | 隨便</annotation>
+		<annotation cp="🥱" type="tts">呵欠</annotation>
 		<annotation cp="😤">不滿 | 冒煙 | 唔開心 | 嬲 | 憤怒 | 生氣 | 臉孔</annotation>
 		<annotation cp="😤" type="tts">↑↑↑</annotation>
 		<annotation cp="😡">不高興 | 唔開心 | 嬲 | 怒 | 惡 | 憤怒 | 氣死 | 生氣 | 紅色 | 臉孔</annotation>
@@ -1013,14 +1013,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🩵" type="tts">↑↑↑</annotation>
 		<annotation cp="💜">喜歡 | 心 | 愛 | 感情 | 紫色 | 鐘意</annotation>
 		<annotation cp="💜" type="tts">↑↑↑</annotation>
-		<annotation cp="🤎">啡 | 啡心｜啡色心｜啡色嘅心 | 啡色 | 喜歡 | 心 | 愛 | 褐色 | 鐘意</annotation>
-		<annotation cp="🤎" type="tts">啡心｜啡色心｜啡色嘅心</annotation>
+		<annotation cp="🤎">啡 | 啡心 | 啡色 | 啡色嘅心 | 啡色心 | 喜歡 | 心 | 愛 | 褐色 | 鐘意</annotation>
+		<annotation cp="🤎" type="tts">啡心</annotation>
 		<annotation cp="🖤">心 | 邪惡 | 黑色</annotation>
 		<annotation cp="🖤" type="tts">↑↑↑</annotation>
 		<annotation cp="🩶">傷心 | 冇心情 | 心型 | 愛心 | 愛情 | 我愛你 | 暗灰色 | 灰 | 灰心 | 灰色 | 灰色心 | 無心情 | 特別 | 石板色 | 銀 | 銀心 | 銀色 | 黑白</annotation>
 		<annotation cp="🩶" type="tts">灰色心</annotation>
-		<annotation cp="🤍">喜歡 | 心 | 愛 | 白 | 白心｜白色心｜白色嘅心 | 白色</annotation>
-		<annotation cp="🤍" type="tts">白心｜白色心｜白色嘅心</annotation>
+		<annotation cp="🤍">喜歡 | 心 | 愛 | 白 | 白心 | 白色 | 白色嘅心 | 白色心</annotation>
+		<annotation cp="🤍" type="tts">白心</annotation>
 		<annotation cp="💋">吻痕 | 唇印 | 嘴唇 | 性感 | 愛 | 感情 | 接吻 | 浪漫 | 約會 | 親 | 親嘴 | 錫</annotation>
 		<annotation cp="💋" type="tts">↑↑↑</annotation>
 		<annotation cp="💯">100 | 100 分 | 一百 | 一百分 | 中 | 分數 | 同意 | 啱 | 對 | 正確 | 滿分 | 百分百 | 肯定 | 認同</annotation>
@@ -1075,8 +1075,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👌" type="tts">↑↑↑</annotation>
 		<annotation cp="🤌">哎 | 嗯 | 好味 | 手 | 手勢 | 抓 | 捉 | 放鬆 | 等會 | 耐心 | 耐性 | 點</annotation>
 		<annotation cp="🤌" type="tts">↑↑↑</annotation>
-		<annotation cp="🤏">一點 | 少數 | 少量 | 捏｜少少｜一啲啲 | 捏指 | 有點 | 略為 | 細</annotation>
-		<annotation cp="🤏" type="tts">捏｜少少｜一啲啲</annotation>
+		<annotation cp="🤏">一啲啲 | 一點 | 少少 | 少數 | 少量 | 捏 | 捏指 | 有點 | 略為 | 細</annotation>
+		<annotation cp="🤏" type="tts">捏</annotation>
 		<annotation cp="✌">v | V字手勢 | v手 | yeah | 剪刀手勢 | 勝利之手 | 勝利手勢 | 和平 | 手 | 手勢</annotation>
 		<annotation cp="✌" type="tts">V字手勢</annotation>
 		<annotation cp="🤞">交叉 | 好運 | 手 | 手勢 | 手指 | 祝福</annotation>
@@ -1199,7 +1199,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👱‍♀" type="tts">金髮女人</annotation>
 		<annotation cp="🧓">不分性別 | 中性 | 人物 | 年邁 | 年長 | 灰髮 | 白髮 | 老人 | 老人家 | 老年人 | 長者</annotation>
 		<annotation cp="🧓" type="tts">↑↑↑</annotation>
-		<annotation cp="👴">人物 | 伯伯 | 光頭 | 地中海 | 智慧 | 爺爺 | 男士 | 男性 | 祖父 | 禿頭 | 老 | 老人 | 老公公｜老伯伯 | 脫髮</annotation>
+		<annotation cp="👴">人物 | 伯伯 | 光頭 | 地中海 | 智慧 | 爺爺 | 男士 | 男性 | 祖父 | 禿頭 | 老 | 老人 | 老伯伯 | 老公公 | 脫髮</annotation>
 		<annotation cp="👴" type="tts">老人</annotation>
 		<annotation cp="👵">人物 | 女士 | 女性 | 婆婆 | 嫲嫲 | 嬤嬤 | 智慧 | 爛髮型 | 祖母 | 老人 | 老太太 | 老婆婆 | 老婦 | 老花 | 金髮 | 阿婆</annotation>
 		<annotation cp="👵" type="tts">老婦</annotation>
@@ -1209,7 +1209,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙍‍♂" type="tts">男子皺眉</annotation>
 		<annotation cp="🙍‍♀">女人 | 女子皺眉 | 皺眉 | 表情</annotation>
 		<annotation cp="🙍‍♀" type="tts">女子皺眉</annotation>
-		<annotation cp="🙎">厭惡 | 唔高興 | 嘟嘴 | 失望 | 嬲 | 扁咀 | 撅嘴 | 撅嘴嘅人 | 撅嘴嘅人｜嬲 | 皺眉 | 短髮 | 討厭</annotation>
+		<annotation cp="🙎">厭惡 | 唔高興 | 嘟嘴 | 失望 | 嬲 | 扁咀 | 撅嘴 | 撅嘴嘅人 | 皺眉 | 短髮 | 討厭</annotation>
 		<annotation cp="🙎" type="tts">撅嘴嘅人</annotation>
 		<annotation cp="🙎‍♂">sad | 不滿 | 不高興 | 人物 | 姿勢 | 撅嘴 | 男人 | 男士 | 男子噘嘴 | 男性 | 表情</annotation>
 		<annotation cp="🙎‍♂" type="tts">男子噘嘴</annotation>
@@ -1223,21 +1223,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🙅‍♀" type="tts">用手臂做出交叉手勢嘅女人</annotation>
 		<annotation cp="🙆">o | OK | 人物 | 可以 | 女士 | 女性 | 好 | 打手勢 | 用手勢表示 OK 嘅人 | 通過</annotation>
 		<annotation cp="🙆" type="tts">用手勢表示 OK 嘅人</annotation>
-		<annotation cp="🙆‍♂">o | OK | 人物 | 可以 | 可以｜男人｜手勢 | 打可以手勢的男士 | 打手勢 | 用手勢表示 OK 嘅男人 | 男士 | 男性 | 通過</annotation>
+		<annotation cp="🙆‍♂">o | OK | 人物 | 可以 | 手勢 | 打可以手勢的男士 | 打手勢 | 用手勢表示 OK 嘅男人 | 男人 | 男士 | 男性 | 通過</annotation>
 		<annotation cp="🙆‍♂" type="tts">用手勢表示 OK 嘅男人</annotation>
-		<annotation cp="🙆‍♀">OK | 可以｜女人｜手勢 | 用手勢表示 OK 嘅女人</annotation>
+		<annotation cp="🙆‍♀">OK | 可以 | 女人 | 手勢 | 用手勢表示 OK 嘅女人</annotation>
 		<annotation cp="🙆‍♀" type="tts">用手勢表示 OK 嘅女人</annotation>
-		<annotation cp="💁">介紹 | 冇所謂 | 彈頭髮 | 撥頭髮 | 攤開手｜貼士 | 攤開手嘅人 | 是但啦 | 時尚 | 有請 | 求其 | 無所謂 | 隨便</annotation>
+		<annotation cp="💁">介紹 | 冇所謂 | 彈頭髮 | 撥頭髮 | 攤開手 | 攤開手嘅人 | 是但啦 | 時尚 | 有請 | 求其 | 無所謂 | 貼士 | 隨便</annotation>
 		<annotation cp="💁" type="tts">攤開手嘅人</annotation>
-		<annotation cp="💁‍♂">人物 | 八卦 | 大膽 | 彈頭髮 | 撥頭髮 | 攤開手｜貼士｜男人 | 時尚 | 時髦 | 活潑 | 無禮 | 男士 | 男子抬手 | 男性 | 隨便</annotation>
+		<annotation cp="💁‍♂">人物 | 八卦 | 大膽 | 彈頭髮 | 撥頭髮 | 攤開手 | 時尚 | 時髦 | 活潑 | 無禮 | 男人 | 男士 | 男子抬手 | 男性 | 貼士 | 隨便</annotation>
 		<annotation cp="💁‍♂" type="tts">男子抬手</annotation>
-		<annotation cp="💁‍♀">攤開手｜貼士｜女人 | 攤開手嘅女人</annotation>
+		<annotation cp="💁‍♀">女人 | 攤開手 | 攤開手嘅女人 | 貼士</annotation>
 		<annotation cp="💁‍♀" type="tts">攤開手嘅女人</annotation>
 		<annotation cp="🙋">hi | me | 交俾我 | 哈囉 | 問題 | 我 | 我OK | 我知 | 我知道 | 手 | 有問題 | 舉手 | 舉起一隻手 | 開心</annotation>
 		<annotation cp="🙋" type="tts">舉起一隻手</annotation>
-		<annotation cp="🙋‍♂">hi | 人物 | 問題 | 喂 | 嗨 | 姿勢 | 我 | 我知道 | 手 | 手勢 | 男士 | 男性 | 發問 | 舉手 | 舉手的男士 | 開心｜舉起一隻手｜男人｜哈囉</annotation>
-		<annotation cp="🙋‍♂" type="tts">開心｜舉起一隻手｜男人｜哈囉｜hi</annotation>
-		<annotation cp="🙋‍♀">開心｜舉起一隻手｜女人｜哈囉｜hi | 開心嘅女人舉起一隻手</annotation>
+		<annotation cp="🙋‍♂">hi | 人物 | 哈囉 | 問題 | 喂 | 嗨 | 姿勢 | 我 | 我知道 | 手 | 手勢 | 男人 | 男士 | 男性 | 發問 | 舉手 | 舉手的男士 | 舉起一隻手 | 開心</annotation>
+		<annotation cp="🙋‍♂" type="tts">開心</annotation>
+		<annotation cp="🙋‍♀">hi | 哈囉 | 女人 | 舉起一隻手 | 開心 | 開心嘅女人舉起一隻手</annotation>
 		<annotation cp="🙋‍♀" type="tts">開心嘅女人舉起一隻手</annotation>
 		<annotation cp="🧏">人物 | 殘障 | 無障礙 | 耳朵 | 耳聾 | 聆聽 | 聽 | 聽力 | 聽障人士 | 聾</annotation>
 		<annotation cp="🧏" type="tts">↑↑↑</annotation>
@@ -1245,23 +1245,23 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧏‍♂" type="tts">聽障男人</annotation>
 		<annotation cp="🧏‍♀">女 | 聽障 | 聽障女人</annotation>
 		<annotation cp="🧏‍♀" type="tts">聽障女人</annotation>
-		<annotation cp="🙇">sor | 唔好意思｜對唔住｜sorry｜麻煩晒 | 唔該晒 | 對不起 | 感激 | 抱歉 | 求求你 | 跪求 | 道歉 | 鞠躬</annotation>
+		<annotation cp="🙇">sor | sorry | 唔好意思 | 唔該晒 | 對不起 | 對唔住 | 感激 | 抱歉 | 求求你 | 跪求 | 道歉 | 鞠躬 | 麻煩晒</annotation>
 		<annotation cp="🙇" type="tts">↑↑↑</annotation>
-		<annotation cp="🙇‍♂">鞠躬｜唔好意思｜對唔住｜sorry｜男人｜道歉 | 鞠躬嘅男人</annotation>
+		<annotation cp="🙇‍♂">sorry | 唔好意思 | 對唔住 | 男人 | 道歉 | 鞠躬 | 鞠躬嘅男人</annotation>
 		<annotation cp="🙇‍♂" type="tts">鞠躬嘅男人</annotation>
-		<annotation cp="🙇‍♀">下跪 | 人物 | 冥想 | 唔好意思｜sorry｜女人｜道歉 | 女士 | 女性 | 姿勢 | 對不起 | 對唔住 | 抱歉 | 道歉 | 鞠躬 | 鞠躬嘅女人 | 鞠躬的女士</annotation>
+		<annotation cp="🙇‍♀">sorry | 下跪 | 人物 | 冥想 | 唔好意思 | 女人 | 女士 | 女性 | 姿勢 | 對不起 | 對唔住 | 抱歉 | 道歉 | 鞠躬 | 鞠躬嘅女人 | 鞠躬的女士</annotation>
 		<annotation cp="🙇‍♀" type="tts">鞠躬嘅女人</annotation>
-		<annotation cp="🤦">不敢相信｜不相信 | 冇眼睇 | 唉 | 女人 | 捂臉 | 無奈 | 無眼睇 | 無言 | 遮住塊面 | 遮住面 | 錯愕 | 難以置信</annotation>
+		<annotation cp="🤦">不敢相信 | 不相信 | 冇眼睇 | 唉 | 女人 | 捂臉 | 無奈 | 無眼睇 | 無言 | 遮住塊面 | 遮住面 | 錯愕 | 難以置信</annotation>
 		<annotation cp="🤦" type="tts">遮住塊面</annotation>
-		<annotation cp="🤦‍♂">不敢相信｜不相信｜男 | 人物 | 冇眼睇 | 唉 | 捂臉 | 無眼睇 | 遮住面 | 遮住面嘅男人 | 難以置信</annotation>
+		<annotation cp="🤦‍♂">不敢相信 | 不相信 | 人物 | 冇眼睇 | 唉 | 捂臉 | 無眼睇 | 男 | 遮住面 | 遮住面嘅男人 | 難以置信</annotation>
 		<annotation cp="🤦‍♂" type="tts">遮住面嘅男人</annotation>
-		<annotation cp="🤦‍♀">facepalm | 不敢相信｜不相信｜女 | 冇眼睇 | 唉 | 捂臉 | 無奈 | 無眼睇 | 無言 | 遮住面 | 遮住面嘅女人 | 錯愕 | 難以置信</annotation>
+		<annotation cp="🤦‍♀">facepalm | 不敢相信 | 不相信 | 冇眼睇 | 唉 | 女 | 捂臉 | 無奈 | 無眼睇 | 無言 | 遮住面 | 遮住面嘅女人 | 錯愕 | 難以置信</annotation>
 		<annotation cp="🤦‍♀" type="tts">遮住面嘅女人</annotation>
 		<annotation cp="🤷">冇所謂 | 冇計 | 冇辦法 | 可能係 | 我唔知 | 是但 | 是但啦 | 求其 | 無奈 | 無所謂 | 疑惑 | 聳肩 | 聳肩嘅人 | 隨便</annotation>
 		<annotation cp="🤷" type="tts">聳肩嘅人</annotation>
-		<annotation cp="🤷‍♂">不知道 | 冇所謂 | 冇計 | 冇辦法 | 唔知 | 攤手 | 是但 | 是但啦 | 無奈 | 無所謂 | 無扶 | 疑惑｜男人 | 聳肩 | 聳肩嘅男人 | 隨便</annotation>
+		<annotation cp="🤷‍♂">不知道 | 冇所謂 | 冇計 | 冇辦法 | 唔知 | 攤手 | 是但 | 是但啦 | 無奈 | 無所謂 | 無扶 | 男人 | 疑惑 | 聳肩 | 聳肩嘅男人 | 隨便</annotation>
 		<annotation cp="🤷‍♂" type="tts">聳肩嘅男人</annotation>
-		<annotation cp="🤷‍♀">不知道 | 冇計 | 冇辦法 | 唔知 | 攤手 | 是但 | 求其 | 無扶 | 無計 | 無辦法 | 疑惑｜女人 | 聳肩 | 聳肩嘅女人 | 隨便</annotation>
+		<annotation cp="🤷‍♀">不知道 | 冇計 | 冇辦法 | 唔知 | 女人 | 攤手 | 是但 | 求其 | 無扶 | 無計 | 無辦法 | 疑惑 | 聳肩 | 聳肩嘅女人 | 隨便</annotation>
 		<annotation cp="🤷‍♀" type="tts">聳肩嘅女人</annotation>
 		<annotation cp="🧑‍⚕">↑↑↑</annotation>
 		<annotation cp="🧑‍⚕" type="tts">↑↑↑</annotation>
@@ -1391,7 +1391,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤴" type="tts">↑↑↑</annotation>
 		<annotation cp="👸">人物 | 公主 | 女兒 | 女士 | 女性 | 女王 | 女皇 | 王冠 | 王后 | 皇冠 | 皇后 | 童話 | 老婆</annotation>
 		<annotation cp="👸" type="tts">↑↑↑</annotation>
-		<annotation cp="👳">人物 | 包頭 | 包頭巾 | 回教徒 | 戴頭巾嘅人 | 戴頭巾嘅人｜戴頭巾 | 特本 | 男士 | 穆斯林 | 錫克教 | 錫克教徒 | 頭巾</annotation>
+		<annotation cp="👳">人物 | 包頭 | 包頭巾 | 回教徒 | 戴頭巾 | 戴頭巾嘅人 | 特本 | 男士 | 穆斯林 | 錫克教 | 錫克教徒 | 頭巾</annotation>
 		<annotation cp="👳" type="tts">戴頭巾嘅人</annotation>
 		<annotation cp="👳‍♂">戴頭巾 | 戴頭巾嘅男人 | 男 | 綁頭巾 | 頭巾</annotation>
 		<annotation cp="👳‍♂" type="tts">戴頭巾嘅男人</annotation>
@@ -1461,47 +1461,47 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧚‍♀" type="tts">女仙子</annotation>
 		<annotation cp="🧛">不死族 | 亡靈 | 吸血殭屍 | 吸血鬼 | 德古拉 | 殭屍 | 男吸血鬼 | 萬聖節</annotation>
 		<annotation cp="🧛" type="tts">↑↑↑</annotation>
-		<annotation cp="🧛‍♂">不死族 | 德古拉｜男吸血鬼 | 男吸血鬼</annotation>
+		<annotation cp="🧛‍♂">不死族 | 德古拉 | 男吸血鬼</annotation>
 		<annotation cp="🧛‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧛‍♀">不死族 | 女吸血鬼 | 德古拉｜女吸血鬼</annotation>
+		<annotation cp="🧛‍♀">不死族 | 女吸血鬼 | 德古拉</annotation>
 		<annotation cp="🧛‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="🧜">ariel | 人魚 | 海底生物 | 童話 | 美人魚</annotation>
 		<annotation cp="🧜" type="tts">↑↑↑</annotation>
-		<annotation cp="🧜‍♂">男人魚 | 男人魚｜人魚</annotation>
+		<annotation cp="🧜‍♂">人魚 | 男人魚</annotation>
 		<annotation cp="🧜‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧜‍♀">美人魚 | 美人魚｜人魚</annotation>
+		<annotation cp="🧜‍♀">人魚 | 美人魚</annotation>
 		<annotation cp="🧜‍♀" type="tts">↑↑↑</annotation>
-		<annotation cp="🧝">妖怪 | 精靈 | 精靈｜魔法 | 魔戒 | 魔法 | 魔界</annotation>
+		<annotation cp="🧝">妖怪 | 精靈 | 魔戒 | 魔法 | 魔界</annotation>
 		<annotation cp="🧝" type="tts">精靈</annotation>
-		<annotation cp="🧝‍♂">男精靈 | 男精靈｜魔法</annotation>
+		<annotation cp="🧝‍♂">男精靈 | 魔法</annotation>
 		<annotation cp="🧝‍♂" type="tts">↑↑↑</annotation>
-		<annotation cp="🧝‍♀">女精靈 | 女精靈｜魔法</annotation>
+		<annotation cp="🧝‍♀">女精靈 | 魔法</annotation>
 		<annotation cp="🧝‍♀" type="tts">↑↑↑</annotation>
 		<annotation cp="🧞">燈神 | 神燈 | 精靈 | 許願 | 許願燈 | 阿拉丁神燈</annotation>
 		<annotation cp="🧞" type="tts">燈神</annotation>
-		<annotation cp="🧞‍♂">男燈神 | 精靈｜男燈神</annotation>
+		<annotation cp="🧞‍♂">男燈神 | 精靈</annotation>
 		<annotation cp="🧞‍♂" type="tts">男燈神</annotation>
-		<annotation cp="🧞‍♀">女燈神 | 精靈｜女燈神</annotation>
+		<annotation cp="🧞‍♀">女燈神 | 精靈</annotation>
 		<annotation cp="🧞‍♀" type="tts">女燈神</annotation>
-		<annotation cp="🧟">不死人｜行屍 | 喪屍 | 恐怖 | 殭屍 | 驚嚇 | 鬼</annotation>
+		<annotation cp="🧟">不死人 | 喪屍 | 恐怖 | 殭屍 | 行屍 | 驚嚇 | 鬼</annotation>
 		<annotation cp="🧟" type="tts">喪屍</annotation>
-		<annotation cp="🧟‍♂">男喪屍 | 男喪屍｜男殭屍｜不死人｜行屍</annotation>
+		<annotation cp="🧟‍♂">不死人 | 男喪屍 | 男殭屍 | 行屍</annotation>
 		<annotation cp="🧟‍♂" type="tts">男喪屍</annotation>
-		<annotation cp="🧟‍♀">女喪屍 | 女喪屍｜女殭屍｜不死人｜行屍</annotation>
+		<annotation cp="🧟‍♀">不死人 | 女喪屍 | 女殭屍 | 行屍</annotation>
 		<annotation cp="🧟‍♀" type="tts">女喪屍</annotation>
 		<annotation cp="🧌">山怪 | 巨人 | 怪物 | 惡棍 | 深山大野人 | 野人 | 魔怪</annotation>
 		<annotation cp="🧌" type="tts">↑↑↑</annotation>
 		<annotation cp="💆">facial | 人物 | 做facial | 女士 | 女性 | 按摩 | 接受頭部按摩嘅人 | 放鬆 | 正在接受按摩的人 | 美容 | 臉孔 | 舒緩 | 髮廊</annotation>
 		<annotation cp="💆" type="tts">接受頭部按摩嘅人</annotation>
-		<annotation cp="💆‍♂">facial | 人物 | 按摩 | 按摩｜男人 | 接受按摩的男人 | 接受頭部按摩嘅男人 | 放鬆 | 男士按摩 | 男士美容 | 男性 | 臉孔 | 舒緩</annotation>
+		<annotation cp="💆‍♂">facial | 人物 | 按摩 | 接受按摩的男人 | 接受頭部按摩嘅男人 | 放鬆 | 男人 | 男士按摩 | 男士美容 | 男性 | 臉孔 | 舒緩</annotation>
 		<annotation cp="💆‍♂" type="tts">接受頭部按摩嘅男人</annotation>
-		<annotation cp="💆‍♀">按摩｜女人 | 接受按摩的女人 | 接受頭部按摩嘅女人</annotation>
+		<annotation cp="💆‍♀">女人 | 按摩 | 接受按摩的女人 | 接受頭部按摩嘅女人</annotation>
 		<annotation cp="💆‍♀" type="tts">接受頭部按摩嘅女人</annotation>
 		<annotation cp="💇">人物 | 剪頭髮 | 剪髮 | 女士 | 女性 | 理髮 | 理髮師 | 美容 | 飛髮</annotation>
 		<annotation cp="💇" type="tts">剪頭髮</annotation>
-		<annotation cp="💇‍♂">人物 | 剪緊頭髮嘅男人 | 剪頭髮 | 剪髮｜男人 | 理髮 | 理髮師 | 男士 | 男性 | 美容 | 飛髮</annotation>
+		<annotation cp="💇‍♂">人物 | 剪緊頭髮嘅男人 | 剪頭髮 | 剪髮 | 理髮 | 理髮師 | 男人 | 男士 | 男性 | 美容 | 飛髮</annotation>
 		<annotation cp="💇‍♂" type="tts">剪緊頭髮嘅男人</annotation>
-		<annotation cp="💇‍♀">剪緊頭髮嘅女人 | 剪頭髮 | 剪髮｜女人 | 理髮 | 飛髮</annotation>
+		<annotation cp="💇‍♀">剪緊頭髮嘅女人 | 剪頭髮 | 剪髮 | 女人 | 理髮 | 飛髮</annotation>
 		<annotation cp="💇‍♀" type="tts">剪緊頭髮嘅女人</annotation>
 		<annotation cp="🚶">人物 | 單人 | 慢跑 | 散步 | 步行 | 漫步 | 行人 | 行路 | 走路 | 遠足</annotation>
 		<annotation cp="🚶" type="tts">↑↑↑</annotation>
@@ -1511,7 +1511,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🚶‍♀" type="tts">行路嘅女人</annotation>
 		<annotation cp="🧍">人物 | 企 | 企係度嘅人 | 站立 | 站著</annotation>
 		<annotation cp="🧍" type="tts">企係度嘅人</annotation>
-		<annotation cp="🧍‍♂">企係度嘅男人 | 男 | 站立 ｜ 企</annotation>
+		<annotation cp="🧍‍♂">企 | 企係度嘅男人 | 男 | 站立</annotation>
 		<annotation cp="🧍‍♂" type="tts">企係度嘅男人</annotation>
 		<annotation cp="🧍‍♀">企 | 企係度嘅女人 | 女 | 站立</annotation>
 		<annotation cp="🧍‍♀" type="tts">企係度嘅女人</annotation>
@@ -1541,7 +1541,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="👩‍🦽" type="tts">坐輪椅嘅女人</annotation>
 		<annotation cp="🏃">人物 | 快跑 | 快速 | 男士 | 男性 | 跑步 | 跑步嘅人 | 跑步的男士 | 跑者 | 馬拉松</annotation>
 		<annotation cp="🏃" type="tts">跑步嘅人</annotation>
-		<annotation cp="🏃‍♂">男跑手 | 跑步 | 跑步嘅男人｜比賽 | 跑者 | 馬拉松</annotation>
+		<annotation cp="🏃‍♂">比賽 | 男跑手 | 跑步 | 跑步嘅男人 | 跑者 | 馬拉松</annotation>
 		<annotation cp="🏃‍♂" type="tts">男跑手</annotation>
 		<annotation cp="🏃‍♀">人物 | 女士 | 女性 | 快速 | 比賽 | 跑步 | 跑步嘅女人 | 跑步的女士 | 跑者 | 馬拉松</annotation>
 		<annotation cp="🏃‍♀" type="tts">跑步嘅女人</annotation>
@@ -1553,9 +1553,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🕴" type="tts">着住西裝飄浮嘅男人</annotation>
 		<annotation cp="👯">兔女郎 | 兔耳 | 兔耳仔 | 女士 | 孖女 | 孖妹 | 孖生女 | 派對 | 舞蹈員 | 跳舞 | 雙胞胎</annotation>
 		<annotation cp="👯" type="tts">↑↑↑</annotation>
-		<annotation cp="👯‍♂">人物 | 兄弟 | 兔子 | 兔耳 | 兔耳仔｜男人 | 巴打 | 戴兔耳仔嘅男人 | 撞衫 | 派對 | 男士 | 男性 | 絲打 | 舞蹈員 | 芭蕾 | 跳舞 | 雙胞胎</annotation>
+		<annotation cp="👯‍♂">人物 | 兄弟 | 兔子 | 兔耳 | 兔耳仔 | 巴打 | 戴兔耳仔嘅男人 | 撞衫 | 派對 | 男人 | 男士 | 男性 | 絲打 | 舞蹈員 | 芭蕾 | 跳舞 | 雙胞胎</annotation>
 		<annotation cp="👯‍♂" type="tts">戴兔耳仔嘅男人</annotation>
-		<annotation cp="👯‍♀">戴兔耳仔嘅女人 | 戴兔耳仔嘅女人｜兔耳仔｜女人 | 跳舞</annotation>
+		<annotation cp="👯‍♀">兔耳仔 | 女人 | 戴兔耳仔嘅女人 | 跳舞</annotation>
 		<annotation cp="👯‍♀" type="tts">戴兔耳仔嘅女人</annotation>
 		<annotation cp="🧖">放鬆 | 桑拿 | 桑拿房 | 焗桑拿 | 焗桑拿嘅人 | 蒸氣室 | 蒸氣房 | 蒸氣桑拿 | 蒸氣浴</annotation>
 		<annotation cp="🧖" type="tts">焗桑拿嘅人</annotation>
@@ -1571,17 +1571,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧗‍♀" type="tts">攀岩嘅女人</annotation>
 		<annotation cp="🤺">劍 | 劍擊 | 劍擊運動員 | 擊劍 | 運動</annotation>
 		<annotation cp="🤺" type="tts">劍擊運動員</annotation>
-		<annotation cp="🏇">比賽 | 賭馬 | 賽馬 | 跑馬 | 運動 | 馬 | 馬會 | 騎師｜馬賽 | 騎術 | 騎馬</annotation>
+		<annotation cp="🏇">比賽 | 賭馬 | 賽馬 | 跑馬 | 運動 | 馬 | 馬會 | 馬賽 | 騎師 | 騎術 | 騎馬</annotation>
 		<annotation cp="🏇" type="tts">騎馬</annotation>
 		<annotation cp="⛷">滑雪 | 雪</annotation>
 		<annotation cp="⛷" type="tts">↑↑↑</annotation>
 		<annotation cp="🏂">單板滑雪 | 滑雪 | 滑雪板 | 玩滑雪板 | 運動 | 雪</annotation>
 		<annotation cp="🏂" type="tts">玩滑雪板</annotation>
-		<annotation cp="🏌">一杆入洞 | 哥爾夫 | 哥爾夫球 | 打golf | 打高爾夫球 | 打高爾夫球嘅人｜高爾夫 | 揮杆 | 杆 | 球 | 高爾夫 | 高爾夫球 | 高球</annotation>
+		<annotation cp="🏌">一杆入洞 | 哥爾夫 | 哥爾夫球 | 打golf | 打高爾夫球 | 打高爾夫球嘅人 | 揮杆 | 杆 | 球 | 高爾夫 | 高爾夫球 | 高球</annotation>
 		<annotation cp="🏌" type="tts">打高爾夫球</annotation>
-		<annotation cp="🏌‍♂">打高爾夫球嘅男人 | 打高爾夫球嘅男人｜高爾夫球｜男人</annotation>
+		<annotation cp="🏌‍♂">打高爾夫球嘅男人 | 男人 | 高爾夫球</annotation>
 		<annotation cp="🏌‍♂" type="tts">打高爾夫球嘅男人</annotation>
-		<annotation cp="🏌‍♀">人物 | 哥爾夫 | 女士 | 女性 | 打golf | 打高爾夫球嘅女人 | 打高爾夫球嘅女人｜高爾夫球｜女人 | 球 | 運動 | 高爾夫 | 高球</annotation>
+		<annotation cp="🏌‍♀">人物 | 哥爾夫 | 女人 | 女士 | 女性 | 打golf | 打高爾夫球嘅女人 | 球 | 運動 | 高爾夫 | 高爾夫球 | 高球</annotation>
 		<annotation cp="🏌‍♀" type="tts">打高爾夫球嘅女人</annotation>
 		<annotation cp="🏄">人物 | 水上運動 | 沙灘 | 海洋 | 海灘 | 滑浪 | 男士 | 男性 | 衝浪 | 運動</annotation>
 		<annotation cp="🏄" type="tts">滑浪</annotation>
@@ -1591,21 +1591,21 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🏄‍♀" type="tts">滑浪嘅女人</annotation>
 		<annotation cp="🚣">划船 | 划艇 | 撐船 | 撐艇 | 爬船 | 獨木舟 | 船 | 船仔 | 遊河 | 遊湖 | 釣魚</annotation>
 		<annotation cp="🚣" type="tts">撐艇</annotation>
-		<annotation cp="🚣‍♂">划艇嘅男人 | 小船 | 撐艇｜船 | 撐艇嘅男人</annotation>
+		<annotation cp="🚣‍♂">划艇嘅男人 | 小船 | 撐艇 | 撐艇嘅男人 | 船</annotation>
 		<annotation cp="🚣‍♂" type="tts">撐艇嘅男人</annotation>
 		<annotation cp="🚣‍♀">人物 | 划艇 | 划艇嘅女人 | 女士 | 女性 | 小船 | 撐艇 | 撐艇嘅女人 | 河 | 湖 | 舟 | 船 | 釣魚</annotation>
 		<annotation cp="🚣‍♀" type="tts">撐艇嘅女人</annotation>
-		<annotation cp="🏊">人物 | 泳手 | 游水 | 游水｜游水嘅人 | 游泳 | 游泳的男士 | 男士 | 男性 | 自由式 | 運動</annotation>
+		<annotation cp="🏊">人物 | 泳手 | 游水 | 游水嘅人 | 游泳 | 游泳的男士 | 男士 | 男性 | 自由式 | 運動</annotation>
 		<annotation cp="🏊" type="tts">游水</annotation>
-		<annotation cp="🏊‍♂">游水｜游水嘅男人 | 男泳手</annotation>
+		<annotation cp="🏊‍♂">游水 | 游水嘅男人 | 男泳手</annotation>
 		<annotation cp="🏊‍♂" type="tts">男泳手</annotation>
-		<annotation cp="🏊‍♀">人物 | 女士 | 女性 | 女泳手 | 泳手 | 游水｜游水嘅女人 | 游泳 | 游泳的女士 | 自由式 | 運動</annotation>
+		<annotation cp="🏊‍♀">人物 | 女士 | 女性 | 女泳手 | 泳手 | 游水 | 游水嘅女人 | 游泳 | 游泳的女士 | 自由式 | 運動</annotation>
 		<annotation cp="🏊‍♀" type="tts">女泳手</annotation>
-		<annotation cp="⛹">人物 | 帶波 | 打波 | 打籃球 | 拍波｜打緊波嘅人 | 球員 | 男士 | 男性 | 籃球 | 運動員 | 運球</annotation>
+		<annotation cp="⛹">人物 | 帶波 | 打波 | 打籃球 | 打緊波嘅人 | 拍波 | 球員 | 男士 | 男性 | 籃球 | 運動員 | 運球</annotation>
 		<annotation cp="⛹" type="tts">打緊波嘅人</annotation>
-		<annotation cp="⛹‍♂">打波｜拍波｜男人 | 打緊波嘅男人</annotation>
+		<annotation cp="⛹‍♂">打波 | 打緊波嘅男人 | 拍波 | 男人</annotation>
 		<annotation cp="⛹‍♂" type="tts">打緊波嘅男人</annotation>
-		<annotation cp="⛹‍♀">人物 | 女士 | 女性 | 打波 | 打籃球 | 打緊波嘅女人 | 拍波｜女人 | 球 | 球員 | 運動員 | 運球 | 運球的女士</annotation>
+		<annotation cp="⛹‍♀">人物 | 女人 | 女士 | 女性 | 打波 | 打籃球 | 打緊波嘅女人 | 拍波 | 球 | 球員 | 運動員 | 運球 | 運球的女士</annotation>
 		<annotation cp="⛹‍♀" type="tts">打緊波嘅女人</annotation>
 		<annotation cp="🏋">人物 | 健美 | 健身 | 男士 | 男性 | 舉重 | 舉鐵 | 運動員 | 鍛煉</annotation>
 		<annotation cp="🏋" type="tts">↑↑↑</annotation>
@@ -1621,9 +1621,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🚴‍♀" type="tts">女單車手</annotation>
 		<annotation cp="🚵">人物 | 單車 | 山地單車 | 爬山單車 | 男士 | 男性 | 越野單車 | 踩單車 | 踩爬山單車 | 運動 | 騎單車</annotation>
 		<annotation cp="🚵" type="tts">踩爬山單車</annotation>
-		<annotation cp="🚵‍♂">男 | 踩爬山單車｜爬山單車 | 踩爬山單車嘅男人</annotation>
+		<annotation cp="🚵‍♂">爬山單車 | 男 | 踩爬山單車 | 踩爬山單車嘅男人</annotation>
 		<annotation cp="🚵‍♂" type="tts">踩爬山單車嘅男人</annotation>
-		<annotation cp="🚵‍♀">人物 | 單車 | 女 | 女士 | 女性 | 山地單車 | 踩單車 | 踩爬山單車｜爬山單車 | 踩爬山單車嘅女人 | 運動 | 騎單車</annotation>
+		<annotation cp="🚵‍♀">人物 | 單車 | 女 | 女士 | 女性 | 山地單車 | 爬山單車 | 踩單車 | 踩爬山單車 | 踩爬山單車嘅女人 | 運動 | 騎單車</annotation>
 		<annotation cp="🚵‍♀" type="tts">踩爬山單車嘅女人</annotation>
 		<annotation cp="🤸">側手翻 | 打關斗 | 興奮 | 體操 | 體操女</annotation>
 		<annotation cp="🤸" type="tts">側手翻</annotation>
@@ -1641,7 +1641,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤽" type="tts">水球</annotation>
 		<annotation cp="🤽‍♂">人物 | 打水球 | 打水球嘅男人 | 水上運動 | 水球 | 男士 | 男性 | 運動</annotation>
 		<annotation cp="🤽‍♂" type="tts">打水球嘅男人</annotation>
-		<annotation cp="🤽‍♀">人物 | 女士 | 女性 | 打水球嘅女人｜打水球｜水球 | 水上運動 | 運動</annotation>
+		<annotation cp="🤽‍♀">人物 | 女士 | 女性 | 打水球 | 打水球嘅女人 | 水上運動 | 水球 | 運動</annotation>
 		<annotation cp="🤽‍♀" type="tts">打水球嘅女人</annotation>
 		<annotation cp="🤾">射波 | 射球 | 射門 | 射龍門 | 手球 | 攻擊 | 波 | 跳射 | 進攻</annotation>
 		<annotation cp="🤾" type="tts">↑↑↑</annotation>
@@ -1651,9 +1651,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🤾‍♀" type="tts">打手球嘅女人</annotation>
 		<annotation cp="🤹">平衡感 | 技藝 | 抛波 | 抛波表演 | 特技 | 耍雜技 | 雜技 | 雜耍</annotation>
 		<annotation cp="🤹" type="tts">耍雜技</annotation>
-		<annotation cp="🤹‍♂">人物 | 抛波雜技 | 拋波 | 拋球 | 男士 | 男性 | 耍雜技｜雜技｜男 | 耍雜技嘅男人</annotation>
+		<annotation cp="🤹‍♂">人物 | 抛波雜技 | 拋波 | 拋球 | 男 | 男士 | 男性 | 耍雜技 | 耍雜技嘅男人 | 雜技</annotation>
 		<annotation cp="🤹‍♂" type="tts">耍雜技嘅男人</annotation>
-		<annotation cp="🤹‍♀">人物 | 女士 | 女性 | 拋球 | 耍雜技｜雜技｜女 | 耍雜技嘅女人 | 雜耍</annotation>
+		<annotation cp="🤹‍♀">人物 | 女 | 女士 | 女性 | 拋球 | 耍雜技 | 耍雜技嘅女人 | 雜技 | 雜耍</annotation>
 		<annotation cp="🤹‍♀" type="tts">耍雜技嘅女人</annotation>
 		<annotation cp="🧘">冥想 | 呼吸 | 打坐 | 放鬆 | 深呼吸 | 瑜伽 | 瑜伽女 | 瑜珈 | 盤腿坐 | 盤腿坐嘅人 | 蓮花坐 | 靜觀</annotation>
 		<annotation cp="🧘" type="tts">盤腿坐嘅人</annotation>
@@ -1661,9 +1661,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧘‍♂" type="tts">盤腿坐嘅男人</annotation>
 		<annotation cp="🧘‍♀">冥想 | 打坐 | 瑜珈 | 盤腿坐 | 盤腿坐嘅女人 | 蓮花坐</annotation>
 		<annotation cp="🧘‍♀" type="tts">盤腿坐嘅女人</annotation>
-		<annotation cp="🛀">人物 | 沖涼 | 洗澡 | 浴缸 | 浸浴嘅人｜浸浴 | 淋浴</annotation>
+		<annotation cp="🛀">人物 | 沖涼 | 洗澡 | 浴缸 | 浸浴 | 浸浴嘅人 | 淋浴</annotation>
 		<annotation cp="🛀" type="tts">浸浴嘅人</annotation>
-		<annotation cp="🛌">唞 | 小睡 | 床 | 早唞 | 早抖 | 晚安 | 疲倦 | 睡眠 | 睡覺 | 瞓覺嘅人｜瞓覺 | 訓覺 | 酒店</annotation>
+		<annotation cp="🛌">唞 | 小睡 | 床 | 早唞 | 早抖 | 晚安 | 疲倦 | 睡眠 | 睡覺 | 瞓覺 | 瞓覺嘅人 | 訓覺 | 酒店</annotation>
 		<annotation cp="🛌" type="tts">瞓覺</annotation>
 		<annotation cp="🧑‍🤝‍🧑">人物 | 情侶 | 手 | 拖手 | 拖手的人 | 握手</annotation>
 		<annotation cp="🧑‍🤝‍🧑" type="tts">拖手的人</annotation>
@@ -2989,7 +2989,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="💎" type="tts">↑↑↑</annotation>
 		<annotation cp="🔇">喇叭 | 安靜 | 揚聲器 | 聲音 | 關掉喇叭 | 靜音 | 音響</annotation>
 		<annotation cp="🔇" type="tts">↑↑↑</annotation>
-		<annotation cp="🔈">喇叭 | 小聲 | 揚聲器 | 柔和 | 細聲｜喇叭 | 細聲喇叭 | 聲音 | 音樂 | 音量 | 音響</annotation>
+		<annotation cp="🔈">喇叭 | 小聲 | 揚聲器 | 柔和 | 細聲 | 細聲喇叭 | 聲音 | 音樂 | 音量 | 音響</annotation>
 		<annotation cp="🔈" type="tts">細聲喇叭</annotation>
 		<annotation cp="🔉">中音量 | 喇叭 | 揚聲器 | 聲量中等 | 聲量中等嘅喇叭 | 聲音 | 音樂 | 音量 | 音響</annotation>
 		<annotation cp="🔉" type="tts">聲量中等嘅喇叭</annotation>
@@ -3009,7 +3009,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🎼" type="tts">↑↑↑</annotation>
 		<annotation cp="🎵">聲音 | 音樂 | 音符</annotation>
 		<annotation cp="🎵" type="tts">↑↑↑</annotation>
-		<annotation cp="🎶">三個音符 | 聲音 | 音樂 | 音符 | 音符｜三個音符</annotation>
+		<annotation cp="🎶">三個音符 | 聲音 | 音樂 | 音符</annotation>
 		<annotation cp="🎶" type="tts">三個音符</annotation>
 		<annotation cp="🎙">咪高風 | 工作室 | 錄音室咪高風 | 音樂 | 麥克風</annotation>
 		<annotation cp="🎙" type="tts">錄音室咪高風</annotation>
@@ -3055,7 +3055,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="☎" type="tts">↑↑↑</annotation>
 		<annotation cp="📞">溝通 | 聽筒 | 通訊 | 電話 | 電話筒</annotation>
 		<annotation cp="📞" type="tts">電話筒</annotation>
-		<annotation cp="📟">傳呼機｜Call機 | 溝通 | 秘書台 | 通訊</annotation>
+		<annotation cp="📟">Call機 | 傳呼機 | 溝通 | 秘書台 | 通訊</annotation>
 		<annotation cp="📟" type="tts">傳呼機</annotation>
 		<annotation cp="📠">fax | 傳真 | 傳真機 | 通訊</annotation>
 		<annotation cp="📠" type="tts">↑↑↑</annotation>
@@ -3105,9 +3105,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📹" type="tts">錄影機</annotation>
 		<annotation cp="📼">vhs | 懷舊 | 磁帶 | 錄影帶</annotation>
 		<annotation cp="📼" type="tts">↑↑↑</annotation>
-		<annotation cp="🔍">仔細 | 向左嘅放大鏡 | 向左放大鏡 | 實驗室 | 小心 | 工具 | 搜索 | 放大｜搜尋 | 放大鏡 | 玻璃 | 科學 | 線索 | 調查</annotation>
+		<annotation cp="🔍">仔細 | 向左嘅放大鏡 | 向左放大鏡 | 實驗室 | 小心 | 工具 | 搜尋 | 搜索 | 放大 | 放大鏡 | 玻璃 | 科學 | 線索 | 調查</annotation>
 		<annotation cp="🔍" type="tts">向左嘅放大鏡</annotation>
-		<annotation cp="🔎">仔細 | 向右嘅放大鏡 | 向右放大鏡 | 實驗室 | 小心 | 工具 | 搜索 | 放大｜搜尋 | 放大鏡 | 玻璃 | 科學 | 線索 | 調查</annotation>
+		<annotation cp="🔎">仔細 | 向右嘅放大鏡 | 向右放大鏡 | 實驗室 | 小心 | 工具 | 搜尋 | 搜索 | 放大 | 放大鏡 | 玻璃 | 科學 | 線索 | 調查</annotation>
 		<annotation cp="🔎" type="tts">向右嘅放大鏡</annotation>
 		<annotation cp="🕯">光線 | 悼念 | 燭光 | 蠟燭</annotation>
 		<annotation cp="🕯" type="tts">↑↑↑</annotation>
@@ -3125,17 +3125,17 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📕" type="tts">閂埋嘅書</annotation>
 		<annotation cp="📖">圖書館 | 小說 | 打開 | 打開嘅書 | 書 | 書本 | 書籍 | 知識 | 閱讀</annotation>
 		<annotation cp="📖" type="tts">打開嘅書</annotation>
-		<annotation cp="📗">封面 | 小説 | 書本 | 書籍 | 第二冊 | 綠色簿｜書｜綠色 | 關閉</annotation>
+		<annotation cp="📗">封面 | 小説 | 書 | 書本 | 書籍 | 第二冊 | 綠色 | 綠色簿 | 關閉</annotation>
 		<annotation cp="📗" type="tts">綠色簿</annotation>
-		<annotation cp="📘">封面 | 小説 | 書本 | 書籍 | 第三冊 | 藍色簿｜書｜藍色 | 關閉</annotation>
+		<annotation cp="📘">封面 | 小説 | 書 | 書本 | 書籍 | 第三冊 | 藍色 | 藍色簿 | 關閉</annotation>
 		<annotation cp="📘" type="tts">藍色簿</annotation>
-		<annotation cp="📙">封面 | 小説 | 書本 | 書籍 | 橙色簿｜書｜橙色 | 第四冊 | 關閉</annotation>
+		<annotation cp="📙">封面 | 小説 | 書 | 書本 | 書籍 | 橙色 | 橙色簿 | 第四冊 | 關閉</annotation>
 		<annotation cp="📙" type="tts">橙色簿</annotation>
 		<annotation cp="📚">一疊書 | 圖書館 | 學校 | 小說 | 書 | 書本 | 書籍 | 知識</annotation>
 		<annotation cp="📚" type="tts">一疊書</annotation>
 		<annotation cp="📓">日記 | 書 | 筆記本 | 筆記簿 | 簿 | 紙</annotation>
 		<annotation cp="📓" type="tts">筆記簿</annotation>
-		<annotation cp="📒">帳簿｜簿 | 筆記本 | 筆記簿 | 紙 | 賬本</annotation>
+		<annotation cp="📒">帳簿 | 筆記本 | 筆記簿 | 簿 | 紙 | 賬本</annotation>
 		<annotation cp="📒" type="tts">帳簿</annotation>
 		<annotation cp="📃">彎曲嘅文件 | 捲曲 | 文件 | 文件檔 | 書頁 | 紙</annotation>
 		<annotation cp="📃" type="tts">彎曲嘅文件</annotation>
@@ -3153,7 +3153,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🔖" type="tts">↑↑↑</annotation>
 		<annotation cp="🏷">tag | 標籤</annotation>
 		<annotation cp="🏷" type="tts">標籤</annotation>
-		<annotation cp="💰">$ | 一袋錢｜錢袋｜錢 | 富有 | 成本 | 支付 | 有米 | 有錢 | 現金 | 發達 | 財富 | 賭注 | 金</annotation>
+		<annotation cp="💰">$ | 一袋錢 | 富有 | 成本 | 支付 | 有米 | 有錢 | 現金 | 發達 | 財富 | 賭注 | 金 | 錢 | 錢袋</annotation>
 		<annotation cp="💰" type="tts">一袋錢</annotation>
 		<annotation cp="🪙">歐元 | 硬幣 | 財富 | 金幣 | 金錢 | 銀行 | 錢 | 黃金</annotation>
 		<annotation cp="🪙" type="tts">↑↑↑</annotation>
@@ -3181,9 +3181,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📨" type="tts">來信</annotation>
 		<annotation cp="📩">e-mail | email | inbox | 下 | 信 | 信件 | 信封 | 寄信 | 接收 | 收到 | 有箭嘴嘅信封 | 發出 | 發送 | 箭咀 | 送出 | 通訊 | 郵件 | 電子郵件 | 電郵</annotation>
 		<annotation cp="📩" type="tts">有箭嘴嘅信封</annotation>
-		<annotation cp="📤">e-mail | email | 信件 | 寄件箱 | 發出 | 送出 | 郵件 | 郵箱｜信 | 電子郵件 | 電郵</annotation>
+		<annotation cp="📤">e-mail | email | 信 | 信件 | 寄件箱 | 發出 | 送出 | 郵件 | 郵箱 | 電子郵件 | 電郵</annotation>
 		<annotation cp="📤" type="tts">寄件箱</annotation>
-		<annotation cp="📥">e-mail | email | 信件 | 接收 | 收件箱 | 無電郵 | 郵件｜ 收到 | 郵箱｜信 | 電子郵件 | 電郵</annotation>
+		<annotation cp="📥">e-mail | email | 信 | 信件 | 接收 | 收件箱 | 收到 | 無電郵 | 郵件 | 郵箱 | 電子郵件 | 電郵</annotation>
 		<annotation cp="📥" type="tts">收件箱</annotation>
 		<annotation cp="📦">包裹 | 派遞 | 箱 | 箱子 | 送貨 | 通訊 | 速遞 | 運輸</annotation>
 		<annotation cp="📦" type="tts">↑↑↑</annotation>
@@ -3217,9 +3217,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="💼" type="tts">↑↑↑</annotation>
 		<annotation cp="📁">文件夾 | 檔案 | 檔案夾</annotation>
 		<annotation cp="📁" type="tts">文件夾</annotation>
-		<annotation cp="📂">打開｜文件夾｜文件 | 打開嘅文件夾 | 檔案 | 檔案夾</annotation>
+		<annotation cp="📂">打開 | 打開嘅文件夾 | 文件 | 文件夾 | 檔案 | 檔案夾</annotation>
 		<annotation cp="📂" type="tts">打開嘅文件夾</annotation>
-		<annotation cp="🗂">分隔 | 分隔｜卡 | 卡片 | 文件夾 | 活頁文件夾 | 索引 | 索引分隔卡</annotation>
+		<annotation cp="🗂">分隔 | 卡 | 卡片 | 文件夾 | 活頁文件夾 | 索引 | 索引分隔卡</annotation>
 		<annotation cp="🗂" type="tts">索引分隔卡</annotation>
 		<annotation cp="📅">七月十七日 | 日曆 | 日期</annotation>
 		<annotation cp="📅" type="tts">日曆</annotation>
@@ -3233,7 +3233,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📇" type="tts">↑↑↑</annotation>
 		<annotation cp="📈">向上 | 向上折線圖 | 圖形 | 圖表 | 增加 | 增長 | 數據 | 業績 | 正向 | 線條 | 表現 | 趨勢</annotation>
 		<annotation cp="📈" type="tts">向上折線圖</annotation>
-		<annotation cp="📉">下跌 | 下降 | 向下 | 向下折線圖 | 圖形 | 圖表 | 數據 | 業績 | 減少 | 線條 | 趨勢 | 趨勢｜下跌</annotation>
+		<annotation cp="📉">下跌 | 下降 | 向下 | 向下折線圖 | 圖形 | 圖表 | 數據 | 業績 | 減少 | 線條 | 趨勢</annotation>
 		<annotation cp="📉" type="tts">向下折線圖</annotation>
 		<annotation cp="📊">圖形 | 圖表 | 數據 | 條形圖 | 棒形圖 | 資料</annotation>
 		<annotation cp="📊" type="tts">棒形圖</annotation>
@@ -3241,7 +3241,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📋" type="tts">剪貼簿</annotation>
 		<annotation cp="📌">圖釘 | 大學 | 大頭釘</annotation>
 		<annotation cp="📌" type="tts">大頭釘</annotation>
-		<annotation cp="📍">位置 | 圓形 | 圓頭大頭釘｜大頭釘 | 圖釘 | 地圖 | 大頭針 | 置頂 | 釘選</annotation>
+		<annotation cp="📍">位置 | 圓形 | 圓頭大頭釘 | 圖釘 | 地圖 | 大頭釘 | 大頭針 | 置頂 | 釘選</annotation>
 		<annotation cp="📍" type="tts">圓頭大頭釘</annotation>
 		<annotation cp="📎">萬字夾 | 迴紋針</annotation>
 		<annotation cp="📎" type="tts">萬字夾</annotation>
@@ -3253,13 +3253,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="📐" type="tts">↑↑↑</annotation>
 		<annotation cp="✂">切割 | 剪 | 剪刀 | 工具 | 鉸剪 | 骹剪</annotation>
 		<annotation cp="✂" type="tts">骹剪</annotation>
-		<annotation cp="🗃">卡片檔案盒｜卡片｜盒 | 名片 | 文件盒 | 活頁文件夾 | 盒子 | 箱子</annotation>
+		<annotation cp="🗃">卡片 | 卡片檔案盒 | 名片 | 文件盒 | 活頁文件夾 | 盒 | 盒子 | 箱子</annotation>
 		<annotation cp="🗃" type="tts">卡片檔案盒</annotation>
 		<annotation cp="🗄">file | 檔案 | 檔案櫃 | 櫃子 | 歸檔</annotation>
 		<annotation cp="🗄" type="tts">↑↑↑</annotation>
 		<annotation cp="🗑">垃圾桶</annotation>
 		<annotation cp="🗑" type="tts">垃圾桶</annotation>
-		<annotation cp="🔒">私隱 | 鎖 | 鎖上 ｜上鎖 | 鎖定 | 關閉</annotation>
+		<annotation cp="🔒">上鎖 | 私隱 | 鎖 | 鎖上 | 鎖定 | 關閉</annotation>
 		<annotation cp="🔒" type="tts">鎖</annotation>
 		<annotation cp="🔓">打開 | 破解 | 解鎖 | 鎖 | 鎖定 | 開鎖</annotation>
 		<annotation cp="🔓" type="tts">↑↑↑</annotation>
@@ -3269,7 +3269,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🔐" type="tts">↑↑↑</annotation>
 		<annotation cp="🔑">密碼 | 解鎖 | 鎖匙 | 鎖定 | 鑰匙</annotation>
 		<annotation cp="🔑" type="tts">↑↑↑</annotation>
-		<annotation cp="🗝">線索 | 舊鎖匙｜鎖匙 | 舊鑰匙 | 鑰匙</annotation>
+		<annotation cp="🗝">線索 | 舊鎖匙 | 舊鑰匙 | 鎖匙 | 鑰匙</annotation>
 		<annotation cp="🗝" type="tts">舊鎖匙</annotation>
 		<annotation cp="🔨">工具 | 槌 | 維修 | 鎚仔 | 鎚子</annotation>
 		<annotation cp="🔨" type="tts">鎚仔</annotation>
@@ -3277,9 +3277,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🪓" type="tts">↑↑↑</annotation>
 		<annotation cp="⛏">十字鋤 | 十字鎬 | 工具 | 採礦 | 槌 | 鎚子 | 鎬 | 鑿</annotation>
 		<annotation cp="⛏" type="tts">十字鋤</annotation>
-		<annotation cp="⚒">十字鎬 | 工具 | 槌 | 鎚仔｜十字鋤 | 鎚仔同十字鋤 | 鎚子 | 鎬</annotation>
+		<annotation cp="⚒">十字鋤 | 十字鎬 | 工具 | 槌 | 鎚仔 | 鎚仔同十字鋤 | 鎚子 | 鎬</annotation>
 		<annotation cp="⚒" type="tts">鎚仔同十字鋤</annotation>
-		<annotation cp="🛠">士巴拿 | 工具 | 扳手 | 槌 | 鎚仔｜鎚子 | 鎚仔同士巴拿</annotation>
+		<annotation cp="🛠">士巴拿 | 工具 | 扳手 | 槌 | 鎚仔 | 鎚仔同士巴拿 | 鎚子</annotation>
 		<annotation cp="🛠" type="tts">鎚仔同士巴拿</annotation>
 		<annotation cp="🗡">刀 | 劍 | 匕首 | 小刀 | 武器</annotation>
 		<annotation cp="🗡" type="tts">↑↑↑</annotation>
@@ -3335,7 +3335,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🧬" type="tts">↑↑↑</annotation>
 		<annotation cp="🔬">實驗 | 實驗室 | 工具 | 科學 | 顯微鏡</annotation>
 		<annotation cp="🔬" type="tts">↑↑↑</annotation>
-		<annotation cp="🔭">e.t. | 工具 | 接觸 | 望遠鏡 | 科學 | 觀測｜工具</annotation>
+		<annotation cp="🔭">e.t. | 工具 | 接觸 | 望遠鏡 | 科學 | 觀測</annotation>
 		<annotation cp="🔭" type="tts">↑↑↑</annotation>
 		<annotation cp="📡">外星人 | 天線 | 太空 | 宇宙 | 碟 | 科學 | 衛星</annotation>
 		<annotation cp="📡" type="tts">↑↑↑</annotation>
@@ -3363,7 +3363,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🪟" type="tts">↑↑↑</annotation>
 		<annotation cp="🛏">床 | 睡床 | 睡眠 | 睡覺 | 訓覺 | 酒店</annotation>
 		<annotation cp="🛏" type="tts">↑↑↑</annotation>
-		<annotation cp="🛋">梳化 | 梳化和座地燈 | 沙發｜座地燈 | 燈 | 酒店</annotation>
+		<annotation cp="🛋">座地燈 | 梳化 | 梳化和座地燈 | 沙發 | 燈 | 酒店</annotation>
 		<annotation cp="🛋" type="tts">梳化和座地燈</annotation>
 		<annotation cp="🪑">凳 | 坐下 | 座位 | 椅子</annotation>
 		<annotation cp="🪑" type="tts">↑↑↑</annotation>
@@ -3381,13 +3381,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<annotation cp="🪒" type="tts">↑↑↑</annotation>
 		<annotation cp="🧴">lotion | 乳液 | 保濕 | 保濕霜 | 洗頭水 | 洗髮水 | 潤膚乳 | 潤膚乳樽 | 瓶子 | 防曬 | 防曬霜</annotation>
 		<annotation cp="🧴" type="tts">潤膚乳樽</annotation>
-		<annotation cp="🧷">別針 | 安全別針 | 尿片｜punk rock | 扣針</annotation>
+		<annotation cp="🧷">punk rock | 別針 | 安全別針 | 尿片 | 扣針</annotation>
 		<annotation cp="🧷" type="tts">扣針</annotation>
 		<annotation cp="🧹">女巫 | 掃帚 | 掃把 | 清掃 | 清潔</annotation>
 		<annotation cp="🧹" type="tts">↑↑↑</annotation>
 		<annotation cp="🧺">洗衣 | 洗衫 | 種菜 | 籃 | 籃子 | 農業 | 野餐</annotation>
 		<annotation cp="🧺" type="tts">籃</annotation>
-		<annotation cp="🧻">一捲廁紙 | 廁紙｜紙巾 | 捲筒紙 | 衛生紙</annotation>
+		<annotation cp="🧻">一捲廁紙 | 廁紙 | 捲筒紙 | 紙巾 | 衛生紙</annotation>
 		<annotation cp="🧻" type="tts">一捲廁紙</annotation>
 		<annotation cp="🪣">桶 | 水桶</annotation>
 		<annotation cp="🪣" type="tts">↑↑↑</annotation>

--- a/common/annotationsDerived/zh_Hant_HK.xml
+++ b/common/annotationsDerived/zh_Hant_HK.xml
@@ -1228,16 +1228,6 @@ Derived short names and annotations, using GenerateDerivedAnnotations.java. See 
 		<annotation cp="🙋🏾‍♂" type="tts">開心｜舉起一隻手｜男人｜哈囉｜hi：中深皮膚</annotation>
 		<annotation cp="🙋🏿‍♂">hi | 人物 | 問題 | 喂 | 嗨 | 姿勢 | 我 | 我知道 | 手 | 手勢 | 男士 | 男性 | 發問 | 舉手 | 舉手的男士 | 開心｜舉起一隻手｜男人｜哈囉 | 黑皮膚</annotation>
 		<annotation cp="🙋🏿‍♂" type="tts">開心｜舉起一隻手｜男人｜哈囉｜hi：黑皮膚</annotation>
-		<annotation cp="🙋🏻‍♀">白皮膚 | 開心｜舉起一隻手｜女人｜哈囉｜hi | 開心嘅女人舉起一隻手</annotation>
-		<annotation cp="🙋🏻‍♀" type="tts">開心嘅女人舉起一隻手：白皮膚</annotation>
-		<annotation cp="🙋🏼‍♀">開心｜舉起一隻手｜女人｜哈囉｜hi | 開心嘅女人舉起一隻手 | 黃皮膚</annotation>
-		<annotation cp="🙋🏼‍♀" type="tts">開心嘅女人舉起一隻手：黃皮膚</annotation>
-		<annotation cp="🙋🏽‍♀">中等皮膚 | 開心｜舉起一隻手｜女人｜哈囉｜hi | 開心嘅女人舉起一隻手</annotation>
-		<annotation cp="🙋🏽‍♀" type="tts">開心嘅女人舉起一隻手：中等皮膚</annotation>
-		<annotation cp="🙋🏾‍♀">中深皮膚 | 開心｜舉起一隻手｜女人｜哈囉｜hi | 開心嘅女人舉起一隻手</annotation>
-		<annotation cp="🙋🏾‍♀" type="tts">開心嘅女人舉起一隻手：中深皮膚</annotation>
-		<annotation cp="🙋🏿‍♀">開心｜舉起一隻手｜女人｜哈囉｜hi | 開心嘅女人舉起一隻手 | 黑皮膚</annotation>
-		<annotation cp="🙋🏿‍♀" type="tts">開心嘅女人舉起一隻手：黑皮膚</annotation>
 		<annotation cp="🧏🏻">人物 | 殘障 | 無障礙 | 白皮膚 | 耳朵 | 耳聾 | 聆聽 | 聽 | 聽力 | 聽障人士 | 聾</annotation>
 		<annotation cp="🧏🏼">人物 | 殘障 | 無障礙 | 耳朵 | 耳聾 | 聆聽 | 聽 | 聽力 | 聽障人士 | 聾 | 黃皮膚</annotation>
 		<annotation cp="🧏🏽">中等皮膚 | 人物 | 殘障 | 無障礙 | 耳朵 | 耳聾 | 聆聽 | 聽 | 聽力 | 聽障人士 | 聾</annotation>

--- a/tools/cldr-apps/.settings/org.eclipse.wst.common.component
+++ b/tools/cldr-apps/.settings/org.eclipse.wst.common.component
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><project-modules id="moduleCoreId"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -408,8 +408,7 @@ public class DisplayAndInputProcessor {
 
     private static final String BAR_VL = "\\|"; // U+007C VERTICAL LINE (pipe, bar) literal
     private static final String BAR_EL = "\\s+l\\s+"; // U+006C LATIN SMALL LETTER L with space
-    private static final String BAR_DANDA = "।"; // U+0964 DEVANAGARI DANDA
-    private static final String BAR_REGEX = "(" + BAR_VL + "|" + BAR_EL + "|" + BAR_DANDA + ")";
+    private static final String BAR_REGEX = "(" + BAR_EL + "|[︳︱।|｜⎸⎹⏐￨❘])";
     public static final Splitter SPLIT_BAR =
             Splitter.on(Pattern.compile(BAR_REGEX)).trimResults().omitEmptyStrings();
     static final Splitter SPLIT_SPACE = Splitter.on(' ').trimResults().omitEmptyStrings();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDisplayAndInputProcessor.java
@@ -2,6 +2,7 @@ package org.unicode.cldr.unittest;
 
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharSequences;
+import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSetIterator;
 import java.util.Arrays;
@@ -761,6 +762,12 @@ public class TestDisplayAndInputProcessor extends TestFmwk {
         assertEquals("U+0964 DEVANAGARI DANDA without spaces becomes pipe", normVal, val);
         val = daip.processInput(xpath, "a  ।  b", null);
         assertEquals("U+0964 DEVANAGARI DANDA with spaces becomes pipe", normVal, val);
+        for (String s : new UnicodeSet("[︳︱।|｜⎸⎹⏐￨❘]")) {
+            val = daip.processInput(xpath, "a" + s + "b", null);
+            assertEquals(Utility.hex(s) + UCharacter.getName(s, ","), normVal, val);
+        }
+        val = daip.processInput(xpath, "a  ┃  b", null);
+        assertEquals("Other vertical bar doesn't change", "a ┃ b", val);
     }
 
     public void TestFSR() {


### PR DESCRIPTION
CLDR-18692

- Broadened the number of look-alikes for | in annotations.
- Added test
- Ran over current annotations (to fix blue star)

Characters are now: https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%EF%B8%B3%EF%B8%B1%E0%A5%A4%7C%EF%BD%9C%E2%8E%B8%E2%8E%B9%E2%8F%90%EF%BF%A8%E2%9D%98%5D



- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
