### PR TITLE
CLDR-18761 Use Vue for Info Panel voting table; show vote type, days ago

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -469,16 +469,6 @@ function reallyUpdateRow(tr, theRow) {
       tr.rawValueToItem[item.rawValue] = item; // back link by value
     }
   }
-
-  /*
-   * Update the vote info.
-   */
-  if (theRow.votingResults) {
-    cldrInfo.updateRowVoteInfo(tr, theRow);
-  } else {
-    tr.voteDiv = null;
-  }
-
   tr.statusAction = cldrSurvey.parseStatusAction(theRow.statusAction);
   tr.canModify = tr.theTable.json.canModify && tr.statusAction.vote;
   tr.ticketOnly = tr.theTable.json.canModify && tr.statusAction.ticket;
@@ -1130,6 +1120,8 @@ function updateRowNoAbstainCell(tr, theRow, noCell, proposedCell, protoButton) {
     surlink.className = "alert alert-info fix-popover-help";
     const link = cldrDom.createChunk(cldrText.get("file_a_ticket"), "a");
     const curLocale = cldrStatus.getCurrentLocale();
+    // The "trac" link is antiquated, but (as of 2025-06) still works to some extent, redirecting to
+    // https://cldr.unicode.org/requesting_changes#TOC-Filing-a-Ticket
     const newUrl =
       "http://unicode.org/cldr/trac" +
       "/newticket?component=data&summary=" +

--- a/tools/cldr-apps/js/src/esm/cldrVoteTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrVoteTable.mjs
@@ -1,0 +1,152 @@
+/*
+ * cldrVoteTable: add table showing votes in Info Panel
+ */
+import * as cldrNotify from "./cldrNotify.mjs";
+import * as cldrSurvey from "../esm/cldrSurvey.mjs";
+import * as cldrText from "../esm/cldrText.mjs";
+import * as cldrUserLevels from "./cldrUserLevels.mjs";
+import * as cldrVue from "./cldrVue.mjs";
+
+import InfoVoting from "../views/InfoVoting.vue";
+
+function add(containerEl, votingResults, item, value, totalVoteCount) {
+  try {
+    const voteRows = addRows(votingResults, item, value);
+    if (!voteRows?.length) {
+      console.log("cldrVoteTable: no rows added; value = " + value);
+      return;
+    }
+    /*
+     * baileyClass is for inherited items, which may get a colored background on the vote count matching the colored
+     * background of the candidate value: "alias", "fallback", "fallback_root", etc.
+     */
+    const baileyClass =
+      item.rawValue === cldrSurvey.INHERITANCE_MARKER ? item.pClass : "";
+    const wrapper = cldrVue.mount(InfoVoting, containerEl);
+    wrapper.setData({
+      totalVoteCount: totalVoteCount,
+      voteRows: voteRows,
+      baileyClass: baileyClass,
+    });
+  } catch (e) {
+    console.error("Error loading InfoVoting vue " + e.message + " / " + e.name);
+    cldrNotify.exception(e, "while loading InfoVoting");
+  }
+}
+
+function addRows(votingResults, item, value) {
+  const itemVotesLength = item.votes ? Object.keys(item.votes).length : 0;
+  const anon =
+    itemVotesLength == 1 &&
+    cldrUserLevels.match(
+      item.votes[Object.keys(item.votes)[0]].level,
+      cldrUserLevels.ANONYMOUS
+    );
+  const voteRows = [];
+  if (itemVotesLength == 0 || anon) {
+    addAnonVote(voteRows, anon);
+  } else {
+    updateRowVoteInfoForAllOrgs(voteRows, votingResults, value, item);
+  }
+  return voteRows;
+}
+
+function addAnonVote(voteRows, anon) {
+  const noVotes = cldrText.get("voteInfo_noVotes");
+  const anonVoter = anon ? cldrText.get("voteInfo_anon") : "";
+  const voteInfo = {
+    voteCount: noVotes,
+    userName: anonVoter,
+    email: "",
+    details: null,
+  };
+  voteRows.push(makeVoteObj("" /* org */, voteInfo));
+}
+
+/**
+ * Update the vote info for one candidate item in this row, looping through all the orgs.
+ *
+ * @param {Array} voteRows the array of voteRow objects to append to
+ * @param {Object} votingResults the voting results
+ * @param {String} value the value of the candidate item
+ * @param {Object} item the candidate item
+ */
+function updateRowVoteInfoForAllOrgs(voteRows, votingResults, value, item) {
+  for (let org in votingResults.orgs) {
+    // org is a string like "microsoft"
+    const theOrg = votingResults.orgs[org]; // theOrg is an object
+    const orgVoteValue = theOrg.votes[value]; // orgVoteValue is a number
+
+    // This function is not called with "anonymous" imported losing votes (orgVoteValue === 0)
+    // so we don't need to handle them here or distinguish 0/null/undefined for orgVoteValue.
+    if (orgVoteValue) {
+      // Someone in the org actually voted for it
+      let topVoter = null; // top voter for this item
+      let topVoterTime = 0; // Calculating the latest time for a user from same org
+      // find a top-ranking voter to use for the top line
+      for (let voter in item.votes) {
+        const voteInfo = item.votes[voter];
+        if (
+          voteInfo.org == org &&
+          getActualVoteCount(voteInfo) == theOrg.votes[value]
+        ) {
+          if (topVoterTime != 0) {
+            // Get the latest time vote only
+            if (
+              votingResults.nameTime[`#${topVoter}`] <
+              votingResults.nameTime[`#${voter}`]
+            ) {
+              topVoter = voter;
+              topVoterTime = votingResults.nameTime[`#${topVoter}`];
+            }
+          } else {
+            topVoter = voter;
+            topVoterTime = votingResults.nameTime[`#${topVoter}`];
+          }
+        }
+      }
+      if (!topVoter) {
+        // just find someone in the right org
+        for (let voter in item.votes) {
+          if (item.votes[voter].org == org) {
+            topVoter = voter;
+            break;
+          }
+        }
+      }
+      voteRows.push(makeVoteObj(org, item.votes[topVoter]));
+      for (let voter in item.votes) {
+        if (item.votes[voter].org != org || voter == topVoter) {
+          continue; // skip; wrong org or already done
+        }
+        voteRows.push(makeVoteObj("" /* org */, item.votes[voter]));
+      }
+    }
+  }
+}
+
+function makeVoteObj(org, voteInfo) {
+  return {
+    org: org,
+    voteCount: getActualVoteCount(voteInfo),
+    userName: getName(voteInfo),
+    email: getEmail(voteInfo),
+    details: voteInfo.voteDetails,
+  };
+}
+
+function getActualVoteCount(voteInfo) {
+  return voteInfo.voteDetails?.override || voteInfo.votes;
+}
+
+function getName(voteInfo) {
+  return voteInfo?.name || cldrText.get("emailHidden");
+}
+
+function getEmail(voteInfo) {
+  return voteInfo?.email
+    ? voteInfo.email.replace(" (at) ", "@")
+    : cldrText.get("emailHidden");
+}
+
+export { add };

--- a/tools/cldr-apps/js/src/views/InfoVoting.vue
+++ b/tools/cldr-apps/js/src/views/InfoVoting.vue
@@ -1,0 +1,191 @@
+<script setup>
+import { reactive, ref } from "vue";
+
+import * as cldrText from "../esm/cldrText.mjs";
+
+// Currently cldrText has "Org." but not "User"
+const orgColumnHeader = cldrText.get("voteInfo_orgColumn");
+
+// For "(no votes)", prevent line break between "no" and "votes"
+const noVotes = cldrText.get("voteInfo_noVotes").replace(" ", "\u00A0");
+
+let totalVoteCount = ref(0);
+let voteRows = null;
+let gotVoteRows = ref(false);
+let baileyClass = ref("");
+let gotNoVotes = ref(false);
+
+function setData(data) {
+  totalVoteCount.value = data.totalVoteCount;
+  voteRows = reactive(data.voteRows);
+  gotVoteRows.value = Boolean(data.voteRows);
+  baileyClass.value = data.baileyClass;
+  gotNoVotes.value = Boolean(!data.voteRows[0].voteCount);
+}
+
+function abbreviateDetails(row) {
+  // Example: "-23 B" where -23 means 23 days ago; B means BULK_UPLOAD
+  const daysAgo = row.details?.daysAgo;
+  let abbreviation = !daysAgo ? "0" : "-" + daysAgo;
+  // Based on server enum VoteType: NONE, UNKNOWN, DIRECT, AUTO_IMPORT, MANUAL_IMPORT, BULK_UPLOAD.
+  // NONE and UNKNOWN should not occur unless the vote was years ago.
+  // MANUAL_IMPORT votes are imported anonymous zero votes.
+  // DIRECT is default; don't show anything for DIRECT. Otherwise, show first letter, like "A" for AUTO_IMPORT.
+  const type = row.details?.voteType || "?";
+  if (type !== "DIRECT") {
+    // U+202F NARROW NO-BREAK SPACE
+    abbreviation += "\u202F" + type.charAt(0);
+  }
+  return abbreviation;
+}
+
+function describeDaysAgo(row) {
+  const daysAgo = row.details?.daysAgo;
+  if (!daysAgo) {
+    return "Less than one day ago";
+  } else if (Number(daysAgo) === 1) {
+    return "About one day ago";
+  } else {
+    return daysAgo + " days ago";
+  }
+}
+
+function describeVoteType(row) {
+  // Display, for example, "AUTO_IMPORT" as "AUTO IMPORT"
+  const type = row.details?.voteType.replace("_", " ") || "?";
+  return "Vote type: " + type;
+}
+
+function shortName(name) {
+  // Very long names (which sometimes are email addresses) tend to
+  // make the table too wide, causing vertical scrollbars or otherwise
+  // making the table hard to read. The threshold length is roughly
+  // based on observation with current data/fonts/layout.
+  return name.length < 21 ? name : name.substring(0, 18) + "...";
+}
+
+function sendEmail(row) {
+  location.href = "mailto:" + row.email;
+}
+
+function voteCountClass(row) {
+  let c = "centerVoteCount";
+  if (baileyClass.value) {
+    c += " " + baileyClass.value;
+  }
+  // If an org has more than one row, only the first (top) such row counts
+  // towards the total. Subsequent rows for the same org have blank in
+  // the Org. column (meaning "same") and they have a different style
+  // (like italic) for the number.
+  c += row.org ? " orgTop" : " orgSame";
+  return c;
+}
+
+defineExpose({
+  setData,
+});
+</script>
+
+<template>
+  <div class="hideOverflow">
+    <table v-if="gotVoteRows">
+      <thead>
+        <tr>
+          <th>{{ orgColumnHeader }}</th>
+          <th class="userColumn">User</th>
+          <th></th>
+          <th class="centerVoteCount">
+            {{ totalVoteCount }}
+          </th>
+        </tr>
+      </thead>
+      <tbody v-if="gotNoVotes">
+        <tr>
+          <td>{{ noVotes }}</td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+      </tbody>
+      <tbody v-else>
+        <tr v-for="row of voteRows" :key="row">
+          <td>{{ row.voteCount ? row.org : noVotes }}</td>
+          <td class="userColumn">
+            <div v-if="row.email.includes('@')">
+              <a-popover>
+                <template #content
+                  ><div class="centerEmail">
+                    {{ row.userName }}
+                    <br />
+                    {{ row.email }}
+                    <br />
+                    <a-button @click="sendEmail(row)">Send email</a-button>
+                  </div></template
+                >
+                {{ shortName(row.userName) }}
+              </a-popover>
+            </div>
+            <div v-else>
+              {{ shortName(row.userName) }}
+            </div>
+          </td>
+          <td>
+            <a-popover placement="topRight">
+              <template #content
+                ><div>
+                  {{ describeDaysAgo(row) }}<br />{{ describeVoteType(row) }}
+                </div>
+              </template>
+              {{ abbreviateDetails(row) }}
+            </a-popover>
+          </td>
+          <td :class="voteCountClass(row)">{{ row.voteCount }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.hideOverflow {
+  overflow-x: hidden;
+}
+
+table {
+  width: 100%;
+  margin-top: 10px;
+  margin-bottom: 2px;
+}
+
+th,
+td {
+  padding-bottom: 2px !important;
+  padding-top: 2px !important;
+  padding-left: 4px !important;
+  padding-right: 4px !important;
+}
+
+td {
+  border-top: 1px solid black;
+}
+
+.userColumn {
+  width: 100%;
+}
+
+.centerEmail {
+  text-align: center;
+}
+
+.centerVoteCount {
+  text-align: center;
+}
+
+.orgTop {
+  font-weight: bold;
+}
+
+.orgSame {
+  font-style: italic;
+}
+</style>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -2792,8 +2792,7 @@ public class SurveyAjax extends HttpServlet {
                             }
                         }
                         CheckCLDR.StatusAction status =
-                                cPhase.getAcceptNewItemAction(
-                                        ci, pvi, CheckCLDR.InputMethod.BULK, ph, cs.user);
+                                cPhase.getAcceptNewItemAction(ci, pvi, ph, cs.user);
 
                         if (status != CheckCLDR.StatusAction.ALLOW) {
                             result = "Item will be skipped. (" + status + ")";

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -99,8 +99,7 @@ public class VoteAPIHelper {
             Instant then = epochSecondFormatter.parse(epoch, Instant::from);
             LocalDate thatDay = then.atZone(zone).toLocalDate();
             LocalDate today = LocalDate.now(zone);
-            long diff = Math.abs(ChronoUnit.DAYS.between(thatDay, today));
-            return (diff < 1) ? 1 : diff;
+            return Math.abs(ChronoUnit.DAYS.between(thatDay, today));
         }
     }
 
@@ -541,11 +540,7 @@ public class VoteAPIHelper {
                     r.statusAction =
                             SurveyMain.checkCLDRPhase(locale)
                                     .getAcceptNewItemAction(
-                                            ci,
-                                            dataRow,
-                                            CheckCLDR.InputMethod.DIRECT,
-                                            stf.getPathHeader(xp),
-                                            mySession.user);
+                                            ci, dataRow, stf.getPathHeader(xp), mySession.user);
                     if (!r.statusAction.isForbidden()) {
                         try {
                             final BallotBox<UserRegistry.User> ballotBox =

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckCLDR.java
@@ -159,18 +159,10 @@ public abstract class CheckCLDR implements CheckAccessor {
             return isForbidden;
         }
 
-        public boolean canShow() {
-            return !isForbidden;
-        }
-
         public boolean canVote() {
             // the one non-voting case
             if (this == ALLOW_TICKET_ONLY) return false;
             return !isForbidden();
-        }
-
-        public boolean canSubmit() {
-            return (this == ALLOW);
         }
     }
 
@@ -301,15 +293,12 @@ public abstract class CheckCLDR implements CheckAccessor {
          * @param enteredValue If null, means an abstention. If voting for an existing value,
          *     pathValueInfo.getValues().contains(enteredValue) MUST be true
          * @param pathValueInfo
-         * @param inputMethod
-         * @param status
          * @param userInfo
          * @return
          */
         public StatusAction getAcceptNewItemAction(
                 CandidateInfo enteredValue,
                 PathValueInfo pathValueInfo,
-                InputMethod inputMethod,
                 PathHeader ph,
                 UserInfo userInfo // can get voterInfo from this.
                 ) {


### PR DESCRIPTION
-New cldrVoteTable.mjs and VotingTable.vue, displaying abbreviated vote type and days ago without requiring hover

-Do not create voteDiv for each row when loading the page (do not call cldrInfo.updateRowVoteInfo from cldrTable; do not use cloneNode which is problematic for Vue)

-Instead, create voteDiv when showing Info Panel for the row in question

-In VoteAPIHelper.java, revise daysSinceDate to round down to zero where appropriate

-Delete some dead code from CheckCLDR.java, VoteAPIHelper.java, and SurveyAjax.java (unused functions canShow, canSubmit; unused function parameters), which became apparent while investigating ticketLink (trac), related to refactoring of addVoteDivAndTicketLink

-Comments, including comment in cldrTable.mjs about trac link that looks like dead code but is not entirely dead

CLDR-18761

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
