### PR TITLE
CLDR-17599 Path descriptions: enable macro substitution

### DIFF
--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/util/TestCLDRLinks.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/util/TestCLDRLinks.java
@@ -101,7 +101,7 @@ public class TestCLDRLinks {
         // this gets all URLs in references
         PathDescriptionParser pathDescriptionParser = new PathDescriptionParser();
         String fileName = PathDescription.pathDescriptionFileName;
-        pathDescriptionParser.parse(PathDescription.getBigString(fileName));
+        pathDescriptionParser.parse(fileName);
         for (final String url : urlsFromString(pathDescriptionParser.getReferences())) {
             urls.putIfAbsent(url, fileName);
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -58,11 +58,9 @@ public class PathDescription {
 
     private static final PathDescriptionParser hintsParser = new PathDescriptionParser();
 
-    private static final RegexLookup<Pair<String, String>> pathHandling =
-            parser.parse(pathDescriptionString);
+    private static RegexLookup<Pair<String, String>> pathHandling = null;
 
-    private static final RegexLookup<Pair<String, String>> pathHintsHandling =
-            hintsParser.parse(pathDescriptionHintsString);
+    private static RegexLookup<Pair<String, String>> pathHintsHandling = null;
 
     /** markdown to append */
     private static final String references = parser.getReferences();
@@ -80,8 +78,18 @@ public class PathDescription {
     }
 
     /** for tests */
-    static RegexLookup<Pair<String, String>> getPathHandling() {
+    public static RegexLookup<Pair<String, String>> getPathHandling() {
+        if (pathHandling == null) {
+            pathHandling = parser.parse(pathDescriptionFileName);
+        }
         return pathHandling;
+    }
+
+    private static RegexLookup<Pair<String, String>> getPathHintsHandling() {
+        if (pathHintsHandling == null) {
+            pathHintsHandling = hintsParser.parse(pathDescriptionHintsFileName);
+        }
+        return pathHintsHandling;
     }
 
     // set in construction
@@ -127,7 +135,7 @@ public class PathDescription {
 
     public String getRawDescription(String path, Object context) {
         status.clear();
-        final Pair<String, String> entry = pathHandling.get(path, context, pathArguments);
+        final Pair<String, String> entry = getPathHandling().get(path, context, pathArguments);
         if (entry == null) {
             return null;
         }
@@ -135,8 +143,9 @@ public class PathDescription {
     }
 
     public String getHintRawDescription(String path, Object context) {
+
         status.clear();
-        final Pair<String, String> entry = pathHintsHandling.get(path, context, pathArguments);
+        final Pair<String, String> entry = getPathHintsHandling().get(path, context, pathArguments);
         if (entry == null) {
             return null;
         }
@@ -147,7 +156,7 @@ public class PathDescription {
             String path, Object context, Output<Finder> matcherFound, Set<String> failures) {
         status.clear();
         final Pair<String, String> entry =
-                pathHandling.get(path, context, pathArguments, matcherFound, failures);
+                getPathHandling().get(path, context, pathArguments, matcherFound, failures);
         if (entry == null) {
             return null;
         }
@@ -157,7 +166,7 @@ public class PathDescription {
     public String getDescription(String path, String value, Object context) {
         status.clear();
 
-        final Pair<String, String> entry = pathHandling.get(path, context, pathArguments);
+        final Pair<String, String> entry = getPathHandling().get(path, context, pathArguments);
         String description;
         String markdown;
         if (entry == null) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
@@ -2,291 +2,296 @@
 
 See PathDescriptions.md for documentation.
 
+# VARIABLES
+%anyAttribute = ([^"]*)
+
 ## HINT descriptions
 
 ### HINT
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="duration-day"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="duration-day"\](/displayName|/unitPattern\[@count="%anyAttribute"\])`
 
 "day" here means a time duration of 24 hours, not a calendar day
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="ckb"\]\[@alt="menu"\]$`
+- `localeDisplayNames/languages/language\[@type="ckb"\]\[@alt="menu"\]`
 
 a form of the name that will sort next to Kurdish, if the standard name does not already do that
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="calendar"\]\[@type="roc"\]$`
+- `localeDisplayNames/types/type\[@key="calendar"\]\[@type="roc"\]`
 
 also called "Republic of China Calendar", "Republican Calendar"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="ckb"\]\[@alt="variant"\]$`
+- `localeDisplayNames/languages/language\[@type="ckb"\]\[@alt="variant"\]`
 
 an alternate form using Sorani or Central, whichever is not used by the standard name
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="energy-calorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="energy-calorie"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 calories as used in chemistry, not the same as food calorie
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(narrow|short)"\]/unit\[@type="energy-foodcalorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="(narrow|short)"\]/unit\[@type="energy-foodcalorie"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 kilocalories for food energy, may have same translation as energy-kilocalorie; displayed as Cal in the US/UK
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="long"\]/unit\[@type="energy-foodcalorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="long"\]/unit\[@type="energy-foodcalorie"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 kilocalories for food energy, may have same translation as energy-kilocalorie; displayed as Calories in the US/UK
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="energy-kilocalorie"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="energy-kilocalorie"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 kilocalories for uses not specific to food energy, such as chemistry
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="area-acre"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="area-acre"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 refers specifically to an English acre
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="mass-ton"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="mass-ton"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 refers to U.S. short ton, not U.K. long ton or metric ton
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/scripts/script\[@type="Aran"\]$`
+- `localeDisplayNames/scripts/script\[@type="Aran"\]`
 
 special code identifies a style variant of Arabic script
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/scripts/script\[@type="Qaag"\]$`
+- `localeDisplayNames/scripts/script\[@type="Qaag"\]`
 
 special code identifies non-standard Myanmar encoding for use with Zawgyi font
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="clc"\]$`
+- `localeDisplayNames/languages/language\[@type="clc"\]`
 
 also referred to as "Tsilhqot’in"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="ikt"\]$`
+- `localeDisplayNames/languages/language\[@type="ikt"\]`
 
 also referred to as "Inuinnaqtun"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="kwk"\]$`
+- `localeDisplayNames/languages/language\[@type="kwk"\]`
 
 previously referred to as "Kwakiutl"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="moe"\]$`
+- `localeDisplayNames/languages/language\[@type="moe"\]`
 
 also referred to as "Montagnais"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="ojs"\]$`
+- `localeDisplayNames/languages/language\[@type="ojs"\]`
 
 also referred to as "Severn Ojibwa"
 
-### HINT
-- `^//ldml/localeDisplayNames/languages/language\[@type="oka"\]$`
-  also referred to as "Nsyilxcən"
+###
 
-### HINT
+- `localeDisplayNames/languages/language\[@type="oka"\]`
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="pqm"\]$`
+also referred to as "Nsyilxcən"
+
+###
+
+- `localeDisplayNames/languages/language\[@type="pqm"\]`
 
 also referred to as "Maliseet–Passamaquoddy"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="slh"\]$`
+- `localeDisplayNames/languages/language\[@type="slh"\]`
 
 also referred to as "Southern Puget Sound Salish"
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="zh"\]$`
+- `localeDisplayNames/languages/language\[@type="zh"\]`
 
 specifically, Mandarin Chinese
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/scripts/script\[@type="Han(s|t)"\]$$`
+- `localeDisplayNames/scripts/script\[@type="Han(s|t)"\]`
 
 this version of the script name is used in combination with the language name for Chinese
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/scripts/script\[@type="Han(s|t)"\]\[@alt="stand-alone"\]$`
+- `localeDisplayNames/scripts/script\[@type="Han(s|t)"\]\[@alt="stand-alone"\]`
 
 this version of the script name is used in isolation, not combined with the language name for Chinese
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Central"\]/long/daylight$`
+- `dates/timeZoneNames/metazone\[@type="America_Central"\]/long/daylight`
 
 translate as "North American Central Daylight Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Central"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="America_Central"\]/long/standard`
 
 translate as "North American Central Standard Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Central"\]/long/generic$`
+- `dates/timeZoneNames/metazone\[@type="America_Central"\]/long/generic`
 
 translate as "North American Central Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/daylight$`
+- `dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/daylight`
 
 translate as "North American Eastern Daylight Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/standard`
 
 translate as "North American Eastern Standard Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/generic$`
+- `dates/timeZoneNames/metazone\[@type="America_Eastern"\]/long/generic`
 
 translate as "North American Eastern Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/daylight$`
+- `dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/daylight`
 
 translate as "North American Mountain Daylight Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/standard`
 
 translate as "North American Mountain Standard Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/generic$`
+- `dates/timeZoneNames/metazone\[@type="America_Mountain"\]/long/generic`
 
 translate as "North American Mountain Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/daylight$`
+- `dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/daylight`
 
 translate as "North American Pacific Daylight Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/standard`
 
 translate as "North American Pacific Standard Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/generic$`
+- `dates/timeZoneNames/metazone\[@type="America_Pacific"\]/long/generic`
 
 translate as "North American Pacific Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="Chamorro"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="Chamorro"\]/long/standard`
 
 translate as just "Chamorro Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="Guam"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="Guam"\]/long/standard`
 
 translate as just "Guam Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="Gulf"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="Gulf"\]/long/standard`
 
 translate as just "Gulf Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="India"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="India"\]/long/standard`
 
 translate as just "India Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="Singapore"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="Singapore"\]/long/standard`
 
 translate as just "Singapore Time"
 
-### HINT
+###
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="Africa_Southern"\]/long/standard$`
+- `dates/timeZoneNames/metazone\[@type="Africa_Southern"\]/long/standard`
 
 translate as just "South Africa Time"
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-pixel-per-(centimeter|inch)"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="graphics-pixel-per-(centimeter|inch)"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 typically used for display resolution
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-dot-per-(centimeter|inch)"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="graphics-dot-per-(centimeter|inch)"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 typically used for printer resolution
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-em"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="graphics-em"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 typographic length equal to a font’s point size
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-megapixel"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="graphics-megapixel"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 used for counting the individual elements in bitmap image
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="graphics-pixel"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="graphics-pixel"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 used for counting the individual elements in bitmap image; in some contexts means 1⁄96 inch
 
-### HINT
+###
 
-- `^//ldml/units/unitLength\[@type="(long|narrow|short)"\]/unit\[@type="mass-stone"\]/(displayName|unitPattern\[@count="one"\]|unitPattern\[@count="other"\])$`
+- `units/unitLength\[@type="%unitLengths"\]/unit\[@type="mass-stone"\]/(displayName|unitPattern\[@count="%anyAttribute"\])`
 
 used in UK/Ireland for body weight, equal to 14 pounds
 
-### HINT
+###
 
-- `^//ldml/localeDisplayNames/territories/territory\[@type="(003|018|021|057|CD|CG|CI|FK|FM|HK|MM|MO|PS|SZ|TL|ZA)"\](\[@alt="(variant|short)"\])?$`
+- `localeDisplayNames/territories/territory\[@type="(003|018|021|057|CD|CG|CI|FK|FM|HK|MM|MO|PS|SZ|TL|ZA)"\](\[@alt="(variant|short)"\])?`
 
 warning, see info panel on right
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
@@ -4,7 +4,7 @@ Example Entry:
 
     ### First Day of the Week
 
-    - `^//ldml/localeDisplayNames/types/type\[@key="fw"]\[@type="([^"]*)"]`
+    - `localeDisplayNames/types/type\[@key="fw"]\[@type="%anyAttribute"]`
 
     The name of “first day of the week is {1}”. For more information, please see [Locale Option Names].
 
@@ -15,77 +15,80 @@ Example Entry:
 3. Finally is markdown, continuing up to the next line beginning with `#`.  Please keep all URLs in [References](#references), which is copied to every markdown fragment. This way we can share URLs and use more natural sounding links.
 4. Double hash (`##`) are used to group sections. These may not be blank. The last section is special and is named `References`.
 
+# VARIABLES
+%anyAttribute = ([^"]*)
+
 ## ROOT descriptions (using special placeholders). Must occur first.
 
 ### ROOT territory
 
-- `^//ldml/localeDisplayNames/territories/territory\[@type="(CD|DG|CG|003|021|ZA|018|FK|MK|MM|TW|HK|MO)"]`
+- `localeDisplayNames/territories/territory\[@type="(CD|DG|CG|003|021|ZA|018|FK|MK|MM|TW|HK|MO)"]`
 
 Warning - the region {0} requires special attention! Note: before translating, be sure to read [Country Names].
 
 ### ROOT script
 
-- `^//ldml/localeDisplayNames/scripts/script\[@type="(Z[^"]*)"]`
+- `localeDisplayNames/scripts/script\[@type="(Z[^"]*)"]`
 
 The name of the script (writing system) with Unicode script code = {0}. Note: before translating, be sure to read [Script Names].
 
 ### ROOT timezone
 
-- `^//ldml/dates/timeZoneNames/zone\[@type="([^"]*)"]/exemplarCity`
+- `dates/timeZoneNames/zone\[@type="%anyAttribute"]/exemplarCity`
 
 The name of {0}. For more information, see [Time Zone City Names].
 
 ### ROOT language
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="([^"]*)"]\[@menu="([^"]*)"]`
+- `localeDisplayNames/languages/language\[@type="%anyAttribute"]\[@menu="%anyAttribute"]`
 
 The name of the language with Unicode language code = {0}, _and_ menu type = {0}. **Be sure to read about this in [Language Names]**.
 
 ### ROOT language
 
-- `^//ldml/localeDisplayNames/languages/language\[@type="([^"]*)"]`
+- `localeDisplayNames/languages/language\[@type="%anyAttribute"]`
 
 The name of the language with Unicode language code = {0}. For more information, see [Language Names].
 
 ### ROOT script
 
-- `^//ldml/localeDisplayNames/scripts/script\[@type="([^"]*)"]`
+- `localeDisplayNames/scripts/script\[@type="%anyAttribute"]`
 
 The name of the script (writing system) with Unicode script code = {0}. For more information, see [Script Names].
 
 ### ROOT territory
 
-- `^//ldml/localeDisplayNames/territories/territory\[@type="([^"]*)"]`
+- `localeDisplayNames/territories/territory\[@type="%anyAttribute"]`
 
 The name of the country or region with Unicode region code = {0}. For more information, see [Country Names].
 
 ### ROOT territory
 
-- `^//ldml/localeDisplayNames/subdivisions/subdivision\[@type="([^"]*)"]`
+- `localeDisplayNames/subdivisions/subdivision\[@type="%anyAttribute"]`
 
 The name of the country subdivision with Unicode subdivision code = {0}. For more information, see [Country Names].
 
 ### ROOT currency
 
-- `^//ldml/numbers/currencies/currency\[@type="([^"]*)"]/symbol$`
+- `numbers/currencies/currency\[@type="%anyAttribute"]/symbol`
 
 The symbol for the currency with the ISO currency code = {0}. For more information, see [Currency Names].
 
 ### ROOT currency
 
-- `^//ldml/numbers/currencies/currency\[@type="([^"]*)"]/symbol\[@alt="narrow"]`
+- `numbers/currencies/currency\[@type="%anyAttribute"]/symbol\[@alt="narrow"]`
 
 The NARROW form of the symbol used for the currency with the ISO currency code = {0}, when the known context is already enough to distinguish the symbol from other currencies that may use the same symbol. Normally, this does not need to be changed from the inherited value. For more information, see [Currency Names].
 
 ### ROOT currency
 
-- `^//ldml/numbers/currencies/currency\[@type="([^"]*)"]/symbol\[@alt="([^"]++)"]`
+- `numbers/currencies/currency\[@type="%anyAttribute"]/symbol\[@alt="([^"]++)"]`
 
 An alternative form of the symbol used for the currency with the ISO currency code = {0}. Usually occurs shortly after a new currency symbol is introduced. For more information, see [Currency Names].
 
 ### ROOT currency
 
-- `^//ldml/numbers/currencies/currency\[@type="([^"]*)"]/displayName`
+- `numbers/currencies/currency\[@type="%anyAttribute"]/displayName`
 
 The name of the currency with the ISO currency code = {0}. For more information, see [Currency Names].
 
@@ -94,7 +97,7 @@ The name of the currency with the ISO currency code = {0}. For more information,
 
 ### ROOT metazone
 
-- `^//ldml/dates/timeZoneNames/metazone\[@type="([^"]*)"](.*)/(.*)`
+- `dates/timeZoneNames/metazone\[@type="%anyAttribute"](.*)/(.*)`
 
 The name of the timezone for “{0}”. Note: before translating, be sure to read [Time Zone City Names].
 
@@ -102,249 +105,249 @@ The name of the timezone for “{0}”. Note: before translating, be sure to rea
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="collation"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="collation"]\[@type="%anyAttribute"]`
 
 The name of “{1} collation” (sorting order). For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="numbers"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="numbers"]\[@type="%anyAttribute"]`
 
 The name of “{1} number system”. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="roc"]`
+- `localeDisplayNames/types/type\[@key="calendar"]\[@type="roc"]`
 
 The name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”). For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="([^"]*)"]\[@alt="variant"]`
+- `localeDisplayNames/types/type\[@key="calendar"]\[@type="%anyAttribute"]\[@alt="variant"]`
 
 The alternate name of “{1} calendar”. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="calendar"]\[@type="%anyAttribute"]`
 
 The name of “{1} calendar”. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="em"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="em"]\[@type="%anyAttribute"]`
 
 The name of “emoji presentation style {1}”. For more information, please see [Locale Option Names].
 
 ### First Day of the Week
 
-- `^//ldml/localeDisplayNames/types/type\[@key="fw"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="fw"]\[@type="%anyAttribute"]`
 
 The name of “first day of the week is {1}”. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="lb"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="lb"]\[@type="%anyAttribute"]`
 
 The name of “{1} line break style”. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="([^"]*)"]\[@type="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="%anyAttribute"]\[@type="%anyAttribute"]`
 
 The name of the “{2} {1}”. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/keys/key\[@type="([^"]*)"]`
