### PR TITLE
CLDR-17016 Add missing likely subtags

### DIFF
--- a/common/supplemental/likelySubtags.xml
+++ b/common/supplemental/likelySubtags.xml
@@ -16,6 +16,9 @@ not be patched by hand, as any changes made in that fashion may be lost.
     <likelySubtags>
 		<likelySubtag from="aa" to="aa_Latn_ET"/>		<!--Afar‧?‧?	➡ Afar‧Latin‧Ethiopia-->
 		<likelySubtag from="ab" to="ab_Cyrl_GE"/>		<!--Abkhazian‧?‧?	➡ Abkhazian‧Cyrillic‧Georgia-->
+		<likelySubtag from="abq" to="abq_Cyrl_RU"/>		<!--Abaza‧?‧?	➡ Abaza‧Cyrillic‧Russia-->
+		<likelySubtag from="abq_TR" to="abq_Latn_TR"/>		<!--Abaza‧?‧Türkiye	➡ Abaza‧Latin‧Türkiye-->
+		<likelySubtag from="abq_Latn" to="abq_Latn_TR"/>		<!--Abaza‧Latin‧?	➡ Abaza‧Latin‧Türkiye-->
 		<likelySubtag from="abr" to="abr_Latn_GH"/>		<!--Abron‧?‧?	➡ Abron‧Latin‧Ghana-->
 		<likelySubtag from="ace" to="ace_Latn_ID"/>		<!--Acehnese‧?‧?	➡ Acehnese‧Latin‧Indonesia-->
 		<likelySubtag from="ach" to="ach_Latn_UG"/>		<!--Acoli‧?‧?	➡ Acoli‧Latin‧Uganda-->
@@ -259,6 +262,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="got" to="got_Goth_UA"/>		<!--Gothic‧?‧?	➡ Gothic‧Gothic‧Ukraine-->
 		<likelySubtag from="grb" to="grb_Latn_LR"/>		<!--Grebo‧?‧?	➡ Grebo‧Latin‧Liberia-->
 		<likelySubtag from="grc" to="grc_Grek_GR"/>		<!--Ancient Greek‧?‧?	➡ Ancient Greek‧Greek‧Greece-->
+		<likelySubtag from="grr" to="grr_Arab_DZ"/>		<!--Taznatit‧?‧?	➡ Taznatit‧Arabic‧Algeria-->
 		<likelySubtag from="grt" to="grt_Beng_IN"/>		<!--Garo‧?‧?	➡ Garo‧Bangla‧India-->
 		<likelySubtag from="gsw" to="gsw_Latn_CH"/>		<!--Swiss German‧?‧?	➡ Swiss German‧Latin‧Switzerland-->
 		<likelySubtag from="gu" to="gu_Gujr_IN"/>		<!--Gujarati‧?‧?	➡ Gujarati‧Gujarati‧India-->
@@ -537,6 +541,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="myv" to="myv_Cyrl_RU"/>		<!--Erzya‧?‧?	➡ Erzya‧Cyrillic‧Russia-->
 		<likelySubtag from="myx" to="myx_Latn_UG"/>		<!--Masaaba‧?‧?	➡ Masaaba‧Latin‧Uganda-->
 		<likelySubtag from="myz" to="myz_Mand_IR"/>		<!--Classical Mandaic‧?‧?	➡ Classical Mandaic‧Mandaean‧Iran-->
+		<likelySubtag from="mzb" to="mzb_Arab_DZ"/>		<!--Tumzabt‧?‧?	➡ Tumzabt‧Arabic‧Algeria-->
 		<likelySubtag from="mzn" to="mzn_Arab_IR"/>		<!--Mazanderani‧?‧?	➡ Mazanderani‧Arabic‧Iran-->
 		<likelySubtag from="na" to="na_Latn_NR"/>		<!--Nauru‧?‧?	➡ Nauru‧Latin‧Nauru-->
 		<likelySubtag from="nan" to="nan_Hans_CN"/>		<!--Min Nan Chinese‧?‧?	➡ Min Nan Chinese‧Simplified‧China-->
