### PR TITLE
CLDR-18843 Remove organization Special

### DIFF
--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/OrgList.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/OrgList.java
@@ -59,9 +59,7 @@ public class OrgList {
                         () -> {
                             Map<String, String> map = new TreeMap<>();
                             for (Organization o : Organization.values()) {
-                                if (o.visibleOnFrontEnd()) {
-                                    map.put(o.name(), o.getDisplayName());
-                                }
+                                map.put(o.name(), o.getDisplayName());
                             }
                             return map;
                         });

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/SubmissionLocales.java
@@ -37,10 +37,6 @@ public final class SubmissionLocales {
     public static final Set<String> CLDR_LOCALES =
             StandardCodes.make().getLocaleToLevel(Organization.cldr).keySet();
 
-    /** This is the 'special' list from Locales.txt */
-    public static final Set<String> SPECIAL_ORG_LOCALES =
-            StandardCodes.make().getLocaleToLevel(Organization.special).keySet();
-
     /**
      * Non-CLDR Locales, but consistently have high level of engagement from volunteers to keep at
      * modern level. Reevaluate for each release based on meeting 95+% of modern, moderate, and
@@ -49,16 +45,10 @@ public final class SubmissionLocales {
     public static Set<String> HIGH_LEVEL_LOCALES =
             ImmutableSet.of(
                     // Note: ALL of these were found in Locales.txt under cldr.
-                    "chr", // Cherokee
                     "gd", // Scottish Gaelic, Gaelic
-                    "fo", // Faroese
                     "kok", // Konkani
                     "pcm", // Nigerian Pidgin
-                    "ha", // Hausa
-                    "hsb", // Upper Sorbian
-                    "dsb", // Lower Sorbian
-                    "yue_Hans", // Cantonese (Simplified)
-                    "to" //  Tongan
+                    "ha" // Hausa
                     );
 
     public static final Set<String> CLDR_OR_HIGH_LEVEL_LOCALES =
@@ -98,7 +88,6 @@ public final class SubmissionLocales {
         LOCALES_FOR_LIMITED = ImmutableSortedSet.copyOf(temp);
 
         Set<String> temp2 = new HashSet<>(CLDR_LOCALES);
-        temp2.removeAll(SPECIAL_ORG_LOCALES);
         TC_ORG_LOCALES = ImmutableSortedSet.copyOf(temp2);
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLocaleGrowth.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ChartLocaleGrowth.java
@@ -54,9 +54,6 @@ public class ChartLocaleGrowth {
             testInfo.getSupplementalDataInfo();
     static final Set<String> CldrModernLocales =
             StandardCodes.make().getLocaleCoverageLocales(Organization.cldr, Set.of(Level.MODERN));
-    static final Set<String> SpecialLocales =
-            StandardCodes.make()
-                    .getLocaleCoverageLocales(Organization.special, Set.of(Level.MODERN));
 
     private static org.unicode.cldr.util.Factory factory =
             testInfo.getCommonAndSeedAndMainAndAnnotationsFactory();
@@ -371,7 +368,6 @@ public class ChartLocaleGrowth {
 
             if (showMissing) {
                 if (CldrModernLocales.contains(locale)) {
-                    final boolean isSpecial = SpecialLocales.contains(locale);
                     if (firstShowMissing) {
                         firstShowMissing = false;
                         log.printlnWithTabs(
@@ -388,7 +384,7 @@ public class ChartLocaleGrowth {
                             16,
                             locale
                                     + "\t"
-                                    + (isSpecial ? "" : "TC")
+                                    + "TC"
                                     + show(
                                             Level.CORE,
                                             foundCounter,
@@ -414,23 +410,21 @@ public class ChartLocaleGrowth {
                                             foundCounter,
                                             unconfirmedCounter,
                                             missingCounter));
-                    if (!isSpecial) {
-                        long count = unconfirmedCounter.getTotal() + missingCounter.getTotal();
-                        for (Entry<MissingStatus, String> statusAndPath : missingPaths.entrySet()) {
-                            logPaths.printlnWithTabs(
-                                    3,
-                                    locale
-                                            + "\t"
-                                            + count
-                                            + "\t"
-                                            + statusAndPath.getKey()
-                                            + "\t"
-                                            + statusAndPath.getValue());
-                        }
-                        for (String path : unconfirmedPaths) {
-                            logPaths.printlnWithTabs(
-                                    3, locale + "\t" + count + "\tunconfirmed\t" + path);
-                        }
+                    long count = unconfirmedCounter.getTotal() + missingCounter.getTotal();
+                    for (Entry<MissingStatus, String> statusAndPath : missingPaths.entrySet()) {
+                        logPaths.printlnWithTabs(
+                                3,
+                                locale
+                                        + "\t"
+                                        + count
+                                        + "\t"
+                                        + statusAndPath.getKey()
+                                        + "\t"
+                                        + statusAndPath.getValue());
+                    }
+                    for (String path : unconfirmedPaths) {
+                        logPaths.printlnWithTabs(
+                                3, locale + "\t" + count + "\tunconfirmed\t" + path);
                     }
                     int line = 0;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListCoverageLevels.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ListCoverageLevels.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
-import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.collect.TreeMultimap;
 import com.google.common.collect.TreeMultiset;
@@ -69,10 +68,7 @@ public class ListCoverageLevels {
 
     static final StandardCodes stdCodes = StandardCodes.make();
 
-    static final Set<String> cldrCoverage =
-            Sets.difference(
-                    stdCodes.getLocaleCoverageLocales(Organization.cldr),
-                    stdCodes.getLocaleCoverageLocales(Organization.special));
+    static final Set<String> cldrCoverage = stdCodes.getLocaleCoverageLocales(Organization.cldr);
 
     private static String levelName(Level level) {
         return level == Level.COMPREHENSIVE ? "ꞏ" + level : level.toString();

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowInconsistentAvailable.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowInconsistentAvailable.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.text.DateIntervalInfo;
 import com.ibm.icu.text.DateIntervalInfo.PatternInfo;
@@ -86,18 +85,14 @@ public class ShowInconsistentAvailable {
     public static void main(String[] args) {
         MyOptions.parse(args);
         Set<String> cldrLocales = StandardCodes.make().getLocaleCoverageLocales(Organization.cldr);
-        Set<String> specialLocales =
-                StandardCodes.make().getLocaleCoverageLocales(Organization.special);
-        final Set<String> cldrLocalesWithoutSpecial = Sets.difference(cldrLocales, specialLocales);
-
         if (MyOptions.ordering.option.doesOccur()) {
-            showOrdering(cldrLocalesWithoutSpecial);
+            showOrdering(cldrLocales);
         }
         if (MyOptions.root.option.doesOccur()) {
             getRootPaths();
         }
         if (MyOptions.inconsistencies.option.doesOccur()) {
-            showInconsistencies(cldrLocalesWithoutSpecial);
+            showInconsistencies(cldrLocales);
         }
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLocaleCoverage.java
@@ -603,7 +603,6 @@ public class ShowLocaleCoverage {
 
                     final Level cldrLocaleLevelGoal =
                             SC.getLocaleCoverageLevel(Organization.cldr, locale);
-                    final String specialFlag = getSpecialFlag(locale);
 
                     final boolean cldrLevelGoalBasicToModern =
                             Level.CORE_TO_MODERN.contains(cldrLocaleLevelGoal);
@@ -652,8 +651,7 @@ public class ShowLocaleCoverage {
                         }
                         String goalFlag = cldrLocaleLevelGoal == adjustedGoal ? "" : "*";
                         tsv_missing_counts.println(
-                                specialFlag
-                                        + locale
+                                locale
                                         + "\t"
                                         + goalFlag
                                         + adjustedGoal
@@ -710,7 +708,6 @@ public class ShowLocaleCoverage {
                                                 locale,
                                                 language,
                                                 script,
-                                                specialFlag,
                                                 file.getStringValue(path),
                                                 goalLevel,
                                                 foundLevel,
@@ -730,7 +727,6 @@ public class ShowLocaleCoverage {
                                                 locale,
                                                 language,
                                                 script,
-                                                specialFlag,
                                                 file.getStringValue(path),
                                                 goalLevel,
                                                 foundLevel,
@@ -775,8 +771,7 @@ public class ShowLocaleCoverage {
                                             .collect(Collectors.joining("; "));
 
                             tsv_missing_basic.println(
-                                    specialFlag
-                                            + locale //
+                                    locale //
                                             + "\t"
                                             + statusData.missing //
                                             + "\t"
@@ -791,8 +786,7 @@ public class ShowLocaleCoverage {
                                     );
                         }
                         tsv_missing_basic.println(
-                                specialFlag
-                                        + locale //
+                                locale //
                                         + "\t"
                                         + starredCounter.missingTotal //
                                         + "\t"
@@ -888,7 +882,7 @@ public class ShowLocaleCoverage {
                     final String visibleLevelGoal =
                             cldrLocaleLevelGoal == Level.UNDETERMINED
                                     ? ""
-                                    : specialFlag + cldrLocaleLevelGoal.toString();
+                                    : cldrLocaleLevelGoal.toString();
                     final String goalComparedToComputed =
                             computed == cldrLocaleLevelGoal
                                     ? " ≡"
@@ -1060,10 +1054,7 @@ public class ShowLocaleCoverage {
                                     + localeSet.size()
                                     + "\t"
                                     + Joiner.on(" ")
-                                            .join(
-                                                    localeSet.stream()
-                                                            .map(x -> x + getSpecialFlag(x))
-                                                            .collect(Collectors.toSet()))
+                                            .join(localeSet.stream().collect(Collectors.toSet()))
                                     + "\t"
                                     + phString);
                 }
@@ -1085,12 +1076,6 @@ public class ShowLocaleCoverage {
 
     private static String linkTsv(String tsvFileName, String anchorText) {
         return "<a href='" + TSV_BASE + tsvFileName + "' target='cldr-tsv'>" + anchorText + "</a>";
-    }
-
-    private static String getSpecialFlag(String locale) {
-        return SC.getLocaleCoverageLevel(Organization.special, locale) == Level.UNDETERMINED
-                ? ""
-                : "‡";
     }
 
     private static class IterableFilter implements Iterable<String> {
@@ -1153,7 +1138,6 @@ public class ShowLocaleCoverage {
             String locale,
             String language,
             String script,
-            String specialFlag,
             String nativeValue,
             Level cldrLocaleLevelGoal,
             Level itemLevel,
@@ -1185,8 +1169,7 @@ public class ShowLocaleCoverage {
         }
 
         String line =
-                specialFlag
-                        + language
+                language
                         + "\t"
                         + ENGLISH.nameGetter().getNameFromIdentifier(language)
                         + "\t"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CalculateLocaleCoverage.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CalculateLocaleCoverage.java
@@ -241,7 +241,6 @@ public class CalculateLocaleCoverage {
 
                 final Level cldrLocaleLevelGoal =
                         SC.getLocaleCoverageLevel(Organization.cldr, locale);
-                final String specialFlag = getSpecialFlag(locale);
 
                 final boolean cldrLevelGoalBasicToModern =
                         Level.CORE_TO_MODERN.contains(cldrLocaleLevelGoal);
@@ -456,13 +455,6 @@ public class CalculateLocaleCoverage {
         long end = System.currentTimeMillis();
         logger.info(
                 (end - start) + " millis = " + ((end - start) / localeCount) + " millis/locale");
-    }
-
-    private static String getSpecialFlag(String locale) {
-        return StandardCodes.make().getLocaleCoverageLevel(Organization.special, locale)
-                        == Level.UNDETERMINED
-                ? ""
-                : "‡";
     }
 
     private static class IterableFilter implements Iterable<String> {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DiffLanguageGroups.java
@@ -78,10 +78,7 @@ public class DiffLanguageGroups {
                                 temp.put(x.getKey(), LanguageStatus.OTHER_BASIC_PLUS);
                         });
 
-        Sets.difference(
-                        StandardCodes.make().getLocaleCoverageLocales(Organization.cldr),
-                        StandardCodes.make().getLocaleCoverageLocales(Organization.special))
-                .stream()
+        StandardCodes.make().getLocaleCoverageLocales(Organization.cldr).stream()
                 .forEach(
                         x -> {
                             if (!x.contains("_")) temp.put(x, LanguageStatus.TC);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/Organization.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/Organization.java
@@ -77,7 +77,6 @@ public enum Organization {
     sil("SIL", "SIL International"),
     silicon("Stanford SILICON"),
     sitelen_pona("Sitelen Pona", "Sitelen Pona Publishers and Typographers Association"),
-    special("High Coverage and Generated"),
     srilanka("Sri Lanka ICTA", "Sri Lanka"),
     sunuwar_ws("Sunuwar Sewa Samaj", "Sunuwar Welfare Society"),
     surveytool("Survey Tool"),
@@ -178,9 +177,5 @@ public enum Organization {
             }
         }
         return localeSet;
-    }
-
-    public boolean visibleOnFrontEnd() {
-        return this != Organization.special;
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/VettingViewer.java
@@ -1297,8 +1297,6 @@ public class VettingViewer<T> {
     private String getLocaleStatusColumn(CLDRLocale locale) {
         if (SpecialLocales.getType(locale) == SpecialLocales.Type.algorithmic) {
             return "AL"; // algorithmic
-        } else if (Organization.special.getCoveredLocales().containsLocaleOrParent(locale)) {
-            return "HC"; // high coverage
         } else if (Organization.cldr.getCoveredLocales().containsLocaleOrParent(locale)) {
             return "TC"; // Technical Committee
         } else {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Locales.txt
@@ -540,9 +540,6 @@ Cldr	;	be	;	modern	;	T5	Belarusian
 Cldr	;	cy	;	modern	;	T5	Welsh
 Cldr	;	yue	;	modern	;	T5	Cantonese
 
-#Cldr	Tier	generated
-Cldr	;	sr_Latn	;	modern		;	Tx	Serbian (auto-generated)
-
 #Cldr regional (from Google)
 Cldr	;	es_US	;	modern	; TR Spanish (United States)
 Cldr	;	es_MX	;	modern	; TR Spanish (Mexico)
@@ -553,8 +550,6 @@ Cldr	;	fr_CA	;	modern	; TR French (Canada)
 Cldr	;	de_CH	;	modern	; TR High German (Switzerland)
 
 #Cldr	other (from Apple)
-#Cldr    ;   fo  ;   modern
-#Cldr    ;   to  ;   moderate	# maybe different level from Apple's
 Cldr	;	en_AU	;	modern
 Cldr	;	es_MX	;	modern
 Cldr	;	fr_CA	;	modern
@@ -609,31 +604,17 @@ Cldr    ; doi ; basic ; Dogri
 
 #Cldr other (high coverage locales)
 
-Cldr  ; hsb ; modern ; Upper Sorbian
-Cldr  ; dsb ; modern  ; Lower Sorbian
 Cldr  ; gd  ; modern  ; Scottish Gaelic
-Cldr  ; chr ; modern  ; Cherokee
-Cldr	;	to	;	moderate ; Tongan
-Cldr  ; yue_Hans  ; modern  ; Cantonese (Simplified)
 
-Cldr  ; fo  ; moderate  ; Faroese
-Cldr  ; qu ; modern  ; Quechua
-Cldr  ; br  ; moderate  ; Breton
-Cldr  ; sc  ; moderate  ; Sardinian
-Cldr  ; kgp ; moderate  ; Kaingang
-Cldr  ; yrl ; moderate  ; Nheetgatu
-Cldr  ; ast ; moderate  ; Asturian
-Cldr  ; ff_Adlm ; moderate ; Fulah (Adlam)
-
-Cldr  ; bs_Cyrl ; basic ; Bosnian (Cyrillic)
-Cldr  ; ia  ; basic ; Interlingua
-Cldr  ; kea ; basic ; Kabuverdianu
-Cldr  ; rm  ; basic ; Romansh
 Cldr	;	tg	;	moderate ; Tajik
 Cldr	;	ti	;	moderate ; Tigrinya
 Cldr	;	tt	;	moderate ; Tatar
-Cldr  ; uz_Cyrl ; basic ; Uzbek (Cyrillic)
 Cldr	;	wo	;	moderate ; Wolof
+
+# These 3 are needed to pass test TestCLDRLocaleCoverage.TestCldrSuperset
+Cldr	;	sr_Latn	;   modern	 ;	Tx	Serbian (auto-generated)
+Cldr    ;   qu      ;   modern   ; Quechua
+Cldr	;	to	    ;   moderate ; Tongan
 
 Bangor_Univ ;   cy   ;    modern  ; Welsh
 
@@ -1018,24 +999,3 @@ yahoo ; mul ; modern ;
 #Example of using weight and pathMatch:
 #iaap ; @weight=4 @pathMatch=annotations1,anotations2,characterLabel1,characterLabel2 * ; moderate ;
 
-special	;	ast	;	moderate	;	Asturian
-special ;	br	;	moderate	;	Breton
-special ; bs_Cyrl ; basic ; Bosnian (Cyrillic)
-special ;	chr	;	modern	;	Cherokee
-special ; cv  ; moderate ; Chuvash
-special ;	dsb	;	modern	;	Lower Sorbian
-special ;	ff	;	basic	;	Fulah
-special ;	ff_Adlm	;	moderate	;	Fulah (Adlam)
-special ;	fo	;	moderate	;	Faroese
-special ; ia  ; basic ; Interlingua
-special ;	hsb	;	modern	;	Upper Sorbian
-special ; kea ; basic ; Kabuverdianu
-special ;	kgp	;	moderate	;	Kaingang
-special ; rm  ; basic ; Romansh
-special ;	sc	;	moderate	;	Sardinian
-special ;	sr_Latn	;	modern	;	Serbian (Latn)
-special ;	yrl	;	moderate	;	Nheengatu
-special ;	yue_Hans	;	modern	;	Cantonese (Simplified)
-special ; uz_Cyrl ; basic ; Uzbek (Cyrillic)
-special	;	to	;	moderate ; Tongan
-special  ; qu  ; moderate  ; Quechua

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/tool/ListProblemDates.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/tool/ListProblemDates.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 import com.google.common.collect.TreeMultimap;
 import com.ibm.icu.text.UnicodeSet;
 import java.time.Instant;
@@ -31,10 +30,8 @@ import org.unicode.cldr.util.StandardCodes;
 import org.unicode.cldr.util.XPathParts;
 
 public class ListProblemDates {
-    private static final SetView<String> TC_LOCALES =
-            Sets.difference(
-                    StandardCodes.make().getLocaleCoverageLocales(Organization.cldr),
-                    StandardCodes.make().getLocaleCoverageLocales(Organization.special));
+    private static final Set<String> TC_LOCALES =
+            StandardCodes.make().getLocaleCoverageLocales(Organization.cldr);
     private static final String SAMPLE_ISO_DATE = "2020-01-02T03:04:05Z";
     private static final CLDRConfig CLDR_CONFIG = CLDRConfig.getInstance();
     private static final Factory FACTORY = CLDR_CONFIG.getCldrFactory();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRLocaleCoverage.java
@@ -271,18 +271,16 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                 cldrLocales != null && !cldrLocales.isEmpty());
     }
 
-    /** Tests that cldr+special is a superset of the TC locales, with the right levels */
+    /** Tests that cldr is a superset of the TC locales, with the right levels */
     public void TestCldrSuperset() {
         final Set<Organization> orgs = Organization.getTCOrgs();
 
         Map<Organization, Map<String, Level>> orgToLevels = new TreeMap<>();
         orgs.forEach(org -> orgToLevels.put(org, sc.getLocalesToLevelsFor(org)));
 
-        Map<String, Level> special = sc.getLocalesToLevelsFor(Organization.special);
-
         Map<String, Level> cldr = sc.getLocalesToLevelsFor(Organization.cldr);
 
-        // check that the cldr locales (+ special) have the max level of the TC locales
+        // check that the cldr locales have the max level of the TC locales
 
         for (Entry<String, Level> entry : cldr.entrySet()) {
             final String locale = entry.getKey();
@@ -299,7 +297,6 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                                             }));
 
             Level cldrLevel = entry.getValue();
