### PR TITLE
CLDR-18492 BRS currency update

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -355,7 +355,7 @@ The printed version of ISO-4217:2001
         </region>
         <region iso3166="CU">
             <currency iso4217="CUP" from="1859-01-01"/>
-            <currency iso4217="CUC" from="1994-01-01" to="2021-01-01"/>
+            <currency iso4217="CUC" from="1994-01-01" to="2021-06-01"/>
             <!-- currency iso4217="USD" from="1994"/ --><!-- Unofficially used -->
             <currency iso4217="USD" from="1899-01-01" to="1959-01-01"/>
         </region>

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -78,6 +78,7 @@ For terms of use, see https://www.unicode.org/copyright.html
             <info iso4217="VND" digits="0" rounding="0"/>
             <info iso4217="VUV" digits="0" rounding="0"/>
             <info iso4217="XAF" digits="0" rounding="0"/>
+			<info iso4217="XAU" digits="2" rounding="0"/>
             <info iso4217="XOF" digits="0" rounding="0"/>
             <info iso4217="XPF" digits="0" rounding="0"/>
             <info iso4217="YER" digits="0" rounding="0"/>
@@ -1188,6 +1189,7 @@ The printed version of ISO-4217:2001
             <currency iso4217="RHD" from="1970-02-17" to="1980-04-18"/>
         </region>
         <region iso3166="ZZ">
+            <currency iso4217="XAD" tender="false"/>
             <currency iso4217="XAG" tender="false"/>
             <currency iso4217="XAU" tender="false"/>
             <currency iso4217="XBA" tender="false"/>

--- a/common/validity/currency.xml
+++ b/common/validity/currency.xml
@@ -42,7 +42,7 @@
 		</id>
 		<!-- Deprecated values are those that are not legal tender in some country after 2025.
 			 More detailed usage information needed for some implementations is in supplemental data. -->
-		<id type='currency' idStatus='deprecated'>		<!-- 152 items -->
+		<id type='currency' idStatus='deprecated'>		<!-- 153 items -->
 			ADP AFA ALK ANG AOK AON AOR ARA ARL~M ARP ATS AZM
 			BAD BAN BEC BEF BEL BGL~M BGO BOL BOP BOV BRB~C BRE BRN BRR BRZ BUK BYB BYR
 			CHE CHW CLE~F CNH CNX COU CSD CSK CUC CYP
@@ -62,7 +62,7 @@
 			TJR TMM TPE TRL
 			UAK UGS USN USS UYI UYP UYW
 			VEB VED VEF VNN
-			XAG XAU XBA~D XDR XEU XFO XFU XPD XPT XRE XSU XTS XUA
+			XAD XAG XAU XBA~D XDR XEU XFO XFU XPD XPT XRE XSU XTS XUA
 			YDD YUD YUM~N YUR
 			ZAL ZMK ZRN ZRZ ZWD ZWL ZWR
 		</id>

--- a/docs/site/development/updating-codes/update-currency-codes.md
+++ b/docs/site/development/updating-codes/update-currency-codes.md
@@ -10,8 +10,8 @@ title: Update Currency Codes
 - **Use git diff to sanity check the two XML files against the old, and check them in.**
   - **"git diff \-w" is helpful to ignore whitespace. If there are only whitespace changes, there's no need to check them in.**
 - **Check the** [ISO amendments] **to get changes that will happen during the current cycle.**
-- Example: <https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-176.pdf>
-- It appears right now like there is no good way to collect all the amendments that are applicable, except to change "176" in the above link by incrementing until error \#404 results. So:
+- Example: <https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/amendments/dl-currency-iso-amendment-179.pdf>
+- It appears right now like there is no good way to collect all the amendments that are applicable, except to change "179" in the above link by incrementing until error \#404 results. So:
 - *Review all amendments that are dated after the previous update , and patch the XML files and the* ```supplementalData.xml``` *as below.*
 - *Record the last number viewed in the URL above.*
 - *(There is a "download all amendments" link now that has a spreadsheet summary.)*

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CountItems.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -125,9 +126,11 @@ public class CountItems {
         try {
             String methodName = System.getProperty("method");
             if (methodName != null) {
+                System.err.println("Calling -Dmethod=" + methodName);
                 CldrUtility.callMethod(methodName, CountItems.class);
             } else {
-                ShowZoneEquivalences.getZoneEquivalences();
+                throw new IllegalArgumentException(
+                        "Error. This tool, unusually, requires the -Dmethod= property to be set.  Use -Dmethod=getZoneEquivalences to get the old default behavior.");
             }
         } finally {
             deltaTime = System.currentTimeMillis() - deltaTime;
@@ -1181,5 +1184,9 @@ public class CountItems {
         System.out.println("Unique Values\t" + decimal.format(values.size()));
         System.out.println("Unique Full Paths\t" + decimal.format(fullpaths.size()));
         return count;
+    }
+
+    public static void getZoneEquivalences() throws IOException, ParseException {
+        ShowZoneEquivalences.getZoneEquivalences();
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/IsoCurrencyParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/IsoCurrencyParser.java
@@ -94,6 +94,7 @@ public class IsoCurrencyParser {
                     .put("MEMBER COUNTRIES OF THE AFRICAN DEVELOPMENT BANK GROUP", "ZZ")
                     .put("SISTEMA UNITARIO DE COMPENSACION REGIONAL DE PAGOS \"SUCRE\"", "ZZ")
                     .put("EUROPEAN MONETARY CO-OPERATION FUND (EMCF)", "ZZ")
+                    .put("ARAB MONETARY FUND", "ZZ")
                     .put("TÜRKİYE", "TR")
                     .put("TURKEY", "TR")
                     .put("BURMA", "MY")

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/ISO4217.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/ISO4217.txt
@@ -9,6 +9,7 @@
 # = P for codes that will be in current, customary use, but the 'from' date is in the future.
 currency	|	XAG	|	Silver	|	ZZ	|	(no country)	|	C
 currency	|	XAU	|	Gold	|	ZZ	|	(no country)	|	C
+currency	|	XAD	|	Arab Montary Fund	|	ZZ	|	(no country)	|	F
 currency	|	XBA	|	Bond Markets Units European Composite Unit (EURCO)	|	ZZ	|	(no country)	|	C
 currency	|	XBB	|	European Monetary Unit (E.M.U.-6) 	|	ZZ	|	(no country)	|	C
 currency	|	XBC	|	European Unit of Account 9(E.U.A.-9)	|	ZZ	|	(no country)	|	C

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/dl_iso_table_a1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2025-03-31">
+<ISO_4217 Pblshd="2025-05-12">
 	<CcyTbl>
 		<CcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -66,6 +66,13 @@
 			<CcyNm>East Caribbean Dollar</CcyNm>
 			<Ccy>XCD</Ccy>
 			<CcyNbr>951</CcyNbr>
+			<CcyMnrUnts>2</CcyMnrUnts>
+		</CcyNtry>
+		<CcyNtry>
+			<CtryNm>ARAB MONETARY FUND</CtryNm>
+			<CcyNm>Arab Accounting Dinar</CcyNm>
+			<Ccy>XAD</Ccy>
+			<CcyNbr>396</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>


### PR DESCRIPTION
CLDR-18492

- update latest data from SIX
- amendments include 179 (XAD) and 178 (CUC)
- fixed a problem with CountItems tool where it would silently succeed if a -Dmethod was not chosen

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
