### PR TITLE
CLDR-18846 update Romanian data

### DIFF
--- a/common/rbnf/ro.xml
+++ b/common/rbnf/ro.xml
@@ -27,14 +27,14 @@ x.x: << virgulă >>;
 3: trei;
 4: patru;
 5: cinci;
-6: şase;
-7: şapte;
+6: șase;
+7: șapte;
 8: opt;
 9: nouă;
 10: zece;
 11: unsprezece;
 12: >>sprezece;
-20: <%spellout-cardinal-feminine<zeci[ şi >>];
+20: <%spellout-cardinal-feminine<zeci[ și >>];
 100: una sută[ >>];
 200: <%spellout-cardinal-feminine< sute[ >>];
 1000: una mie[ >>];
@@ -56,7 +56,7 @@ x.x: << virgulă >>;
 2: două;
 3: =%spellout-cardinal-masculine=;
 12: >>sprezece;
-20: <%spellout-cardinal-feminine<zeci[ şi >>];
+20: <%spellout-cardinal-feminine<zeci[ și >>];
 100: una sută[ >>];
 200: <%spellout-cardinal-feminine< sute[ >>];
 1000: una mie[ >>];
@@ -76,7 +76,7 @@ x.x: << virgulă >>;
 0: zero;
 1: unu;
 2: =%spellout-cardinal-feminine=;
-20: <%spellout-cardinal-feminine<zeci[ şi >>];
+20: <%spellout-cardinal-feminine<zeci[ și >>];
 100: una sută[ >>];
 200: <%spellout-cardinal-feminine< sute[ >>];
 1000: una mie[ >>];
@@ -108,14 +108,14 @@ x.x: << virgulă >>;
                 <rbnfrule value="3">trei;</rbnfrule>
                 <rbnfrule value="4">patru;</rbnfrule>
                 <rbnfrule value="5">cinci;</rbnfrule>
-                <rbnfrule value="6">şase;</rbnfrule>
-                <rbnfrule value="7">şapte;</rbnfrule>
+                <rbnfrule value="6">șase;</rbnfrule>
+                <rbnfrule value="7">șapte;</rbnfrule>
                 <rbnfrule value="8">opt;</rbnfrule>
                 <rbnfrule value="9">nouă;</rbnfrule>
                 <rbnfrule value="10">zece;</rbnfrule>
                 <rbnfrule value="11">unsprezece;</rbnfrule>
                 <rbnfrule value="12">→→sprezece;</rbnfrule>
-                <rbnfrule value="20">←%spellout-cardinal-feminine←zeci[ şi →→];</rbnfrule>
+                <rbnfrule value="20">←%spellout-cardinal-feminine←zeci[ și →→];</rbnfrule>
                 <rbnfrule value="100">una sută[ →→];</rbnfrule>
                 <rbnfrule value="200">←%spellout-cardinal-feminine← sute[ →→];</rbnfrule>
                 <rbnfrule value="1000">una mie[ →→];</rbnfrule>
@@ -138,7 +138,7 @@ x.x: << virgulă >>;
                 <rbnfrule value="2">două;</rbnfrule>
                 <rbnfrule value="3">=%spellout-cardinal-masculine=;</rbnfrule>
                 <rbnfrule value="12">→→sprezece;</rbnfrule>
-                <rbnfrule value="20">←%spellout-cardinal-feminine←zeci[ şi →→];</rbnfrule>
+                <rbnfrule value="20">←%spellout-cardinal-feminine←zeci[ și →→];</rbnfrule>
                 <rbnfrule value="100">una sută[ →→];</rbnfrule>
                 <rbnfrule value="200">←%spellout-cardinal-feminine← sute[ →→];</rbnfrule>
                 <rbnfrule value="1000">una mie[ →→];</rbnfrule>
@@ -159,7 +159,7 @@ x.x: << virgulă >>;
                 <rbnfrule value="0">zero;</rbnfrule>
                 <rbnfrule value="1">unu;</rbnfrule>
                 <rbnfrule value="2">=%spellout-cardinal-feminine=;</rbnfrule>
-                <rbnfrule value="20">←%spellout-cardinal-feminine←zeci[ şi →→];</rbnfrule>
+                <rbnfrule value="20">←%spellout-cardinal-feminine←zeci[ și →→];</rbnfrule>
                 <rbnfrule value="100">una sută[ →→];</rbnfrule>
                 <rbnfrule value="200">←%spellout-cardinal-feminine← sute[ →→];</rbnfrule>
                 <rbnfrule value="1000">una mie[ →→];</rbnfrule>


### PR DESCRIPTION
CLDR-18846

- [X] This PR completes the ticket.

The exemplar data in common/main/ro.xml seems fine. U+0219 and U+021A (the preferred forms) appear in the main exemplar and U+015F and U+0163 appear in the auxiliary exemplar.

The ten changes in common/rbnf/ro.xml are all changing U+015F to U+0219.

ALLOW_MANY_COMMITS=true
