### PR TITLE
CLDR-17599 Path descriptions: fix static init references bug; remove …

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescription.java
@@ -53,17 +53,12 @@ public class PathDescription {
     private static final Map<String, String> ZONE2COUNTRY =
             STANDARD_CODES.zoneParser.getZoneToCountry();
 
-    /** <Description, Markdown> */
-    private static final PathDescriptionParser parser = new PathDescriptionParser();
-
-    private static final PathDescriptionParser hintsParser = new PathDescriptionParser();
-
     private static RegexLookup<Pair<String, String>> pathHandling = null;
 
     private static RegexLookup<Pair<String, String>> pathHintsHandling = null;
 
-    /** markdown to append */
-    private static final String references = parser.getReferences();
+    /** Markdown to append from PathDescriptions.md. Initialized in getPathHandling */
+    private static String references = null;
 
     /** for tests, returns the big string */
     static String getBigString(String fileName) {
@@ -77,17 +72,22 @@ public class PathDescription {
         }
     }
 
-    /** for tests */
+    /** Public for tests */
     public static RegexLookup<Pair<String, String>> getPathHandling() {
         if (pathHandling == null) {
+            PathDescriptionParser parser = new PathDescriptionParser();
             pathHandling = parser.parse(pathDescriptionFileName);
+            references = parser.getReferences();
         }
         return pathHandling;
     }
 
     private static RegexLookup<Pair<String, String>> getPathHintsHandling() {
         if (pathHintsHandling == null) {
+            PathDescriptionParser hintsParser = new PathDescriptionParser();
             pathHintsHandling = hintsParser.parse(pathDescriptionHintsFileName);
+            // Note: Hints currently use no references. If they did, they could be
+            // initialized here by hintReferences = hintsParser.getReferences()
         }
         return pathHintsHandling;
     }
@@ -143,7 +143,6 @@ public class PathDescription {
     }
 
     public String getHintRawDescription(String path, Object context) {
-
         status.clear();
         final Pair<String, String> entry = getPathHintsHandling().get(path, context, pathArguments);
         if (entry == null) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescriptionParser.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PathDescriptionParser.java
@@ -36,7 +36,6 @@ public class PathDescriptionParser {
                     "Failed parsing " + fileName + ":" + n + ": at " + section + "#" + description,
                     t);
         }
-
         return lookup;
     }
 
@@ -159,6 +158,10 @@ public class PathDescriptionParser {
     private void end() {
         if (!inReferences()) {
             throw new IllegalArgumentException("End of lines when not in # " + REFERENCES);
+        }
+        if (getReferences().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "No references were found in section: " + REFERENCES);
         }
         // no need to call endHeader here as there isn't anything to terminate in references.
     }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptionHints.md
@@ -10,289 +10,289 @@ See PathDescriptions.md for documentation.
 
 ### HINT
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="duration-day"\](/displayName|/unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="duration-day"](/displayName|/unitPattern[@count="%anyAttribute"])$`
 
 "day" here means a time duration of 24 hours, not a calendar day
 
 ###
 
-- `localeDisplayNames/languages/language[@type="ckb"\][@alt="menu"\]$`
+- `localeDisplayNames/languages/language[@type="ckb"][@alt="menu"]$`
 
 a form of the name that will sort next to Kurdish, if the standard name does not already do that
 
 ###
 
-- `localeDisplayNames/types/type[@key="calendar"\][@type="roc"\]$`
+- `localeDisplayNames/types/type[@key="calendar"][@type="roc"]$`
 
 also called "Republic of China Calendar", "Republican Calendar"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="ckb"\][@alt="variant"\]$`
+- `localeDisplayNames/languages/language[@type="ckb"][@alt="variant"]$`
 
 an alternate form using Sorani or Central, whichever is not used by the standard name
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="energy-calorie"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="energy-calorie"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 calories as used in chemistry, not the same as food calorie
 
 ###
 
-- `units/unitLength[@type="(narrow|short)"\]/unit[@type="energy-foodcalorie"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="(narrow|short)"]/unit[@type="energy-foodcalorie"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 kilocalories for food energy, may have same translation as energy-kilocalorie; displayed as Cal in the US/UK
 
 ###
 
-- `units/unitLength[@type="long"\]/unit[@type="energy-foodcalorie"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="long"]/unit[@type="energy-foodcalorie"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 kilocalories for food energy, may have same translation as energy-kilocalorie; displayed as Calories in the US/UK
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="energy-kilocalorie"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="energy-kilocalorie"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 kilocalories for uses not specific to food energy, such as chemistry
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="area-acre"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="area-acre"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 refers specifically to an English acre
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="mass-ton"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="mass-ton"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 refers to U.S. short ton, not U.K. long ton or metric ton
 
 ###
 
-- `localeDisplayNames/scripts/script[@type="Aran"\]$`
+- `localeDisplayNames/scripts/script[@type="Aran"]$`
 
 special code identifies a style variant of Arabic script
 
 ###
 
-- `localeDisplayNames/scripts/script[@type="Qaag"\]$`
+- `localeDisplayNames/scripts/script[@type="Qaag"]$`
 
 special code identifies non-standard Myanmar encoding for use with Zawgyi font
 
 ###
 
-- `localeDisplayNames/languages/language[@type="clc"\]$`
+- `localeDisplayNames/languages/language[@type="clc"]$`
 
 also referred to as "Tsilhqot’in"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="ikt"\]$`
+- `localeDisplayNames/languages/language[@type="ikt"]$`
 
 also referred to as "Inuinnaqtun"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="kwk"\]$`
+- `localeDisplayNames/languages/language[@type="kwk"]$`
 
 previously referred to as "Kwakiutl"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="moe"\]$`
+- `localeDisplayNames/languages/language[@type="moe"]$`
 
 also referred to as "Montagnais"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="ojs"\]$`
+- `localeDisplayNames/languages/language[@type="ojs"]$`
 
 also referred to as "Severn Ojibwa"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="oka"\]$`
+- `localeDisplayNames/languages/language[@type="oka"]$`
 
 also referred to as "Nsyilxcən"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="pqm"\]$`
