### PR TITLE
CLDR-16819 Change text of one notification; renaming; refactoring

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPI.java
@@ -177,7 +177,6 @@ public class VoteAPI {
         public static final class Row {
 
             public static final class Candidate {
-                public String displayValue;
                 public String example;
                 public String history;
                 public boolean isBaselineValue;
@@ -418,7 +417,7 @@ public class VoteAPI {
         public boolean didVote;
 
         @Schema(description = "If set, some other reason why the submission failed.")
-        public String didNotSubmit;
+        public String reasonNotSubmitted;
 
         @Schema(description = "If not ALLOW_*, gives reason why the voting was not allowed.")
         public StatusAction statusAction = null;
@@ -427,15 +426,15 @@ public class VoteAPI {
         public CheckStatusSummary[] testResults;
 
         @Schema(description = "True if testResults include warnings.")
-        public boolean testWarnings;
+        public boolean hasTestWarnings;
 
         @Schema(description = "True if testResults include errors.")
-        public boolean testErrors;
+        public boolean hasTestErrors;
 
         void setTestResults(List<CheckStatus> testResults) {
             this.testResults = new CheckStatusSummary[testResults.size()];
-            this.testWarnings = has(testResults, CheckStatus.warningType);
-            this.testErrors = has(testResults, CheckStatus.errorType);
+            this.hasTestWarnings = has(testResults, CheckStatus.warningType);
+            this.hasTestErrors = has(testResults, CheckStatus.errorType);
             for (int i = 0; i < testResults.size(); i++) {
                 this.testResults[i] = new CheckStatusSummary(testResults.get(i));
             }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/VoteAPIHelper.java
@@ -646,7 +646,7 @@ public class VoteAPIHelper {
 
     private static void normalizedToZeroLengthError(VoteResponse r, List<CheckStatus> result) {
         final String message = "DAIP returned a 0 length string";
-        r.didNotSubmit = message;
+        r.reasonNotSubmitted = message;
         r.statusAction = CheckCLDR.StatusAction.FORBID_ERRORS;
         String[] list = {message};
         result.add(

--- a/tools/cldr-apps/src/test/java/org/unicode/cldr/web/DataDrivenSTTestHandler.java
+++ b/tools/cldr-apps/src/test/java/org/unicode/cldr/web/DataDrivenSTTestHandler.java
@@ -484,11 +484,11 @@ final class DataDrivenSTTestHandler extends XMLFileReader.SimpleHandler {
                         "exception="
                                 + needException
                                 + " but got status "
-                                + r.didNotSubmit
+                                + r.reasonNotSubmitted
                                 + " - "
                                 + r.toString());
             } else {
-                System.out.println(" status = " + r.didNotSubmit);
+                System.out.println(" status = " + r.reasonNotSubmitted);
             }
         } catch (Throwable iae) {
             if (needException == true) {


### PR DESCRIPTION
-Change notification heading, from: Response to voting; to: Vote not allowed

-Rename three json response items: name should sound like boolean if and only if it is boolean; change boolean testWarnings/testErrors to hasTestWarnings/hasTestErrors; change String didNotSubmit to reasonNotSubmitted

-Refactor JS function showProposedItem: do not use absence or presence of json parameter to distinguish between vote submitted or not submitted; divide into smaller functions showVoteNotSubmitted, showVoteNotAllowed, showProposedItem

CLDR-16819

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
