### PR TITLE
CLDR-18451 Update TerritoryInfo references after v48 changes

### DIFF
--- a/docs/site/downloads/cldr-48.md
+++ b/docs/site/downloads/cldr-48.md
@@ -25,9 +25,7 @@ This data is also a factor in determining which languages are supported on mobil
 
 Some of the most significant changes in this release are:
 - Updated for Unicode 17, including new names and search terms for new emoji, new sort-order, Han → Latin romanization additions for many characters.
-- Many additions to language data including:
-    - Likely Subtags, for deriving the likely script and region from the language (used in many processes).
-    - Language populations in countries: significant updates to improve accuracy and maintainability.
+- Many additions to language data supporting Likely Subtags, for deriving the likely script and region from the language (used in many processes).
 - Updated to the latest external standards and data sources, such as the language subtag registry, UN M49 macro regions, ISO 4217 currencies, etc.
 - New formatting options
     - Rational number formats added, allowing for formats like 5½.
@@ -313,7 +311,7 @@ The following files are new in the release:
 ## Migration
 
 - Number patterns that did not have a specific numberSystem (such as `latn` or `arab`) had been deprecated for many releases, and were finally removed.
-- Additionally, language and territory data in `languageData` and `territoryInfo` data received significant updates to improve accuracy and maintainability [CLDR-18087]
+- Additionally, language and territory data in `languageData` and `territoryInfo` data received significant updates to improve accuracy and maintainability [CLDR-18087] In particular, the `territories` attribute in `languageData` was deprecated and removed, as it was unclear and prone to misunderstanding. Implementations that used this data may need to adjust accordingly, using `territoryInfo`.
 - The likely language for Belarus changed to Russian [CLDR-14479]
 - [Using Time Zone Names](https://www.unicode.org/reports/tr35/dev/tr35-dates.html#using-time-zone-names) Removed the "specific location format" and modified the fallback behavior of 'z'.
 - [Unit Identifier Normalization](https://www.unicode.org/reports/tr35/dev/#tr35-general.html) Modified the normalization process.

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ConvertLanguageData.java
@@ -352,14 +352,16 @@ public class ConvertLanguageData {
                                         TreeSet.class));
             }
             if (languageInCountryData.officialStatus.isMajor()) {
-                // Output will look like <language type="sw" territories="TZ"/>
+                // This is no longer saved to output
+                // It used to appear like: <language type="sw" territories="TZ"/>
                 status_territories.put(
                         BasicLanguageData.Type.primary, languageInCountryData.countryCode);
             } else if (languageInCountryData.officialStatus.isOfficial()
                     || languageInCountryData.getLanguagePopulation()
                             >= cutoff * languageInCountryData.countryPopulation
                     || languageInCountryData.getLanguagePopulation() >= 1000000) {
-                // Output will look like <language type="sw" territories="CD" alt="secondary"/>
+                // This is no longer saved to output
+                // It used to appear like: <language type="sw" territories="CD" alt="secondary"/>
                 status_territories.put(
                         BasicLanguageData.Type.secondary, languageInCountryData.countryCode);
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowLanguages.java
@@ -918,7 +918,7 @@ public class ShowLanguages {
                         ; // nothing
                     else if ("secondary".equals(alt)) language += "*";
                     else language += "*" + alt;
-                    // <language type="af" scripts="Latn" territories="ZA"/>
+                    // <language type="af" scripts="Latn"/>
                     addTokens(language, attributes.get("territories"), " ", language_territories);
                     continue;
                 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -2456,10 +2456,9 @@ public class SupplementalDataInfo {
 
         private void handleLanguageData(XPathValue parts) {
             // <languageData>
-            // <language type="aa" scripts="Latn" territories="DJ ER ET"/> <!--
+            // <language type="aa" scripts="Latn"/> <!--
             // Reflecting submitted data, cldrbug #1013 -->
-            // <language type="ab" scripts="Cyrl" territories="GE"
-            // alt="secondary"/>
+            // <language type="ab" scripts="Cyrl" alt="secondary"/>
             String language = parts.getAttributeValue(2, "type");
             BasicLanguageData languageData = new BasicLanguageData();
             languageData.setType(


### PR DESCRIPTION
This is a followup from https://github.com/unicode-org/cldr/pull/5148 -- checking other references in code to languageData/language/territories and updating them. The biggest change is updating the release notes.

https://unicode-org.atlassian.net/browse/CLDR-18451

CLDR-18451

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
