### PR TITLE
CLDR-18852 Gujr transform

### DIFF
--- a/common/transforms/Gujarati-Latin.xml
+++ b/common/transforms/Gujarati-Latin.xml
@@ -10,7 +10,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 	<transforms>
 		<transform source="Gujr" target="Latn" direction="forward" alias="Gujarati-Latin und-Latn-t-und-gujr">
 			<tRule>
-::[।-॥ઁ-ઃઅ-ઍએ-ઑઓ-નપ-રલ-ળવ-હ઼-ૅે-ૉો-્ૐૠૡ૦-૯];
+::[।-॥ઁ-ઃઅ-ઍએ-ઑઓ-નપ-રલ-ળવ-હ઼-ૅે-ૉો-્ૐૠૡ૦-૯૰];
 ::NFD;
 ::Gujarati-InterIndic;
 ::InterIndic-Latin;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRTransforms.java
@@ -957,7 +957,7 @@ public class CLDRTransforms {
 
     /**
      * Gets a transform from a script to Latin. for testing For a locale, use
-     * ExemplarUtilities.getScript(locale) to get the script
+     * ExemplarUtilities.getLikelyScript(locale) to get the script
      */
     public static Transliterator getTestingLatinScriptTransform(final String script) {
         String id;

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExemplarUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExemplarUtilities.java
@@ -9,7 +9,7 @@ public class ExemplarUtilities {
     static LikelySubtags ls = new LikelySubtags();
     static LanguageTagParser ltp = new LanguageTagParser();
 
-    public static synchronized String getScript(String locale) {
+    public static synchronized String getLikelyScript(String locale) {
         String max = ls.maximize(locale);
         return ltp.set(max).getScript();
     }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -900,12 +900,10 @@ public class TestTransforms extends TestFmwkPlus {
             if (!ltp.set(locale).getRegion().isEmpty()) {
                 continue;
             }
-            String max = ls.maximize(locale);
-            final String script = ltp.set(max).getScript();
+            final String script = ExemplarUtilities.getLikelyScript(locale);
             if (script.equals("Latn")) {
                 continue;
             }
-
             Transliterator t;
             try {
                 t = CLDRTransforms.getTestingLatinScriptTransform(script);
@@ -928,7 +926,7 @@ public class TestTransforms extends TestFmwkPlus {
                         locale
                                 + " "
                                 + script
-                                + " transform doesn't handle "
+                                + "-Latin transform doesn't handle "
                                 + badPlusSample.size()
                                 + " code points:\n"
                                 + badPlusSample);
@@ -964,11 +962,6 @@ public class TestTransforms extends TestFmwkPlus {
             for (String s : suppressHack) {
                 allMissing.scriptMissing.remove(s);
             }
-            if (allMissing.scriptMissing.containsKey("\u0AF0")
-                    && logKnownIssue("CLDR-18852", "U+0AF0 missing in Gujr translit")) {
-                allMissing.scriptMissing.remove("\u0AF0");
-            }
-
             for (String script : allMissing.scriptMissing.values()) {
                 UnicodeSet missingFoScript = allMissing.scriptMissing.getKeys(script);
                 String localeForScript =
@@ -1012,7 +1005,11 @@ public class TestTransforms extends TestFmwkPlus {
             public String toString() {
                 return String.format(
                         "%s;\t%s;\t%s;\t%s;\t%s",
-                        locale, ExemplarUtilities.getScript(locale), path, value, transformed);
+                        locale,
+                        ExemplarUtilities.getLikelyScript(locale),
+                        path,
+                        value,
+                        transformed);
             }
         }
 


### PR DESCRIPTION
- remove log known issue
- rename ExemplarUtilities.getScript() to getLikelyScript() (and use it)
- clarify the transliterator used

And the actual fix:
- add U+0AF0 to the filter at the top of the Gujarati-Latin transform.

CLDR-18852

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
