### PR TITLE
CLDR-18727 Fix fetching set of user-modifiable locales

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrMenu.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrMenu.mjs
@@ -84,10 +84,7 @@ function makeSafe(s) {
 
 async function getInitialMenusEtc() {
   const theLocale = cldrStatus.getCurrentLocale() || "root";
-  const xurl = getMenusAjaxUrl(
-    theLocale,
-    false /* do not fetch locale map here */
-  );
+  const xurl = getMenusAjaxUrl(theLocale, true /* fetch canmodify here */);
   await fetch(xurl)
     .then(cldrAjax.handleFetchErrors)
     .then((r) => r.json())
@@ -349,7 +346,7 @@ function getMenusFromServer() {
   if (!curLocale) {
     return;
   }
-  const url = getMenusAjaxUrl(curLocale, false /* do not get locmap */);
+  const url = getMenusAjaxUrl(curLocale, false /* do not get canmodify */);
   cldrLoad.myLoad(url, "menus", function (json) {
     if (!cldrLoad.verifyJson(json, "menus")) {
       console.log("JSON verification failed for menus in cldrLoad");
@@ -506,9 +503,11 @@ function updateTitleAndSection(menuMap) {
 }
 
 /**
- * TODO: document and encapsulate "canmodify"
+ * Store the locales that the current user has permission to modify.
+ * This affects whether they are treated as "read-only" in the left-sidebar
+ * locale selection menu.
  */
-let canmodify = {};
+const canmodify = {};
 
 function setupCanModify(json) {
   if (json.canmodify) {
@@ -530,11 +529,11 @@ function getCoverageMenu() {
   return coverageMenu;
 }
 
-function getMenusAjaxUrl(locale, getLocmap) {
+function getMenusAjaxUrl(locale, getCanModify) {
   const p = new URLSearchParams();
   p.append("what", "menus"); // cf. WHAT_GET_MENUS in SurveyAjax.java
   p.append("_", locale);
-  p.append("locmap", !!getLocmap);
+  p.append("canmodify", !!getCanModify);
   p.append("s", cldrStatus.getSessionId());
   p.append("cacheKill", cldrSurvey.cacheBuster());
   return cldrAjax.makeUrl(p);

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -117,6 +117,7 @@ public class SurveyAjax extends HttpServlet {
     public static final String WHAT_ADMIN_PANEL = "admin_panel"; // cldrAdmin.js
     public static final String WHAT_RECENT_ACTIVITY = "recent_activity"; // cldrRecentActivity.js
     public static final String WHAT_ERROR_SUBTYPES = "error_subtypes"; // cldrErrorSubtyes.js
+    private static final String WHAT_LOCALE_MAP = "locmap";
 
     public static final int oldestVersionForImportingVotes =
             25; // Oldest table is cldr_vote_value_25, as of 2018-05-23.
@@ -604,20 +605,18 @@ public class SurveyAjax extends HttpServlet {
                             r.put("reports", reports);
                         }
 
-                        if ("true".equals(request.getParameter("locmap"))) {
-                            r.put("locmap", getJSONLocMap(sm));
-
-                            // list of modifyable locales
-                            JSONArray modifyableLocs = new JSONArray();
+                        if ("true".equals(request.getParameter("canmodify"))) {
+                            // list of modifiable locales
+                            JSONArray modifiableLocs = new JSONArray();
                             Set<CLDRLocale> rolocs = SurveyMain.getReadOnlyLocales();
                             for (CLDRLocale al : SurveyMain.getLocales()) {
                                 if (rolocs.contains(al)) continue;
                                 if (UserRegistry.userCanModifyLocale(mySession.user, al)) {
-                                    modifyableLocs.put(al.getBaseName());
+                                    modifiableLocs.put(al.getBaseName());
                                 }
                             }
-                            if (modifyableLocs.length() > 0) {
-                                r.put("canmodify", modifyableLocs);
+                            if (modifiableLocs.length() > 0) {
+                                r.put("canmodify", modifiableLocs);
                             }
                             /*
                              * If this user's old winning votes can be imported, and haven't already been imported,
@@ -771,7 +770,7 @@ public class SurveyAjax extends HttpServlet {
                                 ErrorCode.E_INTERNAL);
                     }
                 }
-            } else if (what.equals("locmap")) {
+            } else if (what.equals(WHAT_LOCALE_MAP)) {
                 final SurveyJSONWrapper r = newJSONStatusQuick();
                 r.put("locmap", getJSONLocMap(sm));
                 send(r, out);


### PR DESCRIPTION
-Repurpose the boolean parameter of getMenusAjaxUrl and SurveyAjax.WHAT_GET_MENUS to indicate whether to fetch canmodify (it is never used for fetching locmap anymore)

-Define a constant SurveyAjax.WHAT_LOCALE_MAP for consistency with other values for what

-Spelling: modifiable

-Comments

CLDR-18727

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
