### PR TITLE
CLDR-18591 Restore CLDRFile API for unicodetools

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRFile.java
@@ -3338,4 +3338,36 @@ public class CLDRFile implements Freezable<CLDRFile>, Iterable<String>, LocaleSt
         }
         return value;
     }
+
+    // The following deprecated constants and methods are implemented only for backward
+    // compatibility with https://github.com/unicode-org/unicodetools
+
+    @Deprecated public static final int LANGUAGE_NAME = 0, SCRIPT_NAME = 1, TERRITORY_NAME = 2;
+
+    @Deprecated
+    public String getName(int type, String code) {
+        switch (type) {
+            case LANGUAGE_NAME:
+                return nameGetter.getNameFromTypeEnumCode(NameType.LANGUAGE, code);
+            case SCRIPT_NAME:
+                return nameGetter.getNameFromTypeEnumCode(NameType.SCRIPT, code);
+            case TERRITORY_NAME:
+                return nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, code);
+            default:
+                throw new IllegalArgumentException("Unrecognized type");
+        }
+    }
+
+    @Deprecated
+    public String getName(String code) {
+        return nameGetter.getNameFromIdentifier(code);
+    }
+
+    @Deprecated
+    public String getName(String type, String code) {
+        if (!type.equals("territory")) {
+            throw new IllegalArgumentException("First argument should be territory");
+        }
+        return nameGetter.getNameFromTypeEnumCode(NameType.TERRITORY, code);
+    }
 }


### PR DESCRIPTION
-Restore three methods and three constants, only for backward compatibility

-Based on inspection only, these appear to be the only getName codes and methods currently needed by unicodetools, but testing may prove that more are needed

CLDR-18591

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
