### PR TITLE
CLDR-18888 change incorrect ISO 636 references to ISO 639

### DIFF
--- a/docs/site/development/development-process/design-proposals.md
+++ b/docs/site/development/development-process/design-proposals.md
@@ -50,7 +50,7 @@ In each proposal, please add a header and a TOC if it is longer than a page. You
 
 [Islamic Calendar Types](/development/development-process/design-proposals/islamic-calendar-types)
 
-[ISO 636 Deprecation Requests - DRAFT](/development/development-process/design-proposals/iso-636-deprecation-requests-draft)
+[ISO 639 Deprecation Requests - DRAFT](/development/development-process/design-proposals/iso-639-deprecation-requests-draft)
 
 [JSON Packaging (Approved by the CLDR TC on 2015-03-25)](/development/development-process/design-proposals/json-packaging-approved-by-the-cldr-tc-on-2015-03-25)
 

--- a/docs/site/development/development-process/design-proposals/bcp-47-changes-draft.md
+++ b/docs/site/development/development-process/design-proposals/bcp-47-changes-draft.md
@@ -70,8 +70,8 @@ Macrolanguage Table
 | Norwegian ' no ' | Norwegian Bokmal ' nob ' = nb | To regularize, we may want to switch in CLDR from nb as the 'norm' to no. |
 | Serbo-croatian ' sh ' |  | *This is a complex situation, and we'll probably leave as is.* |
 | Kurdish 'ku' | Northern Kurdish 'kmr'? | We probably want to change the default content locale to ku-Latn |
-| Akan ' ak ' | Twi ' tw ' and Fanti ' fat' | This appears to be a mistake in ISO 639. See: ISO 636 Deprecation Requests . |
-| Persian  fas (fa) | Western Farsi pes and prs Dari | This appears to be a mistake in ISO 639. See: ISO 636 Deprecation Requests . |
+| Akan ' ak ' | Twi ' tw ' and Fanti ' fat' | This appears to be a mistake in ISO 639. See: ISO 639 Deprecation Requests . |
+| Persian  fas (fa) | Western Farsi pes and prs Dari | This appears to be a mistake in ISO 639. See: ISO 639 Deprecation Requests . |
 
 These would also go into the \<alias> element of the supplemental metadata. We may add more such aliases over time, as we find new predominant forms. Note that we still need to offer both aliases for translation in many cases. For example, we want to show both 'no' and 'nb'.
 

--- a/docs/site/development/development-process/design-proposals/iso-639-deprecation-requests-draft.md
+++ b/docs/site/development/development-process/design-proposals/iso-639-deprecation-requests-draft.md
@@ -1,8 +1,8 @@
 ---
-title: ISO 636 Deprecation Requests - DRAFT
+title: ISO 639 Deprecation Requests - DRAFT
 ---
 
