### PR TITLE
CLDR-18697 Use static PathStarrer.computeIfAbsent where possible

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckConsistentCasing.java
@@ -301,7 +301,6 @@ public class CheckConsistentCasing extends FactoryCheckCLDR {
         for (Category category : Category.values()) {
             counters.put(category, new Counter<CasingType>());
         }
-        PathStarrer starrer = new PathStarrer();
         boolean isRoot = "root".equals(resolved.getLocaleID());
         Set<String> missing = !DEBUG ? null : new TreeSet<>();
 
@@ -323,7 +322,7 @@ public class CheckConsistentCasing extends FactoryCheckCLDR {
                 CasingType ft = CasingType.from(value);
                 counters.get(category).add(ft, 1);
             } else if (DEBUG) {
-                String starred = starrer.set(path);
+                String starred = PathStarrer.computeIfAbsent(path);
                 missing.add(starred);
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleCache.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleCache.java
@@ -52,7 +52,18 @@ public class ExampleCache {
      */
     private static final String NONE = "\uFFFF";
 
-    /** The nested cache mapping is: starredPath → (starlessPath → (value → html)). */
+    /**
+     * The nested cache mapping is: starredPath → (starlessPath → (value → html)).
+     *
+     * <p>PathStarrer is used for getting starredPath from an ordinary (starless) path. Inclusion of
+     * starred paths enables performance improvement with AVOID_CLEARING_CACHE.
+     *
+     * <p>starredPath is the key for the highest level of the nested cache.
+     *
+     * <p>Compare starred "//ldml/localeDisplayNames/languages/language[@type=\"*\"]" with starless
+     * "//ldml/localeDisplayNames/languages/language[@type=\"aa\"]". There are fewer starred paths
+     * than starless paths. ExampleDependencies.dependencies has starred paths for that reason.
+     */
     private final ThreadSafeMapOfMapOfMap<String, String, String, String> cache =
             new ThreadSafeMapOfMapOfMap<>();
 
@@ -83,18 +94,6 @@ public class ExampleCache {
             return clearableCache;
         }
     }
-
-    /**
-     * The PathStarrer is for getting starredPath from an ordinary (starless) path. Inclusion of
-     * starred paths enables performance improvement with AVOID_CLEARING_CACHE.
-     *
-     * <p>starredPath is the key for the highest level of the nested cache.
-     *
-     * <p>Compare starred "//ldml/localeDisplayNames/languages/language[@type=\"*\"]" with starless
-     * "//ldml/localeDisplayNames/languages/language[@type=\"aa\"]". There are fewer starred paths
-     * than starless paths. ExampleDependencies.dependencies has starred paths for that reason.
-     */
-    private final PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("*");
 
     /**
      * For testing, caching can be disabled for some ExampleCaches while still enabled for others.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnglishChanged.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnglishChanged.java
@@ -55,9 +55,8 @@ public class GenerateEnglishChanged {
         Set<String> paths = new TreeSet<>();
         With.in(englishTrunk).toCollection(paths);
         With.in(englishLastRelease).toCollection(paths);
-        PathStarrer starrer = new PathStarrer();
         final String placeholder = "×";
-        starrer.setSubstitutionPattern(placeholder);
+        PathStarrer starrer = new PathStarrer().setSubstitutionPattern(placeholder);
 
         Set<String> abbreviatedPaths = new LinkedHashSet<>();
         Multimap<String, List<String>> pathsDiffer = LinkedHashMultimap.create();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateItemCounts.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateItemCounts.java
@@ -37,7 +37,6 @@ import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdData.Attribute;
 import org.unicode.cldr.util.DtdData.Element;
 import org.unicode.cldr.util.DtdType;
-import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.PathUtilities;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.RegexUtilities;
@@ -361,8 +360,6 @@ public class GenerateItemCounts {
     static class AttributeTypes {
         Relation<String, String> elementPathToAttributes =
                 Relation.of(new TreeMap<String, Set<String>>(), TreeSet.class);
-        final PathStarrer PATH_STARRER = new PathStarrer().setSubstitutionPattern("*");
-        final Set<String> STARRED_PATHS = new TreeSet<>();
         StringBuilder elementPath = new StringBuilder();
 
         public void add(String path) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/SearchXml.java
@@ -67,7 +67,6 @@ public class SearchXml {
     private static Counter<String> kountRegexMatches;
     private static Counter<String> starCounter;
     private static final Set<String> ERRORS = new LinkedHashSet<>();
-    private static final PathStarrer pathStarrer = new PathStarrer();
     private static PathHeader.Factory PATH_HEADER_FACTORY = null;
 
     static final Options myOptions =
@@ -468,7 +467,7 @@ public class SearchXml {
                     }
 
                     if (starCounter != null) {
-                        starCounter.add(pathStarrer.set(path), 1);
+                        starCounter.add(PathStarrer.computeIfAbsent(path), 1);
                     }
                     ++total;
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowInconsistentAvailable.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowInconsistentAvailable.java
@@ -54,7 +54,6 @@ public class ShowInconsistentAvailable {
     static FormatParser fp = new DateTimePatternGenerator.FormatParser();
     static Factory f = CONFIG.getCldrFactory();
     static PathHeader.Factory phf = PathHeader.getFactory();
-    static PathStarrer ps = new PathStarrer();
     static int counter = 0;
     static Set<String> nullErrors = new LinkedHashSet<>();
 
@@ -286,7 +285,7 @@ public class ShowInconsistentAvailable {
                 continue;
             }
             if (SHOW_PROGRESS_RAW) {
-                ps.set(path);
+                PathStarrer.computeIfAbsent(path);
                 String value = cldrFile.getStringValue(path);
                 String skeleton = parts.getAttributeValue(-1, "id");
                 String alt = parts.getAttributeValue(-1, "alt");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VerifyConverterResults.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/VerifyConverterResults.java
@@ -37,7 +37,6 @@ import org.unicode.cldr.util.XPathParts;
 public class VerifyConverterResults {
     public static final CLDRConfig CONFIG = CLDRConfig.getInstance();
     public static final SupplementalDataInfo SDI = CONFIG.getSupplementalDataInfo();
-    public static final PathStarrer PATH_STARRER = new PathStarrer().setSubstitutionPattern("*");
 
     enum SourceType {
         text,
@@ -213,7 +212,7 @@ public class VerifyConverterResults {
                 return;
             }
             filedata.put(dir + "\t" + name + "\t" + path, value);
-            starredData.put(dir + "\t" + name + "\t" + PATH_STARRER.set(path), value);
+            starredData.put(dir + "\t" + name + "\t" + PathStarrer.computeIfAbsent(path), value);
         }
 
         void print(boolean isVerbose) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathStarrer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathStarrer.java
@@ -2,7 +2,6 @@ package org.unicode.cldr.util;
 
 import com.google.common.base.Joiner;
 import com.ibm.icu.impl.Utility;
-import com.ibm.icu.text.Transform;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,7 +15,7 @@ import java.util.regex.Pattern;
  *
  * @author markdavis
  */
-public class PathStarrer implements Transform<String, String> {
+public class PathStarrer {
     public static final String STAR_PATTERN = "([^\"]*+)";
 
     private String starredPathString;
@@ -46,7 +45,15 @@ public class PathStarrer implements Transform<String, String> {
 
     public String set(String path) {
         XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed();
-        return set(parts, Collections.emptySet());
+        attributes.clear();
+        for (int i = 0; i < parts.size(); ++i) {
+            for (String key : parts.getAttributeKeys(i)) {
+                attributes.add(parts.getAttributeValue(i, key));
+                parts.setAttribute(i, key, substitutionPattern);
+            }
+        }
+        starredPathString = parts.toString();
+        return starredPathString;
     }
 
     /**
@@ -55,7 +62,7 @@ public class PathStarrer implements Transform<String, String> {
      * @param parts
      * @return
      */
-    public String set(XPathParts parts, Set<String> skipAttributes) {
+    public String setSkippingAttributes(XPathParts parts, Set<String> skipAttributes) {
         attributes.clear();
         for (int i = 0; i < parts.size(); ++i) {
             for (String key : parts.getAttributeKeys(i)) {
@@ -100,18 +107,9 @@ public class PathStarrer implements Transform<String, String> {
         return starredPathString;
     }
 
-    public String getSubstitutionPattern() {
-        return substitutionPattern;
-    }
-
     public PathStarrer setSubstitutionPattern(String substitutionPattern) {
         this.substitutionPattern = substitutionPattern;
         return this;
-    }
-
-    @Override
-    public String transform(String source) {
-        return set(source);
     }
 
     // Used for coverage lookups - strips off the leading ^ and trailing $ from regexp pattern.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -58,7 +58,9 @@ public class TestAlt extends TestFmwk {
                     if (altValue != null) {
                         altPaths.put(xpath, locale);
                         logln(locale + "\t" + xpath);
-                        String starredPath = pathStarrer.set(parts.cloneAsThawed(), SINGLETON_ALT);
+                        String starredPath =
+                                pathStarrer.setSkippingAttributes(
+                                        parts.cloneAsThawed(), SINGLETON_ALT);
                         String attrs = pathStarrer.getAttributesString("|");
                         final XPathParts noAlt = parts.cloneAsThawed().removeAttribute(i, "alt");
                         String plainPath = noAlt.toString();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -219,7 +219,6 @@ public class TestCoverageLevel extends TestFmwkPlus {
 
     public void oldTestInvariantPaths() {
         org.unicode.cldr.util.Factory factory = testInfo.getCldrFactory();
-        PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("*");
         SupplementalDataInfo sdi =
                 SupplementalDataInfo.getInstance(CLDRPaths.DEFAULT_SUPPLEMENTAL_DIRECTORY);
 
@@ -236,7 +235,7 @@ public class TestCoverageLevel extends TestFmwkPlus {
             CLDRFile cldrFileToCheck = factory.make(locale, true);
             for (String path : cldrFileToCheck.fullIterable()) {
                 allPaths.add(path);
-                String starred = pathStarrer.set(path);
+                String starred = PathStarrer.computeIfAbsent(path);
                 Level level = sdi.getCoverageLevel(path, locale);
                 starredToLocalesToLevels.put(starred, locale, level, true);
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -770,32 +770,23 @@ public class TestPathHeader extends TestFmwkPlus {
                 PatternCache.get("https://cldr.unicode.org/translation/[-a-zA-Z0-9_]").matcher("");
         // https://cldr.unicode.org/translation/plurals#TOC-Minimal-Pairs
         Set<String> alreadySeen = new HashSet<>();
-        PathStarrer starrer = new PathStarrer();
 
         checkPathDescriptionCompleteness(
-                pathDescription,
-                normal,
-                "//ldml/numbers/defaultNumberingSystem",
-                alreadySeen,
-                starrer);
+                pathDescription, normal, "//ldml/numbers/defaultNumberingSystem", alreadySeen);
         for (PathHeader pathHeader : getPathHeaders(english)) {
             if (pathHeader.shouldHide()) {
                 continue;
             }
             String path = pathHeader.getOriginalPath();
-            checkPathDescriptionCompleteness(pathDescription, normal, path, alreadySeen, starrer);
+            checkPathDescriptionCompleteness(pathDescription, normal, path, alreadySeen);
         }
     }
 
     public void checkPathDescriptionCompleteness(
-            PathDescription pathDescription,
-            Matcher normal,
-            String path,
-            Set<String> alreadySeen,
-            PathStarrer starrer) {
+            PathDescription pathDescription, Matcher normal, String path, Set<String> alreadySeen) {
         String value = english.getStringValue(path);
         String description = pathDescription.getDescription(path, value, null);
-        String starred = starrer.set(path);
+        String starred = PathStarrer.computeIfAbsent(path);
         if (alreadySeen.contains(starred)) {
             return;
         }
@@ -1010,8 +1001,7 @@ public class TestPathHeader extends TestFmwkPlus {
     }
 
     public void TestZ() {
-        PathStarrer pathStarrer = new PathStarrer();
-        pathStarrer.setSubstitutionPattern("%A");
+        PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("%A");
 
         Set<PathHeader> sorted = new TreeSet<>();
         Map<String, String> missing = new TreeMap<>();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -450,7 +450,6 @@ public class TestPaths extends TestFmwkPlus {
     public void TestNonLdml() {
         int maxPerDirectory = getInclusion() <= 5 ? 20 : Integer.MAX_VALUE;
         CheckDeprecated checkDeprecated = new CheckDeprecated(this);
-        PathStarrer starrer = new PathStarrer();
         StringBuilder removed = new StringBuilder();
         Set<String> nonFinalValues = new LinkedHashSet<>();
         Set<String> skipLast = new HashSet(Arrays.asList("version", "generation"));
@@ -574,14 +573,14 @@ public class TestPaths extends TestFmwkPlus {
                         } else {
                             seen.add(pair);
                             if (!nonFinalValues.isEmpty()) {
-                                String starredPath = starrer.set(path);
+                                String starredPath = PathStarrer.computeIfAbsent(path);
                                 if (!seenStarred.contains(starredPath)) {
                                     seenStarred.add(starredPath);
                                     logln("Non-node values: " + nonFinalValues + "\t" + path);
                                 }
                             }
                             if (isVerbose()) {
-                                String starredPath = starrer.set(path);
+                                String starredPath = PathStarrer.computeIfAbsent(path);
                                 if (!seenStarred.contains(starredPath)) {
                                     seenStarred.add(starredPath);
                                     logln("@" + "\t" + cleaned + "\t" + removed);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPersonNameFormatter.java
@@ -572,10 +572,9 @@ public class TestPersonNameFormatter extends TestFmwk {
 
         // List all the paths that have dependencies, so we can verify they are ok
 
-        PathStarrer ps = new PathStarrer().setSubstitutionPattern("*");
         for (String path : resolved) {
             if (path.startsWith("//ldml/personNames") && !path.endsWith("/alias")) {
-                logln(ps.set(path));
+                logln(PathStarrer.computeIfAbsent(path));
             }
         }
 


### PR DESCRIPTION
-Assume that it is safe to use STAR_PATTERN instead of simple *

-Change starrer.set to static PathStarrer.computeIfAbsent if pattern is * or unchanged from default STAR_PATTERN, unless getAttributes is called on an instance

-Remove implements Transform and the transform method, apparently unused for PathStarrer

-Remove unused method getSubstitutionPattern

-Remove already-unused ExampleCache.pathStarrer; revise related comments

-Rename the 2-argument set method to setSkippingAttributes, to disambiguate at least for now; the 2-argument method has only a single caller, in TestAlt

-In the 1-argument set method, avoid calling the 2-argument method, for simplicity and performance, at least for now

CLDR-18697

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
