### PR TITLE
CLDR-18690 Simplify invariant digit ordinals to avoid roundtrip parse errors

### DIFF
--- a/common/rbnf/az.xml
+++ b/common/rbnf/az.xml
@@ -183,19 +183,14 @@ x.x: =#,##0.#=;
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%digits-ordinal-indicator:
-0: ''inci;
 %digits-ordinal:
 -x: −>>;
-0: =#,##0==%%digits-ordinal-indicator=;
+0: =#,##0='inci;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="digits-ordinal-indicator" access="private">
-                <rbnfrule value="0">''inci;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0==%%digits-ordinal-indicator=;</rbnfrule>
+                <rbnfrule value="0">=#,##0='inci;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>

--- a/common/rbnf/it.xml
+++ b/common/rbnf/it.xml
@@ -1166,33 +1166,23 @@ x.x: =#,##0.#=;
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%dord-mascabbrev:
-0: º;
 %digits-ordinal-masculine:
 -x: −>>;
-0: =#,##0==%%dord-mascabbrev=;
-%%dord-femabbrev:
-0: ª;
+0: =#,##0=º;
 %digits-ordinal-feminine:
 -x: −>>;
-0: =#,##0==%%dord-femabbrev=;
+0: =#,##0=ª;
 %digits-ordinal:
 0: =%digits-ordinal-masculine=;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="dord-mascabbrev" access="private">
-                <rbnfrule value="0">º;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal-masculine">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0==%%dord-mascabbrev=;</rbnfrule>
-            </ruleset>
-            <ruleset type="dord-femabbrev" access="private">
-                <rbnfrule value="0">ª;</rbnfrule>
+                <rbnfrule value="0">=#,##0=º;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal-feminine">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0==%%dord-femabbrev=;</rbnfrule>
+                <rbnfrule value="0">=#,##0=ª;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal">
                 <rbnfrule value="0">=%digits-ordinal-masculine=;</rbnfrule>

--- a/common/rbnf/ky.xml
+++ b/common/rbnf/ky.xml
@@ -339,19 +339,14 @@ x.x: =#,##0.#=;
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%digits-ordinal-indicator:
-0: ''инчи;
 %digits-ordinal:
 -x: −>>;
-0: =#,##0==%%digits-ordinal-indicator=;
+0: =#,##0='инчи;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="digits-ordinal-indicator" access="private">
-                <rbnfrule value="0">''инчи;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0==%%digits-ordinal-indicator=;</rbnfrule>
+                <rbnfrule value="0">=#,##0='инчи;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>


### PR DESCRIPTION
CLDR-18690

The flat rules were tested and verified with [Number Format Tester](https://st.unicode.org/cldr-apps/numbers.jsp).

- [x] This PR completes the ticket.