+- `localeDisplayNames/languages/language[@type="pqm"]$`
 
 also referred to as "Maliseet–Passamaquoddy"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="slh"\]$`
+- `localeDisplayNames/languages/language[@type="slh"]$`
 
 also referred to as "Southern Puget Sound Salish"
 
 ###
 
-- `localeDisplayNames/languages/language[@type="zh"\]$`
+- `localeDisplayNames/languages/language[@type="zh"]$`
 
 specifically, Mandarin Chinese
 
 ###
 
-- `localeDisplayNames/scripts/script[@type="Han(s|t)"\]$`
+- `localeDisplayNames/scripts/script[@type="Han(s|t)"]$`
 
 this version of the script name is used in combination with the language name for Chinese
 
 ###
 
-- `localeDisplayNames/scripts/script[@type="Han(s|t)"\][@alt="stand-alone"\]$`
+- `localeDisplayNames/scripts/script[@type="Han(s|t)"][@alt="stand-alone"]$`
 
 this version of the script name is used in isolation, not combined with the language name for Chinese
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Central"\]/long/daylight$`
+- `dates/timeZoneNames/metazone[@type="America_Central"]/long/daylight$`
 
 translate as "North American Central Daylight Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Central"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="America_Central"]/long/standard$`
 
 translate as "North American Central Standard Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Central"\]/long/generic$`
+- `dates/timeZoneNames/metazone[@type="America_Central"]/long/generic$`
 
 translate as "North American Central Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Eastern"\]/long/daylight$`
+- `dates/timeZoneNames/metazone[@type="America_Eastern"]/long/daylight$`
 
 translate as "North American Eastern Daylight Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Eastern"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="America_Eastern"]/long/standard$`
 
 translate as "North American Eastern Standard Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Eastern"\]/long/generic$`
+- `dates/timeZoneNames/metazone[@type="America_Eastern"]/long/generic$`
 
 translate as "North American Eastern Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Mountain"\]/long/daylight$`
+- `dates/timeZoneNames/metazone[@type="America_Mountain"]/long/daylight$`
 
 translate as "North American Mountain Daylight Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Mountain"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="America_Mountain"]/long/standard$`
 
 translate as "North American Mountain Standard Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Mountain"\]/long/generic$`
+- `dates/timeZoneNames/metazone[@type="America_Mountain"]/long/generic$`
 
 translate as "North American Mountain Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Pacific"\]/long/daylight$`
+- `dates/timeZoneNames/metazone[@type="America_Pacific"]/long/daylight$`
 
 translate as "North American Pacific Daylight Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Pacific"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="America_Pacific"]/long/standard$`
 
 translate as "North American Pacific Standard Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="America_Pacific"\]/long/generic$`
+- `dates/timeZoneNames/metazone[@type="America_Pacific"]/long/generic$`
 
 translate as "North American Pacific Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="Chamorro"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="Chamorro"]/long/standard$`
 
 translate as just "Chamorro Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="Guam"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="Guam"]/long/standard$`
 
 translate as just "Guam Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="Gulf"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="Gulf"]/long/standard$`
 
 translate as just "Gulf Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="India"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="India"]/long/standard$`
 
 translate as just "India Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="Singapore"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="Singapore"]/long/standard$`
 
 translate as just "Singapore Time"
 
 ###
 
-- `dates/timeZoneNames/metazone[@type="Africa_Southern"\]/long/standard$`
+- `dates/timeZoneNames/metazone[@type="Africa_Southern"]/long/standard$`
 
 translate as just "South Africa Time"
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="graphics-pixel-per-(centimeter|inch)"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="graphics-pixel-per-(centimeter|inch)"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 typically used for display resolution
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="graphics-dot-per-(centimeter|inch)"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="graphics-dot-per-(centimeter|inch)"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 typically used for printer resolution
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="graphics-em"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="graphics-em"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 typographic length equal to a font’s point size
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="graphics-megapixel"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="graphics-megapixel"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 used for counting the individual elements in bitmap image
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="graphics-pixel"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="graphics-pixel"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 used for counting the individual elements in bitmap image; in some contexts means 1⁄96 inch
 
 ###
 
-- `units/unitLength[@type="%unitLengths"\]/unit[@type="mass-stone"\]/(displayName|unitPattern[@count="%anyAttribute"\])$`
+- `units/unitLength[@type="%unitLengths"]/unit[@type="mass-stone"]/(displayName|unitPattern[@count="%anyAttribute"])$`
 
 used in UK/Ireland for body weight, equal to 14 pounds
 
 ###
 
-- `localeDisplayNames/territories/territory[@type="(003|018|021|057|CD|CG|CI|FK|FM|HK|MM|MO|PS|SZ|TL|ZA)"\]([@alt="(variant|short)"\])?$`
+- `localeDisplayNames/territories/territory[@type="(003|018|021|057|CD|CG|CI|FK|FM|HK|MM|MO|PS|SZ|TL|ZA)"]([@alt="(variant|short)"])?$`
 
 warning, see info panel on right
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
@@ -4,7 +4,7 @@ Example Entry:
 
     ### First Day of the Week
 
-    - `localeDisplayNames/types/type[@key="fw"\][@type="%anyAttribute"\]`
+    - `localeDisplayNames/types/type[@key="fw"][@type="%anyAttribute"]`
 
     The name of “first day of the week is {1}”. For more information, please see [Locale Option Names].
 
@@ -31,73 +31,73 @@ Example Entry:
 
 ### ROOT territory
 
-- `localeDisplayNames/territories/territory[@type="(CD|DG|CG|003|021|ZA|018|FK|MK|MM|TW|HK|MO)"\]`
+- `localeDisplayNames/territories/territory[@type="(CD|DG|CG|003|021|ZA|018|FK|MK|MM|TW|HK|MO)"]`
 
 Warning - the region {0} requires special attention! Note: before translating, be sure to read [Country Names].
 
 ### ROOT script
 
-- `localeDisplayNames/scripts/script[@type="(Z%nonQuote*)"\]`
+- `localeDisplayNames/scripts/script[@type="(Z%nonQuote*)"]`
 
 The name of the script (writing system) with Unicode script code = {0}. Note: before translating, be sure to read [Script Names].
 
 ### ROOT timezone
 
-- `dates/timeZoneNames/zone[@type="%anyAttribute"\]/exemplarCity`
+- `dates/timeZoneNames/zone[@type="%anyAttribute"]/exemplarCity`
 
 The name of {0}. For more information, see [Time Zone City Names].
 
 ### ROOT language
 
-- `localeDisplayNames/languages/language[@type="%anyAttribute"\][@menu="%anyAttribute"\]`
+- `localeDisplayNames/languages/language[@type="%anyAttribute"][@menu="%anyAttribute"]`
 
 The name of the language with Unicode language code = {0}, _and_ menu type = {0}. **Be sure to read about this in [Language Names]**.
 
 ### ROOT language
 
-- `localeDisplayNames/languages/language[@type="%anyAttribute"\]`
+- `localeDisplayNames/languages/language[@type="%anyAttribute"]`
 
 The name of the language with Unicode language code = {0}. For more information, see [Language Names].
 
 ### ROOT script
 
-- `localeDisplayNames/scripts/script[@type="%anyAttribute"\]`
+- `localeDisplayNames/scripts/script[@type="%anyAttribute"]`
 
 The name of the script (writing system) with Unicode script code = {0}. For more information, see [Script Names].
 
 ### ROOT territory
 
