### PR TITLE
CLDR-18697 Remove all PathStarrer methods except get and getWithPattern

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartDelta.java
@@ -591,19 +591,17 @@ public class ChartDelta extends Chart {
         return old.getSourceLocaleID(oldStylePath, oldStatus);
     }
 
-    PathStarrer starrer = new PathStarrer().setSubstitutionPattern("%A");
-
     private PathHeader getPathHeader(String path) {
         try {
             PathHeader ph = phf.fromPath(path);
             if (ph.getPageId() == PageId.Unknown) {
-                String star = starrer.set(path);
+                String star = PathStarrer.getWithPattern(path, PathStarrer.PERCENT_A_PATTERN);
                 badHeaders.add(star);
                 return null;
             }
             return ph;
         } catch (Exception e) {
-            String star = starrer.set(path);
+            String star = PathStarrer.getWithPattern(path, PathStarrer.PERCENT_A_PATTERN);
             badHeaders.add(star);
             // System.err.println("Skipping path with bad PathHeader: " + path);
             return null;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowStarredCoverage.java
@@ -166,10 +166,11 @@ public class ShowStarredCoverage {
             EnumSet.of(PageId.Fields, PageId.Gregorian, PageId.Generic);
 
     private static String condense(PathHeader ph) {
-        // Replace PathStarrer.STAR_PATTERN with simple "*" for compatibility with other
+        // Use PathStarrer.SIMPLE_STAR_PATTERN ("*") for compatibility with other
         // code used by ShowStarredCoverage. Also, collapse alts.
         final String starredPath =
-                PathStarrer.getWithPattern(ph.getOriginalPath(), "*").replace("[@alt=\"*\"]", "");
+                PathStarrer.getWithPattern(ph.getOriginalPath(), PathStarrer.SIMPLE_STAR_PATTERN)
+                        .replace("[@alt=\"*\"]", "");
         SectionId sectionId = ph.getSectionId();
         PageId pageId = ph.getPageId();
         String category = sectionId + "|" + pageId;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdPathIterator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DtdPathIterator.java
@@ -142,13 +142,11 @@ public class DtdPathIterator {
                 CLDRConfig.getInstance().getCommonAndSeedAndMainAndAnnotationsFactory();
 
         // get all the actual starred patterns
-
-        PathStarrer ps = new PathStarrer().setSubstitutionPattern("%A");
         Map<String, String> starredToSample = new TreeMap<>();
         for (String locale : Arrays.asList("en", "de", "zh", "ar", "ru")) {
             CLDRFile cfile = factory.make(locale, true);
             for (String path : cfile.fullIterable()) {
-                String starred = ps.set(path);
+                String starred = PathStarrer.getWithPattern(path, PathStarrer.PERCENT_A_PATTERN);
                 starred = starred.replace("[@alt=\"%A\"]", "");
                 if (!starredToSample.containsKey(starred)
                         && !starred.endsWith("/alias")

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/RegexLookup.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/RegexLookup.java
@@ -641,14 +641,12 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
         @Override
         public void put(Finder pattern, T value) {
             // System.out.println("pattern.toString() is => "+pattern.toString());
-            List<String> attributes = new ArrayList<>();
             String starPattern =
                     starPatternTransform(
                             pattern.toString()
                                     .replaceAll(
                                             "\\(\\[\\^\"\\]\\*\\)",
-                                            PathStarrer.SIMPLE_STAR_PATTERN),
-                            attributes);
+                                            PathStarrer.SIMPLE_STAR_PATTERN));
             // System.out.println("Putting => "+starPattern);
             List<SPNode> candidates = _spmap.get(starPattern);
             if (candidates == null) {
@@ -662,8 +660,7 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
 
         @Override
         public T get(Finder finder) {
-            List<String> attributes = new ArrayList<>();
-            String starPattern = starPatternTransform(finder.toString(), attributes);
+            String starPattern = starPatternTransform(finder.toString());
             List<SPNode> candidates = _spmap.get(starPattern);
             if (candidates == null) {
                 return null;
@@ -685,8 +682,7 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
             List<SPNode> list = new ArrayList<>();
             List<T> retList = new ArrayList<>();
 
-            List<String> attributes = new ArrayList<>();
-            String starPattern = starPatternTransform(pattern, attributes);
+            String starPattern = starPatternTransform(pattern);
             List<SPNode> candidates = _spmap.get(starPattern);
             if (candidates == null) {
                 return retList;
@@ -772,18 +768,16 @@ public class RegexLookup<T> implements Iterable<Map.Entry<Finder, T>> {
         }
 
         // Used for coverage lookups - strips off the leading ^ and trailing $ from regexp pattern.
-        private String starPatternTransform(String path, List<String> attributes) {
+        private String starPatternTransform(String path) {
             final Pattern ATTRIBUTE_PATTERN_OLD = PatternCache.get("=\"([^\"]*)\"");
             Matcher starAttributeMatcher = ATTRIBUTE_PATTERN_OLD.matcher(path);
             StringBuilder starredPathOld = new StringBuilder();
-            attributes.clear();
             int lastEnd = 0;
             while (starAttributeMatcher.find()) {
                 int start = starAttributeMatcher.start(1);
                 int end = starAttributeMatcher.end(1);
                 starredPathOld.append(path, lastEnd, start);
                 starredPathOld.append(PathStarrer.SIMPLE_STAR_PATTERN);
-                attributes.add(path.substring(start, end));
                 lastEnd = end;
             }
             starredPathOld.append(path.substring(lastEnd));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAlt.java
@@ -6,10 +6,11 @@ import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.impl.Row;
 import com.ibm.icu.impl.Row.R4;
 import com.ibm.icu.util.Output;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.unicode.cldr.icu.dev.test.TestFmwk;
@@ -21,7 +22,6 @@ import org.unicode.cldr.util.PathStarrer;
 import org.unicode.cldr.util.XPathParts;
 
 public class TestAlt extends TestFmwk {
-    private static final Set<String> SINGLETON_ALT = Collections.singleton("alt");
     static CLDRConfig testInfo = CLDRConfig.getInstance();
 
     public static void main(String[] args) {
@@ -32,7 +32,6 @@ public class TestAlt extends TestFmwk {
         Factory cldrFactory = testInfo.getCldrFactory();
         HashMap<String, String> altPaths = new HashMap<>();
         Multimap<String, R4<String, String, String, String>> altStarred = TreeMultimap.create();
-        PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("*");
         final Set<String> available = new LinkedHashSet<>();
         available.add("root");
         available.add("en");
@@ -58,10 +57,9 @@ public class TestAlt extends TestFmwk {
                     if (altValue != null) {
                         altPaths.put(xpath, locale);
                         logln(locale + "\t" + xpath);
-                        String starredPath =
-                                pathStarrer.setSkippingAttributes(
-                                        parts.cloneAsThawed(), SINGLETON_ALT);
-                        String attrs = pathStarrer.getAttributesString("|");
+                        final List<String> attributes = new ArrayList<>();
+                        String starredPath = starSkippingAlt(parts.cloneAsThawed(), attributes);
+                        String attrs = Joiner.on("|").join(attributes);
                         final XPathParts noAlt = parts.cloneAsThawed().removeAttribute(i, "alt");
                         String plainPath = noAlt.toString();
                         altStarred.put(
@@ -81,9 +79,22 @@ public class TestAlt extends TestFmwk {
         }
     }
 
+    private String starSkippingAlt(XPathParts parts, List<String> attributes) {
+        attributes.clear();
+        for (int i = 0; i < parts.size(); ++i) {
+            for (String key : parts.getAttributeKeys(i)) {
+                if (!"alt".equals(key)) {
+                    attributes.add(parts.getAttributeValue(i, key));
+                    parts.setAttribute(i, key, PathStarrer.SIMPLE_STAR_PATTERN);
+                }
+            }
+        }
+        return parts.toString();
+    }
+
     public void testAlt() {
-        Output<String> pathWhereFound = new Output<String>();
-        Output<String> localeWhereFound = new Output<String>();
+        Output<String> pathWhereFound = new Output<>();
+        Output<String> localeWhereFound = new Output<>();
 
         CLDRFile testCldrFile = CLDRConfig.getInstance().getCLDRFile("fr_CA", true);
         String plain = "//ldml/localeDisplayNames/languages/language[@type=\"af\"]";

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestExampleGenerator.java
@@ -1935,8 +1935,6 @@ public class TestExampleGenerator extends TestFmwk {
                 new HashSet<>(); // assume whether there is an example is independent of locale, to
         // speed up the test.
         final String separator = "•";
-        PathStarrer ps = new PathStarrer();
-        ps.setSubstitutionPattern("*");
 
         // Setup for calling phase.getShowRowAction
         DummyPathValueInfo dummyPathValueInfo = null;
@@ -2007,9 +2005,10 @@ public class TestExampleGenerator extends TestFmwk {
                 if (level.isAtLeast(Level.COMPREHENSIVE)) {
                     continue;
                 }
-                String starred = ps.set(xpath);
-                String attrs = ps.getAttributesString(separator);
-
+                String starred = PathStarrer.getWithPattern(xpath, PathStarrer.SIMPLE_STAR_PATTERN);
+                String attrs =
+                        Joiner.on(separator)
+                                .join(XPathParts.getFrozenInstance(xpath).getAttributeValues());
                 PathHeader ph = phf.fromPath(xpath);
                 if (CHECK_ROW_ACTION) {
                     dummyPathValueInfo.setXpath(xpath);
@@ -2036,12 +2035,12 @@ public class TestExampleGenerator extends TestFmwk {
                         continue;
                     }
 
-                    samplesForWithout.put(key, sampleAttrAndValue(ps, separator, value));
+                    samplesForWithout.put(key, sampleAttrAndValue(attrs, value));
                     sampleUrlForWithout.put(key, ph.getUrl(BaseUrl.PRODUCTION, localeId));
                     countWithoutExamples.add(key, 1);
                 } else {
                     if (!samplesForWith.containsKey(key)) {
-                        samplesForWith.put(key, sampleAttrAndValue(ps, separator, value));
+                        samplesForWith.put(key, sampleAttrAndValue(attrs, value));
                     }
                     countWithExamples.add(key, 1);
                 }
@@ -2352,8 +2351,8 @@ public class TestExampleGenerator extends TestFmwk {
         return result;
     }
 
-    public String sampleAttrAndValue(PathStarrer ps, final String separator, String value) {
-        return ps.getAttributesString(separator) + "➔«" + value + "»";
+    private String sampleAttrAndValue(String attrs, String value) {
+        return attrs + "➔«" + value + "»";
     }
 
     public void testRationals() {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -1002,8 +1002,6 @@ public class TestPathHeader extends TestFmwkPlus {
     }
 
     public void TestZ() {
-        PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("%A");
-
         Set<PathHeader> sorted = new TreeSet<>();
         Map<String, String> missing = new TreeMap<>();
         Map<String, String> skipped = new TreeMap<>();
@@ -1014,12 +1012,14 @@ public class TestPathHeader extends TestFmwkPlus {
             PathHeader pathHeader = pathHeaderFactory.fromPath(path);
             String value = english.getStringValue(path);
             if (pathHeader == null) {
-                final String starred = pathStarrer.set(path);
+                final String starred =
+                        PathStarrer.getWithPattern(path, PathStarrer.PERCENT_A_PATTERN);
                 missing.put(starred, value + "\t" + path);
                 continue;
             }
             if (pathHeader.getSection().equalsIgnoreCase("skip")) {
-                final String starred = pathStarrer.set(path);
+                final String starred =
+                        PathStarrer.getWithPattern(path, PathStarrer.PERCENT_A_PATTERN);
                 skipped.put(starred, value + "\t" + path);
                 continue;
             }
@@ -1330,7 +1330,6 @@ public class TestPathHeader extends TestFmwkPlus {
 
     private class PathChecker {
         PathHeader.Factory phf = pathHeaderFactory;
-        PathStarrer starrer = new PathStarrer().setSubstitutionPattern("%A");
 
         Set<String> badHeaders = new TreeSet<>();
         Map<PathHeader, PathHeader> goodHeaders = new HashMap<>();
@@ -1397,7 +1396,7 @@ public class TestPathHeader extends TestFmwkPlus {
             } catch (Exception e) {
                 message = ": Exception in path header: " + e.getMessage();
             }
-            String star = starrer.set(path);
+            String star = PathStarrer.getWithPattern(path, PathStarrer.PERCENT_A_PATTERN);
             if (badHeaders.add(star)) {
                 errln(star + message + ", " + ph);
                 System.out.println(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathStarrer.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathStarrer.java
@@ -21,37 +21,28 @@ public class TestPathStarrer extends TestFmwk {
         // For non-parallel testing, the size of TEST_COUNT should make little difference; don't
         // waste a lot of time.
         final int TEST_COUNT = 1000;
-        final PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("*");
         alreadyReportedFailure = false; // reset
         for (int pass = 0; pass < 2; pass++) {
-            IntStream.range(0, TEST_COUNT).forEach(i -> doOnePath(pathStarrer, i));
+            IntStream.range(0, TEST_COUNT).forEach(this::doOnePath);
         }
     }
 
-    // TODO: enable testParallel. Currently it fails since PathStarrer is not thread-safe.
-    // Alternatively, remove the method PathStarrer.set, and use PathStarrer.computeIfAbsent
-    // instead.
-    // Reference: https://unicode-org.atlassian.net/browse/CLDR-18697
-
-    /*
     public void testParallel() {
         // For parallel testing, the size of TEST_COUNT makes a big difference to whether the test
         // passes or fails. In part, we are testing whether PathStarrer is thread-safe. If it
         // isn't, much randomness is involved. A large number is required here to make failure
         // likely if PathStarrer is not thread-safe.
         final int TEST_COUNT = 1000000;
-        final PathStarrer pathStarrer = new PathStarrer().setSubstitutionPattern("*");
         alreadyReportedFailure = false; // reset
-        IntStream.range(0, TEST_COUNT).parallel().forEach(i -> doOnePath(pathStarrer, i));
+        IntStream.range(0, TEST_COUNT).parallel().forEach(this::doOnePath);
     }
-     */
 
-    private void doOnePath(PathStarrer pathStarrer, int i) {
+    private void doOnePath(int i) {
         if (alreadyReportedFailure) {
             return;
         }
         String path = "//" + i;
-        String starred = pathStarrer.set(path);
+        String starred = PathStarrer.getWithPattern(path, PathStarrer.SIMPLE_STAR_PATTERN);
         assertEquals("Path should match", path, starred);
         if (!path.equals(starred)) {
             alreadyReportedFailure = true;


### PR DESCRIPTION
-Change all pathStarrer.set to PathStarrer.get or PathStarrer.getWithPattern

-New constants PathStarrer.PERCENT_A_PATTERN and PathStarrer.SIMPLE_STAR_PATTERN

-Move other code (not general-purpose) from PathStarrer to private methods in RegexLookup and TestAlt

-New private RegexLookup.StarPatternMap.starPatternTransform corresponds to old PathStarrer.setOld and PathStarrer.transform2

-New private TestAlt.starSkippingAlt corresponds to old PathStarrer.setSkippingAttributes

-Revise TestPathStarrer to test PathStarrer.getWithPattern instead of PathStarrer.set; enable TestPathStarrer.testParallel

CLDR-18697

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
