### PR TITLE
CLDR-18891 update TestTransforms tests to run register() first

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -115,7 +115,6 @@ public class TestTransforms extends TestFmwkPlus {
 
     public void TestCyrillicLatin() {
         // this method only works for 'leaf' rule-based translators
-        register();
         Transliterator cyrillic_latin = Transliterator.getInstance("Cyrillic-Latin");
         Transliterator latin_cyrillic = cyrillic_latin.getInverse();
         checkSimpleRoundTrip(cyrillic_latin, latin_cyrillic, new UnicodeSet("[ӧӦ ӱӰӯӮ\\p{M}]"));
@@ -150,7 +149,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestUzbek() {
-        register();
         Transliterator cyrillicToLatin = Transliterator.getInstance("uz_Cyrl-uz_Latn");
         Transliterator latinToCyrillic = cyrillicToLatin.getInverse();
         // for (Transliterator t2 : t.getElements()) {
@@ -255,7 +253,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestBackslashHalfwidth() throws Exception {
-        register();
         // CLDRTransforms.registerCldrTransforms(null,
         // "(?i)(Fullwidth-Halfwidth|Halfwidth-Fullwidth)", isVerbose() ?
         // getLogPrintWriter() : null);
@@ -280,7 +277,7 @@ public class TestTransforms extends TestFmwkPlus {
 
     boolean registered = false;
 
-    void register() {
+    protected void init() throws Exception {
         if (!registered) {
             CLDRTransforms.registerCldrTransforms(
                     null, null, isVerbose() ? getLogPrintWriter() : null, true);
@@ -404,7 +401,6 @@ public class TestTransforms extends TestFmwkPlus {
                     "Ethiopic-Musnad");
 
     public void TestTransformIDs() {
-        register();
         Map<String, File> transforms = getTransformIDs(CLDRPaths.TRANSFORMS_DIRECTORY);
         for (Map.Entry<String, File> entry : transforms.entrySet()) {
             checkTransformID(entry.getKey(), entry.getValue());
@@ -435,7 +431,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void Test1461() {
-        register();
 
         String[][] tests = {
             {"transliterator=", "Katakana-Latin"},
@@ -477,7 +472,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void Test8921() {
-        register();
         Transliterator trans = Transliterator.getInstance("Latin-ASCII");
         assertEquals("Test8921", "Kornil'ev Kirill", trans.transliterate("Kornilʹev Kirill"));
     }
@@ -537,7 +531,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestData() {
-        register();
         try {
             // get the folder name
             String name = TestTransforms.class.getResource(".").toString();
@@ -657,7 +650,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestCasing() {
-        register();
         String greekSource = "ΟΔΌΣ Οδός Σο ΣΟ oΣ ΟΣ σ ἕξ";
         // Transliterator.DEBUG = true;
         Transliterator elTitle =
@@ -793,19 +785,16 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void Test9925() {
-        register();
         Transliterator pinyin = getTransliterator("und-Latn-t-und-hani");
         assertEquals("賈 bug", "jiǎ", pinyin.transform("賈"));
     }
 
     public void TestHiraKata() { // for CLDR-13127 and ...
-        register();
         Transliterator hiraKata = getTransliterator("Hiragana-Katakana");
         assertEquals("Hira-Kata", hiraKata.transform("゛゜ わ゙ ゟ"), "゛゜ ヷ ヨリ");
     }
 
     public void TestHani() {
-        register();
         Transliterator haniLatn = getTransliterator("und-Latn-t-und-hani");
         Transliterator hansLatn1 = getTransliterator("und-Latn-t-und-hans");
         Transliterator hansLatn2 = getTransliterator("Hans-Latn");
@@ -837,7 +826,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestZawgyiToUnicode10899() {
-        register();
         // Some tests for the transformation of Zawgyi font encoding to Unicode Burmese.
         Transliterator z2u = getTransliterator("my-t-my-s0-zawgyi");
 
@@ -861,7 +849,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestUnicodeToZawgyi111107() {
-        register();
         // Some tests for the transformation from Unicode to Zawgyi font encoding
         Transliterator u2z = getTransliterator("my-t-my-d0-zawgyi");
 
@@ -885,7 +872,6 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestLocales() {
-        register();
         Set<String> modernCldr =
                 StandardCodes.make()
                         .getLocaleCoverageLocales(Organization.cldr, ImmutableSet.of(Level.MODERN));

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -404,6 +404,7 @@ public class TestTransforms extends TestFmwkPlus {
                     "Ethiopic-Musnad");
 
     public void TestTransformIDs() {
+        register();
         Map<String, File> transforms = getTransformIDs(CLDRPaths.TRANSFORMS_DIRECTORY);
         for (Map.Entry<String, File> entry : transforms.entrySet()) {
             checkTransformID(entry.getKey(), entry.getValue());
@@ -836,6 +837,7 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestZawgyiToUnicode10899() {
+        register();
         // Some tests for the transformation of Zawgyi font encoding to Unicode Burmese.
         Transliterator z2u = getTransliterator("my-t-my-s0-zawgyi");
 
@@ -859,6 +861,7 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestUnicodeToZawgyi111107() {
+        register();
         // Some tests for the transformation from Unicode to Zawgyi font encoding
         Transliterator u2z = getTransliterator("my-t-my-d0-zawgyi");
 
@@ -882,6 +885,7 @@ public class TestTransforms extends TestFmwkPlus {
     }
 
     public void TestLocales() {
+        register();
         Set<String> modernCldr =
                 StandardCodes.make()
                         .getLocaleCoverageLocales(Organization.cldr, ImmutableSet.of(Level.MODERN));


### PR DESCRIPTION
CLDR-18891

Allows this to run where it failed before.

```shell
$ mvn --file=tools/pom.xml -pl cldr-code test  '-Dorg.unicode.cldr.unittest.testArgs=-e10 -n -filter:TestLocales' -Dtest=org.unicode.cldr.unittest.TestShim
```


- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
