### PR TITLE
CLDR-18772 Add Official Status Column to language-territory charts

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -1217,18 +1217,7 @@ public class ShowLanguages {
                     new FormattedFileWriter(
                             null,
                             "Language-Territory Information",
-                            null
-                            // "<div  style='margin:1em'><p>The language data is provided for
-                            // localization testing, and is under development for CLDR 1.5. "
-                            // +
-                            // "To add a new territory for a language, see the <i>add new</i> links
-                            // below. " +
-                            // "For more information, see <a
-                            // href=\"territory_language_information.html\">Territory-Language
-                            // Information.</a>"
-                            // +
-                            // "<p></div>"
-                            ,
+                            null,
                             SUPPLEMENTAL_INDEX_ANCHORS);
             PrintWriter pw21 = new PrintWriter(ffw);
             PrintWriter pw2 = pw21;
@@ -1251,8 +1240,6 @@ public class ShowLanguages {
                                     CldrUtility.getDoubleLinkMsg(),
                                     "class='source'",
                                     true)
-                            // .addColumn("Report Bug", "class='target'", null, "class='target'",
-                            // false)
                             .addColumn("Territory", "class='target'", null, "class='target'", true)
                             .addColumn(
                                     "Code",
@@ -1261,11 +1248,17 @@ public class ShowLanguages {
                                     "class='target'",
                                     true)
                             .addColumn(
+                                    "Official Status",
+                                    "class='target'",
+                                    null,
+                                    "class='target'",
+                                    false)
+                            .addColumn(
                                     "Language Population",
                                     "class='target'",
                                     "{0,number,#,#@@}",
                                     "class='targetRight'",
-                                    true)
+                                    false)
                             .setSortPriority(1)
                             .setSortAscending(false)
                     // .addColumn("Territory Population", "class='target'", "{0,number,#,##0}",
@@ -1278,10 +1271,9 @@ public class ShowLanguages {
                     // "class='targetRight'", true)
                     ;
             TreeSet<String> languages = new TreeSet<>();
-            Collection<Comparable[]> data = new ArrayList<>();
-            String msg = "<br><i>Please click on each country code</i>";
+            Collection<Comparable<?>[]> data = new ArrayList<>(); // For HTML
 
-            Collection<Comparable[]> plainData = new ArrayList<>();
+            Collection<Comparable<?>[]> plainData = new ArrayList<>(); // For TSV
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 // PopulationData territoryData =
@@ -1296,87 +1288,45 @@ public class ShowLanguages {
                             supplementalDataInfo.getLanguageAndTerritoryPopulationData(
                                     languageCode, territoryCode);
                     languages.add(languageCode);
-                    Comparable[] items =
-                            new Comparable[] {
+                    Comparable<?>[] items =
+                            new Comparable<?>[] {
                                 getFirstPrimaryWeight(getLanguageName(languageCode)),
-                                getLanguageName(languageCode), // + getLanguagePluralMessage(msg,
-                                // languageCode),
-                                languageCode,
-                                // bug,
-                                territoryName + getOfficialStatus(territoryCode, languageCode),
-                                territoryCode,
-                                languageData.getPopulation(),
-                                // population,
-                                // languageliteracy,
-                                // territoryLiteracy,
-                                // gdp
-                            };
-                    Comparable[] plainItems =
-                            new Comparable[] {
-                                getLanguageName(languageCode), // + getLanguagePluralMessage(msg,
-                                // languageCode),
+                                getLanguageName(languageCode),
                                 languageCode,
                                 territoryName,
                                 territoryCode,
-                                getRawOfficialStatus(territoryCode, languageCode),
+                                getOfficialStatus(territoryCode, languageCode).replace('_', ' '),
                                 languageData.getPopulation(),
-                                languageData.getLiteratePopulation()
+                                // territory population,
+                                // language literacy,
+                                // territory literacy,
+                                // territory gdp
+                            };
+                    Comparable<?>[] plainItems =
+                            new Comparable<?>[] {
+                                getLanguageName(languageCode),
+                                languageCode,
+                                territoryName,
+                                territoryCode,
+                                getOfficialStatus(territoryCode, languageCode),
+                                Math.round(languageData.getPopulation()),
+                                Math.round(languageData.getLiteratePopulation()),
                             };
 
                     data.add(items);
                     plainData.add(plainItems);
                 }
             }
-            for (String languageCode : languages) {
-                Comparable[] items =
-                        new Comparable[] {
-                            getFirstPrimaryWeight(getLanguageName(languageCode)),
-                            getLanguageName(
-                                    languageCode), // + getLanguagePluralMessage(msg, languageCode),
-                            languageCode,
-                            // bug,
-                            addBug(
-                                    1217,
-                                    "<i>add new</i>",
-                                    "<email>",
-                                    "Add territory to "
-                                            + getLanguageName(languageCode)
-                                            + " ("
-                                            + languageCode
-                                            + ")",
-                                    "<territory, speaker population in territory, and references>"),
-                            "",
-                            0.0d,
-                            // 0.0d,
-                            // 0.0d,
-                            // 0.0d,
-                            // gdp
-                        };
-                data.add(items);
-            }
-            Comparable[][] flattened = data.toArray(new Comparable[data.size()][]);
+            Comparable<?>[][] flattened = data.toArray(new Comparable[data.size()][]);
             String value = tablePrinter.addRows(flattened).toTable();
             pw2.println(value);
             pw2.close();
             try (PrintWriter pw21plain =
                     FileUtilities.openUTF8Writer(ffw.getDir(), ffw.getBaseFileName() + ".txt")) {
-                for (Comparable[] row : plainData) {
+                for (Comparable<?>[] row : plainData) {
                     pw21plain.println(Joiner.on("\t").join(row));
                 }
             }
-        }
-
-        private String getLanguagePluralMessage(String msg, String languageCode) {
-            String mainLanguageCode = new LanguageTagParser().set(languageCode).getLanguage();
-            String messageWithPlurals =
-                    msg
-                            + ", on <a href='language_plural_rules.html#"
-                            + mainLanguageCode
-                            + "'>plurals</a>"
-                            + ", and on <a href='likely_subtags.html#"
-                            + mainLanguageCode
-                            + "'>likely-subtags</a>";
-            return messageWithPlurals;
         }
 
         private String getLanguageName(String languageCode) {
@@ -1679,24 +1629,24 @@ public class ShowLanguages {
                             "<a href=\"language_territory_information.html#{0}\">{0}</a>",
                             "class='target'",
                             false)
+                    .addColumn("Official Status", "class='target'", null, "class='target'", false)
                     .addColumn(
                             "Lang. Pop.",
                             "class='target'",
                             "{0,number,#,#@@}",
                             "class='targetRight'",
-                            true)
+                            false)
                     .addColumn(
                             "Pop.%",
-                            "class='target'", "{0,number,@@}%", "class='targetRight'", true)
+                            "class='target'", "{0,number,@@}%", "class='targetRight'", false)
                     .setSortAscending(false)
                     .setSortPriority(1)
                     .addColumn(
                             "Literacy%",
-                            "class='target'", "{0,number,@@}%", "class='targetRight'", true)
+                            "class='target'", "{0,number,#0.0}%", "class='targetRight'", true)
                     .addColumn(
                             "Written%",
-                            "class='target'", "{0,number,@@}%", "class='targetRight'", true)
-                    .addColumn("Report Bug", "class='target'", null, "class='target'", false);
+                            "class='target'", "{0,number,#0.0}%", "class='targetRight'", true);
 
             for (String territoryCode : supplementalDataInfo.getTerritoriesWithPopulationData()) {
                 String territoryName =
@@ -1713,9 +1663,11 @@ public class ShowLanguages {
                             supplementalDataInfo.getLanguageAndTerritoryPopulationData(
                                     languageCode, territoryCode);
                     double languagePopulationPercent =
-                            100 * languageData.getPopulation() / territoryData2.getPopulation();
-                    double languageliteracy = languageData.getLiteratePopulationPercent();
-                    double writingFrequency = languageData.getWritingPercent();
+                            100.0 * languageData.getPopulation() / territoryData2.getPopulation();
+                    double languageliteracy =
+                            Math.round(10.0 * languageData.getLiteratePopulationPercent()) / 10.0;
+                    double writingFrequency =
+                            Math.round(10.0 * languageData.getWritingPercent()) / 10.0;
 
                     tablePrinter
                             .addRow()
@@ -1723,57 +1675,15 @@ public class ShowLanguages {
                             .addCell(territoryName)
                             .addCell(territoryCode)
                             .addCell(territoryLiteracy)
-                            .addCell(
-                                    getLanguageName(languageCode)
-                                            + getOfficialStatus(territoryCode, languageCode))
+                            .addCell(getLanguageName(languageCode))
                             .addCell(languageCode)
+                            .addCell(getOfficialStatus(territoryCode, languageCode))
                             .addCell(languageData.getPopulation())
                             .addCell(languagePopulationPercent)
                             .addCell(languageliteracy)
                             .addCell(writingFrequency)
-                            .addCell(
-                                    addBug(
-                                            1217,
-                                            "<i>bug</i>",
-                                            "<email>",
-                                            "Fix info for "
-                                                    + getLanguageName(languageCode)
-                                                    + " ("
-                                                    + languageCode
-                                                    + ")"
-                                                    + " in "
-                                                    + territoryName
-                                                    + " ("
-                                                    + territoryCode
-                                                    + ")",
-                                            "<fixed data for territory, plus references>"))
                             .finishRow();
                 }
-
-                tablePrinter
-                        .addRow()
-                        .addCell(getFirstPrimaryWeight(territoryName))
-                        .addCell(territoryName)
-                        .addCell(territoryCode)
-                        .addCell(territoryLiteracy)
-                        .addCell(
-                                addBug(
-                                        1217,
-                                        "<i>add new</i>",
-                                        "<email>",
-                                        "Add language to "
-                                                + territoryName
-                                                + "("
-                                                + territoryCode
-                                                + ")",
-                                        "<language, speaker pop. and literacy in territory, plus references>"))
-                        .addCell("")
-                        .addCell(0.0d)
-                        .addCell(0.0d)
-                        .addCell(0.0d)
-                        .addCell(0.0d)
-                        .addCell("")
-                        .finishRow();
             }
             String value = tablePrinter.toTable();
             pw2.println(value);
@@ -1905,18 +1815,7 @@ public class ShowLanguages {
                     supplementalDataInfo.getLanguageAndTerritoryPopulationData(
                             languageCode, territoryCode);
             if (x == null || x.getOfficialStatus() == OfficialStatus.unknown) return "";
-            return " <span title='"
-                    + x.getOfficialStatus().toString().replace('_', ' ')
-                    + "'>{"
-                    + x.getOfficialStatus().toShortString()
-                    + "}</span>";
-        }
-
-        private String getRawOfficialStatus(String territoryCode, String languageCode) {
-            PopulationData x =
-                    supplementalDataInfo.getLanguageAndTerritoryPopulationData(
-                            languageCode, territoryCode);
-            if (x == null || x.getOfficialStatus() == OfficialStatus.unknown) return "";
+            // Change enum to string, replacing _ with space and converting to titlecase
             return x.getOfficialStatus().toString();
         }
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/chart_messages.html
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/chart_messages.html
@@ -45,63 +45,88 @@ DIV.1st {
 			</tr>
 			<tr>
 				<td>territory_language_information</td>
-				<td>The main goal for CLDR language data is to provide
+				<td>
+					The main goal for CLDR language data is to provide
 					approximate figures for the literate, functional population for
 					each language in each territory: that is, the population that is
 					able to read and write each language, and is comfortable enough to
 					use it with computers.
-					<p>The GDP and Literacy figures are taken from the World Bank
-						where available, otherwise supplemented by FactBook data and other
-						sources. The GDP figures are "PPP (constant 2000 international
-						$)". Much of the per-language data is taken from the Ethnologue,
-						but is supplemented and processed using many other sources,
-						including per-country census data. (The focus of the Ethnologue is
-						native speakers, which includes people who are not literate, and
-						excludes people who are functional second-langauge users.)</p>
 					<p>
+						Language population estimates come from various sources.
+						In general, they are meant to represent the number of people that speak the language in they given country.
+						When possible, the numbers include usage as both people's first language (L1) or a later language (L2, L3...) they could use in conversation or technology.
+						Not all numbers may be up-to-date or completely comparable, as the data is collected from various sources. 
+						Much of the data is sourced by per-country census data or Ethnologue.
+					</p>
+					<p>
+						Literacy figures are taken from <a href="https://www.cia.gov/the-world-factbook/field/literacy/">The World Factbook</a>
+						data and the <a href="https://data.un.org/Data.aspx?d=POP&f=tableCode%3a31">United Nations Statistics Division</a>.
 						The literacy rate may be discounted to reflect the actual usage of
 						the written form in normal daily life. Thus languages that are
 						typically not written, such as Swiss German, will be given a low
 						literacy rate, even though the whole population <i>could</i> write
 						in Swiss German.
 					</p>
-					<p>The percentages may add up to more than 100% due to
+					<p>
+						Official status may have a few different values. "Official" means its the 
+						language of national government transactions and is recognized as that
+						in the law -- whereas "de facto official" means it is used in practice
+						but not written in the national law. "Official regional" is official in
+						a subdivision of the territory. "Recognized" means that while its not
+						the primary language, it is recognized by the government in law -- there
+						may be missing values for recognized languages in this table.
+					</p>
+					<p>
+						The percentages may add up to more than 100% due to
 						multilingual populations, or may be less than 100% due to
 						illiteracy or because the data has not yet been gathered or
-						processed. Languages with a small population may be omitted.</p>
-					<p>Official status is supplied where available, formatted as
-						{O}. Hovering with the mouse shows a short description.</p>
+						processed. Languages with a small population may be omitted.
+					</p>
 					<ul>
-						<li><b>Likely languages and scripts:</b>To see (and verify)
-							the likely languages and scripts for this subtag, click on the
-							country code.</li>
-						<li><b>Reporting Defects:</b> If you find errors or omissions
-							in this data, please report the information with the <i>bug</i>
-							or <i>add new</i> links, below.</li>
-						<li><b>XML Source:</b> <a
-							href="https://github.com/unicode-org/cldr/tree/main/common/supplemental/supplementalData.xml">
-								supplementalData.xml</a> (see the &lt;territoryInfo&gt;,
-							&lt;calendarData&gt;, &lt;weekData&gt;, and
-							&lt;measurementData&gt; elements)</li>
+						<li>
+							<b>Reporting Defects:</b>
+							If you find errors or omissions in this data, please
+							<a href="https://cldr.unicode.org/requesting_changes#TOC-Filing-a-Ticket">file a JIRA ticket</a>
+							to amend the data.
+						</li>
+						<li>
+							<b>XML Source:</b>
+							<a href="https://github.com/unicode-org/cldr/tree/main/common/supplemental/supplementalData.xml">
+								supplementalData.xml</a> (see the &lt;territoryInfo&gt; element)
+						</li>
+						<li>
+							<b>TSV version:</b>
+							<a href="../tsv/territory_language_information.tsv">territory_language_information.tsv</a>
+							for this table in a table-separated values format.
+						</li>
 					</ul>
 				</td>
 			</tr>
 			<tr>
 				<td>language_territory_information</td>
 				<td>
-					<p align="left">
+					<p>
 						For information on the meaning of
-						the different values, see <a
-							href="territory_language_information.html">Territory-Language
-							Information</a>.
+						the different values, see
+						<a href="territory_language_information.html">Territory-Language Information</a>.
 					</p>
 					<ul>
-						<li><b>Reporting Defects:</b> If you find errors or omissions
-							in this data, or add a new territory for a language, see the <i>add
-								new</i> links below.</li>
-						<li><b>XML Source:</b> <a
-							href="https://github.com/unicode-org/cldr/tree/main/common/supplemental/supplementalData.xml">
-								supplementalData.xml</a> (see the &lt;territoryInfo&gt; element)</li>
+						<li>
+							<b>Reporting Defects:</b>
+							If you find errors or omissions in this data, please
+							<a href="https://cldr.unicode.org/requesting_changes#TOC-Filing-a-Ticket">file a JIRA ticket</a>
+							to amend the data.
+						</li>
+						<li>
+							<b>XML Source:</b>
+							<a href="https://github.com/unicode-org/cldr/tree/main/common/supplemental/supplementalData.xml">
+								supplementalData.xml</a> (see the &lt;territoryInfo&gt; element)
+						</li>
+						<li>
+							<b>TSV version:</b>
+							<a href="language_territory_information.txt">territory_language_information.txt</a>
+							for this table in a table-separated values format.
+						</li>
 					</ul>
 				</td>
 			</tr>


### PR DESCRIPTION
CLDR-18722

- [x] This PR completes the ticket.

This PR makes many updates to the language-territory charts. The biggest is to add the official status column, but while I was here I made a number of formatting improvements that should improve the view of the tables. See these screenshots and descriptions of changes or the PR on cldr-staging https://github.com/unicode-org/cldr-staging/pull/191 :

|Page|Changes|Before|After|
|--|--|--|--|
|[Territory Language Information](https://www.unicode.org/cldr/charts/48/supplemental/territory_language_information.html)|Clarified descriptions, adding some links. Added reporting bug link, TSV link & official status context. Removed references to GDP and likely subtags (the old info was just wrong)|<img width="1007" alt="Screenshot 2025-07-09 at 12 52 17" src="https://github.com/user-attachments/assets/6525af0e-dfba-415b-947b-bf8b67d70a01" />|<img width="1008" alt="Screenshot 2025-07-09 at 12 53 37" src="https://github.com/user-attachments/assets/16e2328f-466b-4314-97d5-40efe6be7fda" />
|""|Moved official status to column. Changed percent rounding to better display & merge. Removed report bug & add new links (moved to page description) |<img width="1004" alt="Screenshot 2025-07-09 at 12 52 23" src="https://github.com/user-attachments/assets/50b8ed21-c350-42b0-ac38-a938bdb0a9a6" />|<img width="1001" alt="Screenshot 2025-07-09 at 12 53 50" src="https://github.com/user-attachments/assets/78d84669-be82-43d5-b366-d5c2de3ab9ef" />
|""|In addition to the ones mentioned: fixed NaNs, stopped merging pop estimates since its not known if they overlap or are different #s.|<img width="1010" alt="Screenshot 2025-07-09 at 12 55 02" src="https://github.com/user-attachments/assets/cfc59584-a746-47a3-a303-6459b19a7b7a" />|<img width="1001" alt="Screenshot 2025-07-09 at 12 55 16" src="https://github.com/user-attachments/assets/90898ce8-4546-4879-aeb0-a3496dfb1685" />
|[Language Territory Information](https://www.unicode.org/cldr/charts/48/supplemental/language_territory_information.html)|Added links to report feedback, the TSV version. Removed add new link. Added official status column|<img width="998" alt="Screenshot 2025-07-09 at 12 52 33" src="https://github.com/user-attachments/assets/c357ed03-12db-44e6-badb-2a5abc7b8063" />|<img width="1001" alt="Screenshot 2025-07-09 at 12 53 29" src="https://github.com/user-attachments/assets/026c49d0-5ab1-4e5f-b89d-7235931f27f5" />
|[language territory information.txt](https://www.unicode.org/cldr/charts/48/supplemental/language_territory_information.txt)|Numbers rounded -- they were fractions because the data is stored as percents and we lose precision.|<img width="708" alt="Screenshot 2025-07-09 at 12 52 55" src="https://github.com/user-attachments/assets/3e3fecaf-445f-41f7-af70-822723c39954" />|<img width="638" alt="Screenshot 2025-07-09 at 12 53 04" src="https://github.com/user-attachments/assets/3b5004eb-1a5a-4291-9b22-0899a964f09e" />



ALLOW_MANY_COMMITS=true
