### PR TITLE
CLDR-18837 Button to download generated VXML in a zip

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrGenerateVxml.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrGenerateVxml.mjs
@@ -76,8 +76,9 @@ function requestVxml(requestType) {
 }
 
 async function download(directory) {
+  const dirName = directory.split("/").pop(); // only the part after slash
   const p = new URLSearchParams();
-  p.append("directory", directory);
+  p.append("dirName", dirName);
   const url = cldrAjax.makeApiUrl(VXML_DOWNLOAD_URL, p);
   try {
     const response = await cldrAjax.doFetch(url);
@@ -89,7 +90,7 @@ async function download(directory) {
     a.href = window.URL.createObjectURL(
       new Blob([bytes], { type: "application/octet-stream" })
     );
-    a.download = directory.split("/").pop() + ".zip";
+    a.download = dirName + ".zip";
     a.click();
   } catch (e) {
     cldrNotify.exception(e, "Downloading VXML");

--- a/tools/cldr-apps/js/src/views/GenerateVxml.vue
+++ b/tools/cldr-apps/js/src/views/GenerateVxml.vue
@@ -44,6 +44,10 @@ function cancel() {
   status.value = STATUS.STOPPED;
 }
 
+function download() {
+  cldrGenerateVxml.download(directory.value);
+}
+
 function canCancel() {
   return status.value === STATUS.WAITING || status.value === STATUS.PROCESSING;
 }
@@ -100,6 +104,15 @@ defineExpose({
       <span>Directory created: {{ directory }}</span>
       &nbsp;
       <button @click="copyDirectory()">Copy</button>
+      &nbsp;
+      <!-- Allow downloading even if STATUS.STOPPED. If generation or verification failed,
+        downloading may still help with diagnosing partial/problematic output. -->
+      <button
+        v-if="status == STATUS.SUCCEEDED || status == STATUS.STOPPED"
+        @click="download()"
+      >
+        Download
+      </button>
     </p>
     <p v-if="message">{{ message }}</p>
     <p v-if="localeId">

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/OutputFileManager.java
@@ -213,6 +213,11 @@ public class OutputFileManager {
     }
 
     public static Set<CLDRLocale> createVxmlLocaleSet() {
+        if (false) { // Debugging only, to save time! Test with aa only
+            Set<CLDRLocale> set = new TreeSet<>();
+            set.add(CLDRLocale.getInstance("aa"));
+            return set;
+        }
         Set<CLDRLocale> set = new TreeSet<>(SurveyMain.getLocalesSet());
         // skip "en" and "root", since they should never be changed by the Survey Tool
         set.remove(CLDRLocale.getInstance("en"));

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/GenerateVxml.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/GenerateVxml.java
@@ -1,5 +1,6 @@
 package org.unicode.cldr.web.api;
 
+import java.io.File;
 import java.io.IOException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.*;
@@ -12,6 +13,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.Zipper;
 import org.unicode.cldr.web.*;
 
 @ApplicationScoped
@@ -133,5 +135,60 @@ public class GenerateVxml {
 
         @Schema(description = "Verification warning messages")
         public String[] verificationWarnings;
+    }
+
+    @GET
+    @Path("/download")
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Operation(summary = "Download VXML", description = "Download VXML as zip file")
+    @APIResponses(
+            value = {
+                @APIResponse(
+                        responseCode = "200",
+                        description = "Download VXML",
+                        content =
+                                @Content(
+                                        mediaType = "application/zip",
+                                        schema = @Schema(implementation = Response.class))),
+                @APIResponse(responseCode = "403", description = "Forbidden"),
+                @APIResponse(responseCode = "404", description = "Not Found"),
+                @APIResponse(
+                        responseCode = "500",
+                        description = "Internal Server Error",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = STError.class))),
+            })
+    public Response downloadVxml(
+            @QueryParam("directory") @Schema(description = "The directory containing VXML")
+                    String directory,
+            @HeaderParam(Auth.SESSION_HEADER) String sessionString) {
+        try {
+            CookieSession cs = Auth.getSession(sessionString);
+            if (cs == null) {
+                return Auth.noSessionResponse();
+            }
+            if (!UserRegistry.userIsTCOrStronger(cs.user)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
+            if (SurveyMain.isBusted()
+                    || !SurveyMain.wasInitCalled()
+                    || !SurveyMain.triedToStartUp()) {
+                return STError.surveyNotQuiteReady();
+            }
+            cs.userDidAction();
+            File dir = new File(directory);
+            File parent = CookieSession.sm.getVetdir();
+            if (!directory.startsWith(parent.toString())
+                    || !dir.isDirectory()
+                    || !dir.getCanonicalFile().toString().equals(directory)) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+            File zipFile = Zipper.zipDirectory(dir);
+            return Response.ok(zipFile).header("Content-Type", "application/zip").build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e).build();
+        }
     }
 }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/GenerateVxml.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/GenerateVxml.java
@@ -193,18 +193,17 @@ public class GenerateVxml {
     }
 
     /**
-     * Sanitize the "user-provided" dirName, normally actually provided by the
-     * back end, but possibly concocted by evildoers. It should contain no slashes
-     * or periods, and should match one of the "vetdata-..." siblings of the
-     * automatic vetdata dir CookieSession.sm.getVetdir(). Some of this sanitizing
-     * is redundant and is really intended to satisfy automatic checkers and prevent
-     * failures like "Uncontrolled data used in path expression".
+     * Sanitize the "user-provided" dirName, normally actually provided by the back end, but
+     * possibly concocted by evildoers. It should contain no slashes or periods, and should match
+     * one of the "vetdata-..." siblings of the automatic vetdata dir CookieSession.sm.getVetdir().
+     * Some of this sanitizing is redundant and is really intended to satisfy automatic checkers and
+     * prevent failures like "Uncontrolled data used in path expression".
      *
      * @param dirName the directory name (not full path)
      * @return the directory (sibling of the automatic vetdata directory)
      */
     private File getDirectory(String dirName) {
-         if (dirName.contains("/") || dirName.contains(".")) {
+        if (dirName.contains("/") || dirName.contains(".")) {
             return null;
         }
         File autoVetDir = CookieSession.sm.getVetdir();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Zipper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Zipper.java
@@ -1,0 +1,66 @@
+package org.unicode.cldr.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class Zipper {
+
+    private static final int BUFFER_SIZE = 4096;
+
+    /**
+     * Create a zip file from the given directory.
+     *
+     * <p>If the directory is /foo/bar, then the zip file will be /foo/bar.zip
+     *
+     * @param dir the given directory
+     * @return the zip file
+     * @throws IOException if unable to read/write files
+     */
+    public static File zipDirectory(File dir) throws IOException {
+        String zipFileName = dir.getAbsolutePath() + ".zip";
+        FileOutputStream fos = new FileOutputStream(zipFileName);
+        ZipOutputStream zos = new ZipOutputStream(fos);
+        zipFile(dir, dir.getName(), zos);
+        zos.close();
+        fos.close();
+        return new File(zipFileName);
+    }
+
+    /**
+     * Create a zip file from the given file or directory
+     *
+     * <p>Note: this function calls itself recursively
+     *
+     * @param file the file or directory to zip
+     * @param name the name of the file, including its slash-separated path when called recursively
+     * @param zos the ZipOutputStream
+     * @throws IOException if unable to read/write files
+     */
+    private static void zipFile(File file, String name, ZipOutputStream zos) throws IOException {
+        if (file.isDirectory()) {
+            zos.putNextEntry(new ZipEntry(name.endsWith("/") ? name : name + "/"));
+            zos.closeEntry();
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    if (!child.isHidden()) {
+                        zipFile(child, name + "/" + child.getName(), zos);
+                    }
+                }
+            }
+        } else {
+            FileInputStream fis = new FileInputStream(file);
+            zos.putNextEntry(new ZipEntry(name));
+            byte[] bytes = new byte[BUFFER_SIZE];
+            int length;
+            while ((length = fis.read(bytes)) >= 0) {
+                zos.write(bytes, 0, length);
+            }
+            fis.close();
+        }
+    }
+}


### PR DESCRIPTION
-Button causes creation of a zip file with the same parent as the vxml directory, and downloads it

-New utility Zipper.java uses ZipOutputStream, etc.

CLDR-18837

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
