### PR TITLE
CLDR-18745 cldr_dynamic_prompter.py

### DIFF
--- a/tools/scripts/llm/ticket_valdator/cldr_dynamic_prompter.py
+++ b/tools/scripts/llm/ticket_valdator/cldr_dynamic_prompter.py
@@ -2,16 +2,14 @@
 """
 cldr_dynamic_prompter.py
 
-What it does: prints a short, ticket-specific LLM prompt for a CLDR JIRA ticket.
-Usage:
-  python cldr_dynamic_prompter.py CLDR-1234
-  python cldr_dynamic_prompter.py CLDR-1234 --category "Software Bug"
-  python cldr_dynamic_prompter.py CLDR-1234 --auto-category
+Print a short, ticket-specific LLM prompt for a CLDR JIRA ticket.
+Now supports --template to load the prompt from a separate file.
 """
 
 import re
 import sys
 import argparse
+from pathlib import Path
 from typing import Optional, Dict, List
 
 from jira import JIRA
@@ -21,15 +19,17 @@ from cldr_ticket_reader import get_ticket_details_string
 # CONFIG: paste credentials
 # =========================
 JIRA_SERVER = "https://unicode-org.atlassian.net"
-JIRA_USER_EMAIL = "MAIL"  # <-- Replace with your email
-JIRA_API_TOKEN = "API OF JIRA"    # <-- Replace with your API token
-
+JIRA_USER_EMAIL = "YOUR MAIL !!!"           # <-- your email
+JIRA_API_TOKEN  = "JIRA API KEY"  # <-- your API token
 
 # optional; only needed if you use --auto-category
-OPENAI_API_KEY = "OpenAI API KEY!!"
-OPENAI_MODEL = "gpt-4o-mini"
+OPENAI_API_KEY = "OPEN AI API KEY"  # keep empty if not using auto-category
+OPENAI_MODEL   = "gpt-4o-mini"
 
 CATEGORIES = ("Data Accuracy", "Documentation Issue", "Software Bug", "Feature Request")
+
+# Default template path (relative to this file)
+DEFAULT_TEMPLATE = Path(__file__).parent / "templates" / "phase1_prompt.md"
 
 # -----------------------------
 # Jira + parsing helpers
@@ -37,8 +37,7 @@ CATEGORIES = ("Data Accuracy", "Documentation Issue", "Software Bug", "Feature R
 
 def get_jira_client_from_config() -> JIRA:
     if not JIRA_USER_EMAIL or not JIRA_API_TOKEN:
-        print("Error: fill JIRA_USER_EMAIL and JIRA_API_TOKEN in cldr_dynamic_prompter.py", file=sys.stderr)
-        sys.exit(2)
+        raise RuntimeError("JIRA creds missing: set JIRA_USER_EMAIL and JIRA_API_TOKEN in cldr_dynamic_prompter.py")
     return JIRA(server=JIRA_SERVER, basic_auth=(JIRA_USER_EMAIL, JIRA_API_TOKEN))
 
 def _get_match(pattern: str, text: str, flags=0, default: str = "") -> str:
@@ -48,14 +47,21 @@ def _get_match(pattern: str, text: str, flags=0, default: str = "") -> str:
 def parse_report_text(report_text: str) -> Optional[Dict[str, str]]:
     """Extract fields from cldr_ticket_reader.py's report string."""
     try:
-        title = _get_match(r"^Title:\s*(.*)$", report_text, re.MULTILINE)
-        reporter = _get_match(r"^Reporter:\s*(.*)$", report_text, re.MULTILINE, "N/A")
-        priority = _get_match(r"^Priority:\s*(.*)$", report_text, re.MULTILINE, "N/A")
-        components = _get_match(r"^Components:\s*(.*)$", report_text, re.MULTILINE, "None")
-        labels = _get_match(r"^Labels:\s*(.*)$", report_text, re.MULTILINE, "None")
-        desc = _get_match(r"Description:\s*\n---\n(.*?)\n---", report_text, re.DOTALL, "")
+        title       = _get_match(r"^Title:\s*(.*)$", report_text, re.MULTILINE)
+        reporter    = _get_match(r"^Reporter:\s*(.*)$", report_text, re.MULTILINE, "N/A")
+        priority    = _get_match(r"^Priority:\s*(.*)$", report_text, re.MULTILINE, "N/A")
+        components  = _get_match(r"^Components:\s*(.*)$", report_text, re.MULTILINE, "None")
+        labels      = _get_match(r"^Labels:\s*(.*)$", report_text, re.MULTILINE, "None")
+        desc        = _get_match(r"Description:\s*\n---\n(.*?)\n---", report_text, re.DOTALL, "")
         code_blocks = re.findall(r"\{code.*?\}(.*?)\{code\}", desc, re.DOTALL)
-        has_code = bool(code_blocks)
+        has_code    = bool(code_blocks)
+        links_block = _get_match(r"Connected Work Items:\n(.*?)\n\nDescription:", report_text, re.DOTALL, "")
+        connected_items = []
+        if links_block:
+            for ln in links_block.splitlines():
+                t = ln.strip().lstrip("-• ").strip()
+                if t:
+                    connected_items.append(t)
         return {
             "title": title,
             "description": desc,
@@ -63,6 +69,7 @@ def parse_report_text(report_text: str) -> Optional[Dict[str, str]]:
             "priority": priority,
             "components": components,
             "labels": labels,
+            "connected_items": connected_items,
             "has_code": has_code,
         }
     except Exception:
@@ -75,7 +82,7 @@ def fetch_ticket_data(ticket_key: str, jira_client: JIRA) -> Dict[str, str]:
     if data:
         return data
 
-    # fallback
+    # fallback (rare)
     issue = jira_client.issue(ticket_key)
     title = getattr(issue.fields, "summary", "") or ""
     description = getattr(issue.fields, "description", "") or ""
@@ -91,6 +98,7 @@ def fetch_ticket_data(ticket_key: str, jira_client: JIRA) -> Dict[str, str]:
         "priority": priority,
         "components": components,
         "labels": labels,
+        "connected_items": [],
         "has_code": has_code,
     }
 
