### PR TITLE
CLDR-16762 Add plural rules for Interlingue

### DIFF
--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -3592,18 +3592,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="other" draft="unconfirmed">0 milles</pattern>
-					<pattern type="10000" count="other" draft="unconfirmed">00 milles</pattern>
-					<pattern type="100000" count="other" draft="unconfirmed">000 milles</pattern>
-					<pattern type="1000000" count="other" draft="unconfirmed">0 milliones</pattern>
-					<pattern type="10000000" count="other" draft="unconfirmed">00 milliones</pattern>
-					<pattern type="100000000" count="other" draft="unconfirmed">000 milliones</pattern>
-					<pattern type="1000000000" count="other" draft="unconfirmed">0 milliardes</pattern>
-					<pattern type="10000000000" count="other" draft="unconfirmed">00 milliardes</pattern>
-					<pattern type="100000000000" count="other" draft="unconfirmed">000 milliardes</pattern>
-					<pattern type="1000000000000" count="other" draft="unconfirmed">0 billiones</pattern>
-					<pattern type="10000000000000" count="other" draft="unconfirmed">00 billiones</pattern>
-					<pattern type="100000000000000" count="other" draft="unconfirmed">000 billiones</pattern>
+					<pattern type="1000" count="one">0 mill</pattern>
+					<pattern type="1000" count="other">0 milles</pattern>
+					<pattern type="10000" count="one">00 mill</pattern>
+					<pattern type="10000" count="other">00 milles</pattern>
+					<pattern type="100000" count="one">000 mill</pattern>
+					<pattern type="100000" count="other">000 milles</pattern>
+					<pattern type="1000000" count="one">0 million</pattern>
+					<pattern type="1000000" count="other">0 milliones</pattern>
+					<pattern type="10000000" count="one">00 million</pattern>
+					<pattern type="10000000" count="other">00 milliones</pattern>
+					<pattern type="100000000" count="one">000 million</pattern>
+					<pattern type="100000000" count="other">000 milliones</pattern>
+					<pattern type="1000000000" count="one">0 milliard</pattern>
+					<pattern type="1000000000" count="other">0 milliardes</pattern>
+					<pattern type="10000000000" count="one">00 milliard</pattern>
+					<pattern type="10000000000" count="other">00 milliardes</pattern>
+					<pattern type="100000000000" count="one">000 milliard</pattern>
+					<pattern type="100000000000" count="other">000 milliardes</pattern>
+					<pattern type="1000000000000" count="one">0 billion</pattern>
+					<pattern type="1000000000000" count="other">0 billiones</pattern>
+					<pattern type="10000000000000" count="one">00 billion</pattern>
+					<pattern type="10000000000000" count="other">00 billiones</pattern>
+					<pattern type="100000000000000" count="one">000 billion</pattern>
+					<pattern type="100000000000000" count="other">000 billiones</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">
@@ -4600,6 +4612,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range" draft="unconfirmed">{0}..{1}</pattern>
 		</miscPatterns>
 		<minimalPairs>
+			<pluralMinimalPairs count="one">{0} die</pluralMinimalPairs>
 			<pluralMinimalPairs count="other" draft="contributed">{0} dies</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Li {0}-im edition</ordinalMinimalPairs>
 		</minimalPairs>

--- a/common/supplemental/ordinals.xml
+++ b/common/supplemental/ordinals.xml
@@ -13,7 +13,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 1: other -->
 
-        <pluralRules locales="af am an ar ast bg bs ce cs da de dsb el es et eu fa fi fy gl gsw he hr hsb ia id in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
+        <pluralRules locales="af am an ar ast bg bs ce cs da de dsb el es et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
             <pluralRule count="other"> @integer 0~15, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 

--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -27,7 +27,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
             <pluralRule count="one">i = 0,1 @integer 0, 1 @decimal 0.0~1.5</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="ast de en et fi fy gl ia io ji lij nl sc sv sw ur yi">
+        <pluralRules locales="ast de en et fi fy gl ia ie io ji lij nl sc sv sw ur yi">
             <pluralRule count="one">i = 1 and v = 0 @integer 1</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>


### PR DESCRIPTION
Interlingue does not have plural rules set up -- this change update them to the recommendation in the ticket CLDR-16762

CLDR-16762

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
