### PR TITLE
CLDR-18576 start/end in era supplemental data

### DIFF
--- a/docs/ldml/tr35-modifications.md
+++ b/docs/ldml/tr35-modifications.md
@@ -59,6 +59,9 @@ The LDML specification is divided into the following parts:
 
 ### Locale Identifiers
 * [Special Script Codes](tr35.md#special-script-codes) Added the `Hntl` compound script. (This is also reflected in the `<scriptData>` elements in supplementalData.xml.)
+* [Likely Subtags](tr35.md#likely-subtags) Changed the Canonicalize step to point to the section on canonicalization.
+* [Unicode Locale Identifier](tr35.md#unicode-locale-identifier) Changed the `attribute` component in the EBNF to be `uattribute` for consistency with `ufield`, etc.
+and to reduce confusion with XML attributes.
   
 ### Misc.
 * [Character Elements](tr35-general.md#character-elements) Added new exemplar types.
@@ -75,6 +78,7 @@ and updated the guidelines for using the different `dateTimeFormat` types.
 * [Time Zone Format Terminology](tr35-dates.md#time-zone-format-terminology) Added the **Localized GMT format** (replacing the **Specific location format**).
 This affects the behavior of the `z` timezone format symbol.
 There is also now a mechanism for finding the region code from short timezone identifier, which is used for the _non-location formats (generic or specific)_
+* [Calendar Data](tr35-dates.md#calendar-data) Specified more precisely the meaning of the `era` attributes in supplemental data, and how to determine the transition point in time between eras.
 
 ### Numbers
 * [Plural rules syntax](tr35-numbers.md#plural-rules-syntax) Added substantial clarifications and new examples.

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -511,14 +511,14 @@ A _Unicode locale identifier_ is composed of a Unicode language identifier plus 
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------- |
 | <a name="unicode_locale_id" href="#unicode_locale_id">`unicode_locale_id`</a>                         | `= unicode_language_id`<br/>  `extensions*`<br/>  `pu_extensions? ;` |
 | <a name="extensions" href="#extensions">`extensions`</a>                                              | `= unicode_locale_extensions`<br/>`\| transformed_extensions`<br/>` \| other_extensions ;` |
-| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>  `((sep ufield)+`<br/>  `\|(sep attribute)+ (sep ufield)*) ;` |
+| <a name="unicode_locale_extensions" href="#unicode_locale_extensions">`unicode_locale_extensions`</a> | `= sep [uU]`<br/>  `((sep keyword)+`<br/>  `\|(sep uattribute)+ (sep ufield)*) ;` |
 | <a name="transformed_extensions" href="#transformed_extensions">`transformed_extensions`</a>          | `= sep [tT]`<br/>  `((sep tlang (sep tfield)*)`<br/>  `\| (sep tfield)+) ;` |
 | <a name="pu_extensions" href="#pu_extensions">`pu_extensions`</a>                                     | `= sep [xX]`<br/>`  (sep alphanum{1,8})+ ;` |
 | <a name="other_extensions" href="#other_extensions">`other_extensions`</a>                            | `= sep [alphanum-[tTuUxX]]`<br/>`  (sep alphanum{2,8})+ ;` |
 | <a name="ufield" href="#ufield">`ufield`</a><br/>(Also known as `keyword`)                            | `= ukey (sep uvalue)? ;` |
 | <a name="ukey" href="#ukey">`ukey`</a><br/>(Also known as `key`)                                      | `= alphanum alpha ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-47/common/bcp47) <br/>(Note that this is narrower than in [[RFC6067](https://www.ietf.org/rfc/rfc6067.txt)], so that it is disjoint with `tkey`.) |
 | <a name="uvalue" href="#uvalue">`uvalue`</a><br/>(Also known as `type`)                               | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Key_Type_Definitions)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-47/common/bcp47) |
-| `attribute`                                                                                           | `= alphanum{3,8} ;` |
+| <a name="uattribute" href="#uattribute">`uattribute`</a><br/>(Also known as `attribute`)              | `= alphanum{3,8} ;` |
 | <a name="unicode_subdivision_id" href="#unicode_subdivision_id">`unicode_subdivision_id`</a>          | `= `[`unicode_region_subtag`](#unicode_region_subtag)` unicode_subdivision_suffix ;` | [`validity`](#unicode_subdivision_subtag_validity)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-47/common/validity/subdivision.xml) |
 | `unicode_subdivision_suffix`                                                                          | `= alphanum{1,4} ;` |
 | <a name="unicode_measure_unit" href="#unicode_measure_unit">`unicode_measure_unit`</a>                | `= alphanum{3,8}`<br/>`  (sep alphanum{3,8})* ;` | [`validity`](#Validity_Data)<br/>[`latest-data`](https://github.com/unicode-org/cldr/blob/maint/maint-47/common/validity/unit.xml) |
@@ -2507,18 +2507,14 @@ A subtag is called _empty_ if it is a missing script or region subtag, or it is 
 This operation is performed in the following way.
 
 1. **Canonicalize.**
-   1. Make sure the input locale is in canonical form: uses the right separator, and has the right casing.
-   2. Replace any deprecated subtags with their canonical values using the `<alias>` data in supplemental metadata. Use the first value in the replacement list, if it exists.
-      Language tag replacements may have multiple parts, such as "sh" ➞ "sr_Latn" or "mo" ➞ "ro_MD". In such a case, the original script and/or region are retained if there is
-      one. Thus "sh_Arab_AQ" ➞ "sr_Arab_AQ", not "sr_Latn_AQ".
-      * There are certain exceptions to this: some implementations still use three obsolete language subtags: iw, in, and yi.
-        The likely subtags data currently supports those implementations by providing elements that handle them,
-        with the deprecated code on both sides: `<likelySubtag from="iw"to="iw_Hebr_IL"/>`
-        Such implementations may refrain from replacing those deprecated tags.
-   3. If the tag is a legacy language tag (marked as “Type: grandfathered” in BCP 47; see `<variable id="$grandfathered" type="choice">` in the supplemental data), then return it.
-   4. Remove the script code 'Zzzz' and the region code 'ZZ' if they occur.
-   5. Get the components of the cleaned-up source tag _(language<sub>s</sub>, script<sub>s</sub>,_ and _region<sub>s</sub>_), plus any variants and extensions.
-   6. If the language is not 'und' and the other two components are not empty, return the language tag composed of _language<sub>s</sub>\_script<sub>s</sub>\_region<sub>s</sub>_ + variants + extensions.
+   1. Canonicalize the locale ID, according to [LocaleID Canonicalization](#annex-c-localeid-canonicalization).
+       * Some implementations still use three obsolete language subtags: iw, in, and yi.
+The likely subtags data currently supports those implementations by providing elements that handle them, with the deprecated code on both sides:
+`<likelySubtag from="iw" to="iw_Hebr_IL"/>`.
+Such implementations may refrain from replacing those deprecated tags while canonicalizing.
+   2. Remove the script code 'Zzzz' and the region code 'ZZ' if they occur.
+   3. Get the components of the cleaned-up source tag _(language<sub>s</sub>, script<sub>s</sub>,_ and _region<sub>s</sub>_), plus any variants and extensions.
+   4. If the language is not 'und' and the other two components are not empty, return the language tag composed of _language<sub>s</sub>\_script<sub>s</sub>\_region<sub>s</sub>_ + variants + extensions.
 2. **Lookup.** Look up each of the following in order, and stop on the first match:
    1. _language<sub>s</sub>\_script<sub>s</sub>\_region<sub>s</sub>_
    2. _language<sub>s</sub>\_script<sub>s</sub>_


### PR DESCRIPTION
CLDR-18576

This needed a bit more surgery than I thought.
- replaced outdated examples
- cleaned up the `type`
- connected start/end to to/from
- defined some illegal cases
- dropped a bunch of outdated conditions (the 1/2/3) in the diff

**Question**
why do some calendars have a code and others do not?
```xml
    <calendar type="persian">
      <calendarSystem type="solar"/>
      <eras>
          <era type="0" start="622-03-21" code="ap"/> <!-- Anno Persico -->
      </eras>
    </calendar>
    <calendar type="dangi">
      <calendarSystem type="lunisolar"/>
      <eras>
          <era type="0" start="-2332-02-15"/> <!-- 'sequential' year -->
      </eras>
    </calendar>
```

I'll also file a ticket for the following:
- https://github.com/unicode-org/cldr/blob/main/docs/ldml/tr35.md#date-and-date-ranges
  - Should mention start/end (used in eras)
  - The DTD should allow what the spec has, eg 1900-09-30 10:45:00 (optionally omitting minute, or minute-second)
  - The spec has "The dates and times are specified in local time, unless otherwise noted." But we don't define how an implementation is to compute _which_ local time is meant. And should we support timezones in start/end?
- To clean up edge cases, we should:
  - deprecate `end` attributes, and only have start dates.
  - force the `type` values to have the same order as the start dates. That is, if we have
    - \<era type=X start=Y>
	- \<era type=Z start=W>
	- then x < Z iff Y < W

That is in https://unicode-org.atlassian.net/browse/CLDR-19023, with a few more details.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