@@ -118,7 +126,7 @@ def auto_pick_category(title: str, description: str) -> str:
         cat = (resp.choices[0].message.content or "").strip().strip('"')
         return cat if cat in CATEGORIES else "Triage"
     except Exception as e:
-        print(f"Auto-category failed, falling back to 'Triage': {e}", file=sys.stderr)
+        print(f"[warn] Auto-category failed; using 'Triage': {e}", file=sys.stderr)
         return "Triage"
 
 # -----------------------------
@@ -132,9 +140,9 @@ def _norm_list_field(s: str) -> List[str]:
 
 def detect_topic(data: Dict[str, str]) -> str:
     title = (data.get("title") or "").lower()
-    desc = (data.get("description") or "").lower()
+    desc  = (data.get("description") or "").lower()
     components = _norm_list_field(data.get("components"))
-    labels = _norm_list_field(data.get("labels"))
+    labels     = _norm_list_field(data.get("labels"))
     text = " ".join([title, desc] + components + labels)
 
     if any(k in text for k in ["intervalformatfallback", "datetime", "date time", "date-time", "skeleton", "pattern", "quotes", "apostrophe"]):
@@ -154,7 +162,7 @@ def detect_topic(data: Dict[str, str]) -> str:
     return "General/Locale Data"
 
 # -----------------------------
-# Prompt builders
+# Built-in prompt builders (fallback if no template)
 # -----------------------------
 
 def build_triage_prompt(data: Dict[str, str]) -> str:
@@ -267,15 +275,89 @@ Topic: {topic}
     return base + topic_asks.get(topic, topic_asks["General/Locale Data"])
 
 # -----------------------------
+# Template loading + rendering
+# -----------------------------
+
+def load_template(path: Path) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+def render_template(tmpl: str, mapping: Dict[str, str]) -> str:
+    """Replace {{KEY}} tokens with mapping values (simple placeholder engine)."""
+    def _sub(m):
+        key = m.group(1).strip()
+        return mapping.get(key, "")
+    return re.sub(r"\{\{\s*([A-Z0-9_]+)\s*\}\}", _sub, tmpl)
+
+def build_from_template(ticket_key: str, template_path: Path, jira: Optional[JIRA]) -> str:
+    if jira is not None:
+        try:
+            data = fetch_ticket_data(ticket_key, jira)
+        except Exception as e:
+            print(f"[warn] Jira fetch failed, rendering template with placeholders: {e}", file=sys.stderr)
+            data = None
+    else:
+        data = None
+
+    if data is None:
+        # offline/placeholder mapping (still prints a prompt)
+        mapping = {
+            "TICKET_ID": ticket_key,
+            "TITLE": "(unavailable: Jira error)",
+            "DESCRIPTION": "(unavailable: Jira error)",
+            "COMPONENTS": "None",
+            "LABELS": "None",
+            "REPORTER": "N/A",
+            "PRIORITY": "N/A",
+            "CONNECTED_ITEMS": "None",
+            "HAS_CODE_BLOCK": "false",
+        }
+    else:
+        connected = ", ".join(data["connected_items"]) if data.get("connected_items") else "None"
+        mapping = {
+            "TICKET_ID": ticket_key,
+            "TITLE": data["title"],
+            "DESCRIPTION": data["description"],
+            "COMPONENTS": data["components"],
+            "LABELS": data["labels"],
+            "REPORTER": data["reporter"],
+            "PRIORITY": data["priority"],
+            "CONNECTED_ITEMS": connected,
+            "HAS_CODE_BLOCK": str(data["has_code"]).lower(),
+        }
+
+    tmpl = load_template(template_path)
+    return render_template(tmpl, mapping)
+
+# -----------------------------
 # PUBLIC API for other tools
 # -----------------------------
 
