### PR TITLE
CLDR-13542 Fix remaining apostrophe groupings

### DIFF
--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -41,6 +41,9 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<exemplarCharacters type="punctuation-auxiliary" draft="contributed">↑↑↑</exemplarCharacters>
 	</characters>
 	<numbers>
+		<symbols numberSystem="latn">
+			<group>'</group>
+		</symbols>
 		<currencies>
 			<currency type="BYN">
 				<displayName>Weissrussischer Rubel</displayName>

--- a/common/main/lmo.xml
+++ b/common/main/lmo.xml
@@ -129,7 +129,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</otherNumberingSystems>
 		<symbols numberSystem="latn">
 			<decimal draft="contributed">,</decimal>
-			<group draft="contributed">’</group>
+			<group draft="contributed">'</group>
 			<percentSign draft="contributed">↑↑↑</percentSign>
 			<plusSign draft="contributed">↑↑↑</plusSign>
 			<minusSign draft="contributed">↑↑↑</minusSign>

--- a/common/main/tn.xml
+++ b/common/main/tn.xml
@@ -655,7 +655,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimumGroupingDigits draft="contributed">↑↑↑</minimumGroupingDigits>
 		<symbols numberSystem="latn">
 			<decimal>↑↑↑</decimal>
-			<group>’</group>
+			<group>'</group>
 			<percentSign>↑↑↑</percentSign>
 			<plusSign>↑↑↑</plusSign>
 			<minusSign>↑↑↑</minusSign>

--- a/common/main/wal.xml
+++ b/common/main/wal.xml
@@ -346,7 +346,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<traditional>ethi</traditional>
 		</otherNumberingSystems>
 		<symbols numberSystem="latn">
-			<group draft="unconfirmed">’</group>
+			<group draft="unconfirmed">'</group>
 		</symbols>
 		<currencyFormats numberSystem="latn">
 			<currencyFormatLength>


### PR DESCRIPTION
CLDR-13542

When I looked into this, I found that it was DAIP that was automatically changing the grouping separator. So aside from CH, the other cases (DDL locales) were probably originally entered as straight apostrophes.

In addition, somehow the following removed the grouping separator from de_CH, so this restores it (with the straight/ASCII) version.

- [v48 BRS generate algorithmic](https://github.com/unicode-org/cldr/pull/4961)
- https://github.com/unicode-org/cldr/commit/7fa7166e5fddf418739f35c06ee41eb16aeab5dd#diff-77acfe3eceed0aced87a3ee1334bb6499a63279f711f8733362d1e602b71d138L4932 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
