### PR TITLE
CLDR-18805 Make Info Panel forum permissions same as in Forum page

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrForum.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForum.mjs
@@ -186,8 +186,7 @@ function loadBad(ourDiv, json) {
 function loadOk(ourDiv, json, userId, forumMessage) {
   /*
    * The server has already confirmed that the user is logged in and has permission to view the forum.
-   * Note: the criteria (here) for posting in the main forum window are less strict than in the info
-   * panel; see the other call to setUserCanPost. Here, we have no "json.canModify" set by the server.
+   * It is assumed here that permission to view equals permission to post.
    */
   setUserCanPost(true);
 

--- a/tools/cldr-apps/js/src/esm/cldrForumPanel.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrForumPanel.mjs
@@ -40,7 +40,6 @@ function loadInfo(frag, tr, theRow) {
   if (!frag || !tr || !theRow) {
     return;
   }
-  cldrForum.setUserCanPost(tr.theTable.json.canModify);
   addTopButtons(theRow, frag);
   const div = document.createElement("div");
   div.className = FORUM_DIV_CLASS;
@@ -68,7 +67,12 @@ function fetchAndLoadPosts(frag, div, tr, theRow) {
       url: ourUrl,
       handleAs: "json",
       load: function (json) {
-        if (json && json.forum_count !== undefined) {
+        cldrDom.setDisplayed(loader2, false);
+        if (json?.err_code === "E_NO_PERMISSION") {
+          cldrForum.setUserCanPost(false);
+        } else if (json && json.forum_count !== undefined) {
+          // It is assumed here that permission to view equals permission to post.
+          cldrForum.setUserCanPost(true);
           const nrPosts = parseInt(json.forum_count);
           havePosts(nrPosts, div, tr, loader2);
         } else {
@@ -114,8 +118,6 @@ function getUsersValue(theRow) {
 }
 
 function havePosts(nrPosts, div, tr, loader2) {
-  cldrDom.setDisplayed(loader2, false); // not needed
-
   if (nrPosts == 0) {
     return; // nothing to do
   }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/SurveyAjax.java
@@ -516,18 +516,9 @@ public class SurveyAjax extends HttpServlet {
                             new SurveyBulkClosePosts(sm, execute).getJson(r);
                         }
                         send(r, out);
-                    } else if (what.equals(WHAT_FORUM_COUNT)) {
-                        mySession.userDidAction();
-                        SurveyJSONWrapper r = newJSONStatus(request, sm);
-                        r.put("what", what);
-                        CLDRLocale locale = CLDRLocale.getInstance(loc);
-                        int id = Integer.parseInt(xpath);
-                        r.put(what, sm.fora.postCountFor(locale, id));
-                        send(r, out);
-                    } else if (what.equals(WHAT_FORUM_FETCH)) {
+                    } else if (what.equals(WHAT_FORUM_COUNT) || what.equals(WHAT_FORUM_FETCH)) {
                         SurveyJSONWrapper r = newJSONStatus(request, sm);
                         CLDRLocale locale = CLDRLocale.getInstance(loc);
-                        int id = Integer.parseInt(xpath);
                         if (mySession.user == null) {
                             r.put("err", "Not logged in.");
                             r.put("err_code", ErrorCode.E_NOT_LOGGED_IN.name());
@@ -537,9 +528,14 @@ public class SurveyAjax extends HttpServlet {
                         } else {
                             mySession.userDidAction();
                             r.put("what", what);
-                            r.put("loc", loc);
-                            r.put("xpath", xpath);
-                            r.put("ret", sm.fora.toJSON(mySession, locale, id, 0));
+                            int id = Integer.parseInt(xpath);
+                            if (what.equals(WHAT_FORUM_COUNT)) {
+                                r.put(what, sm.fora.postCountFor(locale, id));
+                            } else { // WHAT_FORUM_FETCH
+                                r.put("loc", loc);
+                                r.put("xpath", xpath);
+                                r.put("ret", sm.fora.toJSON(mySession, locale, id, 0));
+                            }
                         }
                         send(r, out);
                     } else if (what.equals(WHAT_FORUM_POST)) {


### PR DESCRIPTION
-Require same permission for what=WHAT_FORUM_COUNT as for WHAT_FORUM_FETCH (formerly WHAT_FORUM_COUNT required no permission)

-On front end, for Info Panel, determine permission to post from the response to what=WHAT_FORUM_COUNT

-Note: the inconsistency became evident when CLDR_PHASE was changed from VETTING to VETTING_CLOSED

CLDR-18805

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