-def make_prompt(ticket_key: str, category: Optional[str] = None, auto_category: bool = False) -> str:
+def make_prompt(ticket_key: str,
+                category: Optional[str] = None,
+                auto_category: bool = False,
+                template: Optional[str] = None) -> str:
     """
     Return a ready-to-send prompt string for the given ticket.
-    Other tools import and call this.
+    If a template file exists (explicit path or default), use it; otherwise fall back to built-ins.
     """
-    jira = get_jira_client_from_config()
+    # Try to get Jira; do not crash if it fails.
+    jira = None
+    try:
+        jira = get_jira_client_from_config()
+    except Exception as e:
+        print(f"[warn] Jira not available: {e}", file=sys.stderr)
+
+    # Prefer template if provided or default exists
+    template_path = Path(template) if template else DEFAULT_TEMPLATE
+    if template_path.exists():
+        return build_from_template(ticket_key, template_path, jira)
+
+    # Fallback to built-in prompts (requires Jira; will warn if missing)
+    if jira is None:
+        # Minimal fallback prompt if Jira is totally unavailable and no template is supplied
+        return f"Ticket {ticket_key}: Jira unavailable and no template provided."
+
     data = fetch_ticket_data(ticket_key, jira)
 
     if category:
@@ -287,7 +369,6 @@ def make_prompt(ticket_key: str, category: Optional[str] = None, auto_category: 
 
     if chosen == "Triage":
         return build_triage_prompt(data)
-
     topic = detect_topic(data)
     return build_topic_prompt(chosen, topic, data)
 
@@ -301,11 +382,12 @@ def main():
         description="Print a ticket-specific LLM prompt for a CLDR JIRA ticket."
     )
     parser.add_argument("ticket_key", help="e.g., CLDR-12345")
+    parser.add_argument("--template", help="Path to a prompt template (default: templates/phase1_prompt.md)")
     parser.add_argument("--category", choices=list(CATEGORIES) + ["Triage"])
     parser.add_argument("--auto-category", action="store_true")
     args = parser.parse_args()
 
-    prompt = make_prompt(args.ticket_key, category=args.category, auto_category=args.auto_category)
+    prompt = make_prompt(args.ticket_key, category=args.category, auto_category=args.auto_category, template=args.template)
     print(prompt)
 
 if __name__ == "__main__":


### PR DESCRIPTION
CLDR-18745




# Phase-1: Robust Prompt Generator + Template Support

## Summary

Make `cldr_dynamic_prompter.py` reliably print a ticket-specific prompt every time and support editable prompt templates. If Jira is unavailable (auth/network), the tool still prints a prompt using placeholders instead of failing.

## What Changed

* **New `--template` flag**: load a prompt from a file (e.g., `phase1_prompt.md`); simple `{{TOKEN}}` replacement (`{{TITLE}}`, `{{DESCRIPTION}}`, etc.).
* **Graceful degradation**: if Jira fetch fails, render the template with placeholders and emit a warning (no empty output).
* **Public API**: `make_prompt(ticket_key, category=None, auto_category=False, template=None)` — backward compatible; new `template` arg.
* **Built-in prompts** retained as fallback when no template is provided.
* **No repetition** of Title/Description; concise, ticket-aware content.

## Usage

```bash
# Use external template (recommended)
python cldr_dynamic_prompter.py CLDR-12345 --template phase1_prompt.md

# Built-in triage prompt
python cldr_dynamic_prompter.py CLDR-12345

# Force category
python cldr_dynamic_prompter.py CLDR-12345 --category "Documentation Issue"

# Auto-pick category (requires OPENAI_API_KEY in file)
python cldr_dynamic_prompter.py CLDR-12345 --auto-category
```

## Why

* Matches feedback to “move the prompt into a separate file” for easy edits.
* Reduces failure modes during demos; always prints something useful.

## Notes

* Keep secrets out of the repo (tokens in local dev only).
* Template tokens supported: `{{TICKET_ID}}`, `{{TITLE}}`, `{{DESCRIPTION}}`, `{{COMPONENTS}}`, `{{LABELS}}`, `{{REPORTER}}`, `{{PRIORITY}}`, `{{CONNECTED_ITEMS}}`, `{{HAS_CODE_BLOCK}}`.


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
