### PR TITLE
CLDR-18615 Detect page from xpath if obsolete page name is used

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -399,10 +399,16 @@ function getSingleRowUrl(theRow) {
 
 function getPageUrl(curLocale, curPage, curId) {
   let p = null;
-  if (curId && !curPage) {
+  if (curId) {
+    if (!curPage) {
+      curPage = "auto";
+    }
+    // xpstrid is normally only used on the server if page is "auto". However, sometimes a row is bookmarked
+    // and the page name changes, but xpstrid is still valid, and the bookmark can still be used. In that
+    // case the server will treat the obsolete page name the same as "auto", and use xpstrid to determine
+    // the correct current page name.
     p = new URLSearchParams();
     p.append("xpstrid", curId);
-    curPage = "auto";
   }
   const api = "voting/" + curLocale + "/page/" + curPage;
   return cldrAjax.makeApiUrl(api, p);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyMain.java
@@ -424,6 +424,8 @@ public class SurveyMain extends HttpServlet implements CLDRProgressIndicator, Ex
 
     /** Ensure that CLDR Tools is functioning */
     private void ensureCldrToolsIsFunctioning() {
+        // Note: this method assumes that PathHeader.PageId.forString throws an exception if the
+        // name isn't recognized
         PathHeader.PageId.forString(PathHeader.PageId.Africa.name());
     }
 

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/WebContext.java
@@ -1560,11 +1560,7 @@ public class WebContext implements Cloneable, Appendable {
 
     public static PageId getPageId(String pageField) {
         if (pageField != null && !pageField.isEmpty()) {
-            try {
-                return PathHeader.PageId.forString(pageField);
-            } catch (Exception e) {
-                // ignore.
-            }
+            return PathHeader.PageId.fromString(pageField);
         }
         return null;
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -125,7 +125,7 @@ public class VoteAPI {
                     @PathParam("page")
                     String page,
             @QueryParam("xpstrid")
-                    @Schema(description = "Xpath string ID if page is auto")
+                    @Schema(description = "Xpath string ID if page is auto or invalid")
                     @DefaultValue("")
                     String xpstrid,
             @HeaderParam(Auth.SESSION_HEADER) String session) {
@@ -137,6 +137,9 @@ public class VoteAPI {
          *    https://cldr-smoke.unicode.org/cldr-apps/v#/zh_Hant//2703e9d07ab2ef3a
          * can be used instead of
          *    https://cldr-smoke.unicode.org/cldr-apps/v#/zh_Hant/Alphabetic_Information/2703e9d07ab2ef3a
+         *
+         * It also enables determining the correct page name if the given page name is invalid or
+         * obsolete but xpstrid is still valid, as sometimes happens with an old bookmarked URL.
          */
         return VoteAPIHelper.handleGetOnePage(loc, session, page, xpstrid);
     }
@@ -162,7 +165,7 @@ public class VoteAPI {
         public List<CheckStatusSummary> tests = new ArrayList<>();
 
         // we only want to store one example for each subtype.
-        private Set<CheckStatus.Subtype> allSubtypes = new HashSet<>();
+        private final Set<CheckStatus.Subtype> allSubtypes = new HashSet<>();
 
         boolean isEmpty() {
             return tests.isEmpty();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathHeader.java
@@ -354,8 +354,23 @@ public class PathHeader implements Comparable<PathHeader> {
         /**
          * Construct a pageId given a string
          *
-         * @param name
-         * @return
+         * @param name the name of a page, such as "Alphabetic Information"
+         * @return the PageId, or null
+         */
+        public static PageId fromString(String name) {
+            try {
+                return PageIdNames.forString(name);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        /**
+         * Construct a pageId given a string
+         *
+         * @param name the name of a page, such as "Alphabetic Information"
+         * @return the PageId
+         * @throws ICUException if the name is not recognized
          */
         public static PageId forString(String name) {
             try {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAnnotations.java
@@ -240,6 +240,8 @@ public class TestAnnotations extends TestFmwkPlus {
             String emoji = s.getKey();
             Annotations annotations = s.getValue();
             final String rawCategory = Emoji.getMajorCategory(emoji);
+            // Note: this call to PageId.forString possibly assumes it throws an exception if
+            // rawCategory isn't recognized as a page ID.
             PageId majorCategory = PageId.forString(rawCategory);
             if (majorCategory == PageId.Symbols) {
                 majorCategory = PageId.EmojiSymbols;


### PR DESCRIPTION
-Extend the existing usage of page=auto to handle obsolete/invalid page names

-On the front end, always include xpstrid in the page request, if available

-On the back end, do not reject the combination of page and xpstrid; instead use xpstrid as a fallback to determine the page

-New PageId.fromString is the same as PageId.forString, except it returns null instead of throwing ICUException; PageId.forString still has other callers; changing them seems risky and out of scope for this PR, except for WebContext.getPageId

-Fix some compiler warnings

-Comments

CLDR-18615

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
