### PR TITLE
CLDR-18697 New PathStarrer.getWithPattern; make STAR_PATTERN private

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnglishChanged.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateEnglishChanged.java
@@ -40,14 +40,14 @@ public class GenerateEnglishChanged {
         String[] base = {"common"};
         File[] addStandardSubdirectories =
                 CLDR_CONFIG.addStandardSubdirectories(
-                        CLDR_CONFIG.fileArrayFromStringArray(TRUNK_DIRECTORY, base));
+                        CLDRConfig.fileArrayFromStringArray(TRUNK_DIRECTORY, base));
 
         Factory factoryTrunk = SimpleFactory.make(addStandardSubdirectories, ".*");
         CLDRFile englishTrunk = factoryTrunk.make("en", true);
 
         addStandardSubdirectories =
                 CLDR_CONFIG.addStandardSubdirectories(
-                        CLDR_CONFIG.fileArrayFromStringArray(RELEASE_DIRECTORY, base));
+                        CLDRConfig.fileArrayFromStringArray(RELEASE_DIRECTORY, base));
 
         Factory factoryLastRelease = SimpleFactory.make(addStandardSubdirectories, ".*");
         CLDRFile englishLastRelease = factoryLastRelease.make("en", true);
@@ -56,7 +56,6 @@ public class GenerateEnglishChanged {
         With.in(englishTrunk).toCollection(paths);
         With.in(englishLastRelease).toCollection(paths);
         final String placeholder = "×";
-        PathStarrer starrer = new PathStarrer().setSubstitutionPattern(placeholder);
 
         Set<String> abbreviatedPaths = new LinkedHashSet<>();
         Multimap<String, List<String>> pathsDiffer = LinkedHashMultimap.create();
@@ -75,7 +74,7 @@ public class GenerateEnglishChanged {
                     continue;
                 }
                 abbreviatedPaths.add(abbrPath);
-                String starred = starrer.set(abbrPath);
+                String starred = PathStarrer.getWithPattern(abbrPath, placeholder);
                 pathsDiffer.put(
                         starred,
                         ImmutableList.copyOf(
@@ -94,7 +93,6 @@ public class GenerateEnglishChanged {
         System.out.println("Errors: " + errorCount);
 
         if (TRIAL) {
-            String multipath = "(";
 
             for (Entry<String, Collection<List<String>>> entry : pathsDiffer.asMap().entrySet()) {
                 String path = entry.getKey();
@@ -104,7 +102,7 @@ public class GenerateEnglishChanged {
                     if (store == null) {
                         store = new ArrayList<>();
                         for (int i = 0; i < list.size(); ++i) {
-                            store.add(new LinkedHashSet<String>());
+                            store.add(new LinkedHashSet<>());
                         }
                     }
                     for (int i = 0; i < list.size(); ++i) {
@@ -113,29 +111,25 @@ public class GenerateEnglishChanged {
                 }
                 System.out.println(path + "\t" + store);
                 path = path.replace("[", "\\[");
-
-                for (int i = 0; i < store.size(); ++i) {
-                    Set<String> attrValues = store.get(i);
-                    UnicodeSet alphabet = new UnicodeSet();
-                    for (String attrValue : attrValues) {
-                        alphabet.addAll(attrValue);
+                if (store != null) {
+                    for (Set<String> attrValues : store) {
+                        UnicodeSet alphabet = new UnicodeSet();
+                        for (String attrValue : attrValues) {
+                            alphabet.addAll(attrValue);
+                        }
+                        // System.out.println(alphabet.toPattern(false));
+                        String compressed =
+                                MinimizeRegex.compressWith(
+                                        attrValues, alphabet); // (attrValues, alphabet);
+                        // String compressed = MinimizeRegex.simplePattern(attrValues);//
+                        // (attrValues,
+                        // alphabet);
+                        path = path.replaceFirst(placeholder, "(" + compressed + ")");
                     }
-                    // System.out.println(alphabet.toPattern(false));
-                    String compressed =
-                            MinimizeRegex.compressWith(
-                                    attrValues, alphabet); // (attrValues, alphabet);
-                    // String compressed = MinimizeRegex.simplePattern(attrValues);// (attrValues,
-                    // alphabet);
-                    path = path.replaceFirst(placeholder, "(" + compressed + ")");
                 }
-                multipath += "|" + path;
-
                 System.out.println(path);
             }
-            multipath += ")";
-            Pattern pathPattern = Pattern.compile(multipath);
         }
-        // System.out.println(compressed);
     }
 
     static Matcher partToRemove =
@@ -149,7 +143,6 @@ public class GenerateEnglishChanged {
                     .matcher("");
 
     private static String abbreviatePath(String path) {
-        String result = partToRemove.reset(path).replaceAll("");
-        return result;
+        return partToRemove.reset(path).replaceAll("");
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -166,11 +166,10 @@ public class ShowStarredCoverage {
             EnumSet.of(PageId.Fields, PageId.Gregorian, PageId.Generic);
 
     private static String condense(PathHeader ph) {
-        final String starPatternPath = PathStarrer.get(ph.getOriginalPath());
         // Replace PathStarrer.STAR_PATTERN with simple "*" for compatibility with other
         // code used by ShowStarredCoverage. Also, collapse alts.
         final String starredPath =
-                starPatternPath.replace(PathStarrer.STAR_PATTERN, "*").replace("[@alt=\"*\"]", "");
+                PathStarrer.getWithPattern(ph.getOriginalPath(), "*").replace("[@alt=\"*\"]", "");
         SectionId sectionId = ph.getSectionId();
         PageId pageId = ph.getPageId();
         String category = sectionId + "|" + pageId;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathStarrer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathStarrer.java
@@ -15,7 +15,14 @@ import java.util.regex.Pattern;
  * @author markdavis
  */
 public class PathStarrer {
-    public static final String STAR_PATTERN = "([^\"]*+)";
+    /**
+     * The default pattern to replace attribute values in paths to make starred paths. This pattern
+     * is assumed never to occur literally in an ordinary non-starred path. Cached starred paths use
+     * this pattern, and starred paths with other patterns may be produced by replacing all
+     * occurrences of STAR_PATTERN with another pattern. In this context, the replacement is
+     * literal, not using regular expressions.
+     */
+    private static final String STAR_PATTERN = "([^\"]*+)";
 
     private final List<String> attributes = new ArrayList<>();
     private String substitutionPattern = STAR_PATTERN;
@@ -24,7 +31,12 @@ public class PathStarrer {
 
     private static final ConcurrentHashMap<String, String> STAR_CACHE = new ConcurrentHashMap<>();
 
-    /** Thread-safe version, only STAR_PATTERN */
+    /**
+     * Get a starred version of the given path, using the default STAR_PATTERN
+     *
+     * @param path the original path
+     * @return the starred path
+     */
     public static String get(String path) {
         return STAR_CACHE.computeIfAbsent(
                 path,
@@ -39,6 +51,18 @@ public class PathStarrer {
                 });
     }
 
+    /**
+     * Get a starred version of the given path, using the given pattern
+     *
+     * @param path the original path
+     * @return the starred path
+     */
+    public static String getWithPattern(String path, String pattern) {
+        return get(path).replace(STAR_PATTERN, pattern);
+    }
+
+    // TODO: make this method thread-safe, or remove it and use get/getWithPattern instead.
+    // Reference: https://unicode-org.atlassian.net/browse/CLDR-18697
     public String set(String path) {
         XPathParts parts = XPathParts.getFrozenInstance(path).cloneAsThawed();
         attributes.clear();


### PR DESCRIPTION
-New getWithPattern gets default starred path, then replaces STAR_PATTERN with given pattern

-Use getWithPattern in GenerateEnglishChanged and ShowStarredCoverage

-Assume STAR_PATTERN would never occur (literally, not as regex) in an unstarred path

-Make STAR_PATTERN private for encapsulation, leaving open options for refactoring

-Fix compiler warnings in GenerateEnglishChanged, mostly automatic refactoring

-Comments

CLDR-18697

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
