### PR TITLE
CLDR-18831 Fix hi/Hindi locale display name coverage

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -102,7 +102,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%keys100" value="(col(Alternate|Backwards|CaseFirst|CaseLevel|HiraganaQuaternary|Normalization|Numeric|Reorder|Strength)|kv|sd|timezone|va|variableTop|x)"/>
 		<coverageVariable key="%language30" value="und"/>
 		<coverageVariable key="%language40" value="(de(_(AT|CH))?|en(_(AU|CA|GB|US))?|es(_(ES|419|MX))?|fr(_(CA|CH))?|it|ja|pt(_(BR|PT))?|ru|zh(_(Hans|Hant))?)"/>
-		<coverageVariable key="%language60" value="(ar(_001)?|bn|hi(_Latn)|id|ko|nl(_BE)?|pl|th|tr)"/>
+		<coverageVariable key="%language60" value="(ar(_001)?|bn|hi(_Latn)?|id|ko|nl(_BE)?|pl|th|tr)"/>
 		<coverageVariable key="%language60_CM" value="(bas|bax|bbj|bfd|bkm|bss|bum|byv|ewo|ff|kkj|maf|nnh|yav|ybb)"/>
 		<coverageVariable key="%language60_EU" value="(cs|da|e[lt]|fi|hu|lv|mt|s[klv])"/>
 		<coverageVariable key="%language60_GA" value="(fan|mye)"/>


### PR DESCRIPTION
The Regex to verify Hindi is translated is written incorrectly. It should be `hi(_Latn)?` so it means "hi or hi_Latn" but its written `hi(_Latn)` which will only match hi_Latn.

It's an easy fix and afaik no locales dropped in coverage -- but now new locales will see the gap in the survey tool. Many generated files change because there is a new value found now @ moderate.

CLDR-18831

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