-- `localeDisplayNames/territories/territory[@type="%anyAttribute"\]`
+- `localeDisplayNames/territories/territory[@type="%anyAttribute"]`
 
 The name of the country or region with Unicode region code = {0}. For more information, see [Country Names].
 
 ### ROOT territory
 
-- `localeDisplayNames/subdivisions/subdivision[@type="%anyAttribute"\]`
+- `localeDisplayNames/subdivisions/subdivision[@type="%anyAttribute"]`
 
 The name of the country subdivision with Unicode subdivision code = {0}. For more information, see [Country Names].
 
 ### ROOT currency
 
-- `numbers/currencies/currency[@type="%anyAttribute"\]/symbol$`
+- `numbers/currencies/currency[@type="%anyAttribute"]/symbol$`
 
 The symbol for the currency with the ISO currency code = {0}. For more information, see [Currency Names].
 
 ### ROOT currency
 
-- `numbers/currencies/currency[@type="%anyAttribute"\]/symbol[@alt="narrow"\]`
+- `numbers/currencies/currency[@type="%anyAttribute"]/symbol[@alt="narrow"]`
 
 The NARROW form of the symbol used for the currency with the ISO currency code = {0}, when the known context is already enough to distinguish the symbol from other currencies that may use the same symbol. Normally, this does not need to be changed from the inherited value. For more information, see [Currency Names].
 
 ### ROOT currency
 
-- `numbers/currencies/currency[@type="%anyAttribute"\]/symbol[@alt="(%nonQuote++)"\]`
+- `numbers/currencies/currency[@type="%anyAttribute"]/symbol[@alt="(%nonQuote++)"]`
 
 An alternative form of the symbol used for the currency with the ISO currency code = {0}. Usually occurs shortly after a new currency symbol is introduced. For more information, see [Currency Names].
 
 ### ROOT currency
 
-- `numbers/currencies/currency[@type="%anyAttribute"\]/displayName`
+- `numbers/currencies/currency[@type="%anyAttribute"]/displayName`
 
 The name of the currency with the ISO currency code = {0}. For more information, see [Currency Names].
 
@@ -106,7 +106,7 @@ The name of the currency with the ISO currency code = {0}. For more information,
 
 ### ROOT metazone
 
-- `dates/timeZoneNames/metazone[@type="%anyAttribute"\](.*)/(.*)`
+- `dates/timeZoneNames/metazone[@type="%anyAttribute"](.*)/(.*)`
 
 The name of the timezone for “{0}”. Note: before translating, be sure to read [Time Zone City Names].
 
@@ -114,117 +114,117 @@ The name of the timezone for “{0}”. Note: before translating, be sure to rea
 
 ###
 
-- `localeDisplayNames/types/type[@key="collation"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="collation"][@type="%anyAttribute"]`
 
 The name of “{1} collation” (sorting order). For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="numbers"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="numbers"][@type="%anyAttribute"]`
 
 The name of “{1} number system”. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="calendar"\][@type="roc"\]`