+- `localeDisplayNames/keys/key\[@type="%anyAttribute"]`
 
 The name of the system for “{1}”. For more information, please see [Locale Option Names].
 
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="collation"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="collation"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “{1} collation” (sorting order) — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="numbers"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="numbers"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “{1} number system” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="roc"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="calendar"]\[@type="roc"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”) — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="calendar"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="calendar"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “{1} calendar” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="em"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="em"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “emoji presentation style {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="fw"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="fw"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “first day of the week is {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="lb"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="lb"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of “{1} line break style” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/types/type\[@key="([^"]*)"]\[@type="([^"]*)"]\[@scope="([^"]*)"]`
+- `localeDisplayNames/types/type\[@key="%anyAttribute"]\[@type="%anyAttribute"]\[@scope="%anyAttribute"]`
 
 The _core_ name of the “{2} {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 
 ###
 
-- `^//ldml/localeDisplayNames/variants/variant[@type="([^"]*)"]`
+- `localeDisplayNames/variants/variant[@type="%anyAttribute"]`
 
 The name of the language variant with code {0}. For more information, please see [Language Names].
 
 ###
 
-- `^//ldml/characters/exemplarCharacters$`
+- `characters/exemplarCharacters`
 
 Defines the set of characters used in your language. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
 ###
 
-- `^//ldml/characters/exemplarCharacters\[@type="([^"]*)"]`
+- `characters/exemplarCharacters\[@type="%anyAttribute"]`
 
 Defines the set of characters used in your language for the “{1}” category. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
 ###
 
-- `^//ldml/characters/parseLenients`
+- `characters/parseLenients`
 
 Defines sets of characters that are treated as equivalent in parsing. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
 ###
 
-- `^//ldml/characters/ellipsis\[@type="([^"]*)"]`
+- `characters/ellipsis\[@type="%anyAttribute"]`
 
 Supply the ellipsis pattern for when the {1} part of a string is omitted. Note: before translating, be sure to read [Characters].
 
 ###
 
-- `^//ldml/characters/moreInformation`
+- `characters/moreInformation`
 
 The character or short string used to indicate that more information is available. Note: before translating, be sure to read [Characters].
 
 ###
 
-- `^//ldml/delimiters/alternateQuotationEnd`
+- `delimiters/alternateQuotationEnd`
 
 Supply the (alternate) ending quotation mark (the right mark except in BIDI languages). Note: before translating, be sure to read [Characters].
 
 ###
 
-- `^//ldml/delimiters/alternateQuotationStart`
+- `delimiters/alternateQuotationStart`
 
 Supply the (alternate) starting quotation mark (the left mark except in BIDI languages). Note: before translating, be sure to read [Characters].
 
 ###
 
-- `^//ldml/delimiters/quotationEnd`
+- `delimiters/quotationEnd`
 
 Supply the ending quotation mark (the right mark except in BIDI languages). Note: before translating, be sure to read [Characters].
 
 ###
 
-- `^//ldml/delimiters/quotationStart`
+- `delimiters/quotationStart`
 
 Supply the starting quotation mark (the left mark except in BIDI languages). Note: before translating, be sure to read [Characters].
 
 ###
 
-- `^//ldml/localeDisplayNames/localeDisplayPattern/localePattern`
+- `localeDisplayNames/localeDisplayPattern/localePattern`
 
 The pattern used to compose locale (language) names. Note: before translating, be sure to read [Locale Patterns].
 
 ###
 
-- `^//ldml/localeDisplayNames/localeDisplayPattern/localeSeparator`
+- `localeDisplayNames/localeDisplayPattern/localeSeparator`
 
 The separator used to compose modifiers in locale (language) names. Note: before translating, be sure to read [Locale Patterns].
 
 ###
 
-- `^//ldml/localeDisplayNames/localeDisplayPattern/localeKeyTypePattern`
+- `localeDisplayNames/localeDisplayPattern/localeKeyTypePattern`
 
 The pattern used to compose key-type values in locale (language) names. Note: before translating, be sure to read [Locale Patterns].
 
 ###
 
-- `^//ldml/layout/orientation/characterOrder`
+- `layout/orientation/characterOrder`
 
 Specifies the horizontal direction of text in the language. Valid values are "left-to-right" or "right-to-left". For more information, see [Units Misc Help].
 
 ###
 
-- `^//ldml/layout/orientation/lineOrder`
+- `layout/orientation/lineOrder`
 
 Specifies the vertical direction of text in the language. Valid values are "top-to-bottom" or "bottom-to-top". For more information, see [Units Misc Help].
 
 ###
 
-- `^//ldml/numbers/symbols\[@numberSystem="([a-z]*)"]/(\w++)`
+- `numbers/symbols\[@numberSystem="([a-z]*)"]/(\w++)`
 
 The {2} symbol used in the {1} numbering system. NOTE: especially for the decimal and grouping symbol, before translating, be sure to read [Numbers].
 
 ###
 
-- `^//ldml/numbers/defaultNumberingSystem`
+- `numbers/defaultNumberingSystem`
 
 The default numbering system used in this locale. For more information, please see [Numbering Systems].
 
 ###
 
-- `^//ldml/numbers/minimumGroupingDigits`
+- `numbers/minimumGroupingDigits`
 
 The default minimum number of digits before a grouping separator used in this locale. For more information, please see [Numbering Systems].
 
 ###
 
-- `^//ldml/numbers/otherNumberingSystems/(\w++)`
+- `numbers/otherNumberingSystems/(\w++)`
 
 The {1} numbering system used in this locale. For more information, please see [Numbering Systems].
 
 ###
 
-- `^//ldml/dates/timeZoneNames/regionFormat\[@type="standard"]`
+- `dates/timeZoneNames/regionFormat\[@type="standard"]`
 
 The pattern used to compose standard (winter) fallback time zone names, such as 'Germany Winter Time'. Note: before translating, be sure to read [Time Zone City Names].
 
 ###
 
-- `^//ldml/dates/timeZoneNames/regionFormat\[@type="daylight"]`
+- `dates/timeZoneNames/regionFormat\[@type="daylight"]`
 
 The pattern used to compose daylight (summer) fallback time zone names, such as 'Germany Summer Time'. Note: before translating, be sure to read [Time Zone City Names].
 
 ###
 
-- `^//ldml/dates/timeZoneNames/regionFormat`
+- `dates/timeZoneNames/regionFormat`
 
 The pattern used to compose generic fallback time zone names, such as 'Germany Time'. Note: before translating, be sure to read [Time Zone City Names].
 
 ###
 
-- `^//ldml/dates/timeZoneNames/(fallback|fallbackRegion|gmtZero|gmtUnknown|gmt|hour|region)Format`
+- `dates/timeZoneNames/(fallback|fallbackRegion|gmtZero|gmtUnknown|gmt|hour|region)Format`
 
 The {1} pattern used to compose time zone names. Note: before translating, be sure to read [Time Zone City Names].
 
@@ -352,193 +355,193 @@ The {1} pattern used to compose time zone names. Note: before translating, be su
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/compoundUnit\[@type="([^"]*)"]/compoundUnitPattern1`
+- `units/unitLength\[@type="%anyAttribute"]/compoundUnit\[@type="%anyAttribute"]/compoundUnitPattern1`
 
 Special pattern used to compose powers of a unit, such as meters squared. Note: before translating, be sure to read [Compound Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/compoundUnit\[@type="([^"]*)"]/compoundUnitPattern`
+- `units/unitLength\[@type="%anyAttribute"]/compoundUnit\[@type="%anyAttribute"]/compoundUnitPattern`
 
 Special pattern used to compose forms of two units, such as meters per second. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/compoundUnit\[@type="([^"]*)"]/unitPrefixPattern`
