### PR TITLE
CLDR-16755 Error fixing/testing for links in PathDescriptions

### DIFF
--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/util/TestCLDRLinks.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/util/TestCLDRLinks.java
@@ -100,9 +100,10 @@ public class TestCLDRLinks {
 
         // this gets all URLs in references
         PathDescriptionParser pathDescriptionParser = new PathDescriptionParser();
-        pathDescriptionParser.parse(PathDescription.getPathDescriptionString());
+        String fileName = PathDescription.pathDescriptionFileName;
+        pathDescriptionParser.parse(PathDescription.getBigString(fileName));
         for (final String url : urlsFromString(pathDescriptionParser.getReferences())) {
-            urls.putIfAbsent(url, "PathDescriptions.md");
+            urls.putIfAbsent(url, fileName);
         }
 
         assertNotEquals(0, urls.size(), "PathDescription had no urls");

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -79,10 +79,6 @@ public class PathDescription {
         }
     }
 
-    static String getPathDescriptionHintsString() {
-        return pathDescriptionHintsString;
-    }
-
     /** for tests */
     static RegexLookup<Pair<String, String>> getPathHandling() {
         return pathHandling;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -18,13 +18,17 @@ import org.unicode.cldr.util.RegexLookup.Finder;
 
 public class PathDescription {
     /** Remember to quote any [ character! */
+    public static final String pathDescriptionFileName = "PathDescriptions.md";
+
+    public static final String pathDescriptionHintsFileName = "PathDescriptionHints.md";
+
     private static final String pathDescriptionString =
-            CldrUtility.getUTF8Data("PathDescriptions.md")
+            CldrUtility.getUTF8Data(pathDescriptionFileName)
                     .lines()
                     .collect(Collectors.joining("\n"));
 
     private static final String pathDescriptionHintsString =
-            CldrUtility.getUTF8Data("PathDescriptionHints.md")
+            CldrUtility.getUTF8Data(pathDescriptionHintsFileName)
                     .lines()
                     .collect(Collectors.joining("\n"));
 
@@ -64,8 +68,19 @@ public class PathDescription {
     private static final String references = parser.getReferences();
 
     /** for tests, returns the big string */
-    static String getPathDescriptionString() {
-        return pathDescriptionString;
+    static String getBigString(String fileName) {
+        switch (fileName) {
+            case pathDescriptionFileName:
+                return pathDescriptionString;
+            case pathDescriptionHintsFileName:
+                return pathDescriptionHintsString;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    static String getPathDescriptionHintsString() {
+        return pathDescriptionHintsString;
     }
 
     /** for tests */

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
@@ -294,6 +294,7 @@ warning, see info panel on right
 
 <!--
 This section is appended to every markdown fragment.
-All links should be https://cldr.unicode.org/translation/
-Currently, for hints, there are no reference links.
+All links should be cldr.unicode.org/translation/
+Currently, for hints, there are no actual reference links yet, but a "Placeholder" reference link is included for testing. 
 -->
+[Placeholder]: https://cldr.unicode.org/translation/units

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
@@ -220,19 +220,19 @@ The name of the language variant with code {0}. For more information, please see
 
 - `^//ldml/characters/exemplarCharacters$`
 
-Defines the set of characters used in your language. _To change this item, you have to flag it for review\!_ See [Changing Protected Items](https://cldr.unicode.org/translation/getting-started/guide#change-protected-items). Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
+Defines the set of characters used in your language. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
 ###
 
 - `^//ldml/characters/exemplarCharacters\[@type="([^"]*)"]`
 
-Defines the set of characters used in your language for the “{1}” category. _To change this item, you have to flag it for review\!_ See [Changing Protected Items](https://cldr.unicode.org/translation/getting-started/guide#change-protected-items). Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
+Defines the set of characters used in your language for the “{1}” category. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
 ###
 
 - `^//ldml/characters/parseLenients`
 
-Defines sets of characters that are treated as equivalent in parsing. _To change this item, you have to flag it for review\!_ See [Changing Protected Items](https://cldr.unicode.org/translation/getting-started/guide#change-protected-items). Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
+Defines sets of characters that are treated as equivalent in parsing. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
 ###
 
@@ -1087,9 +1087,10 @@ A set of keywords for a character or sequence. For more information, see [Short 
 
 <!--
 This section is appended to every markdown fragment.
-All links should be https://cldr.unicode.org/translation/
+All links should be cldr.unicode.org/translation/
 -->
 
+[Changing Protected Items]: https://cldr.unicode.org/translation/getting-started/guide#change-protected-items
 [Characters]: https://cldr.unicode.org/translation/characters
 [Character Labels]: https://cldr.unicode.org/translation/characters/character-labels
 [Compound Units]: https://cldr.unicode.org/translation/units/unit-names-and-patterns#compound-units


### PR DESCRIPTION
-Move http links to bottom of PathDescriptions.md (references)

-Add unit test to check that http links only occur at the bottom (references, that is, lines starting with left bracket)

-Apply the same tests to PathDescriptionHints.md as to PathDescriptions.md

-Make .md filenames public, for messages, since some tests now apply to both PathDescriptionHints.md and PathDescriptions.md

-Two small simplifications for lambdas in TestPathDescription.java, per IntelliJ compiler warnings/autocorrections

CLDR-16755

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
