### PR TITLE
CLDR-18798 bad locales: call out bad locales in user list

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAccount.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAccount.mjs
@@ -403,6 +403,7 @@ function getUserTableRow(u, json) {
     // 5th column: "Locales"
     "<td>" +
     getUserLocales(u) +
+    getBadLocales(u) +
     "</td>" +
     // 6th column: "Seen"
     "<td>" +
@@ -631,6 +632,20 @@ function getUserLocales(u) {
   } else {
     return prettyLocaleList(u.data.locales);
   }
+}
+
+function getBadLocales(u) {
+  if (!u.data.badLocales) return "";
+  return (
+    "<div class='d-item-err'>ERRORS: " +
+    u.data.badLocales
+      .map(
+        (s) =>
+          `<tt class='codebox' title='Locale is invalid or not present in Survey Tool'>${s}</tt>`
+      )
+      .join(" ") +
+    "</div>\n"
+  );
 }
 
 function getInterestLocalesHtml(json) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserList.java
@@ -451,6 +451,7 @@ public class UserList {
         boolean havePermToChange = me.isAdminFor(user);
         boolean userCanDeleteUser = UserRegistry.userCanDeleteUser(me, user.id, user.userlevel);
         VoteResolver.Level level = VoteResolver.Level.fromSTLevel(user.userlevel);
+        // TODO: why doesn't this use u.toJSONObject()?
         shownUsers.put(
                 new JSONObject()
                         .put("actions", u.ua)
@@ -462,6 +463,7 @@ public class UserList {
                         .put("intlocs", user.intlocs)
                         .put("lastlogin", user.last_connect)
                         .put("locales", normalizeLocales(user.locales))
+                        .put("badLocales", user.badLocales)
                         .put("name", user.name)
                         .put("org", user.org)
                         .put("seen", seen)

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleNormalizer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LocaleNormalizer.java
@@ -187,7 +187,7 @@ public class LocaleNormalizer {
         if (localeList == null || (localeList = localeList.trim()).length() == 0) {
             return newSet;
         }
-        final String[] array = localeList.split("[, \t\u00a0\\s]+"); // whitespace
+        final String[] array = splitToArray(localeList);
         for (String s : array) {
             CLDRLocale locale = CLDRLocale.getInstance(s);
             if (knownLocales == null || knownLocales.contains(locale)) {
@@ -201,6 +201,14 @@ public class LocaleNormalizer {
             }
         }
         return newSet;
+    }
+
+    public static String[] splitToArray(String localeList) {
+        if (localeList == null || localeList.isEmpty()) {
+            return new String[0];
+        }
+        final String[] array = localeList.trim().split("[, \t\u00a0\\s]+"); // whitespace
+        return array;
     }
 
     private static LocaleSet intersectKnownWithOrgLocales(LocaleSet orgLocaleSet) {


### PR DESCRIPTION
- we are already normalizing away 'bad' (invalid or missing locales) from the user list
- this code _preserves_ anything that was normalized away and presents it in the user list
- error can be corrected by calling 'set locales' and changing the locales, as the 'set locale' function will overwrite the locales list and does not allow invalid or missing locales to be set.

CLDR-18798

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true

<img width="1271" height="152" alt="image" src="https://github.com/user-attachments/assets/5f784d1e-01e2-4bcb-a52a-7cd1bd2ad6bd" />