+- `units/unitLength\[@type="%anyAttribute"]/compoundUnit\[@type="%anyAttribute"]/unitPrefixPattern`
 
 Special pattern used to compose a metric prefix with a unit, such as kilo{0} with meters to produce kilometers. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/coordinateUnit/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/coordinateUnit/displayName`
 
 Display name ({1} form) for the type of direction used in latitude and longitude, such as north or east. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/coordinateUnit/coordinateUnitPattern\[@type="([^"]*)"]`
+- `units/unitLength\[@type="%anyAttribute"]/coordinateUnit/coordinateUnitPattern\[@type="%anyAttribute"]`
 
 Special pattern used in latitude and longitude, such as 12°N. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="area-acre"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="area-acre"]/displayName`
 
 Display name ({1} form) for “area-acre”, referring specifically to an English acre. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="duration-day"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="duration-day"]/displayName`
 
 Display name ({1} form) for “duration-day”, meaning a time duration of 24 hours (not a calendar day). Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="energy-calorie"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="energy-calorie"]/displayName`
 
 Display name ({1} form) for “energy-calorie”, calories as used in chemistry, not the same as food calorie. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="energy-foodcalorie"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="energy-foodcalorie"]/displayName`
 
 Display name ({1} form) for “energy-foodcalorie”, kilocalories for food energy; may have same translation as energy-kilocalorie. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="energy-kilocalorie"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="energy-kilocalorie"]/displayName`
 
 Display name ({1} form) for “energy-kilocalorie”, kilocalories for uses not specific to food energy, such as chemistry. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-em"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-em"]/displayName`
 
 Display name ({1} form) for “graphics-em”, referring to typographic length equal to a font’s point size. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-pixel"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-pixel"]/displayName`
 
 Display name ({1} form) for “graphics-pixel”, used for counting the individual elements in bitmap image. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-megapixel"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-megapixel"]/displayName`
 
 Display name ({1} form) for “graphics-megapixel”, used for counting the individual elements in bitmap image. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-pixel-per-centimeter"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-pixel-per-centimeter"]/displayName`
 
 Display name ({1} form) for “graphics-pixel-per-centimeter”, typically used for display resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-pixel-per-inch"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-pixel-per-inch"]/displayName`
 
 Display name ({1} form) for “graphics-pixel-per-inch”, typically used for display resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-dot-per-centimeter"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-dot-per-centimeter"]/displayName`
 
 Display name ({1} form) for “graphics-dot-per-centimeter”, typically used for printer resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="graphics-dot-per-inch"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="graphics-dot-per-inch"]/displayName`
 
 Display name ({1} form) for “graphics-dot-per-inch”, typically used for printer resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="length-point"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="length-point"]/displayName`
 
 Display name ({1} form) for “length-point”, referring to a typographic point, 1/72 inch. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="mass-stone"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="mass-stone"]/displayName`
 
 Display name ({1} form) for “mass-stone”, used in UK/Ireland for body weight, equal to 14 pounds. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="mass-ton"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="mass-ton"]/displayName`
 
 Display name ({1} form) for “mass-ton”, meaning U.S. short ton, not U.K. long ton or metric ton. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="([^"]*)"]/displayName`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="%anyAttribute"]/displayName`
 
 Display name ({1} form) for “{2}”. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="([^"]*)"]/unitPattern`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="%anyAttribute"]/unitPattern`
 
 [ICU Syntax] Special pattern used to compose plural for {1} forms of “{2}”. Note: before translating, be sure to read [Plurals].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="([^"]*)"]/gender`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="%anyAttribute"]/gender`
 
 Gender ({1} form) for “{2}”. Note: before translating, be sure to read [Grammatical Inflection].
 
 ###
 
-- `^//ldml/units/unitLength\[@type="([^"]*)"]/unit\[@type="([^"]*)"]/perUnitPattern`
+- `units/unitLength\[@type="%anyAttribute"]/unit\[@type="%anyAttribute"]/perUnitPattern`
 
 Special pattern ({1} form) used to compose values per unit, such as “meters per {2}”. Note: before translating, be sure to read [Units].
 
 ###
 
