### PR TITLE
CLDR-11536 Fixed literal quoting in intervalFormatFallback, clarified quoting requirement in spec

### DIFF
--- a/common/main/es_CO.xml
+++ b/common/main/es_CO.xml
@@ -69,7 +69,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="GyMMMEd" draft="contributed">E, d MMM 'de' y G</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">{0} ‘al’ {1}</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} al {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d 'a' d</greatestDifference>
 						</intervalFormatItem>
@@ -269,7 +269,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMd" draft="contributed">d 'de' MMM 'de' y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">{0} ‘al’ {1}</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} al {1}</intervalFormatFallback>
 						<intervalFormatItem id="d">
 							<greatestDifference id="d" draft="contributed">d 'a' d</greatestDifference>
 						</intervalFormatItem>

--- a/common/main/vmw.xml
+++ b/common/main/vmw.xml
@@ -102,7 +102,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 						<dateFormatItem id="yMMMd" draft="contributed">d MMM y</dateFormatItem>
 					</availableFormats>
 					<intervalFormats>
-						<intervalFormatFallback draft="contributed">{0} ‘mpakha’ {1}</intervalFormatFallback>
+						<intervalFormatFallback draft="contributed">{0} mpakha {1}</intervalFormatFallback>
 					</intervalFormats>
 				</dateTimeFormats>
 			</calendar>


### PR DESCRIPTION
CLDR-11536

- [x] This PR completes the ticket.

- Remove attempted quoting of literal text in intervalFormatFallback (literal text in that pattern should not be quoted; but in the cases here the attempt to quote was also using curly quotes)

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-11536)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
