### PR TITLE
CLDR-18840 Regenerate currency formats

### DIFF
--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -3384,16 +3384,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="unconfirmed">Гаиана</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">Ҳаваи-алеуттәи астандартә аамҭа</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">Ҳаваи-алеуттәи аамҭа</generic>
 					<standard draft="unconfirmed">Ҳаваи-алеуттәи астандартә аамҭа</standard>
 					<daylight draft="unconfirmed">Ҳаваи-алеуттәи аԥхынтәи аамҭа</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">Ҳаваи-алеуттәи астандартә аамҭа</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3965,9 +3965,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -4311,16 +4311,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guiana-tyd</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleoete-standaardtyd</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleoete-tyd</generic>
 					<standard>Hawaii-Aleoete-standaardtyd</standard>
 					<daylight>Hawaii-Aleoete-dagligtyd</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleoete-standaardtyd</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4950,53 +4950,53 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 k</pattern>
 					<pattern type="1000" count="other">¤0 k</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 k</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 k</pattern>
 					<pattern type="10000" count="other">¤00 k</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 k</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 k</pattern>
 					<pattern type="100000" count="other">¤000 k</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 k</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 m</pattern>
 					<pattern type="1000000" count="other">¤0 m</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 m</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 m</pattern>
 					<pattern type="10000000" count="other">¤00 m</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 m</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 m</pattern>
 					<pattern type="100000000" count="other">¤000 m</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 m</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 mjd</pattern>
 					<pattern type="1000000000" count="other">¤0 mjd</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 mjd</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 mjd</pattern>
 					<pattern type="10000000000" count="other">¤00 mjd</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 mjd</pattern>
 					<pattern type="100000000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 mjd</pattern>
 					<pattern type="100000000000" count="other">¤000 mjd</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 mjd</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 bn</pattern>
 					<pattern type="1000000000000" count="other">¤0 bn</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 bn</pattern>
 					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 bn</pattern>
 					<pattern type="10000000000000" count="other">¤00 bn</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 bn</pattern>
 					<pattern type="100000000000000" count="one">¤000 bn</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 bn</pattern>
 					<pattern type="100000000000000" count="other">¤000 bn</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 bn</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -3813,16 +3813,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Gayana Berɛ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutian Susudua Berɛ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutian Berɛ</generic>
 					<standard>Hawaii-Aleutian Susudua Berɛ</standard>
 					<daylight>Hawaii-Aleutian Awia Berɛ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutian Susudua Berɛ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4444,13 +4444,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000" count="other">¤00K</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="100000" count="other">¤000K</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="other">¤0M</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="other">¤00M</pattern>
@@ -4459,12 +4459,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000" count="one">¤0G</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000000000" count="other">¤0G</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="10000000000" count="one">¤00G</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00G</pattern>
 					<pattern type="10000000000" count="other">¤00G</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00G</pattern>
 					<pattern type="100000000000" count="one">↑↑↑</pattern>

--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -4460,9 +4460,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="other">¤000M</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="1000000000" count="one">¤0G</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0G</pattern>
 					<pattern type="1000000000" count="other">¤0G</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0G</pattern>
 					<pattern type="10000000000" count="one">¤00G</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00G</pattern>
 					<pattern type="10000000000" count="other">¤00G</pattern>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -5309,16 +5309,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>የጉያና ሰዓት</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>የሃዋይ አሌኡት መደበኛ ሰዓት አቆጣጠር</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>የሃዋይ አሌኡት ሰዓት አቆጣጠር</generic>
 					<standard>የሃዋይ አሌኡት መደበኛ ሰዓት አቆጣጠር</standard>
 					<daylight>የሃዋይ አሌኡት የቀን ሰዓት አቆጣጠር</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>የሃዋይ አሌኡት መደበኛ ሰዓት አቆጣጠር</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/an.xml
+++ b/common/main/an.xml
@@ -1400,9 +1400,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="unconfirmed">{0} {1}</unitPattern>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -5576,16 +5576,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>توقيت غيانا</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>توقيت هاواي ألوتيان الرسمي</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>توقيت هاواي ألوتيان</generic>
 					<standard>توقيت هاواي ألوتيان الرسمي</standard>
 					<daylight>توقيت هاواي ألوتيان الصيفي</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>توقيت هاواي ألوتيان الرسمي</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6401,7 +6401,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="noCurrency">؜#,##0.00;(؜#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6409,161 +6413,161 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="contributed">‏#,##0.00;‏-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>؜#,##0.00¤;(؜#,##0.00¤)</pattern>
 					<pattern alt="alphaNextToNumber">؜#,##0.00 ¤;(؜#,##0.00 ¤)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="noCurrency">؜#,##0.00;(؜#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="zero">↑↑↑</pattern>
-					<pattern type="1000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000" count="two">↑↑↑</pattern>
-					<pattern type="1000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000" count="few">↑↑↑</pattern>
-					<pattern type="1000" count="few" alt="alphaNextToNumber">0 آلاف ¤</pattern>
-					<pattern type="1000" count="many">↑↑↑</pattern>
-					<pattern type="1000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000" count="other">0 ألف ¤</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000" count="zero">↑↑↑</pattern>
-					<pattern type="10000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000" count="two">↑↑↑</pattern>
-					<pattern type="10000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000" count="few">↑↑↑</pattern>
-					<pattern type="10000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000" count="many">↑↑↑</pattern>
-					<pattern type="10000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000" count="other">00 ألف ¤</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000" count="zero">↑↑↑</pattern>
-					<pattern type="100000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000" count="two">↑↑↑</pattern>
-					<pattern type="100000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000" count="few">↑↑↑</pattern>
-					<pattern type="100000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000" count="many">↑↑↑</pattern>
-					<pattern type="100000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 ألف ¤</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000" count="zero">↑↑↑</pattern>
-					<pattern type="1000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 مليون ¤</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000" count="zero">↑↑↑</pattern>
-					<pattern type="10000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 مليون ¤</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000" count="zero">↑↑↑</pattern>
-					<pattern type="100000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 مليون ¤</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000" count="zero">↑↑↑</pattern>
-					<pattern type="1000000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0 مليار ¤</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000" count="zero">↑↑↑</pattern>
-					<pattern type="10000000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 مليار ¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000" count="zero">↑↑↑</pattern>
-					<pattern type="100000000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 مليار ¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="zero">↑↑↑</pattern>
-					<pattern type="1000000000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 ترليون ¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="zero">↑↑↑</pattern>
-					<pattern type="10000000000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 ترليون ¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="zero">↑↑↑</pattern>
-					<pattern type="100000000000000" count="zero" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000000" count="two" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000000000" count="few" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000000" count="many" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 ترليون ¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern type="1000" count="zero">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="zero" alt="alphaNextToNumber">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="one">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="two">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="two" alt="alphaNextToNumber">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="few">‏0 آلاف ¤</pattern>
+					<pattern type="1000" count="few" alt="alphaNextToNumber">‏0 آلاف ¤</pattern>
+					<pattern type="1000" count="many">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="many" alt="alphaNextToNumber">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="other">‏0 ألف ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">‏0 ألف ¤</pattern>
+					<pattern type="10000" count="zero">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="zero" alt="alphaNextToNumber">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="one">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="two">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="two" alt="alphaNextToNumber">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="few">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="few" alt="alphaNextToNumber">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="many">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="many" alt="alphaNextToNumber">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="other">‏00 ألف ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">‏00 ألف ¤</pattern>
+					<pattern type="100000" count="zero">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="zero" alt="alphaNextToNumber">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="one">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="two">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="two" alt="alphaNextToNumber">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="few">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="few" alt="alphaNextToNumber">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="many">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="many" alt="alphaNextToNumber">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="other">‏000 ألف ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">‏000 ألف ¤</pattern>
+					<pattern type="1000000" count="zero">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="zero" alt="alphaNextToNumber">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="one">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="two">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="two" alt="alphaNextToNumber">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="few">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="few" alt="alphaNextToNumber">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="many">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="many" alt="alphaNextToNumber">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="other">‏0 مليون ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">‏0 مليون ¤</pattern>
+					<pattern type="10000000" count="zero">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="zero" alt="alphaNextToNumber">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="one">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="two">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="two" alt="alphaNextToNumber">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="few">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="few" alt="alphaNextToNumber">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="many">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="many" alt="alphaNextToNumber">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="other">‏00 مليون ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">‏00 مليون ¤</pattern>
+					<pattern type="100000000" count="zero">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="zero" alt="alphaNextToNumber">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="one">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="two">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="two" alt="alphaNextToNumber">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="few">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="few" alt="alphaNextToNumber">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="many">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="many" alt="alphaNextToNumber">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="other">‏000 مليون ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">‏000 مليون ¤</pattern>
+					<pattern type="1000000000" count="zero">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="zero" alt="alphaNextToNumber">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="one">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="two">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="two" alt="alphaNextToNumber">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="few">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="few" alt="alphaNextToNumber">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="many">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="many" alt="alphaNextToNumber">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="other">‏0 مليار ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">‏0 مليار ¤</pattern>
+					<pattern type="10000000000" count="zero">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="zero" alt="alphaNextToNumber">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="one">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="two">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="two" alt="alphaNextToNumber">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="few">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="few" alt="alphaNextToNumber">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="many">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="many" alt="alphaNextToNumber">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="other">‏00 مليار ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">‏00 مليار ¤</pattern>
+					<pattern type="100000000000" count="zero">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="zero" alt="alphaNextToNumber">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="one">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="two">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="two" alt="alphaNextToNumber">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="few">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="few" alt="alphaNextToNumber">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="many">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="many" alt="alphaNextToNumber">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="other">‏000 مليار ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">‏000 مليار ¤</pattern>
+					<pattern type="1000000000000" count="zero">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="zero" alt="alphaNextToNumber">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="one">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="two">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="two" alt="alphaNextToNumber">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="few">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="few" alt="alphaNextToNumber">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="many">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="many" alt="alphaNextToNumber">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="other">‏0 ترليون ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">‏0 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="zero">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="zero" alt="alphaNextToNumber">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="one">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="two">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="two" alt="alphaNextToNumber">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="few">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="few" alt="alphaNextToNumber">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="many">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="many" alt="alphaNextToNumber">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="other">‏00 ترليون ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">‏00 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="zero">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="zero" alt="alphaNextToNumber">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="one">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="two">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="two" alt="alphaNextToNumber">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="few">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="few" alt="alphaNextToNumber">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="many">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="many" alt="alphaNextToNumber">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="other">‏000 ترليون ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">‏000 ترليون ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/ar_SA.xml
+++ b/common/main/ar_SA.xml
@@ -1454,9 +1454,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‏#,##0.00 ¤;‏-#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="noCurrency">؜#,##0.00;(؜#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="zero">↑↑↑</unitPattern>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -4236,16 +4236,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>গায়ানাৰ সময়</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>হাৱাই-এলিউশ্বনৰ মান সময়</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>হাৱাই-এলিউশ্বনৰ সময়</generic>
 					<standard>হাৱাই-এলিউশ্বনৰ মান সময়</standard>
 					<daylight>হাৱাই-এলিউশ্বনৰ ডেলাইট সময়</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>হাৱাই-এলিউশ্বনৰ মান সময়</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4892,7 +4892,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4900,12 +4904,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -4915,26 +4919,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000" count="other">¤ 0 হাজাৰ</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
 					<pattern type="10000" count="other">¤ 00 হাজাৰ</pattern>
-					<pattern type="100000" count="one">¤ 000 হাজাৰ</pattern>
-					<pattern type="100000" count="other">¤ 000 হাজাৰ</pattern>
+					<pattern type="100000" count="one">¤ 0 লাখ</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 0 লাখ</pattern>
+					<pattern type="100000" count="other">¤ 0 লাখ</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0 লাখ</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="other">¤ 0 নিযুত</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000" count="other">¤ 00 নিযুত</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">¤ 000 নিযুত</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤ 0 শত কোটি</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤ 00 শত কোটি</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ 000 শত কোটি</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">¤ 0 শত পৰাৰ্দ্ধ</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">¤ 00 শত পৰাৰ্দ্ধ</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ 000 শত পৰাৰ্দ্ধ</pattern>
+					<pattern type="100000000" count="one">¤ 0 নিঃ</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 0 নিঃ</pattern>
+					<pattern type="100000000" count="other">¤ 0 নিঃ</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 0 নিঃ</pattern>
+					<pattern type="1000000000" count="one">¤ 0 শঃ কোঃ</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 শঃ কোঃ</pattern>
+					<pattern type="1000000000" count="other">¤ 0 শঃ কোঃ</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 শঃ কোঃ</pattern>
+					<pattern type="10000000000" count="one">¤ 00 শঃ কোঃ</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 শঃ কোঃ</pattern>
+					<pattern type="10000000000" count="other">¤ 00 শঃ কোঃ</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 শঃ কোঃ</pattern>
+					<pattern type="100000000000" count="one">¤ 000 শঃ কঃ</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 শঃ কঃ</pattern>
+					<pattern type="100000000000" count="other">¤ 000 শঃ কঃ</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 শঃ কঃ</pattern>
+					<pattern type="1000000000000" count="one">¤ 0 শঃ পঃ</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 শঃ পঃ</pattern>
+					<pattern type="1000000000000" count="other">¤ 0 শঃ পঃ</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 শঃ পঃ</pattern>
+					<pattern type="10000000000000" count="one">¤ 00 শঃ পঃ</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 শঃ পঃ</pattern>
+					<pattern type="10000000000000" count="other">¤ 00 শঃ পঃ</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 শঃ পঃ</pattern>
+					<pattern type="100000000000000" count="one">¤ 000 শঃ পঃ</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 শঃ পঃ</pattern>
+					<pattern type="100000000000000" count="other">¤ 000 শঃ পঃ</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 শঃ পঃ</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/asa.xml
+++ b/common/main/asa.xml
@@ -595,7 +595,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -6510,6 +6510,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Hora de La Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hora estándar de Hawaii-Aleutianes</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hora de Hawaii-Aleutianes</generic>
@@ -6521,11 +6526,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
 				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hora estándar de Hawaii-Aleutianes</standard>
-				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>
@@ -7191,10 +7191,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -4662,16 +4662,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Qayana Vaxtı</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havay-Aleut Standart Vaxtı</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havay-Aleut Vaxtı</generic>
 					<standard>Havay-Aleut Standart Vaxtı</standard>
 					<daylight>Havay-Aleut Yay Vaxtı</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havay-Aleut Standart Vaxtı</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5377,7 +5377,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5385,13 +5390,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -5402,24 +5407,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="10000" count="other">00K ¤</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
 					<pattern type="100000" count="other">000K ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0M ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00M ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000M ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0G ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00G ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000G ¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0T ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00T ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000T ¤</pattern>
+					<pattern type="1000000" count="one">0 mln ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 mln ¤</pattern>
+					<pattern type="1000000" count="other">0 mln ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 mln ¤</pattern>
+					<pattern type="10000000" count="one">00 mln ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 mln ¤</pattern>
+					<pattern type="10000000" count="other">00 mln ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 mln ¤</pattern>
+					<pattern type="100000000" count="one">000 mln ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 mln ¤</pattern>
+					<pattern type="100000000" count="other">000 mln ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 mln ¤</pattern>
+					<pattern type="1000000000" count="one">0 mlrd ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0 mlrd ¤</pattern>
+					<pattern type="1000000000" count="other">0 mlrd ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 mlrd ¤</pattern>
+					<pattern type="10000000000" count="one">00 mlrd ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 mlrd ¤</pattern>
+					<pattern type="10000000000" count="other">00 mlrd ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 mlrd ¤</pattern>
+					<pattern type="100000000000" count="one">000 mlrd ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 mlrd ¤</pattern>
+					<pattern type="100000000000" count="other">000 mlrd ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 mlrd ¤</pattern>
+					<pattern type="1000000000000" count="one">0 trln ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 trln ¤</pattern>
+					<pattern type="1000000000000" count="other">0 trln ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 trln ¤</pattern>
+					<pattern type="10000000000000" count="one">00 trln ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 trln ¤</pattern>
+					<pattern type="10000000000000" count="other">00 trln ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 trln ¤</pattern>
+					<pattern type="100000000000000" count="one">000 trln ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 trln ¤</pattern>
+					<pattern type="100000000000000" count="other">000 trln ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 trln ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/az_Cyrl.xml
+++ b/common/main/az_Cyrl.xml
@@ -1216,10 +1216,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ba.xml
+++ b/common/main/ba.xml
@@ -5118,16 +5118,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Гайана ваҡыты</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавай-Алеут стандарт ваҡыты</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавай-Алеут ваҡыты</generic>
 					<standard>Гавай-Алеут стандарт ваҡыты</standard>
 					<daylight>Гавай-Алеут йәйге ваҡыты</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавай-Алеут стандарт ваҡыты</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -8002,11 +8002,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>#,##0.00 ¤;(¤#,##0.00 ¤)</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
@@ -8034,11 +8034,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
-					<pattern>#,##0.00 ¤;(¤#,##0.00 ¤)</pattern>
+					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
@@ -8078,7 +8078,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8110,7 +8110,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8142,7 +8142,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8174,7 +8174,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8206,7 +8206,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8238,7 +8238,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8270,7 +8270,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8302,7 +8302,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8334,7 +8334,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8366,7 +8366,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8398,7 +8398,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8430,7 +8430,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8462,7 +8462,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8494,7 +8494,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8526,7 +8526,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8558,7 +8558,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8590,7 +8590,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8622,7 +8622,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8654,7 +8654,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8686,7 +8686,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8718,7 +8718,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8750,7 +8750,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8782,7 +8782,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8814,7 +8814,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8846,7 +8846,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8877,7 +8877,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8908,7 +8908,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8940,7 +8940,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -8972,12 +8972,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -9004,7 +9004,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9036,7 +9036,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9068,7 +9068,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9100,7 +9100,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9132,7 +9132,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9164,7 +9164,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9196,7 +9196,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9228,7 +9228,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9260,7 +9260,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9292,7 +9292,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9324,7 +9324,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9356,7 +9356,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9388,7 +9388,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9420,7 +9420,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9452,7 +9452,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9484,7 +9484,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9516,7 +9516,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9548,7 +9548,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9580,7 +9580,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9612,7 +9612,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9644,7 +9644,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9676,7 +9676,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9708,7 +9708,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9740,7 +9740,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9772,7 +9772,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9804,7 +9804,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9836,7 +9836,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9867,7 +9867,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="segment">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9898,7 +9898,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9930,7 +9930,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9961,7 +9961,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="sinh">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -9992,7 +9992,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10023,7 +10023,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10054,7 +10054,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="sunu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10085,7 +10085,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10117,7 +10117,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10148,7 +10148,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10179,7 +10179,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10210,7 +10210,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10241,7 +10241,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10272,7 +10272,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="tirh">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10303,7 +10303,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="tnsa">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10334,7 +10334,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10365,7 +10365,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="wara">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -10396,7 +10396,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<currencyFormats numberSystem="wcho">
 			<currencyFormatLength>
 				<currencyFormat type="standard">
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">

--- a/common/main/bal.xml
+++ b/common/main/bal.xml
@@ -415,16 +415,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>گرین‌وِچ مین ٹائم</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="provisional">هئواییئے گیشّتگێن ساهت</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="provisional">هئواییئے ساهت</generic>
 					<standard draft="provisional">هئواییئے گیشّتگێن ساهت</standard>
 					<daylight draft="provisional">هئواییئے گرماگی ساهت</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="provisional">هئواییئے گیشّتگێن ساهت</standard>
 				</long>
 			</metazone>
 			<metazone type="Indonesia_Central">

--- a/common/main/bal_Latn.xml
+++ b/common/main/bal_Latn.xml
@@ -5114,16 +5114,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyánáay wahd</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawái/Alushiay anjári wahd</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawái/Alushiay wahd</generic>
 					<standard>Hawái/Alushiay anjári wahd</standard>
 					<daylight>Hawái/Alushiay garmági wahd</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawái/Alushiay anjári wahd</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/bas.xml
+++ b/common/main/bas.xml
@@ -611,7 +611,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -4630,16 +4630,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Час Гаяны</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавайска-Алеуцкі стандартны час</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавайска-Алеуцкі час</generic>
 					<standard>Гавайска-Алеуцкі стандартны час</standard>
 					<daylight>Гавайска-Алеуцкі летні час</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавайска-Алеуцкі стандартны час</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5290,12 +5290,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/be_TARASK.xml
+++ b/common/main/be_TARASK.xml
@@ -4192,16 +4192,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="provisional">↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="provisional">Гавайска-Алэвуцкі змоўчны час</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="provisional">Гавайска-Алевуцкі час</generic>
 					<standard draft="provisional">Гавайска-Алэвуцкі змоўчны час</standard>
 					<daylight draft="provisional">Гавайска-Алевуцкі летні час</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="provisional">Гавайска-Алэвуцкі змоўчны час</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4836,9 +4836,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="provisional">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="provisional">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -4303,16 +4303,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">Waktu Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">Waktu Pakem Hawai-Aléut</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">Waktu Hawai-Aléut</generic>
 					<standard draft="unconfirmed">Waktu Pakem Hawai-Aléut</standard>
 					<daylight draft="unconfirmed">Waktu Musim Pentèr Hawai-Aléut</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">Waktu Pakem Hawai-Aléut</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -4618,16 +4618,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Гаяна</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Хавайско-алеутско стандартно време</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Хавайско-алеутско време</generic>
 					<standard>Хавайско-алеутско стандартно време</standard>
 					<daylight>Хавайско-алеутско лятно часово време</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Хавайско-алеутско стандартно време</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5245,12 +5245,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency">0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -3489,16 +3489,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyanaa kaakɔŋkɔŋɔ̀</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Awayɩɩ n’Alewutii kaakɔŋkɔŋɔ̀ ɖeiɖei</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Awayɩɩ n’Alewutii kaakɔŋkɔŋɔ̀</generic>
 					<standard>Awayɩɩ n’Alewutii kaakɔŋkɔŋɔ̀ ɖeiɖei</standard>
 					<daylight>Awayɩɩ n’Alewutii kaakɔŋkɔŋɔ̀ gafʊbaka</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Awayɩɩ n’Alewutii kaakɔŋkɔŋɔ̀ ɖeiɖei</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4136,13 +4136,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/bm_Nkoo.xml
+++ b/common/main/bm_Nkoo.xml
@@ -168,6 +168,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -5613,16 +5613,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>গুয়ানা সময়</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>হাওয়াই-আলেউত মানক সময়</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>হাওয়াই-আলেউত সময়</generic>
 					<standard>হাওয়াই-আলেউত মানক সময়</standard>
 					<daylight>হাওয়াই-আলেউত দিবালোক সময়</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>হাওয়াই-আলেউত মানক সময়</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6363,14 +6363,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">000 কো ¤</pattern>
 					<pattern type="1000000000" count="other">000 কো¤</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">000 কো ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">0000 কো ¤</pattern>
-					<pattern type="10000000000" count="other">0000 কো¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">0000 কো ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">00000 কো ¤</pattern>
-					<pattern type="100000000000" count="other">00000 কো¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">00000 কো ¤</pattern>
+					<pattern type="10000000000" count="one">0 শত কো¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">0 শত কো ¤</pattern>
+					<pattern type="10000000000" count="other">0শত কো¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">0শত কো ¤</pattern>
+					<pattern type="100000000000" count="one">0কো¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">0কো ¤</pattern>
+					<pattern type="100000000000" count="other">0কো¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">0কো ¤</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 লা'.'কো'.' ¤</pattern>
 					<pattern type="1000000000000" count="other">0 লা'.'কো'.'¤</pattern>

--- a/common/main/bn_IN.xml
+++ b/common/main/bn_IN.xml
@@ -663,6 +663,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##,##0.00;(¤#,##,##0.00)</pattern>

--- a/common/main/bqi.xml
+++ b/common/main/bqi.xml
@@ -406,6 +406,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">‎#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">‎#,##0.00;‎(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -413,13 +419,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">‎¤ #,##0.00</pattern>
-					<pattern alt="alphaNextToNumber" draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">‎#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">‎¤ #,##0.00;‎(¤ #,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber" draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">‎#,##0.00;‎(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -8840,16 +8840,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>eur Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>eur cʼhoañv Hawaii hag an Aleouted</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>eur Hawaii hag an Aleouted</generic>
 					<standard>eur cʼhoañv Hawaii hag an Aleouted</standard>
 					<daylight>eur hañv Hawaii hag an Aleouted</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>eur cʼhoañv Hawaii hag an Aleouted</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -9747,9 +9747,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -9769,137 +9771,137 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber" draft="provisional">0 k ¤</pattern>
-					<pattern type="1000" count="two">↑↑↑</pattern>
-					<pattern type="1000" count="two" alt="alphaNextToNumber" draft="provisional">0 k ¤</pattern>
-					<pattern type="1000" count="few">↑↑↑</pattern>
-					<pattern type="1000" count="few" alt="alphaNextToNumber" draft="provisional">0 k ¤</pattern>
-					<pattern type="1000" count="many">↑↑↑</pattern>
-					<pattern type="1000" count="many" alt="alphaNextToNumber" draft="provisional">0 k ¤</pattern>
-					<pattern type="1000" count="other">0 k¤</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber" draft="provisional">0 k ¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber" draft="provisional">00 k ¤</pattern>
-					<pattern type="10000" count="two">↑↑↑</pattern>
-					<pattern type="10000" count="two" alt="alphaNextToNumber" draft="provisional">00 k ¤</pattern>
-					<pattern type="10000" count="few">↑↑↑</pattern>
-					<pattern type="10000" count="few" alt="alphaNextToNumber" draft="provisional">00 k ¤</pattern>
-					<pattern type="10000" count="many">↑↑↑</pattern>
-					<pattern type="10000" count="many" alt="alphaNextToNumber" draft="provisional">00 k ¤</pattern>
-					<pattern type="10000" count="other">00 k¤</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber" draft="provisional">00 k ¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber" draft="provisional">000 k ¤</pattern>
-					<pattern type="100000" count="two">↑↑↑</pattern>
-					<pattern type="100000" count="two" alt="alphaNextToNumber" draft="provisional">000 k ¤</pattern>
-					<pattern type="100000" count="few">↑↑↑</pattern>
-					<pattern type="100000" count="few" alt="alphaNextToNumber" draft="provisional">000 k ¤</pattern>
-					<pattern type="100000" count="many">↑↑↑</pattern>
-					<pattern type="100000" count="many" alt="alphaNextToNumber" draft="provisional">000 k ¤</pattern>
-					<pattern type="100000" count="other">000 k¤</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber" draft="provisional">000 k ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber" draft="provisional">0 M ¤</pattern>
-					<pattern type="1000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000" count="two" alt="alphaNextToNumber" draft="provisional">0 M ¤</pattern>
-					<pattern type="1000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000" count="few" alt="alphaNextToNumber" draft="provisional">0 M ¤</pattern>
-					<pattern type="1000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000" count="many" alt="alphaNextToNumber" draft="provisional">0 M ¤</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber" draft="provisional">0 M ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber" draft="provisional">00 M ¤</pattern>
-					<pattern type="10000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000" count="two" alt="alphaNextToNumber" draft="provisional">00 M ¤</pattern>
-					<pattern type="10000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000" count="few" alt="alphaNextToNumber" draft="provisional">00 M ¤</pattern>
-					<pattern type="10000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000" count="many" alt="alphaNextToNumber" draft="provisional">00 M ¤</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber" draft="provisional">00 M ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber" draft="provisional">000 M ¤</pattern>
-					<pattern type="100000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000" count="two" alt="alphaNextToNumber" draft="provisional">000 M ¤</pattern>
-					<pattern type="100000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000" count="few" alt="alphaNextToNumber" draft="provisional">000 M ¤</pattern>
-					<pattern type="100000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000" count="many" alt="alphaNextToNumber" draft="provisional">000 M ¤</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber" draft="provisional">000 M ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber" draft="provisional">0 G ¤</pattern>
-					<pattern type="1000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000" count="two" alt="alphaNextToNumber" draft="provisional">0 G ¤</pattern>
-					<pattern type="1000000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000000" count="few" alt="alphaNextToNumber" draft="provisional">0 G ¤</pattern>
-					<pattern type="1000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000" count="many" alt="alphaNextToNumber" draft="provisional">0 G ¤</pattern>
-					<pattern type="1000000000" count="other">0 G¤</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber" draft="provisional">0 G ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber" draft="provisional">00 G ¤</pattern>
-					<pattern type="10000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000" count="two" alt="alphaNextToNumber" draft="provisional">00 G ¤</pattern>
-					<pattern type="10000000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000000" count="few" alt="alphaNextToNumber" draft="provisional">00 G ¤</pattern>
-					<pattern type="10000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000" count="many" alt="alphaNextToNumber" draft="provisional">00 G ¤</pattern>
-					<pattern type="10000000000" count="other">00 G¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber" draft="provisional">00 G ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber" draft="provisional">000 G ¤</pattern>
-					<pattern type="100000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000" count="two" alt="alphaNextToNumber" draft="provisional">000 G ¤</pattern>
-					<pattern type="100000000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000000" count="few" alt="alphaNextToNumber" draft="provisional">000 G ¤</pattern>
-					<pattern type="100000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000" count="many" alt="alphaNextToNumber" draft="provisional">000 G ¤</pattern>
-					<pattern type="100000000000" count="other">000 G¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber" draft="provisional">000 G ¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber" draft="provisional">0 T ¤</pattern>
-					<pattern type="1000000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000000" count="two" alt="alphaNextToNumber" draft="provisional">0 T ¤</pattern>
-					<pattern type="1000000000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000000000" count="few" alt="alphaNextToNumber" draft="provisional">0 T ¤</pattern>
-					<pattern type="1000000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000000" count="many" alt="alphaNextToNumber" draft="provisional">0 T ¤</pattern>
-					<pattern type="1000000000000" count="other">0 T¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber" draft="provisional">0 T ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber" draft="provisional">00 T ¤</pattern>
-					<pattern type="10000000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000000" count="two" alt="alphaNextToNumber" draft="provisional">00 T ¤</pattern>
-					<pattern type="10000000000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000000000" count="few" alt="alphaNextToNumber" draft="provisional">00 T ¤</pattern>
-					<pattern type="10000000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000000" count="many" alt="alphaNextToNumber" draft="provisional">00 T ¤</pattern>
-					<pattern type="10000000000000" count="other">00 T¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber" draft="provisional">00 T ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber" draft="provisional">000 T ¤</pattern>
-					<pattern type="100000000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000000" count="two" alt="alphaNextToNumber" draft="provisional">000 T ¤</pattern>
-					<pattern type="100000000000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000000000" count="few" alt="alphaNextToNumber" draft="provisional">000 T ¤</pattern>
-					<pattern type="100000000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000000" count="many" alt="alphaNextToNumber" draft="provisional">000 T ¤</pattern>
-					<pattern type="100000000000000" count="other">000 T¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber" draft="provisional">000 T ¤</pattern>
+					<pattern type="1000" count="one">0k ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="two">0k ¤</pattern>
+					<pattern type="1000" count="two" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="few">0k ¤</pattern>
+					<pattern type="1000" count="few" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="many">0k ¤</pattern>
+					<pattern type="1000" count="many" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="other">0k ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="10000" count="one">00k ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="two">00k ¤</pattern>
+					<pattern type="10000" count="two" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="few">00k ¤</pattern>
+					<pattern type="10000" count="few" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="many">00k ¤</pattern>
+					<pattern type="10000" count="many" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="other">00k ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="100000" count="one">000k ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="two">000k ¤</pattern>
+					<pattern type="100000" count="two" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="few">000k ¤</pattern>
+					<pattern type="100000" count="few" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="many">000k ¤</pattern>
+					<pattern type="100000" count="many" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="other">000k ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="1000000" count="one">0M ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="1000000" count="two">0M ¤</pattern>
+					<pattern type="1000000" count="two" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="1000000" count="few">0M ¤</pattern>
+					<pattern type="1000000" count="few" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="1000000" count="many">0M ¤</pattern>
+					<pattern type="1000000" count="many" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="1000000" count="other">0M ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="10000000" count="one">00M ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="10000000" count="two">00M ¤</pattern>
+					<pattern type="10000000" count="two" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="10000000" count="few">00M ¤</pattern>
+					<pattern type="10000000" count="few" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="10000000" count="many">00M ¤</pattern>
+					<pattern type="10000000" count="many" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="10000000" count="other">00M ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="100000000" count="one">000M ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="100000000" count="two">000M ¤</pattern>
+					<pattern type="100000000" count="two" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="100000000" count="few">000M ¤</pattern>
+					<pattern type="100000000" count="few" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="100000000" count="many">000M ¤</pattern>
+					<pattern type="100000000" count="many" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="100000000" count="other">000M ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="1000000000" count="one">0G ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="1000000000" count="two">0G ¤</pattern>
+					<pattern type="1000000000" count="two" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="1000000000" count="few">0G ¤</pattern>
+					<pattern type="1000000000" count="few" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="1000000000" count="many">0G ¤</pattern>
+					<pattern type="1000000000" count="many" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="1000000000" count="other">0G ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="10000000000" count="one">00G ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="10000000000" count="two">00G ¤</pattern>
+					<pattern type="10000000000" count="two" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="10000000000" count="few">00G ¤</pattern>
+					<pattern type="10000000000" count="few" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="10000000000" count="many">00G ¤</pattern>
+					<pattern type="10000000000" count="many" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="10000000000" count="other">00G ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="100000000000" count="one">000G ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="100000000000" count="two">000G ¤</pattern>
+					<pattern type="100000000000" count="two" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="100000000000" count="few">000G ¤</pattern>
+					<pattern type="100000000000" count="few" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="100000000000" count="many">000G ¤</pattern>
+					<pattern type="100000000000" count="many" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="100000000000" count="other">000G ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="1000000000000" count="one">0T ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="1000000000000" count="two">0T ¤</pattern>
+					<pattern type="1000000000000" count="two" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="1000000000000" count="few">0T ¤</pattern>
+					<pattern type="1000000000000" count="few" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="1000000000000" count="many">0T ¤</pattern>
+					<pattern type="1000000000000" count="many" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="1000000000000" count="other">0T ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="10000000000000" count="one">00T ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="10000000000000" count="two">00T ¤</pattern>
+					<pattern type="10000000000000" count="two" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="10000000000000" count="few">00T ¤</pattern>
+					<pattern type="10000000000000" count="few" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="10000000000000" count="many">00T ¤</pattern>
+					<pattern type="10000000000000" count="many" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="10000000000000" count="other">00T ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="100000000000000" count="one">000T ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000T ¤</pattern>
+					<pattern type="100000000000000" count="two">000T ¤</pattern>
+					<pattern type="100000000000000" count="two" alt="alphaNextToNumber">000T ¤</pattern>
+					<pattern type="100000000000000" count="few">000T ¤</pattern>
+					<pattern type="100000000000000" count="few" alt="alphaNextToNumber">000T ¤</pattern>
+					<pattern type="100000000000000" count="many">000T ¤</pattern>
+					<pattern type="100000000000000" count="many" alt="alphaNextToNumber">000T ¤</pattern>
+					<pattern type="100000000000000" count="other">000T ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one">{0} {1}</unitPattern>

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -4337,16 +4337,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>गुयाना सम</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हावाई-एल्युतियान थाखोआरि सम</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हावाई-एल्युतियान सम</generic>
 					<standard>हावाई-एल्युतियान थाखोआरि सम</standard>
 					<daylight>हावाई-एल्युतियान सानारि सम</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हावाई-एल्युतियान थाखोआरि सम</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5014,6 +5014,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5021,39 +5025,65 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">¤0K</pattern>
