### PR TITLE
CLDR-18750 Fix compact examples

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -560,6 +560,12 @@ public class ICUServiceBuilder {
         "integer", "decimal", "percent", "scientific"
     }; // // "standard", , "INR",
 
+    // add symbols for clarity.
+    public static int integer = 0, decimal = 2, percent = 3, scientific = 4;
+
+    // ICUServiceBuilder needs a much more substantial overhaul, so adding an enum would be wasted
+    // effort
+
     private static class MyCurrency extends Currency {
         String symbol;
         String displayName;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSamples.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PluralSamples.java
@@ -9,9 +9,9 @@ import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 
 public class PluralSamples {
     private static final Map<String, PluralSamples> cache = new ConcurrentHashMap<>();
-    private static final int SAMPLE_SIZE = 4;
+    private static final int SAMPLE_SIZE = 6;
     private final Map<Count, Double>[] samples =
-            new Map[SAMPLE_SIZE]; // we do 1, 2, 3, and 4 decimals
+            new Map[SAMPLE_SIZE]; // we do up to 1,000,000 — needed for Compact decimal
 
     public PluralSamples(String locale) {
         SupplementalDataInfo info = SupplementalDataInfo.getInstance();
@@ -22,6 +22,10 @@ public class PluralSamples {
         samples[1] = Collections.unmodifiableMap(getValuesForDigits(pluralInfo, total, 10, 99));
         samples[2] = Collections.unmodifiableMap(getValuesForDigits(pluralInfo, total, 100, 999));
         samples[3] = Collections.unmodifiableMap(getValuesForDigits(pluralInfo, total, 1000, 9999));
+        samples[4] =
+                Collections.unmodifiableMap(getValuesForDigits(pluralInfo, total, 10000, 99999));
+        samples[5] =
+                Collections.unmodifiableMap(getValuesForDigits(pluralInfo, total, 100000, 999999));
     }
 
     private Map<Count, Double> getValuesForDigits(


### PR DESCRIPTION
CLDR-18750

The compact number examples were wrong and confusion. In particular the value "0" is special, and means "revert to non-compact form", but people were seeing items like "2" for a range from 1000 to 9999.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
