### PR TITLE
CLDR-18712 Don't include grammar for new units

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/GrammarInfo.java
@@ -758,8 +758,29 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
                     "knot", // US/UK specific
                     "astronomical-unit", // specialized
                     "dalton", // specialized
-                    "electronvolt" // specialized
-                    );
+                    "electronvolt", // specialized
+
+                    // specialized
+                    "g-force",
+                    "steradian",
+                    "katal",
+                    "ofglucose",
+                    "part",
+                    "coulomb",
+                    "farad",
+                    "henry",
+                    "siemens",
+                    "becquerel",
+                    "calorie-it",
+                    "gray",
+                    "sievert",
+                    "kilogram-force",
+                    "em",
+                    "tesla",
+                    "weber",
+                    "ofhg",
+                    "light-speed",
+                    "fluid-ounce-metric");
 
     public static Set<String> getSpecialsToTranslate() {
         return INCLUDE_OTHER;
@@ -770,11 +791,12 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
     /** Internal class for thread-safety */
     static class UnitsToAddGrammar {
         static final Set<String> data;
+        static final Set<String> skipped;
 
         static {
             final CLDRConfig config = CLDRConfig.getInstance();
             final UnitConverter converter = config.getSupplementalDataInfo().getUnitConverter();
-            Set<String> missing = new TreeSet<>();
+            Set<String> _skipped = new TreeSet<>();
             Set<String> _data = new TreeSet<>();
             for (String path :
                     With.in(
@@ -784,22 +806,31 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
                 String unit = parts.getAttributeValue(3, "type");
                 // Add simple units
                 String shortUnit = converter.getShortId(unit);
+
                 if (INCLUDE_OTHER.contains(shortUnit)) {
                     _data.add(unit);
                     continue;
                 }
-                if (!EXCLUDE_GRAMMAR.contains(shortUnit)) {
-                    Set<UnitSystem> systems = converter.getSystemsEnum(shortUnit);
-                    // we now add all SI and metric and si_acceptable and metric_adjacent
-                    if (!Collections.disjoint(systems, UnitSystem.SiOrMetric)) {
-                        _data.add(unit);
-                        continue;
-                    }
+
+                if (EXCLUDE_GRAMMAR.contains(shortUnit)) {
+                    _skipped.add(unit);
+                    continue;
                 }
-                missing.add(unit);
+
+                // we now add all SI and metric and si_acceptable and metric_adjacent
+
+                Set<UnitSystem> systems = converter.getSystemsEnum(shortUnit);
+                if (!Collections.disjoint(systems, UnitSystem.SiOrMetric)) {
+                    _data.add(unit);
+                    continue;
+                }
+
+                // and skip the rest
+
+                _skipped.add(unit);
             }
             if (DEBUG)
-                for (String unit : missing) {
+                for (String unit : _skipped) {
                     String shortUnit = converter.getShortId(unit);
                     System.out.println(
                             "*Skipping\t"
@@ -812,11 +843,17 @@ public class GrammarInfo implements Freezable<GrammarInfo> {
                                     + (converter.isSimple(shortUnit) ? "SIMPLE" : ""));
                 }
             data = ImmutableSet.copyOf(_data);
+            skipped = ImmutableSet.copyOf(_skipped);
         }
     }
 
     /** Return the units that we should get grammar information for. */
     public static Set<String> getUnitsToAddGrammar() {
         return UnitsToAddGrammar.data;
+    }
+
+    /** Return the units that we should get grammar information for. */
+    public static Set<String> getUnitsToSkipGrammar() {
+        return UnitsToAddGrammar.skipped;
     }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -4758,4 +4758,129 @@ public class TestUnits extends TestFmwkPlus {
         }
         return result;
     }
+
+    // for ALL units, should have paths for each unit X
+    // ldml/units/unitLength[@type="long"]/unit[@type="X"]/gender
+    // ldml/units/unitLength[@type="long"]/unit[@type="X"]/displayName
+    // ldml/units/unitLength[@type="short"]/unit[@type="X"]/displayName
+    // ldml/units/unitLength[@type="narrow"]/unit[@type="X"]/displayName
+    // ldml/units/unitLength[@type="long"]/unit[@type="X"]/unitPattern[@count="other"]
+
+    // will also have prefix units (long, narrow, short) (all prefixes)
+    // ldml/units/unitLength[@type="long"]/compoundUnit[@type="10p-1"]/unitPrefixPattern
+
+    // will also have per & times units (long, narrow, short)
+    // ldml/units/unitLength[@type="long"]/compoundUnit[@type="per"]/compoundUnitPattern
+    // ldml/units/unitLength[@type="long"]/compoundUnit[@type="times"]/compoundUnitPattern
+
+    // will also have long power2/power3 in all available plurals/case
+    // ldml/units/unitLength[@type="long"]/compoundUnit[@type="power2"]/compoundUnitPattern1[@count="one"][@gender="feminine"]
+    // ldml/units/unitLength[@type="long"]/compoundUnit[@type="power3"]/compoundUnitPattern1[@count="one"][@gender="feminine"]
+
+    // and short/narrow power2/3, but only for plurals, no case
+    // ldml/units/unitLength[@type="short"]/compoundUnit[@type="power2"]/compoundUnitPattern1[@count="one"]
+    // ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="power2"]/compoundUnitPattern1[@count="one"]
+
+    // For ALL units, if there are plurals for the locale, will have other counts
+    // ldml/units/unitLength[@type="long"]/unit[@type="X"]/unitPattern[@count="Y"]
+
+    // For CORE units, if there is grammar for the locale, will have other cases, eg
+    // ldml/units/unitLength[@type="long"]/unit[@type="volume-cubic-meter"]/unitPattern[@count="one"][@case="dative"]
+
+    // For non-CORE units, if even if there is grammar for the locale, we won't have paths
+    // ldml/units/unitLength[@type="long"]/unit[@type="volume-fluid-ounce-metric"]/unitPattern[@count="one"][@case="dative"]
+
+    private static enum GrammarStatus {
+        always,
+        never
+    }
+
+    public void testSkippedUnitsForGrammer() {
+
+        final Multimap<GrammarStatus, String> statusToLongUnit =
+                ImmutableMultimap.<GrammarStatus, String>builder()
+                        .putAll(
+                                GrammarStatus.never,
+                                //                        "angle-steradian",
+                                //                        "concentr-katal",
+                                //                        "concentr-ofglucose",
+                                //                        "concentr-part",
+                                //                        "electric-coulomb",
+                                //                        "electric-farad",
+                                //                        "electric-henry",
+                                //                        "electric-siemens",
+                                //                        "energy-becquerel",
+                                //                        "energy-calorie-it",
+                                //                        "energy-gray",
+                                //                        "energy-sievert",
+                                //                        "force-kilogram-force",
+                                //                        "magnetic-tesla",
+                                //                        "magnetic-weber",
+                                //                        "pressure-ofhg",
+                                //                        "speed-light-speed",
+                                //                        "volume-fluid-ounce-metric",
+                                "angle-steradian",
+                                "area-bu-jp",
+                                "area-cho",
+                                "area-se-jp",
+                                "concentr-katal",
+                                "concentr-ofglucose",
+                                "concentr-part",
+                                "concentr-portion",
+                                "duration-fortnight",
+                                "electric-coulomb",
+                                "electric-farad",
+                                "electric-henry",
+                                "electric-siemens",
+                                "energy-becquerel",
+                                "energy-british-thermal-unit-it",
+                                "energy-calorie-it",
+                                "energy-gray",
+                                "energy-sievert",
+                                "force-kilogram-force",
+                                "length-chain",
+                                "length-jo-jp",
+                                "length-ken",
+                                "length-ri-jp",
+                                "length-rin",
+                                "length-rod",
+                                "length-shaku-cloth",
+                                "length-shaku-length",
+                                "length-sun",
+                                "magnetic-tesla",
+                                "magnetic-weber",
+                                "mass-fun",
+                                "mass-slug",
+                                "pressure-ofhg",
+                                "speed-light-speed",
+                                "temperature-rankine",
+                                "volume-cup-imperial",
+                                "volume-cup-jp",
+                                "volume-fluid-ounce-metric",
+                                "volume-koku",
+                                "volume-kosaji",
+                                "volume-osaji",
+                                "volume-pint-imperial",
+                                "volume-sai",
+                                "volume-shaku",
+                                "volume-to-jp")
+                        .putAll(GrammarStatus.always, "meter")
+                        .build();
+
+        Set<String> unitsToAdd = GrammarInfo.getUnitsToAddGrammar();
+
+        assertEquals(
+                "Should be missing",
+                Set.of(),
+                Sets.intersection(
+                        new TreeSet<String>(statusToLongUnit.get(GrammarStatus.never)),
+                        unitsToAdd));
+
+        assertEquals(
+                "Should be present always",
+                Set.of(),
+                Sets.intersection(
+                        new TreeSet<String>(statusToLongUnit.get(GrammarStatus.always)),
+                        unitsToAdd));
+    }
 }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -4798,7 +4798,7 @@ public class TestUnits extends TestFmwkPlus {
     public void testSkippedUnitsForGrammer() {
 
         // Note: the list for 'never' also includes the enOrJaOnly units (see above in this file).
-        
+
         final Multimap<GrammarStatus, String> statusToLongUnit =
                 ImmutableMultimap.<GrammarStatus, String>builder()
                         .putAll(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -4797,28 +4797,12 @@ public class TestUnits extends TestFmwkPlus {
 
     public void testSkippedUnitsForGrammer() {
 
+        // Note: the list for 'never' also includes the enOrJaOnly units (see above in this file).
+        
         final Multimap<GrammarStatus, String> statusToLongUnit =
                 ImmutableMultimap.<GrammarStatus, String>builder()
                         .putAll(
                                 GrammarStatus.never,
-                                //                        "angle-steradian",
-                                //                        "concentr-katal",
-                                //                        "concentr-ofglucose",
-                                //                        "concentr-part",
-                                //                        "electric-coulomb",
-                                //                        "electric-farad",
-                                //                        "electric-henry",
-                                //                        "electric-siemens",
-                                //                        "energy-becquerel",
-                                //                        "energy-calorie-it",
-                                //                        "energy-gray",
-                                //                        "energy-sievert",
-                                //                        "force-kilogram-force",
-                                //                        "magnetic-tesla",
-                                //                        "magnetic-weber",
-                                //                        "pressure-ofhg",
-                                //                        "speed-light-speed",
-                                //                        "volume-fluid-ounce-metric",
                                 "angle-steradian",
                                 "area-bu-jp",
                                 "area-cho",


### PR DESCRIPTION
CLDR-18712

- [ ] This PR completes the ticket.

Visible on staging,  https://cldr-staging.unicode.org/cldr-apps/v#/de/OtherUnitsMetric/4cb2101b01962374

![Screenshot 2025-06-04 at 14 16 36](https://github.com/user-attachments/assets/d6acd751-8e8b-44cb-a649-e165740f5765)

Katal is one of the new units. So appears to be working correctly.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