-					<pattern type="1000" count="other">¤0K</pattern>
-					<pattern type="10000" count="one">¤00K</pattern>
-					<pattern type="10000" count="other">¤00K</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">¤000K</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">¤0M</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">¤00M</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">¤000M</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">¤0T</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">¤00T</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="1000" count="one">¤ 0के</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0के</pattern>
+					<pattern type="1000" count="other">¤ 0के</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0के</pattern>
+					<pattern type="10000" count="one">¤ 00के</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00के</pattern>
+					<pattern type="10000" count="other">¤ 00के</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00के</pattern>
+					<pattern type="100000" count="one">¤ 000के</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000के</pattern>
+					<pattern type="100000" count="other">¤ 000के</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000के</pattern>
+					<pattern type="1000000" count="one">¤ 0एम</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0एम</pattern>
+					<pattern type="1000000" count="other">¤ 0एम</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0एम</pattern>
+					<pattern type="10000000" count="one">¤ 00एम</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00एम</pattern>
+					<pattern type="10000000" count="other">¤ 00एम</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00एम</pattern>
+					<pattern type="100000000" count="one">¤ 000एम</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000एम</pattern>
+					<pattern type="100000000" count="other">¤ 000एम</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000एम</pattern>
+					<pattern type="1000000000" count="one">¤ 0बि</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0बि</pattern>
+					<pattern type="1000000000" count="other">¤ 0बि</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0बि</pattern>
+					<pattern type="10000000000" count="one">¤ 00बि</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00बि</pattern>
+					<pattern type="10000000000" count="other">¤ 00बि</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00बि</pattern>
+					<pattern type="100000000000" count="one">¤ 000बि</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000बि</pattern>
+					<pattern type="100000000000" count="other">¤ 000बि</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000बि</pattern>
+					<pattern type="1000000000000" count="one">¤ 0ति</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0ति</pattern>
+					<pattern type="1000000000000" count="other">¤ 0ति</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0ति</pattern>
+					<pattern type="10000000000000" count="one">¤ 00ति</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00ति</pattern>
+					<pattern type="10000000000000" count="other">¤ 00ति</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00ति</pattern>
+					<pattern type="100000000000000" count="one">¤ 000ति</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000ति</pattern>
+					<pattern type="100000000000000" count="other">¤ 000ति</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000ति</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -10500,16 +10500,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Gvajansko vrijeme</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havajsko-aleućansko standardno vrijeme</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havajsko-aleućansko vrijeme</generic>
 					<standard>Havajsko-aleućansko standardno vrijeme</standard>
 					<daylight>Havajsko-aleućansko ljetno vrijeme</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havajsko-aleućansko standardno vrijeme</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -12817,10 +12817,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12845,10 +12847,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12861,10 +12865,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12877,10 +12883,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12893,10 +12901,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12909,10 +12919,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12925,10 +12937,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12941,10 +12955,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12957,10 +12973,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12973,10 +12991,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12989,10 +13009,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13005,10 +13027,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13021,10 +13045,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13037,10 +13063,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13053,10 +13081,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13069,10 +13099,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13085,10 +13117,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13101,10 +13135,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13117,10 +13153,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13133,10 +13171,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13149,10 +13189,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13165,12 +13207,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13223,10 +13265,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13239,10 +13283,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13255,10 +13301,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13271,10 +13319,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13287,10 +13337,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13303,10 +13355,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13319,10 +13373,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13335,10 +13391,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13351,10 +13409,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13367,10 +13427,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13383,10 +13445,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13399,10 +13463,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13415,10 +13481,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13431,10 +13499,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13447,10 +13517,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13463,10 +13535,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13479,10 +13553,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13495,10 +13571,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13511,10 +13589,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13527,10 +13607,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13543,10 +13625,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13559,10 +13643,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13575,10 +13661,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -5052,16 +5052,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Гвајана вријеме</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Хавајско-алеутско стандардно вријеме</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Хавајско-алеутско вријеме</generic>
 					<standard>Хавајско-алеутско стандардно вријеме</standard>
 					<daylight>Хавајско-алеутско љетње рачунање времена</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Хавајско-алеутско стандардно вријеме</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5727,10 +5727,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/bua.xml
+++ b/common/main/bua.xml
@@ -239,6 +239,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -5206,16 +5206,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Hora de Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hora estàndard de Hawaii-Aleutianes</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hora de Hawaii-Aleutianes</generic>
 					<standard>Hora estàndard de Hawaii-Aleutianes</standard>
 					<daylight>Hora d’estiu de Hawaii-Aleutianes</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hora estàndard de Hawaii-Aleutianes</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5860,6 +5860,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5867,41 +5871,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">0 k¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">00 k¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 k¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0000 M¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 kM¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 kM¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 B¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 B¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 B¤</pattern>
+					<pattern type="1000" count="one">0 k ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0 k ¤</pattern>
+					<pattern type="1000" count="other">0 k ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0 k ¤</pattern>
+					<pattern type="10000" count="one">00 k ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00 k ¤</pattern>
+					<pattern type="10000" count="other">00 k ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00 k ¤</pattern>
+					<pattern type="100000" count="one">000 k ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000 k ¤</pattern>
+					<pattern type="100000" count="other">000 k ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 k ¤</pattern>
+					<pattern type="1000000" count="one">0 M ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 M ¤</pattern>
+					<pattern type="1000000" count="other">0 M ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 M ¤</pattern>
+					<pattern type="10000000" count="one">00 M ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 M ¤</pattern>
+					<pattern type="10000000" count="other">00 M ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 M ¤</pattern>
+					<pattern type="100000000" count="one">000 M ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 M ¤</pattern>
+					<pattern type="100000000" count="other">000 M ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 M ¤</pattern>
+					<pattern type="1000000000" count="one">0000 M ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0000 M ¤</pattern>
+					<pattern type="1000000000" count="other">0000 M ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0000 M ¤</pattern>
+					<pattern type="10000000000" count="one">00 kM ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 kM ¤</pattern>
+					<pattern type="10000000000" count="other">00 kM ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 kM ¤</pattern>
+					<pattern type="100000000000" count="one">000 kM ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 kM ¤</pattern>
+					<pattern type="100000000000" count="other">000 kM ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 kM ¤</pattern>
+					<pattern type="1000000000000" count="one">0 B ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 B ¤</pattern>
+					<pattern type="1000000000000" count="other">0 B ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 B ¤</pattern>
+					<pattern type="10000000000000" count="one">00 B ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 B ¤</pattern>
+					<pattern type="10000000000000" count="other">00 B ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 B ¤</pattern>
+					<pattern type="100000000000000" count="one">000 B ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 B ¤</pattern>
+					<pattern type="100000000000000" count="other">000 B ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 B ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -4200,16 +4200,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>𑄉𑄪𑄠𑄚 𑄃𑄧𑄇𑄴𑄖𑄧</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>𑄦𑄧𑄃𑄮𑄠𑄭-𑄃𑄣𑄬𑄃𑄪𑄖𑄴 𑄟𑄚𑄧𑄇𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>𑄦𑄃𑄮𑄠𑄭 𑄃𑄳𑄠𑄣𑄨𑄃𑄪𑄑𑄨𑄠𑄚𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</generic>
 					<standard>𑄦𑄧𑄃𑄮𑄠𑄭-𑄃𑄣𑄬𑄃𑄪𑄖𑄴 𑄟𑄚𑄧𑄇𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</standard>
 					<daylight>𑄦𑄧𑄃𑄮𑄠𑄭-𑄃𑄣𑄬𑄃𑄪𑄖𑄴 𑄘𑄨𑄚𑄮𑄃𑄣𑄮𑄢𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>𑄦𑄧𑄃𑄮𑄠𑄭-𑄃𑄣𑄬𑄃𑄪𑄖𑄴 𑄟𑄚𑄧𑄇𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4830,6 +4830,22 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>#,##,##0.00¤;(#,##,##0.00¤)</pattern>
 					<pattern alt="alphaNextToNumber" draft="provisional">#,##,##0.00 ¤;(#,##,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##,##0.00;(#,##,##0.00)</pattern>
+				</currencyFormat>
+			</currencyFormatLength>
+			<currencyFormatLength type="short">
+				<currencyFormat type="standard">
+					<pattern type="1000000000" count="other">0G¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="10000000000" count="other">00G¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="100000000000" count="other">000G¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="1000000000000" count="other">0T¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="10000000000000" count="other">00T¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="100000000000000" count="other">000T¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one">{0} {1}</unitPattern>

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -3207,16 +3207,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Гайана</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавайн-алеутийн стандартан хан</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавайн-алеутийн хан</generic>
 					<standard>Гавайн-алеутийн стандартан хан</standard>
 					<daylight>Гавайн-алеутийн аьхкенан хан</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавайн-алеутийн стандартан хан</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3797,10 +3797,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -3010,16 +3010,16 @@ the LDML specification (http://unicode.org/reports/tr35/)
 					<standard>Oras sa Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutian Standard Time</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Oras sa Hawaii-Aleutian</generic>
 					<standard>Hawaii-Aleutian Standard Time</standard>
 					<daylight>Hawaii-Aleutian Daylight Time</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutian Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3627,29 +3627,53 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">¤0K</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="1000" count="other">¤0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="10000" count="one">¤00K</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00K</pattern>
 					<pattern type="10000" count="other">¤00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
 					<pattern type="100000" count="one">¤000K</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="100000" count="other">¤000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="1000000" count="one">¤0M</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="other">¤0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="10000000" count="one">¤00M</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="other">¤00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="one">¤000M</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="1000000000" count="one">¤0B</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="1000000000" count="other">¤0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="10000000000" count="one">¤00B</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="other">¤00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="100000000000" count="one">¤000B</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="other">¤000B</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="1000000000000" count="one">¤0T</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="one">¤00T</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="100000000000000" count="one">¤000T</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one">{0} {1}</unitPattern>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -4177,6 +4177,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>ᎦᏯᎾ ᎠᏟᎢᎵᏒ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ᎭᏩᏱ-ᎠᎵᏳᏏᎠᏂ ᎠᏟᎶᏍᏗ ᎠᏟᎢᎵᏒ</standard>
+				</long>
+				<short>
+					<standard>HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ᎭᏩᏱ-ᎠᎵᏳᏏᎠᏂ ᎠᏟᎢᎵᏒ</generic>
@@ -4187,14 +4195,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic>HAT</generic>
 					<standard>HAST</standard>
 					<daylight>HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ᎭᏩᏱ-ᎠᎵᏳᏏᎠᏂ ᎠᏟᎶᏍᏗ ᎠᏟᎢᎵᏒ</standard>
-				</long>
-				<short>
-					<standard>HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/co.xml
+++ b/common/main/co.xml
@@ -1381,10 +1381,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00) ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -1393,10 +1395,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">#,##0.00 ¤;(#,##0.00) ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00) ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/cop.xml
+++ b/common/main/cop.xml
@@ -3059,16 +3059,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ⲅⲩⲁⲛⲁ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ϩⲟⲣⲟⲥ ⲛ̀ϩⲁⲟⲩⲁⲓ-ⲁⲗⲉⲩⲑⲓⲁⲛ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ϩⲁⲟⲩⲁⲓ-ⲁⲗⲉⲩⲑⲓⲁⲛ</generic>
 					<standard draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ϩⲟⲣⲟⲥ ⲛ̀ϩⲁⲟⲩⲁⲓ-ⲁⲗⲉⲩⲑⲓⲁⲛ</standard>
 					<daylight draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ⲧⲟⲟⲩⲓ ⲛ̀ϩⲁⲟⲩⲁⲓ-ⲁⲗⲉⲩⲑⲓⲁⲛ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ϩⲟⲣⲟⲥ ⲛ̀ϩⲁⲟⲩⲁⲓ-ⲁⲗⲉⲩⲑⲓⲁⲛ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -9443,16 +9443,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>guyanský čas</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>havajsko-aleutský standardní čas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>havajsko-aleutský čas</generic>
 					<standard>havajsko-aleutský standardní čas</standard>
 					<daylight>havajsko-aleutský letní čas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>havajsko-aleutský standardní čas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/cu.xml
+++ b/common/main/cu.xml
@@ -896,6 +896,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -10583,6 +10583,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="contributed">GYT</standard>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавайи-Алеут стандартлӑ вӑхӑчӗ</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавайи-Алеут вӑхӑчӗ</generic>
@@ -10593,14 +10601,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">HST</generic>
 					<standard draft="contributed">HST</standard>
 					<daylight draft="contributed">HDT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавайи-Алеут стандартлӑ вӑхӑчӗ</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -14965,6 +14965,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -4762,16 +4762,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Amser Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Amser Safonol Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Amser Hawaii-Aleutian</generic>
 					<standard>Amser Safonol Hawaii-Aleutian</standard>
 					<daylight>Amser Haf Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Amser Safonol Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -4933,16 +4933,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyana-tid</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutian-normaltid</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutian-tid</generic>
 					<standard>Hawaii-Aleutian-normaltid</standard>
 					<daylight>Hawaii-Aleutian-sommertid</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutian-normaltid</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5591,12 +5591,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -5948,16 +5948,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyana-Zeit</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleuten-Normalzeit</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleuten-Zeit</generic>
 					<standard>Hawaii-Aleuten-Normalzeit</standard>
 					<daylight>Hawaii-Aleuten-Sommerzeit</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleuten-Normalzeit</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/de_AT.xml
+++ b/common/main/de_AT.xml
@@ -125,7 +125,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -4418,16 +4418,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5029,13 +5029,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤-#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -5049,45 +5049,45 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000" count="other">↑↑↑</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">0</pattern>
 					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">0</pattern>
+					<pattern type="1000000" count="one">¤ 0 Mio'.'</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 Mio'.'</pattern>
+					<pattern type="1000000" count="other">¤ 0 Mio'.'</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 Mio'.'</pattern>
+					<pattern type="10000000" count="one">¤ 00 Mio'.'</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 Mio'.'</pattern>
+					<pattern type="10000000" count="other">¤ 00 Mio'.'</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 Mio'.'</pattern>
+					<pattern type="100000000" count="one">¤ 000 Mio'.'</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 Mio'.'</pattern>
+					<pattern type="100000000" count="other">¤ 000 Mio'.'</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 Mio'.'</pattern>
+					<pattern type="1000000000" count="one">¤ 0 Mrd'.'</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 Mrd'.'</pattern>
+					<pattern type="1000000000" count="other">¤ 0 Mrd'.'</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 Mrd'.'</pattern>
+					<pattern type="10000000000" count="one">¤ 00 Mrd'.'</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 Mrd'.'</pattern>
+					<pattern type="10000000000" count="other">¤ 00 Mrd'.'</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 Mrd'.'</pattern>
+					<pattern type="100000000000" count="one">¤ 000 Mrd'.'</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 Mrd'.'</pattern>
+					<pattern type="100000000000" count="other">¤ 000 Mrd'.'</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 Mrd'.'</pattern>
+					<pattern type="1000000000000" count="one">¤ 0 Bio'.'</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 Bio'.'</pattern>
+					<pattern type="1000000000000" count="other">¤ 0 Bio'.'</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 Bio'.'</pattern>
+					<pattern type="10000000000000" count="one">¤ 00 Bio'.'</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 Bio'.'</pattern>
+					<pattern type="10000000000000" count="other">¤ 00 Bio'.'</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 Bio'.'</pattern>
+					<pattern type="100000000000000" count="one">¤ 000 Bio'.'</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 Bio'.'</pattern>
+					<pattern type="100000000000000" count="other">¤ 000 Bio'.'</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 Bio'.'</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/de_LI.xml
+++ b/common/main/de_LI.xml
@@ -44,7 +44,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -4086,16 +4086,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyański cas</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaiisko-aleutski standardny cas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaiisko-aleutski cas</generic>
 					<standard>Hawaiisko-aleutski standardny cas</standard>
 					<daylight>Hawaiisko-aleutski lěśojski cas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaiisko-aleutski standardny cas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4746,12 +4746,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/dua.xml
+++ b/common/main/dua.xml
@@ -345,7 +345,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/dv.xml
+++ b/common/main/dv.xml
@@ -142,6 +142,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">¤ #,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/dyo.xml
+++ b/common/main/dyo.xml
@@ -456,7 +456,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/dz.xml
+++ b/common/main/dz.xml
@@ -2050,16 +2050,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>གུ་ཡ་ན་ཆུ་ཚོད</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ཧ་ཝའི་-ཨེ་ལིའུ་ཤེན་ཚད་ལྡན་ཆུ་ཚོད</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ཧ་ཝའི་-ཨེ་ལིའུ་ཤེན་ཆུ་ཚོད</generic>
 					<standard>ཧ་ཝའི་-ཨེ་ལིའུ་ཤེན་ཚད་ལྡན་ཆུ་ཚོད</standard>
 					<daylight>ཧ་ཝའི་-ཨེ་ལིའུ་ཤེན་ཉིན་སྲུང་ཆུ་ཚོད</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ཧ་ཝའི་-ཨེ་ལིའུ་ཤེན་ཚད་ལྡན་ཆུ་ཚོད</standard>
 				</long>
 			</metazone>
 			<metazone type="India">

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -3980,16 +3980,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyana gaƒoƒo me</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutia nutome gaƒoƒo me</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutia gaƒoƒo me</generic>
 					<standard>Hawaii-Aleutia nutome gaƒoƒo me</standard>
 					<daylight>Hawaii-Aleutia kele gaƒoƒo me</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutia nutome gaƒoƒo me</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -5265,16 +5265,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Ώρα Γουιάνας</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Χειμερινή ώρα Χαβάης-Αλεούτιων Νήσων</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ώρα Χαβάης-Αλεούτιων Νήσων</generic>
 					<standard>Χειμερινή ώρα Χαβάης-Αλεούτιων Νήσων</standard>
 					<daylight>Θερινή ώρα Χαβάης-Αλεούτιων Νήσων</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Χειμερινή ώρα Χαβάης-Αλεούτιων Νήσων</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5917,7 +5917,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5237,6 +5237,14 @@ annotations.
 					<standard>Guyana Time</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutian Standard Time</standard>
+				</long>
+				<short>
+					<standard>HST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutian Time</generic>
@@ -5247,14 +5255,6 @@ annotations.
 					<generic>HAT</generic>
 					<standard>HAST</standard>
 					<daylight>HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutian Standard Time</standard>
-				</long>
-				<short>
-					<standard>HST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/en_001.xml
+++ b/common/main/en_001.xml
@@ -1012,16 +1012,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<daylight>∅∅∅</daylight>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<short>
+					<standard>∅∅∅</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<short>
 					<generic>∅∅∅</generic>
 					<standard>∅∅∅</standard>
 					<daylight>∅∅∅</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<short>
-					<standard>∅∅∅</standard>
 				</short>
 			</metazone>
 			<metazone type="Pierre_Miquelon">

--- a/common/main/en_150.xml
+++ b/common/main/en_150.xml
@@ -71,10 +71,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/en_AE.xml
+++ b/common/main/en_AE.xml
@@ -343,16 +343,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>GST</standard>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<short>
+					<standard>∅∅∅</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<short>
 					<generic>∅∅∅</generic>
 					<standard>∅∅∅</standard>
 					<daylight>∅∅∅</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<short>
-					<standard>∅∅∅</standard>
 				</short>
 			</metazone>
 		</timeZoneNames>

--- a/common/main/en_AT.xml
+++ b/common/main/en_AT.xml
@@ -28,6 +28,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">

--- a/common/main/en_AT.xml
+++ b/common/main/en_AT.xml
@@ -32,6 +32,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -5825,16 +5825,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -5605,16 +5605,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/en_CH.xml
+++ b/common/main/en_CH.xml
@@ -337,9 +337,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -6178,16 +6178,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6808,53 +6808,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">¤0k</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="1000" count="other">¤0k</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="10000" count="one">¤00k</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="10000" count="other">¤00k</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="100000" count="one">¤000k</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="100000" count="other">¤000k</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="1000000" count="one">¤0m</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0m</pattern>
 					<pattern type="1000000" count="other">¤0m</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0m</pattern>
 					<pattern type="10000000" count="one">¤00m</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00m</pattern>
 					<pattern type="10000000" count="other">¤00m</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00m</pattern>
 					<pattern type="100000000" count="one">¤000m</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000m</pattern>
 					<pattern type="100000000" count="other">¤000m</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000m</pattern>
 					<pattern type="1000000000" count="one">¤0bn</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0bn</pattern>
 					<pattern type="1000000000" count="other">¤0bn</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0bn</pattern>
 					<pattern type="10000000000" count="one">¤00bn</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00bn</pattern>
 					<pattern type="10000000000" count="other">¤00bn</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00bn</pattern>
 					<pattern type="100000000000" count="one">¤000bn</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000bn</pattern>
 					<pattern type="100000000000" count="other">¤000bn</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000bn</pattern>
 					<pattern type="1000000000000" count="one">¤0tn</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0tn</pattern>
 					<pattern type="1000000000000" count="other">¤0tn</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0tn</pattern>
 					<pattern type="10000000000000" count="one">¤00tn</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00tn</pattern>
 					<pattern type="10000000000000" count="other">¤00tn</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00tn</pattern>
 					<pattern type="100000000000000" count="one">¤000tn</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000tn</pattern>
 					<pattern type="100000000000000" count="other">¤000tn</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000tn</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/en_GE.xml
+++ b/common/main/en_GE.xml
@@ -20,6 +20,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -5595,16 +5595,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6210,8 +6210,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>

--- a/common/main/en_JP.xml
+++ b/common/main/en_JP.xml
@@ -778,16 +778,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>∅∅∅</daylight>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<short>
+					<standard>∅∅∅</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<short>
 					<generic>∅∅∅</generic>
 					<standard>∅∅∅</standard>
 					<daylight>∅∅∅</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<short>
-					<standard>∅∅∅</standard>
 				</short>
 			</metazone>
 		</timeZoneNames>

--- a/common/main/en_MH.xml
+++ b/common/main/en_MH.xml
@@ -55,16 +55,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>∅∅∅</daylight>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<short>
+					<standard>∅∅∅</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<short>
 					<generic>∅∅∅</generic>
 					<standard>∅∅∅</standard>
 					<daylight>∅∅∅</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<short>
-					<standard>∅∅∅</standard>
 				</short>
 			</metazone>
 		</timeZoneNames>

--- a/common/main/en_MP.xml
+++ b/common/main/en_MP.xml
@@ -55,16 +55,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>∅∅∅</daylight>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<short>
+					<standard>∅∅∅</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<short>
 					<generic>∅∅∅</generic>
 					<standard>∅∅∅</standard>
 					<daylight>∅∅∅</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<short>
-					<standard>∅∅∅</standard>
 				</short>
 			</metazone>
 		</timeZoneNames>

--- a/common/main/en_MV.xml
+++ b/common/main/en_MV.xml
@@ -100,6 +100,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/en_NL.xml
+++ b/common/main/en_NL.xml
@@ -25,6 +25,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/en_NL.xml
+++ b/common/main/en_NL.xml
@@ -20,9 +20,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_PL.xml
+++ b/common/main/en_PL.xml
@@ -18,8 +18,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_PT.xml
+++ b/common/main/en_PT.xml
@@ -18,8 +18,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_RO.xml
+++ b/common/main/en_RO.xml
@@ -18,8 +18,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_SI.xml
+++ b/common/main/en_SI.xml
@@ -19,8 +19,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_SK.xml
+++ b/common/main/en_SK.xml
@@ -19,8 +19,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/en_US_POSIX.xml
+++ b/common/main/en_US_POSIX.xml
@@ -45,6 +45,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ 0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ 0.00</pattern>
+					<pattern alt="noCurrency">0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -4160,16 +4160,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>gujana tempo</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havajo-Aleutoj (norma tempo)</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>tempo: Havajo-Aleutoj</generic>
 					<standard>Havajo-Aleutoj (norma tempo)</standard>
 					<daylight>Havajo-Aleutoj (somera tempo)</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havajo-Aleutoj (norma tempo)</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4782,30 +4782,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">0 k¤</pattern>
-					<pattern type="1000" count="other">0 k¤</pattern>
-					<pattern type="10000" count="one">00 k¤</pattern>
-					<pattern type="10000" count="other">00 k¤</pattern>
-					<pattern type="100000" count="one">000 k¤</pattern>
-					<pattern type="100000" count="other">000 k¤</pattern>
-					<pattern type="1000000" count="one">0 M¤</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
-					<pattern type="10000000" count="one">00 M¤</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
-					<pattern type="100000000" count="one">000 M¤</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
-					<pattern type="1000000000" count="one">0 G¤</pattern>
-					<pattern type="1000000000" count="other">0 G¤</pattern>
-					<pattern type="10000000000" count="one">00 G¤</pattern>
-					<pattern type="10000000000" count="other">00 G¤</pattern>
-					<pattern type="100000000000" count="one">000 G¤</pattern>
-					<pattern type="100000000000" count="other">000 G¤</pattern>
-					<pattern type="1000000000000" count="one">0 T¤</pattern>
-					<pattern type="1000000000000" count="other">0 T¤</pattern>
-					<pattern type="10000000000000" count="one">00 T¤</pattern>
-					<pattern type="10000000000000" count="other">00 T¤</pattern>
-					<pattern type="100000000000000" count="one">000 T¤</pattern>
-					<pattern type="100000000000000" count="other">000 T¤</pattern>
+					<pattern type="1000" count="one">0k ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="other">0k ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="10000" count="one">00k ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="other">00k ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="100000" count="one">000k ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="other">000k ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="1000000" count="one">0M ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="1000000" count="other">0M ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="10000000" count="one">00M ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="10000000" count="other">00M ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="100000000" count="one">000M ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="100000000" count="other">000M ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="1000000000" count="one">0G ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="1000000000" count="other">0G ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="10000000000" count="one">00G ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="10000000000" count="other">00G ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="100000000000" count="one">000G ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="100000000000" count="other">000G ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="1000000000000" count="one">0T ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="1000000000000" count="other">0T ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="10000000000000" count="one">00T ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="10000000000000" count="other">00T ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="100000000000000" count="one">000T ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000T ¤</pattern>
+					<pattern type="100000000000000" count="other">000T ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -5376,16 +5376,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>hora de Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>hora estándar de Hawái-Aleutianas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>hora de Hawái-Aleutianas</generic>
 					<standard>hora estándar de Hawái-Aleutianas</standard>
 					<daylight>hora de verano de Hawái-Aleutianas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>hora estándar de Hawái-Aleutianas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6039,7 +6039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -6057,42 +6057,42 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000" count="other">000 mil ¤</pattern>
 					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0000 M¤</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 mil M¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 mil M¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 B¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 B¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 B¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="one">0 M ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 M ¤</pattern>
+					<pattern type="1000000" count="other">0 M ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 M ¤</pattern>
+					<pattern type="10000000" count="one">00 M ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 M ¤</pattern>
+					<pattern type="10000000" count="other">00 M ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 M ¤</pattern>
+					<pattern type="100000000" count="one">000 M ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 M ¤</pattern>
+					<pattern type="100000000" count="other">000 M ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 M ¤</pattern>
+					<pattern type="1000000000" count="one">0000 M ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0000 M ¤</pattern>
+					<pattern type="1000000000" count="other">0000 M ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0000 M ¤</pattern>
+					<pattern type="10000000000" count="one">00 mil M ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 mil M ¤</pattern>
+					<pattern type="10000000000" count="other">00 mil M ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 mil M ¤</pattern>
+					<pattern type="100000000000" count="one">000 mil M ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 mil M ¤</pattern>
+					<pattern type="100000000000" count="other">000 mil M ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 mil M ¤</pattern>
+					<pattern type="1000000000000" count="one">0 B ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 B ¤</pattern>
+					<pattern type="1000000000000" count="other">0 B ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 B ¤</pattern>
+					<pattern type="10000000000000" count="one">00 B ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 B ¤</pattern>
+					<pattern type="10000000000000" count="other">00 B ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 B ¤</pattern>
+					<pattern type="100000000000000" count="one">000 B ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 B ¤</pattern>
+					<pattern type="100000000000000" count="other">000 B ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 B ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -5379,19 +5379,19 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 k</pattern>
 					<pattern type="100000" count="other">¤000 k</pattern>
 					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 k</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000" count="one">¤0 M</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 M</pattern>
 					<pattern type="1000000" count="other">¤0 M</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 M</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000" count="one">¤00 M</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 M</pattern>
 					<pattern type="10000000" count="other">¤00 M</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 M</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000" count="one">¤000 M</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 M</pattern>
 					<pattern type="100000000" count="other">¤000 M</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 M</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000" count="one">¤0000 M</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0000 M</pattern>
 					<pattern type="1000000000" count="other">¤0000 M</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0000 M</pattern>
@@ -5403,15 +5403,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 mil M</pattern>
 					<pattern type="100000000000" count="other">¤000 mil M</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 mil M</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">¤0 B</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 B</pattern>
 					<pattern type="1000000000000" count="other">¤0 B</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 B</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one">¤00 B</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 B</pattern>
 					<pattern type="10000000000000" count="other">¤00 B</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 B</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one">¤000 B</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 B</pattern>
 					<pattern type="100000000000000" count="other">¤000 B</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 B</pattern>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -4744,16 +4744,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5356,12 +5356,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -5371,14 +5371,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 K</pattern>
 					<pattern type="1000" count="other">¤0 K</pattern>
 					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 K</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 K</pattern>
-					<pattern type="10000" count="other">¤00 K</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 K</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 K</pattern>
-					<pattern type="100000" count="other">¤000 K</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 K</pattern>
+					<pattern type="10000" count="one">¤00 k</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 k</pattern>
+					<pattern type="10000" count="other">¤00 k</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 k</pattern>
+					<pattern type="100000" count="one">¤000 k</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 k</pattern>
+					<pattern type="100000" count="other">¤000 k</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 k</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 M</pattern>
 					<pattern type="1000000" count="other">¤0 M</pattern>
@@ -5395,14 +5395,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0000 M</pattern>
 					<pattern type="1000000000" count="other">¤0000 M</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0000 M</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 MRD</pattern>
-					<pattern type="10000000000" count="other">¤00 MRD</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 MRD</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 MRD</pattern>
-					<pattern type="100000000000" count="other">¤000 MRD</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 MRD</pattern>
+					<pattern type="10000000000" count="one">¤00 mil M</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 mil M</pattern>
+					<pattern type="10000000000" count="other">¤00 mil M</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 mil M</pattern>
+					<pattern type="100000000000" count="one">¤000 mil M</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 mil M</pattern>
+					<pattern type="100000000000" count="other">¤000 mil M</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 mil M</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 B</pattern>
 					<pattern type="1000000000000" count="other">¤0 B</pattern>

--- a/common/main/es_AR.xml
+++ b/common/main/es_AR.xml
@@ -342,9 +342,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_CL.xml
+++ b/common/main/es_CL.xml
@@ -303,6 +303,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_CO.xml
+++ b/common/main/es_CO.xml
@@ -390,6 +390,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_DO.xml
+++ b/common/main/es_DO.xml
@@ -163,8 +163,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_EC.xml
+++ b/common/main/es_EC.xml
@@ -214,6 +214,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_GQ.xml
+++ b/common/main/es_GQ.xml
@@ -16,6 +16,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -4365,16 +4365,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4976,65 +4976,65 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">0 k ¤</pattern>
-					<pattern type="1000" count="other">0 k¤</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">0 k ¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">00 k ¤</pattern>
-					<pattern type="10000" count="other">00 k¤</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">00 k ¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">000 k ¤</pattern>
-					<pattern type="100000" count="other">000 k¤</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">000 k ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 M ¤</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 M ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 M ¤</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 M ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 M ¤</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 M ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0000 M ¤</pattern>
-					<pattern type="1000000000" count="other">0000 M¤</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0000 M ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 MRD ¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 MRD ¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 B ¤</pattern>
-					<pattern type="1000000000000" count="other">0 B¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 B ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 B ¤</pattern>
-					<pattern type="10000000000000" count="other">00 B¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 B ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 B ¤</pattern>
-					<pattern type="100000000000000" count="other">000 B¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 B ¤</pattern>
+					<pattern type="1000" count="one">¤0 k</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 k</pattern>
+					<pattern type="1000" count="other">¤0 k</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 k</pattern>
+					<pattern type="10000" count="one">¤00 k</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 k</pattern>
+					<pattern type="10000" count="other">¤00 k</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 k</pattern>
+					<pattern type="100000" count="one">¤000 k</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 k</pattern>
+					<pattern type="100000" count="other">¤000 k</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 k</pattern>
+					<pattern type="1000000" count="one">¤0 M</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 M</pattern>
+					<pattern type="1000000" count="other">¤0 M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 M</pattern>
+					<pattern type="10000000" count="one">¤00 M</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 M</pattern>
+					<pattern type="10000000" count="other">¤00 M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 M</pattern>
+					<pattern type="100000000" count="one">¤000 M</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 M</pattern>
+					<pattern type="100000000" count="other">¤000 M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 M</pattern>
+					<pattern type="1000000000" count="one">¤0000 M</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0000 M</pattern>
+					<pattern type="1000000000" count="other">¤0000 M</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0000 M</pattern>
+					<pattern type="10000000000" count="one">¤00 mil M</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 mil M</pattern>
+					<pattern type="10000000000" count="other">¤00 mil M</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 mil M</pattern>
+					<pattern type="100000000000" count="one">¤000 mil M</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 mil M</pattern>
+					<pattern type="100000000000" count="other">¤000 mil M</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 mil M</pattern>
+					<pattern type="1000000000000" count="one">¤0 B</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 B</pattern>
+					<pattern type="1000000000000" count="other">¤0 B</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 B</pattern>
+					<pattern type="10000000000000" count="one">¤00 B</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 B</pattern>
+					<pattern type="10000000000000" count="other">¤00 B</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 B</pattern>
+					<pattern type="100000000000000" count="one">¤000 B</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 B</pattern>
+					<pattern type="100000000000000" count="other">¤000 B</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 B</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/es_PE.xml
+++ b/common/main/es_PE.xml
@@ -290,7 +290,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/es_PY.xml
+++ b/common/main/es_PY.xml
@@ -214,6 +214,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -4422,6 +4422,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+				<short>
+					<standard>HST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
@@ -4432,14 +4440,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic>HAT</generic>
 					<standard>HAST</standard>
 					<daylight>HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-				<short>
-					<standard>HST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5041,12 +5041,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -5080,26 +5080,26 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="1000000000" count="other">↑↑↑</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 B</pattern>
-					<pattern type="10000000000" count="other">¤00 B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 B</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 B</pattern>
-					<pattern type="100000000000" count="other">¤000 B</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 B</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 T</pattern>
-					<pattern type="1000000000000" count="other">¤0 T</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 T</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 T</pattern>
-					<pattern type="10000000000000" count="other">¤00 T</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 T</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 T</pattern>
-					<pattern type="100000000000000" count="other">¤000 T</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 T</pattern>
+					<pattern type="10000000000" count="one">¤00 mil M</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 mil M</pattern>
+					<pattern type="10000000000" count="other">¤00 mil M</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 mil M</pattern>
+					<pattern type="100000000000" count="one">¤000 mil M</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 mil M</pattern>
+					<pattern type="100000000000" count="other">¤000 mil M</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 mil M</pattern>
+					<pattern type="1000000000000" count="one">¤0 B</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 B</pattern>
+					<pattern type="1000000000000" count="other">¤0 B</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 B</pattern>
+					<pattern type="10000000000000" count="one">¤00 B</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 B</pattern>
+					<pattern type="10000000000000" count="other">¤00 B</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 B</pattern>
+					<pattern type="100000000000000" count="one">¤000 B</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 B</pattern>
+					<pattern type="100000000000000" count="other">¤000 B</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 B</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -5056,27 +5056,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="1000" count="other">↑↑↑</pattern>
 					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
