### PR TITLE
CLDR-18476 Fix typo in future relative-hour-short in es_MX

### DIFF
--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -2620,7 +2620,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<displayName>↑↑↑</displayName>
 				<relativeTime type="future">
 					<relativeTimePattern count="one">en {0} h</relativeTimePattern>
-					<relativeTimePattern count="other">en {0} n</relativeTimePattern>
+					<relativeTimePattern count="other">en {0} h</relativeTimePattern>
 				</relativeTime>
 				<relativeTime type="past">
 					<relativeTimePattern count="one">↑↑↑</relativeTimePattern>


### PR DESCRIPTION
CLDR-18476

Fix typo in future relative-hour-short in es_MX. Also fixes future relative-hour-narrow which inherits the current short value.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
