### PR TITLE
CLDR-17846 Survey Tool shows LTR text in RTL locales with punctuation in wrong place

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -43,6 +43,9 @@ const NO_WINNING_VALUE = "no-winning-value";
  */
 const EMPTY_ELEMENT_VALUE = "❮EMPTY❯";
 
+const TRANS_HINT_ID = "en"; // expected to match SurveyMain.TRANS_HINT_ID
+const TRANS_HINT_DIRECTION = "ltr"; // English is left-to-right
+
 /**
  * Remember the element (HTMLTableCellElement or HTMLDivElement) that was most recently
  * shown as "selected" (displayed with a thick border). When a new element gets selected,
@@ -773,8 +776,7 @@ function updateRowEnglishComparisonCell(tr, theRow, cell) {
       trHint = cldrText.get("empty_comparison_cell_hint");
     }
   }
-  const TRANS_HINT_ID = "en"; // expected to match SurveyMain.TRANS_HINT_ID
-  cldrSurvey.setLang(cell, TRANS_HINT_ID);
+  cldrSurvey.setLang(cell, TRANS_HINT_ID, TRANS_HINT_DIRECTION);
   if (theRow.displayExample || trHint || theRow.forumStatus.hasPosts) {
     const infos = document.createElement("div");
     infos.className = "infos-code";
@@ -811,6 +813,7 @@ function updateRowProposedWinningCell(tr, theRow, cell, protoButton) {
   if (theRow.rowFlagged) {
     const flagIcon = cldrSurvey.addIcon(cell, "s-flag");
     flagIcon.title = cldrText.get("flag_desc");
+    cldrSurvey.setLang(flagIcon, TRANS_HINT_ID, TRANS_HINT_DIRECTION);
   }
   cldrSurvey.setLang(cell, null, theRow.dir);
   tr.proposedcell = cell;


### PR DESCRIPTION
-Specify the direction for the flagged-for-review hover text (s-flag span)

-New constant TRANS_HINT_DIRECTION=ltr (left-to-right) goes with existing constant TRANS_HINT_ID=en; change the scope to the whole cldrText.mjs file since it is now used twice, not only in a single function

CLDR-17846

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