-- `^//ldml/units/durationUnit\[@type="(hms|hm|ms)"]`
+- `units/durationUnit\[@type="(hms|hm|ms)"]`
 
 [ICU Syntax] Special pattern used to compose duration units. Note: before translating, be sure to read [Plurals].
 
 ###
 
-- `^//ldml/numbers/decimalFormats\[@numberSystem="([^"]*)"]/decimalFormatLength\[@type="([^"]*)"]/decimalFormat\[@type="([^"]*)"]/pattern\[@type="([^"]*)"]`
+- `numbers/decimalFormats\[@numberSystem="%anyAttribute"]/decimalFormatLength\[@type="%anyAttribute"]/decimalFormat\[@type="%anyAttribute"]/pattern\[@type="%anyAttribute"]`
 
 Special pattern used for a short version of numbers with the same number of digits as {4}. Note: before translating, be sure to read [Short Numbers].
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/currencyFormatLength\[@type="short"]/currencyFormat\[@type="standard"]/pattern\[@type="(\d+)"]\[@count="([^"]+)"]`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/currencyFormatLength\[@type="short"]/currencyFormat\[@type="standard"]/pattern\[@type="(\d+)"]\[@count="([^"]+)"]`
 
 Special currency pattern used to obtain the abbreviated plural forms of numbers with the same number of digits as {2}. See [Short Numbers] for details.
 
 ###
 
-- `^//ldml/numbers/decimalFormats\[@numberSystem="([^"]*)"]/decimalFormatLength\[@type="short"]/decimalFormat\[@type="standard"]/pattern\[@type="(\d+)"]\[@count="([^"]+)"]`
+- `numbers/decimalFormats\[@numberSystem="%anyAttribute"]/decimalFormatLength\[@type="short"]/decimalFormat\[@type="standard"]/pattern\[@type="(\d+)"]\[@count="([^"]+)"]`
 
 Special decimal pattern used to obtain the abbreviated plural forms of numbers with the same number of digits as {2}. See [Short Numbers] for details.
 
 ###
 
-- `^//ldml/numbers/decimalFormats\[@numberSystem="([^"]*)"]/decimalFormatLength\[@type="long"]/decimalFormat\[@type="standard"]/pattern\[@type="(\d+)"]\[@count="([^"]+)"]`
+- `numbers/decimalFormats\[@numberSystem="%anyAttribute"]/decimalFormatLength\[@type="long"]/decimalFormat\[@type="standard"]/pattern\[@type="(\d+)"]\[@count="([^"]+)"]`
 
 Special decimal pattern used to obtain the long plural forms of numbers with the same number of digits as {2}. See [Plural Numbers] for details.
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/currencyPatternAppendISO`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/currencyPatternAppendISO`
 
 Pattern used to combine a regular currency format with an ISO 4217 code (¤¤). For more information, please see [Number Patterns].
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/unitPattern\[@count="(\w++)"]`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/unitPattern\[@count="(\w++)"]`
 
 Currency format used for numbers of type {2}. For more information, please see [Number Patterns].
 
 ###
 
-- `^//ldml/numbers/miscPatterns\[@numberSystem="([^"]*)"]/pattern\[@type="range"]`
+- `numbers/miscPatterns\[@numberSystem="%anyAttribute"]/pattern\[@type="range"]`
 
 Format used to indicate a range of numbers. The '{'0'}' and '{'1'}' in the pattern represent the lowest and highest numbers in the range, respectively. For more information, please see [Units Misc Help].
 
@@ -546,151 +549,151 @@ Format used to indicate a range of numbers. The '{'0'}' and '{'1'}' in the patte
 
 ###
 
-- `^//ldml/numbers/miscPatterns\[@numberSystem="([^"]*)"]/pattern\[@type="atLeast"]`
+- `numbers/miscPatterns\[@numberSystem="%anyAttribute"]/pattern\[@type="atLeast"]`
 
 Format used to indicate a number is at least a certain value, often combined with other patterns to produce examples such as “≥12kg”. For more information, please see [Units Misc Help].
 
 ###
 
-- `^//ldml/numbers/miscPatterns\[@numberSystem="([^"]*)"]/pattern\[@type="atMost"]`
+- `numbers/miscPatterns\[@numberSystem="%anyAttribute"]/pattern\[@type="atMost"]`
 
 Format used to indicate a number is at most a certain value, often combined with other patterns to produce examples such as “≤12kg”. For more information, please see [Units Misc Help].
 
 ###
 
-- `^//ldml/numbers/miscPatterns\[@numberSystem="([^"]*)"]/pattern\[@type="approximately"]`
+- `numbers/miscPatterns\[@numberSystem="%anyAttribute"]/pattern\[@type="approximately"]`
 
 Format used to indicate a number is approximately a given value, often combined with other patterns to produce examples such as “~12kg”. For more information, please see [Units Misc Help].
 
 ###
 
-- `^//ldml/numbers/minimalPairs/ordinalMinimalPairs\[@ordinal="([^"]*)"]`
+- `numbers/minimalPairs/ordinalMinimalPairs\[@ordinal="%anyAttribute"]`
 
 Minimal pairs for ordinals. For more information, please see [Plural Minimal Pairs].
 
 ###
 
-- `^//ldml/numbers/minimalPairs/pluralMinimalPairs\[@count="([^"]*)"]`
+- `numbers/minimalPairs/pluralMinimalPairs\[@count="%anyAttribute"]`
 
 Minimal pairs for plurals (cardinals). For more information, please see [Plural Minimal Pairs].
 
 ###
 
-- `^//ldml/numbers/minimalPairs/caseMinimalPairs\[@case="([^"]*)"]`
+- `numbers/minimalPairs/caseMinimalPairs\[@case="%anyAttribute"]`
 
 Minimal pairs for cases used in the language. For more information, please see [Grammatical Inflection].
 
 ###
 
-- `^//ldml/numbers/minimalPairs/genderMinimalPairs\[@gender="([^"]*)"]`
+- `numbers/minimalPairs/genderMinimalPairs\[@gender="%anyAttribute"]`
 
 Minimal pairs for genders. For more information, please see [Grammatical Inflection].
 
 ###
 
-- `^//ldml/personNames/nameOrderLocales\[@order="([^"]*)"]`
+- `personNames/nameOrderLocales\[@order="%anyAttribute"]`
 
 Person name order for locales. If there are none with a particular direction, insert ❮EMPTY❯. For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/parameterDefault\[@parameter="([^"]*)"]`
