### PR TITLE
CLDR-18610 VettingParticipation add EMP and MP; revise UI

### DIFF
--- a/tools/cldr-apps/js/src/views/VettingParticipation.vue
+++ b/tools/cldr-apps/js/src/views/VettingParticipation.vue
@@ -9,7 +9,9 @@ let hasPermission = ref(false);
 let message = ref("");
 let percent = ref(0);
 let status = ref(STATUS.INIT);
-let table = null;
+let tableBody = null;
+let tableHeader = null;
+let tableComments = null;
 
 function mounted() {
   cldrVettingParticipation.viewMounted(setData);
@@ -32,7 +34,7 @@ function cancel() {
   message.value = "";
   percent.value = 0;
   status.value = STATUS.STOPPED;
-  table = null;
+  tableBody = tableHeader = tableComments = null;
 }
 
 function canCancel() {
@@ -45,8 +47,14 @@ function setData(data) {
   if (data.status) {
     status.value = data.status;
   }
-  if (data.table) {
-    table = reactive(data.table);
+  if (data.tableHeader) {
+    tableHeader = reactive(data.tableHeader);
+  }
+  if (data.tableBody) {
+    tableBody = reactive(data.tableBody);
+  }
+  if (data.tableComments) {
+    tableComments = reactive(data.tableComments);
   }
 }
 
@@ -87,27 +95,29 @@ defineExpose({
     </p>
     <p v-if="message">{{ message }}</p>
     <hr />
-    <p class="buttons">
-      <button v-if="table" @click="saveAsSheet">
-        Save as Spreadsheet .xlsx
-      </button>
-    </p>
-    <table v-if="table">
-      <thead>
-        <tr>
-          <th v-for="cell of table[0]" :key="cell">
-            {{ cell }}
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(row, index) of table" :key="row">
-          <td v-if="index > 0" v-for="cell of row" :key="cell">
-            {{ cell }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-if="tableHeader && tableComments && tableBody">
+      <p class="buttons">
+        <button @click="saveAsSheet">Save as Spreadsheet .xlsx</button>
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th v-for="(cell, index) of tableHeader" :key="cell">
+              <a-tooltip :title="tableComments[index]">
+                {{ cell }}
+              </a-tooltip>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row of tableBody" :key="row">
+            <td v-for="cell of row" :key="cell">
+              {{ cell }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -128,5 +138,7 @@ td {
 
 th {
   background-color: lightgray;
+  position: sticky;
+  top: 0;
 }
 </style>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/Dashboard.java
@@ -75,6 +75,8 @@ public class Dashboard {
 
         public VoterProgress voterProgress = null;
 
+        public LocaleCompletionData localeCompletionData = null;
+
         @Schema(description = "Coverage level for this dashboard")
         public String coverageLevel = null;
 
@@ -276,6 +278,7 @@ public class Dashboard {
             reviewOutput.hidden = new ReviewHide(args.getUserId(), localeId).get();
             reviewOutput.voterProgress = dd.voterProgress;
             reviewOutput.addReports(args.getUserId(), localeId);
+            reviewOutput.localeCompletionData = dd.localeCompletionData;
         }
         return reviewOutput;
     }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletion.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/LocaleCompletion.java
@@ -28,9 +28,9 @@ import org.unicode.cldr.web.SurveyMain;
 
 /**
  * "A locale has complete coverage when there are no Missing values, no Provisional values, and no
- * Errors (aka no MEPs). The Missing / Provisional values are determined at the Locale.txt coverage
- * levels, while Errors need to be counted at the comprehensive level (because we have to resolve
- * all of them in resolution).
+ * Errors (aka no MEPs). The Missing / Provisional values are determined at the target coverage
+ * levels (not specific to any organization), while Errors need to be counted at the comprehensive
+ * level (because we have to resolve all of them in resolution).
  *
  * <p>"In order to show progress towards completion of the locale, we compare the current status to
  * that of the corresponding baseline (blue star) values. Those baseline values can be computed and
@@ -55,7 +55,7 @@ public class LocaleCompletion {
                 @APIResponse(
                         responseCode = "200",
                         description =
-                                "Voting completion statistics for the requesting user and the given locale and coverage level",
+                                "Voting completion statistics for the given locale at the target coverage level (not specific to any organization)",
                         content =
                                 @Content(
                                         mediaType = "application/json",

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/Summary.java
@@ -615,7 +615,9 @@ public class Summary {
 
             ParticipationResults participationResults =
                     new ParticipationResults(
-                            reviewOutput.voterProgress, reviewOutput.coverageLevel);
+                            reviewOutput.voterProgress,
+                            reviewOutput.coverageLevel,
+                            reviewOutput.localeCompletionData);
             return Response.ok().entity(participationResults).build();
         } finally {
             if (didAcquire) {
@@ -630,10 +632,17 @@ public class Summary {
     public class ParticipationResults {
         public VoterProgress voterProgress;
         public String coverageLevel;
+        public int errorCount, missingCount, provisionalCount;
 
-        public ParticipationResults(VoterProgress voterProgress, String coverageLevel) {
+        public ParticipationResults(
+                VoterProgress voterProgress,
+                String coverageLevel,
+                LocaleCompletionData localeCompletionData) {
             this.voterProgress = voterProgress;
             this.coverageLevel = coverageLevel;
+            this.errorCount = localeCompletionData.errorCount();
+            this.missingCount = localeCompletionData.missingCount();
+            this.provisionalCount = localeCompletionData.provisionalCount();
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -299,6 +299,7 @@ public class VettingViewer<T> {
                 Relation.of(new TreeMap<R2<SectionId, PageId>, Set<WritingInfo>>(), TreeSet.class);
 
         public VoterProgress voterProgress = new VoterProgress();
+        public LocaleCompletionData localeCompletionData = null;
     }
 
     /**
@@ -324,7 +325,7 @@ public class VettingViewer<T> {
         fileInfo.setSorted(dd.sorted);
         fileInfo.setVoterProgressAndId(dd.voterProgress, args.userId);
         fileInfo.getFileInfo();
-
+        dd.localeCompletionData = new LocaleCompletionData(fileInfo.vc.problemCounter);
         return dd;
     }
 


### PR DESCRIPTION
-New columns EMP and MP for Errors, Missing, and Provisional counts, based on organization-specific coverage level for locale

-Add tooltip descriptions (comments) for table column headers, matching those in spreadsheet

-Revise column headers: change Targ. Cover. to Coverage, change Vetter# to User#

-Make table header sticky so it remains visible when scroll down to see lowest rows

-On the back end, revise ReviewOutput and ParticipationResults to include errors/missing/provisional counts from LocaleCompletionData; the data was already computed but not included in the http response

-Revise LocaleCompletion Java comment and API description to clarify what was already true, that LocaleCompletion API uses the target coverage level, which is not specific to any organization (and therefore is unsuitable for the vetting participation table)

CLDR-18610

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
