### PR TITLE
CLDR-19000 json: update again for rational patterns

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/json/LdmlConvertRules.java
@@ -37,6 +37,7 @@ class LdmlConvertRules {
                     "currency:displayName:count",
                     "numbers:symbols:numberSystem",
                     "numbers:decimalFormats:numberSystem",
+                    "numbers:rationalFormats:numberSystem",
                     "numbers:currencyFormats:numberSystem",
                     "numbers:percentFormats:numberSystem",
                     "numbers:scientificFormats:numberSystem",

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/json/pathTransforms.txt
@@ -79,12 +79,16 @@
 > $1/$3
 
 # add type=standard
-< (.*/numbers/(decimal|scientific|percent|currency|rational)Formats\[@numberSystem="([^"]*)"\])/(decimal|scientific|percent|currency|rational)FormatLength/(decimal|scientific|percent|currency|rational)Format\[@type="standard"]/pattern.*$
+< (.*/numbers/(decimal|scientific|percent|currency)Formats\[@numberSystem="([^"]*)"\])/(decimal|scientific|percent|currency)FormatLength/(decimal|scientific|percent|currency|rational)Format\[@type="standard"]/pattern.*$
 > $1/standard
 
 # Add "type" attribute with value "standard" if there is no "type" in "decimalFormatLength".
-< (.*/numbers/(decimal|scientific|percent|rational)Formats\[@numberSystem="([^"]*)"\]/(decimal|scientific|percent|rational)FormatLength)/(.*)$
+< (.*/numbers/(decimal|scientific|percent)Formats\[@numberSystem="([^"]*)"\]/(decimal|scientific|percent)FormatLength)/(.*)$
 > $1[@type="standard"]/$5
+
+# Add "type" attribute with value "standard" if there is no "type".
+< (.*/numbers/(rationalFormats)\[@numberSystem="([^"]*)"\])/(.*)$
+> $1[@type="$2"]/$4
 
 #
 < (.*/listPattern)/(.*)$


### PR DESCRIPTION
- corrects earlier issue
- this PR is based right off **release-48-beta1**

Keys now look like this:

```
  "rationalFormats-numberSystem-latn": {
    "rationalPattern": "{0}⁄{1}",
    "integerAndRationalPattern": "{0} {1}",
    "integerAndRationalPattern-alt-superSub": "{0}⁠{1}",
    "rationalUsage": "sometimes"
  },
```

CLDR-19000

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
