### PR TITLE
CLDR-13542 Fix Swiss grouping separator

### DIFF
--- a/common/main/de_LI.xml
+++ b/common/main/de_LI.xml
@@ -31,7 +31,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 		</symbols>
 		<percentFormats numberSystem="latn">
 			<percentFormatLength>

--- a/common/main/en_CH.xml
+++ b/common/main/en_CH.xml
@@ -330,7 +330,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</dates>
 	<numbers>
 		<symbols numberSystem="latn">
-			<group>’</group>
+			<group>'</group>
 			<superscriptingExponent>·</superscriptingExponent>
 		</symbols>
 		<currencyFormats numberSystem="latn">

--- a/common/main/gsw.xml
+++ b/common/main/gsw.xml
@@ -1913,7 +1913,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
-			<group>’</group>
+			<group>'</group>
 			<list>↑↑↑</list>
 			<percentSign>↑↑↑</percentSign>
 			<plusSign>↑↑↑</plusSign>

--- a/common/main/it_CH.xml
+++ b/common/main/it_CH.xml
@@ -173,7 +173,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal>.</decimal>
-			<group>’</group>
+			<group>'</group>
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>

--- a/common/main/wae.xml
+++ b/common/main/wae.xml
@@ -1452,7 +1452,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	<numbers>
 		<symbols numberSystem="latn">
 			<decimal draft="contributed">,</decimal>
-			<group draft="contributed">’</group>
+			<group draft="contributed">'</group>
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength type="short">

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/DisplayAndInputProcessor.java
@@ -373,10 +373,6 @@ public class DisplayAndInputProcessor {
                 }
             }
         }
-        // Fix up any apostrophes in number symbols
-        if (NUMBER_SEPARATOR_PATTERN.matcher(path).matches()) {
-            value = value.replace('\'', '\u2019');
-        }
         // Fix up any apostrophes as appropriate (Don't do so for things like date patterns...
         if (!APOSTROPHE_SKIP_PATHS.matcher(path).matches()) {
             value = normalizeApostrophes(value);
@@ -566,10 +562,6 @@ public class DisplayAndInputProcessor {
         // Fix up any apostrophes as appropriate (Don't do so for things like date patterns...
         if (!APOSTROPHE_SKIP_PATHS.matcher(path).matches()) {
             value = normalizeApostrophes(value);
-        }
-        // Fix up any apostrophes in number symbols
-        if (NUMBER_SEPARATOR_PATTERN.matcher(path).matches()) {
-            value = value.replace('\'', '\u2019');
         }
         // Fix up hyphens, replacing with N-dash as appropriate
         if (INTERVAL_FORMAT_PATHS.matcher(path).matches()) {


### PR DESCRIPTION
The goal is to change the decimal separator from ’ to ASCII ' for the Swiss locales: to see 

## 1'234,00
instead of
## 1’234,00

Note: gsw is Swiss German, and wal is a kind of Swiss German

CLDR-13542

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