@@ -732,6 +737,9 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="ssy" to="ssy_Latn_ER"/>		<!--Saho‧?‧?	➡ Saho‧Latin‧Eritrea-->
 		<likelySubtag from="st" to="st_Latn_ZA"/>		<!--Southern Sotho‧?‧?	➡ Southern Sotho‧Latin‧South Africa-->
 		<likelySubtag from="stq" to="stq_Latn_DE"/>		<!--Saterland Frisian‧?‧?	➡ Saterland Frisian‧Latin‧Germany-->
+		<likelySubtag from="stu" to="stu_Lana_MM"/>		<!--Samtao‧?‧?	➡ Samtao‧Lanna‧Myanmar (Burma)-->
+		<likelySubtag from="stu_CN" to="stu_Tale_CN"/>		<!--Samtao‧?‧China	➡ Samtao‧Tai Le‧China-->
+		<likelySubtag from="stu_Tale" to="stu_Tale_CN"/>		<!--Samtao‧Tai Le‧?	➡ Samtao‧Tai Le‧China-->
 		<likelySubtag from="su" to="su_Latn_ID"/>		<!--Sundanese‧?‧?	➡ Sundanese‧Latin‧Indonesia-->
 		<likelySubtag from="suk" to="suk_Latn_TZ"/>		<!--Sukuma‧?‧?	➡ Sukuma‧Latin‧Tanzania-->
 		<likelySubtag from="sus" to="sus_Latn_GN"/>		<!--Susu‧?‧?	➡ Susu‧Latin‧Guinea-->
@@ -1237,6 +1245,7 @@ not be patched by hand, as any changes made in that fashion may be lost.
 		<likelySubtag from="und_Krai" to="bap_Krai_IN"/>		<!--?‧Kirat Rai‧?	➡ Bantawa‧Kirat Rai‧India-->
 		<likelySubtag from="und_Kthi" to="bho_Kthi_IN"/>		<!--?‧Kaithi‧?	➡ Bhojpuri‧Kaithi‧India-->
 		<likelySubtag from="und_Lana" to="nod_Lana_TH"/>		<!--?‧Lanna‧?	➡ Northern Thai‧Lanna‧Thailand-->
+		<likelySubtag from="und_Lana_MM" to="stu_Lana_MM"/>		<!--?‧Lanna‧Myanmar (Burma)	➡ Samtao‧Lanna‧Myanmar (Burma)-->
 		<likelySubtag from="und_Laoo" to="lo_Laoo_LA"/>		<!--?‧Lao‧?	➡ Lao‧Lao‧Laos-->
 		<likelySubtag from="und_Latn_AE" to="en_Latn_AE"/>		<!--?‧Latin‧United Arab Emirates	➡ English‧Latin‧United Arab Emirates-->
 		<likelySubtag from="und_Latn_AF" to="tk_Latn_AF"/>		<!--?‧Latin‧Afghanistan	➡ Turkmen‧Latin‧Afghanistan-->

--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -1282,6 +1282,7 @@ XXX Code for transations where no currency is involved
 		<language type="aa" scripts="Latn"/>
 		<language type="ab" scripts="Cyrl"/>
 		<language type="abq" scripts="Cyrl"/>
+		<language type="abq" scripts="Latn" alt="secondary"/>
 		<language type="abr" scripts="Latn"/>
 		<language type="ace" scripts="Latn"/>
 		<language type="ach" scripts="Latn"/>
@@ -1553,6 +1554,8 @@ XXX Code for transations where no currency is involved
 		<language type="got" scripts="Goth"/>
 		<language type="grb" scripts="Latn"/>
 		<language type="grc" scripts="Grek"/>
+		<language type="grr" scripts="Arab"/>
+		<language type="grr" scripts="Tfng" alt="secondary"/>
 		<language type="grt" scripts="Beng"/>
 		<language type="gsw" scripts="Latn"/>
 		<language type="gu" scripts="Gujr"/>
@@ -1826,6 +1829,8 @@ XXX Code for transations where no currency is involved
 		<language type="myv" scripts="Cyrl"/>
 		<language type="myx" scripts="Latn"/>
 		<language type="myz" scripts="Mand"/>
+		<language type="mzb" scripts="Arab"/>
+		<language type="mzb" scripts="Latn" alt="secondary"/>
 		<language type="mzn" scripts="Arab"/>
 		<language type="na" scripts="Latn"/>
 		<language type="nan" scripts="Hans"/>