+- `personNames/parameterDefault\[@parameter="%anyAttribute"]`
 
 Person name default parameters. Make the appropriate formality and length settings for your locale. For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/foreignSpaceReplacement`
+- `personNames/foreignSpaceReplacement`
 
 For foreign personal names displayed in your locale, any special character that replaces a space (defaults to regular space). If spaces are to be removed, insert ❮EMPTY❯. For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/nativeSpaceReplacement`
+- `personNames/nativeSpaceReplacement`
 
 For native personal names displayed in your locale, should be ❮EMPTY❯ if your language doesn't use spaces between any name parts (such as Japanese), and otherwise a space. For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/initialPattern\[@type="initial"]`
+- `personNames/initialPattern\[@type="initial"]`
 
 The pattern used for a single initial in person name formats. For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/initialPattern\[@type="initialSequence"]`
+- `personNames/initialPattern\[@type="initialSequence"]`
 
 The pattern used to compose sequences of initials in person name formats. For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/personName\[@order="([^"]*)"]\[@length="([^"]*)"]\[@usage="referring"]\[@formality="([^"]*)"]`
+- `personNames/personName\[@order="%anyAttribute"]\[@length="%anyAttribute"]\[@usage="referring"]\[@formality="%anyAttribute"]`
 
 Person name formats for referring to a person (with a particular order, length, formality). For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/personName\[@order="([^"]*)"]\[@length="([^"]*)"]\[@usage="addressing"]\[@formality="([^"]*)"]`
