### PR TITLE
CLDR-16819 Improve front-end handling of submissions with errors

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -893,16 +893,6 @@ function updateRowOthersCell(tr, theRow, cell, protoButton) {
   if (!hadOtherItems /*!onIE*/) {
     listen(null, tr, cell);
   }
-  if (
-    tr.myProposal &&
-    tr.myProposal.value &&
-    !cldrSurvey.findItemByValue(theRow.items, tr.myProposal.value)
-  ) {
-    // add back my proposal
-    cell.appendChild(tr.myProposal);
-  } else {
-    tr.myProposal = null; // not needed
-  }
 }
 
 /**


### PR DESCRIPTION
-Eliminate element tr.myProposal, which was displayed temporarily as though it were one of the candidate items received from the server, but had problems such as not being selectable, and staying visible indefinitely but disappearing on refresh; instead, if the vote/submission was rejected, show whatever needs to be shown using the notification interface

-Fix a problem where two notifications were displayed, one on top of the other, if a Vetter voted for an already-winning item with errors (submitted previously by TC); combine into a single notification

-Display the value as part of the notification

-Minor refactoring; remove some dead code

-Comments

CLDR-16819

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
