### PR TITLE
CLDR-18934 fix hv hz in German

### DIFF
--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -3042,8 +3042,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="Hmsv">↑↑↑</dateFormatItem>
 						<dateFormatItem id="hmv">h:mm a v</dateFormatItem>
 						<dateFormatItem id="Hmv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="hv">↑↑↑</dateFormatItem>
-						<dateFormatItem id="Hv" draft="contributed">HH 'h' v</dateFormatItem>
+						<dateFormatItem id="hv">h 'Uhr' a v</dateFormatItem>
+						<dateFormatItem id="Hv">HH 'Uhr' v</dateFormatItem>
 						<dateFormatItem id="M">↑↑↑</dateFormatItem>
 						<dateFormatItem id="Md">d.M.</dateFormatItem>
 						<dateFormatItem id="MEd">E, d.M.</dateFormatItem>


### PR DESCRIPTION
German hv and hz (gregorian) are now patterned after precedent of h, H, and adding v.
I left zh alone, because it looks like an informed choice by the zh vetters.

See the ticket for more information.


CLDR-18934

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