+- `personNames/personName\[@order="%anyAttribute"]\[@length="%anyAttribute"]\[@usage="addressing"]\[@formality="%anyAttribute"]`
 
 Person name format for addressing a person (with a particular order, length, formality). For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/personName\[@order="([^"]*)"]\[@length="([^"]*)"]\[@usage="monogram"]\[@formality="([^"]*)"]`
+- `personNames/personName\[@order="%anyAttribute"]\[@length="%anyAttribute"]\[@usage="monogram"]\[@formality="%anyAttribute"]`
 
 Person name formats for monograms (with a particular order, length, formality). For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/personNames/sampleName`
+- `personNames/sampleName`
 
 Sample names for person name format examples (enter ∅∅∅ for optional unused fields). For more information, please see [Person Name Formats].
 
 ###
 
-- `^//ldml/numbers/rationalFormats\[@numberSystem="([^"]*)"]/rationalPattern`
+- `numbers/rationalFormats\[@numberSystem="%anyAttribute"]/rationalPattern`
 
 A pattern that is used to format a rational fraction (eg, ½), using the numerator and denominator. See [Rational Numbers].
 
 ###
 
-- `^//ldml/numbers/rationalFormats\[@numberSystem="([^"]*)"]/integerAndRationalPattern\[@alt="([^"]*)"]`
+- `numbers/rationalFormats\[@numberSystem="%anyAttribute"]/integerAndRationalPattern\[@alt="%anyAttribute"]`
 
 A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together; only used when the rational fraction does not start with an un-superscripted digit. See [Rational Numbers].
 
 ###
 
-- `^//ldml/numbers/rationalFormats\[@numberSystem="([^"]*)"]/integerAndRationalPattern`
+- `numbers/rationalFormats\[@numberSystem="%anyAttribute"]/integerAndRationalPattern`
 
 A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together. See [Rational Numbers].
 
 ###
 
-- `^//ldml/numbers/rationalFormats\[@numberSystem="([^"]*)"]/rationalUsage`
+- `numbers/rationalFormats\[@numberSystem="%anyAttribute"]/rationalUsage`
 
 A value that is used to indicate the usage of rational fractions (eg, ½) in your language; **only** pick “never” if it never occurs with this numbering system in your language, including text translated from another language. See [Rational Numbers].
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/currencyFormatLength/currencyFormat\[@type="standard"]/pattern\[@type="standard"]\[@alt="alphaNextToNumber"]`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/currencyFormatLength/currencyFormat\[@type="standard"]/pattern\[@type="standard"]\[@alt="alphaNextToNumber"]`
 
 Special pattern used to compose currency values when the currency symbol has a letter adjacent to the number. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/currencyFormatLength/currencyFormat\[@type="standard"]/pattern\[@type="standard"]\[@alt="noCurrency"]`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/currencyFormatLength/currencyFormat\[@type="standard"]/pattern\[@type="standard"]\[@alt="noCurrency"]`
 
 Special pattern used to compose currency values for which no currency symbol should be shown. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/currencyFormatLength/currencyFormat\[@type="accounting"]/pattern`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/currencyFormatLength/currencyFormat\[@type="accounting"]/pattern`
 
 Special pattern used to compose currency values for accounting purposes. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `^//ldml/numbers/currencyFormats\[@numberSystem="([^"]*)"]/currencySpacing/([a-zA-Z]*)/([a-zA-Z]*)`
+- `numbers/currencyFormats\[@numberSystem="%anyAttribute"]/currencySpacing/([a-zA-Z]*)/([a-zA-Z]*)`
 
 Special pattern used to compose currency signs ($2/$3) with numbers. Note: before translating, be sure to read [Number Patterns].
 
@@ -699,387 +702,387 @@ Special pattern used to compose currency signs ($2/$3) with numbers. Note: befor
 
 ###
 
-- `^//ldml/numbers/([a-z]*)Formats(\[@numberSystem="([^"]*)"])?/\1FormatLength/\1Format\[@type="standard"]/pattern\[@type="standard"]$`
+- `numbers/([a-z]*)Formats(\[@numberSystem="%anyAttribute"])?/\1FormatLength/\1Format\[@type="standard"]/pattern\[@type="standard"]`
 
 Special pattern used to compose {1} numbers. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `^//ldml/listPatterns/listPattern/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern/listPatternPart\[@type="2"]`
 
 Special pattern used to make an “and” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make a “and” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="standard-short"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="standard-short"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make a short-style “and” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="standard-short"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="standard-short"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make a short-style “and” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="standard-narrow"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="standard-narrow"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make a short-style “and” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="standard-narrow"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="standard-narrow"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make a short-style “and” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="or"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="or"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make an “or” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="or"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="or"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make an “or” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="or-short"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="or-short"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make an “or” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="or-short"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="or-short"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make an “or” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="or-narrow"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="or-narrow"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make an “or” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="or-narrow"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="or-narrow"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make an “or” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="unit"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="unit"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make a list out of two unit elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="unit"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="unit"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make a list out of more than two unit elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="unit-short"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="unit-short"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make a list out of two abbreviated unit elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="unit-short"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="unit-short"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make a list out of more than two abbreviated unit elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="unit-narrow"]/listPatternPart\[@type="2"]`
+- `listPatterns/listPattern\[@type="unit-narrow"]/listPatternPart\[@type="2"]`
 
 Special pattern used to make a list out of two narrow unit elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/listPatterns/listPattern\[@type="unit-narrow"]/listPatternPart\[@type="([^"]*)"]`
