### PR TITLE
CLDR-18956 json: rbnf: for now just skip the 'new' format content

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrItem.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/CldrItem.java
@@ -385,6 +385,10 @@ public class CldrItem implements Comparable<CldrItem> {
     }
 
     void adjustRbnfPath() {
+        if (getFullPath().contains("/rbnfRules")) {
+            System.err.println("TODO CLDR-18956: skipping NEW rules.");
+            return;
+        }
         XPathParts xpp = XPathParts.getFrozenInstance(getFullPath());
         final String sub = xpp.findAttributeValue("rbnfrule", "value");
         if (sub != null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/Ldml2JsonConverter.java
@@ -759,6 +759,8 @@ public class Ldml2JsonConverter {
             } else {
                 outFilename = js.section + ".json";
             }
+            final String location = filename + " section " + js.packageName + "/" + js.section;
+
             String tier = "";
             boolean writeOther = Boolean.parseBoolean(options.get("other").getValue());
             if (js.section.equals("other") && !writeOther) {
@@ -864,16 +866,18 @@ public class Ldml2JsonConverter {
                     String previousIdentityPath = null;
                     for (CldrItem item : theItems) {
                         if (item.getPath().isEmpty()) {
-                            throw new IllegalArgumentException(
-                                    "empty xpath in "
-                                            + filename
-                                            + " section "
-                                            + js.packageName
-                                            + "/"
-                                            + js.section);
+                            throw new IllegalArgumentException("empty xpath in " + location);
                         }
                         if (type == RunType.rbnf) {
-                            item.adjustRbnfPath();
+                            if (item.getFullPath().contains("/rbnfRules")) {
+                                System.err.println("TODO CLDR-18956: skipping NEW rules.");
+                                continue;
+                            }
+                            try {
+                                item.adjustRbnfPath();
+                            } catch (Throwable t) {
+                                throw new RuntimeException(location + ": " + item.getPath(), t);
+                            }
                         }
 
                         // items in the identity section of a file should only ever contain the


### PR DESCRIPTION
CLDR-18956

For now, this just skips the rbnfRules element and uses the old deprecated content.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
