### PR TITLE
CLDR-18569 Add missing fr-CA short timezone names

### DIFF
--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -6866,11 +6866,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de l’Alaska</standard>
 					<daylight>heure d’été de l’Alaska</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HAK</generic>
-					<standard draft="unconfirmed">HNAK</standard>
-					<daylight draft="unconfirmed">HEAK</daylight>
-				</short>
 			</metazone>
 			<metazone type="Almaty">
 				<long>
@@ -6892,11 +6887,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale du centre nord-américain</standard>
 					<daylight>heure d’été du centre nord-américain</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HC</generic>
-					<standard draft="unconfirmed">HNC</standard>
-					<daylight draft="unconfirmed">HEC</daylight>
-				</short>
 			</metazone>
 			<metazone type="America_Eastern">
 				<long>
@@ -6904,11 +6894,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de l’Est nord-américain</standard>
 					<daylight>heure d’été de l’Est nord-américain</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HE</generic>
-					<standard draft="unconfirmed">HNE</standard>
-					<daylight draft="unconfirmed">HEE</daylight>
-				</short>
 			</metazone>
 			<metazone type="America_Mountain">
 				<long>
@@ -6916,11 +6901,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale des Rocheuses</standard>
 					<daylight>heure d’été des Rocheuses</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HR</generic>
-					<standard draft="unconfirmed">HNR</standard>
-					<daylight draft="unconfirmed">HER</daylight>
-				</short>
 			</metazone>
 			<metazone type="America_Pacific">
 				<long>
@@ -6928,11 +6908,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale du Pacifique nord-américain</standard>
 					<daylight>heure d’été du Pacifique nord-américain</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HP</generic>
-					<standard draft="unconfirmed">HNP</standard>
-					<daylight draft="unconfirmed">HEP</daylight>
-				</short>
 			</metazone>
 			<metazone type="Anadyr">
 				<long>
@@ -6996,11 +6971,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de l’Atlantique</standard>
 					<daylight>heure d’été de l’Atlantique</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HA</generic>
-					<standard draft="unconfirmed">HNA</standard>
-					<daylight draft="unconfirmed">HEA</daylight>
-				</short>
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
@@ -7141,11 +7111,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de Cuba</standard>
 					<daylight>heure d’été de Cuba</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HCU</generic>
-					<standard draft="unconfirmed">HNCU</standard>
-					<daylight draft="unconfirmed">HECU</daylight>
-				</short>
 			</metazone>
 			<metazone type="Davis">
 				<long>
@@ -7187,11 +7152,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale d’Europe de l’Est</standard>
 					<daylight>heure d’été d’Europe de l’Est</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">EET</generic>
-					<standard draft="unconfirmed">EEST</standard>
-					<daylight draft="unconfirmed">EEDT</daylight>
-				</short>
 			</metazone>
 			<metazone type="Europe_Further_Eastern">
 				<long>
@@ -7204,11 +7164,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale d’Europe de l’Ouest</standard>
 					<daylight>heure d’été d’Europe de l’Ouest</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">WET</generic>
-					<standard draft="unconfirmed">WEST</standard>
-					<daylight draft="unconfirmed">WEDT</daylight>
-				</short>
 			</metazone>
 			<metazone type="Falkland">
 				<long>
@@ -7270,11 +7225,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de l’Est du Groenland</standard>
 					<daylight>heure d’été de l’Est du Groenland</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HEG</generic>
-					<standard draft="unconfirmed">HNEG</standard>
-					<daylight draft="unconfirmed">HEEG</daylight>
-				</short>
 			</metazone>
 			<metazone type="Greenland_Western">
 				<long>
@@ -7282,11 +7232,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de l’Ouest du Groenland</standard>
 					<daylight>heure d’été de l’Ouest du Groenland</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HOG</generic>
-					<standard draft="unconfirmed">HNOG</standard>
-					<daylight draft="unconfirmed">HEOG</daylight>
-				</short>
 			</metazone>
 			<metazone type="Guam">
 				<long>
@@ -7307,9 +7252,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<long>
 					<standard>heure normale d’Hawaï - Aléoutiennes</standard>
 				</long>
-				<short>
-					<standard draft="unconfirmed">HNHA</standard>
-				</short>
 			</metazone>
 			<metazone type="Hawaii_Aleutian">
 				<long>
@@ -7317,11 +7259,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale d’Hawaï - Aléoutiennes</standard>
 					<daylight>heure d’été d’Hawaï - Aléoutiennes</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HHA</generic>
-					<standard draft="unconfirmed">HNHA</standard>
-					<daylight draft="unconfirmed">HEHA</daylight>
-				</short>
 			</metazone>
 			<metazone type="Hong_Kong">
 				<long>
@@ -7510,11 +7447,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale du Pacifique mexicain</standard>
 					<daylight>heure d’été du Pacifique mexicain</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HPMX</generic>
-					<standard draft="unconfirmed">HNPMX</standard>
-					<daylight draft="unconfirmed">HEPMX</daylight>
-				</short>
 			</metazone>
 			<metazone type="Mongolia">
 				<long>
@@ -7565,11 +7497,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<standard>heure normale de Terre-Neuve</standard>
 					<daylight>heure d’été de Terre-Neuve</daylight>
 				</long>
-				<short>
-					<generic draft="unconfirmed">HTN</generic>
-					<standard draft="unconfirmed">HNTN</standard>
-					<daylight draft="unconfirmed">HETN</daylight>
-				</short>
 			</metazone>
 			<metazone type="Niue">
 				<long>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -4946,8 +4946,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>heure avancée du Centre</daylight>
 				</long>
 				<short>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>HC</generic>
+					<standard>HNC</standard>
 					<daylight>HAC</daylight>
 				</short>
 			</metazone>
@@ -4958,8 +4958,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>heure avancée de l’Est</daylight>
 				</long>
 				<short>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>HE</generic>
+					<standard>HNE</standard>
 					<daylight>HAE</daylight>
 				</short>
 			</metazone>
@@ -4970,8 +4970,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>heure avancée des Rocheuses</daylight>
 				</long>
 				<short>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>HR</generic>
+					<standard>HNR</standard>
 					<daylight>HAR</daylight>
 				</short>
 			</metazone>
@@ -4982,8 +4982,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<daylight>heure avancée du Pacifique</daylight>
 				</long>
 				<short>
-					<generic>↑↑↑</generic>
-					<standard>↑↑↑</standard>
+					<generic>HP</generic>
+					<standard>HNP</standard>
 					<daylight>HAP</daylight>
 				</short>
 			</metazone>
@@ -5049,6 +5049,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 					<daylight>heure avancée de l’Atlantique</daylight>
 				</long>
+				<short>
+					<generic>HA</generic>
+					<standard>HNA</standard>
+					<daylight>HAA</daylight>
+				</short>
 			</metazone>
 			<metazone type="Australia_Central">
 				<long>
@@ -5645,6 +5650,11 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 					<standard>↑↑↑</standard>
 					<daylight>heure avancée de Saint-Pierre-et-Miquelon</daylight>
 				</long>
+				<short>
+					<generic>HPM</generic>
+					<standard>HNPM</standard>
+					<daylight>HAPM</daylight>
+				</short>
 			</metazone>
 			<metazone type="Pitcairn">
 				<long>


### PR DESCRIPTION
CLDR-18569

Also removes irrelevant short names from `fr.xml`.

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
