### PR TITLE
CLDR-18490 v48 LogKnownIssues (August 2025 edition)

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestAttributeValues.java
@@ -307,9 +307,10 @@ public class TestAttributeValues extends TestFmwk {
         }
 
         void show(DtdType dtdType, boolean verbose, ImmutableSet<ValueStatus> retain) {
-            if (dtdData.dtdType == DtdType.keyboard3
-                    && testLog.logKnownIssue("CLDR-14974", "skipping for keyboard")) {
-                testLog.warnln("keyboard3 is missing validity checks");
+            if (dtdData.dtdType == DtdType.keyboard3) {
+                if (!testLog.logKnownIssue("CLDR-14974", "skipping for keyboard")) {
+                    testLog.errln("keyboard3 is missing validity checks");
+                }
             }
             boolean haveProblems = false;
             for (ValueStatus valueStatus : ValueStatus.values()) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -321,6 +321,10 @@ public class TestDtdData extends TestFmwk {
                 }
                 if (!valueAttributes.isEmpty()) {
                     switch (element.getName()) {
+                        case "ruleset":
+                            logKnownIssue(
+                                    "CLDR-18865", "Need exception for DTD test for migration");
+                            break;
                         case "key":
                         case "territory":
                         case "transform":

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestDtdData.java
@@ -321,9 +321,6 @@ public class TestDtdData extends TestFmwk {
                 }
                 if (!valueAttributes.isEmpty()) {
                     switch (element.getName()) {
-                        case "ruleset":
-                            logKnownIssue("cldrbug:8909", "waiting for RBNF to use data");
-                            break;
                         case "key":
                         case "territory":
                         case "transform":

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -2053,16 +2053,24 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         }
     }
 
+    /**
+     * @param causeError type of issue - warn/err/log
+     * @param message message text
+     * @param logTicket if non-null, attempt log known issue
+     * @param logComment optional comment with log known issue
+     * @see {@link UnicodeKnownIssues}
+     */
     public void errOrLog(
             CoverageIssue causeError, String message, String logTicket, String logComment) {
         switch (causeError) {
             case error:
-                if (logTicket == null) {
-                    errln(message);
+                if (logTicket != null && logKnownIssue(logTicket, logComment)) {
+                    warnln(message);
                     break;
+                } else {
+                    errln(message);
                 }
-                logKnownIssue(logTicket, logComment);
-                // fall through
+                break;
             case warn:
                 warnln(message);
                 break;


### PR DESCRIPTION
TestSupplementalInfo had incorrect logKnownIssues use
- gave a false negative, made it seem as if the test was passing
- test was ignoring the return value of logKnownIssue

CLDR-18490

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
