### PR TITLE
CLDR-17707 adjust "cv" plural rule

### DIFF
--- a/common/supplemental/plurals.xml
+++ b/common/supplemental/plurals.xml
@@ -81,7 +81,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="cv ksh">
+        <pluralRules locales="cv">
+            <pluralRule count="zero">n = 0 @integer 0 @decimal 0.0, 0.00, 0.000, 0.0000</pluralRule>
+            <pluralRule count="one">n = 1 @integer 1 @decimal 0.1~1.0, 1.00, 1.000, 1.0000</pluralRule>
+            <pluralRule count="other"> @integer 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="ksh">
             <pluralRule count="zero">n = 0 @integer 0 @decimal 0.0, 0.00, 0.000, 0.0000</pluralRule>
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="other"> @integer 2~17, 100, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -637,6 +637,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
             {"ga", "many", "0,00"}, // n in 7..10
             {"ar", "zero", "0"}, // n is 0
             {"blo", "zero", "0"}, // n = 0
+            {"cv", "zero", "0"}, // n = 0
             {"cy", "zero", "0"}, // n is 0
             {"ksh", "zero", "0"}, // n is 0
             {"lag", "zero", "0"}, // n is 0


### PR DESCRIPTION
CLDR-17707

- [X] This PR completes the ticket (building on the previous PR)

The previous PR on this ticket added plural rules for Chuvash "cv" after identifying the need for "zero", "one", "other", but in the interests of quickly enabling the extra categories, "cv" was added to the existing "ksh" entry. This PR removes "cv" from the "ksh" entry and makes a separate "cv" entry.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
