### PR TITLE
CLDR-18991 Use latest (Sep 16) version of ICU4J

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -25,7 +25,7 @@
 			release candidate and changes to a version like nn.1-SNAPSHOT, we should just use
 			that so we are always getting the latest version pushed (and should not have CLDR
 			compatibility issues at that point). -->
-		<icu4j.version>78.0.1-20250814.204941-7</icu4j.version> <!-- before ICU rc, specific dated version -->
+		<icu4j.version>78.0.1-20250916.173842-8</icu4j.version> <!-- before ICU rc, specific dated version -->
 		<!--<icu4j.version>78.1-SNAPSHOT</icu4j.version>--> <!-- after ICU rc, latest published version -->
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.3.1</maven-surefire-plugin-version>


### PR DESCRIPTION
CLDR-18991

- [x] This PR completes the ticket.

Update ICU4J used by CLDR (from GitHub maven repo) to ICU4J of 2025-09-16, including:
- ICU-23056 integrate cldr-48-alpha2 (#3643)
- ICU-23104 Fix the handling of part-per-1e9 (#3663)

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-18991)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