@@ -2017,6 +2022,8 @@ XXX Code for transations where no currency is involved
 		<language type="ssy" scripts="Latn"/>
 		<language type="st" scripts="Latn"/>
 		<language type="stq" scripts="Latn"/>
+		<language type="stu" scripts="Lana"/>
+		<language type="stu" scripts="Tale" alt="secondary"/>
 		<language type="su" scripts="Latn"/>
 		<language type="su" scripts="Sund" alt="secondary"/>
 		<language type="suk" scripts="Latn"/>
@@ -2599,6 +2606,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="ru" populationPercent="0.001"/>	<!--Russian-->
 			<languagePopulation type="vi" populationPercent="0.0005"/>	<!--Vietnamese-->
 			<languagePopulation type="uz_Cyrl" populationPercent="0.0004"/>	<!--Uzbek (Cyrillic)-->
+			<languagePopulation type="stu_Tale" populationPercent="0" references="R1386"/>	<!--Samtao (Tai Le)-->
 			<languagePopulation type="lzh" populationPercent="0" references="R1150"/>	<!--Literary Chinese-->
 		</territory>
 		<territory type="CO" gdp="978000000000" literacyPercent="93.6" population="49588400">	<!--Colombia-->
@@ -2705,6 +2713,8 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="mey" populationPercent="11" references="R1379"/>	<!--Hassaniyya-->
 			<languagePopulation type="kab" literacyPercent="10" populationPercent="7.8" references="R1293"/>	<!--Kabyle-->
 			<languagePopulation type="en" populationPercent="7"/>	<!--English-->
+			<languagePopulation type="mzb" populationPercent="0.36" references="R1386"/>	<!--Tumzabt-->
+			<languagePopulation type="grr" populationPercent="0.026" references="R1386"/>	<!--Taznatit-->
 		</territory>
 		<territory type="EA" gdp="7113000000" literacyPercent="97.7" population="150000">	<!--Ceuta & Melilla-->
 			<languagePopulation type="es" populationPercent="98" officialStatus="official" references="R1067"/>	<!--Spanish-->
@@ -3447,6 +3457,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="rhg" populationPercent="1.7"/>	<!--Rohingya-->
 			<languagePopulation type="mnw" populationPercent="1.5"/>	<!--Mon-->
 			<languagePopulation type="hnj" populationPercent="0.022" references="R1107"/>	<!--Hmong Njua-->
+			<languagePopulation type="stu" populationPercent="0.017" references="R1387"/>	<!--Samtao-->
 			<languagePopulation type="kht" populationPercent="0.0074"/>	<!--Khamti-->
 			<languagePopulation type="pi_Mymr" populationPercent="0" references="R1006"/>	<!--Pali (Myanmar)-->
 		</territory>
@@ -3841,6 +3852,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="koi" populationPercent="0.045" officialStatus="official_regional"/>	<!--Komi-Permyak-->
 			<languagePopulation type="pnt_Cyrl" populationPercent="0.04" references="R1335"/>	<!--Pontic (Cyrillic)-->
 			<languagePopulation type="mrj" populationPercent="0.021"/>	<!--Western Mari-->
+			<languagePopulation type="abq" populationPercent="0.021" references="R1040"/>	<!--Abaza-->
 			<languagePopulation type="alt" populationPercent="0.014"/>	<!--Southern Altai-->
 			<languagePopulation type="fi" populationPercent="0.012"/>	<!--Finnish-->
 			<languagePopulation type="sr" populationPercent="0.0041" references="R1040"/>	<!--Serbian-->
@@ -4089,6 +4101,7 @@ XXX Code for transations where no currency is involved
 			<languagePopulation type="sr_Latn" writingPercent="5" populationPercent="0.028" references="R1017"/>	<!--Serbian (Latin)-->
 			<languagePopulation type="lzz" literacyPercent="73" populationPercent="0.025" references="R1137"/>	<!--Laz-->
 			<languagePopulation type="sq" populationPercent="0.021"/>	<!--Albanian-->