+- `listPatterns/listPattern\[@type="unit-narrow"]/listPatternPart\[@type="%anyAttribute"]`
 
 Special pattern used to make a list out of more than two narrow unit elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dayPeriods/dayPeriodContext\[@type="(format)"]/dayPeriodWidth\[@type="([^"]*)"]/dayPeriod\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dayPeriods/dayPeriodContext\[@type="(format)"]/dayPeriodWidth\[@type="%anyAttribute"]/dayPeriod\[@type="%anyAttribute"]`
 
 Provide the {3}, {2} version of the name for the day period code “{4}”. This version must have the right inflection/prepositions/etc. for adding after a number, such as “in the morning” for use in “10:00 in the morning”. To see the time spans for these codes, please see [Date Time]
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dayPeriods/dayPeriodContext\[@type="([^"]*)"]/dayPeriodWidth\[@type="([^"]*)"]/dayPeriod\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dayPeriods/dayPeriodContext\[@type="%anyAttribute"]/dayPeriodWidth\[@type="%anyAttribute"]/dayPeriod\[@type="%anyAttribute"]`
 
 Provide the {3}, {2} version of the name for the day period code “{4}”. To see the time spans for these codes, please see [Date Time]
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/days/dayContext\[@type="([^"]*)"]/dayWidth\[@type="([^"]*)"]/day\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/days/dayContext\[@type="%anyAttribute"]/dayWidth\[@type="%anyAttribute"]/day\[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for day-of-the-week {4}. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/eras/eraAbbr/era\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/eras/eraAbbr/era\[@type="%anyAttribute"]`
 
 Provide the format-abbreviated version of the name for era {2}. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/eras/eraNames/era\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/eras/eraNames/era\[@type="%anyAttribute"]`
 
 Provide the format-wide version of the name for era {1}. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/eras/eraNarrow/era\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/eras/eraNarrow/era\[@type="%anyAttribute"]`
 
 Provide the format-narrow version of the name for era {1}. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/months/monthContext\[@type="([^"]*)"]/monthWidth\[@type="([^"]*)"]/month\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/months/monthContext\[@type="%anyAttribute"]/monthWidth\[@type="%anyAttribute"]/month\[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for month {4}. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/quarters/quarterContext\[@type="([^"]*)"]/quarterWidth\[@type="([^"]*)"]/quarter\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/quarters/quarterContext\[@type="%anyAttribute"]/quarterWidth\[@type="%anyAttribute"]/quarter\[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for quarter {4}. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/displayName`
+- `dates/fields/field\[@type="%anyAttribute"]/displayName`
 
 Provide the name (as it would appear in menus) for the field “{1}”. For more information, please see [Date Time Fields].
 
 ### Relative Today
 
-- `^//ldml/dates/fields/field\[@type="day"]/relative\[@type="0"]`
+- `dates/fields/field\[@type="day"]/relative\[@type="0"]`
 
 Provide the name for today. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Relative before-today
 
-- `^//ldml/dates/fields/field\[@type="day"]/relative\[@type="-([^"]*)"]`
+- `dates/fields/field\[@type="day"]/relative\[@type="-([^"]*)"]`
 
 Provide a name for the day, {1} before today. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Relative after-today
 
-- `^//ldml/dates/fields/field\[@type="day"]/relative\[@type="([^"]*)"]`
+- `dates/fields/field\[@type="day"]/relative\[@type="%anyAttribute"]`
 
 Provide a name for the day, {1} after today. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### This X
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/relative\[@type="0"]`
+- `dates/fields/field\[@type="%anyAttribute"]/relative\[@type="0"]`
 
 Provide the name for “this {1}”. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Last X
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/relative\[@type="-1"]`
+- `dates/fields/field\[@type="%anyAttribute"]/relative\[@type="-1"]`
 
 Provide a name for “last {1}”. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Next X
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/relative\[@type="1"]`
+- `dates/fields/field\[@type="%anyAttribute"]/relative\[@type="1"]`
 
 Provide a name for “next {1}”. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Future Pattern
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/relativeTime\[@type="future"]/relativeTimePattern\[@count="([^"]*)"]`
+- `dates/fields/field\[@type="%anyAttribute"]/relativeTime\[@type="future"]/relativeTimePattern\[@count="%anyAttribute"]`
 
 Provide a pattern used to display times in the future. For more information, please see [Date Time Names].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Past Pattern
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/relativeTime\[@type="past"]/relativeTimePattern\[@count="([^"]*)"]`
+- `dates/fields/field\[@type="%anyAttribute"]/relativeTime\[@type="past"]/relativeTimePattern\[@count="%anyAttribute"]`
 
 Provide a pattern used to display times in the past. For more information, please see [Date Time Names].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ###
 
-- `^//ldml/dates/fields/field\[@type="([^"]*)"]/relativePeriod`
+- `dates/fields/field\[@type="%anyAttribute"]/relativePeriod`
 
 Provide a name for “the {1} of SOME_DATE”. For more information, please see [Date Time Names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/dateTimeFormatLength\[@type="([^"]*)"]/dateTimeFormat\[@type="standard"]/pattern\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/dateTimeFormatLength\[@type="%anyAttribute"]/dateTimeFormat\[@type="standard"]/pattern\[@type="%anyAttribute"]`
 
 Provide the {2} version of the date-time pattern suitable for most use cases, including combining a date with a time range. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/dateTimeFormatLength\[@type="([^"]*)"]/dateTimeFormat\[@type="atTime"]/pattern\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/dateTimeFormatLength\[@type="%anyAttribute"]/dateTimeFormat\[@type="atTime"]/pattern\[@type="%anyAttribute"]`
 
 Provide the {2} version of the date-time pattern suitable for expressing a standard date (e.g. "March 20") at a specific time. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/dateTimeFormatLength\[@type="([^"]*)"]/dateTimeFormat\[@type="relative"]/pattern\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/dateTimeFormatLength\[@type="%anyAttribute"]/dateTimeFormat\[@type="relative"]/pattern\[@type="%anyAttribute"]`
 
 Provide the {2} version of the date-time pattern suitable for expressing a relative date (e.g. "tomorrow") at a specific time. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateFormats/dateFormatLength\[@type="([^"]*)"]/dateFormat\[@type="([^"]*)"]/pattern\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateFormats/dateFormatLength\[@type="%anyAttribute"]/dateFormat\[@type="%anyAttribute"]/pattern\[@type="%anyAttribute"]`
 
 Provide the {2} version of the basic date pattern. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/timeFormats/timeFormatLength\[@type="([^"]*)"]/timeFormat\[@type="([^"]*)"]/pattern\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/timeFormats/timeFormatLength\[@type="%anyAttribute"]/timeFormat\[@type="%anyAttribute"]/pattern\[@type="%anyAttribute"]`
 
 Provide the {2} version of the basic time pattern. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/availableFormats/dateFormatItem\[@id="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/availableFormats/dateFormatItem\[@id="%anyAttribute"]`
 
 Provide the pattern used in your language for the skeleton “{2}”. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/appendItems/appendItem\[@request="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/appendItems/appendItem\[@request="%anyAttribute"]`
 
 Provide the pattern used in your language to append a “{2}” to another format. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/intervalFormats/intervalFormatFallback`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/intervalFormats/intervalFormatFallback`
 
 The pattern used for “fallback” with date/time intervals. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="([^"]*)"]/dateTimeFormats/intervalFormats/intervalFormatItem\[@id="([^"]*)"]/greatestDifference\[@id="([^"]*)"]`
+- `dates/calendars/calendar\[@type="%anyAttribute"]/dateTimeFormats/intervalFormats/intervalFormatItem\[@id="%anyAttribute"]/greatestDifference\[@id="%anyAttribute"]`
 
 The pattern used for the date/time interval skeleton “{2}” when the greatest difference is “{3}”. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="[^"]*"]/cyclicNameSets/cyclicNameSet\[@type="([^"]*)"]/cyclicNameContext\[@type="([^"]*)"]/cyclicNameWidth\[@type="([^"]*)"]/cyclicName\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="[^"]*"]/cyclicNameSets/cyclicNameSet\[@type="%anyAttribute"]/cyclicNameContext\[@type="%anyAttribute"]/cyclicNameWidth\[@type="%anyAttribute"]/cyclicName\[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of type {4} in the {1} name cycle. For more information, please see [Date/time cyclic names].
 
 ###
 
