### PR TITLE
CLDR-18610 VettingParticipation separate E/M/P; Vetters only; further improvements

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrInfo.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrInfo.mjs
@@ -11,7 +11,6 @@ import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
 import * as cldrTable from "./cldrTable.mjs";
 import * as cldrText from "./cldrText.mjs";
-import * as cldrUserLevels from "./cldrUserLevels.mjs";
 import * as cldrVote from "./cldrVote.mjs";
 import * as cldrVoteTable from "./cldrVoteTable.mjs";
 import * as cldrVue from "./cldrVue.mjs";

--- a/tools/cldr-apps/js/src/views/VettingParticipation.vue
+++ b/tools/cldr-apps/js/src/views/VettingParticipation.vue
@@ -12,6 +12,7 @@ let status = ref(STATUS.INIT);
 let tableBody = null;
 let tableHeader = null;
 let tableComments = null;
+let accountColumnIndex = ref(-1);
 
 function mounted() {
   cldrVettingParticipation.viewMounted(setData);
@@ -47,14 +48,11 @@ function setData(data) {
   if (data.status) {
     status.value = data.status;
   }
-  if (data.tableHeader) {
+  if (data.tableHeader && data.tableBody && data.tableComments) {
     tableHeader = reactive(data.tableHeader);
-  }
-  if (data.tableBody) {
     tableBody = reactive(data.tableBody);
-  }
-  if (data.tableComments) {
     tableComments = reactive(data.tableComments);
+    accountColumnIndex.value = data.accountColumnIndex;
   }
 }
 
@@ -69,6 +67,10 @@ function progressBarStatus() {
   } else {
     return "normal";
   }
+}
+
+function accountRecentActivityLink(cell) {
+  return "#recent_activity///" + cell;
 }
 
 function saveAsSheet() {
@@ -111,8 +113,15 @@ defineExpose({
         </thead>
         <tbody>
           <tr v-for="row of tableBody" :key="row">
-            <td v-for="cell of row" :key="cell">
-              {{ cell }}
+            <td v-for="(cell, index) of row" :key="cell">
+              <div v-if="accountColumnIndex == index">
+                <a-tooltip title="Show recent activity ↗">
+                  <a :href="accountRecentActivityLink(cell)" target="_blank">{{ cell }}</a>
+                </a-tooltip>
+              </div>
+              <div v-else>
+                {{ cell }}
+              </div>
             </td>
           </tr>
         </tbody>

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/UserRegistry.java
@@ -1834,6 +1834,10 @@ public class UserRegistry {
         return (u != null) && u.getLevel().isManagerOrStronger();
     }
 
+    public static boolean userIsExactlyVetter(User u) {
+        return (u != null) && u.getLevel().isExactlyVetter();
+    }
+
     public static boolean userIsVetterOrStronger(User u) {
         return (u != null) && u.getLevel().isVetterOrStronger();
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VoteResolver.java
@@ -356,6 +356,10 @@ public class VoteResolver<T> {
             return stlevel <= manager.stlevel;
         }
 
+        public boolean isExactlyVetter() {
+            return stlevel == vetter.stlevel;
+        }
+
         public boolean isVetterOrStronger() {
             return stlevel <= vetter.stlevel;
         }


### PR DESCRIPTION
-Replace two columns EMP and MP by three columns Error, Missing, Provisional

-List only Vetters, not Guests/etc

-Use the authorized locale set (not the interest locale set) for each user; however, if a user has ALL LOCALES, skip that user unless their organization has just one locale, in which case use that locale

-Tell the time (in minutes) it took to wait for the first http response, and the time it took to finish after the wait ended

-Make user account number into a clickable link for Recent Activity, which opens in a separate window

CLDR-18610

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