+					<pattern type="10000" count="one">¤00 K</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 K</pattern>
+					<pattern type="10000" count="other">¤00 K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 K</pattern>
+					<pattern type="100000" count="one">¤000 K</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 K</pattern>
+					<pattern type="100000" count="other">¤000 K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 K</pattern>
+					<pattern type="1000000" count="one">¤0 M</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000" count="one">¤00 M</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="10000000" count="other">↑↑↑</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000" count="one">¤000 M</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000" count="one">¤0000 M</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="1000000000" count="other">↑↑↑</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>

--- a/common/main/es_UY.xml
+++ b/common/main/es_UY.xml
@@ -123,10 +123,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/es_VE.xml
+++ b/common/main/es_VE.xml
@@ -203,6 +203,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -4860,16 +4860,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyana aeg</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleuudi standardaeg</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleuudi aeg</generic>
 					<standard>Hawaii-Aleuudi standardaeg</standard>
 					<daylight>Hawaii-Aleuudi suveaeg</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleuudi standardaeg</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5518,12 +5518,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">#,####0.00 ¤</pattern>
-					<pattern alt="noCurrency">#,####0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">#,####0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -10340,6 +10340,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyanako ordua</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutiar uharteetako ordu estandarra</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutiar uharteetako ordua</generic>
@@ -10350,14 +10358,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutiar uharteetako ordu estandarra</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -12638,6 +12638,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12665,6 +12666,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12680,6 +12682,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12695,6 +12698,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12710,6 +12714,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12725,6 +12730,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12740,6 +12746,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12755,6 +12762,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12770,6 +12778,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12785,6 +12794,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12800,6 +12810,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12815,6 +12826,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12830,6 +12842,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12845,6 +12858,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12860,6 +12874,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12875,6 +12890,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12890,6 +12906,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12905,6 +12922,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12920,6 +12938,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12935,6 +12954,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12950,6 +12970,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12966,7 +12987,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13010,6 +13031,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13025,6 +13047,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13040,6 +13063,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13055,6 +13079,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13070,6 +13095,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13085,6 +13111,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13100,6 +13127,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13115,6 +13143,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13130,6 +13159,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13145,6 +13175,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13160,6 +13191,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13175,6 +13207,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13190,6 +13223,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13205,6 +13239,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13220,6 +13255,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13235,6 +13271,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13250,6 +13287,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13265,6 +13303,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13280,6 +13319,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13295,6 +13335,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13310,6 +13351,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13325,6 +13367,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13340,6 +13383,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ewo.xml
+++ b/common/main/ewo.xml
@@ -614,7 +614,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -5666,16 +5666,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>وقت گویان</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>وقت عادی هاوایی‐الوشن</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>وقت هاوایی‐الوشن</generic>
 					<standard>وقت عادی هاوایی‐الوشن</standard>
 					<daylight>وقت تابستانی هاوایی‐الوشن</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>وقت عادی هاوایی‐الوشن</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6410,8 +6410,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>‎¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber" draft="provisional">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">‎#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6419,8 +6422,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>‎¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber" draft="provisional">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="provisional">‎#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">‎#,##0.00;‎(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6428,65 +6435,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>‎¤ #,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">‎#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>‎¤ #,##0.00;‎(¤ #,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">‎¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">‎#,##0.00;‎(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000" count="other">0 هزار ¤</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">00 هزار ¤</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 هزار ¤</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 میلیون ¤</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 میلیون ¤</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 میلیون ¤</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0 میلیارد ¤</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 میلیارد ¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 میلیارد ¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 هزارمیلیارد ¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 هزارمیلیارد ¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 هزارمیلیارد ¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one">‎¤ 0 هزار</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">‎¤ 0 هزار</pattern>