-- `^//ldml/dates/calendars/calendar\[@type="[^"]*"]/monthPatterns/monthPatternContext\[@type="([^"]*)"]/monthPatternWidth\[@type="([^"]*)"]/monthPattern\[@type="([^"]*)"]`
+- `dates/calendars/calendar\[@type="[^"]*"]/monthPatterns/monthPatternContext\[@type="%anyAttribute"]/monthPatternWidth\[@type="%anyAttribute"]/monthPattern\[@type="%anyAttribute"]`
 
 Provide the {1} and {2} version of the name for {3} month types. For more information, please see [Month Names].
 
 ###
 
-- `^//ldml/localeDisplayNames/transformNames/transformName\[@type="([^"]*)"]`
+- `localeDisplayNames/transformNames/transformName\[@type="%anyAttribute"]`
 
 The name of the transform “{1}”. For more information, please see [Transforms].
 
 ###
 
-- `^//ldml/localeDisplayNames/codePatterns/codePattern[@type="([^"]*)"]`
+- `localeDisplayNames/codePatterns/codePattern[@type="%anyAttribute"]`
 
 The pattern to be used when displaying a name for a character {0}. For more information, please see [Locale Patterns].
 
 ###
 
-- `^//ldml/localeDisplayNames/measurementSystemNames/measurementSystemName\[@type="([^"]*)"]`
+- `localeDisplayNames/measurementSystemNames/measurementSystemName\[@type="%anyAttribute"]`
 
 The name of the measurement system “{1}”. For more information, please see [Units Misc Help].
 
 ###
 
-- `^//ldml/posix/messages/(no|yes)str`
+- `posix/messages/(no|yes)str`
 
 The word for “{1}”, lowercased, plus any abbreviations separated by a colon. For more information, see [Units Misc Help].
 
 ###
 
-- `^//ldml/localeDisplayNames/annotationPatterns/annotationPattern[@type="([^"]*)"]`
+- `localeDisplayNames/annotationPatterns/annotationPattern[@type="%anyAttribute"]`
 
 The pattern to be used when displaying a {1}. For more information, please see [Locale Patterns].
 
 ###
 
-- `^//ldml/characters/stopwords/stopwordList\[@type="([^"]*)"]`
+- `characters/stopwords/stopwordList\[@type="%anyAttribute"]`
 
 The words that should be ignored in sorting in your language. For more information, see [Units Misc Help].
 
 ###
 
-- `^//ldml/dates/timeZoneNames/zone\[@type="([^"]*)"]/([^/]*)/(.*)`
+- `dates/timeZoneNames/zone\[@type="%anyAttribute"]/([^/]*)/(.*)`
 
 Override for the {3}-{2} timezone name for {1}. For more information, see [Time Zone City Names].
 
 ###
 
-- `^//ldml/typographicNames/axisName[@type="([^"]*)"]`
+- `typographicNames/axisName[@type="%anyAttribute"]`
 
 A label for a typographic design axis, such as “Width” or “Weight”. For more information, see [Typography].
 
 ###
 
-- `^//ldml/typographicNames/styleName[@type="([^"]*)"][@subtype="([^"]*)"]`
+- `typographicNames/styleName[@type="%anyAttribute"][@subtype="%anyAttribute"]`
 
 A label for a typographic style, such as “Narrow” or “Semibold”. For more information, see [Typography].
 
 ###
 
-- `^//ldml/typographicNames/featureName[@type="([^"]*)"]`
+- `typographicNames/featureName[@type="%anyAttribute"]`
 
 A label for a typographic feature, such as “Small Capitals”. For more information, see [Typography].
 
 ###
 
-- `^//ldml/characterLabels/characterLabelPattern\[@type="([^"]*)"]\[@count="([^"]*)"]`
+- `characterLabels/characterLabelPattern\[@type="%anyAttribute"]\[@count="%anyAttribute"]`
 
 A label for a set of characters that has a numeric placeholder, such as “1 Stroke”, “2 Strokes”. For more information, see [Character Labels].
 
 ###
 
-- `^//ldml/characterLabels/characterLabelPattern\[@type="([^"]*)"]`
+- `characterLabels/characterLabelPattern\[@type="%anyAttribute"]`
 
 A modifier composed with a label for a set of characters. For more information, see [Character Labels].
 
 ###
 
-- `^//ldml/characterLabels/characterLabel\[@type="([^"]*)"]`
+- `characterLabels/characterLabel\[@type="%anyAttribute"]`
 
 A label for a set of characters. For more information, see [Character Labels].
 
 ###
 
-- `^//ldml/annotations/annotation\[@cp="([^"]*)"]\[@type="tts"]`
+- `annotations/annotation\[@cp="%anyAttribute"]\[@type="tts"]`
 
 A name for a character or sequence. For more information, see [Short Character Names].
 
 ###
 
-- `^//ldml/annotations/annotation\[@cp="([^"]*)"]`
+- `annotations/annotation\[@cp="%anyAttribute"]`
 
 A set of keywords for a character or sequence. For more information, see [Short Character Names].
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPathHeader.java
@@ -794,12 +794,9 @@ public class TestPathHeader extends TestFmwkPlus {
         String errorDescription = null;
         if (description == null) {
             errorDescription = ("Path has no description:\t" + value + "\t" + path);
-        } else if (!description.contains("https://")) {
+        } else if (!(description.contains("[") && description.contains("]"))) {
             errorDescription =
-                    ("Description has no URL:\t" + description + "\t" + value + "\t" + path);
-        } else if (!normal.reset(description).find()) {
-            errorDescription =
-                    ("Description has generic URL, fix to be specific:\t"
+                    ("Description has no bracketed link:\t"
                             + description
                             + "\t"
                             + value

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathDescription.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestPathDescription.java
@@ -19,7 +19,7 @@ public class TestPathDescription {
     private void parseOneString(String fileName) {
         final String bigString = PathDescription.getBigString(fileName);
         final PathDescriptionParser parser = new PathDescriptionParser();
-        final RegexLookup<Pair<String, String>> lookup = parser.parse(bigString);
+        final RegexLookup<Pair<String, String>> lookup = parser.parse(fileName);
 
         assertNotNull(lookup);
         assertNotEquals(0, lookup.size(), "lookup is empty");


### PR DESCRIPTION
-In PathDescriptions.md and PathDescriptionHints.md, use shorter forms of paths, omit ldml, no anchors; use variable anyAttribute instead of raw regex

-Store variables in the .md files; new VARIABLES section, new methods inVariables, addVariable

-In PathDescriptionParser, call lookup.add instead of lookup.addWithoutVariables

-Use lazy initialization for pathHandling and pathHintsHandling, to facilitate debugging

-Revise TestPathHeader.Test8414 to check for brackets instead of http, since URLs moved to bottom of file

-Revise PathDescriptionParser.parse to take file name instead of big string as parameter, so error message has the correct file name

-Make parts of PathDescription.java private if they do not need to be public

CLDR-17599

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
