### PR TITLE
CLDR-18822 Shorter timezone names for KST

### DIFF
--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -6207,9 +6207,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Korea">
 				<long>
-					<generic>대한민국 시간</generic>
-					<standard>대한민국 표준시</standard>
-					<daylight>대한민국 하계 표준시</daylight>
+					<generic>한국 시간/generic>
+					<standard>한국 표준시</standard>
+					<daylight>한국 하계 표준시</daylight>
 				</long>
 			</metazone>
 			<metazone type="Kosrae">


### PR DESCRIPTION
CLDR-18822

Shorter version of timezone names for KST. See CLDR-18822 for full discussion.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
