### PR TITLE
CLDR-18370 Make atTime default for DateTimeFormatType per UTS 35 clarification

### DIFF
--- a/common/testData/datetime/README.md
+++ b/common/testData/datetime/README.md
@@ -12,3 +12,14 @@ The test generator constructs the expected value using the various pieces
 (date format pattern, time format pattern, datetime "glue" pattern)
 and `SimpleDateFormat`s to combine them together.
 Each test case reports the inputs for the test case and the expected value.
+
+The UTS 35 LDML spec for datetime formatting will be updated in CLDR v48 to specify
+that the default value for dateTimeFormatType will be "atTime".
+dateTimeFormatType represents the value that indicates the type of
+datetime "glue" pattern, ex: indicating "atTime" or "standard" pattern.
+By datetime "glue" pattern, we mean the pattern that is used to combine the result
+of date-only formatting and time-only formatting to arrive at the overall combined
+formatting for the datetime object containing both a date and a time.
+Therefore, for test cases in the dataset in which a date and a time are both present
+in the datetime object, if a dateTimeFormatType is not specified explicitly, the
+value should be assumed to be "atTime".

--- a/common/testData/datetime/datetime.json
+++ b/common/testData/datetime/datetime.json
@@ -44,7 +44,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -53,7 +52,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -62,7 +60,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -98,7 +95,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -107,7 +103,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00+10:30[Australia/Adelaide]",
@@ -116,7 +111,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -125,7 +119,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07+09:30[Australia/Adelaide]",
@@ -134,7 +127,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -143,7 +135,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00+09:30[Australia/Adelaide]",
@@ -775,7 +766,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -784,7 +774,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -793,7 +782,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -829,7 +817,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -838,7 +825,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2000-01-01T00:00+10:30[Australia/Adelaide]",
@@ -847,7 +833,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -856,7 +841,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2024-07-01T08:50:07+09:30[Australia/Adelaide]",
@@ -865,7 +849,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -874,7 +857,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "islamic-civil",
     "locale": "ar-SA",
     "input": "2014-07-15T12:00+09:30[Australia/Adelaide]",
@@ -1506,7 +1488,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1515,7 +1496,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1524,7 +1504,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1560,7 +1539,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -1569,7 +1547,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2000-01-01T00:00+10:30[Australia/Adelaide]",
@@ -1578,7 +1555,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -1587,7 +1563,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2024-07-01T08:50:07+09:30[Australia/Adelaide]",
@@ -1596,7 +1571,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -1605,7 +1579,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "buddhist",
     "locale": "th-TH",
     "input": "2014-07-15T12:00+09:30[Australia/Adelaide]",
@@ -2237,7 +2210,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2246,7 +2218,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2255,7 +2226,6 @@
   {
     "dateLength": "full",
     "timeLength": "short",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2291,7 +2261,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
@@ -2300,7 +2269,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2000-01-01T00:00+10:30[Australia/Adelaide]",
@@ -2309,7 +2277,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
@@ -2318,7 +2285,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2024-07-01T08:50:07+09:30[Australia/Adelaide]",
@@ -2327,7 +2293,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
@@ -2336,7 +2301,6 @@
   {
     "dateLength": "short",
     "timeLength": "full",
-    "dateTimeFormatType": "atTime",
     "calendar": "japanese",
     "locale": "ja-JP",
     "input": "2014-07-15T12:00+09:30[Australia/Adelaide]",

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDateTimeTestData.java
@@ -59,7 +59,8 @@ public class GenerateDateTimeTestData {
 
     /**
      * The known set of values used to indicate the type of "glue pattern" aka the dateTimeFormat
-     * type.
+     * type. The default value should be assumed to be AT_TIME if a variable of type
+     * DateTimeFormatType is not set.
      *
      * <p>atTime = the word "at" is inserted between the date and time when formatting both date &
      * time together, at least for long and full dates.
@@ -353,9 +354,10 @@ public class GenerateDateTimeTestData {
         } else if (timeLength == null) {
             formattedDateTime = dateFormatter.format(zdt);
         } else {
-            assert (dateTimeGluePatternFormatType != null);
             String formattedDate = dateFormatter.format(zdt);
             String formattedTime = timeFormatter.format(zdt);
+
+            assert dateTimeGluePatternFormatType != null;
 
             formattedDateTime =
                     localeCldrFile.glueDateTimeFormat(
@@ -572,6 +574,12 @@ public class GenerateDateTimeTestData {
         //  - fractional second digits
         //  - column alignment
         //  - time precision
+
+        // TODO: For semantic skeleton test cases,
+        //     add DateTimeFormatType=STANDARD to test cases
+        //     once CLDR DateTimeFormats constructor can use CLDRFile to get the dateTimeFormat glue
+        //     pattern, since we are currently using ICU to get the dateTimeFormat pattern,
+        //     which defaults to the behavior of DateTimeFormatType.AT_TIME
 
         // 1 (Row 2)
         elem = new FieldStyleComboInput();
@@ -1249,6 +1257,8 @@ public class GenerateDateTimeTestData {
         result.classicalSkeleton = testCase.classicalSkeleton;
         result.dateTimeFormatType =
                 Optional.ofNullable(testCase.testCaseInput.fieldStyleCombo.dateTimeFormatType)
+                        // because AT_TIME is the default, we do not serialize it to the output
+                        .filter(dtft -> dtft != DateTimeFormatType.AT_TIME)
                         .map(DateTimeFormatType::getLabel)
                         .orElse(null);
         result.hourCycle =


### PR DESCRIPTION
According to discussion in today's CLDR design meeting, which clarifies ambiguities around "standard time" vs. "at time" for the "glue pattern" style of formatting when a datetime object contains both a date and a time, the default value should be "at time" in our case.

More specifically, "at time" should be considered the default for formatting a single datetime at a time, and "standard time" should be used in contexts in which multiple datetimes are formatted. In the context of how our test data cases are created, "at time" for a single datetime is appropriate description of this context, so that should be the default.

This change removes explicit references to `atTime` values in the test cases because that will be redundant. We are thus testing that implementations not only are capable of this behavior, but also perform this behavior by default. 

https://github.com/unicode-org/conformance/issues/469

CLDR-18370

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
