### PR TITLE
CLDR-18798 Vetters with bad locale codes: preliminary refactoring

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VotingParticipation.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VotingParticipation.java
@@ -165,16 +165,9 @@ public class VotingParticipation {
     private void appendInterestLocales(
             UserRegistry reg, final Set<String> localesWithVetters, int theirId) {
         final UserRegistry.User theUser = reg.getInfo(theirId);
-        if ((theUser.userlevel > UserRegistry.GUEST)
-                || UserRegistry.userIsLocked(theUser) // skip these
-        ) {
-            return;
+        if (UserRegistry.userIsLocked(theUser)) {
+            return; // skip locked users
         }
-        appendInterestLocales(localesWithVetters, theUser);
-    }
-
-    private void appendInterestLocales(
-            final Set<String> localesWithVetters, final UserRegistry.User theUser) {
         LocaleSet interestLocales = theUser.getInterestLocales();
         if (!interestLocales.isAllLocales()) {
             final Set<CLDRLocale> intSet = interestLocales.getSet();


### PR DESCRIPTION
-Combine two appendInterestLocales methods into one

-Remove redundant comparison with UserRegistry.GUEST; only locked users have higher userLevel than GUEST; numerical comparison of userLevel is hard to understand, should be encapsulated, but is redundant here anyway

CLDR-18798

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