+			<languagePopulation type="abq_Latn" populationPercent="0.015" references="R1388"/>	<!--Abaza (Latin)-->
 			<languagePopulation type="pnt_Latn" populationPercent="0.0061" references="R1336"/>	<!--Pontic (Latin)-->
 			<languagePopulation type="ab" populationPercent="0.0048" references="R1079"/>	<!--Abkhazian-->
 			<languagePopulation type="el" populationPercent="0.0048"/>	<!--Greek-->
@@ -5727,5 +5740,8 @@ XXX Code for transations where no currency is involved
 		<reference type="R1383" uri="https://www.axl.cefan.ulaval.ca/asie/iran.htm">[missing]</reference>
 		<reference type="R1384" uri="https://www.census.gov/data/tables/2013/demo/2009-2013-lang-tables.html">[missing]</reference>
 		<reference type="R1385" uri="https://www.ethnologue.com/language/mww/">[missing]</reference>
+		<reference type="R1386" uri="https://www.ethnologue.com/country/dz/languages">[missing]</reference>
+		<reference type="R1387" uri="https://www.ethnologue.com/country/mm/languages">[missing]</reference>
+		<reference type="R1388">Leclerc (2014)</reference>
 	</references>
 </supplementalData>

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/country_language_population.tsv
@@ -23,6 +23,8 @@ Algeria	DZ	"41,657,488"	73%	"630,000,000,000"		English	en	7%
 Algeria	DZ	"41,657,488"	73%	"630,000,000,000"	official	French	fr	32.9%			https://observatoire.francophonie.org//wp-content/uploads/2022/03/odsef-lfdm-2022.pdf Organisation internationale de la Francophonie Meta-study. Data from 2008 Census
 Algeria	DZ	"41,657,488"	73%	"630,000,000,000"		Hassaniyya (Arabic)	mey_Arab	"4,590,000"			https://www.ethnologue.com/country/dz/languages citation from 2016
 Algeria	DZ	"41,657,488"	73%	"630,000,000,000"		Kabyle	kab	7.8%	10%		http://www.ethnologue.com/show_language.asp?code=kab French mostly used in commerce
+Algeria	DZ	"41,657,488"	73%	"630,000,000,000"		Tumzabt	mzb	"150,000"			https://www.ethnologue.com/country/dz/languages
+Algeria	DZ	"41,657,488"	73%	"630,000,000,000"		Taznatit	grr	"11,000"			https://www.ethnologue.com/country/dz/languages
 American Samoa	AS	"50,826"	97%	"658,000,000"	de_facto_official	English	en	97%
 American Samoa	AS	"50,826"	97%	"658,000,000"	official	Samoan	sm	99%
 Andorra	AD	"85,708"	100%	"3,327,000,000"	official	Catalan	ca	51%
@@ -276,6 +278,7 @@ China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Min Nan Chinese	nan_Hans	"26,
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official_regional	Mongolian (Mongolian)	mn_Mong	"3,600,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Naxi	nxq	"329,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Russian	ru	"14,400"
+China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Samtao (Tai Le script)	stu_Tale	"100"			https://www.ethnologue.com/country/dz/languages 
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Sichuan Yi	ii	"8,260,000"	60%
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"		Tai Nüa	tdd	"267,000"
 China	CN	"1,384,688,986"	95%	"23,210,000,000,000"	official_regional	Tibetan	bo	"2,720,000"
@@ -973,6 +976,7 @@ Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Mon	mnw	"828,000"
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Rohingya	rhg	"930,000"
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Shan	shn	6.4%
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Hmong Njua	hnj	"12,000"			https://joshuaproject.net/languages/hnj
+Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Samtao	stu	"9,550"			https://www.ethnologue.com/country/mm/languages
 Myanmar (Burma)	MM	"55,622,506"	93%	"329,800,000,000"		Pali (Burmese writing)	pi_Mymr	1			Precise data not available
 Namibia	NA	"2,533,224"	89%	"26,600,000,000"		Afrikaans	af	75%			"https://www.cia.gov/library/publications/the-world-factbook/geos/wa.html most of population use Afrikaans commonly, about 89% literacy"
 Namibia	NA	"2,533,224"	89%	"26,600,000,000"	official	English	en	7%
