### PR TITLE
CLDR-19050 Now always use latest published version of ICU4J 78rc

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -62,8 +62,8 @@
 		       between CLDR and the updated version of ICU, which would need to be fixed as part
 		       of the PR.
 			-->
-		<icu4j.version>78.0.1-20250924.061614-9</icu4j.version> <!-- before ICU rc, specific dated version -->
-		<!--<icu4j.version>78.1-SNAPSHOT</icu4j.version>--> <!-- after ICU rc, latest published version -->
+		<!--<icu4j.version>78.0.1-20250924.061614-9</icu4j.version>--> <!-- before ICU rc, specific dated version -->
+		<icu4j.version>78.1-SNAPSHOT</icu4j.version> <!-- after ICU rc, latest published version -->
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
 		<maven-surefire-plugin-version>3.3.1</maven-surefire-plugin-version>
 		<assertj-version>3.26.3</assertj-version>


### PR DESCRIPTION
CLDR-19050

- [x] This PR completes the ticket.

Switch to using ICU4J version 78.1-SNAPSHOT now that ICU is at rc and has branched (so now we just always use the latest version of 78.1 published to the maven GitHub repo, not a specific dated one)

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-19050)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
