### PR TITLE
CLDR-18790 Fetch initial ST status before other tasks

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGui.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGui.mjs
@@ -72,6 +72,7 @@ async function initialSetup() {
     cldrLocales.fetchMap(),
     cldrEscaperLoader.updateEscaperFromServer(),
   ]);
+  await cldrSurvey.fetchInitialStatus();
   // This needs to be done before initial menus.
   cldrLoad.parseHashAndUpdate(cldrLoad.getHash());
   await cldrMenu.getInitialMenusEtc(); // Note: also kicks off auto import

--- a/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrSurvey.mjs
@@ -471,6 +471,32 @@ function standOutMessage(txt) {
 }
 
 /**
+ * This is called once on start-up to fetch initial ST status.
+ *
+ * It is similar to updateStatus but differs in being async and
+ * omitting some complications.
+ *
+ * A status response with status.user is required before many
+ * ST features can perform correctly depending on the user's
+ * permissions, etc.
+ */
+async function fetchInitialStatus() {
+  const url = makeUpdateStatusUrl();
+  return await cldrAjax
+    .doFetch(url)
+    .then(cldrAjax.handleFetchErrors)
+    .then((r) => r.json())
+    .then(updateStatusBox)
+    .catch(initialStatusFailure);
+}
+
+function initialStatusFailure() {
+  throw new Error(
+    "SurveyTool failed getting the initial status. Try back later."
+  );
+}
+
+/**
  * This is called periodically to fetch latest ST status
  */
 function updateStatus() {
@@ -973,6 +999,7 @@ export {
   cloneLocalizeAnon,
   createGravatar,
   expediteStatusUpdate,
+  fetchInitialStatus,
   findItemByValue,
   getDidUnbust,
   getTagChildren,


### PR DESCRIPTION
-New cldrSurvey.fetchInitialStatus, similar to updateStatus but async

-Await completion of cldrSurvey.fetchInitialStatus in cldrGui.initialSetup

CLDR-18790

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
