### PR TITLE
CLDR-18923 Replace straight single quote with right single curly quote

### DIFF
--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -797,10 +797,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l''''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l''uri''' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -808,10 +808,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l''''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1308,10 +1308,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1319,10 +1319,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1330,10 +1330,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l''uri' {0}</pattern>
+							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">

--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -797,10 +797,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -808,10 +808,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1308,10 +1308,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="long">
@@ -1319,10 +1319,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="medium">
@@ -1330,10 +1330,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 							<pattern>↑↑↑</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="atTime">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 						<dateTimeFormat type="relative">
-							<pattern>{1} 'a' 'l'’'uri' {0}</pattern>
+							<pattern>{1} 'a l’uri' {0}</pattern>
 						</dateTimeFormat>
 					</dateTimeFormatLength>
 					<dateTimeFormatLength type="short">


### PR DESCRIPTION
CLDR-18923

Replaced double single straight quotes with a right single curly quote to avoid issue.

Note: Also updated forms for consistency assuming the form is written `l'uri` for all at time formats based on scn phonology.

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