+					<pattern type="1000" count="other">‎¤ 0 هزار</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">‎¤ 0 هزار</pattern>
+					<pattern type="10000" count="one">‎¤ 00 هزار</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">‎¤ 00 هزار</pattern>
+					<pattern type="10000" count="other">‎¤ 00 هزار</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">‎¤ 00 هزار</pattern>
+					<pattern type="100000" count="one">‎¤ 000 هزار</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">‎¤ 000 هزار</pattern>
+					<pattern type="100000" count="other">‎¤ 000 هزار</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">‎¤ 000 هزار</pattern>
+					<pattern type="1000000" count="one">‎¤ 0 میلیون</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">‎¤ 0 میلیون</pattern>
+					<pattern type="1000000" count="other">‎¤ 0 میلیون</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">‎¤ 0 میلیون</pattern>
+					<pattern type="10000000" count="one">‎¤ 00 میلیون</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">‎¤ 00 میلیون</pattern>
+					<pattern type="10000000" count="other">‎¤ 00 میلیون</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">‎¤ 00 میلیون</pattern>
+					<pattern type="100000000" count="one">‎¤ 000 میلیون</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">‎¤ 000 میلیون</pattern>
+					<pattern type="100000000" count="other">‎¤ 000 میلیون</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">‎¤ 000 میلیون</pattern>
+					<pattern type="1000000000" count="one">‎¤ 0 میلیارد</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">‎¤ 0 میلیارد</pattern>
+					<pattern type="1000000000" count="other">‎¤ 0 میلیارد</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">‎¤ 0 میلیارد</pattern>
+					<pattern type="10000000000" count="one">‎¤ 00 میلیارد</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">‎¤ 00 میلیارد</pattern>
+					<pattern type="10000000000" count="other">‎¤ 00 میلیارد</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">‎¤ 00 میلیارد</pattern>
+					<pattern type="100000000000" count="one">‎¤ 000 میلیارد</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">‎¤ 000 میلیارد</pattern>
+					<pattern type="100000000000" count="other">‎¤ 000 میلیارد</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">‎¤ 000 میلیارد</pattern>
+					<pattern type="1000000000000" count="one">‎¤ 0 تریلیون</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">‎¤ 0 تریلیون</pattern>
+					<pattern type="1000000000000" count="other">‎¤ 0 تریلیون</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">‎¤ 0 تریلیون</pattern>
+					<pattern type="10000000000000" count="one">‎¤ 00 تریلیون</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">‎¤ 00 تریلیون</pattern>
+					<pattern type="10000000000000" count="other">‎¤ 00 تریلیون</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">‎¤ 00 تریلیون</pattern>
+					<pattern type="100000000000000" count="one">‎¤ 000 تریلیون</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">‎¤ 000 تریلیون</pattern>
+					<pattern type="100000000000000" count="other">‎¤ 000 تریلیون</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">‎¤ 000 تریلیون</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/fa_AF.xml
+++ b/common/main/fa_AF.xml
@@ -1177,6 +1177,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;‎(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -1184,9 +1189,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;‎(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;‎(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/fa_AF.xml
+++ b/common/main/fa_AF.xml
@@ -1177,6 +1177,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -1189,6 +1190,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">

--- a/common/main/ff.xml
+++ b/common/main/ff.xml
@@ -609,7 +609,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -9778,16 +9778,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤘𞤢𞤴𞤢𞤲𞤢𞥄</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤖𞤢𞤱𞤪𞤵𞤲𞥋𞤣𞤫 𞤖𞤢𞤱𞤢𞥄𞤴𞤭𞥅-𞤀𞤤𞤮𞤧𞤭𞤴𞤢𞤲</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤖𞤢𞤱𞤢𞥄𞤴𞤭𞥅-𞤀𞤤𞤮𞤧𞤭𞤴𞤢𞤲</generic>
 					<standard>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤖𞤢𞤱𞤪𞤵𞤲𞥋𞤣𞤫 𞤖𞤢𞤱𞤢𞥄𞤴𞤭𞥅-𞤀𞤤𞤮𞤧𞤭𞤴𞤢𞤲</standard>
 					<daylight>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤕𞤫𞥅𞤯𞤵 𞤖𞤢𞤱𞤢𞥄𞤴𞤭𞥅-𞤀𞤤𞤮𞤧𞤭𞤴𞤢𞤲</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤖𞤢𞤱𞤪𞤵𞤲𞥋𞤣𞤫 𞤖𞤢𞤱𞤢𞥄𞤴𞤭𞥅-𞤀𞤤𞤮𞤧𞤭𞤴𞤢𞤲</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -12360,30 +12360,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">0𞤓¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">00𞤓¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">000𞤓¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0𞤁¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00𞤁¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000𞤁¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0𞤁𞤶¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00𞤁𞤶¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000𞤁𞤶¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0𞤚¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00𞤚¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000𞤚¤</pattern>
+					<pattern type="1000" count="one">¤ 0𞤓</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0𞤓</pattern>
+					<pattern type="1000" count="other">¤ 0𞤓</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0𞤓</pattern>
+					<pattern type="10000" count="one">¤ 00𞤓</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00𞤓</pattern>
+					<pattern type="10000" count="other">¤ 00𞤓</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00𞤓</pattern>
+					<pattern type="100000" count="one">¤ 000𞤓</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000𞤓</pattern>
+					<pattern type="100000" count="other">¤ 000𞤓</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000𞤓</pattern>
+					<pattern type="1000000" count="one">¤ 0𞤁</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0𞤁</pattern>
+					<pattern type="1000000" count="other">¤ 0𞤁</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0𞤁</pattern>
+					<pattern type="10000000" count="one">¤ 00𞤁</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00𞤁</pattern>
+					<pattern type="10000000" count="other">¤ 00𞤁</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00𞤁</pattern>
+					<pattern type="100000000" count="one">¤ 000𞤁</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000𞤁</pattern>
+					<pattern type="100000000" count="other">¤ 000𞤁</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000𞤁</pattern>
+					<pattern type="1000000000" count="one">¤ 0𞤁𞤶</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0𞤁𞤶</pattern>
+					<pattern type="1000000000" count="other">¤ 0𞤁𞤶</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0𞤁𞤶</pattern>
+					<pattern type="10000000000" count="one">¤ 00𞤁𞤶</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00𞤁𞤶</pattern>
+					<pattern type="10000000000" count="other">¤ 00𞤁𞤶</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00𞤁𞤶</pattern>
+					<pattern type="100000000000" count="one">¤ 000𞤁𞤶</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000𞤁𞤶</pattern>
+					<pattern type="100000000000" count="other">¤ 000𞤁𞤶</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000𞤁𞤶</pattern>
+					<pattern type="1000000000000" count="one">¤ 0𞤚</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0𞤚</pattern>
+					<pattern type="1000000000000" count="other">¤ 0𞤚</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0𞤚</pattern>
+					<pattern type="10000000000000" count="one">¤ 00𞤚</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00𞤚</pattern>
+					<pattern type="10000000000000" count="other">¤ 00𞤚</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00𞤚</pattern>
+					<pattern type="100000000000000" count="one">¤ 000𞤚</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000𞤚</pattern>
+					<pattern type="100000000000000" count="other">¤ 000𞤚</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000𞤚</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -5627,16 +5627,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyanan aika</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havaijin-Aleuttien normaaliaika</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havaijin-Aleuttien aika</generic>
 					<standard>Havaijin-Aleuttien normaaliaika</standard>
 					<daylight>Havaijin-Aleuttien kesäaika</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havaijin-Aleuttien normaaliaika</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6288,7 +6288,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -6425,16 +6425,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Oras sa Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Standard na Oras sa Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Oras sa Hawaii-Aleutian</generic>
 					<standard>Standard na Oras sa Hawaii-Aleutian</standard>
 					<daylight>Oras sa Tag-init ng Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Standard na Oras sa Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -4289,16 +4289,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Gujana tíð</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutian vanlig tíð</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutian tíð</generic>
 					<standard>Hawaii-Aleutian vanlig tíð</standard>
 					<daylight>Hawaii-Aleutian summartíð</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutian vanlig tíð</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -7305,6 +7305,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure du Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>heure normale d’Hawaï - Aléoutiennes</standard>
+				</long>
+				<short>
+					<standard draft="unconfirmed">HNHA</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>heure d’Hawaï - Aléoutiennes</generic>
@@ -7315,14 +7323,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic draft="unconfirmed">HHA</generic>
 					<standard draft="unconfirmed">HNHA</standard>
 					<daylight draft="unconfirmed">HEHA</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>heure normale d’Hawaï - Aléoutiennes</standard>
-				</long>
-				<short>
-					<standard draft="unconfirmed">HNHA</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -5315,16 +5315,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>heure normale d’Hawaï-Aléoutiennes</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>heure d’Hawaï-Aléoutiennes</generic>
 					<standard>heure normale d’Hawaï-Aléoutiennes</standard>
 					<daylight>heure avancée d’Hawaï-Aléoutiennes</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>heure normale d’Hawaï-Aléoutiennes</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5958,53 +5958,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
+					<pattern type="1000" count="one">0 k ¤</pattern>
 					<pattern type="1000" count="one" alt="alphaNextToNumber">0 k ¤</pattern>
-					<pattern type="1000" count="other">0 k¤</pattern>
+					<pattern type="1000" count="other">0 k ¤</pattern>
 					<pattern type="1000" count="other" alt="alphaNextToNumber">0 k ¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
+					<pattern type="10000" count="one">00 k ¤</pattern>
 					<pattern type="10000" count="one" alt="alphaNextToNumber">00 k ¤</pattern>
-					<pattern type="10000" count="other">00 k¤</pattern>
+					<pattern type="10000" count="other">00 k ¤</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">00 k ¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
+					<pattern type="100000" count="one">000 k ¤</pattern>
 					<pattern type="100000" count="one" alt="alphaNextToNumber">000 k ¤</pattern>
-					<pattern type="100000" count="other">000 k¤</pattern>
+					<pattern type="100000" count="other">000 k ¤</pattern>
 					<pattern type="100000" count="other" alt="alphaNextToNumber">000 k ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000" count="one">0 M ¤</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 M ¤</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
+					<pattern type="1000000" count="other">0 M ¤</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 M ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000" count="one">00 M ¤</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 M ¤</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
+					<pattern type="10000000" count="other">00 M ¤</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 M ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000" count="one">000 M ¤</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 M ¤</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
+					<pattern type="100000000" count="other">000 M ¤</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 M ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000" count="one">0 G ¤</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0 G ¤</pattern>
-					<pattern type="1000000000" count="other">0 G¤</pattern>
+					<pattern type="1000000000" count="other">0 G ¤</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 G ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000" count="one">00 G ¤</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 G ¤</pattern>
-					<pattern type="10000000000" count="other">00 G¤</pattern>
+					<pattern type="10000000000" count="other">00 G ¤</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 G ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000" count="one">000 G ¤</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 G ¤</pattern>
-					<pattern type="100000000000" count="other">000 G¤</pattern>
+					<pattern type="100000000000" count="other">000 G ¤</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 G ¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">0 T ¤</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 T ¤</pattern>
-					<pattern type="1000000000000" count="other">0 T¤</pattern>
+					<pattern type="1000000000000" count="other">0 T ¤</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 T ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one">00 T ¤</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 T ¤</pattern>
-					<pattern type="10000000000000" count="other">00 T¤</pattern>
+					<pattern type="10000000000000" count="other">00 T ¤</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 T ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one">000 T ¤</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 T ¤</pattern>
-					<pattern type="100000000000000" count="other">000 T¤</pattern>
+					<pattern type="100000000000000" count="other">000 T ¤</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -4051,16 +4051,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">Guyaana Tidj</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">Hawaii-Aleuten Standard Tidj</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">Hawaii-Aleuten Tidj</generic>
 					<standard draft="unconfirmed">Hawaii-Aleuten Standard Tidj</standard>
 					<daylight draft="unconfirmed">Hawaii-Aleuten Somertidj</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">Hawaii-Aleuten Standard Tidj</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4650,11 +4650,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000" count="other" draft="unconfirmed">¤00K</pattern>
-					<pattern type="100000" count="other" draft="unconfirmed">¤000K</pattern>
-					<pattern type="1000000" count="other" draft="unconfirmed">¤0M</pattern>
-					<pattern type="10000000" count="other" draft="unconfirmed">¤00M</pattern>
-					<pattern type="100000000" count="other" draft="unconfirmed">¤000M</pattern>
+					<pattern type="10000" count="other">¤ 00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="100000" count="other">¤ 000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="1000000" count="other">¤ 0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="10000000" count="other">¤ 00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="100000000" count="other">¤ 000M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="1000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
 					<pattern type="10000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
 					<pattern type="100000000000" count="other" draft="unconfirmed">↑↑↑</pattern>

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -5365,16 +5365,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="contributed">Guyaanske tiid</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="contributed">Hawaii-Aleoetyske standerttiid</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="contributed">Hawaii-Aleoetyske tiid</generic>
 					<standard draft="contributed">Hawaii-Aleoetyske standerttiid</standard>
 					<daylight draft="contributed">Hawaii-Aleoetyske simmertiid</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="contributed">Hawaii-Aleoetyske standerttiid</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6010,9 +6010,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤ #,##0.00-</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ #,##0.00-</pattern>
+					<pattern alt="noCurrency">#,##0.00;#,##0.00-</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -5008,16 +5008,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Am na Guáine</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Am Caighdeánach Haváí-Ailiúit</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Am Haváí-Ailiúit</generic>
 					<standard>Am Caighdeánach Haváí-Ailiúit</standard>
 					<daylight>Am Samhraidh Haváí-Ailiúit</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Am Caighdeánach Haváí-Ailiúit</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5793,123 +5793,123 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="1000" count="two">↑↑↑</pattern>
-					<pattern type="1000" count="two" alt="alphaNextToNumber">¤0K</pattern>
+					<pattern type="1000" count="two" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="1000" count="few">↑↑↑</pattern>
-					<pattern type="1000" count="few" alt="alphaNextToNumber">¤0K</pattern>
+					<pattern type="1000" count="few" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="1000" count="many">↑↑↑</pattern>
-					<pattern type="1000" count="many" alt="alphaNextToNumber">¤0K</pattern>
+					<pattern type="1000" count="many" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="1000" count="other">¤0k</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0k</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="10000" count="two">↑↑↑</pattern>
-					<pattern type="10000" count="two" alt="alphaNextToNumber">¤00K</pattern>
+					<pattern type="10000" count="two" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="10000" count="few">↑↑↑</pattern>
-					<pattern type="10000" count="few" alt="alphaNextToNumber">¤00K</pattern>
+					<pattern type="10000" count="few" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="10000" count="many">↑↑↑</pattern>
-					<pattern type="10000" count="many" alt="alphaNextToNumber">¤00K</pattern>
+					<pattern type="10000" count="many" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="10000" count="other">¤00k</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00k</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="100000" count="two">↑↑↑</pattern>
-					<pattern type="100000" count="two" alt="alphaNextToNumber">¤000K</pattern>
+					<pattern type="100000" count="two" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="100000" count="few">↑↑↑</pattern>
-					<pattern type="100000" count="few" alt="alphaNextToNumber">¤000K</pattern>
+					<pattern type="100000" count="few" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="100000" count="many">↑↑↑</pattern>
-					<pattern type="100000" count="many" alt="alphaNextToNumber">¤000K</pattern>
+					<pattern type="100000" count="many" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="100000" count="other">¤000k</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000k</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="two" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="few" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="many" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="other">¤0M</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="two" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="few" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="many" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="other">¤00M</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="two" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="few" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="many" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="1000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="two" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="1000000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="few" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="1000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="many" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="1000000000" count="other">¤0B</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="two" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="few" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="many" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="10000000000" count="other">¤00B</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="100000000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="two" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="few" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="many" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="100000000000" count="other">¤000B</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="1000000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="two" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="1000000000000" count="few">↑↑↑</pattern>
-					<pattern type="1000000000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="few" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="1000000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="many" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="1000000000000" count="other">¤0T</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="10000000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="two" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="10000000000000" count="few">↑↑↑</pattern>
-					<pattern type="10000000000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="few" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="10000000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="many" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="10000000000000" count="other">¤00T</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="100000000000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
 					<pattern type="100000000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000000" count="two" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="two" alt="alphaNextToNumber">¤ 000T</pattern>
 					<pattern type="100000000000000" count="few">↑↑↑</pattern>
-					<pattern type="100000000000000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="few" alt="alphaNextToNumber">¤ 000T</pattern>
 					<pattern type="100000000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000000" count="many" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="many" alt="alphaNextToNumber">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other">¤000T</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>

--- a/common/main/gaa.xml
+++ b/common/main/gaa.xml
@@ -2345,16 +2345,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight draft="unconfirmed">Greenland Anaigbɛ Be Yɛ Latsa Beiaŋ</daylight>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">Hawaii-Aleutia Be Yɛ Fɛi Beiaŋ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">Hawaii-Aleutia Be</generic>
 					<standard draft="unconfirmed">Hawaii-Aleutia Be Yɛ Fɛi Beiaŋ</standard>
 					<daylight draft="unconfirmed">Hawaii-Aleutia Be Yɛ Latsa Beiaŋ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">Hawaii-Aleutia Be Yɛ Fɛi Beiaŋ</standard>
 				</long>
 			</metazone>
 			<metazone type="Indian_Ocean">
@@ -2448,6 +2448,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -6285,6 +6285,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Àm Guidheàna</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Bun-àm nan Eileanan Hawai’i ’s Aleutach</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Àm nan Eileanan Hawai’i ’s Aleutach</generic>
@@ -6295,14 +6303,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Bun-àm nan Eileanan Hawai’i ’s Aleutach</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -4320,16 +4320,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>hora da Güiana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>hora estándar de Hawai-illas Aleutianas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>hora de Hawai-illas Aleutianas</generic>
 					<standard>hora estándar de Hawai-illas Aleutianas</standard>
 					<daylight>hora de verán de Hawai-illas Aleutianas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>hora estándar de Hawai-illas Aleutianas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4956,7 +4956,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -4967,41 +4967,41 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="10000" count="other">0</pattern>
 					<pattern type="100000" count="one">↑↑↑</pattern>
 					<pattern type="100000" count="other">0</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000" count="one">0 M ¤</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 M ¤</pattern>
-					<pattern type="1000000" count="other">0 M¤</pattern>
+					<pattern type="1000000" count="other">0 M ¤</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 M ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000" count="one">00 M ¤</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 M ¤</pattern>
-					<pattern type="10000000" count="other">00 M¤</pattern>
+					<pattern type="10000000" count="other">00 M ¤</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 M ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000" count="one">000 M ¤</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 M ¤</pattern>
-					<pattern type="100000000" count="other">000 M¤</pattern>
+					<pattern type="100000000" count="other">000 M ¤</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 M ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000" count="one">0000 M ¤</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0000 M ¤</pattern>
-					<pattern type="1000000000" count="other">0000 M¤</pattern>
+					<pattern type="1000000000" count="other">0000 M ¤</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0000 M ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000" count="one">00000 M ¤</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00000 M ¤</pattern>
-					<pattern type="10000000000" count="other">00000 M¤</pattern>
+					<pattern type="10000000000" count="other">00000 M ¤</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00000 M ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000" count="one">000000 M ¤</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000000 M ¤</pattern>
-					<pattern type="100000000000" count="other">000000 M¤</pattern>
+					<pattern type="100000000000" count="other">000000 M ¤</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000000 M ¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">0 B ¤</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 B ¤</pattern>
-					<pattern type="1000000000000" count="other">0 B¤</pattern>
+					<pattern type="1000000000000" count="other">0 B ¤</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 B ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one">00 B ¤</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 B ¤</pattern>
-					<pattern type="10000000000000" count="other">00 B¤</pattern>
+					<pattern type="10000000000000" count="other">00 B ¤</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 B ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one">000 B ¤</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 B ¤</pattern>
-					<pattern type="100000000000000" count="other">000 B¤</pattern>
+					<pattern type="100000000000000" count="other">000 B ¤</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 B ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -2004,7 +2004,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -5195,16 +5195,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ગયાના સમય</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>હવાઇ-એલ્યુશિઅન માનક સમય</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>હવાઈ-એલ્યુશિઅન સમય</generic>
 					<standard>હવાઇ-એલ્યુશિઅન માનક સમય</standard>
 					<daylight>હવાઇ-એલ્યુશિઅન દિવસ સમય</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>હવાઇ-એલ્યુશિઅન માનક સમય</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -4288,16 +4288,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Lokacin Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Lokaci na Hawaii-Aleutian</generic>
 					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
 					<daylight>Lokacin Rana na Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5006,41 +5006,45 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">¤ 0D</pattern>
+					<pattern type="1000" count="one">¤ 0K</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="1000" count="other">¤ 0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
 					<pattern type="10000" count="other">¤ 00D</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
+					<pattern type="100000" count="one">¤ 000D</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000D</pattern>
+					<pattern type="100000" count="other">¤ 000D</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000D</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000" count="other">↑↑↑</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
+					<pattern type="1000000000" count="one">¤ 0B</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B</pattern>
+					<pattern type="1000000000" count="other">¤ 0B</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000" count="one">¤ 00B</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
+					<pattern type="10000000000" count="other">¤ 00B</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000" count="one">¤ 000B</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
+					<pattern type="100000000000" count="other">¤ 000B</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">¤ 0T</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other">¤ 0T</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one">¤ 00T</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other">¤ 00T</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one">¤ 000T</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
-					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -4196,16 +4196,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Lokacin Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Lokaci na Hawaii-Aleutian</generic>
 					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
 					<daylight>Lokacin Rana na Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Tsayayyen Lokacin Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4893,41 +4893,45 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">¤ 0D</pattern>
+					<pattern type="1000" count="one">¤ 0K</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="1000" count="other">¤ 0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
 					<pattern type="10000" count="other">¤ 00D</pattern>
-					<pattern type="100000" count="one">¤ 000K</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
+					<pattern type="100000" count="one">¤ 000D</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000D</pattern>
+					<pattern type="100000" count="other">¤ 000D</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000D</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000" count="other">↑↑↑</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
+					<pattern type="1000000000" count="one">¤ 0B</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B</pattern>
+					<pattern type="1000000000" count="other">¤ 0B</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000" count="one">¤ 00B</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
+					<pattern type="10000000000" count="other">¤ 00B</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000" count="one">¤ 000B</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
+					<pattern type="100000000000" count="other">¤ 000B</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">¤ 0T</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other">¤ 0T</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one">¤ 00T</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other">¤ 00T</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one">¤ 000T</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
-					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/haw.xml
+++ b/common/main/haw.xml
@@ -587,14 +587,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>AKDT</daylight>
 				</short>
 			</metazone>
-			<metazone type="Hawaii_Aleutian">
+			<metazone type="Hawaii">
 				<short>
 					<generic>HAT</generic>
 					<standard>HAST</standard>
 					<daylight>HADT</daylight>
 				</short>
 			</metazone>
-			<metazone type="Hawaii">
+			<metazone type="Hawaii_Aleutian">
 				<short>
 					<generic>HAT</generic>
 					<standard>HAST</standard>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -6356,16 +6356,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>שעון גיאנה</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>שעון האיים האלאוטיים הוואי (חורף)</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>שעון האיים האלאוטיים הוואי</generic>
 					<standard>שעון האיים האלאוטיים הוואי (חורף)</standard>
 					<daylight>שעון האיים האלאוטיים הוואי (קיץ)</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>שעון האיים האלאוטיים הוואי (חורף)</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -7069,113 +7069,113 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">‏#,##0.00‏;‏-#,##0.00‏</pattern>
+					<pattern alt="alphaNextToNumber">‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤</pattern>
+					<pattern alt="noCurrency">‏#,##0.00 ‏;‏-#,##0.00 ‏</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤</pattern>
+					<pattern alt="noCurrency">‏#,##0.00 ‏;‏-#,##0.00 ‏</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K‏</pattern>
-					<pattern type="1000" count="two">↑↑↑</pattern>
-					<pattern type="1000" count="two" alt="alphaNextToNumber">¤ 0K‏</pattern>
-					<pattern type="1000" count="many">↑↑↑</pattern>
-					<pattern type="1000" count="many" alt="alphaNextToNumber">¤ 0K‏</pattern>
-					<pattern type="1000" count="other">¤0K‏</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K‏</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00K‏</pattern>
-					<pattern type="10000" count="two">↑↑↑</pattern>
-					<pattern type="10000" count="two" alt="alphaNextToNumber">¤ 00K‏</pattern>
-					<pattern type="10000" count="many">↑↑↑</pattern>
-					<pattern type="10000" count="many" alt="alphaNextToNumber">¤ 00K‏</pattern>
-					<pattern type="10000" count="other">¤00K‏</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K‏</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K‏</pattern>
-					<pattern type="100000" count="two">↑↑↑</pattern>
-					<pattern type="100000" count="two" alt="alphaNextToNumber">¤ 000K‏</pattern>
-					<pattern type="100000" count="many">↑↑↑</pattern>
-					<pattern type="100000" count="many" alt="alphaNextToNumber">¤ 000K‏</pattern>
-					<pattern type="100000" count="other">¤000K‏</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K‏</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M‏</pattern>
-					<pattern type="1000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000" count="two" alt="alphaNextToNumber">¤ 0M‏</pattern>
-					<pattern type="1000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000" count="many" alt="alphaNextToNumber">¤ 0M‏</pattern>
-					<pattern type="1000000" count="other">¤0M‏</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M‏</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M‏</pattern>
-					<pattern type="10000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000" count="two" alt="alphaNextToNumber">¤ 00M‏</pattern>
-					<pattern type="10000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000" count="many" alt="alphaNextToNumber">¤ 00M‏</pattern>
-					<pattern type="10000000" count="other">¤00M‏</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M‏</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M‏</pattern>
-					<pattern type="100000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000" count="two" alt="alphaNextToNumber">¤ 000M‏</pattern>
-					<pattern type="100000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000" count="many" alt="alphaNextToNumber">¤ 000M‏</pattern>
-					<pattern type="100000000" count="other">¤000M‏</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M‏</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B‏</pattern>
-					<pattern type="1000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000" count="two" alt="alphaNextToNumber">¤ 0B‏</pattern>
-					<pattern type="1000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000" count="many" alt="alphaNextToNumber">¤ 0B‏</pattern>
-					<pattern type="1000000000" count="other">¤0B‏</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B‏</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B‏</pattern>
-					<pattern type="10000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000" count="two" alt="alphaNextToNumber">¤ 00B‏</pattern>
-					<pattern type="10000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000" count="many" alt="alphaNextToNumber">¤ 00B‏</pattern>
-					<pattern type="10000000000" count="other">¤00B‏</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B‏</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B‏</pattern>
-					<pattern type="100000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000" count="two" alt="alphaNextToNumber">¤ 000B‏</pattern>
-					<pattern type="100000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000" count="many" alt="alphaNextToNumber">¤ 000B‏</pattern>
-					<pattern type="100000000000" count="other">¤000B‏</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B‏</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T‏</pattern>
-					<pattern type="1000000000000" count="two">↑↑↑</pattern>
-					<pattern type="1000000000000" count="two" alt="alphaNextToNumber">¤ 0T‏</pattern>
-					<pattern type="1000000000000" count="many">↑↑↑</pattern>
-					<pattern type="1000000000000" count="many" alt="alphaNextToNumber">¤ 0T‏</pattern>
-					<pattern type="1000000000000" count="other">¤0T‏</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T‏</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T‏</pattern>
-					<pattern type="10000000000000" count="two">↑↑↑</pattern>
-					<pattern type="10000000000000" count="two" alt="alphaNextToNumber">¤ 00T‏</pattern>
-					<pattern type="10000000000000" count="many">↑↑↑</pattern>
-					<pattern type="10000000000000" count="many" alt="alphaNextToNumber">¤ 00T‏</pattern>
-					<pattern type="10000000000000" count="other">¤00T‏</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T‏</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T‏</pattern>
-					<pattern type="100000000000000" count="two">↑↑↑</pattern>
-					<pattern type="100000000000000" count="two" alt="alphaNextToNumber">¤ 000T‏</pattern>
-					<pattern type="100000000000000" count="many">↑↑↑</pattern>
-					<pattern type="100000000000000" count="many" alt="alphaNextToNumber">¤ 000T‏</pattern>
-					<pattern type="100000000000000" count="other">¤000T‏</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T‏</pattern>
+					<pattern type="1000" count="one">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="two">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="two" alt="alphaNextToNumber">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="many">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="many" alt="alphaNextToNumber">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="other">‏0K‏ ‏¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">‏0K‏ ‏¤</pattern>
+					<pattern type="10000" count="one">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="two">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="two" alt="alphaNextToNumber">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="many">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="many" alt="alphaNextToNumber">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="other">‏00K‏ ‏¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">‏00K‏ ‏¤</pattern>
+					<pattern type="100000" count="one">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="two">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="two" alt="alphaNextToNumber">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="many">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="many" alt="alphaNextToNumber">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="other">‏000K‏ ‏¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">‏000K‏ ‏¤</pattern>
+					<pattern type="1000000" count="one">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="two">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="two" alt="alphaNextToNumber">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="many">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="many" alt="alphaNextToNumber">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="other">‏0M‏ ‏¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">‏0M‏ ‏¤</pattern>
+					<pattern type="10000000" count="one">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="two">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="two" alt="alphaNextToNumber">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="many">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="many" alt="alphaNextToNumber">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="other">‏00M‏ ‏¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">‏00M‏ ‏¤</pattern>
+					<pattern type="100000000" count="one">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="two">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="two" alt="alphaNextToNumber">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="many">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="many" alt="alphaNextToNumber">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="other">‏000M‏ ‏¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">‏000M‏ ‏¤</pattern>
+					<pattern type="1000000000" count="one">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="two">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="two" alt="alphaNextToNumber">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="many">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="many" alt="alphaNextToNumber">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="other">‏0B‏ ‏¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">‏0B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="one">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="two">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="two" alt="alphaNextToNumber">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="many">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="many" alt="alphaNextToNumber">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="other">‏00B‏ ‏¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">‏00B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="one">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="two">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="two" alt="alphaNextToNumber">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="many">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="many" alt="alphaNextToNumber">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="other">‏000B‏ ‏¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">‏000B‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="one">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="two">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="two" alt="alphaNextToNumber">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="many">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="many" alt="alphaNextToNumber">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="other">‏0T‏ ‏¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">‏0T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="one">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="two">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="two" alt="alphaNextToNumber">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="many">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="many" alt="alphaNextToNumber">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="other">‏00T‏ ‏¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">‏00T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="one">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="two">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="two" alt="alphaNextToNumber">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="many">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="many" alt="alphaNextToNumber">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="other">‏000T‏ ‏¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">‏000T‏ ‏¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -5224,16 +5224,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>गुयाना समय</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाई–आल्यूशन मानक समय</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाई–आल्यूशन समय</generic>
 					<standard>हवाई–आल्यूशन मानक समय</standard>
 					<daylight>हवाई–आल्यूशन डेलाइट समय</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाई–आल्यूशन मानक समय</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6608,7 +6608,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000" count="other">¤00 लाख</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00 लाख</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 0 क॰</pattern>
 					<pattern type="10000000" count="other">¤0 क॰</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0 क॰</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -4892,16 +4892,16 @@ annotations.
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5561,8 +5561,8 @@ annotations.
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5570,8 +5570,8 @@ annotations.
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##,##0.00</pattern>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -5522,16 +5522,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>gvajansko vrijeme</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>havajsko-aleutsko standardno vrijeme</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>havajsko-aleutsko vrijeme</generic>
 					<standard>havajsko-aleutsko standardno vrijeme</standard>
 					<daylight>havajsko-aleutsko ljetno vrijeme</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>havajsko-aleutsko standardno vrijeme</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6204,12 +6204,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -4326,16 +4326,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>guyanski čas</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>hawaiisko-aleutski standardny čas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>hawaiisko-aleutski čas</generic>
 					<standard>hawaiisko-aleutski standardny čas</standard>
 					<daylight>hawaiisko-aleutski lětni čas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>hawaiisko-aleutski standardny čas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4986,12 +4986,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -5253,16 +5253,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>guyanai téli idő</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>hawaii-aleuti téli idő</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>hawaii-aleuti időzóna</generic>
 					<standard>hawaii-aleuti téli idő</standard>
 					<daylight>hawaii-aleuti nyári idő</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>hawaii-aleuti téli idő</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6128,12 +6128,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="provisional">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber" draft="provisional">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -4288,16 +4288,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Գայանայի ժամանակ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Հավայան-ալեության ստանդարտ ժամանակ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Հավայան-ալեության ժամանակ</generic>
 					<standard>Հավայան-ալեության ստանդարտ ժամանակ</standard>
 					<daylight>Հավայան-ալեության ամառային ժամանակ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Հավայան-ալեության ստանդարտ ժամանակ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -4155,16 +4155,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>hora de Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>hora normal de Hawaii-Aleutianas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>hora de Hawaii-Aleutianas</generic>
 					<standard>hora normal de Hawaii-Aleutianas</standard>
 					<daylight>hora estive de Hawaii-Aleutianas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>hora normal de Hawaii-Aleutianas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -6594,6 +6594,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Waktu Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Waktu Standar Hawaii-Aleutian</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Waktu Hawaii-Aleutian</generic>
@@ -6604,14 +6612,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Waktu Standar Hawaii-Aleutian</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -7267,29 +7267,29 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other">¤0 rb</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">0 rb ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 rb</pattern>
 					<pattern type="10000" count="other">¤00 rb</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">00 rb ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 rb</pattern>
 					<pattern type="100000" count="other">¤000 rb</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">000 rb ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 rb</pattern>
 					<pattern type="1000000" count="other">¤0 jt</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 jt ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 jt</pattern>
 					<pattern type="10000000" count="other">¤00 jt</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 jt ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 jt</pattern>
 					<pattern type="100000000" count="other">¤000 jt</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 jt ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 jt</pattern>
 					<pattern type="1000000000" count="other">¤0 M</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 M ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 M</pattern>
 					<pattern type="10000000000" count="other">¤00 M</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 M ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 M</pattern>
 					<pattern type="100000000000" count="other">¤000 M</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 M ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 M</pattern>
 					<pattern type="1000000000000" count="other">¤0 T</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 T ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 T</pattern>
 					<pattern type="10000000000000" count="other">¤00 T</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 T ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 T</pattern>
 					<pattern type="100000000000000" count="other">¤000 T</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 T ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/ie.xml
+++ b/common/main/ie.xml
@@ -3323,16 +3323,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight draft="unconfirmed">témpor estival del occidental Greenland</daylight>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">témpor standard de Hawai e Aleutes</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">témpor de Hawai e Aleutes</generic>
 					<standard draft="unconfirmed">témpor standard de Hawai e Aleutes</standard>
 					<daylight draft="unconfirmed">témpor estival de Hawai e Aleutes</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">témpor standard de Hawai e Aleutes</standard>
 				</long>
 			</metazone>
 			<metazone type="Line_Islands">
@@ -3450,10 +3450,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -4258,16 +4258,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Oge Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Oge Izugbe Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Oge Hawaii-Aleutian</generic>
 					<standard>Oge Izugbe Hawaii-Aleutian</standard>
 					<daylight>Oge Ihe Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Oge Izugbe Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -6821,16 +6821,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Gvæjanatími</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Staðaltími á Havaí og Aleúta</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Tími á Havaí og Aleúta</generic>
 					<standard>Staðaltími á Havaí og Aleúta</standard>
 					<daylight>Sumartími á Havaí og Aleúta</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Staðaltími á Havaí og Aleúta</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -4788,16 +4788,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Ora della Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora standard delle Isole Hawaii-Aleutine</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora delle isole Hawaii-Aleutine</generic>
 					<standard>Ora standard delle Isole Hawaii-Aleutine</standard>
 					<daylight>Ora legale delle Isole Hawaii-Aleutine</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora standard delle Isole Hawaii-Aleutine</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5421,12 +5421,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/it_CH.xml
+++ b/common/main/it_CH.xml
@@ -179,6 +179,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -6767,16 +6767,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ガイアナ時間</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ハワイ・アリューシャン標準時</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ハワイ・アリューシャン時間</generic>
 					<standard>ハワイ・アリューシャン標準時</standard>
 					<daylight>ハワイ・アリューシャン夏時間</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ハワイ・アリューシャン標準時</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -4185,16 +4185,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Wektu Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Wektu Standar Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Wektu Hawaii-Aleutian</generic>
 					<standard>Wektu Standar Hawaii-Aleutian</standard>
 					<daylight>Wektu Ketigo Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Wektu Standar Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4812,8 +4812,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4821,40 +4824,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0È</pattern>
+					<pattern type="1000" count="other">¤ 0È</pattern>
 					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0È</pattern>
-					<pattern type="10000" count="other">¤00È</pattern>
+					<pattern type="10000" count="other">¤ 00È</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00È</pattern>
-					<pattern type="100000" count="other">¤000È</pattern>
+					<pattern type="100000" count="other">¤ 000È</pattern>
 					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000È</pattern>
-					<pattern type="1000000" count="other">¤0Y</pattern>
+					<pattern type="1000000" count="other">¤ 0Y</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0Y</pattern>
-					<pattern type="10000000" count="other">¤00Y</pattern>
+					<pattern type="10000000" count="other">¤ 00Y</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00Y</pattern>
-					<pattern type="100000000" count="other">¤000Y</pattern>
+					<pattern type="100000000" count="other">¤ 000Y</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000Y</pattern>
-					<pattern type="1000000000" count="other">¤0M</pattern>
+					<pattern type="1000000000" count="other">¤ 0M</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
-					<pattern type="10000000000" count="other">¤00M</pattern>
+					<pattern type="10000000000" count="other">¤ 00M</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
-					<pattern type="100000000000" count="other">¤000M</pattern>
+					<pattern type="100000000000" count="other">¤ 000M</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
-					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other">¤ 0T</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other">¤ 00T</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -4757,16 +4757,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>გაიანის დრო</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ჰავაისა და ალეუტის სტანდარტული დრო</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ჰავაისა და ალეუტის დრო</generic>
 					<standard>ჰავაისა და ალეუტის სტანდარტული დრო</standard>
 					<daylight>ჰავაისა და ალეუტის ზაფხულის დრო</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ჰავაისა და ალეუტის სტანდარტული დრო</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5371,12 +5371,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -4171,16 +4171,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">Akud n Gwiyan</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">Akud amezday n Haway-Aliwsyan</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">Akud n Haway-Aliwsyan</generic>
 					<standard draft="unconfirmed">Akud amezday n Haway-Aliwsyan</standard>
 					<daylight draft="unconfirmed">Akud n unebdu n Haway-Aliwsyan</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">Akud amezday n Haway-Aliwsyan</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4777,30 +4777,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="1000" count="other" draft="provisional">0K¤</pattern>
-					<pattern type="10000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="10000" count="other" draft="provisional">00K¤</pattern>
-					<pattern type="100000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="100000" count="other" draft="provisional">000K¤</pattern>
+					<pattern type="1000" count="one">0G¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="1000" count="other">0G¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="10000" count="one">00G¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="10000" count="other">00G¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="100000" count="one">000G¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="100000" count="other">000G¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000G ¤</pattern>
 					<pattern type="1000000" count="one" draft="provisional">↑↑↑</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0M ¤</pattern>
 					<pattern type="1000000" count="other" draft="provisional">0M¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0M ¤</pattern>
 					<pattern type="10000000" count="one" draft="provisional">↑↑↑</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00M ¤</pattern>
 					<pattern type="10000000" count="other" draft="provisional">00M¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00M ¤</pattern>
 					<pattern type="100000000" count="one" draft="provisional">↑↑↑</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000M ¤</pattern>
 					<pattern type="100000000" count="other" draft="provisional">000M¤</pattern>
-					<pattern type="1000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" draft="provisional">0G¤</pattern>
-					<pattern type="10000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" draft="provisional">00G¤</pattern>
-					<pattern type="100000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" draft="provisional">000G¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="1000000000" count="one">0L¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0L ¤</pattern>
+					<pattern type="1000000000" count="other">0L¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0L ¤</pattern>
+					<pattern type="10000000000" count="one">00L¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00L ¤</pattern>
+					<pattern type="10000000000" count="other">00L¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00L ¤</pattern>
+					<pattern type="100000000000" count="one">000L¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000L ¤</pattern>
+					<pattern type="100000000000" count="other">000L¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000L ¤</pattern>
 					<pattern type="1000000000000" count="one" draft="provisional">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0T ¤</pattern>
 					<pattern type="1000000000000" count="other" draft="provisional">0T¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0T ¤</pattern>
 					<pattern type="10000000000000" count="one" draft="provisional">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00T ¤</pattern>
 					<pattern type="10000000000000" count="other" draft="provisional">00T¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00T ¤</pattern>
 					<pattern type="100000000000000" count="one" draft="provisional">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000T ¤</pattern>
 					<pattern type="100000000000000" count="other" draft="provisional">000T¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>

--- a/common/main/kea.xml
+++ b/common/main/kea.xml
@@ -2496,16 +2496,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>Ora di Veron di Gronelándia Osidental</daylight>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora Padron di Avaí i Aleutas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora di Avaí i Aleutas</generic>
 					<standard>Ora Padron di Avaí i Aleutas</standard>
 					<daylight>Ora di Veron di Avaí i Aleutas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora Padron di Avaí i Aleutas</standard>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Pacific">
@@ -2614,10 +2614,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -4564,16 +4564,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Óra Gijỹnỹ tá</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Óra Pã Hava’i kar Arevta Goj-vẽso tá</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Óra Hava’i kar Arevta Goj-vẽso tá</generic>
 					<standard>Óra Pã Hava’i kar Arevta Goj-vẽso tá</standard>
 					<daylight>Rỹ kã óra Hava’i kar Arevta Goj-vẽso tá</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Óra Pã Hava’i kar Arevta Goj-vẽso tá</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -5392,16 +5392,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Гайана уақыты</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавай және Алеут аралдары стандартты уақыты</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавай және Алеут аралдары уақыты</generic>
 					<standard>Гавай және Алеут аралдары стандартты уақыты</standard>
 					<daylight>Гавай және Алеут аралдары жазғы уақыты</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавай және Алеут аралдары стандартты уақыты</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6092,7 +6092,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6100,13 +6105,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -6115,8 +6120,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000" count="other">0 мың ¤</pattern>
 					<pattern type="10000" count="one">↑↑↑</pattern>
 					<pattern type="10000" count="other">00 мың ¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 мың ¤</pattern>
+					<pattern type="100000" count="one">000 м'.' ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000 м'.' ¤</pattern>
+					<pattern type="100000" count="other">000 м'.' ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 м'.' ¤</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="other">0 млн ¤</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>

--- a/common/main/kk_Arab.xml
+++ b/common/main/kk_Arab.xml
@@ -4795,16 +4795,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>گايانا ۋاقىتى</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>گاۆاي جانە الەۋت ارالدارى ستاندارتتى ۋاقىتى</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>گاۆاي جانە الەۋت ارالدارى ۋاقىتى</generic>
 					<standard>گاۆاي جانە الەۋت ارالدارى ستاندارتتى ۋاقىتى</standard>
 					<daylight>گاۆاي جانە الەۋت ارالدارى جازعى ۋاقىتى</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>گاۆاي جانە الەۋت ارالدارى ستاندارتتى ۋاقىتى</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5760,30 +5760,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">0 مىڭ ¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">00 مىڭ ¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 مىڭ ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 ميلليون ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 ميلليون ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 ميلليون ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0 ميلليارد ¤</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 ميلليارد ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 ميلليارد ¤</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 تريلليون ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 تريلليون ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 تريلليون ¤</pattern>
+					<pattern type="1000" count="one">¤ 0 مىڭ</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 مىڭ</pattern>
+					<pattern type="1000" count="other">¤ 0 مىڭ</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 مىڭ</pattern>
+					<pattern type="10000" count="one">¤ 00 مىڭ</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 مىڭ</pattern>
+					<pattern type="10000" count="other">¤ 00 مىڭ</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 مىڭ</pattern>
+					<pattern type="100000" count="one">¤ 000 مىڭ</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 مىڭ</pattern>
+					<pattern type="100000" count="other">¤ 000 مىڭ</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 مىڭ</pattern>
+					<pattern type="1000000" count="one">¤ 0 ميلليون</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 ميلليون</pattern>
+					<pattern type="1000000" count="other">¤ 0 ميلليون</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 ميلليون</pattern>
+					<pattern type="10000000" count="one">¤ 00 ميلليون</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 ميلليون</pattern>
+					<pattern type="10000000" count="other">¤ 00 ميلليون</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 ميلليون</pattern>
+					<pattern type="100000000" count="one">¤ 000 ملن</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 ملن</pattern>
+					<pattern type="100000000" count="other">¤ 000 ملن</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 ملن</pattern>
+					<pattern type="1000000000" count="one">¤ 0 ميلليارد</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 ميلليارد</pattern>
+					<pattern type="1000000000" count="other">¤ 0 ميلليارد</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 ميلليارد</pattern>
+					<pattern type="10000000000" count="one">¤ 00 ملرد</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 ملرد</pattern>
+					<pattern type="10000000000" count="other">¤ 00 ملرد</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 ملرد</pattern>
+					<pattern type="100000000000" count="one">¤ 000 ملرد</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 ملرد</pattern>
+					<pattern type="100000000000" count="other">¤ 000 ملرد</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 ملرد</pattern>
+					<pattern type="1000000000000" count="one">¤ 0 تريلليون</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 تريلليون</pattern>
+					<pattern type="1000000000000" count="other">¤ 0 تريلليون</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 تريلليون</pattern>
+					<pattern type="10000000000000" count="one">¤ 00 ترلن</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 ترلن</pattern>
+					<pattern type="10000000000000" count="other">¤ 00 ترلن</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 ترلن</pattern>
+					<pattern type="100000000000000" count="one">¤ 000 ترلن</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 ترلن</pattern>
+					<pattern type="100000000000000" count="other">¤ 000 ترلن</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 ترلن</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/kl.xml
+++ b/common/main/kl.xml
@@ -1215,6 +1215,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -4176,16 +4176,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ម៉ោង​នៅ​ហ្គីយ៉ាន</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ម៉ោង​ស្តង់ដារ​​នៅ​ហាវៃ-អាល់ដ្យូសិន</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ម៉ោង​​នៅ​ហាវៃ-អាល់ដ្យូសិន</generic>
 					<standard>ម៉ោង​ស្តង់ដារ​​នៅ​ហាវៃ-អាល់ដ្យូសិន</standard>
 					<daylight>ម៉ោង​ពេល​ថ្ងៃ​នៅ​ហាវៃ-អាល់ដ្យូសិន</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ម៉ោង​ស្តង់ដារ​​នៅ​ហាវៃ-អាល់ដ្យូសិន</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4825,30 +4825,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0 ពាន់</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 ពាន់</pattern>
-					<pattern type="10000" count="other">¤00 ពាន់</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 ពាន់</pattern>
-					<pattern type="100000" count="other">¤000 ពាន់</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 ពាន់</pattern>
-					<pattern type="1000000" count="other">¤0 លាន</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 លាន</pattern>
-					<pattern type="10000000" count="other">¤00 លាន</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 លាន</pattern>
-					<pattern type="100000000" count="other">¤000 លាន</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 លាន</pattern>
-					<pattern type="1000000000" count="other">¤0 ប៊ីលាន</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 ប៊ីលាន</pattern>
-					<pattern type="10000000000" count="other">¤00 ប៊ីលាន</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 ប៊ីលាន</pattern>
-					<pattern type="100000000000" count="other">¤000 ប៊ីលាន</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 ប៊ីលាន</pattern>
-					<pattern type="1000000000000" count="other">¤0 ទ្រីលាន</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 ទ្រីលាន</pattern>
-					<pattern type="10000000000000" count="other">¤00 ទ្រីលាន</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 ទ្រីលាន</pattern>
-					<pattern type="100000000000000" count="other">¤000 ទ្រីលាន</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 ទ្រីលាន</pattern>
+					<pattern type="1000" count="other">0ពាន់¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0ពាន់ ¤</pattern>
+					<pattern type="10000" count="other">00 ពាន់¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00 ពាន់ ¤</pattern>
+					<pattern type="100000" count="other">000 ពាន់¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 ពាន់ ¤</pattern>
+					<pattern type="1000000" count="other">0 លាន¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 លាន ¤</pattern>
+					<pattern type="10000000" count="other">00 លាន¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 លាន ¤</pattern>
+					<pattern type="100000000" count="other">000 លាន¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 លាន ¤</pattern>
+					<pattern type="1000000000" count="other">0 ប៊ីលាន¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 ប៊ីលាន ¤</pattern>
+					<pattern type="10000000000" count="other">00 ប៊ីលាន¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 ប៊ីលាន ¤</pattern>
+					<pattern type="100000000000" count="other">000 ប៊ីលាន¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 ប៊ីលាន ¤</pattern>
+					<pattern type="1000000000000" count="other">0 ទ្រីលាន¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 ទ្រីលាន ¤</pattern>
+					<pattern type="10000000000000" count="other">00 ទ្រីលាន¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 ទ្រីលាន ¤</pattern>
+					<pattern type="100000000000000" count="other">000 ទ្រីលាន¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 ទ្រីលាន ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -5180,16 +5180,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ಗಯಾನಾ ಸಮಯ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ಹವಾಯಿ-ಅಲ್ಯುಟಿಯನ್ ಪ್ರಮಾಣಿತ ಸಮಯ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ಹವಾಯಿ-ಅಲ್ಯುಟಿಯನ್ ಸಮಯ</generic>
 					<standard>ಹವಾಯಿ-ಅಲ್ಯುಟಿಯನ್ ಪ್ರಮಾಣಿತ ಸಮಯ</standard>
 					<daylight>ಹವಾಯಿ-ಅಲ್ಯುಟಿಯನ್ ಹಗಲು ಸಮಯ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ಹವಾಯಿ-ಅಲ್ಯುಟಿಯನ್ ಪ್ರಮಾಣಿತ ಸಮಯ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -6099,16 +6099,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>가이아나 시간</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>하와이 알류샨 표준시</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>하와이 알류샨 시간</generic>
 					<standard>하와이 알류샨 표준시</standard>
 					<daylight>하와이 알류샨 하계 표준시</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>하와이 알류샨 표준시</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -4310,16 +4310,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>गुयाना वेळ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाई-अलेयुशिन प्रमाणीत वेळ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाई-अलेयुशिन वेळ</generic>
 					<standard>हवाई-अलेयुशिन प्रमाणीत वेळ</standard>
 					<daylight>हवाई-अलेयुशिन डेलायट वेळ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाई-अलेयुशिन प्रमाणीत वेळ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5036,8 +5036,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -5211,31 +5215,31 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">¤0हज</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤0हज</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0हज</pattern>
 					<pattern type="1000" count="other">¤0हज</pattern>
 					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0हज</pattern>
-					<pattern type="10000" count="one">¤ 00K</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤00हज</pattern>
+					<pattern type="10000" count="one">¤00हज</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00हज</pattern>
 					<pattern type="10000" count="other">¤00हज</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00हज</pattern>
 					<pattern type="100000" count="one">¤0लाख</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤0लाख</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 0लाख</pattern>
 					<pattern type="100000" count="other">¤0लाख</pattern>
 					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0लाख</pattern>
 					<pattern type="1000000" count="one">¤00लाख</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤00लाख</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 00लाख</pattern>
 					<pattern type="1000000" count="other">¤00लाख</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00लाख</pattern>
 					<pattern type="10000000" count="one">¤0कोटी</pattern>
@@ -5243,33 +5247,33 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000" count="other">¤0कोटी</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0कोटी</pattern>
 					<pattern type="100000000" count="one">¤00कोटी</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤00कोटी</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 00कोटी</pattern>
 					<pattern type="100000000" count="other">¤00कोटी</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00कोटी</pattern>
 					<pattern type="1000000000" count="one">¤0अब्ज</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤0अब्ज</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0अब्ज</pattern>
 					<pattern type="1000000000" count="other">¤0अब्ज</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0अब्ज</pattern>
 					<pattern type="10000000000" count="one">¤00अब्ज</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤00अब्ज</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00अब्ज</pattern>
 					<pattern type="10000000000" count="other">¤00अब्ज</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00अब्ज</pattern>
 					<pattern type="100000000000" count="one">¤0निख</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤0निख</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 0निख</pattern>
 					<pattern type="100000000000" count="other">¤0निख</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0निख</pattern>
 					<pattern type="1000000000000" count="one">¤00निख</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤00निख</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 00निख</pattern>
 					<pattern type="1000000000000" count="other">¤00निख</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 00निख</pattern>
 					<pattern type="10000000000000" count="one">¤000निख</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤000निख</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 000निख</pattern>
 					<pattern type="10000000000000" count="other">¤000निख</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 000निख</pattern>
-					<pattern type="100000000000000" count="one">¤000हज'.'निख'.'</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
-					<pattern type="100000000000000" count="other">¤000हज'.'निख'.'</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000हज'.'निख'.'</pattern>
+					<pattern type="100000000000000" count="one">¤0हज'.'निख'.'</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 0हज'.'निख'.'</pattern>
+					<pattern type="100000000000000" count="other">¤0हज'.'निख'.'</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 0हज'.'निख'.'</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/kok_Latn.xml
+++ b/common/main/kok_Latn.xml
@@ -2196,6 +2196,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -2203,22 +2209,40 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other">¤0hoz</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0hoz</pattern>
 					<pattern type="10000" count="other">¤00hoz</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00hoz</pattern>
 					<pattern type="100000" count="other">¤0lak</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0lak</pattern>
 					<pattern type="1000000" count="other">¤00lak</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00lak</pattern>
 					<pattern type="10000000" count="other">¤0ko</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0ko</pattern>
 					<pattern type="100000000" count="other">¤00ko</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00ko</pattern>
 					<pattern type="1000000000" count="other">¤0obz</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0obz</pattern>
 					<pattern type="10000000000" count="other">¤00obz</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00obz</pattern>
 					<pattern type="100000000000" count="other">¤0nikh</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0nikh</pattern>
 					<pattern type="1000000000000" count="other">¤00nikh</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 00nikh</pattern>
 					<pattern type="10000000000000" count="other">¤000nikh</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 000nikh</pattern>
 					<pattern type="100000000000000" count="other">¤0hoz'.'nikh'.'</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 0hoz'.'nikh'.'</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/ks.xml
+++ b/common/main/ks.xml
@@ -3612,16 +3612,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>گُیَنا ٹایِم</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>حَواے اؠلیوٗٹِیَن سٹینڑاڑ ٹایِم</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>حَواے اؠلیوٗٹِیَن ٹایِم</generic>
 					<standard>حَواے اؠلیوٗٹِیَن سٹینڑاڑ ٹایِم</standard>
 					<daylight>حَواے اؠلیوٗٹِیَن سَمَر ٹایِم</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>حَواے اؠلیوٗٹِیَن سٹینڑاڑ ٹایِم</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ksf.xml
+++ b/common/main/ksf.xml
@@ -591,7 +591,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/ksh.xml
+++ b/common/main/ksh.xml
@@ -1904,6 +1904,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -8042,6 +8042,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Saeta Guyanayê</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Saeta Standard a Hawaii-Aleutianê</standard>
+				</long>
+				<short>
+					<standard draft="contributed">SSHA</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Saeta Hawaii-Aleutianê</generic>
@@ -8052,14 +8060,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">SHAL</generic>
 					<standard draft="contributed">SSHA</standard>
 					<daylight draft="contributed">SHHA</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Saeta Standard a Hawaii-Aleutianê</standard>
-				</long>
-				<short>
-					<standard draft="contributed">SSHA</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -11942,7 +11942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11959,7 +11959,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11988,7 +11988,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12005,7 +12005,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12022,7 +12022,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12039,7 +12039,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12056,7 +12056,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12073,7 +12073,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12090,7 +12090,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12107,7 +12107,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12124,7 +12124,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12141,7 +12141,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12158,7 +12158,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12175,7 +12175,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12192,7 +12192,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12209,7 +12209,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12226,7 +12226,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12243,7 +12243,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12260,7 +12260,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12277,7 +12277,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12294,7 +12294,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12311,7 +12311,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12328,7 +12328,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12345,7 +12345,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12362,7 +12362,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12379,7 +12379,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12396,7 +12396,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12413,7 +12413,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12430,7 +12430,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12447,7 +12447,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12464,7 +12464,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12509,7 +12509,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12526,7 +12526,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12543,7 +12543,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12560,7 +12560,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12577,7 +12577,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12594,7 +12594,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12611,7 +12611,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12628,7 +12628,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12645,7 +12645,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12662,7 +12662,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12679,7 +12679,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12696,7 +12696,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12713,7 +12713,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12730,7 +12730,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12747,7 +12747,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12764,7 +12764,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12781,7 +12781,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12798,7 +12798,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12815,7 +12815,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12832,7 +12832,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12849,7 +12849,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12866,7 +12866,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12883,7 +12883,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12900,7 +12900,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12917,7 +12917,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12934,7 +12934,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12951,7 +12951,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12968,7 +12968,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12985,7 +12985,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13002,7 +13002,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13019,7 +13019,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13036,7 +13036,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13053,7 +13053,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13070,7 +13070,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13087,7 +13087,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13104,7 +13104,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13121,7 +13121,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13138,7 +13138,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13155,7 +13155,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13172,7 +13172,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13189,7 +13189,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13206,7 +13206,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13223,7 +13223,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13240,7 +13240,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13257,7 +13257,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13274,7 +13274,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/kxv.xml
+++ b/common/main/kxv.xml
@@ -2845,16 +2845,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>guyān belā</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>hāwāe- aalūsān mānānka belā</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>hāwāe- aalūsān belā</generic>
 					<standard>hāwāe- aalūsān mānānka belā</standard>
 					<daylight>hāwāe- aalūsān ḍelāiṭ belā</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>hāwāe- aalūsān mānānka belā</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3452,8 +3452,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3461,26 +3464,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0h</pattern>
-					<pattern type="10000" count="other">¤00h</pattern>
-					<pattern type="100000" count="other">¤000h</pattern>
-					<pattern type="1000000" count="other">¤0mi</pattern>
-					<pattern type="10000000" count="other">¤00mi</pattern>
-					<pattern type="100000000" count="other">¤000mi</pattern>
-					<pattern type="1000000000" count="other">¤0bi</pattern>
-					<pattern type="10000000000" count="other">¤00bi</pattern>
-					<pattern type="100000000000" count="other">¤000bi</pattern>
-					<pattern type="1000000000000" count="other">¤0tri</pattern>
-					<pattern type="10000000000000" count="other">¤00tri</pattern>
-					<pattern type="100000000000000" count="other">¤000tri</pattern>
+					<pattern type="1000" count="other">¤0 h</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 h</pattern>
+					<pattern type="10000" count="other">¤00 h</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 h</pattern>
+					<pattern type="100000" count="other">¤000 h</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 h</pattern>
+					<pattern type="1000000" count="other">¤0 mi</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 mi</pattern>
+					<pattern type="10000000" count="other">¤00 mi</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 mi</pattern>
+					<pattern type="100000000" count="other">¤000 mi</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 mi</pattern>
+					<pattern type="1000000000" count="other">¤0 bi</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 bi</pattern>
+					<pattern type="10000000000" count="other">¤00 bi</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 bi</pattern>
+					<pattern type="100000000000" count="other">¤000 bi</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 bi</pattern>
+					<pattern type="1000000000000" count="other">¤0 tri</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 tri</pattern>
+					<pattern type="10000000000000" count="other">¤00 tri</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 tri</pattern>
+					<pattern type="100000000000000" count="other">¤000 tri</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 tri</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>

--- a/common/main/kxv_Deva.xml
+++ b/common/main/kxv_Deva.xml
@@ -2732,16 +2732,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>गुयाना बेला</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाति–आल्यूसन मानांकॉ बेला</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाति–आल्यूसन बेला</generic>
 					<standard>हवाति–आल्यूसन मानांकॉ बेला</standard>
 					<daylight>हवाति–आल्यूसन डेलाइट बेला</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाति–आल्यूसन मानांकॉ बेला</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3297,6 +3297,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3304,6 +3310,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/kxv_Orya.xml
+++ b/common/main/kxv_Orya.xml
@@ -2734,16 +2734,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>ଗୁୟାନା ବେଲା</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ହାୱାଇ-ଆଲ୍ୟୁସାନ ମାନାଙ୍କ ବେଲା</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ହାୱାଇ-ଆଲ୍ୟୁସାନ ବେଲା</generic>
 					<standard>ହାୱାଇ-ଆଲ୍ୟୁସାନ ମାନାଙ୍କ ବେଲା</standard>
 					<daylight>ହାୱାଇ-ଆଲ୍ୟୁସାନ ଡେ ଲାଇଟ ବେଲା</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ହାୱାଇ-ଆଲ୍ୟୁସାନ ମାନାଙ୍କ ବେଲା</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3299,6 +3299,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3306,6 +3312,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/kxv_Telu.xml
+++ b/common/main/kxv_Telu.xml
@@ -2708,16 +2708,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>గయానా సమయం</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>హవాయ్-అల్యూషియన్ ప్రామాణిక సమయం</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>హవాయ్-అల్యూషియన్ సమయం</generic>
 					<standard>హవాయ్-అల్యూషియన్ ప్రామాణిక సమయం</standard>
 					<daylight>హవాయ్-అల్యూషియన్ పగటి వెలుతురు సమయం</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>హవాయ్-అల్యూషియన్ ప్రామాణిక సమయం</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3273,6 +3273,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3280,6 +3286,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -4227,16 +4227,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Гвиана убактысы</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавайи-Алеут кышкы убактысы</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавайи-Алеут убактысы</generic>
 					<standard>Гавайи-Алеут кышкы убактысы</standard>
 					<daylight>Гавайи-Алеут жайкы убактысы</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавайи-Алеут кышкы убактысы</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4927,7 +4927,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4935,12 +4939,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/la.xml
+++ b/common/main/la.xml
@@ -1160,6 +1160,60 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</decimalFormat>
 			</decimalFormatLength>
 		</decimalFormats>
+		<currencyFormats numberSystem="latn">
+			<currencyFormatLength type="short">
+				<currencyFormat type="standard">
+					<pattern type="1000" count="one">¤ 0M</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="1000" count="other">¤ 0M</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="10000" count="one">¤ 00M</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="10000" count="other">¤ 00M</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="100000" count="one">¤ 000M</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
+					<pattern type="100000" count="other">¤ 000M</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
+					<pattern type="1000000" count="one">¤ 0 Mn</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 Mn</pattern>
+					<pattern type="1000000" count="other">¤ 0 Mn</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 Mn</pattern>
+					<pattern type="10000000" count="one">¤ 00 Mn</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 Mn</pattern>
+					<pattern type="10000000" count="other">¤ 00 Mn</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 Mn</pattern>
+					<pattern type="100000000" count="one">¤ 000 Mn</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 Mn</pattern>
+					<pattern type="100000000" count="other">¤ 000 Mn</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 Mn</pattern>
+					<pattern type="1000000000" count="one">¤ 0 Md</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 Md</pattern>
+					<pattern type="1000000000" count="other">¤ 0 Md</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 Md</pattern>
+					<pattern type="10000000000" count="one">¤ 00 Md</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 Md</pattern>
+					<pattern type="10000000000" count="other">¤ 00 Md</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 Md</pattern>
+					<pattern type="100000000000" count="one">¤ 000 Md</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 Md</pattern>
+					<pattern type="100000000000" count="other">¤ 000 Md</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 Md</pattern>
+					<pattern type="1000000000000" count="one">¤ 0 mil Md</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 mil Md</pattern>
+					<pattern type="1000000000000" count="other">¤ 0 mil Md</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 mil Md</pattern>
+					<pattern type="10000000000000" count="one">¤ 00 mil Md</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 mil Md</pattern>
+					<pattern type="10000000000000" count="other">¤ 00 mil Md</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 mil Md</pattern>
+					<pattern type="100000000000000" count="one">¤ 000 mil Md</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 mil Md</pattern>
+					<pattern type="100000000000000" count="other">¤ 000 mil Md</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 mil Md</pattern>
+				</currencyFormat>
+			</currencyFormatLength>
+		</currencyFormats>
 		<currencies>
 			<currency type="CHF">
 				<displayName draft="provisional">Francus Helveticus</displayName>

--- a/common/main/lb.xml
+++ b/common/main/lb.xml
@@ -3052,16 +3052,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyana-Zäit</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleuten-Normalzäit</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleuten-Zäit</generic>
 					<standard>Hawaii-Aleuten-Normalzäit</standard>
 					<daylight>Hawaii-Aleuten-Summerzäit</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleuten-Normalzäit</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3656,10 +3656,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -4058,16 +4058,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard draft="unconfirmed">oa da Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">oa standard de Hawaii-Aleutiñe</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">oa de Hawaii-Aleutiñe</generic>
 					<standard draft="unconfirmed">oa standard de Hawaii-Aleutiñe</standard>
 					<daylight draft="unconfirmed">oa de stæ de Hawaii-Aleutiñe</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">oa standard de Hawaii-Aleutiñe</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4659,10 +4659,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/lld.xml
+++ b/common/main/lld.xml
@@ -3599,16 +3599,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Ora dla Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora standard dles Isoles Hawaii-Aleutines</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora dles Isoles Hawaii-Aleutines</generic>
 					<standard>Ora standard dles Isoles Hawaii-Aleutines</standard>
 					<daylight>Ora da d’isté dles Isoles Hawaii-Aleutines</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora standard dles Isoles Hawaii-Aleutines</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4204,12 +4204,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ln.xml
+++ b/common/main/ln.xml
@@ -732,7 +732,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -5558,16 +5558,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ເວລາກາຍອານາ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ເວລາມາດຕະຖານຮາວາຍ-ເອລູທຽນ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ເວລາຮາວາຍ-ເອລູທຽນ</generic>
 					<standard>ເວລາມາດຕະຖານຮາວາຍ-ເອລູທຽນ</standard>
 					<daylight>ເວລາຕອນທ່ຽງຮາວາຍ-ເອລູທຽນ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ເວລາມາດຕະຖານຮາວາຍ-ເອລູທຽນ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6252,8 +6252,40 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+			</currencyFormatLength>
+			<currencyFormatLength type="short">
+				<currencyFormat type="standard">
+					<pattern type="1000" count="other">¤0ພັນ</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0ພັນ</pattern>
+					<pattern type="10000" count="other">¤00ພັນ</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00ພັນ</pattern>
+					<pattern type="100000" count="other">¤000ພັນ</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000ພັນ</pattern>
+					<pattern type="1000000" count="other">¤0ລ້ານ</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0ລ້ານ</pattern>
+					<pattern type="10000000" count="other">¤00ລ້ານ</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00ລ້ານ</pattern>
+					<pattern type="100000000" count="other">¤000ລ້ານ</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000ລ້ານ</pattern>
+					<pattern type="1000000000" count="other">¤0ຕື້</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0ຕື້</pattern>
+					<pattern type="10000000000" count="other">¤00ຕື້</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00ຕື້</pattern>
+					<pattern type="100000000000" count="other">¤000ຕື້</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000ຕື້</pattern>
+					<pattern type="1000000000000" count="other">¤0000ຕື້</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0000ຕື້</pattern>
+					<pattern type="10000000000000" count="other">¤00ພັນຕື້</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00ພັນຕື້</pattern>
+					<pattern type="100000000000000" count="other">¤000ພັນຕື້</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000ພັນຕື້</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -6261,13 +6293,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
@@ -6292,10 +6324,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 ຕື້</pattern>
 					<pattern type="1000000000000" count="other">¤0 ລ້ານລ້ານ</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 ລ້ານລ້ານ</pattern>
-					<pattern type="10000000000000" count="other">¤00 ລ້ານລ້ານ</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 ລ້ານລ້ານ</pattern>
-					<pattern type="100000000000000" count="other">¤000 ລ້ານລ້ານ</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 ລ້ານລ້ານ</pattern>
+					<pattern type="10000000000000" count="other">¤00ລລ</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00ລລ</pattern>
+					<pattern type="100000000000000" count="other">¤000ລລ</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000ລລ</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -6605,16 +6605,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Gajanos laikas</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havajų–Aleutų žiemos laikas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havajų-Aleutų laikas</generic>
 					<standard>Havajų–Aleutų žiemos laikas</standard>
 					<daylight>Havajų–Aleutų vasaros laikas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havajų–Aleutų žiemos laikas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -7311,12 +7311,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/luy.xml
+++ b/common/main/luy.xml
@@ -595,6 +595,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤- #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤- #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;- #,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤- #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;- #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -5014,16 +5014,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Gajānas laiks</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havaju–Aleutu ziemas laiks</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havaju–Aleutu laiks</generic>
 					<standard>Havaju–Aleutu ziemas laiks</standard>
 					<daylight>Havaju–Aleutu vasaras laiks</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havaju–Aleutu ziemas laiks</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5675,12 +5675,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/mai.xml
+++ b/common/main/mai.xml
@@ -3803,16 +3803,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>गुयाना टाइम</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाई-एल्यूटियन मानक टाइम</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाई-एल्यूटियन टाइम</generic>
 					<standard>हवाई-एल्यूटियन मानक टाइम</standard>
 					<daylight>हवाई-एल्यूटियन डेलाइट टाइम</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाई-एल्यूटियन मानक टाइम</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/mi.xml
+++ b/common/main/mi.xml
@@ -3968,16 +3968,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Wā Kaiana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Wā Arowhānui Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Wā Hawaii-Aleutian</generic>
 					<standard>Wā Arowhānui Hawaii-Aleutian</standard>
 					<daylight>Wā Awatea Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Wā Arowhānui Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -5837,16 +5837,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Време во Гвајана</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Стандардно време во Хаваи - Алеутски острови</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Време во Хаваи - Алеутски острови</generic>
 					<standard>Стандардно време во Хаваи - Алеутски острови</standard>
 					<daylight>Летно сметање на времето во Хаваи - Алеутски острови</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Стандардно време во Хаваи - Алеутски острови</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6485,14 +6485,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000" count="other">0 мил'.' ¤</pattern>
 					<pattern type="10000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000" count="other">00 мил'.' ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 мил'.' ¤</pattern>
+					<pattern type="100000000" count="one">000 М ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 М ¤</pattern>
+					<pattern type="100000000" count="other">000 М ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 М ¤</pattern>
 					<pattern type="1000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000" count="other">0 милј'.' ¤</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000000" count="other">00 милј'.' ¤</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 милј'.' ¤</pattern>
+					<pattern type="100000000000" count="one">000 мј'.' ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 мј'.' ¤</pattern>
+					<pattern type="100000000000" count="other">000 ми'.' ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 ми'.' ¤</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000000000" count="other">0 бил'.' ¤</pattern>
 					<pattern type="10000000000000" count="one">↑↑↑</pattern>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -5965,16 +5965,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ഗയാന സമയം</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ഹവായ്-അലൂഷ്യൻ സ്റ്റാൻഡേർഡ് സമയം</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ഹവായ്-അലൂഷ്യൻ സമയം</generic>
 					<standard>ഹവായ്-അലൂഷ്യൻ സ്റ്റാൻഡേർഡ് സമയം</standard>
 					<daylight>ഹവായ്-അലൂഷ്യൻ ഡേലൈറ്റ് സമയം</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ഹവായ്-അലൂഷ്യൻ സ്റ്റാൻഡേർഡ് സമയം</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -4759,16 +4759,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Гайанагийн цаг</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Хавай-Алеутын стандарт цаг</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Хавай-Алеутын цаг</generic>
 					<standard>Хавай-Алеутын стандарт цаг</standard>
 					<daylight>Хавай-Алеутын зуны цаг</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Хавай-Алеутын стандарт цаг</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6336,11 +6336,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6363,11 +6365,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6378,11 +6382,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6393,11 +6399,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6408,11 +6416,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6423,11 +6433,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6438,11 +6450,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6453,11 +6467,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6468,11 +6484,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6483,11 +6501,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6498,11 +6518,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6513,11 +6535,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6528,11 +6552,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6543,11 +6569,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6558,11 +6586,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6573,11 +6603,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6588,11 +6620,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6603,11 +6637,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6618,11 +6654,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6633,11 +6671,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6648,11 +6688,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6663,51 +6705,63 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00¤</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">¤ 0 мянга</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">¤ 00 мянга</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">000 мянган ¤</pattern>
-					<pattern type="100000" count="other">¤000 мянга</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">000 мянган ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 сая ¤</pattern>
-					<pattern type="1000000" count="other">¤0 сая</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 сая ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 сая ¤</pattern>
-					<pattern type="10000000" count="other">¤00 сая</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 сая ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 сая ¤</pattern>
-					<pattern type="100000000" count="other">¤000 сая</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 сая ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0 тэрбум ¤</pattern>
-					<pattern type="1000000000" count="other">¤0 тэрбум</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 тэрбум ¤</pattern>
+					<pattern type="1000" count="one">¤ 0 мян'.'</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 мян'.'</pattern>
+					<pattern type="1000" count="other">¤ 0 мян</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 мян</pattern>
+					<pattern type="10000" count="one">¤ 00 мян'.'</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 мян'.'</pattern>
+					<pattern type="10000" count="other">¤ 00 мян</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 мян</pattern>
+					<pattern type="100000" count="one">¤ 000 мян'.'</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 мян'.'</pattern>
+					<pattern type="100000" count="other">¤ 000 мян</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 мян</pattern>
+					<pattern type="1000000" count="one">¤ 0 сая</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 сая</pattern>
+					<pattern type="1000000" count="other">¤ 0 сая</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 сая</pattern>
+					<pattern type="10000000" count="one">¤ 00 сая</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 сая</pattern>
+					<pattern type="10000000" count="other">¤ 00 сая</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 сая</pattern>
+					<pattern type="100000000" count="one">¤ 000 сая</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 сая</pattern>
+					<pattern type="100000000" count="other">¤ 000 сая</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 сая</pattern>
+					<pattern type="1000000000" count="one">¤ 0 тэрбум</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 тэрбум</pattern>
+					<pattern type="1000000000" count="other">¤ 0 тэрбум</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 тэрбум</pattern>
 					<pattern type="10000000000" count="one">↑↑↑</pattern>
 					<pattern type="10000000000" count="other">¤ 00 тэрбум</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ 000 тэрбум</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">¤ 0 их наяд</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">¤ 00 их наяд</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ 000 их наяд</pattern>
+					<pattern type="100000000000" count="one">¤ 000Т</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000Т</pattern>
+					<pattern type="100000000000" count="other">¤ 000Т</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000Т</pattern>
+					<pattern type="1000000000000" count="one">¤ 0ИН</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0ИН</pattern>
+					<pattern type="1000000000000" count="other">¤ 0ИН</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0ИН</pattern>
+					<pattern type="10000000000000" count="one">¤ 00ИН</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00ИН</pattern>
+					<pattern type="10000000000000" count="other">¤ 00ИН</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00ИН</pattern>
+					<pattern type="100000000000000" count="one">¤ 000ИН</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000ИН</pattern>
+					<pattern type="100000000000000" count="other">¤ 000ИН</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000ИН</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6718,11 +6772,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6733,11 +6789,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6748,11 +6806,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6763,12 +6823,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6779,11 +6840,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6794,11 +6857,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6809,11 +6874,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6824,11 +6891,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6839,10 +6908,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6853,11 +6925,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6868,11 +6942,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6883,11 +6959,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6898,11 +6976,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6913,11 +6993,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6928,11 +7010,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6943,11 +7027,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6958,11 +7044,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6973,11 +7061,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6988,11 +7078,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -7003,11 +7095,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -7018,11 +7112,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -7033,11 +7129,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -7048,11 +7146,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -5205,16 +5205,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>गयाना वेळ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाई-अलूशन प्रमाण वेळ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाई-अलूशन वेळ</generic>
 					<standard>हवाई-अलूशन प्रमाण वेळ</standard>
 					<daylight>हवाई-अलूशन सूर्यप्रकाश वेळ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाई-अलूशन प्रमाण वेळ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -6440,16 +6440,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Waktu Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Waktu Piawai Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Waktu Hawaii-Aleutian</generic>
 					<standard>Waktu Piawai Hawaii-Aleutian</standard>
 					<daylight>Waktu Siang Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Waktu Piawai Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ms_Arab.xml
+++ b/common/main/ms_Arab.xml
@@ -929,6 +929,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">{0} {1}</unitPattern>

--- a/common/main/ms_Arab_BN.xml
+++ b/common/main/ms_Arab_BN.xml
@@ -46,6 +46,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
 				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencies>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -4168,16 +4168,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ဂိုင်ယာနာ အချိန်</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ဟာဝိုင်ယီ အယ်လူးရှန်း စံတော်ချိန်</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ဟာဝိုင်ယီ အယ်လူးရှန်း အချိန်</generic>
 					<standard>ဟာဝိုင်ယီ အယ်လူးရှန်း စံတော်ချိန်</standard>
 					<daylight>ဟာဝိုင်ယီ အယ်လူးရှန်း နွေရာသီ စံတော်ချိန်</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ဟာဝိုင်ယီ အယ်လူးရှန်း စံတော်ချိန်</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4817,7 +4817,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -4828,18 +4828,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤ 0 ထောင်</pattern>
-					<pattern type="10000" count="other">¤ 0 သောင်း</pattern>
-					<pattern type="100000" count="other">¤ 0 သိန်း</pattern>
-					<pattern type="1000000" count="other">¤ 0 သန်း</pattern>
-					<pattern type="10000000" count="other">¤ 0 ကုဋေ</pattern>
-					<pattern type="100000000" count="other">¤ 00 ကုဋေ</pattern>
-					<pattern type="1000000000" count="other">¤ 000 ကုဋေ</pattern>
-					<pattern type="10000000000" count="other">¤ 0000 ကုဋေ</pattern>
-					<pattern type="100000000000" count="other">¤ ကုဋေ 0 သောင်း</pattern>
-					<pattern type="1000000000000" count="other">¤ ကုဋေ 0 သိန်း</pattern>
-					<pattern type="10000000000000" count="other">¤ ကုဋေ 0 သန်း</pattern>
-					<pattern type="100000000000000" count="other">¤ 0 ကောဋိ</pattern>
+					<pattern type="1000" count="other">0 ထောင် ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0 ထောင် ¤</pattern>
+					<pattern type="10000" count="other">0 သောင်း ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">0 သောင်း ¤</pattern>
+					<pattern type="100000" count="other">0 သိန်း ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">0 သိန်း ¤</pattern>
+					<pattern type="1000000" count="other">0 သန်း ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 သန်း ¤</pattern>
+					<pattern type="10000000" count="other">0 ကုဋေ ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">0 ကုဋေ ¤</pattern>
+					<pattern type="100000000" count="other">00 ကုဋေ ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">00 ကုဋေ ¤</pattern>
+					<pattern type="1000000000" count="other">000 ဋေ ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">000 ဋေ ¤</pattern>
+					<pattern type="10000000000" count="other">ဋေ 0 ထ ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">ဋေ 0 ထ ¤</pattern>
+					<pattern type="100000000000" count="other">ဋေ 0 သ ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">ဋေ 0 သ ¤</pattern>
+					<pattern type="1000000000000" count="other">ဋေ 0 သိန်း ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">ဋေ 0 သိန်း ¤</pattern>
+					<pattern type="10000000000000" count="other">ဋေ 0 သန်း ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">ဋေ 0 သန်း ¤</pattern>
+					<pattern type="100000000000000" count="other">0 ကောဋိ ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">0 ကောဋိ ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -4849,6 +4861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -4822,7 +4822,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -4863,6 +4863,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern>↑↑↑</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/nds.xml
+++ b/common/main/nds.xml
@@ -1909,6 +1909,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">{0} {1}</unitPattern>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -4663,16 +4663,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>गुयाना समय</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाई-एलुटियन मानक समय</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाई-एलुटियन समय</generic>
 					<standard>हवाई-एलुटियन मानक समय</standard>
 					<daylight>हवाई-एलुटियन दिवा समय</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाई-एलुटियन मानक समय</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5317,7 +5317,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5325,12 +5329,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -10596,6 +10596,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyaanse tijd</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleoetische standaardtijd</standard>
+				</long>
+				<short>
+					<standard>HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleoetische tijd</generic>
@@ -10606,14 +10614,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic>HAT</generic>
 					<standard>HAST</standard>
 					<daylight>HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleoetische standaardtijd</standard>
-				</long>
-				<short>
-					<standard>HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -12897,10 +12897,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12924,10 +12926,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12939,10 +12943,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12954,10 +12960,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12969,10 +12977,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12984,10 +12994,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12999,10 +13011,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13014,10 +13028,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13029,10 +13045,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13044,10 +13062,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13059,10 +13079,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13074,10 +13096,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13089,10 +13113,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13104,10 +13130,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13119,10 +13147,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13134,10 +13164,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13149,10 +13181,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13164,10 +13198,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13179,10 +13215,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13194,10 +13232,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13209,10 +13249,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13224,12 +13266,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00;¤ -#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13293,10 +13335,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13308,10 +13352,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13323,10 +13369,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13338,10 +13386,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13353,10 +13403,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13368,10 +13420,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13383,10 +13437,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13398,10 +13454,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13413,10 +13471,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13428,10 +13488,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13443,10 +13505,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13458,10 +13522,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13473,10 +13539,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13488,10 +13556,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13503,10 +13573,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13518,10 +13590,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13533,10 +13607,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13548,10 +13624,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13563,10 +13641,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13578,10 +13658,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13593,10 +13675,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13608,10 +13692,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -13623,10 +13709,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/nl_BE.xml
+++ b/common/main/nl_BE.xml
@@ -111,6 +111,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤ -#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/nmg.xml
+++ b/common/main/nmg.xml
@@ -595,7 +595,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -5273,16 +5273,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>sommartid for Hawaii og Aleutene</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5887,65 +5887,65 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 k</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one">0k ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="other">0k ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="10000" count="one">00k ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="other">00k ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="100000" count="one">000k ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="other">000k ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="1000000" count="one">0 mill'.' ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 mill'.' ¤</pattern>
+					<pattern type="1000000" count="other">0 mill'.' ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 mill'.' ¤</pattern>
+					<pattern type="10000000" count="one">00 mill'.' ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 mill'.' ¤</pattern>
+					<pattern type="10000000" count="other">00 mill'.' ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 mill'.' ¤</pattern>
+					<pattern type="100000000" count="one">000 mill'.' ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 mill'.' ¤</pattern>
+					<pattern type="100000000" count="other">000 mill'.' ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 mill'.' ¤</pattern>
+					<pattern type="1000000000" count="one">0 mrd'.' ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0 mrd'.' ¤</pattern>
+					<pattern type="1000000000" count="other">0 mrd'.' ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="one">00 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="other">00 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="one">000 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="other">000 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 mrd'.' ¤</pattern>
+					<pattern type="1000000000000" count="one">0 bill'.' ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 bill'.' ¤</pattern>
+					<pattern type="1000000000000" count="other">0 bill'.' ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="one">00 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="other">00 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="one">000 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="other">000 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 bill'.' ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -9440,6 +9440,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>guyansk tid</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>normaltid for Hawaii og Aleutene</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>tidssone for Hawaii og Aleutene</generic>
@@ -9450,14 +9458,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>normaltid for Hawaii og Aleutene</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -11509,6 +11509,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11521,6 +11522,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11533,6 +11535,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11545,6 +11548,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11557,6 +11561,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11569,6 +11574,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11581,6 +11587,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11593,6 +11600,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11605,6 +11613,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11617,6 +11626,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11629,6 +11639,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11641,6 +11652,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11653,6 +11665,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11665,6 +11678,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11677,6 +11691,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11689,6 +11704,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11701,6 +11717,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11713,6 +11730,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11722,65 +11740,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤;-#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000" count="other">¤ 0k</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">¤ 00k</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">¤ 000k</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">¤ 0 mill'.'</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">¤ 00 mill'.'</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">¤ 000 mill'.'</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤ 0 mrd'.'</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤ 00 mrd'.'</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ 000 mrd'.'</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">¤ 0 bill'.'</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">¤ 00 bill'.'</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ 000 bill'.'</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one">0k ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="1000" count="other">0k ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0k ¤</pattern>
+					<pattern type="10000" count="one">00k ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="10000" count="other">00k ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00k ¤</pattern>
+					<pattern type="100000" count="one">000k ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="100000" count="other">000k ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000k ¤</pattern>
+					<pattern type="1000000" count="one">0 mill'.' ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 mill'.' ¤</pattern>
+					<pattern type="1000000" count="other">0 mill'.' ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 mill'.' ¤</pattern>
+					<pattern type="10000000" count="one">00 mill'.' ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 mill'.' ¤</pattern>
+					<pattern type="10000000" count="other">00 mill'.' ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 mill'.' ¤</pattern>
+					<pattern type="100000000" count="one">000 mill'.' ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 mill'.' ¤</pattern>
+					<pattern type="100000000" count="other">000 mill'.' ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 mill'.' ¤</pattern>
+					<pattern type="1000000000" count="one">0 mrd'.' ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0 mrd'.' ¤</pattern>
+					<pattern type="1000000000" count="other">0 mrd'.' ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="one">00 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="other">00 mrd'.' ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="one">000 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="other">000 mrd'.' ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 mrd'.' ¤</pattern>
+					<pattern type="1000000000000" count="one">0 bill'.' ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 bill'.' ¤</pattern>
+					<pattern type="1000000000000" count="other">0 bill'.' ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="one">00 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="other">00 bill'.' ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="one">000 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="other">000 bill'.' ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 bill'.' ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -11794,6 +11812,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11806,6 +11825,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11818,6 +11838,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11830,6 +11851,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11842,6 +11864,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11854,6 +11877,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11866,6 +11890,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11878,6 +11903,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11890,6 +11916,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11902,6 +11929,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11914,6 +11942,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11926,6 +11955,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11938,6 +11968,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11950,6 +11981,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11962,6 +11994,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11974,6 +12007,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11986,6 +12020,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -11998,6 +12033,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -12010,6 +12046,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -12022,6 +12059,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -12034,6 +12072,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>
@@ -12046,6 +12085,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="contributed">↑↑↑</unitPattern>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -11506,9 +11506,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11519,9 +11522,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11532,9 +11538,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11545,9 +11554,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11558,9 +11570,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11571,9 +11586,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11584,9 +11602,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11597,9 +11618,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11610,9 +11634,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11623,9 +11650,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11636,9 +11666,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11649,9 +11682,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11662,9 +11698,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11675,9 +11714,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11688,9 +11730,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11701,9 +11746,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11714,9 +11762,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11727,9 +11778,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11809,9 +11863,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11822,9 +11879,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11835,9 +11895,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11848,9 +11911,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11861,9 +11927,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11874,9 +11943,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11887,9 +11959,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11900,9 +11975,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11913,9 +11991,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11926,9 +12007,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11939,9 +12023,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11952,9 +12039,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11965,9 +12055,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11978,9 +12071,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -11991,9 +12087,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12004,9 +12103,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12017,9 +12119,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12030,9 +12135,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12043,9 +12151,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12056,9 +12167,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12069,9 +12183,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -12082,9 +12199,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="contributed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/nqo.xml
+++ b/common/main/nqo.xml
@@ -2903,16 +2903,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>ߜ߭ߎߦߣߊ߫ ߕߎ߬ߡߊ߬ߘߊ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ߤߥߊߦ - ߊߟߋߦߎߕߌߦߊ߲߫ ߕߎ߬ߡߘߊ߬ ߛߎߡߊ߲ߘߊ߲ߕߊ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ߤߥߊߦ - ߊߟߋߦߎߕߌߦߊ߲߫ ߕߎ߬ߡߊ߬ߘߊ</generic>
 					<standard>ߤߥߊߦ - ߊߟߋߦߎߕߌߦߊ߲߫ ߕߎ߬ߡߘߊ߬ ߛߎߡߊ߲ߘߊ߲ߕߊ</standard>
 					<daylight>ߤߥߊߦ - ߊߟߋߦߎߕߌߦߊ߲߫ ߕߟߋ߬ߡߊ߬ ߕߎߡߘߊ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ߤߥߊߦ - ߊߟߋߦߎߕߌߦߊ߲߫ ߕߎ߬ߡߘߊ߬ ߛߎߡߊ߲ߘߊ߲ߕߊ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/oc.xml
+++ b/common/main/oc.xml
@@ -3325,16 +3325,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">ora de la Guayana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">ora estandarda de Hawai-Aleutianes</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">ora de Hawai-Aleutianes</generic>
 					<standard draft="unconfirmed">ora estandarda de Hawai-Aleutianes</standard>
 					<daylight draft="unconfirmed">ora d’estiu de Hawai-Aleutianes</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">ora estandarda de Hawai-Aleutianes</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5538,11 +5538,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5564,11 +5566,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5578,11 +5582,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5592,11 +5598,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5606,11 +5614,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5620,11 +5630,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5634,11 +5646,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5648,11 +5662,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5662,11 +5678,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5676,11 +5694,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5690,11 +5710,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5704,11 +5726,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5718,11 +5742,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5732,11 +5758,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5746,11 +5774,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5760,11 +5790,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5774,11 +5806,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5788,11 +5822,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5802,11 +5838,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5816,11 +5854,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5830,11 +5870,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5844,27 +5886,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">#,##0.00¤;(#,##0.00¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other" draft="unconfirmed">0K¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0K ¤</pattern>
 					<pattern type="10000" count="other" draft="unconfirmed">00K¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00K ¤</pattern>
 					<pattern type="100000" count="other" draft="unconfirmed">000K¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000K ¤</pattern>
 					<pattern type="1000000" count="other" draft="unconfirmed">0M¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0M ¤</pattern>
 					<pattern type="10000000" count="other" draft="unconfirmed">00M¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00M ¤</pattern>
 					<pattern type="100000000" count="other" draft="unconfirmed">000M¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000M ¤</pattern>
 					<pattern type="1000000000" count="other" draft="unconfirmed">0G¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0G ¤</pattern>
 					<pattern type="10000000000" count="other" draft="unconfirmed">00G¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00G ¤</pattern>
 					<pattern type="100000000000" count="other" draft="unconfirmed">000G¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000G ¤</pattern>
 					<pattern type="1000000000000" count="other" draft="unconfirmed">0T¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0T ¤</pattern>
 					<pattern type="10000000000000" count="other" draft="unconfirmed">00T¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00T ¤</pattern>
 					<pattern type="100000000000000" count="other" draft="unconfirmed">000T¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5874,11 +5930,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5888,11 +5946,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5902,11 +5962,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5916,11 +5978,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5930,11 +5994,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5944,11 +6010,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5958,11 +6026,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5972,11 +6042,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -5986,11 +6058,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6000,11 +6074,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6014,11 +6090,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6028,11 +6106,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6042,11 +6122,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6056,11 +6138,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6070,11 +6154,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6084,11 +6170,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6098,11 +6186,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6112,11 +6202,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6126,11 +6218,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6140,11 +6234,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6154,11 +6250,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6168,11 +6266,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>
@@ -6182,11 +6282,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -3810,6 +3810,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3821,6 +3822,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3832,6 +3834,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3843,6 +3846,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3854,6 +3858,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3865,6 +3870,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3876,6 +3882,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3887,6 +3894,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3898,6 +3906,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3909,6 +3918,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3920,6 +3930,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3931,6 +3942,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3942,6 +3954,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3953,6 +3966,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3964,6 +3978,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3975,6 +3990,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3986,6 +4002,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3997,6 +4014,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4008,6 +4026,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4019,6 +4038,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4030,6 +4050,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4055,6 +4076,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4066,6 +4088,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4077,6 +4100,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4088,6 +4112,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4099,6 +4124,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4110,6 +4136,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4121,6 +4148,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4132,6 +4160,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4143,6 +4172,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4154,6 +4184,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4165,6 +4196,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4176,6 +4208,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4187,6 +4220,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4198,6 +4232,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4209,6 +4244,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4220,6 +4256,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4231,6 +4268,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4242,6 +4280,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4253,6 +4292,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4264,6 +4304,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4275,6 +4316,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4286,6 +4328,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4297,6 +4340,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
 					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -3036,16 +3036,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">ora de Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">ora estandard de Hawai-Aleutianes</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">↑↑↑</generic>
 					<standard draft="unconfirmed">ora estandard de Hawai-Aleutianes</standard>
 					<daylight draft="unconfirmed">↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">ora estandard de Hawai-Aleutianes</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3804,148 +3804,232 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</percentFormats>
 		<currencyFormats numberSystem="adlm">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="arabext">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="bali">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="beng">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="brah">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="cakm">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="cham">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="fullwide">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gong">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gonm">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="gujr">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="hanidec">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="java">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="kali">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="khmr">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="knda">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="lana">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="lanatham">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="laoo">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -3953,172 +4037,266 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">#,##0.00¤</pattern>
-					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>
 		</currencyFormats>
 		<currencyFormats numberSystem="lepc">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="limb">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mlym">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mong">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mtei">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymr">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="mymrshan">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="nkoo">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="olck">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="orya">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="osma">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="rohg">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="saur">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="shrd">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sora">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="sund">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="takr">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="talu">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tamldec">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="telu">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="thai">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="tibt">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="vaii">
 			<currencyFormatLength>
+				<currencyFormat type="standard">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/om.xml
+++ b/common/main/om.xml
@@ -3704,6 +3704,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Sa’aatii Guyaanaa</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Sa’aatii Istaandaardii Haawayi-Alewutiyan</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAS</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Sa’aatii Haawayi-Alewutiyan</generic>
@@ -3714,14 +3722,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAS</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Sa’aatii Istaandaardii Haawayi-Alewutiyan</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAS</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -4476,16 +4476,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ଗୁଏନା ସମୟ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ହୱାଇ-ଆଲେଉଟିୟ ମାନାଙ୍କ ସମୟ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ହୱାଇ-ଆଲେଉଟିୟ ସମୟ</generic>
 					<standard>ହୱାଇ-ଆଲେଉଟିୟ ମାନାଙ୍କ ସମୟ</standard>
 					<daylight>ହୱାଇ-ଆଲେଉଟିୟ ଦିବାଲୋକ ସମୟ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ହୱାଇ-ଆଲେଉଟିୟ ମାନାଙ୍କ ସମୟ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5216,17 +5216,17 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000" count="other">¤000ବି</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000ବି</pattern>
 					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0ଟ୍ରି</pattern>
 					<pattern type="1000000000000" count="other">¤0ଟ୍ରି</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0ଟ୍ରି</pattern>
 					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00ଟ୍ରି</pattern>
 					<pattern type="10000000000000" count="other">¤00ଟ୍ରି</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00ଟ୍ରି</pattern>
 					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000ଟ୍ରି</pattern>
 					<pattern type="100000000000000" count="other">¤000ଟ୍ରି</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000ଟ୍ରି</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -5061,16 +5061,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ਗੁਯਾਨਾ ਵੇਲਾ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ਹਵਾਈ-ਅਲੇਯੂਸ਼ਿਅਨ ਮਿਆਰੀ ਵੇਲਾ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ਹਵਾਈ-ਅਲੇਯੂਸ਼ਿਅਨ ਵੇਲਾ</generic>
 					<standard>ਹਵਾਈ-ਅਲੇਯੂਸ਼ਿਅਨ ਮਿਆਰੀ ਵੇਲਾ</standard>
 					<daylight>ਹਵਾਈ-ਅਲੇਯੂਸ਼ਿਅਨ ਪ੍ਰਕਾਸ਼ ਵੇਲਾ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ਹਵਾਈ-ਅਲੇਯੂਸ਼ਿਅਨ ਮਿਆਰੀ ਵੇਲਾ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5899,7 +5899,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency" draft="contributed">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5916,7 +5920,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
@@ -5925,7 +5929,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -5936,30 +5940,30 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">¤ 0 ਹਜ਼ਾਰ</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">¤ 00 ਹਜ਼ਾਰ</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">¤ 0 ਲੱਖ</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">¤ 00 ਲੱਖ</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">¤ 0 ਕਰੋੜ</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">¤ 00 ਕਰੋੜ</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤ 0 ਅਰਬ</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤ 00 ਅਰਬ</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ 0 ਖਰਬ</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">¤ 00 ਖਰਬ</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">¤ 0 ਨੀਲ</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ 00 ਨੀਲ</pattern>
+					<pattern type="1000" count="one">¤0 ਹਜ਼ਾਰ</pattern>
+					<pattern type="1000" count="other">¤0 ਹਜ਼ਾਰ</pattern>
+					<pattern type="10000" count="one">¤00 ਹਜ਼ਾਰ</pattern>
+					<pattern type="10000" count="other">¤00 ਹਜ਼ਾਰ</pattern>
+					<pattern type="100000" count="one">¤0 ਲੱਖ</pattern>
+					<pattern type="100000" count="other">¤0 ਲੱਖ</pattern>
+					<pattern type="1000000" count="one">¤00 ਲੱਖ</pattern>
+					<pattern type="1000000" count="other">¤00 ਲੱਖ</pattern>
+					<pattern type="10000000" count="one">¤0 ਕਰੋੜ</pattern>
+					<pattern type="10000000" count="other">¤0 ਕਰੋੜ</pattern>
+					<pattern type="100000000" count="one">¤00 ਕਰੋੜ</pattern>
+					<pattern type="100000000" count="other">¤00 ਕਰੋੜ</pattern>
+					<pattern type="1000000000" count="one">¤0 ਅਰਬ</pattern>
+					<pattern type="1000000000" count="other">¤0 ਅਰਬ</pattern>
+					<pattern type="10000000000" count="one">¤00 ਅਰਬ</pattern>
+					<pattern type="10000000000" count="other">¤00 ਅਰਬ</pattern>
+					<pattern type="100000000000" count="one">¤0 ਖਰਬ</pattern>
+					<pattern type="100000000000" count="other">¤0 ਖਰਬ</pattern>
+					<pattern type="1000000000000" count="one">¤00 ਖਰਬ</pattern>
+					<pattern type="1000000000000" count="other">¤00 ਖਰਬ</pattern>
+					<pattern type="10000000000000" count="one">¤0 ਨੀਲ</pattern>
+					<pattern type="10000000000000" count="other">¤0 ਨੀਲ</pattern>
+					<pattern type="100000000000000" count="one">¤00 ਨੀਲ</pattern>
+					<pattern type="100000000000000" count="other">¤00 ਨੀਲ</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -5914,6 +5914,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="guru">
@@ -5922,6 +5925,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern>↑↑↑</pattern>
 					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5934,36 +5940,60 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">¤0 ਹਜ਼ਾਰ</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 ਹਜ਼ਾਰ</pattern>
 					<pattern type="1000" count="other">¤0 ਹਜ਼ਾਰ</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 ਹਜ਼ਾਰ</pattern>
 					<pattern type="10000" count="one">¤00 ਹਜ਼ਾਰ</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 ਹਜ਼ਾਰ</pattern>
 					<pattern type="10000" count="other">¤00 ਹਜ਼ਾਰ</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 ਹਜ਼ਾਰ</pattern>
 					<pattern type="100000" count="one">¤0 ਲੱਖ</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 0 ਲੱਖ</pattern>
 					<pattern type="100000" count="other">¤0 ਲੱਖ</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0 ਲੱਖ</pattern>
 					<pattern type="1000000" count="one">¤00 ਲੱਖ</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 00 ਲੱਖ</pattern>
 					<pattern type="1000000" count="other">¤00 ਲੱਖ</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00 ਲੱਖ</pattern>
 					<pattern type="10000000" count="one">¤0 ਕਰੋੜ</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 0 ਕਰੋੜ</pattern>
 					<pattern type="10000000" count="other">¤0 ਕਰੋੜ</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0 ਕਰੋੜ</pattern>
 					<pattern type="100000000" count="one">¤00 ਕਰੋੜ</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 00 ਕਰੋੜ</pattern>
 					<pattern type="100000000" count="other">¤00 ਕਰੋੜ</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00 ਕਰੋੜ</pattern>
 					<pattern type="1000000000" count="one">¤0 ਅਰਬ</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 ਅਰਬ</pattern>
 					<pattern type="1000000000" count="other">¤0 ਅਰਬ</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 ਅਰਬ</pattern>
 					<pattern type="10000000000" count="one">¤00 ਅਰਬ</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 ਅਰਬ</pattern>
 					<pattern type="10000000000" count="other">¤00 ਅਰਬ</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 ਅਰਬ</pattern>
 					<pattern type="100000000000" count="one">¤0 ਖਰਬ</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 0 ਖਰਬ</pattern>
 					<pattern type="100000000000" count="other">¤0 ਖਰਬ</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0 ਖਰਬ</pattern>
 					<pattern type="1000000000000" count="one">¤00 ਖਰਬ</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 00 ਖਰਬ</pattern>
 					<pattern type="1000000000000" count="other">¤00 ਖਰਬ</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 00 ਖਰਬ</pattern>
 					<pattern type="10000000000000" count="one">¤0 ਨੀਲ</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 0 ਨੀਲ</pattern>
 					<pattern type="10000000000000" count="other">¤0 ਨੀਲ</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 0 ਨੀਲ</pattern>
 					<pattern type="100000000000000" count="one">¤00 ਨੀਲ</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 00 ਨੀਲ</pattern>
 					<pattern type="100000000000000" count="other">¤00 ਨੀਲ</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 00 ਨੀਲ</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/pap.xml
+++ b/common/main/pap.xml
@@ -2010,30 +2010,54 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000" count="other" draft="unconfirmed">¤0mil</pattern>
-					<pattern type="10000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000" count="other" draft="unconfirmed">¤00mil</pattern>
-					<pattern type="100000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000" count="other" draft="unconfirmed">¤000mil</pattern>
-					<pattern type="1000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000" count="other" draft="unconfirmed">¤0mion</pattern>
-					<pattern type="10000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000" count="other" draft="unconfirmed">¤00mion</pattern>
-					<pattern type="100000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000" count="other" draft="unconfirmed">¤000mion</pattern>
-					<pattern type="1000000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" draft="unconfirmed">¤0bion</pattern>
-					<pattern type="10000000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" draft="unconfirmed">¤00bion</pattern>
-					<pattern type="100000000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" draft="unconfirmed">¤000bion</pattern>
-					<pattern type="1000000000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" draft="unconfirmed">¤0trion</pattern>
-					<pattern type="10000000000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" draft="unconfirmed">¤00trion</pattern>
-					<pattern type="100000000000000" count="one" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" draft="unconfirmed">¤000trion</pattern>
+					<pattern type="1000" count="one">¤ 0mil</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0mil</pattern>
+					<pattern type="1000" count="other">¤ 0mil</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0mil</pattern>
+					<pattern type="10000" count="one">¤ 00mil</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00mil</pattern>
+					<pattern type="10000" count="other">¤ 00mil</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00mil</pattern>
+					<pattern type="100000" count="one">¤ 000mil</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000mil</pattern>
+					<pattern type="100000" count="other">¤ 000mil</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000mil</pattern>
+					<pattern type="1000000" count="one">¤ 0mion</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0mion</pattern>
+					<pattern type="1000000" count="other">¤ 0mion</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0mion</pattern>
+					<pattern type="10000000" count="one">¤ 00mion</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00mion</pattern>
+					<pattern type="10000000" count="other">¤ 00mion</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00mion</pattern>
+					<pattern type="100000000" count="one">¤ 000mion</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000mion</pattern>
+					<pattern type="100000000" count="other">¤ 000mion</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000mion</pattern>
+					<pattern type="1000000000" count="one">¤ 0bion</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0bion</pattern>
+					<pattern type="1000000000" count="other">¤ 0bion</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0bion</pattern>
+					<pattern type="10000000000" count="one">¤ 00bion</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00bion</pattern>
+					<pattern type="10000000000" count="other">¤ 00bion</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00bion</pattern>
+					<pattern type="100000000000" count="one">¤ 000bion</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000bion</pattern>
+					<pattern type="100000000000" count="other">¤ 000bion</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000bion</pattern>
+					<pattern type="1000000000000" count="one">¤ 0trion</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0trion</pattern>
+					<pattern type="1000000000000" count="other">¤ 0trion</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0trion</pattern>
+					<pattern type="10000000000000" count="one">¤ 00trion</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00trion</pattern>
+					<pattern type="10000000000000" count="other">¤ 00trion</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00trion</pattern>
+					<pattern type="100000000000000" count="one">¤ 000trion</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000trion</pattern>
+					<pattern type="100000000000000" count="other">¤ 000trion</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000trion</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one" draft="unconfirmed">↑↑↑</unitPattern>

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -4116,16 +4116,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Gayána Taim</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaií-Elúshián Fíksd Taim</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaií-Elúshián Taim</generic>
 					<standard>Hawaií-Elúshián Fíksd Taim</standard>
 					<daylight>Hawaií-Elúshián Délaít Taim</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaií-Elúshián Fíksd Taim</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -5403,16 +5403,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>czas Gujana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaje-Aleuty (czas standardowy)</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>czas Hawaje-Aleuty</generic>
 					<standard>Hawaje-Aleuty (czas standardowy)</standard>
 					<daylight>Hawaje-Aleuty (czas letni)</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaje-Aleuty (czas standardowy)</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6090,7 +6090,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/pms.xml
+++ b/common/main/pms.xml
@@ -162,6 +162,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/prg.xml
+++ b/common/main/prg.xml
@@ -879,6 +879,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="zero" draft="unconfirmed">{0} {1}</unitPattern>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -4501,16 +4501,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>د ګوانانا وخت</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>هوایی الیوتین معیاری وخت</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>هوایی الیوتین وخت</generic>
 					<standard>هوایی الیوتین معیاری وخت</standard>
 					<daylight>هوایی الیوتین رڼا ورځې وخت</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>هوایی الیوتین معیاری وخت</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5203,6 +5203,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
@@ -5214,40 +5218,60 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">0K ¤</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">00K ¤</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">000K ¤</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0M ¤</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00M ¤</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000M ¤</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0G ¤</pattern>
-					<pattern type="10000000000" count="one">00G ¤</pattern>
+					<pattern type="1000" count="one">¤ 0K</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="1000" count="other">¤ 0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="10000" count="one">¤ 00K</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="10000" count="other">¤ 00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="100000" count="one">¤ 000K</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="100000" count="other">¤ 000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="1000000" count="one">¤ 0M</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="1000000" count="other">¤ 0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="10000000" count="one">¤ 00M</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="10000000" count="other">¤ 00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="100000000" count="one">¤ 000M</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
+					<pattern type="100000000" count="other">¤ 000M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
+					<pattern type="1000000000" count="one">¤ 0B</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B</pattern>
+					<pattern type="1000000000" count="other">¤ 0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
+					<pattern type="10000000000" count="one">¤ 00B</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
+					<pattern type="10000000000" count="other">¤ 00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
+					<pattern type="100000000000" count="one">¤ 000G</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000G</pattern>
+					<pattern type="100000000000" count="other">¤ 000B</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0T ¤</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00T ¤</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000T ¤</pattern>
+					<pattern type="1000000000000" count="one">¤ 0T</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="1000000000000" count="other">¤ 0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="10000000000000" count="one">¤ 00T</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="10000000000000" count="other">¤ 00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="100000000000000" count="one">¤ 000T</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
+					<pattern type="100000000000000" count="other">¤ 000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/ps_PK.xml
+++ b/common/main/ps_PK.xml
@@ -204,12 +204,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>د فرانسے سویل او انټارټيک وخت</standard>
 				</long>
 			</metazone>
-			<metazone type="Hawaii_Aleutian">
+			<metazone type="Hawaii">
 				<long>
 					<daylight>هوایی الیوتین رڼا ورځے وخت</daylight>
 				</long>
 			</metazone>
-			<metazone type="Hawaii">
+			<metazone type="Hawaii_Aleutian">
 				<long>
 					<daylight>هوایی الیوتین رڼا ورځے وخت</daylight>
 				</long>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -5485,16 +5485,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Horário da Guiana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Horário Padrão do Havaí e Ilhas Aleutas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Horário do Havaí e Ilhas Aleutas</generic>
 					<standard>Horário Padrão do Havaí e Ilhas Aleutas</standard>
 					<daylight>Horário de Verão do Havaí e Ilhas Aleutas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Horário Padrão do Havaí e Ilhas Aleutas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -4768,16 +4768,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Hora da Guiana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hora padrão do Havai e Aleutas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hora do Havai e Aleutas</generic>
 					<standard>Hora padrão do Havai e Aleutas</standard>
 					<daylight>Hora de verão do Havai e Aleutas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hora padrão do Havai e Aleutas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5599,18 +5599,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000000000" count="other">000 mM ¤</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 B ¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 B ¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 B ¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">0 Bi ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 Bi ¤</pattern>
+					<pattern type="1000000000000" count="other">0 Bi ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 Bi ¤</pattern>
+					<pattern type="10000000000000" count="one">00 Bi ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 Bi ¤</pattern>
+					<pattern type="10000000000000" count="other">00 Bi ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 Bi ¤</pattern>
+					<pattern type="100000000000000" count="one">000 Bi ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 Bi ¤</pattern>
+					<pattern type="100000000000000" count="other">000 Bi ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 Bi ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -4037,16 +4037,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Hora de Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hora Estandar de Hawai-Aleutiano</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hora de Hawai-Aleutiano</generic>
 					<standard>Hora Estandar de Hawai-Aleutiano</standard>
 					<daylight>Hora de Verano de Hawai-Aleutiano</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hora Estandar de Hawai-Aleutiano</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4635,7 +4635,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
 					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/rif.xml
+++ b/common/main/rif.xml
@@ -3114,16 +3114,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">akud n guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">akud anaway n haway-alucyan</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">akud n haway-alucyan</generic>
 					<standard draft="unconfirmed">akud anaway n haway-alucyan</standard>
 					<daylight draft="unconfirmed">akud n uzil n haway-alucyan</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">akud anaway n haway-alucyan</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -3695,29 +3695,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber" draft="unconfirmed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" draft="unconfirmed">↑↑↑</pattern>
+					<pattern type="1000" count="other">0K ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0K ¤</pattern>
+					<pattern type="10000" count="other">00K ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00K ¤</pattern>
+					<pattern type="100000" count="other">000K ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000K ¤</pattern>
+					<pattern type="1000000" count="other">0M ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0M ¤</pattern>
+					<pattern type="10000000" count="other">00M ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00M ¤</pattern>
+					<pattern type="100000000" count="other">000M ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000M ¤</pattern>
+					<pattern type="1000000000" count="other">0G ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0G ¤</pattern>
+					<pattern type="10000000000" count="other">00G ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00G ¤</pattern>
+					<pattern type="100000000000" count="other">000G ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000G ¤</pattern>
+					<pattern type="1000000000000" count="other">0T ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0T ¤</pattern>
+					<pattern type="10000000000000" count="other">00T ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00T ¤</pattern>
+					<pattern type="100000000000000" count="other">000T ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000T ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other" draft="unconfirmed">↑↑↑</unitPattern>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -4416,16 +4416,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>temp da la Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>temp normal dal Hawai e las Aleutinas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>temp dal Hawai e las Aleutinas</generic>
 					<standard>temp normal dal Hawai e las Aleutinas</standard>
 					<daylight>temp da stad dal Hawai e da las Aleutinas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>temp normal dal Hawai e las Aleutinas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5047,23 +5047,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000" count="one">0</pattern>
 					<pattern type="100000" count="other">0</pattern>
 					<pattern type="1000000" count="one">¤0 miu'.'</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 miu'.'</pattern>
 					<pattern type="1000000" count="other">¤0 miu'.'</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 miu'.'</pattern>
 					<pattern type="10000000" count="one">¤00 miu'.'</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 miu'.'</pattern>
 					<pattern type="10000000" count="other">¤00 miu'.'</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 miu'.'</pattern>
 					<pattern type="100000000" count="one">¤000 miu'.'</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 miu'.'</pattern>
 					<pattern type="100000000" count="other">¤000 miu'.'</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 miu'.'</pattern>
 					<pattern type="1000000000" count="one">¤0 mia'.'</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 mia'.'</pattern>
 					<pattern type="1000000000" count="other">¤0 mia'.'</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 mia'.'</pattern>
 					<pattern type="10000000000" count="one">¤00 mia'.'</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 mia'.'</pattern>
 					<pattern type="10000000000" count="other">¤00 mia'.'</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 mia'.'</pattern>
 					<pattern type="100000000000" count="one">¤000 mia'.'</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 mia'.'</pattern>
 					<pattern type="100000000000" count="other">¤000 mia'.'</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 mia'.'</pattern>
 					<pattern type="1000000000000" count="one">¤0 biu'.'</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 biu'.'</pattern>
 					<pattern type="1000000000000" count="other">¤0 biu'.'</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 biu'.'</pattern>
 					<pattern type="10000000000000" count="one">¤00 biu'.'</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 biu'.'</pattern>
 					<pattern type="10000000000000" count="other">¤00 biu'.'</pattern>
-					<pattern type="100000000000000" count="one">¤000 biu'.'</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 biu'.'</pattern>
+					<pattern type="100000000000000" count="one">¤000T biu'.'</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T biu'.'</pattern>
 					<pattern type="100000000000000" count="other">¤000 biu'.'</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 biu'.'</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -5946,16 +5946,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Ora din Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora standard din Hawaii-Aleutine</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora din Hawaii-Aleutine</generic>
 					<standard>Ora standard din Hawaii-Aleutine</standard>
 					<daylight>Ora de vară din Hawaii-Aleutine</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora standard din Hawaii-Aleutine</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6608,24 +6608,24 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">0 mie ¤</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000" count="few">↑↑↑</pattern>
-					<pattern type="1000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000" count="other">0 mii ¤</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="few">↑↑↑</pattern>
-					<pattern type="10000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">00 mii ¤</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="few">↑↑↑</pattern>
-					<pattern type="100000" count="few" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 mii ¤</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one">0 K ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0 K ¤</pattern>
+					<pattern type="1000" count="few">0 K ¤</pattern>
+					<pattern type="1000" count="few" alt="alphaNextToNumber">0 K ¤</pattern>
+					<pattern type="1000" count="other">0 K ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0 K ¤</pattern>
+					<pattern type="10000" count="one">00 K ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00 K ¤</pattern>
+					<pattern type="10000" count="few">00 K ¤</pattern>
+					<pattern type="10000" count="few" alt="alphaNextToNumber">00 K ¤</pattern>
+					<pattern type="10000" count="other">00 K ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00 K ¤</pattern>
+					<pattern type="100000" count="one">000 K ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000 K ¤</pattern>
+					<pattern type="100000" count="few">000 K ¤</pattern>
+					<pattern type="100000" count="few" alt="alphaNextToNumber">000 K ¤</pattern>
+					<pattern type="100000" count="other">000 K ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 K ¤</pattern>
 					<pattern type="1000000" count="one">↑↑↑</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="1000000" count="few">↑↑↑</pattern>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -5906,16 +5906,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Гайана</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавайско-алеутское стандартное время</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавайско-алеутское время</generic>
 					<standard>Гавайско-алеутское стандартное время</standard>
 					<daylight>Гавайско-алеутское летнее время</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавайско-алеутское стандартное время</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/sa.xml
+++ b/common/main/sa.xml
@@ -955,6 +955,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
 				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
+				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
@@ -966,6 +970,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>

--- a/common/main/sah.xml
+++ b/common/main/sah.xml
@@ -1435,10 +1435,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sat.xml
+++ b/common/main/sat.xml
@@ -2270,16 +2270,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight draft="unconfirmed">ᱯᱟᱪᱮ ᱜᱽᱨᱤᱱᱞᱮᱱᱰ ᱥᱤᱛᱩᱝ ᱚᱠᱛᱚ</daylight>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">ᱦᱟᱣᱟᱭᱤᱼᱟᱞᱮᱣᱴᱤᱭᱟᱱ ᱢᱟᱱᱚᱠ ᱚᱠᱛᱚ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">ᱦᱟᱣᱟᱭᱤᱼᱟᱞᱮᱣᱴᱤᱭᱟᱱ ᱚᱠᱛᱚ</generic>
 					<standard draft="unconfirmed">ᱦᱟᱣᱟᱭᱤᱼᱟᱞᱮᱣᱴᱤᱭᱟᱱ ᱢᱟᱱᱚᱠ ᱚᱠᱛᱚ</standard>
 					<daylight draft="unconfirmed">ᱦᱟᱣᱟᱭᱤᱼᱟᱞᱮᱣᱴᱤᱭᱟᱱ ᱥᱤᱧᱟᱜ ᱚᱠᱛᱚ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">ᱦᱟᱣᱟᱭᱤᱼᱟᱞᱮᱣᱴᱤᱭᱟᱱ ᱢᱟᱱᱚᱠ ᱚᱠᱛᱚ</standard>
 				</long>
 			</metazone>
 			<metazone type="Mexico_Pacific">

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -10377,16 +10377,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Ora de sa Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora istandard de sas ìsulas Hawaii-Aleutinas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora de sas ìsulas Hawaii-Aleutinas</generic>
 					<standard>Ora istandard de sas ìsulas Hawaii-Aleutinas</standard>
 					<daylight>Ora legale de sas ìsulas Hawaii-Aleutinas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora istandard de sas ìsulas Hawaii-Aleutinas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -3549,6 +3549,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Ura dâ Guiana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ura sulari di l’Hawaai</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ura di l’Hawaai</generic>
@@ -3559,14 +3567,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ura sulari di l’Hawaai</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -4573,16 +4573,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>گيانائي وقت</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>هوائي اليوٽين جو معياري وقت</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>هوائي اليوٽين جو وقت</generic>
 					<standard>هوائي اليوٽين جو معياري وقت</standard>
 					<daylight>هوائي اليوٽين جي ڏينهن جو وقت</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>هوائي اليوٽين جو معياري وقت</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5314,6 +5314,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern>↑↑↑</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="deva">
@@ -5321,6 +5324,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5333,60 +5339,60 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0هزار</pattern>
-					<pattern type="1000" count="other">¤0هزار</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0هزار</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00هزار</pattern>
-					<pattern type="10000" count="other">¤00هزار</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00هزار</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000لک</pattern>
-					<pattern type="100000" count="other">¤000لک</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000لک</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 00لک</pattern>
-					<pattern type="1000000" count="other">¤00لک</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00لک</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 0ڪروڙ</pattern>
-					<pattern type="10000000" count="other">¤0ڪروڙ</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0ڪروڙ</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 00ڪروڙ</pattern>
-					<pattern type="100000000" count="other">¤00ڪروڙ</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00ڪروڙ</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0ارب</pattern>
-					<pattern type="1000000000" count="other">¤0ارب</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0ارب</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00ارب</pattern>
-					<pattern type="10000000000" count="other">¤00ارب</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00ارب</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 0کرب</pattern>
-					<pattern type="100000000000" count="other">¤0کرب</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0کرب</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0ٽرلين</pattern>
-					<pattern type="1000000000000" count="other">¤0ٽرلين</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0ٽرلين</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00ٽرلين</pattern>
-					<pattern type="10000000000000" count="other">¤00ٽرلين</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00ٽرلين</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000ٽرلين</pattern>
-					<pattern type="100000000000000" count="other">¤000ٽرلين</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000ٽرلين</pattern>
+					<pattern type="1000" count="one">¤ 0 هزار</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 هزار</pattern>
+					<pattern type="1000" count="other">¤ 0 هزار</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 هزار</pattern>
+					<pattern type="10000" count="one">¤ 00 هزار</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 هزار</pattern>
+					<pattern type="10000" count="other">¤ 00 هزار</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 هزار</pattern>
+					<pattern type="100000" count="one">¤ 000 هزار</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 هزار</pattern>
+					<pattern type="100000" count="other">¤ 000 هزار</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 هزار</pattern>
+					<pattern type="1000000" count="one">¤ 0 ملين</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 ملين</pattern>
+					<pattern type="1000000" count="other">¤ 0 ملين</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 ملين</pattern>
+					<pattern type="10000000" count="one">¤ 00 ملين</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 ملين</pattern>
+					<pattern type="10000000" count="other">¤ 00 ملين</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 ملين</pattern>
+					<pattern type="100000000" count="one">¤ 000 ملين</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 ملين</pattern>
+					<pattern type="100000000" count="other">¤ 000 ملين</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 ملين</pattern>
+					<pattern type="1000000000" count="one">¤ 0 بلين</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 بلين</pattern>
+					<pattern type="1000000000" count="other">¤ 0 بلين</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 بلين</pattern>
+					<pattern type="10000000000" count="one">¤ 00 بلين</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 بلين</pattern>
+					<pattern type="10000000000" count="other">¤ 00 بلين</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 بلين</pattern>
+					<pattern type="100000000000" count="one">¤ 000 بلين</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 بلين</pattern>
+					<pattern type="100000000000" count="other">¤ 000 بلين</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 بلين</pattern>
+					<pattern type="1000000000000" count="one">¤ 0 ٽرلين</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 ٽرلين</pattern>
+					<pattern type="1000000000000" count="other">¤ 0 ٽرلين</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 ٽرلين</pattern>
+					<pattern type="10000000000000" count="one">¤ 00 ٽرلين</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 ٽرلين</pattern>
+					<pattern type="10000000000000" count="other">¤ 00 ٽرلين</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 ٽرلين</pattern>
+					<pattern type="100000000000000" count="one">¤ 000 ٽرلين</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 ٽرلين</pattern>
+					<pattern type="100000000000000" count="other">¤ 000 ٽرلين</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 ٽرلين</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/se.xml
+++ b/common/main/se.xml
@@ -1275,10 +1275,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/se_FI.xml
+++ b/common/main/se_FI.xml
@@ -1707,16 +1707,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyana áigi</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-aleuhtalaš dálveáigi</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-aleuhtalaš áigi</generic>
 					<standard>Hawaii-aleuhtalaš dálveáigi</standard>
 					<daylight>Hawaii-aleuhtalaš geasseáigi</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-aleuhtalaš dálveáigi</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/sg.xml
+++ b/common/main/sg.xml
@@ -606,6 +606,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;¤-#,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00;-#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/shn.xml
+++ b/common/main/shn.xml
@@ -8781,6 +8781,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="contributed">GYT</standard>
 				</short>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>လၵ်းၸဵင် ၶၢဝ်းယၢမ်း ႁႃႇဝၢႆးဢီး-ဢလူးသျၼ်ႇ</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ၶၢဝ်းယၢမ်း ႁႃႇဝၢႆးဢီး-ဢလူးသျၼ်ႇ</generic>
@@ -8791,14 +8799,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>လၵ်းၸဵင် ၶၢဝ်းယၢမ်း ႁႃႇဝၢႆးဢီး-ဢလူးသျၼ်ႇ</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -4236,16 +4236,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>ගයනා වේලාව</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>හවායි-අලෙයුතියාන් සම්මත වේලාව</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>හවායි-අලෙයුතියාන් වේලාව</generic>
 					<standard>හවායි-අලෙයුතියාන් සම්මත වේලාව</standard>
 					<daylight>හවායි-අලෙයුතියාන් දිවාආලෝක වේලාව</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>හවායි-අලෙයුතියාන් සම්මත වේලාව</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -5188,16 +5188,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>guyanský čas</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>havajsko-aleutský štandardný čas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>havajsko-aleutský čas</generic>
 					<standard>havajsko-aleutský štandardný čas</standard>
 					<daylight>havajsko-aleutský letný čas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>havajsko-aleutský štandardný čas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5887,12 +5887,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -5396,16 +5396,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Gvajanski čas</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havajski aleutski standardni čas</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havajski aleutski čas</generic>
 					<standard>Havajski aleutski standardni čas</standard>
 					<daylight>Havajski aleutski poletni čas</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havajski aleutski standardni čas</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/smn.xml
+++ b/common/main/smn.xml
@@ -1412,10 +1412,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -8714,6 +8714,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Waqtiga Guyaana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Waqtiga Caadiga Ah ee Hawaay-Alutiyaan</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Waqtiga Hawaay-Alutiyaan</generic>
@@ -8724,14 +8732,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Waqtiga Caadiga Ah ee Hawaay-Alutiyaan</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -4612,16 +4612,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Ora e Guajanës</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora standarde e Ishujve Hauai-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora e Ishujve Hauai-Aleutian</generic>
 					<standard>Ora standarde e Ishujve Hauai-Aleutian</standard>
 					<daylight>Ora verore e Ishujve Hauai-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora standarde e Ishujve Hauai-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -5217,16 +5217,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Гвајана време</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Хавајско-алеутско стандардно време</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Хавајско-алеутско време</generic>
 					<standard>Хавајско-алеутско стандардно време</standard>
 					<daylight>Хавајско-алеутско летње време</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Хавајско-алеутско стандардно време</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5899,12 +5899,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sr_Cyrl_BA.xml
+++ b/common/main/sr_Cyrl_BA.xml
@@ -4507,16 +4507,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Гвајана вријеме</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Хавајско-алеутско стандардно вријеме</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Хавајско-алеутско вријеме</generic>
 					<standard>Хавајско-алеутско стандардно вријеме</standard>
 					<daylight>Хавајско-алеутско љетње вријеме</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Хавајско-алеутско стандардно вријеме</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5136,12 +5136,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -5115,16 +5115,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Gvajana vreme</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havajsko-aleutsko standardno vreme</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havajsko-aleutsko vreme</generic>
 					<standard>Havajsko-aleutsko standardno vreme</standard>
 					<daylight>Havajsko-aleutsko letnje vreme</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havajsko-aleutsko standardno vreme</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5791,10 +5791,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sr_Latn_BA.xml
+++ b/common/main/sr_Latn_BA.xml
@@ -4458,16 +4458,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Gvajana vrijeme</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Havajsko-aleutsko standardno vrijeme</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Havajsko-aleutsko vrijeme</generic>
 					<standard>Havajsko-aleutsko standardno vrijeme</standard>
 					<daylight>Havajsko-aleutsko ljetnje vrijeme</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Havajsko-aleutsko standardno vrijeme</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5087,9 +5087,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -6215,16 +6215,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyanatid</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Honolulu, normaltid</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Honolulutid</generic>
 					<standard>Honolulu, normaltid</standard>
 					<daylight>Honolulu, sommartid</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Honolulu, normaltid</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6919,12 +6919,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sv_FI.xml
+++ b/common/main/sv_FI.xml
@@ -2480,16 +2480,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -2894,10 +2894,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -4954,48 +4954,48 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">¤ elfu 0;elfu -0</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ elfu 0;elfu -0</pattern>
-					<pattern type="1000" count="other">¤ elfu 0;elfu -0</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ elfu 0;elfu -0</pattern>
-					<pattern type="10000" count="one">¤ elfu 00;elfu -00</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ elfu 00;elfu -00</pattern>
-					<pattern type="10000" count="other">¤ elfu 00;elfu -00</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ elfu 00;elfu -00</pattern>
-					<pattern type="100000" count="one">¤ elfu 000;elfu -000</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ elfu 000;elfu -000</pattern>
-					<pattern type="100000" count="other">¤ elfu 000;elfu -000</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ elfu 000;elfu -000</pattern>
-					<pattern type="1000000" count="one">¤ 0M;-0M</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M;-0M</pattern>
+					<pattern type="1000" count="one">¤ elfu 0;¤ elfu -0</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ elfu 0;¤ elfu -0</pattern>
+					<pattern type="1000" count="other">¤ elfu 0;¤ elfu -0</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ elfu 0;¤ elfu -0</pattern>
+					<pattern type="10000" count="one">¤ elfu 00;¤ elfu -00</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ elfu 00;¤ elfu -00</pattern>
+					<pattern type="10000" count="other">¤ elfu 00;¤ elfu -00</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ elfu 00;¤ elfu -00</pattern>
+					<pattern type="100000" count="one">¤ elfu 000;¤ elfu -000</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ elfu 000;¤ elfu -000</pattern>
+					<pattern type="100000" count="other">¤ elfu 000;¤ elfu -000</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ elfu 000;¤ elfu -000</pattern>
+					<pattern type="1000000" count="one">¤ 0M;¤ -0M</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M;¤ -0M</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">¤ 00M;-00M</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M;-00M</pattern>
+					<pattern type="10000000" count="one">¤ 00M;¤ -00M</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M;¤ -00M</pattern>
 					<pattern type="10000000" count="other">¤ 00M</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
-					<pattern type="100000000" count="one">¤ 000M;-000M</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M;-000M</pattern>
+					<pattern type="100000000" count="one">¤ 000M;¤ -000M</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M;¤ -000M</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">¤ 0B;-0B</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B;-0B</pattern>
-					<pattern type="1000000000" count="other">¤ 0B;-0B</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B;-0B</pattern>
-					<pattern type="10000000000" count="one">¤ 00B;-00B</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B;-00B</pattern>
-					<pattern type="10000000000" count="other">¤ 00B;-00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B;-00B</pattern>
-					<pattern type="100000000000" count="one">¤ 000B;-000B</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B;-000B</pattern>
-					<pattern type="100000000000" count="other">¤ 000B;-000B</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B;-000B</pattern>
-					<pattern type="1000000000000" count="one">¤ 0T;-0T</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T;-0T</pattern>
+					<pattern type="1000000000" count="one">¤ 0B;¤ -0B</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B;¤ -0B</pattern>
+					<pattern type="1000000000" count="other">¤ 0B;¤ -0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B;¤ -0B</pattern>
+					<pattern type="10000000000" count="one">¤ 00B;¤ -00B</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B;¤ -00B</pattern>
+					<pattern type="10000000000" count="other">¤ 00B;¤ -00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B;¤ -00B</pattern>
+					<pattern type="100000000000" count="one">¤ 000B;¤ -000B</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B;¤ -000B</pattern>
+					<pattern type="100000000000" count="other">¤ 000B;¤ -000B</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B;¤ -000B</pattern>
+					<pattern type="1000000000000" count="one">¤ 0T;¤ -0T</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T;¤ -0T</pattern>
 					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">¤ 00T;-00T</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T;-00T</pattern>
+					<pattern type="10000000000000" count="one">¤ 00T;¤ -00T</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T;¤ -00T</pattern>
 					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">¤ 000T;-000T</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T;-000T</pattern>
+					<pattern type="100000000000000" count="one">¤ 000T;¤ -000T</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T;¤ -000T</pattern>
 					<pattern type="100000000000000" count="other">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -4316,16 +4316,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Saa za Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Saa za Wastani za Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Saa za Hawaii-Aleutian</generic>
 					<standard>Saa za Wastani za Hawaii-Aleutian</standard>
 					<daylight>Saa za Mchana za Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Saa za Wastani za Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4954,30 +4954,50 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">¤ elfu0</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">¤ elfu00;¤elfu -00</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">¤ laki000;¤laki -000</pattern>
-					<pattern type="1000000" count="one">¤ 0M;¤-0M</pattern>
+					<pattern type="1000" count="one">¤ elfu 0;elfu -0</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ elfu 0;elfu -0</pattern>
+					<pattern type="1000" count="other">¤ elfu 0;elfu -0</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ elfu 0;elfu -0</pattern>
+					<pattern type="10000" count="one">¤ elfu 00;elfu -00</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ elfu 00;elfu -00</pattern>
+					<pattern type="10000" count="other">¤ elfu 00;elfu -00</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ elfu 00;elfu -00</pattern>
+					<pattern type="100000" count="one">¤ elfu 000;elfu -000</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ elfu 000;elfu -000</pattern>
+					<pattern type="100000" count="other">¤ elfu 000;elfu -000</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ elfu 000;elfu -000</pattern>
+					<pattern type="1000000" count="one">¤ 0M;-0M</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M;-0M</pattern>
 					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">¤ 00M;¤M-00M</pattern>
-					<pattern type="10000000" count="other">¤ 00M;¤-00M</pattern>
-					<pattern type="100000000" count="one">¤ 000M;¤Milioni-000</pattern>
+					<pattern type="10000000" count="one">¤ 00M;-00M</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M;-00M</pattern>
+					<pattern type="10000000" count="other">¤ 00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="100000000" count="one">¤ 000M;-000M</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M;-000M</pattern>
 					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤ 0B;¤-0B</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤ 00B;¤-00B</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ 000B;¤-000B</pattern>
-					<pattern type="1000000000000" count="one">¤ 0T;¤-0T</pattern>
+					<pattern type="1000000000" count="one">¤ 0B;-0B</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B;-0B</pattern>
+					<pattern type="1000000000" count="other">¤ 0B;-0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B;-0B</pattern>
+					<pattern type="10000000000" count="one">¤ 00B;-00B</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B;-00B</pattern>
+					<pattern type="10000000000" count="other">¤ 00B;-00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B;-00B</pattern>
+					<pattern type="100000000000" count="one">¤ 000B;-000B</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B;-000B</pattern>
+					<pattern type="100000000000" count="other">¤ 000B;-000B</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B;-000B</pattern>
+					<pattern type="1000000000000" count="one">¤ 0T;-0T</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T;-0T</pattern>
 					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">¤ 00T;¤-00T</pattern>
+					<pattern type="10000000000000" count="one">¤ 00T;-00T</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T;-00T</pattern>
 					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ 000T;¤-000T</pattern>
+					<pattern type="100000000000000" count="one">¤ 000T;-000T</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T;-000T</pattern>
+					<pattern type="100000000000000" count="other">¤ 000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -4134,16 +4134,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4737,35 +4737,55 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">¤ M0;¤-M0</pattern>
+					<pattern type="1000" count="one">¤ elfu 0</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ elfu 0</pattern>
+					<pattern type="1000" count="other">¤ elfu 0</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ elfu 0</pattern>
+					<pattern type="10000" count="one">¤ elfu 00</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ elfu 00</pattern>
+					<pattern type="10000" count="other">¤ elfu 00</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ elfu 00</pattern>
+					<pattern type="100000" count="one">¤ elfu 000</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ elfu 000</pattern>
+					<pattern type="100000" count="other">¤ elfu 000</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ elfu 000</pattern>
+					<pattern type="1000000" count="one">¤ M0</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ M0</pattern>
 					<pattern type="1000000" count="other">¤ M0</pattern>
-					<pattern type="10000000" count="one">¤ M00;¤M-M00</pattern>
-					<pattern type="10000000" count="other">¤ M00;¤-M00</pattern>
-					<pattern type="100000000" count="one">¤ M000;¤M-000</pattern>
+					<pattern type="10000000" count="one">¤ M00</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ M00</pattern>
+					<pattern type="10000000" count="other">¤ M00</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ M00</pattern>
+					<pattern type="100000000" count="one">¤ M000</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ M000</pattern>
 					<pattern type="100000000" count="other">¤ M000</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤ B0;¤-B0</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤ B00;¤-B00</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ B000;¤-B000</pattern>
-					<pattern type="1000000000000" count="one">¤ T0;¤-T0</pattern>
+					<pattern type="1000000000" count="one">¤ B0</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ B0</pattern>
+					<pattern type="1000000000" count="other">¤ B0</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ B0</pattern>
+					<pattern type="10000000000" count="one">¤ B00</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ B00</pattern>
+					<pattern type="10000000000" count="other">¤ B00</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ B00</pattern>
+					<pattern type="100000000000" count="one">¤ B000</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ B000</pattern>
+					<pattern type="100000000000" count="other">¤ B000</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ B000</pattern>
+					<pattern type="1000000000000" count="one">¤ T0</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ T0</pattern>
 					<pattern type="1000000000000" count="other">¤ T0</pattern>
-					<pattern type="10000000000000" count="one">¤ T00;¤-T00</pattern>
+					<pattern type="10000000000000" count="one">¤ T00</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ T00</pattern>
 					<pattern type="10000000000000" count="other">¤ T00</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ T000;¤-T000</pattern>
+					<pattern type="100000000000000" count="one">¤ T000</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ T000</pattern>
+					<pattern type="100000000000000" count="other">¤ T000</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ T000</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -3788,16 +3788,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>ܥܕܢܐ ܕܓܘܝܐܢܐ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ܥܕܢܐ ܡܫܘܚܬܢܝܬܐ ܕܗܐܘܐܝܝ ܐܠܘܫܝܢ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ܥܕܢܐ ܕܗܐܘܐܝܝ ܐܠܘܫܝܢ</generic>
 					<standard>ܥܕܢܐ ܡܫܘܚܬܢܝܬܐ ܕܗܐܘܐܝܝ ܐܠܘܫܝܢ</standard>
 					<daylight>ܥܕܢܐ ܕܒܗܪ ܝܘܡܐ ܕܗܐܘܐܝܝ ܐܠܘܫܝܢ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ܥܕܢܐ ܡܫܘܚܬܢܝܬܐ ܕܗܐܘܐܝܝ ܐܠܘܫܝܢ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -3772,16 +3772,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">Gujana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">Hawaje-Aleuty (sztandardowy czas)</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">Hawaje-Aleuty</generic>
 					<standard draft="unconfirmed">Hawaje-Aleuty (sztandardowy czas)</standard>
 					<daylight draft="unconfirmed">Hawaje-Aleuty (latowy czas)</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">Hawaje-Aleuty (sztandardowy czas)</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4204,6 +4204,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">¤ #,##0.00</pattern>

--- a/common/main/szl.xml
+++ b/common/main/szl.xml
@@ -4208,6 +4208,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern draft="unconfirmed">¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency" draft="unconfirmed">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -6032,7 +6032,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -5261,16 +5261,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>கயானா நேரம்</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ஹவாய்-அலேஷியன் நிலையான நேரம்</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ஹவாய்-அலேஷியன் நேரம்</generic>
 					<standard>ஹவாய்-அலேஷியன் நிலையான நேரம்</standard>
 					<daylight>ஹவாய்-அலேஷியன் பகலொளி நேரம்</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ஹவாய்-அலேஷியன் நிலையான நேரம்</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5963,7 +5963,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency" draft="contributed">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
@@ -5974,54 +5974,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">¤0K</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
-					<pattern type="10000" count="one">¤00K</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00K</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
-					<pattern type="100000" count="one">¤000K</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
-					<pattern type="1000000" count="one">¤0M</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
-					<pattern type="1000000" count="other">¤0M</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
-					<pattern type="10000000" count="one">¤00M</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
-					<pattern type="100000000" count="one">¤000M</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
-					<pattern type="1000000000" count="one">¤0B</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="10000000000" count="one">¤00B</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="100000000000" count="one">¤000B</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
-					<pattern type="1000000000000" count="one">¤0T</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
-					<pattern type="10000000000000" count="one">¤00T</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
-					<pattern type="100000000000000" count="one">¤000T</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
-					<pattern type="100000000000000" count="other">¤000T</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
+					<pattern type="1000" count="one">¤0ஆ</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0ஆ</pattern>
+					<pattern type="1000" count="other">¤0ஆ</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0ஆ</pattern>
+					<pattern type="10000" count="one">¤00ஆ</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00ஆ</pattern>
+					<pattern type="10000" count="other">¤00ஆ</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00ஆ</pattern>
+					<pattern type="100000" count="one">¤000ஆ</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000ஆ</pattern>
+					<pattern type="100000" count="other">¤000ஆ</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000ஆ</pattern>
+					<pattern type="1000000" count="one">¤0மி</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0மி</pattern>
+					<pattern type="1000000" count="other">¤0மி</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0மி</pattern>
+					<pattern type="10000000" count="one">¤00மி</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00மி</pattern>
+					<pattern type="10000000" count="other">¤00மி</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00மி</pattern>
+					<pattern type="100000000" count="one">¤000மி</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000மி</pattern>
+					<pattern type="100000000" count="other">¤000மி</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000மி</pattern>
+					<pattern type="1000000000" count="one">¤0பி</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0பி</pattern>
+					<pattern type="1000000000" count="other">¤0பி</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0பி</pattern>
+					<pattern type="10000000000" count="one">¤00பி</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00பி</pattern>
+					<pattern type="10000000000" count="other">¤00பி</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00பி</pattern>
+					<pattern type="100000000000" count="one">¤000பி</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000பி</pattern>
+					<pattern type="100000000000" count="other">¤000பி</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000பி</pattern>
+					<pattern type="1000000000000" count="one">¤0டி</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0டி</pattern>
+					<pattern type="1000000000000" count="other">¤0டி</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0டி</pattern>
+					<pattern type="10000000000000" count="one">¤00டி</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00டி</pattern>
+					<pattern type="10000000000000" count="other">¤00டி</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00டி</pattern>
+					<pattern type="100000000000000" count="one">¤000டி</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000டி</pattern>
+					<pattern type="100000000000000" count="other">¤000டி</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000டி</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>
@@ -6033,7 +6033,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00</pattern>
 					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/ta_MY.xml
+++ b/common/main/ta_MY.xml
@@ -49,6 +49,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ta_MY.xml
+++ b/common/main/ta_MY.xml
@@ -49,7 +49,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
-					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/ta_SG.xml
+++ b/common/main/ta_SG.xml
@@ -49,6 +49,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ta_SG.xml
+++ b/common/main/ta_SG.xml
@@ -49,7 +49,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤ #,##0.00</pattern>
-					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -5183,16 +5183,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>గయానా సమయం</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>హవాయ్-అల్యూషియన్ ప్రామాణిక సమయం</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>హవాయ్-అల్యూషియన్ సమయం</generic>
 					<standard>హవాయ్-అల్యూషియన్ ప్రామాణిక సమయం</standard>
 					<daylight>హవాయ్-అల్యూషియన్ పగటి వెలుతురు సమయం</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>హవాయ్-అల్యూషియన్ ప్రామాణిక సమయం</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -3956,16 +3956,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Вақти Гайана</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Вақти стандартии Ҳавайӣ-Алеутӣ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Вақти Ҳавайӣ-Алеутӣ</generic>
 					<standard>Вақти стандартии Ҳавайӣ-Алеутӣ</standard>
 					<daylight>Вақти рӯзонаи Ҳавайӣ-Алеутӣ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Вақти стандартии Ҳавайӣ-Алеутӣ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4601,7 +4601,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4609,23 +4614,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0 ҳазор</pattern>
-					<pattern type="10000" count="other">¤00 ҳазор</pattern>
-					<pattern type="100000" count="other">¤000 ҳазор</pattern>
-					<pattern type="1000000" count="other">¤0 млн</pattern>
-					<pattern type="10000000" count="other">¤00 млн</pattern>
-					<pattern type="100000000" count="other">¤000 млн</pattern>
+					<pattern type="1000" count="other">0 ҳзр'.' ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0 ҳзр'.' ¤</pattern>
+					<pattern type="10000" count="other">00 ҳзр'.' ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00 ҳзр'.' ¤</pattern>
+					<pattern type="100000" count="other">000 ҳзр'.' ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 ҳзр'.' ¤</pattern>
+					<pattern type="1000000" count="other">0 млн'.' ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 млн'.' ¤</pattern>
+					<pattern type="10000000" count="other">00 млн'.' ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 млн'.' ¤</pattern>
+					<pattern type="100000000" count="other">000 млн'.' ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 млн'.' ¤</pattern>
 					<pattern type="1000000000" count="other">0 млрд'.' ¤</pattern>
 					<pattern type="10000000000" count="other">00 млрд'.' ¤</pattern>
 					<pattern type="100000000000" count="other">000 млрд'.' ¤</pattern>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -6392,16 +6392,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>เวลากายอานา</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>เวลามาตรฐานฮาวาย-อะลูเชียน</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>เวลาฮาวาย-อะลูเชียน</generic>
 					<standard>เวลามาตรฐานฮาวาย-อะลูเชียน</standard>
 					<daylight>เวลาออมแสงฮาวาย-อะลูเชียน</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>เวลามาตรฐานฮาวาย-อะลูเชียน</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -4555,16 +4555,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>ግዜ ጉያና</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ናይ መደበኛ ሃዋይ-ኣሌውቲያን ግዘ</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ናይ ሃዋይ-ኣሌውቲያን ግዘ</generic>
 					<standard>ናይ መደበኛ ሃዋይ-ኣሌውቲያን ግዘ</standard>
 					<daylight>ናይ መዓልቲ ሃዋይ-ኣሌውቲያን ግዘ</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ናይ መደበኛ ሃዋይ-ኣሌውቲያን ግዘ</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -4354,16 +4354,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Gaýana wagty</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Gawaý-Aleut standart wagty</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Gawaý-Aleut wagty</generic>
 					<standard>Gawaý-Aleut standart wagty</standard>
 					<daylight>Gawaý-Aleut tomusky wagty</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Gawaý-Aleut standart wagty</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5071,7 +5071,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -5079,13 +5084,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -5125,16 +5125,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>houa fakakuiana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>houa fakahauaiʻi-aleuti taimi totonu</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>houa fakahauaiʻi-aleuti</generic>
 					<standard>houa fakahauaiʻi-aleuti taimi totonu</standard>
 					<daylight>houa fakahauaiʻi-aleuti taimi liliu</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>houa fakahauaiʻi-aleuti taimi totonu</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/tok.xml
+++ b/common/main/tok.xml
@@ -882,12 +882,13 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,#0.00</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,#0.00</pattern>
+					<pattern alt="noCurrency">#,#0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,#0.00</pattern>
+					<pattern alt="noCurrency">#,#0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>

--- a/common/main/tpi.xml
+++ b/common/main/tpi.xml
@@ -262,6 +262,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -5288,16 +5288,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Guyana Saati</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleut Standart Saati</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleut Saati</generic>
 					<standard>Hawaii-Aleut Standart Saati</standard>
 					<daylight>Hawaii-Aleut Yaz Saati</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleut Standart Saati</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6081,65 +6081,65 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##0.00</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000" count="other">0 B ¤</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000" count="other">00 B ¤</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="other">000 B ¤</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000" count="other">0 Mn ¤</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">00 Mn ¤</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000" count="other">000 Mn ¤</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">0 Mr ¤</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">00 Mr ¤</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">000 Mr ¤</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">0 Tn ¤</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">00 Tn ¤</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">000 Tn ¤</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="one">¤0 B</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 B</pattern>
+					<pattern type="1000" count="other">¤0 B</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 B</pattern>
+					<pattern type="10000" count="one">¤00 B</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 B</pattern>
+					<pattern type="10000" count="other">¤00 B</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 B</pattern>
+					<pattern type="100000" count="one">¤000 B</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000 B</pattern>
+					<pattern type="100000" count="other">¤000 B</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000 B</pattern>
+					<pattern type="1000000" count="one">¤0 Mn</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0 Mn</pattern>
+					<pattern type="1000000" count="other">¤0 Mn</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0 Mn</pattern>
+					<pattern type="10000000" count="one">¤00 Mn</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00 Mn</pattern>
+					<pattern type="10000000" count="other">¤00 Mn</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00 Mn</pattern>
+					<pattern type="100000000" count="one">¤000 Mn</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000 Mn</pattern>
+					<pattern type="100000000" count="other">¤000 Mn</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000 Mn</pattern>
+					<pattern type="1000000000" count="one">¤0 Mr</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 Mr</pattern>
+					<pattern type="1000000000" count="other">¤0 Mr</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 Mr</pattern>
+					<pattern type="10000000000" count="one">¤00 Mr</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 Mr</pattern>
+					<pattern type="10000000000" count="other">¤00 Mr</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 Mr</pattern>
+					<pattern type="100000000000" count="one">¤000 Mr</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000 Mr</pattern>
+					<pattern type="100000000000" count="other">¤000 Mr</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000 Mr</pattern>
+					<pattern type="1000000000000" count="one">¤0 Tn</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 Tn</pattern>
+					<pattern type="1000000000000" count="other">¤0 Tn</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 Tn</pattern>
+					<pattern type="10000000000000" count="one">¤00 Tn</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 Tn</pattern>
+					<pattern type="10000000000000" count="other">¤00 Tn</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 Tn</pattern>
+					<pattern type="100000000000000" count="one">¤000 Tn</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 Tn</pattern>
+					<pattern type="100000000000000" count="other">¤000 Tn</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 Tn</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/trw.xml
+++ b/common/main/trw.xml
@@ -3350,16 +3350,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard draft="unconfirmed">گیانا سی وَخ</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="unconfirmed">ہوائی الیوٹیئن اسٹینڈرڈ ٹائم</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="unconfirmed">ہوائی الیوٹیئن ٹائم</generic>
 					<standard draft="unconfirmed">ہوائی الیوٹیئن اسٹینڈرڈ ٹائم</standard>
 					<daylight draft="unconfirmed">ہوائی الیوٹیئن ڈے لائٹ ٹائم</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="unconfirmed">ہوائی الیوٹیئن اسٹینڈرڈ ٹائم</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -3802,16 +3802,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Гайана вакыты</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавай-Алеут стандарт вакыты</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавай-Алеут вакыты</generic>
 					<standard>Гавай-Алеут стандарт вакыты</standard>
 					<daylight>Гавай-Алеут җәйге вакыты</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавай-Алеут стандарт вакыты</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4403,29 +4403,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0 мең</pattern>
-					<pattern type="10000" count="other">¤00 мең</pattern>
-					<pattern type="100000" count="other">¤000 мең</pattern>
-					<pattern type="1000000" count="other">¤0 млн</pattern>
-					<pattern type="10000000" count="other">¤00 млн</pattern>
-					<pattern type="100000000" count="other">¤000 млн</pattern>
-					<pattern type="1000000000" count="other">¤0 млрд</pattern>
-					<pattern type="10000000000" count="other">¤00 млрд</pattern>
-					<pattern type="100000000000" count="other">¤000 млрд</pattern>
-					<pattern type="1000000000000" count="other">¤0 трлн</pattern>
-					<pattern type="10000000000000" count="other">¤00 трлн</pattern>
-					<pattern type="100000000000000" count="other">¤000 трлн</pattern>
+					<pattern type="1000" count="other">0 мең ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0 мең ¤</pattern>
+					<pattern type="10000" count="other">00 мең ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00 мең ¤</pattern>
+					<pattern type="100000" count="other">000 мең ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 мең ¤</pattern>
+					<pattern type="1000000" count="other">0 млн ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 млн ¤</pattern>
+					<pattern type="10000000" count="other">00 млн ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 млн ¤</pattern>
+					<pattern type="100000000" count="other">000 млн ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 млн ¤</pattern>
+					<pattern type="1000000000" count="other">0 млрд ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 млрд ¤</pattern>
+					<pattern type="10000000000" count="other">00 млрд ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 млрд ¤</pattern>
+					<pattern type="100000000000" count="other">000млрд ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000млрд ¤</pattern>
+					<pattern type="1000000000000" count="other">0 трлн ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 трлн ¤</pattern>
+					<pattern type="10000000000000" count="other">00 трлн ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 трлн ¤</pattern>
+					<pattern type="100000000000000" count="other">000 трлн ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 трлн ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO draft="unconfirmed">↑↑↑</currencyPatternAppendISO>

--- a/common/main/tzm.xml
+++ b/common/main/tzm.xml
@@ -572,7 +572,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/ug.xml
+++ b/common/main/ug.xml
@@ -2563,16 +2563,16 @@ Reviewed by Waris Abdukerim Janbaz <oyghan@gmail.com> of the Uyghur Computer Sci
 					<standard draft="contributed">گىۋىيانا ۋاقتى</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard draft="contributed">ھاۋاي-ئالېيۇت ئۆلچەملىك ۋاقتى</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic draft="contributed">ھاۋاي-ئالېيۇت ۋاقتى</generic>
 					<standard draft="contributed">ھاۋاي-ئالېيۇت ئۆلچەملىك ۋاقتى</standard>
 					<daylight draft="contributed">ھاۋاي-ئالېيۇت يازلىق ۋاقتى</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard draft="contributed">ھاۋاي-ئالېيۇت ئۆلچەملىك ۋاقتى</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -5597,16 +5597,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>за часом у Ґаяні</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>за стандартним гавайсько-алеутським часом</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>за гавайсько-алеутським часом</generic>
 					<standard>за стандартним гавайсько-алеутським часом</standard>
 					<daylight>за літнім гавайсько-алеутським часом</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>за стандартним гавайсько-алеутським часом</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6296,7 +6296,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -5660,7 +5660,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="10000" count="one">¤00 ہزار</pattern>
 					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 ہزار</pattern>
 					<pattern type="10000" count="other">¤00 ہزار</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 ہزار</pattern>
 					<pattern type="100000" count="one">¤0 لاکھ</pattern>
 					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 0 لاکھ</pattern>
 					<pattern type="100000" count="other">¤0 لاکھ</pattern>
@@ -5670,35 +5670,35 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000" count="other">¤00 لاکھ</pattern>
 					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00 لاکھ</pattern>
 					<pattern type="10000000" count="one">¤0 کروڑ</pattern>
-					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 0 کروڑ</pattern>
 					<pattern type="10000000" count="other">¤0 کروڑ</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0 کروڑ</pattern>
 					<pattern type="100000000" count="one">¤00 کروڑ</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 00 کروڑ</pattern>
 					<pattern type="100000000" count="other">¤00 کروڑ</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00 کروڑ</pattern>
 					<pattern type="1000000000" count="one">¤0 ارب</pattern>
-					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0 ارب</pattern>
 					<pattern type="1000000000" count="other">¤0 ارب</pattern>
 					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 ارب</pattern>
 					<pattern type="10000000000" count="one">¤00 ارب</pattern>
 					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 ارب</pattern>
 					<pattern type="10000000000" count="other">¤00 ارب</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 ارب</pattern>
 					<pattern type="100000000000" count="one">¤0 کھرب</pattern>
 					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 0 کھرب</pattern>
 					<pattern type="100000000000" count="other">¤0 کھرب</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0 کھرب</pattern>
 					<pattern type="1000000000000" count="one">¤00 کھرب</pattern>
 					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 00 کھرب</pattern>
 					<pattern type="1000000000000" count="other">¤00 کھرب</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 00 کھرب</pattern>
 					<pattern type="10000000000000" count="one">¤00 ٹریلین</pattern>
-					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00 ٹریلین</pattern>
 					<pattern type="10000000000000" count="other">¤00 ٹریلین</pattern>
 					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 ٹریلین</pattern>
 					<pattern type="100000000000000" count="one">¤000 ٹریلین</pattern>
-					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000 ٹریلین</pattern>
 					<pattern type="100000000000000" count="other">¤000 ٹریلین</pattern>
 					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 ٹریلین</pattern>
 				</currencyFormat>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -4916,16 +4916,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>گیانا کا وقت</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>ہوائی الیوٹیئن اسٹینڈرڈ ٹائم</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>ہوائی الیوٹیئن ٹائم</generic>
 					<standard>ہوائی الیوٹیئن اسٹینڈرڈ ٹائم</standard>
 					<daylight>ہوائی الیوٹیئن ڈے لائٹ ٹائم</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>ہوائی الیوٹیئن اسٹینڈرڈ ٹائم</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5653,54 +5653,54 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="one" alt="alphaNextToNumber">¤0 ہزار</pattern>
-					<pattern type="1000" count="other">¤ 0 ہزار</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤0 ہزار</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="one" alt="alphaNextToNumber">¤00 ہزار</pattern>
-					<pattern type="10000" count="other">¤ 00 ہزار</pattern>
+					<pattern type="1000" count="one">¤0 ہزار</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0 ہزار</pattern>
+					<pattern type="1000" count="other">¤0 ہزار</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 ہزار</pattern>
+					<pattern type="10000" count="one">¤00 ہزار</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00 ہزار</pattern>
+					<pattern type="10000" count="other">¤00 ہزار</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="one" alt="alphaNextToNumber">¤0 لاکھ</pattern>
-					<pattern type="100000" count="other">¤ 0 لاکھ</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">¤0 لاکھ</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤00 لاکھ</pattern>
-					<pattern type="1000000" count="other">¤ 00 لاکھ</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤00 لاکھ</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
+					<pattern type="100000" count="one">¤0 لاکھ</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 0 لاکھ</pattern>
+					<pattern type="100000" count="other">¤0 لاکھ</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0 لاکھ</pattern>
+					<pattern type="1000000" count="one">¤00 لاکھ</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 00 لاکھ</pattern>
+					<pattern type="1000000" count="other">¤00 لاکھ</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00 لاکھ</pattern>
+					<pattern type="10000000" count="one">¤0 کروڑ</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000" count="other">¤ 0 کروڑ</pattern>
+					<pattern type="10000000" count="other">¤0 کروڑ</pattern>
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000000" count="one">¤00 کروڑ</pattern>
-					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤00 کروڑ</pattern>
-					<pattern type="100000000" count="other">¤ 00 کروڑ</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤00 کروڑ</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 00 کروڑ</pattern>
+					<pattern type="100000000" count="other">¤00 کروڑ</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00 کروڑ</pattern>
+					<pattern type="1000000000" count="one">¤0 ارب</pattern>
 					<pattern type="1000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">¤ 0 ارب</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤0 ارب</pattern>
+					<pattern type="1000000000" count="other">¤0 ارب</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 ارب</pattern>
 					<pattern type="10000000000" count="one">¤00 ارب</pattern>
-					<pattern type="10000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">¤ 00 ارب</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00 ارب</pattern>
+					<pattern type="10000000000" count="other">¤00 ارب</pattern>
 					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="100000000000" count="one">¤0 کھرب</pattern>
-					<pattern type="100000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">¤ 0 کھرب</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 0 کھرب</pattern>
+					<pattern type="100000000000" count="other">¤0 کھرب</pattern>
 					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0 ٹریلین</pattern>
-					<pattern type="1000000000000" count="other">¤0 ٹریلین</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0 ٹریلین</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
+					<pattern type="1000000000000" count="one">¤00 کھرب</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 00 کھرب</pattern>
+					<pattern type="1000000000000" count="other">¤00 کھرب</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 00 کھرب</pattern>
+					<pattern type="10000000000000" count="one">¤00 ٹریلین</pattern>
 					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">¤ 00 ٹریلین</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤00 ٹریلین</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
+					<pattern type="10000000000000" count="other">¤00 ٹریلین</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00 ٹریلین</pattern>
+					<pattern type="100000000000000" count="one">¤000 ٹریلین</pattern>
 					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">¤ 000 ٹریلین</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤000 ٹریلین</pattern>
+					<pattern type="100000000000000" count="other">¤000 ٹریلین</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000 ٹریلین</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/ur_IN.xml
+++ b/common/main/ur_IN.xml
@@ -520,7 +520,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="noCurrency" draft="provisional">#,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -4435,16 +4435,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Gayana vaqti</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Gavayi-aleut standart vaqti</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Gavayi-aleut vaqti</generic>
 					<standard>Gavayi-aleut standart vaqti</standard>
 					<daylight>Gavayi-aleut yozgi vaqti</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Gavayi-aleut standart vaqti</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5138,6 +5138,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern>↑↑↑</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
+				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
 		<currencyFormats numberSystem="latn">
@@ -5149,7 +5152,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>¤#,##0.00;(¤#,##0.00)</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##0.00;(¤ #,##0.00)</pattern>
 					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/uz_Arab.xml
+++ b/common/main/uz_Arab.xml
@@ -225,6 +225,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="unconfirmed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/uz_Cyrl.xml
+++ b/common/main/uz_Cyrl.xml
@@ -2027,16 +2027,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Гайана вақти</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Гавайи-алеут стандарт вақти</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Гавайи-алеут вақти</generic>
 					<standard>Гавайи-алеут стандарт вақти</standard>
 					<daylight>Гавайи-алеут кундузги вақти</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Гавайи-алеут стандарт вақти</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -2678,7 +2678,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -2686,39 +2690,65 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="1000" count="other" draft="provisional">¤ 0минг</pattern>
-					<pattern type="10000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="10000" count="other" draft="provisional">¤ 00минг</pattern>
-					<pattern type="100000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="100000" count="other" draft="provisional">¤ 000минг</pattern>
-					<pattern type="1000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="1000000" count="other" draft="provisional">¤ 0млн</pattern>
-					<pattern type="10000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="10000000" count="other" draft="provisional">¤ 00млн</pattern>
-					<pattern type="100000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="100000000" count="other" draft="provisional">¤ 000млн</pattern>
-					<pattern type="1000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="1000000000" count="other" draft="provisional">¤ 0млрд</pattern>
-					<pattern type="10000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="10000000000" count="other" draft="provisional">¤ 00млрд</pattern>
-					<pattern type="100000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="100000000000" count="other" draft="provisional">¤ 000млрд</pattern>
-					<pattern type="1000000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other" draft="provisional">¤ 0трлн</pattern>
-					<pattern type="10000000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other" draft="provisional">¤ 00трлн</pattern>
-					<pattern type="100000000000000" count="one" draft="provisional">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other" draft="provisional">¤ 000трлн</pattern>
+					<pattern type="1000" count="one">0минг ¤</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">0минг ¤</pattern>
+					<pattern type="1000" count="other">0минг ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0минг ¤</pattern>
+					<pattern type="10000" count="one">00минг ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00минг ¤</pattern>
+					<pattern type="10000" count="other">00минг ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00минг ¤</pattern>
+					<pattern type="100000" count="one">000минг ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000минг ¤</pattern>
+					<pattern type="100000" count="other">000минг ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000минг ¤</pattern>
+					<pattern type="1000000" count="one">0млн ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0млн ¤</pattern>
+					<pattern type="1000000" count="other">0млн ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0млн ¤</pattern>
+					<pattern type="10000000" count="one">00млн ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00млн ¤</pattern>
+					<pattern type="10000000" count="other">00млн ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00млн ¤</pattern>
+					<pattern type="100000000" count="one">000млн ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000млн ¤</pattern>
+					<pattern type="100000000" count="other">000млн ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000млн ¤</pattern>
+					<pattern type="1000000000" count="one">0млрд ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0млрд ¤</pattern>
+					<pattern type="1000000000" count="other">0млрд ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0млрд ¤</pattern>
+					<pattern type="10000000000" count="one">00млрд ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00млрд ¤</pattern>
+					<pattern type="10000000000" count="other">00млрд ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00млрд ¤</pattern>
+					<pattern type="100000000000" count="one">000млрд ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000млрд ¤</pattern>
+					<pattern type="100000000000" count="other">000млрд ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000млрд ¤</pattern>
+					<pattern type="1000000000000" count="one">0трлн ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0трлн ¤</pattern>
+					<pattern type="1000000000000" count="other">0трлн ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0трлн ¤</pattern>
+					<pattern type="10000000000000" count="one">00трлн ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00трлн ¤</pattern>
+					<pattern type="10000000000000" count="other">00трлн ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00трлн ¤</pattern>
+					<pattern type="100000000000000" count="one">000трлн ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000трлн ¤</pattern>
+					<pattern type="100000000000000" count="other">000трлн ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000трлн ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="one">{0} {1}</unitPattern>

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -1777,8 +1777,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="Hmsv">HH:mm:ss (v)</dateFormatItem>
 						<dateFormatItem id="hmv">h:mm a (v)</dateFormatItem>
 						<dateFormatItem id="Hmv">HH:mm (v)</dateFormatItem>
-						<dateFormatItem id="Hv">'h'HH v</dateFormatItem>
 						<dateFormatItem id="hv">↑↑↑</dateFormatItem>
+						<dateFormatItem id="Hv">'h'HH v</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Md">dd/MM</dateFormatItem>
 						<dateFormatItem id="MEd">E dd/MM</dateFormatItem>
@@ -4252,16 +4252,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Ora de la Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Ora normale de Hawai e Aleutine</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Ora de Hawai e Aleutine</generic>
 					<standard>Ora normale de Hawai e Aleutine</standard>
 					<daylight>Ora d’istà de Hawai e Aleutine</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Ora normale de Hawai e Aleutine</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4857,41 +4857,64 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="contributed">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber" draft="contributed">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency">↑↑↑</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">0</pattern>
-					<pattern type="1000" count="other">0</pattern>
-					<pattern type="10000" count="one">0</pattern>
-					<pattern type="10000" count="other">0</pattern>
-					<pattern type="100000" count="one">0</pattern>
-					<pattern type="100000" count="other">0</pattern>
-					<pattern type="1000000" count="one">0 mln ¤</pattern>
-					<pattern type="1000000" count="other">0 mln ¤</pattern>
-					<pattern type="10000000" count="one">00 mln ¤</pattern>
-					<pattern type="10000000" count="other">00 mln ¤</pattern>
-					<pattern type="100000000" count="one">000 mln ¤</pattern>
-					<pattern type="100000000" count="other">000 mln ¤</pattern>
-					<pattern type="1000000000" count="one">0 mld ¤</pattern>
-					<pattern type="1000000000" count="other">0 mld ¤</pattern>
-					<pattern type="10000000000" count="one">00 mld ¤</pattern>
-					<pattern type="10000000000" count="other">00 mld ¤</pattern>
-					<pattern type="100000000000" count="one">000 mld ¤</pattern>
-					<pattern type="100000000000" count="other">000 mld ¤</pattern>
-					<pattern type="1000000000000" count="one">0 bln ¤</pattern>
-					<pattern type="1000000000000" count="other">0 bln ¤</pattern>
-					<pattern type="10000000000000" count="one">00 bln ¤</pattern>
-					<pattern type="10000000000000" count="other">00 bln ¤</pattern>
-					<pattern type="100000000000000" count="one">000 bln ¤</pattern>
-					<pattern type="100000000000000" count="other">000 bln ¤</pattern>
+					<pattern type="1000" count="other">0 mila ¤</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0 mila ¤</pattern>
+					<pattern type="10000" count="one">00 mila ¤</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">00 mila ¤</pattern>
+					<pattern type="10000" count="other">00 mila ¤</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">00 mila ¤</pattern>
+					<pattern type="100000" count="one">000 mila ¤</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">000 mila ¤</pattern>
+					<pattern type="100000" count="other">000 mila ¤</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">000 mila ¤</pattern>
+					<pattern type="1000000" count="one">0 mln ¤</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">0 mln ¤</pattern>
+					<pattern type="1000000" count="other">0 mln ¤</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">0 mln ¤</pattern>
+					<pattern type="10000000" count="one">00 mln ¤</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">00 mln ¤</pattern>
+					<pattern type="10000000" count="other">00 mln ¤</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">00 mln ¤</pattern>
+					<pattern type="100000000" count="one">000 mln ¤</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">000 mln ¤</pattern>
+					<pattern type="100000000" count="other">000 mln ¤</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">000 mln ¤</pattern>
+					<pattern type="1000000000" count="one">0 mld ¤</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">0 mld ¤</pattern>
+					<pattern type="1000000000" count="other">0 mld ¤</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">0 mld ¤</pattern>
+					<pattern type="10000000000" count="one">00 mld ¤</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">00 mld ¤</pattern>
+					<pattern type="10000000000" count="other">00 mld ¤</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">00 mld ¤</pattern>
+					<pattern type="100000000000" count="one">000 mld ¤</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">000 mld ¤</pattern>
+					<pattern type="100000000000" count="other">000 mld ¤</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">000 mld ¤</pattern>
+					<pattern type="1000000000000" count="one">0 bln ¤</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">0 bln ¤</pattern>
+					<pattern type="1000000000000" count="other">0 bln ¤</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">0 bln ¤</pattern>
+					<pattern type="10000000000000" count="one">00 bln ¤</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">00 bln ¤</pattern>
+					<pattern type="10000000000000" count="other">00 bln ¤</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">00 bln ¤</pattern>
+					<pattern type="100000000000000" count="one">000 bln ¤</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">000 bln ¤</pattern>
+					<pattern type="100000000000000" count="other">000 bln ¤</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">000 bln ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>{0} ¤¤</currencyPatternAppendISO>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -7116,6 +7116,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Giờ Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Giờ Chuẩn Hawaii-Aleut</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Giờ Hawaii-Aleut</generic>
@@ -7126,14 +7134,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Giờ Chuẩn Hawaii-Aleut</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -7808,8 +7808,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
-					<pattern alt="noCurrency">#,##0.00;(#,##0.00)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+					<pattern alt="noCurrency">#,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/vmw.xml
+++ b/common/main/vmw.xml
@@ -159,6 +159,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern draft="contributed">#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -3571,16 +3571,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Waxtu Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Waxtu buñ jagleel Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Waxtu Hawaii-Aleutian</generic>
 					<standard>Waxtu buñ jagleel Hawaii-Aleutian</standard>
 					<daylight>Waxtu bëccëg bu Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Waxtu buñ jagleel Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4163,18 +4163,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0K</pattern>
-					<pattern type="10000" count="other">¤00K</pattern>
-					<pattern type="100000" count="other">¤000K</pattern>
-					<pattern type="1000000" count="other">¤0M</pattern>
-					<pattern type="10000000" count="other">¤00M</pattern>
-					<pattern type="100000000" count="other">¤000M</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
-					<pattern type="1000000000000" count="other">¤0T</pattern>
-					<pattern type="10000000000000" count="other">¤00T</pattern>
-					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="1000" count="other">¤ 0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
+					<pattern type="10000" count="other">¤ 00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
+					<pattern type="100000" count="other">¤ 000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
+					<pattern type="1000000" count="other">¤ 0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
+					<pattern type="10000000" count="other">¤ 00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
+					<pattern type="100000000" count="other">¤ 000M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
+					<pattern type="1000000000" count="other">¤ 0B</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
+					<pattern type="10000000000" count="other">¤ 00B</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
+					<pattern type="100000000000" count="other">¤ 000B</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
+					<pattern type="1000000000000" count="other">¤ 0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
+					<pattern type="10000000000000" count="other">¤ 00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
+					<pattern type="100000000000000" count="other">¤ 000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -4249,29 +4249,53 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="one">¤0K</pattern>
+					<pattern type="1000" count="one" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="1000" count="other">¤0K</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="10000" count="one">¤00K</pattern>
+					<pattern type="10000" count="one" alt="alphaNextToNumber">¤ 00K</pattern>
 					<pattern type="10000" count="other">¤00K</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
 					<pattern type="100000" count="one">¤000K</pattern>
+					<pattern type="100000" count="one" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="100000" count="other">¤000K</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="1000000" count="one">¤0M</pattern>
+					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="other">¤0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="10000000" count="one">¤00M</pattern>
+					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="other">¤00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="one">¤000M</pattern>
+					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="1000000000" count="one">¤0G</pattern>
+					<pattern type="1000000000" count="one" alt="alphaNextToNumber">¤ 0G</pattern>
 					<pattern type="1000000000" count="other">¤0G</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0G</pattern>
 					<pattern type="10000000000" count="one">¤00G</pattern>
+					<pattern type="10000000000" count="one" alt="alphaNextToNumber">¤ 00G</pattern>
 					<pattern type="10000000000" count="other">¤00G</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00G</pattern>
 					<pattern type="100000000000" count="one">¤000G</pattern>
+					<pattern type="100000000000" count="one" alt="alphaNextToNumber">¤ 000G</pattern>
 					<pattern type="100000000000" count="other">¤000G</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000G</pattern>
 					<pattern type="1000000000000" count="one">¤0T</pattern>
+					<pattern type="1000000000000" count="one" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="one">¤00T</pattern>
+					<pattern type="10000000000000" count="one" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="100000000000000" count="one">¤000T</pattern>
+					<pattern type="100000000000000" count="one" alt="alphaNextToNumber">¤ 000T</pattern>
 					<pattern type="100000000000000" count="other">¤000T</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -3626,16 +3626,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Guyana Time</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaii-Aleutian Standard Time</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaii-Aleutian Time</generic>
 					<standard>Hawaii-Aleutian Standard Time</standard>
 					<daylight>Hawaii-Aleutian Daylight Time</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaii-Aleutian Standard Time</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4248,30 +4248,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="one">¤0K</pattern>
+					<pattern type="1000" count="other">¤0K</pattern>
+					<pattern type="10000" count="one">¤00K</pattern>
+					<pattern type="10000" count="other">¤00K</pattern>
+					<pattern type="100000" count="one">¤000K</pattern>
+					<pattern type="100000" count="other">¤000K</pattern>
+					<pattern type="1000000" count="one">¤0M</pattern>
+					<pattern type="1000000" count="other">¤0M</pattern>
+					<pattern type="10000000" count="one">¤00M</pattern>
+					<pattern type="10000000" count="other">¤00M</pattern>
+					<pattern type="100000000" count="one">¤000M</pattern>
+					<pattern type="100000000" count="other">¤000M</pattern>
+					<pattern type="1000000000" count="one">¤0G</pattern>
+					<pattern type="1000000000" count="other">¤0G</pattern>
+					<pattern type="10000000000" count="one">¤00G</pattern>
+					<pattern type="10000000000" count="other">¤00G</pattern>
+					<pattern type="100000000000" count="one">¤000G</pattern>
+					<pattern type="100000000000" count="other">¤000G</pattern>
+					<pattern type="1000000000000" count="one">¤0T</pattern>
+					<pattern type="1000000000000" count="other">¤0T</pattern>
+					<pattern type="10000000000000" count="one">¤00T</pattern>
+					<pattern type="10000000000000" count="other">¤00T</pattern>
+					<pattern type="100000000000000" count="one">¤000T</pattern>
+					<pattern type="100000000000000" count="other">¤000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/xnr.xml
+++ b/common/main/xnr.xml
@@ -3810,16 +3810,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>गुयाना दा टैम</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>हवाई–आल्यूशन दा मानक टैम</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>हवाई–आल्यूशन दा टैम</generic>
 					<standard>हवाई–आल्यूशन दा मानक टैम</standard>
 					<daylight>हवाई–आल्यूशन दे ध्याड़े दे उजाले दा टैम</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>हवाई–आल्यूशन दा मानक टैम</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4414,8 +4414,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>↑↑↑</pattern>
-					<pattern alt="alphaNextToNumber">↑↑↑</pattern>
-					<pattern alt="noCurrency">↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 		</currencyFormats>
@@ -4423,26 +4426,41 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>¤#,##,##0.00</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
+					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>↑↑↑</pattern>
+					<pattern alt="alphaNextToNumber">¤ #,##,##0.00</pattern>
 					<pattern alt="noCurrency">#,##,##0.00</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
-					<pattern type="1000" count="other">¤0 हज़ार</pattern>
-					<pattern type="10000" count="other">¤00 हज़ार</pattern>
+					<pattern type="1000" count="other">¤0 हजार</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0 हजार</pattern>
+					<pattern type="10000" count="other">¤00 हजार</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00 हजार</pattern>
 					<pattern type="100000" count="other">¤0 लख</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 0 लख</pattern>
 					<pattern type="1000000" count="other">¤00 लख</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 00 लख</pattern>
 					<pattern type="10000000" count="other">¤0 क॰</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0 क॰</pattern>
 					<pattern type="100000000" count="other">¤00 क॰</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 00 क॰</pattern>
 					<pattern type="1000000000" count="other">¤0 अ॰</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0 अ॰</pattern>
 					<pattern type="10000000000" count="other">¤00 अ॰</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00 अ॰</pattern>
 					<pattern type="100000000000" count="other">¤0 ख॰</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0 ख॰</pattern>
 					<pattern type="1000000000000" count="other">¤00 ख॰</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 00 ख॰</pattern>
 					<pattern type="10000000000000" count="other">¤0 नील</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 0 नील</pattern>
 					<pattern type="100000000000000" count="other">¤00 नील</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 00 नील</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<unitPattern count="other">↑↑↑</unitPattern>

--- a/common/main/xog.xml
+++ b/common/main/xog.xml
@@ -591,7 +591,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
+				</currencyFormat>
+				<currencyFormat type="accounting">
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyFormatLength type="short">

--- a/common/main/yav.xml
+++ b/common/main/yav.xml
@@ -597,10 +597,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength>
 				<currencyFormat type="standard">
 					<pattern>#,##0.00 ¤</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤</pattern>
 					<pattern alt="noCurrency" draft="provisional">↑↑↑</pattern>
 				</currencyFormat>
 				<currencyFormat type="accounting">
 					<pattern>#,##0.00 ¤;(#,##0.00 ¤)</pattern>
+					<pattern alt="alphaNextToNumber">#,##0.00 ¤;(#,##0.00 ¤)</pattern>
 					<pattern alt="noCurrency" draft="provisional">#,##0.00;(#,##0.00)</pattern>
 				</currencyFormat>
 			</currencyFormatLength>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -4059,16 +4059,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Àkókò Gúyànà</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Àkókò Àfẹnukò Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Àkókò Hawaii-Aleutian</generic>
 					<standard>Àkókò Àfẹnukò Hawaii-Aleutian</standard>
 					<daylight>Àkókò Ojúmọmọ Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Àkókò Àfẹnukò Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4669,12 +4669,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
+					<pattern type="1000000000" count="other">¤0G</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0G</pattern>
+					<pattern type="10000000000" count="other">¤00G</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00G</pattern>
+					<pattern type="100000000000" count="other">¤000G</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000G</pattern>
 					<pattern type="1000000000000" count="other">¤0T</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="other">¤00T</pattern>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -3970,16 +3970,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>Àkókò Gúyànà</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Àkókò Àfɛnukò Hawaii-Aleutian</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Àkókò Hawaii-Aleutian</generic>
 					<standard>Àkókò Àfɛnukò Hawaii-Aleutian</standard>
 					<daylight>Àkókò Ojúmɔmɔ Hawaii-Aleutian</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Àkókò Àfɛnukò Hawaii-Aleutian</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -4574,12 +4574,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
 					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
-					<pattern type="1000000000" count="other">¤0B</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
-					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
-					<pattern type="100000000000" count="other">¤000B</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
+					<pattern type="1000000000" count="other">¤0G</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0G</pattern>
+					<pattern type="10000000000" count="other">¤00G</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00G</pattern>
+					<pattern type="100000000000" count="other">¤000G</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000G</pattern>
 					<pattern type="1000000000000" count="other">¤0T</pattern>
 					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="other">¤00T</pattern>

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -4562,16 +4562,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Giyana Hurariyu</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Hawaí asuí Kapuã-ita Areuta-ita Hurariyu Retewa</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Hawaí asuí Kapuã-ita Areuta-ita Hurariyu</generic>
 					<standard>Hawaí asuí Kapuã-ita Areuta-ita Hurariyu Retewa</standard>
 					<daylight>Hawaí asuí Kapuã-ita Areuta-ita Kurasí Ara Hurariyu</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Hawaí asuí Kapuã-ita Areuta-ita Hurariyu Retewa</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -6362,16 +6362,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>蓋亞那時間</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>夏威夷-阿留申標準時間</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>夏威夷-阿留申時間</generic>
 					<standard>夏威夷-阿留申標準時間</standard>
 					<daylight>夏威夷-阿留申夏令時間</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>夏威夷-阿留申標準時間</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -7052,17 +7052,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other">¤0千</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0千</pattern>
 					<pattern type="10000" count="other">¤0萬</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 0萬</pattern>
 					<pattern type="100000" count="other">¤00萬</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 00萬</pattern>
 					<pattern type="1000000" count="other">¤000萬</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 000萬</pattern>
 					<pattern type="10000000" count="other">¤0000萬</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0000萬</pattern>
 					<pattern type="100000000" count="other">¤0億</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 0億</pattern>
 					<pattern type="1000000000" count="other">¤00億</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 00億</pattern>
 					<pattern type="10000000000" count="other">¤000億</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 000億</pattern>
 					<pattern type="100000000000" count="other">¤0000億</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0000億</pattern>
 					<pattern type="1000000000000" count="other">¤0兆</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0兆</pattern>
 					<pattern type="10000000000000" count="other">¤00兆</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00兆</pattern>
 					<pattern type="100000000000000" count="other">¤000兆</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000兆</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -6274,16 +6274,16 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>盖亚那时间</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>夏威夷-阿留申标准时间</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>夏威夷-阿留申时间</generic>
 					<standard>夏威夷-阿留申标准时间</standard>
 					<daylight>夏威夷-阿留申夏令时间</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>夏威夷-阿留申标准时间</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -6953,16 +6953,27 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other">0</pattern>
 					<pattern type="10000" count="other">¤0万</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 0万</pattern>
 					<pattern type="100000" count="other">¤00万</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 00万</pattern>
 					<pattern type="1000000" count="other">¤000万</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 000万</pattern>
 					<pattern type="10000000" count="other">¤0000万</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0000万</pattern>
 					<pattern type="100000000" count="other">¤0亿</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 0亿</pattern>
 					<pattern type="1000000000" count="other">¤00亿</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 00亿</pattern>
 					<pattern type="10000000000" count="other">¤000亿</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 000亿</pattern>
 					<pattern type="100000000000" count="other">¤0000亿</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0000亿</pattern>
 					<pattern type="1000000000000" count="other">¤0兆</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0兆</pattern>
 					<pattern type="10000000000000" count="other">¤00兆</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00兆</pattern>
 					<pattern type="100000000000000" count="other">¤000兆</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000兆</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -7831,16 +7831,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>圭亚那时间</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>夏威夷-阿留申标准时间</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>夏威夷-阿留申时间</generic>
 					<standard>夏威夷-阿留申标准时间</standard>
 					<daylight>夏威夷-阿留申夏令时间</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>夏威夷-阿留申标准时间</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -9635,7 +9635,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other">0</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0千</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">0</pattern>
 					<pattern type="10000" count="other">¤0万</pattern>
 					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 0万</pattern>
 					<pattern type="100000" count="other">¤00万</pattern>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -9840,6 +9840,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>蓋亞那時間</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>夏威夷-阿留申標準時間</standard>
+				</long>
+				<short>
+					<standard draft="contributed">HAST</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>夏威夷-阿留申時間</generic>
@@ -9850,14 +9858,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<generic draft="contributed">HAT</generic>
 					<standard draft="contributed">HAST</standard>
 					<daylight draft="contributed">HADT</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>夏威夷-阿留申標準時間</standard>
-				</long>
-				<short>
-					<standard draft="contributed">HAST</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -12198,27 +12198,27 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000" count="other">0</pattern>
 					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
 					<pattern type="10000" count="other">¤0萬</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 0萬</pattern>
 					<pattern type="100000" count="other">¤00萬</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 00萬</pattern>
 					<pattern type="1000000" count="other">¤000萬</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 000萬</pattern>
 					<pattern type="10000000" count="other">¤0000萬</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 0000萬</pattern>
 					<pattern type="100000000" count="other">¤0億</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 0億</pattern>
 					<pattern type="1000000000" count="other">¤00億</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 00億</pattern>
 					<pattern type="10000000000" count="other">¤000億</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 000億</pattern>
 					<pattern type="100000000000" count="other">¤0000億</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 0000億</pattern>
 					<pattern type="1000000000000" count="other">¤0兆</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0兆</pattern>
 					<pattern type="10000000000000" count="other">¤00兆</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00兆</pattern>
 					<pattern type="100000000000000" count="other">¤000兆</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000兆</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -9879,6 +9879,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>圭亞那時間</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>↑↑↑</standard>
+				</long>
+				<short>
+					<standard>↑↑↑</standard>
+				</short>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>↑↑↑</generic>
@@ -9889,14 +9897,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
 					<daylight>↑↑↑</daylight>
-				</short>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>↑↑↑</standard>
-				</long>
-				<short>
-					<standard>↑↑↑</standard>
 				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -11188,29 +11188,29 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<currencyFormatLength type="short">
 				<currencyFormat type="standard">
 					<pattern type="1000" count="other">¤0K</pattern>
-					<pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000" count="other" alt="alphaNextToNumber">¤ 0K</pattern>
 					<pattern type="10000" count="other">¤00K</pattern>
-					<pattern type="10000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000" count="other" alt="alphaNextToNumber">¤ 00K</pattern>
 					<pattern type="100000" count="other">¤000K</pattern>
-					<pattern type="100000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="1000000" count="other">¤0M</pattern>
-					<pattern type="1000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="10000000" count="other">¤00M</pattern>
-					<pattern type="10000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>
-					<pattern type="100000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000" count="other" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="1000000000" count="other">¤0B</pattern>
-					<pattern type="1000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000" count="other" alt="alphaNextToNumber">¤ 0B</pattern>
 					<pattern type="10000000000" count="other">¤00B</pattern>
-					<pattern type="10000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000" count="other" alt="alphaNextToNumber">¤ 00B</pattern>
 					<pattern type="100000000000" count="other">¤000B</pattern>
-					<pattern type="100000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000" count="other" alt="alphaNextToNumber">¤ 000B</pattern>
 					<pattern type="1000000000000" count="other">¤0T</pattern>
-					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="1000000000000" count="other" alt="alphaNextToNumber">¤ 0T</pattern>
 					<pattern type="10000000000000" count="other">¤00T</pattern>
-					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="10000000000000" count="other" alt="alphaNextToNumber">¤ 00T</pattern>
 					<pattern type="100000000000000" count="other">¤000T</pattern>
-					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>
+					<pattern type="100000000000000" count="other" alt="alphaNextToNumber">¤ 000T</pattern>
 				</currencyFormat>
 			</currencyFormatLength>
 			<currencyPatternAppendISO>↑↑↑</currencyPatternAppendISO>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -5542,9 +5542,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="1000000" count="one">¤0M</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="1000000" count="other">¤0M</pattern>
+					<pattern type="1000000" count="other" alt="alphaNextToNumber">¤ 0M</pattern>
 					<pattern type="10000000" count="one">¤00M</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="10000000" count="other">¤00M</pattern>
+					<pattern type="10000000" count="other" alt="alphaNextToNumber">¤ 00M</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -4821,16 +4821,16 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>Isikhathi sase-Guyana</standard>
 				</long>
 			</metazone>
+			<metazone type="Hawaii">
+				<long>
+					<standard>Isikhathi sase-Hawaii-Aleutia esijwayelekile</standard>
+				</long>
+			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
 					<generic>Isikhathi sase-Hawaii-Aleutia</generic>
 					<standard>Isikhathi sase-Hawaii-Aleutia esijwayelekile</standard>
 					<daylight>Isikhathi sase-Hawaii-Aleutia sasemini</daylight>
-				</long>
-			</metazone>
-			<metazone type="Hawaii">
-				<long>
-					<standard>Isikhathi sase-Hawaii-Aleutia esijwayelekile</standard>
 				</long>
 			</metazone>
 			<metazone type="Hong_Kong">
@@ -5541,10 +5541,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<pattern type="100000" count="other" alt="alphaNextToNumber">¤ 000K</pattern>
 					<pattern type="1000000" count="one">¤0M</pattern>
 					<pattern type="1000000" count="one" alt="alphaNextToNumber">¤ 0M</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
+					<pattern type="1000000" count="other">¤0M</pattern>
 					<pattern type="10000000" count="one">¤00M</pattern>
 					<pattern type="10000000" count="one" alt="alphaNextToNumber">¤ 00M</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
+					<pattern type="10000000" count="other">¤00M</pattern>
 					<pattern type="100000000" count="one">↑↑↑</pattern>
 					<pattern type="100000000" count="one" alt="alphaNextToNumber">¤ 000M</pattern>
 					<pattern type="100000000" count="other">¤000M</pattern>

--- a/docs/site/development/cldr-big-red-switch/cldrmodify-passes.md
+++ b/docs/site/development/cldr-big-red-switch/cldrmodify-passes.md
@@ -67,7 +67,7 @@ There are a number of "one time fixes" that are in the CLDRModify code. The typi
 #### Inactive options
 The following are some of the **inactive** options. The code remains in case we want to adapt for future cases, but don't use them unless you fix the code to do what you want, and carefully diff the results. You will have to enable them in checkSuboptions(): limits the ones that are active to prevent mistakes.
 
-1. \-fc: Transition from an old currency to a new currency.  This fix is quite useful when a country introduces a new currency code ( usually due to a devaluation ), but the name remains the same.  In order to use this fix, modify the following values in the CLDRModify code under "**fixList.add('c', "Fix transiton from an old currency code to a new one**"
+1. \-fc: Transition from an old currency to a new currency. This fix is quite useful when a country introduces a new currency code (usually due to a devaluation), but the name remains the same. In order to use this fix, modify the following values in the CLDRModify code under "**fixList.add('c', "Fix transiton from an old currency code to a new one**"
     1. Change the String oldCurrencyCode and newCurrencyCode to reflect the currency codes you are transitioning.  
     2. Change the int fromDate and toDate to reflect the dates that the old currency was in circulation.
 These will be used to create the date range in the old currency string.  

--- a/docs/site/development/cldr-big-red-switch/cldrmodify-passes.md
+++ b/docs/site/development/cldr-big-red-switch/cldrmodify-passes.md
@@ -23,7 +23,7 @@ For the purpose of this document, we'll assume you are generating into {cldrdata
 ### Passes
 
   * Each pass will go from a sourceDir (default=CLDRPaths.***MAIN\_DIRECTORY)*** to a targetDir (default \= CLDRPaths.***GEN\_DIRECTORY*** \+ "cldrModify/")  
-  * Empty the contents of targetDir before running.  (If you forget, just remember after building to delete the old files.)
+  * Empty the contents of targetDir before running. (If you forget, just remember after building to delete the old files.)
   * Each time you will run CLDRModify with the standard options, plus one of the listed [Options](#options) bulleted below.
   * The console will list changes made, such as:  
      * Creating File: {cldrdata}/dropbox\\gen\\main\\zh\_Hant.xml  

--- a/docs/site/development/cldr-big-red-switch/cldrmodify-passes.md
+++ b/docs/site/development/cldr-big-red-switch/cldrmodify-passes.md
@@ -6,7 +6,7 @@ title: CLDRModify Passes
 
 ## Main Process
 
-This section describes how to run the CLDRModify passes for the mechanical cleanup of the data before release.
+This section describes how to run the CLDRModify passes for the mechanical cleanup of the data at various points in the BRS.
 
 ### Successive Passes
 
@@ -16,28 +16,27 @@ You will run CLDRModify with different options, in multiple passes.
    1. ***This sanity check is important,*** since the regularizing often reveals problems in the original. For example, a date format like MMM'-yy regularizes to MMM-'yy' \-- but the original was clearly an error.
    1. If you need to do a single file over again (eg resolving conflicts), use the \-m option on CLDRModify, as described below.
 
-### After passes
-
-* After you are all done, run ConsoleCheckCLDR once more, to make sure you didn't introduce any new errors.
-
 **Details**
 
 For the purpose of this document, we'll assume you are generating into {cldrdata}/dropbox/gen/main/ as the target directory. Change any instance below to the directory that you actually use.
 
 ### Passes
 
-* Each pass will go from a sourceDir (default=CLDRPaths.***MAIN\_DIRECTORY)*** to a targetDir (default \= CLDRPaths.***GEN\_DIRECTORY*** \+ "cldrModify/")  
-  * Empty the contents of targetDir before running.  
-  * Each time you will run CLDRModify with the standard options, plus one of the listed [Options](#options) bulleted below.  
+  * Each pass will go from a sourceDir (default=CLDRPaths.***MAIN\_DIRECTORY)*** to a targetDir (default \= CLDRPaths.***GEN\_DIRECTORY*** \+ "cldrModify/")  
+  * Empty the contents of targetDir before running.  (If you forget, just remember after building to delete the old files.)
+  * Each time you will run CLDRModify with the standard options, plus one of the listed [Options](#options) bulleted below.
+  * The console will list changes made, such as:  
+     * Creating File: {cldrdata}/dropbox\\gen\\main\\zh\_Hant.xml  
+     * \*Renaming old {cldrdata}/dropbox\\gen\\main\\zh\_Hant.xml  
+     * %zh\_Hant\_HK    \-    Replacing: \<yy'年'M'月'd'日'\>    by \<yy年M月d日\>     at: //ldml/dates/calendars/calendar\[@type="gregorian"\]/dateFormats/dateFormatLength\[@type="short"\]/dateFormat\[@type="standard"\]/pattern\[@type="standard"\]  
   * After building, remember to refresh data files with F5 if you are using Eclipse, after building.  
   * Dif sourceDir and targetDir directories to make sure that there aren't any spurious changes.  
   * Then copy the targetDir files to the sourceDir files  
   * Run ConsoleCheckCLDR to verify that no errors have been introduced. Standard options, plus:  
-    * *// set this to test in the original directory:* \-DCLDR\_MAIN={sourceDir}. You can set up some configuration.  
+    * *// set this to test in the original directory:* \-DCLDR\_MAIN={sourceDir}.  
     * \-e  
     * \-z final\_testing  
-  * If ok, check in (see [How to check in consistently after each pass](#how-to-check-in-consistently-after-each-pass)).  
-  * Otherwise, either manually patch, or revert from SVN Head files to get back to a clean state, fix, and repeat.
+  * Otherwise, either manually patch, or revert from HEAD files to get back to a clean state, fix, and repeat.
 
 ### Options
 
@@ -48,46 +47,35 @@ Standard Options: add to your regular preferences \-DSHOW\_FILES *plus* your cho
    1. \-s{cldrdir}**/common/subdivisions** 
    1. \-s{cldrdir}**/exemplars/main**
 
-Other options for each pass:  
+#### Other options for each pass:  
 
 You will have to repeat this cycle if any outside changes are made to the data\!
 
-One-Time Fixes
+#### One-Time Fixes
 
-There are a number of "one time fixes" that are in the CLDRModify code. The code remains in case we want to adapt for future cases, but don't use them unless you fix the code to do what you want, and carefully diff the results. Here are some of them:
+There are a number of "one time fixes" that are in the CLDRModify code. The typical ones run at start and end of the release are:
 
-1. \-fk: use a configuration file. Details on [CLDRModify Config](cldrmodify-using-config-file)  
-   2. \-fe: fix Interindic. If you need to make changes in transliteration, you might want to modify this and run it.  
-   3. \-fs: Fix the stand-alone narrow values.  
-   4. \-fu: Fix the unit patterns.  
-   5. \-fd: Fix dates  
-   6. \-fz: Fix exemplars  
-   7. \-fr: Fix references and standard  
-   8. \-fc: Transition from an old currency to a new currency.  This fix is quite useful when a country introduces a new currency code ( usually due to a devaluation ), but the name remains the same.  In order to use this fix, modify the following values in the CLDRModify code under "**fixList.add('c', "Fix transiton from an old currency code to a new one**"  
-      1. Change the String oldCurrencyCode and newCurrencyCode to reflect the currency codes you are transitioning.  
-      2. Change the int fromDate and toDate to reflect the dates that the old currency was in circulation. These will be used to create the date range in the old currency string.  
-      3. Run the CLDRModify tool as usual, diff the results and check in.
+0. _no settings_: simply reformat the file. Recommended to do this first, so that the later diffs are clean.
+1. \-fP: Apply DAIP (DisplayAndInputProcessor) to clean up values from manual changes
+2. \-fC: Generate derived /main path-values for all locales
+    * Currently this needs to be run multiple times, until there are no more changes. This is because modifications trickle down due to inheritance.
+3. \-fE: Fix null/inherited values in en.xml.
 
-## How to check in consistently after each pass
+#### Config file
+1. \-fk: use a configuration file; see the details on [CLDRModify Config](cldrmodify-using-config-file).
 
-### Sanity Check
+#### Inactive options
+The following are some of the **inactive** options. The code remains in case we want to adapt for future cases, but don't use them unless you fix the code to do what you want, and carefully diff the results. You will have to enable them in checkSuboptions(): limits the ones that are active to prevent mistakes.
 
-1. The console will list changes made, such as:  
-   * Creating File: {cldrdata}/dropbox\\gen\\main\\zh\_Hant.xml  
-     * \*Renaming old {cldrdata}/dropbox\\gen\\main\\zh\_Hant.xml  
-     * %zh\_Hant\_HK    \-    Replacing: \<yy'年'M'月'd'日'\>    by \<yy年M月d日\>     at: //ldml/dates/calendars/calendar\[@type="gregorian"\]/dateFormats/dateFormatLength\[@type="short"\]/dateFormat\[@type="standard"\]/pattern\[@type="standard"\]  
-2. The diff folder in the output has CompareIt\! bat files for each change, or you can use SVN diff after moving to the SVN folder by doing the Copy and then checking.
-
-### Copy Files
-
-* Copy from the target directory (eg {cldrdata}/dropbox\\gen\\main) to the svn directory (eg {cldrdata}/common\\main)  
-  * Run CLDRModify again, with nothing but standard options. This will verify that there are no xml errors.  
-    * There should be no change in the output; thus you should not see anything but \_unchanged\_.....xml files in the target directory.
-
-### Now ready to check in
-
-* Run the CLDR Unit Tests to make sure you didn't break anything  
-  * Run ConsoleCheckCLDR \-e \-z final\_testing  
-  * Check in \- I usually use a comment such as "cldrbug 1234: BRS Task A21 : CLDRModify \-fp"
-
-**If someone checks in a change in the middle of one of your passes, it is generally easier to check in the rest of the changes, check out a clean copy of that file, and return the pass with only that file. The \-m(uk) option can be used to restrict the pass to only uk.xml, for example.**
+1. \-fc: Transition from an old currency to a new currency.  This fix is quite useful when a country introduces a new currency code ( usually due to a devaluation ), but the name remains the same.  In order to use this fix, modify the following values in the CLDRModify code under "**fixList.add('c', "Fix transiton from an old currency code to a new one**"
+    1. Change the String oldCurrencyCode and newCurrencyCode to reflect the currency codes you are transitioning.  
+    2. Change the int fromDate and toDate to reflect the dates that the old currency was in circulation.
+These will be used to create the date range in the old currency string.  
+      4. Run the CLDRModify tool as usual, diff the results and check in.
+2. \-fe: fix Interindic. If you need to make changes in transliteration, you probably want to modify this and run it.  
+4. \-fs: Fix the stand-alone narrow values.  
+5. \-fu: Fix the unit patterns.  
+6. \-fd: Fix dates  
+7. \-fz: Fix exemplars  
+8. \-fr: Fix references and standard
+9. ...

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedMain.java
@@ -1,6 +1,7 @@
 package org.unicode.cldr.tool;
 
 import com.google.common.base.Objects;
+import com.ibm.icu.text.SimpleFormatter;
 import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.Output;
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CodePointEscaper;
@@ -29,8 +31,12 @@ import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.XPathParts;
 
 public class GenerateDerivedMain {
+    private static final boolean DEBUG = System.getProperty("GenerateDerivedMain:DEBUG") != null;
+    ;
+    private static final SimpleFormatter CURRENCY_FORMAT =
+            SimpleFormatter.compile(
+                    "//ldml/numbers/currencyFormats[@numberSystem=\"{0}\"]/currencyFormatLength/currencyFormat[@type=\"{1}\"]/pattern[@type=\"standard\"]");
     private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
-    private static final boolean DEBUG = false;
     static Factory cldrFactory = CLDR_CONFIG.getCldrFactory();
     static PathHeader.Factory phf = PathHeader.getFactory();
 
@@ -39,6 +45,7 @@ public class GenerateDerivedMain {
         System.out.println(
                 Joiners.TAB.join(
                         "locale",
+                        "numberSystem",
                         "code",
                         "status",
                         "oldValue",
@@ -46,11 +53,13 @@ public class GenerateDerivedMain {
                         "es.oldValue",
                         "es.newValue"));
 
-        Map<String, Level> items = StandardCodes.make().getLocalesToLevelsFor(Organization.cldr);
+        Map<String, Level> cldrLocaleLevels =
+                StandardCodes.make().getLocalesToLevelsFor(Organization.cldr);
+        Set<String> locales = Set.of("af"); // cldrFactory.getAvailable();
         Set<String> noDifference = new LinkedHashSet<>();
         Set<String> wsDifference = new LinkedHashSet<>();
-        for (Entry<String, Level> item : items.entrySet()) {
-            String locale = item.getKey();
+        for (String locale : locales) {
+            Level level = cldrLocaleLevels.getOrDefault(locale, Level.BASIC);
             if (DEBUG) System.out.println("\nLocale " + locale);
             Set<XPathParts> basis = new TreeSet<>();
             CLDRFile resolvedCldrFile = cldrFactory.make(locale, true);
@@ -66,6 +75,7 @@ public class GenerateDerivedMain {
                     .forEach(
                             ph -> {
                                 String path = ph.getOriginalPath();
+                                XPathParts parts = XPathParts.getFrozenInstance(path);
                                 String oldValue = resolvedCldrFile.getStringValue(path);
                                 String newValue = results.get(path);
                                 boolean newIsNull = newValue == null;
@@ -74,6 +84,8 @@ public class GenerateDerivedMain {
                                 }
                                 String eOldValue = escape(oldValue);
                                 String eNewValue = escape(newValue);
+
+                                String numberSystem = parts.getAttributeValue(2, "numberSystem");
 
                                 Status status = getStatus(oldValue, newValue, newIsNull);
                                 if (status.compareTo(maxDifference.value) > 0) {
@@ -89,6 +101,7 @@ public class GenerateDerivedMain {
                                 toPrint.add(
                                         Joiners.TAB.join(
                                                 locale,
+                                                numberSystem,
                                                 modCode,
                                                 status.symbol,
                                                 oldValue,
@@ -194,7 +207,7 @@ public class GenerateDerivedMain {
 
         Map<String, CurrencyData> numberSystemToCurrencyData = new TreeMap<>();
 
-        // we get the unresolved paths, so we don't get all the aliased number systems, etc.
+        // we only get the unresolved paths, so we don't get all the aliased number systems, etc.
 
         for (String path : unresolvedCldrFile.iterableWithoutExtras()) {
             XPathParts parts = XPathParts.getFrozenInstance(path);
@@ -237,7 +250,9 @@ public class GenerateDerivedMain {
         }
 
         if (DEBUG) {
-            numberSystemToCurrencyData.entrySet().stream().forEach(System.out::println);
+            System.out.println("Unresolved file paths");
+            numberSystemToCurrencyData.entrySet().stream()
+                    .forEach(x -> System.out.println(valuesFor(x, unresolvedCldrFile)));
         }
 
         Map<String, String> result = new TreeMap<>();
@@ -245,7 +260,16 @@ public class GenerateDerivedMain {
         // process; using the resolved values
 
         for (Entry<String, CurrencyData> entry : numberSystemToCurrencyData.entrySet()) {
+            String numberSystem = entry.getKey();
             CurrencyData currencyData = entry.getValue();
+
+            // Handle strange case, where one of the patterns in currencyData is fleshed out, and
+            // the other isn't.
+            if (currencyData.standardPath == null) {
+                currencyData.setStandardPath(numberSystem);
+            } else if (currencyData.accountingPath == null) {
+                currencyData.setAccountingPath(numberSystem);
+            }
 
             final XPathParts standardPath = currencyData.getStandardPath();
             PartsForCompact partsForCompact = new PartsForCompact();
@@ -258,7 +282,14 @@ public class GenerateDerivedMain {
                 }
                 addPathValue(result, standardPath, standardValue, partsForCompact);
             }
-
+            if (partsForCompact.currencyPattern == null) {
+                throw new IllegalArgumentException(
+                        Joiners.TAB.join(
+                                "Failed to find currency pattern: ",
+                                resolvedCldrFile.getLocaleID(),
+                                entry.getKey(),
+                                entry.getValue()));
+            }
             final XPathParts accountingPath = currencyData.getAccountingPath();
             if (accountingPath != null) {
                 basis.add(accountingPath);
@@ -304,6 +335,10 @@ public class GenerateDerivedMain {
             }
         }
         return result;
+    }
+
+    private static String valuesFor(Entry<String, CurrencyData> x, CLDRFile unresolvedCldrFile) {
+        return Joiners.N.join(x.getKey(), x.getValue().toStringWithValue(unresolvedCldrFile));
     }
 
     private static class PartsForCompact {
@@ -393,8 +428,25 @@ public class GenerateDerivedMain {
     }
 
     static final class CurrencyData {
+        enum Type {
+            standard,
+            accounting
+        }
+
         public XPathParts getStandardPath() {
             return standardPath;
+        }
+
+        public void setStandardPath(String numberSystem) {
+            setStandardPath(
+                    XPathParts.getFrozenInstance(
+                            CURRENCY_FORMAT.format(numberSystem, Type.standard.toString())));
+        }
+
+        public void setAccountingPath(String numberSystem) {
+            setAccountingPath(
+                    XPathParts.getFrozenInstance(
+                            CURRENCY_FORMAT.format(numberSystem, Type.accounting.toString())));
         }
 
         public void setStandardPath(XPathParts standardPath) {
@@ -437,6 +489,22 @@ public class GenerateDerivedMain {
                     "compactPaths",
                     compactPaths.size(),
                     Joiners.N.join(compactPaths));
+        }
+
+        public String toStringWithValue(CLDRFile cldrFile) {
+            return Joiners.N.join(
+                    Joiners.TAB.join(
+                            "standardPath",
+                            standardPath,
+                            cldrFile.getStringValue(standardPath.toString())),
+                    Joiners.TAB.join(
+                            "accountingPath",
+                            accountingPath,
+                            cldrFile.getStringValue(accountingPath.toString())),
+                    Joiners.TAB.join("compactPaths", compactPaths.size()),
+                    compactPaths.stream()
+                            .map(x -> Joiners.TAB.join(x, cldrFile.getStringValue(x.toString())))
+                            .collect(Collectors.joining("\n")));
         }
 
         private static CurrencyData get(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedMain.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedMain.java
@@ -55,7 +55,7 @@ public class GenerateDerivedMain {
 
         Map<String, Level> cldrLocaleLevels =
                 StandardCodes.make().getLocalesToLevelsFor(Organization.cldr);
-        Set<String> locales = Set.of("af"); // cldrFactory.getAvailable();
+        Set<String> locales = DEBUG ? Set.of("sw") : cldrFactory.getAvailable();
         Set<String> noDifference = new LinkedHashSet<>();
         Set<String> wsDifference = new LinkedHashSet<>();
         for (String locale : locales) {


### PR DESCRIPTION
CLDR-18840

This modifies CLDRModify to add an -fC option, which adds derived currency path/value pairs to the locales. It also processes the files with that option. It uses the standard currency format and the accounting currency format to generate alternate formats: alphaNextToNumber, noCurrency, and the currency format for compact numbers. This ensures consistency across all of these formats.

For example:
* common/main/af.xml had <pattern type="1000" count="other" alt="alphaNextToNumber">↑↑↑</pattern>, but that resolves to ¤0 k, which for alphaNextToNumber needs a space before the 0.

It also fixes some significant other glitches in the data. For example, one line in ba.xml had two ¤ in the negative format, one on both sides of the number. I had to fix this manually so that the tool could run. (Filed a ticket to detect.)

Notes:
1. I don't expect more than spot-checks; there are quite a number of changes. Reviewers should just spot-check a few sample locales.
   * To see what changed, sometimes you have to look at what a value like ↑↑↑ or missing would have been. Remember that count="x" will inherit from count="other", and alt="x" will inherit from the no-alt version.
   * The noCurrency values will not have a currency, and the alphaNextToNumber will have a space between the currency and number.
   * Sometimes you won't see a difference, where the only difference is in a space (eg, no-breaking vs breaking).
3. A recent change to the Hawaii metazones changed the ordering of elements in the current main file to be non-canonical. If we had time to first do a CLDRModify pass on main to clean up the format, then some files would disappear once rebased, but for now, just ignore the Hawaii changes.
    * For example, common/main/am.xml has no changes other than to the Hawaii metazones
4. A current limitation is that the tool needs to be run more than once, in case items are created the first time that also generate others.  (TODO recorded in CLDR-18840)
5. One other limitation is that sometimes it generates an explicit value when ↑↑↑ would be sufficient. Those have identical effects for the production software, so that is not a serious issue.
6. Many files like ba.xml have an excessive number of comprehensive numbering systems, most or all of which just inherit.

Code

tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateDerivedMain.java
* Most of the code is here. The main method is just is just for development. A later PR will move this to a test class (TODO recorded in CLDR-18840).
* It gathers data from each file, then uses that to generate the new paths, and returns those that are different (from the resolved value).

tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
* The change is to hook up a new -fC to use GenerateDerivedMain.getPathValuesToAdd() 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
7. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
8. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
