### PR TITLE
CLDR-18898 Use latest (Aug 14) version of ICU4J, remove some logKnownIssue skips

### DIFF
--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LanguageTest.java
@@ -159,10 +159,6 @@ public class LanguageTest extends TestFmwk {
         Set<String> needTransfer = new LinkedHashSet<>();
         Set<String> unicodeScripts = getUnicodeScripts();
         for (String script : unicodeScripts) {
-            if (script.equals("Chis")) {
-                logKnownIssue("ICU-23038", "ICU4J UScript still supports CHISOI");
-                continue;
-            }
             String likely = likelyMap.get("und_" + script);
             if (likely == null) {
                 final String data = script2likely.get(script);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/LikelySubtagsTest.java
@@ -310,17 +310,13 @@ public class LikelySubtagsTest extends TestFmwk {
             int ch = current.charAt(0);
             int script = UScript.getScript(ch);
             String shortName = UScript.getShortName(script);
-            if (shortName.equals("Chis")) {
-                logKnownIssue("ICU-23038", "ICU4J UScript still supports CHISOI");
-            } else {
-                Info i = ScriptMetadata.getInfo(shortName);
-                if (i == null) {
-                    errln("Script Metadata is missing: " + shortName);
-                    continue;
-                }
-                if (i.likelyLanguage.equals("und") && !exceptions.contains(shortName)) {
-                    errln("Script has no likely language: " + shortName);
-                }
+            Info i = ScriptMetadata.getInfo(shortName);
+            if (i == null) {
+                errln("Script Metadata is missing: " + shortName);
+                continue;
+            }
+            if (i.likelyLanguage.equals("und") && !exceptions.contains(shortName)) {
+                errln("Script has no likely language: " + shortName);
             }
             toRemove.applyIntPropertyValue(UProperty.SCRIPT, script);
             current.removeAll(toRemove);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestScriptMetadata.java
@@ -113,10 +113,6 @@ public class TestScriptMetadata extends TestFmwkPlus {
         for (int i = UScript.COMMON; i < UScript.CODE_LIMIT; ++i) {
             String longName = UScript.getName(i);
             String shortName = UScript.getShortName(i);
-            if (shortName.equals("Chis")) {
-                logKnownIssue("ICU-23038", "ICU4J UScript still supports CHISOI");
-                continue;
-            }
             Info info = ScriptMetadata.getInfo(i);
             if (info != null) {
                 map.put(info.idUsage, longName + "\t(" + shortName + ")\t" + info);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -2118,10 +2118,6 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         List<Integer> unicodeDigits = new ArrayList<>();
         for (int cp = UCharacter.MIN_CODE_POINT; cp <= UCharacter.MAX_CODE_POINT; cp++) {
             if (UCharacter.getType(cp) == UCharacterEnums.ECharacterCategory.DECIMAL_DIGIT_NUMBER) {
-                if (UScript.getShortName(UScript.getScript(cp)).equals("Chis")) {
-                    logKnownIssue("ICU-23038", "ICU4J UCharacter still supports CHISOI");
-                    continue;
-                }
                 unicodeDigits.add(cp);
             }
         }

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -25,7 +25,7 @@
 			release candidate and changes to a version like nn.1-SNAPSHOT, we should just use
 			that so we are always getting the latest version pushed (and should not have CLDR
 			compatibility issues at that point). -->
-		<icu4j.version>78.0.1-20250805.181531-5</icu4j.version> <!-- before ICU rc, specific dated version -->
+		<icu4j.version>78.0.1-20250814.204941-7</icu4j.version> <!-- before ICU rc, specific dated version -->
 		<!--<icu4j.version>78.1-SNAPSHOT</icu4j.version>--> <!-- after ICU rc, latest published version -->
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.3.1</maven-surefire-plugin-version>


### PR DESCRIPTION
CLDR-18898

- [x] This PR completes the ticket.

Update CLDR to use the latest published version of ICU4J (from 2025-08-14, but latest change was Mon Aug 11), which includes the Unicode 17 updates from Markus of 2025-08-08 including removing Chisoi script. Remove some logKnownIssue test skips related to Chisoi script.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18898)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
