### PR TITLE
CLDR-17354 offer to reload instead of failing with obscure message when navigating

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrNotify.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrNotify.mjs
@@ -128,10 +128,12 @@ function exception(e, context) {
  *
  * @param {String} message the title, displayed at the top (plain text)
  * @param {String} description a description of the problem, possibly HTML
+ * @param {Error} err an optional exception
  */
-function openWithHtml(message, description) {
+function openWithHtml(message, description, err) {
+  if (err) console.error(err);
   if (hasDataDog) {
-    datadogLogs.logger.error(message, { description });
+    datadogLogs.logger.error(message, { description }, err);
   }
   try {
     const NotificationPopupWrapper = cldrVue.mount(


### PR DESCRIPTION
- make loadAllRows async
- check the fetch result in loadAllRows - throw exception if fetch is failing rather than trying to decode JSON
- show a popup on loadAllRows failure to suggest reload
- add an exception parameter to cldrNotify.openWithHtml

<img width="612" alt="image" src="https://github.com/user-attachments/assets/0c64eb1f-35f5-47aa-90a1-d8f7dc745ef6" />


CLDR-17354

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
