### PR TITLE
CLDR-11586 change fraction digits to 0 for COP,HUF,IDR,PKR; cashRounding to 5 for HUF

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -22,7 +22,7 @@ For terms of use, see https://www.unicode.org/copyright.html
             <info iso4217="CHF" digits="2" rounding="0" cashRounding="5"/>
             <info iso4217="CLF" digits="4" rounding="0"/>
             <info iso4217="CLP" digits="0" rounding="0"/>
-            <info iso4217="COP" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
+            <info iso4217="COP" digits="0" rounding="0"/>
             <info iso4217="CRC" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
             <info iso4217="CZK" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
             <info iso4217="DEFAULT" digits="2" rounding="0"/>
@@ -31,8 +31,8 @@ For terms of use, see https://www.unicode.org/copyright.html
             <info iso4217="ESP" digits="0" rounding="0"/>
             <info iso4217="GNF" digits="0" rounding="0"/>
             <info iso4217="GYD" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
-            <info iso4217="HUF" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
-            <info iso4217="IDR" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
+            <info iso4217="HUF" digits="0" rounding="0" cashRounding="5"/>
+            <info iso4217="IDR" digits="0" rounding="0"/>
             <info iso4217="IQD" digits="0" rounding="0"/>
             <info iso4217="IRR" digits="0" rounding="0"/>
             <info iso4217="ISK" digits="0" rounding="0"/>
@@ -55,7 +55,7 @@ For terms of use, see https://www.unicode.org/copyright.html
             <info iso4217="MUR" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
             <info iso4217="NOK" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
             <info iso4217="OMR" digits="3" rounding="0"/>
-            <info iso4217="PKR" digits="2" rounding="0" cashDigits="0" cashRounding="0"/>
+            <info iso4217="PKR" digits="0" rounding="0"/>
             <info iso4217="PYG" digits="0" rounding="0"/>
             <info iso4217="RSD" digits="0" rounding="0"/>
             <info iso4217="RWF" digits="0" rounding="0"/>


### PR DESCRIPTION
CLDR-11586

- [x] This PR completes the ticket.

Change fraction digits to 0 for COP, HUF, IDR, PKR; also cashRounding to 5 for HUF.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-11586)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
