### PR TITLE
CLDR-18850 v48 BRS vxml: logknownissue for unit tests

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -969,11 +969,16 @@ public class TestTransforms extends TestFmwkPlus {
             // Suppress Common/Inherited characters that are given scx properties
             UnicodeSet suppressHack =
                     new UnicodeSet(
-                                    "[\u0301\u0300\u0306\u0302\u030C\u030A\u0308\u0303\u0307\u0304\u0309\u0310\u0323-\u0325\u0330\u0331 \u00B7 \u02BC \u3007 \u0E19\u0E22\u0E28\u0E39\u0E4C\uE070\u0AF0]")
+                                    "[\u0301\u0300\u0306\u0302\u030C\u030A\u0308\u0303\u0307\u0304\u0309\u0310\u0323-\u0325\u0330\u0331 \u00B7 \u02BC \u3007 \u0E19\u0E22\u0E28\u0E39\u0E4C\uE070]")
                             .freeze();
             for (String s : suppressHack) {
                 allMissing.scriptMissing.remove(s);
             }
+            if (allMissing.scriptMissing.containsKey("\u0AF0")
+                    && logKnownIssue("CLDR-18852", "U+0AF0 missing in Gujr translit")) {
+                allMissing.scriptMissing.remove("\u0AF0");
+            }
+
             for (String script : allMissing.scriptMissing.values()) {
                 UnicodeSet missingFoScript = allMissing.scriptMissing.getKeys(script);
                 String localeForScript =


### PR DESCRIPTION
CLDR-18850

- move one issues to logKnownIssues

add logknownissue for Gujr transform to CLDR-18852 for U+0AF0
the workaround was in https://github.com/unicode-org/cldr/pull/4889 but was subsumed under #4888

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
