### PR TITLE
CLDR-18876 Fix long compact decimal format in en_IN

### DIFF
--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -6145,10 +6145,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<pattern type="100000000" count="other" draft="contributed">00 crore</pattern>
 					<pattern type="1000000000" count="one" draft="contributed">000 crore</pattern>
 					<pattern type="1000000000" count="other" draft="contributed">000 crore</pattern>
-					<pattern type="10000000000" count="one" draft="contributed">0T crore</pattern>
-					<pattern type="10000000000" count="other" draft="contributed">0T crore</pattern>
-					<pattern type="100000000000" count="one" draft="contributed">00T crore</pattern>
-					<pattern type="100000000000" count="other" draft="contributed">00T crore</pattern>
+					<pattern type="10000000000" count="one" draft="contributed">0000 crore</pattern>
+					<pattern type="10000000000" count="other" draft="contributed">0000 crore</pattern>
+					<pattern type="100000000000" count="one" draft="contributed">00000 crore</pattern>
+					<pattern type="100000000000" count="other" draft="contributed">00000 crore</pattern>
 					<pattern type="1000000000000" count="one" draft="contributed">0 lakh crore</pattern>
 					<pattern type="1000000000000" count="other" draft="contributed">0 lakh crore</pattern>
 					<pattern type="10000000000000" count="one" draft="contributed">00 lakh crore</pattern>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -6131,30 +6131,30 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</decimalFormatLength>
 			<decimalFormatLength type="long">
 				<decimalFormat>
-					<pattern type="1000" count="one">↑↑↑</pattern>
-					<pattern type="1000" count="other">↑↑↑</pattern>
-					<pattern type="10000" count="one">↑↑↑</pattern>
-					<pattern type="10000" count="other">↑↑↑</pattern>
-					<pattern type="100000" count="one">↑↑↑</pattern>
-					<pattern type="100000" count="other">↑↑↑</pattern>
-					<pattern type="1000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000" count="other">↑↑↑</pattern>
-					<pattern type="1000000000000" count="one">↑↑↑</pattern>
-					<pattern type="1000000000000" count="other">↑↑↑</pattern>
-					<pattern type="10000000000000" count="one">↑↑↑</pattern>
-					<pattern type="10000000000000" count="other">↑↑↑</pattern>
-					<pattern type="100000000000000" count="one">↑↑↑</pattern>
-					<pattern type="100000000000000" count="other">↑↑↑</pattern>
+					<pattern type="1000" count="one" draft="contributed">↑↑↑</pattern>
+					<pattern type="1000" count="other" draft="contributed">↑↑↑</pattern>
+					<pattern type="10000" count="one" draft="contributed">↑↑↑</pattern>
+					<pattern type="10000" count="other" draft="contributed">↑↑↑</pattern>
+					<pattern type="100000" count="one" draft="contributed">0 lakh</pattern>
+					<pattern type="100000" count="other" draft="contributed">0 lakh</pattern>
+					<pattern type="1000000" count="one" draft="contributed">00 lakh</pattern>
+					<pattern type="1000000" count="other" draft="contributed">00 lakh</pattern>
+					<pattern type="10000000" count="one" draft="contributed">0 crore</pattern>
+					<pattern type="10000000" count="other" draft="contributed">0 crore</pattern>
+					<pattern type="100000000" count="one" draft="contributed">00 crore</pattern>
+					<pattern type="100000000" count="other" draft="contributed">00 crore</pattern>
+					<pattern type="1000000000" count="one" draft="contributed">000 crore</pattern>
+					<pattern type="1000000000" count="other" draft="contributed">000 crore</pattern>
+					<pattern type="10000000000" count="one" draft="contributed">0T crore</pattern>
+					<pattern type="10000000000" count="other" draft="contributed">0T crore</pattern>
+					<pattern type="100000000000" count="one" draft="contributed">00T crore</pattern>
+					<pattern type="100000000000" count="other" draft="contributed">00T crore</pattern>
+					<pattern type="1000000000000" count="one" draft="contributed">0 lakh crore</pattern>
+					<pattern type="1000000000000" count="other" draft="contributed">0 lakh crore</pattern>
+					<pattern type="10000000000000" count="one" draft="contributed">00 lakh crore</pattern>
+					<pattern type="10000000000000" count="other" draft="contributed">00 lakh crore</pattern>
+					<pattern type="100000000000000" count="one" draft="contributed">000 lakh crore</pattern>
+					<pattern type="100000000000000" count="other" draft="contributed">000 lakh crore</pattern>
 				</decimalFormat>
 			</decimalFormatLength>
 			<decimalFormatLength type="short">


### PR DESCRIPTION
CLDR-18876

Fix long compact decimal format in en_IN based on CLDR-13759. Used inheritance instead of T for values below a lakh since  CLDR-17232, and it should have enough space if thousand is what's used in en.

We should investigate why this wasn't raised as an issue when the vetters reviewed the numbers report.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
