### PR TITLE
CLDR-18839 Reference specific dated asset for ICU4J (until it is rc)

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,11 +19,14 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- Note: see https://github.com/unicode-org/icu/packages/1954682/versions
-			for the icu4j.version tag to use. In general we should just use the latest
-			SNAPSHOT for the ICU version that we want, so this should only need updating
-			when the ICU version changes e.g. from 74.0.1, to 74.1, to 75.0.1, then to 75.1.
-			You can use github actions in icu to manually push the latest SNAPSHOT version. -->
-		<icu4j.version>78.0.1-SNAPSHOT</icu4j.version>
+			for the icu4j.version tag to use. While latest ICU4J has a published version
+			like nn.0.1-SNAPSHOT (i.e. before release candidate), we should use a specific
+			dated asset as found by clicking the version at the link above. When ICU4J reaches
+			release candidate and changes to a version like nn.1-SNAPSHOT, we should just use
+			that so we are always getting the latest version pushed (and should not have CLDR
+			compatibility issues at that point). -->
+		<icu4j.version>78.0.1-20250521.091503-4</icu4j.version> <!-- before ICU rc, specific dated version -->
+		<!--<icu4j.version>78.1-SNAPSHOT</icu4j.version>--> <!-- after ICU rc, latest published version -->
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.3.1</maven-surefire-plugin-version>
 		<assertj-version>3.26.3</assertj-version>


### PR DESCRIPTION
CLDR-18839

- [x] This PR completes the ticket.

Until ICU gets to rc, reference a specific ICU4J dated asset within the version number (78.0.1-SNAPSHOT). Prevents ICU4J changes from breaking CLDR; this way a PR can check the changes.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