+- `localeDisplayNames/types/type[@key="calendar"][@type="roc"]`
 
 The name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”). For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="calendar"\][@type="%anyAttribute"\][@alt="variant"\]`
+- `localeDisplayNames/types/type[@key="calendar"][@type="%anyAttribute"][@alt="variant"]`
 
 The alternate name of “{1} calendar”. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="calendar"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="calendar"][@type="%anyAttribute"]`
 
 The name of “{1} calendar”. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="em"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="em"][@type="%anyAttribute"]`
 
 The name of “emoji presentation style {1}”. For more information, please see [Locale Option Names].
 
 ### First Day of the Week
 
-- `localeDisplayNames/types/type[@key="fw"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="fw"][@type="%anyAttribute"]`
 
 The name of “first day of the week is {1}”. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="lb"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="lb"][@type="%anyAttribute"]`
 
 The name of “{1} line break style”. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="%anyAttribute"\][@type="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="%anyAttribute"][@type="%anyAttribute"]`
 
 The name of the “{2} {1}”. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/keys/key[@type="%anyAttribute"\]`
+- `localeDisplayNames/keys/key[@type="%anyAttribute"]`
 
 The name of the system for “{1}”. For more information, please see [Locale Option Names].
 
 
 ###
 
-- `localeDisplayNames/types/type[@key="collation"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="collation"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of “{1} collation” (sorting order) — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="numbers"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="numbers"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of “{1} number system” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="calendar"\][@type="roc"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="calendar"][@type="roc"][@scope="%anyAttribute"]`
 
 The _core_ name of “roc calendar” (common names include “Minguo Calendar”, “Republic of China Calendar”, and “Republican Calendar”) — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="calendar"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="calendar"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of “{1} calendar” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="em"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="em"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of “emoji presentation style {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="fw"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="fw"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of “first day of the week is {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="lb"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="lb"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of “{1} line break style” — **without the key name**. For more information, please see [Locale Option Names].
 
 ###
 
-- `localeDisplayNames/types/type[@key="%anyAttribute"\][@type="%anyAttribute"\][@scope="%anyAttribute"\]`
+- `localeDisplayNames/types/type[@key="%anyAttribute"][@type="%anyAttribute"][@scope="%anyAttribute"]`
 
 The _core_ name of the “{2} {1}” — **without the key name**. For more information, please see [Locale Option Names].
 
 
 ###
 
-- `localeDisplayNames/variants/variant[@type="%anyAttribute"\]`
+- `localeDisplayNames/variants/variant[@type="%anyAttribute"]`
 
 The name of the language variant with code {0}. For more information, please see [Language Names].
 
@@ -236,7 +236,7 @@ Defines the set of characters used in your language. _To change this item, you h
 
 ###
 
-- `characters/exemplarCharacters[@type="%anyAttribute"\]`
+- `characters/exemplarCharacters[@type="%anyAttribute"]`
 
 Defines the set of characters used in your language for the “{1}” category. _To change this item, you have to flag it for review\!_ See [Changing Protected Items]. Before filing any tickets to request changes, be sure to also read [Exemplar Characters].
 
@@ -248,7 +248,7 @@ Defines sets of characters that are treated as equivalent in parsing. _To change
 
 ###
 
-- `characters/ellipsis[@type="%anyAttribute"\]`
+- `characters/ellipsis[@type="%anyAttribute"]`
 
 Supply the ellipsis pattern for when the {1} part of a string is omitted. Note: before translating, be sure to read [Characters].
 
@@ -314,7 +314,7 @@ Specifies the vertical direction of text in the language. Valid values are "top-
 
 ###
 
-- `numbers/symbols[@numberSystem="(%lowercaseLetters)"\]/(\w++)`
+- `numbers/symbols[@numberSystem="(%lowercaseLetters)"]/(\w++)`
 
 The {2} symbol used in the {1} numbering system. NOTE: especially for the decimal and grouping symbol, before translating, be sure to read [Numbers].
 
@@ -338,13 +338,13 @@ The {1} numbering system used in this locale. For more information, please see [
 
 ###
 
-- `dates/timeZoneNames/regionFormat[@type="standard"\]`
+- `dates/timeZoneNames/regionFormat[@type="standard"]`
 
 The pattern used to compose standard (winter) fallback time zone names, such as 'Germany Winter Time'. Note: before translating, be sure to read [Time Zone City Names].
 
 ###
 
-- `dates/timeZoneNames/regionFormat[@type="daylight"\]`
+- `dates/timeZoneNames/regionFormat[@type="daylight"]`
 
 The pattern used to compose daylight (summer) fallback time zone names, such as 'Germany Summer Time'. Note: before translating, be sure to read [Time Zone City Names].
 
@@ -364,193 +364,193 @@ The {1} pattern used to compose time zone names. Note: before translating, be su
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/compoundUnit[@type="%anyAttribute"\]/compoundUnitPattern1`
+- `units/unitLength[@type="%anyAttribute"]/compoundUnit[@type="%anyAttribute"]/compoundUnitPattern1`
 
 Special pattern used to compose powers of a unit, such as meters squared. Note: before translating, be sure to read [Compound Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/compoundUnit[@type="%anyAttribute"\]/compoundUnitPattern`
+- `units/unitLength[@type="%anyAttribute"]/compoundUnit[@type="%anyAttribute"]/compoundUnitPattern`
 
 Special pattern used to compose forms of two units, such as meters per second. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/compoundUnit[@type="%anyAttribute"\]/unitPrefixPattern`
+- `units/unitLength[@type="%anyAttribute"]/compoundUnit[@type="%anyAttribute"]/unitPrefixPattern`
 
 Special pattern used to compose a metric prefix with a unit, such as kilo{0} with meters to produce kilometers. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/coordinateUnit/displayName`
+- `units/unitLength[@type="%anyAttribute"]/coordinateUnit/displayName`
 
 Display name ({1} form) for the type of direction used in latitude and longitude, such as north or east. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/coordinateUnit/coordinateUnitPattern[@type="%anyAttribute"\]`
+- `units/unitLength[@type="%anyAttribute"]/coordinateUnit/coordinateUnitPattern[@type="%anyAttribute"]`
 
 Special pattern used in latitude and longitude, such as 12°N. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="area-acre"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="area-acre"]/displayName`
 
 Display name ({1} form) for “area-acre”, referring specifically to an English acre. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="duration-day"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="duration-day"]/displayName`
 
 Display name ({1} form) for “duration-day”, meaning a time duration of 24 hours (not a calendar day). Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="energy-calorie"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="energy-calorie"]/displayName`
 
 Display name ({1} form) for “energy-calorie”, calories as used in chemistry, not the same as food calorie. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="energy-foodcalorie"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="energy-foodcalorie"]/displayName`
 
 Display name ({1} form) for “energy-foodcalorie”, kilocalories for food energy; may have same translation as energy-kilocalorie. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="energy-kilocalorie"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="energy-kilocalorie"]/displayName`
 
 Display name ({1} form) for “energy-kilocalorie”, kilocalories for uses not specific to food energy, such as chemistry. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-em"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-em"]/displayName`
 
 Display name ({1} form) for “graphics-em”, referring to typographic length equal to a font’s point size. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-pixel"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-pixel"]/displayName`
 
 Display name ({1} form) for “graphics-pixel”, used for counting the individual elements in bitmap image. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-megapixel"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-megapixel"]/displayName`
 
 Display name ({1} form) for “graphics-megapixel”, used for counting the individual elements in bitmap image. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-pixel-per-centimeter"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-pixel-per-centimeter"]/displayName`
 
 Display name ({1} form) for “graphics-pixel-per-centimeter”, typically used for display resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-pixel-per-inch"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-pixel-per-inch"]/displayName`
 
 Display name ({1} form) for “graphics-pixel-per-inch”, typically used for display resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-dot-per-centimeter"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-dot-per-centimeter"]/displayName`
 
 Display name ({1} form) for “graphics-dot-per-centimeter”, typically used for printer resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="graphics-dot-per-inch"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="graphics-dot-per-inch"]/displayName`
 
 Display name ({1} form) for “graphics-dot-per-inch”, typically used for printer resolution. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="length-point"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="length-point"]/displayName`
 
 Display name ({1} form) for “length-point”, referring to a typographic point, 1/72 inch. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="mass-stone"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="mass-stone"]/displayName`
 
 Display name ({1} form) for “mass-stone”, used in UK/Ireland for body weight, equal to 14 pounds. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="mass-ton"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="mass-ton"]/displayName`
 
 Display name ({1} form) for “mass-ton”, meaning U.S. short ton, not U.K. long ton or metric ton. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="%anyAttribute"\]/displayName`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="%anyAttribute"]/displayName`
 
 Display name ({1} form) for “{2}”. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="%anyAttribute"\]/unitPattern`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="%anyAttribute"]/unitPattern`
 
 [ICU Syntax] Special pattern used to compose plural for {1} forms of “{2}”. Note: before translating, be sure to read [Plurals].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="%anyAttribute"\]/gender`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="%anyAttribute"]/gender`
 
 Gender ({1} form) for “{2}”. Note: before translating, be sure to read [Grammatical Inflection].
 
 ###
 
-- `units/unitLength[@type="%anyAttribute"\]/unit[@type="%anyAttribute"\]/perUnitPattern`
+- `units/unitLength[@type="%anyAttribute"]/unit[@type="%anyAttribute"]/perUnitPattern`
 
 Special pattern ({1} form) used to compose values per unit, such as “meters per {2}”. Note: before translating, be sure to read [Units].
 
 ###
 
-- `units/durationUnit[@type="(hms|hm|ms)"\]`
+- `units/durationUnit[@type="(hms|hm|ms)"]`
 
 [ICU Syntax] Special pattern used to compose duration units. Note: before translating, be sure to read [Plurals].
 
 ###
 
-- `numbers/decimalFormats[@numberSystem="%anyAttribute"\]/decimalFormatLength[@type="%anyAttribute"\]/decimalFormat[@type="%anyAttribute"\]/pattern[@type="%anyAttribute"\]`
+- `numbers/decimalFormats[@numberSystem="%anyAttribute"]/decimalFormatLength[@type="%anyAttribute"]/decimalFormat[@type="%anyAttribute"]/pattern[@type="%anyAttribute"]`
 
 Special pattern used for a short version of numbers with the same number of digits as {4}. Note: before translating, be sure to read [Short Numbers].
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/currencyFormatLength[@type="short"\]/currencyFormat[@type="standard"\]/pattern[@type="(\d+)"\][@count="(%nonQuote+)"\]`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/currencyFormatLength[@type="short"]/currencyFormat[@type="standard"]/pattern[@type="(\d+)"][@count="(%nonQuote+)"]`
 
 Special currency pattern used to obtain the abbreviated plural forms of numbers with the same number of digits as {2}. See [Short Numbers] for details.
 
 ###
 
-- `numbers/decimalFormats[@numberSystem="%anyAttribute"\]/decimalFormatLength[@type="short"\]/decimalFormat[@type="standard"\]/pattern[@type="(\d+)"\][@count="(%nonQuote+)"\]`
+- `numbers/decimalFormats[@numberSystem="%anyAttribute"]/decimalFormatLength[@type="short"]/decimalFormat[@type="standard"]/pattern[@type="(\d+)"][@count="(%nonQuote+)"]`
 
 Special decimal pattern used to obtain the abbreviated plural forms of numbers with the same number of digits as {2}. See [Short Numbers] for details.
 
 ###
 
-- `numbers/decimalFormats[@numberSystem="%anyAttribute"\]/decimalFormatLength[@type="long"\]/decimalFormat[@type="standard"\]/pattern[@type="(\d+)"\][@count="(%nonQuote+)"\]`
+- `numbers/decimalFormats[@numberSystem="%anyAttribute"]/decimalFormatLength[@type="long"]/decimalFormat[@type="standard"]/pattern[@type="(\d+)"][@count="(%nonQuote+)"]`
 
 Special decimal pattern used to obtain the long plural forms of numbers with the same number of digits as {2}. See [Plural Numbers] for details.
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/currencyPatternAppendISO`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/currencyPatternAppendISO`
 
 Pattern used to combine a regular currency format with an ISO 4217 code (¤¤). For more information, please see [Number Patterns].
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/unitPattern[@count="(\w++)"\]`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/unitPattern[@count="(\w++)"]`
 
 Currency format used for numbers of type {2}. For more information, please see [Number Patterns].
 
 ###
 
-- `numbers/miscPatterns[@numberSystem="%anyAttribute"\]/pattern[@type="range"\]`
+- `numbers/miscPatterns[@numberSystem="%anyAttribute"]/pattern[@type="range"]`
 
 Format used to indicate a range of numbers. The '{'0'}' and '{'1'}' in the pattern represent the lowest and highest numbers in the range, respectively. For more information, please see [Units Misc Help].
 
@@ -558,55 +558,55 @@ Format used to indicate a range of numbers. The '{'0'}' and '{'1'}' in the patte
 
 ###
 
-- `numbers/miscPatterns[@numberSystem="%anyAttribute"\]/pattern[@type="atLeast"\]`
+- `numbers/miscPatterns[@numberSystem="%anyAttribute"]/pattern[@type="atLeast"]`
 
 Format used to indicate a number is at least a certain value, often combined with other patterns to produce examples such as “≥12kg”. For more information, please see [Units Misc Help].
 
 ###
 
-- `numbers/miscPatterns[@numberSystem="%anyAttribute"\]/pattern[@type="atMost"\]`
+- `numbers/miscPatterns[@numberSystem="%anyAttribute"]/pattern[@type="atMost"]`
 
 Format used to indicate a number is at most a certain value, often combined with other patterns to produce examples such as “≤12kg”. For more information, please see [Units Misc Help].
 
 ###
 
-- `numbers/miscPatterns[@numberSystem="%anyAttribute"\]/pattern[@type="approximately"\]`
+- `numbers/miscPatterns[@numberSystem="%anyAttribute"]/pattern[@type="approximately"]`
 
 Format used to indicate a number is approximately a given value, often combined with other patterns to produce examples such as “~12kg”. For more information, please see [Units Misc Help].
 
 ###
 
-- `numbers/minimalPairs/ordinalMinimalPairs[@ordinal="%anyAttribute"\]`
+- `numbers/minimalPairs/ordinalMinimalPairs[@ordinal="%anyAttribute"]`
 
 Minimal pairs for ordinals. For more information, please see [Plural Minimal Pairs].
 
 ###
 
-- `numbers/minimalPairs/pluralMinimalPairs[@count="%anyAttribute"\]`
+- `numbers/minimalPairs/pluralMinimalPairs[@count="%anyAttribute"]`
 
 Minimal pairs for plurals (cardinals). For more information, please see [Plural Minimal Pairs].
 
 ###
 
-- `numbers/minimalPairs/caseMinimalPairs[@case="%anyAttribute"\]`
+- `numbers/minimalPairs/caseMinimalPairs[@case="%anyAttribute"]`
 
 Minimal pairs for cases used in the language. For more information, please see [Grammatical Inflection].
 
 ###
 
-- `numbers/minimalPairs/genderMinimalPairs[@gender="%anyAttribute"\]`
+- `numbers/minimalPairs/genderMinimalPairs[@gender="%anyAttribute"]`
 
 Minimal pairs for genders. For more information, please see [Grammatical Inflection].
 
 ###
 
-- `personNames/nameOrderLocales[@order="%anyAttribute"\]`
+- `personNames/nameOrderLocales[@order="%anyAttribute"]`
 
 Person name order for locales. If there are none with a particular direction, insert ❮EMPTY❯. For more information, please see [Person Name Formats].
 
 ###
 
-- `personNames/parameterDefault[@parameter="%anyAttribute"\]`
+- `personNames/parameterDefault[@parameter="%anyAttribute"]`
 
 Person name default parameters. Make the appropriate formality and length settings for your locale. For more information, please see [Person Name Formats].
 
@@ -624,31 +624,31 @@ For native personal names displayed in your locale, should be ❮EMPTY❯ if you
 
 ###
 
-- `personNames/initialPattern[@type="initial"\]`
+- `personNames/initialPattern[@type="initial"]`
 
 The pattern used for a single initial in person name formats. For more information, please see [Person Name Formats].
 
 ###
 
-- `personNames/initialPattern[@type="initialSequence"\]`
+- `personNames/initialPattern[@type="initialSequence"]`
 
 The pattern used to compose sequences of initials in person name formats. For more information, please see [Person Name Formats].
 
 ###
 
-- `personNames/personName[@order="%anyAttribute"\][@length="%anyAttribute"\][@usage="referring"\][@formality="%anyAttribute"\]`
+- `personNames/personName[@order="%anyAttribute"][@length="%anyAttribute"][@usage="referring"][@formality="%anyAttribute"]`
 
 Person name formats for referring to a person (with a particular order, length, formality). For more information, please see [Person Name Formats].
 
 ###
 
-- `personNames/personName[@order="%anyAttribute"\][@length="%anyAttribute"\][@usage="addressing"\][@formality="%anyAttribute"\]`
+- `personNames/personName[@order="%anyAttribute"][@length="%anyAttribute"][@usage="addressing"][@formality="%anyAttribute"]`
 
 Person name format for addressing a person (with a particular order, length, formality). For more information, please see [Person Name Formats].
 
 ###
 
-- `personNames/personName[@order="%anyAttribute"\][@length="%anyAttribute"\][@usage="monogram"\][@formality="%anyAttribute"\]`
+- `personNames/personName[@order="%anyAttribute"][@length="%anyAttribute"][@usage="monogram"][@formality="%anyAttribute"]`
 
 Person name formats for monograms (with a particular order, length, formality). For more information, please see [Person Name Formats].
 
@@ -660,49 +660,49 @@ Sample names for person name format examples (enter ∅∅∅ for optional unuse
 
 ###
 
-- `numbers/rationalFormats[@numberSystem="%anyAttribute"\]/rationalPattern`
+- `numbers/rationalFormats[@numberSystem="%anyAttribute"]/rationalPattern`
 
 A pattern that is used to format a rational fraction (eg, ½), using the numerator and denominator. See [Rational Numbers].
 
 ###
 
-- `numbers/rationalFormats[@numberSystem="%anyAttribute"\]/integerAndRationalPattern[@alt="%anyAttribute"\]`
+- `numbers/rationalFormats[@numberSystem="%anyAttribute"]/integerAndRationalPattern[@alt="%anyAttribute"]`
 
 A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together; only used when the rational fraction does not start with an un-superscripted digit. See [Rational Numbers].
 
 ###
 
-- `numbers/rationalFormats[@numberSystem="%anyAttribute"\]/integerAndRationalPattern`
+- `numbers/rationalFormats[@numberSystem="%anyAttribute"]/integerAndRationalPattern`
 
 A pattern that is used to “glue” an integer and a formatted rational fraction (eg, ½) together. See [Rational Numbers].
 
 ###
 
-- `numbers/rationalFormats[@numberSystem="%anyAttribute"\]/rationalUsage`
+- `numbers/rationalFormats[@numberSystem="%anyAttribute"]/rationalUsage`
 
 A value that is used to indicate the usage of rational fractions (eg, ½) in your language; **only** pick “never” if it never occurs with this numbering system in your language, including text translated from another language. See [Rational Numbers].
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/currencyFormatLength/currencyFormat[@type="standard"\]/pattern[@type="standard"\][@alt="alphaNextToNumber"\]`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/currencyFormatLength/currencyFormat[@type="standard"]/pattern[@type="standard"][@alt="alphaNextToNumber"]`
 
 Special pattern used to compose currency values when the currency symbol has a letter adjacent to the number. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/currencyFormatLength/currencyFormat[@type="standard"\]/pattern[@type="standard"\][@alt="noCurrency"\]`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/currencyFormatLength/currencyFormat[@type="standard"]/pattern[@type="standard"][@alt="noCurrency"]`
 
 Special pattern used to compose currency values for which no currency symbol should be shown. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/currencyFormatLength/currencyFormat[@type="accounting"\]/pattern`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/currencyFormatLength/currencyFormat[@type="accounting"]/pattern`
 
 Special pattern used to compose currency values for accounting purposes. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `numbers/currencyFormats[@numberSystem="%anyAttribute"\]/currencySpacing/(%letters)/(%letters)`
+- `numbers/currencyFormats[@numberSystem="%anyAttribute"]/currencySpacing/(%letters)/(%letters)`
 
 Special pattern used to compose currency signs ($2/$3) with numbers. Note: before translating, be sure to read [Number Patterns].
 
@@ -711,315 +711,315 @@ Special pattern used to compose currency signs ($2/$3) with numbers. Note: befor
 
 ###
 
-- `numbers/(%lowercaseLetters)Formats([@numberSystem="%anyAttribute"\])?/\1FormatLength/\1Format[@type="standard"\]/pattern[@type="standard"\]$`
+- `numbers/(%lowercaseLetters)Formats([@numberSystem="%anyAttribute"])?/\1FormatLength/\1Format[@type="standard"]/pattern[@type="standard"]$`
 
 Special pattern used to compose {1} numbers. Note: before translating, be sure to read [Number Patterns].
 
 ###
 
-- `listPatterns/listPattern/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern/listPatternPart[@type="2"]`
 
 Special pattern used to make an “and” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make a “and” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="standard-short"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="standard-short"]/listPatternPart[@type="2"]`
 
 Special pattern used to make a short-style “and” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="standard-short"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="standard-short"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make a short-style “and” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="standard-narrow"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="standard-narrow"]/listPatternPart[@type="2"]`
 
 Special pattern used to make a short-style “and” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="standard-narrow"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="standard-narrow"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make a short-style “and” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="or"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="or"]/listPatternPart[@type="2"]`
 
 Special pattern used to make an “or” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="or"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="or"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make an “or” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="or-short"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="2"]`
 
 Special pattern used to make an “or” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="or-short"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="or-short"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make an “or” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="or-narrow"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="2"]`
 
 Special pattern used to make an “or” list out of two standard elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="or-narrow"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="or-narrow"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make an “or” list out of more than two standard elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="unit"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="unit"]/listPatternPart[@type="2"]`
 
 Special pattern used to make a list out of two unit elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="unit"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="unit"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make a list out of more than two unit elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="unit-short"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="unit-short"]/listPatternPart[@type="2"]`
 
 Special pattern used to make a list out of two abbreviated unit elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="unit-short"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="unit-short"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make a list out of more than two abbreviated unit elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="unit-narrow"\]/listPatternPart[@type="2"\]`
+- `listPatterns/listPattern[@type="unit-narrow"]/listPatternPart[@type="2"]`
 
 Special pattern used to make a list out of two narrow unit elements. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `listPatterns/listPattern[@type="unit-narrow"\]/listPatternPart[@type="%anyAttribute"\]`
+- `listPatterns/listPattern[@type="unit-narrow"]/listPatternPart[@type="%anyAttribute"]`
 
 Special pattern used to make a list out of more than two narrow unit elements. This is used for the {1} portion of the list. Note: before translating, be sure to read [Lists].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dayPeriods/dayPeriodContext[@type="(format)"\]/dayPeriodWidth[@type="%anyAttribute"\]/dayPeriod[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dayPeriods/dayPeriodContext[@type="(format)"]/dayPeriodWidth[@type="%anyAttribute"]/dayPeriod[@type="%anyAttribute"]`
 
 Provide the {3}, {2} version of the name for the day period code “{4}”. This version must have the right inflection/prepositions/etc. for adding after a number, such as “in the morning” for use in “10:00 in the morning”. To see the time spans for these codes, please see [Date Time]
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dayPeriods/dayPeriodContext[@type="%anyAttribute"\]/dayPeriodWidth[@type="%anyAttribute"\]/dayPeriod[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dayPeriods/dayPeriodContext[@type="%anyAttribute"]/dayPeriodWidth[@type="%anyAttribute"]/dayPeriod[@type="%anyAttribute"]`
 
 Provide the {3}, {2} version of the name for the day period code “{4}”. To see the time spans for these codes, please see [Date Time]
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/days/dayContext[@type="%anyAttribute"\]/dayWidth[@type="%anyAttribute"\]/day[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/days/dayContext[@type="%anyAttribute"]/dayWidth[@type="%anyAttribute"]/day[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for day-of-the-week {4}. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/eras/eraAbbr/era[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/eras/eraAbbr/era[@type="%anyAttribute"]`
 
 Provide the format-abbreviated version of the name for era {2}. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/eras/eraNames/era[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/eras/eraNames/era[@type="%anyAttribute"]`
 
 Provide the format-wide version of the name for era {1}. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/eras/eraNarrow/era[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/eras/eraNarrow/era[@type="%anyAttribute"]`
 
 Provide the format-narrow version of the name for era {1}. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/months/monthContext[@type="%anyAttribute"\]/monthWidth[@type="%anyAttribute"\]/month[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/months/monthContext[@type="%anyAttribute"]/monthWidth[@type="%anyAttribute"]/month[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for month {4}. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/quarters/quarterContext[@type="%anyAttribute"\]/quarterWidth[@type="%anyAttribute"\]/quarter[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/quarters/quarterContext[@type="%anyAttribute"]/quarterWidth[@type="%anyAttribute"]/quarter[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for quarter {4}. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/fields/field[@type="%anyAttribute"\]/displayName`
+- `dates/fields/field[@type="%anyAttribute"]/displayName`
 
 Provide the name (as it would appear in menus) for the field “{1}”. For more information, please see [Date Time Fields].
 
 ### Relative Today
 
-- `dates/fields/field[@type="day"\]/relative[@type="0"\]`
+- `dates/fields/field[@type="day"]/relative[@type="0"]`
 
 Provide the name for today. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Relative before-today
 
-- `dates/fields/field[@type="day"\]/relative[@type="-(%nonQuote*)"\]`
+- `dates/fields/field[@type="day"]/relative[@type="-(%nonQuote*)"]`
 
 Provide a name for the day, {1} before today. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Relative after-today
 
-- `dates/fields/field[@type="day"\]/relative[@type="%anyAttribute"\]`
+- `dates/fields/field[@type="day"]/relative[@type="%anyAttribute"]`
 
 Provide a name for the day, {1} after today. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### This X
 
-- `dates/fields/field[@type="%anyAttribute"\]/relative[@type="0"\]`
+- `dates/fields/field[@type="%anyAttribute"]/relative[@type="0"]`
 
 Provide the name for “this {1}”. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Last X
 
-- `dates/fields/field[@type="%anyAttribute"\]/relative[@type="-1"\]`
+- `dates/fields/field[@type="%anyAttribute"]/relative[@type="-1"]`
 
 Provide a name for “last {1}”. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Next X
 
-- `dates/fields/field[@type="%anyAttribute"\]/relative[@type="1"\]`
+- `dates/fields/field[@type="%anyAttribute"]/relative[@type="1"]`
 
 Provide a name for “next {1}”. For more information, please see [Relative Dates].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Future Pattern
 
-- `dates/fields/field[@type="%anyAttribute"\]/relativeTime[@type="future"\]/relativeTimePattern[@count="%anyAttribute"\]`
+- `dates/fields/field[@type="%anyAttribute"]/relativeTime[@type="future"]/relativeTimePattern[@count="%anyAttribute"]`
 
 Provide a pattern used to display times in the future. For more information, please see [Date Time Names].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ### Past Pattern
 
-- `dates/fields/field[@type="%anyAttribute"\]/relativeTime[@type="past"\]/relativeTimePattern[@count="%anyAttribute"\]`
+- `dates/fields/field[@type="%anyAttribute"]/relativeTime[@type="past"]/relativeTimePattern[@count="%anyAttribute"]`
 
 Provide a pattern used to display times in the past. For more information, please see [Date Time Names].
 The lettercasing should be appropriate for the top example. If the lettercasing is then wrong for the bottom example, please file a ticket to fix contextTransforms/relative/stand-alone.
 
 ###
 
-- `dates/fields/field[@type="%anyAttribute"\]/relativePeriod`
+- `dates/fields/field[@type="%anyAttribute"]/relativePeriod`
 
 Provide a name for “the {1} of SOME_DATE”. For more information, please see [Date Time Names].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/dateTimeFormatLength[@type="%anyAttribute"\]/dateTimeFormat[@type="standard"\]/pattern[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/dateTimeFormatLength[@type="%anyAttribute"]/dateTimeFormat[@type="standard"]/pattern[@type="%anyAttribute"]`
 
 Provide the {2} version of the date-time pattern suitable for most use cases, including combining a date with a time range. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/dateTimeFormatLength[@type="%anyAttribute"\]/dateTimeFormat[@type="atTime"\]/pattern[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/dateTimeFormatLength[@type="%anyAttribute"]/dateTimeFormat[@type="atTime"]/pattern[@type="%anyAttribute"]`
 
 Provide the {2} version of the date-time pattern suitable for expressing a standard date (e.g. "March 20") at a specific time. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/dateTimeFormatLength[@type="%anyAttribute"\]/dateTimeFormat[@type="relative"\]/pattern[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/dateTimeFormatLength[@type="%anyAttribute"]/dateTimeFormat[@type="relative"]/pattern[@type="%anyAttribute"]`
 
 Provide the {2} version of the date-time pattern suitable for expressing a relative date (e.g. "tomorrow") at a specific time. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateFormats/dateFormatLength[@type="%anyAttribute"\]/dateFormat[@type="%anyAttribute"\]/pattern[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateFormats/dateFormatLength[@type="%anyAttribute"]/dateFormat[@type="%anyAttribute"]/pattern[@type="%anyAttribute"]`
 
 Provide the {2} version of the basic date pattern. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/timeFormats/timeFormatLength[@type="%anyAttribute"\]/timeFormat[@type="%anyAttribute"\]/pattern[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/timeFormats/timeFormatLength[@type="%anyAttribute"]/timeFormat[@type="%anyAttribute"]/pattern[@type="%anyAttribute"]`
 
 Provide the {2} version of the basic time pattern. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/availableFormats/dateFormatItem[@id="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/availableFormats/dateFormatItem[@id="%anyAttribute"]`
 
 Provide the pattern used in your language for the skeleton “{2}”. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/appendItems/appendItem[@request="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/appendItems/appendItem[@request="%anyAttribute"]`
 
 Provide the pattern used in your language to append a “{2}” to another format. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/intervalFormats/intervalFormatFallback`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/intervalFormats/intervalFormatFallback`
 
 The pattern used for “fallback” with date/time intervals. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%anyAttribute"\]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="%anyAttribute"\]/greatestDifference[@id="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%anyAttribute"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="%anyAttribute"]/greatestDifference[@id="%anyAttribute"]`
 
 The pattern used for the date/time interval skeleton “{2}” when the greatest difference is “{3}”. Note: before translating, be sure to read [Date Time Patterns].
 
 ###
 
-- `dates/calendars/calendar[@type="%nonQuote*"\]/cyclicNameSets/cyclicNameSet[@type="%anyAttribute"\]/cyclicNameContext[@type="%anyAttribute"\]/cyclicNameWidth[@type="%anyAttribute"\]/cyclicName[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%nonQuote*"]/cyclicNameSets/cyclicNameSet[@type="%anyAttribute"]/cyclicNameContext[@type="%anyAttribute"]/cyclicNameWidth[@type="%anyAttribute"]/cyclicName[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of type {4} in the {1} name cycle. For more information, please see [Date/time cyclic names].
 
 ###
 
-- `dates/calendars/calendar[@type="%nonQuote*"\]/monthPatterns/monthPatternContext[@type="%anyAttribute"\]/monthPatternWidth[@type="%anyAttribute"\]/monthPattern[@type="%anyAttribute"\]`
+- `dates/calendars/calendar[@type="%nonQuote*"]/monthPatterns/monthPatternContext[@type="%anyAttribute"]/monthPatternWidth[@type="%anyAttribute"]/monthPattern[@type="%anyAttribute"]`
 
 Provide the {1} and {2} version of the name for {3} month types. For more information, please see [Month Names].
 
 ###
 
-- `localeDisplayNames/transformNames/transformName[@type="%anyAttribute"\]`
+- `localeDisplayNames/transformNames/transformName[@type="%anyAttribute"]`
 
 The name of the transform “{1}”. For more information, please see [Transforms].
 
 ###
 
-- `localeDisplayNames/codePatterns/codePattern[@type="%anyAttribute"\]`
+- `localeDisplayNames/codePatterns/codePattern[@type="%anyAttribute"]`
 
 The pattern to be used when displaying a name for a character {0}. For more information, please see [Locale Patterns].
 
 ###
 
-- `localeDisplayNames/measurementSystemNames/measurementSystemName[@type="%anyAttribute"\]`
+- `localeDisplayNames/measurementSystemNames/measurementSystemName[@type="%anyAttribute"]`
 
 The name of the measurement system “{1}”. For more information, please see [Units Misc Help].
 
@@ -1031,67 +1031,67 @@ The word for “{1}”, lowercased, plus any abbreviations separated by a colon.
 
 ###
 
-- `localeDisplayNames/annotationPatterns/annotationPattern[@type="%anyAttribute"\]`
+- `localeDisplayNames/annotationPatterns/annotationPattern[@type="%anyAttribute"]`
 
 The pattern to be used when displaying a {1}. For more information, please see [Locale Patterns].
 
 ###
 
-- `characters/stopwords/stopwordList[@type="%anyAttribute"\]`
+- `characters/stopwords/stopwordList[@type="%anyAttribute"]`
 
 The words that should be ignored in sorting in your language. For more information, see [Units Misc Help].
 
 ###
 
-- `dates/timeZoneNames/zone[@type="%anyAttribute"\]/(%nonSlash*)/(.*)`
+- `dates/timeZoneNames/zone[@type="%anyAttribute"]/(%nonSlash*)/(.*)`
 
 Override for the {3}-{2} timezone name for {1}. For more information, see [Time Zone City Names].
 
 ###
 
-- `typographicNames/axisName[@type="%anyAttribute"\]`
+- `typographicNames/axisName[@type="%anyAttribute"]`
 
 A label for a typographic design axis, such as “Width” or “Weight”. For more information, see [Typography].
 
 ###
 
-- `typographicNames/styleName[@type="%anyAttribute"\][@subtype="%anyAttribute"\]`
+- `typographicNames/styleName[@type="%anyAttribute"][@subtype="%anyAttribute"]`
 
 A label for a typographic style, such as “Narrow” or “Semibold”. For more information, see [Typography].
 
 ###
 
-- `typographicNames/featureName[@type="%anyAttribute"\]`
+- `typographicNames/featureName[@type="%anyAttribute"]`
 
 A label for a typographic feature, such as “Small Capitals”. For more information, see [Typography].
 
 ###
 
-- `characterLabels/characterLabelPattern[@type="%anyAttribute"\][@count="%anyAttribute"\]`
+- `characterLabels/characterLabelPattern[@type="%anyAttribute"][@count="%anyAttribute"]`
 
 A label for a set of characters that has a numeric placeholder, such as “1 Stroke”, “2 Strokes”. For more information, see [Character Labels].
 
 ###
 
-- `characterLabels/characterLabelPattern[@type="%anyAttribute"\]`
+- `characterLabels/characterLabelPattern[@type="%anyAttribute"]`
 
 A modifier composed with a label for a set of characters. For more information, see [Character Labels].
 
 ###
 
-- `characterLabels/characterLabel[@type="%anyAttribute"\]`
+- `characterLabels/characterLabel[@type="%anyAttribute"]`
 
 A label for a set of characters. For more information, see [Character Labels].
 
 ###
 
-- `annotations/annotation[@cp="%anyAttribute"\][@type="tts"\]`
+- `annotations/annotation[@cp="%anyAttribute"][@type="tts"]`
 
 A name for a character or sequence. For more information, see [Short Character Names].
 
 ###
 
-- `annotations/annotation[@cp="%anyAttribute"\]`
+- `annotations/annotation[@cp="%anyAttribute"]`
 
 A set of keywords for a character or sequence. For more information, see [Short Character Names].
 


### PR DESCRIPTION
…backslashes in .md

-No static init for PathDescription.references; parser.getReferences must run after parser.parse

-Make PathDescriptionParser objects temporary, not static, since no longer needed after getPathHandling and getPathHintsHandling have run

-Escaping with backslash is unnecessary when a closing bracket does not correspond to a regex opening bracket

CLDR-17599

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