-            Level specialLevel = special.get(locale);
             boolean cldrLevelIsModern = cldrLevel.compareTo(Level.MODERN) >= 0;
 
             // check the vote count
@@ -339,8 +336,7 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
             }
 
             // check the max level
-            Level maxLevel =
-                    Level.max(specialLevel, Level.max(orgToLevel.values().toArray(new Level[0])));
+            Level maxLevel = Level.max(orgToLevel.values().toArray(new Level[0]));
             assertEquals(
                     "cldr level = max for "
                             + locale
@@ -359,10 +355,6 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
                             final Organization org = e.getKey();
                             final Map<String, Level> l = e.getValue();
                             checkCldrContains("cldr", cldr, org.name(), l);
-                            checkCldrContains("cldr", cldr, "special", l);
-                            // check that special doesn't overlap with TC, except for locales in
-                            // LOCALE_CONTAINMENT_EXCEPTIONS
-                            checkDisjoint("special", special, org.name(), l);
                         });
     }
 
@@ -412,9 +404,6 @@ public class TestCLDRLocaleCoverage extends TestFmwkPlus {
         final Set<String> defaultContentLocales = sd.getDefaultContentLocales();
 
         for (Organization organization : sc.getLocaleCoverageOrganizations()) {
-            if (organization == Organization.special) {
-                continue;
-            }
             final Map<String, Level> localesToLevels = sc.getLocalesToLevelsFor(organization);
             for (Entry<String, Level> localeAndLevel : localesToLevels.entrySet()) {
                 String originalLocale = localeAndLevel.getKey();

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestTransforms.java
@@ -875,10 +875,6 @@ public class TestTransforms extends TestFmwkPlus {
         Set<String> modernCldr =
                 StandardCodes.make()
                         .getLocaleCoverageLocales(Organization.cldr, ImmutableSet.of(Level.MODERN));
-        Set<String> special =
-                StandardCodes.make()
-                        .getLocaleCoverageLocales(
-                                Organization.special, ImmutableSet.of(Level.MODERN));
         Factory factory = CLDRConfig.getInstance().getCommonAndSeedAndMainAndAnnotationsFactory();
         Set<String> missing = new TreeSet<>();
         SampleDataSet badPlusSample = new SampleDataSet();
@@ -894,9 +890,6 @@ public class TestTransforms extends TestFmwkPlus {
         Set<Pair<String, String>> badLocaleScript = new TreeSet<>();
 
         for (String locale : modernCldr) {
-            if (special.contains(locale)) {
-                continue;
-            }
             if (!ltp.set(locale).getRegion().isEmpty()) {
                 continue;
             }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestUnits.java
@@ -4530,10 +4530,7 @@ public class TestUnits extends TestFmwkPlus {
         Set<String> available = factory.getAvailableLanguages();
         Set<String> TC =
                 Sets.intersection(
-                        available,
-                        Sets.difference(
-                                STANDARD_CODES.getLocaleCoverageLocales(Organization.cldr),
-                                STANDARD_CODES.getLocaleCoverageLocales(Organization.special)));
+                        available, STANDARD_CODES.getLocaleCoverageLocales(Organization.cldr));
         // UnitId id = converter.createUnitId("light-speed-second");
         // String lightSeconds1 = id.toString(cldrFile,"long", "other", "nominative", null, true);
         if (isVerbose()) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestStandardCodes.java
@@ -19,7 +19,6 @@ public class TestStandardCodes {
         "doi,BASIC", // CLDR locale
         "nn,MODERN", // CLDR locale
         "hnj,MODERN", // Maximum coverage (hmong)
-        "br,MODERATE", // Maximum (Breton)
         "zxx,BASIC", // "all others: BASIC"
     })
     void testTargetCoverageLevel(final String locale, final String level) {


### PR DESCRIPTION
-Remove Organization.special and special.visibleOnFrontEnd

-Remove all lines from Locales.txt referencing special organization

-Remove lines from Locales.txt referencing Cldr organization where same locale was included for special, with 3 exceptions: sr_Latn, qu, to, which are needed to pass test TestCLDRLocaleCoverage.TestCldrSuperset

-Remove SubmissionLocales.SPECIAL_ORG_LOCALES, no longer need to subtract from CLDR locales

-Revise SubmissionLocales.HIGH_LEVEL_LOCALES, removing some special locales

-Remove ChartLocaleGrowth.SpecialLocales, isSpecial

-No longer need to subtract special from CLDR locales in ListCoverageLevels, ShowInconsistentAvailable, DiffLanguageGroups, ListProblemDates, TestUnits

-In ShowLocaleCoverage, remove specialFlag

-In VettingViewer, remove HC = high coverage for special locales

-In TestStandardCodes.testTargetCoverageLevel, remove assertion for locale br

CLDR-18843

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
