### PR TITLE
CLDR-17599 Test changing implementation of Hints to resemble PathDescription

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -23,6 +23,11 @@ public class PathDescription {
                     .lines()
                     .collect(Collectors.joining("\n"));
 
+    private static final String pathDescriptionHintsString =
+            CldrUtility.getUTF8Data("PathDescriptionHints.md")
+                    .lines()
+                    .collect(Collectors.joining("\n"));
+
     private static final Logger logger = Logger.getLogger(PathDescription.class.getName());
 
     public enum ErrorHandling {
@@ -47,19 +52,24 @@ public class PathDescription {
     /** <Description, Markdown> */
     private static final PathDescriptionParser parser = new PathDescriptionParser();
 
+    private static final PathDescriptionParser hintsParser = new PathDescriptionParser();
+
     private static final RegexLookup<Pair<String, String>> pathHandling =
             parser.parse(pathDescriptionString);
+
+    private static final RegexLookup<Pair<String, String>> pathHintsHandling =
+            hintsParser.parse(pathDescriptionHintsString);
 
     /** markdown to append */
     private static final String references = parser.getReferences();
 
     /** for tests, returns the big string */
-    static final String getPathDescriptionString() {
+    static String getPathDescriptionString() {
         return pathDescriptionString;
     }
 
     /** for tests */
-    static final RegexLookup<Pair<String, String>> getPathHandling() {
+    static RegexLookup<Pair<String, String>> getPathHandling() {
         return pathHandling;
     }
 
@@ -107,6 +117,15 @@ public class PathDescription {
     public String getRawDescription(String path, Object context) {
         status.clear();
         final Pair<String, String> entry = pathHandling.get(path, context, pathArguments);
+        if (entry == null) {
+            return null;
+        }
+        return entry.getSecond();
+    }
+
+    public String getHintRawDescription(String path, Object context) {
+        status.clear();
+        final Pair<String, String> entry = pathHintsHandling.get(path, context, pathArguments);
         if (entry == null) {
             return null;
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/TranslationHints.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/TranslationHints.java
@@ -35,4 +35,11 @@ public class TranslationHints {
             }
         }
     }
+
+    public static Map<String, String> getMap() {
+        if (xpathToHint == null) {
+            initXpathToHint();
+        }
+        return xpathToHint;
+    }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
@@ -1,0 +1,334 @@
+# Data for generating "hint" descriptions of paths in Survey Tool
+
+See PathDescriptions.md for documentation.
+
+## HINT descriptions
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="duration-day"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+"day" here means a time duration of 24 hours, not a calendar day
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="ckb"\]\[@alt="menu"\]$`
+
+a form of the name that will sort next to Kurdish, if the standard name does not already do that
+
+### HINT
+
+- `^//ldml/localeDisplayNames/types/type\[@key="calendar"\]\[@type="roc"\]$`
+
+also called "Republic of China Calendar", "Republican Calendar"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="ckb"\]\[@alt="variant"\]$`
+
+an alternate form using Sorani or Central, whichever is not used by the standard name
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="energy-calorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+calories as used in chemistry, not the same as food calorie
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(narrow|short)"\]/unit\[@type="energy-foodcalorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+kilocalories for food energy, may have same translation as energy-kilocalorie; displayed as Cal in the US/UK
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="long"\]/unit\[@type="energy-foodcalorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+kilocalories for food energy, may have same translation as energy-kilocalorie; displayed as Calories in the US/UK
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="energy-kilocalorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+kilocalories for uses not specific to food energy, such as chemistry
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="area-acre"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+refers specifically to an English acre
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="mass-ton"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+refers to U.S. short ton, not U.K. long ton or metric ton
+
+### HINT
+
+- `^//ldml/localeDisplayNames/scripts/script\[@type="Aran"\]$`
+
+special code identifies a style variant of Arabic script
+
+### HINT
+
+- `^//ldml/localeDisplayNames/scripts/script\[@type="Qaag"\]$`
+
+special code identifies non-standard Myanmar encoding for use with Zawgyi font
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="clc"\]$`
+
+also referred to as "Tsilhqot’in"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="ikt"\]$`
+
+also referred to as "Inuinnaqtun"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="kwk"\]$`
+
+previously referred to as "Kwakiutl"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="moe"\]$`
+
+also referred to as "Montagnais"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="ojs"\]$`
+
+also referred to as "Severn Ojibwa"
+
+### HINT
+- `^//ldml/localeDisplayNames/languages/language\[@type="oka"\]$`
+  also referred to as "Nsyilxcən"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="pqm"\]$`
+
+also referred to as "Maliseet–Passamaquoddy"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="slh"\]$`
+
+also referred to as "Southern Puget Sound Salish"
+
+### HINT
+
+- `^//ldml/localeDisplayNames/languages/language\[@type="zh"\]$`
+
+specifically, Mandarin Chinese
+
+### HINT
+
+- `^//ldml/localeDisplayNames/scripts/script\[@type="Han(s|t)"\]$$`
+
+this version of the script name is used in combination with the language name for Chinese
+
+### HINT
+
+- `^//ldml/localeDisplayNames/scripts/script\[@type="Han(s|t)"\]\[@alt="stand-alone"\]$`
+
+this version of the script name is used in isolation, not combined with the language name for Chinese
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Central"\]/long/daylight$`
+
+translate as "North American Central Daylight Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Central"\]/long/standard$`
+
+translate as "North American Central Standard Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Central"\]/long/generic$`
+
+translate as "North American Central Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/daylight$`
+
+translate as "North American Eastern Daylight Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/standard$`
+
+translate as "North American Eastern Standard Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/generic$`
+
+translate as "North American Eastern Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/daylight$`
+
+translate as "North American Mountain Daylight Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/standard$`
+
+translate as "North American Mountain Standard Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/generic$`
+
+translate as "North American Mountain Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/daylight$`
+
+translate as "North American Pacific Daylight Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/standard$`
+
+translate as "North American Pacific Standard Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/generic$`
+
+translate as "North American Pacific Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="Chamorro"\]/long/standard$`
+
+translate as just "Chamorro Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="Guam"\]/long/standard$`
+
+translate as just "Guam Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="Gulf"\]/long/standard$`
+
+translate as just "Gulf Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="India"\]/long/standard$`
+
+translate as just "India Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="Singapore"\]/long/standard$`
+
+translate as just "Singapore Time"
+
+### HINT
+
+- `^//ldml/dates/timeZoneNames/metazone\[@type="Africa_Southern"\]/long/standard$`
+
+translate as just "South Africa Time"
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-pixel-per-(centimeter|inch)"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+typically used for display resolution
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-dot-per-(centimeter|inch)"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+typically used for printer resolution
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-em"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+typographic length equal to a font’s point size
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-megapixel"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+used for counting the individual elements in bitmap image
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-pixel"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+used for counting the individual elements in bitmap image; in some contexts means 1⁄96 inch
+
+### HINT
+
+- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="mass-stone"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+
+used in UK/Ireland for body weight, equal to 14 pounds
+
+### HINT
+
+- `^//ldml/localeDisplayNames/territories/territory\[@type="(003|018|021|057|CD|CG|CI|FK|FM|HK|MM|MO|PS|SZ|TL|ZA)"\](\[@alt="(variant|short)"\])?$`
+
+warning, see info panel on right
+
+## References
+
+<!--
+This section is appended to every markdown fragment.
+All links should be https://cldr.unicode.org/translation/
+-->
+
+[Characters]: https://cldr.unicode.org/translation/characters
+[Character Labels]: https://cldr.unicode.org/translation/characters/character-labels
+[Compound Units]: https://cldr.unicode.org/translation/units/unit-names-and-patterns#compound-units
+[Country Names]: https://cldr.unicode.org/translation/displaynames/countryregion-territory-names
+[Currency Names]: https://cldr.unicode.org/translation/currency-names-and-symbols
+[Date Time]: https://cldr.unicode.org/translation/date-time/date-time-names#datetime-names
+[Date Time Names]: https://cldr.unicode.org/translation/date-time/date-time-names
+[Date/time cyclic names]: https://cldr.unicode.org/translation/date-time/date-time-names#non-gregorian-calendar-considerations
+[Date Time Fields]: https://cldr.unicode.org/translation/date-time/date-time-names#date-field-names
+[Month Names]: https://cldr.unicode.org/translation/date-time/date-time-names#months-of-the-year
+[Relative Dates]: https://cldr.unicode.org/translation/date-time/date-time-names#relative-date-and-time
+[Date Time Patterns]: https://cldr.unicode.org/translation/date-time/date-time-patterns
+[Exemplar Characters]: https://cldr.unicode.org/translation/core-data/exemplars
+[Grammatical Inflection]: https://cldr.unicode.org/translation/grammatical-inflection
+[Locale Option Names]: https://cldr.unicode.org/translation/displaynames/locale-option-names-key
+[Language Names]: https://cldr.unicode.org/translation/displaynames/languagelocale-names
+[Lists]: https://cldr.unicode.org/translation/miscellaneous-displaying-lists
+[Locale Patterns]: https://cldr.unicode.org/translation/displaynames/languagelocale-name-patterns
+[Numbering Systems]: https://cldr.unicode.org/translation/core-data/numbering-systems
+[Numbers]: https://cldr.unicode.org/translation/currency-names-and-symbols
+[Plural Numbers]: https://cldr.unicode.org/translation/number-currency-formats/number-and-currency-patterns#plural-forms-of-numbers
+[Short Numbers]: https://cldr.unicode.org/translation/number-currency-formats/number-and-currency-patterns#compact-decimal-formatting
+[Number Patterns]: https://cldr.unicode.org/translation/number-currency-formats/number-and-currency-patterns#types-of-number-patterns
+[Rational Numbers]: https://cldr.unicode.org/translation/number-currency-formats/number-and-currency-patterns#rational-formatting
+[Parse Lenient]: https://cldr.unicode.org/translation/core-data/characters#parse-parse-lenient
+[Person Name Formats]: https://cldr.unicode.org/translation/miscellaneous-person-name-formats
+[Plurals]: https://cldr.unicode.org/translation/getting-started/plurals
+[Plural Minimal Pairs]: https://cldr.unicode.org/translation/getting-started/plurals#minimal-pairs
+[Script Names]: https://cldr.unicode.org/translation/displaynames/script-names
+[Short Character Names]: https://cldr.unicode.org/translation/characters/short-names-and-keywords#short-character-names
+[Transforms]: https://cldr.unicode.org/translation/transforms
+[Typography]: https://cldr.unicode.org/translation/characters/typographic-names
+[Time Zone City Names]: https://cldr.unicode.org/translation/time-zones-and-city-names
+[Units]: https://cldr.unicode.org/translation/units
+[Units Misc Help]: https://cldr.unicode.org/translation/units

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathDescription.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathDescription.java
@@ -86,16 +86,32 @@ public class TestPathDescription {
     @Test
     void testHints() {
         CLDRConfig config = CLDRConfig.getInstance();
+        CLDRFile eng = config.getEnglish();
         PathDescription pathDescriptionFactory =
                 new PathDescription(
                         config.getSupplementalDataInfo(),
-                        config.getEnglish(),
+                        eng,
                         null,
                         null,
                         PathDescription.ErrorHandling.CONTINUE);
 
         Map<String, String> xpathToHint = TranslationHints.getMap();
         xpathToHint.forEach((path, hint) -> confirmInPD(pathDescriptionFactory, path, hint));
+        for (String path : eng) {
+            String description = pathDescriptionFactory.getHintRawDescription(path, null);
+            String hint = TranslationHints.get(path);
+            if (hint != null || description != null) {
+                assertEquals(
+                        hint,
+                        description,
+                        "Cycling through English paths, description should match hint for path "
+                                + path
+                                + "; description "
+                                + description
+                                + "; hint "
+                                + hint);
+            }
+        }
     }
 
     private void confirmInPD(PathDescription pathDescriptionFactory, String path, String hint) {
@@ -104,7 +120,7 @@ public class TestPathDescription {
         assertEquals(
                 hint,
                 description,
-                "Description does not match hint for path "
+                "Cycling through TranslationHints, description should match hint for path "
                         + path
                         + "; description "
                         + description

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathDescription.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathDescription.java
@@ -1,8 +1,6 @@
 package org.unicode.cldr.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -83,5 +81,34 @@ public class TestPathDescription {
                                                             + e.getValue();
                                                 })
                                         .collect(Collectors.joining("\n")));
+    }
+
+    @Test
+    void testHints() {
+        CLDRConfig config = CLDRConfig.getInstance();
+        PathDescription pathDescriptionFactory =
+                new PathDescription(
+                        config.getSupplementalDataInfo(),
+                        config.getEnglish(),
+                        null,
+                        null,
+                        PathDescription.ErrorHandling.CONTINUE);
+
+        Map<String, String> xpathToHint = TranslationHints.getMap();
+        xpathToHint.forEach((path, hint) -> confirmInPD(pathDescriptionFactory, path, hint));
+    }
+
+    private void confirmInPD(PathDescription pathDescriptionFactory, String path, String hint) {
+        final String description = pathDescriptionFactory.getHintRawDescription(path, null);
+        assertNotNull(description, "Null description for path " + path + "; expected: " + hint);
+        assertEquals(
+                hint,
+                description,
+                "Description does not match hint for path "
+                        + path
+                        + "; description "
+                        + description
+                        + "; hint "
+                        + hint);
     }
 }


### PR DESCRIPTION
-New PathDescriptionHints.md could replace hints.txt, similar format to PathDescription.md

-Work in progress: still use hints.txt rather than PathDescriptionHints.md, except for the test showing they match

-Possibly the data will be combined in a single file but for now PathDescriptionHints.md and PathDescription.md are separate files

-New PathDescription.getHintRawDescription serves the same purpose as old TranslationHints.get

-New unit test TestPathDescription.testHints confirms that PathDescription.getHintRawDescription returns the same value as TranslationHints.get for all paths in hints.txt

-Fix compiler warnings by deleting final from static final for two methods

CLDR-17599

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