@@ -1169,6 +1173,7 @@ Romania	RO	"21,457,116"	98%	"483,400,000,000"	official	Romanian	ro	90%
 Romania	RO	"21,457,116"	98%	"483,400,000,000"		Serbian (Latin)	sr_Latn	"26,500"
 Romania	RO	"21,457,116"	98%	"483,400,000,000"		Spanish	es	10%
 Romania	RO	"21,457,116"	98%	"483,400,000,000"		Turkish	tr	"28,100"
+Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Abaza	abq	"30,194"			http://rosstat.gov.ru/vpn_popul 2020 Russian Census
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"	official_regional	Adyghe	ady	"125,000"
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"		Armenian	hy	"1,200,000"	50%		https://en.wikipedia.org/wiki/Armenians_in_Russia Census figures cited there seem to put Armenian using pop between 50-75%. Using 50%.
 Russia	RU	"142,122,776"	100%	"4,016,000,000,000"	official_regional	Avaric	av	"552,000"
@@ -1419,6 +1424,7 @@ Tunisia	TN	"11,516,189"	79%	"137,700,000,000"	official	Arabic	ar	90%
 Tunisia	TN	"11,516,189"	79%	"137,700,000,000"	official	French	fr	52.5%			https://observatoire.francophonie.org//wp-content/uploads/2022/03/odsef-lfdm-2022.pdf Organisation internationale de la Francophonie Meta-study. Data from 2014 census
 Tunisia	TN	"11,516,189"	79%	"137,700,000,000"		Tunisian Arabic	aeb	90%
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Abkhazian	ab	"4,000"			http://www.ethnologue.com/show_language.asp?code=abk 96% bilingual in Turkish.
+Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Abaza (Latin alphabet)	abq_Latn	"12,000"			Leclerc (2014)
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Adyghe	ady	"316,000"
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Albanian	sq	"16,900"
 Turkey	TR	"81,257,239"	94%	"2,186,000,000,000"		Arabic	ar	"453,000"

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/language_script.tsv
@@ -5,6 +5,7 @@
 aa	Afar	primary	Latn	Latin
 ab	Abkhazian	primary	Cyrl	Cyrillic
 abq	Abaza	primary	Cyrl	Cyrillic
+abq	Abaza	secondary	Latn	Latin
 abr	Abron	primary	Latn	Latin
 ace	Achinese	primary	Latn	Latin
 ach	Acoli	primary	Latn	Latin
@@ -293,6 +294,8 @@ gos	Gronings	primary	Latn	Latin
 got	Gothic	primary	Goth	Gothic
 grb	Grebo	primary	Latn	Latin
 grc	Ancient Greek	primary	Grek	Greek
+grr	Taznatit	primary	Arab	Arabic
+grr	Taznatit	secondary	Tfng	Tifinagh
 grt	Garo	primary	Beng	Bangla
 gsw	Swiss German	primary	Latn	Latin
 gu	Gujarati	primary	Gujr	Gujarati
@@ -586,6 +589,8 @@ my	Burmese	primary	Mymr	Myanmar
 myv	Erzya	primary	Cyrl	Cyrillic
 myx	Masaaba	primary	Latn	Latin
 myz	Classical Mandaic	primary	Mand	Mandaean
+mzb	Tumzabt	primary	Arab	Arabic
+mzb	Tumzabt	secondary	Latn	Latin
 mzn	Mazanderani	primary	Arab	Arabic
 na	Nauru	primary	Latn	Latin
 nan	Min Nan Chinese	primary	Hans	Simplified
@@ -798,6 +803,8 @@ srx	Sirmauri	primary	Deva	Devanagari
 ss	Swati	primary	Latn	Latin
 ssy	Saho	primary	Latn	Latin
 st	Southern Sotho	primary	Latn	Latin
+stu	Samtao	primary	Lana	Lanna
+stu	Samtao	secondary	Tale	Tai Le
 stq	Saterland Frisian	primary	Latn	Latin
 su	Sundanese	primary	Latn	Latin
 su	Sundanese	secondary	Sund	Sundanese


### PR DESCRIPTION
For some reason these languages weren't successfully imported from langtags.json.

Therefore, I found records of populations for all 4 languages and updated the script information, then re-generated likely subtags.

```
mvn package -DskipTests=true &&  java -jar tools/cldr-code/target/cldr-code.jar ConvertLanguageData &&  java -jar tools/cldr-code/target/cldr-code.jar GenerateLikelySubtags
```

CLDR-17016

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