-# ISO 636 Deprecation Requests - DRAFT
+# ISO 639 Deprecation Requests - DRAFT
 
 We have become aware over time of cases where ISO 639 inaccurately assigns different language codes to the same language. Its goal is to distinguish all and only those languages that are are not mutually comprehensible. Making too many distinctions can be as harmful as making too few, since it artificially separates two dialects, and disrupts the ability of software to identify them as variants. The remedy used in the past has been to deprecate codes: for example, [mol (mo)](http://www.sil.org/iso639-3/documentation.asp?id=mol) has been merged with [rol (ro)](http://www.sil.org/iso639-3/documentation.asp?id=rol). See also [Picking the Right Language Code](/index/cldr-spec/picking-the-right-language-code) and [Language Distance Data](/development/development-process/design-proposals/language-distance-data).
 

--- a/docs/site/development/development-process/design-proposals/language-distance-data.md
+++ b/docs/site/development/development-process/design-proposals/language-distance-data.md
@@ -115,7 +115,7 @@ Note that this doesn't have to be an N x M algorithm. Because there is a minimum
 
 ## Data Sample
 
-The data is designed to be relatively simple to understand. It would typically be processed into an internal format for fast processing. The data does not need to be exact; only the relative computed values are important. However, for keep the types of fields apart, they are given very different values. TODO: add values for [ISO 636 Deprecation Requests - DRAFT](/development/development-process/design-proposals/iso-636-deprecation-requests-draft)
+The data is designed to be relatively simple to understand. It would typically be processed into an internal format for fast processing. The data does not need to be exact; only the relative computed values are important. However, for keep the types of fields apart, they are given very different values. TODO: add values for [ISO 639 Deprecation Requests - DRAFT](/development/development-process/design-proposals/iso-639-deprecation-requests-draft)
 
 \<languageDistances>
 

--- a/docs/site/development/updating-codes/external-version-metadata.md
+++ b/docs/site/development/updating-codes/external-version-metadata.md
@@ -17,7 +17,7 @@ title: Updating External Version Metadata
 | UN literacy data | [un_literacy.csv](https://github.com/unicode-org/cldr/blob/master/tools/java/org/unicode/cldr/util/data/external/un_literacy.csv) | Date at top | 2012-08 |
 | Worldbank data | [world_bank_data.csv](https://github.com/unicode-org/cldr/blob/master/tools/java/org/unicode/cldr/util/data/external/world_bank_data.csv) | Date at bottom | 2020-12-16 |
 | Factbook data | [factbook_population.txt](https://github.com/unicode-org/cldr/blob/master/tools/java/org/unicode/cldr/util/data/external/factbook_population.txt) | record when downloaded in TBD |   |
-| ISO 636 (language) data | [iso-639-3-version.tab](https://github.com/unicode-org/cldr/blob/master/tools/java/org/unicode/cldr/util/data/iso-639-3-version.tab) | Date in YYYYMMDD format | 2021-02-02 |
+| ISO 639 (language) data | [iso-639-3-version.tab](https://github.com/unicode-org/cldr/blob/master/tools/java/org/unicode/cldr/util/data/iso-639-3-version.tab) | Date in YYYYMMDD format | 2021-02-02 |
 | ISO subdivision codes | iso subdivision codes | record when downloaded  in TBD |   |
 | ISO subdivision names | iso subdivision names | record when downloaded  in TBD |   |
 | ISO currency data | iso currency data | record when downloaded  in TBD |   |

--- a/docs/site/index/cldr-spec/picking-the-right-language-code.md
+++ b/docs/site/index/cldr-spec/picking-the-right-language-code.md
@@ -76,7 +76,7 @@ For compatibility, it is strongly recommended that all implementations accept bo
 
 ### Macrolanguages
 
-ISO (and hence BCP 47\) has the notion of an individual language (like en \= English) versus a Collection or Macrolanguage. For compatibility, Unicode language and locale identifiers always use the Macrolanguage to identify the predominant form. Thus the Macrolanguage subtag "zh" (Chinese) is used instead of "cmn" (Mandarin). Similarly, suppose that you are looking for Kurdish written in Latin letters, as in Turkey. It is a mistake to think that because that is in the north, that you should use the subtag 'kmr' for Northern Kurdish. You should instead use [ku\-Latn\-TR](http://ku-latn/). See also: [ISO 636 Deprecation Requests](/development/development-process/design-proposals/iso-636-deprecation-requests-draft).
+ISO (and hence BCP 47\) has the notion of an individual language (like en \= English) versus a Collection or Macrolanguage. For compatibility, Unicode language and locale identifiers always use the Macrolanguage to identify the predominant form. Thus the Macrolanguage subtag "zh" (Chinese) is used instead of "cmn" (Mandarin). Similarly, suppose that you are looking for Kurdish written in Latin letters, as in Turkey. It is a mistake to think that because that is in the north, that you should use the subtag 'kmr' for Northern Kurdish. You should instead use [ku\-Latn\-TR](http://ku-latn/). See also: [ISO 639 Deprecation Requests](/development/development-process/design-proposals/iso-639-deprecation-requests-draft).
 
 Unicode language identifiers do not allow the "extlang" form defined in BCP 47\. For example, use "yue" instead of "zh\-yue" for Cantonese.
 

--- a/docs/site/sitemap.tsv
+++ b/docs/site/sitemap.tsv
@@ -204,7 +204,7 @@ index
 			development/development-process/design-proposals/hebrew-months
 			development/development-process/design-proposals/index-characters
 			development/development-process/design-proposals/islamic-calendar-types
-			development/development-process/design-proposals/iso-636-deprecation-requests-draft
+			development/development-process/design-proposals/iso-639-deprecation-requests-draft
 			development/development-process/design-proposals/json-packaging-approved-by-the-cldr-tc-on-2015-03-25
 			development/development-process/design-proposals/language-data-consistency
 			development/development-process/design-proposals/language-distance-data


### PR DESCRIPTION
CLDR-18888

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
