### PR TITLE
CLDR-16292 Plural rules in Spanish should return different ordinal types for number 1 and 3

### DIFF
--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -7731,7 +7731,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pluralMinimalPairs count="one">{0} día</pluralMinimalPairs>
 			<pluralMinimalPairs count="many">{0} de días</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">{0} días</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">Toma la {0}.ª a la derecha.</ordinalMinimalPairs>
+            <ordinalMinimalPairs ordinal="one">El {0}.ᵉʳ equipo clasificado ganó.</ordinalMinimalPairs>
+			<ordinalMinimalPairs ordinal="other">El equipo {0}.º clasificado ganó.</ordinalMinimalPairs>
 			<genderMinimalPairs gender="feminine">La {0} es...</genderMinimalPairs>
 			<genderMinimalPairs gender="masculine">El {0} es…</genderMinimalPairs>
 		</minimalPairs>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -6511,7 +6511,8 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<pluralMinimalPairs count="one">↑↑↑</pluralMinimalPairs>
 			<pluralMinimalPairs count="many">↑↑↑</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">↑↑↑</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
+            <ordinalMinimalPairs ordinal="one">El {0}ᵉʳ. equipo clasificado ganó.</ordinalMinimalPairs>
+            <ordinalMinimalPairs ordinal="other">El equipo {0}º. clasificado ganó.</ordinalMinimalPairs>
 			<genderMinimalPairs gender="feminine">↑↑↑</genderMinimalPairs>
 			<genderMinimalPairs gender="masculine">↑↑↑</genderMinimalPairs>
 		</minimalPairs>

--- a/common/rbnf/es.xml
+++ b/common/rbnf/es.xml
@@ -552,17 +552,9 @@ x.x: =#,##0.#=;
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%dord-mascabbrev:
-0: º;
-1: ᵉʳ;
-2: º;
-3: ᵉʳ;
-4: º;
-20: >>;
-100: >>;
 %digits-ordinal-masculine-adjective:
 -x: −>>;
-0: =#,##0=.=%%dord-mascabbrev=;
+0: =#,##0=.$(ordinal,one{ᵉʳ}other{º})$;
 %digits-ordinal-masculine:
 -x: −>>;
 0: =#,##0=.º;
@@ -579,18 +571,9 @@ x.x: =#,##0.#=;
 0: =%digits-ordinal-masculine=;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="dord-mascabbrev" access="private">
-                <rbnfrule value="0">º;</rbnfrule>
-                <rbnfrule value="1">ᵉʳ;</rbnfrule>
-                <rbnfrule value="2">º;</rbnfrule>
-                <rbnfrule value="3">ᵉʳ;</rbnfrule>
-                <rbnfrule value="4">º;</rbnfrule>
-                <rbnfrule value="20">→→;</rbnfrule>
-                <rbnfrule value="100">→→;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal-masculine-adjective">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=.=%%dord-mascabbrev=;</rbnfrule>
+                <rbnfrule value="0">=#,##0=.$(ordinal,one{ᵉʳ}other{º})$;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal-masculine">
                 <rbnfrule value="-x">−→→;</rbnfrule>

--- a/common/rbnf/es_419.xml
+++ b/common/rbnf/es_419.xml
@@ -14,17 +14,9 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%dord-mascabbrev:
-0: º;
-1: ᵉʳ;
-2: º;
-3: ᵉʳ;
-4: º;
-20: >>;
-100: >>;
 %digits-ordinal-masculine-adjective:
 -x: −>>;
-0: =#,##0==%%dord-mascabbrev=.;
+0: =#,##0=$(ordinal,one{ᵉʳ}other{º})$.;
 %digits-ordinal-masculine:
 -x: −>>;
 0: =#,##0=º.;
@@ -41,18 +33,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 0: =%digits-ordinal-masculine=;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="dord-mascabbrev" access="private">
-                <rbnfrule value="0">º;</rbnfrule>
-                <rbnfrule value="1">ᵉʳ;</rbnfrule>
-                <rbnfrule value="2">º;</rbnfrule>
-                <rbnfrule value="3">ᵉʳ;</rbnfrule>
-                <rbnfrule value="4">º;</rbnfrule>
-                <rbnfrule value="20">→→;</rbnfrule>
-                <rbnfrule value="100">→→;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal-masculine-adjective">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0==%%dord-mascabbrev=.;</rbnfrule>
+                <rbnfrule value="0">=#,##0=$(ordinal,one{ᵉʳ}other{º})$.;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal-masculine">
                 <rbnfrule value="-x">−→→;</rbnfrule>

--- a/common/supplemental/ordinals.xml
+++ b/common/supplemental/ordinals.xml
@@ -13,7 +13,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 1: other -->
 
-        <pluralRules locales="am an ar ast bs ce cs cv da de dsb el es et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
+        <pluralRules locales="am an ar ast bs ce cs cv da de dsb el et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
             <pluralRule count="other"> @integer 0~15, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 
@@ -34,6 +34,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
         <pluralRules locales="ne">
             <pluralRule count="one">n = 1..4 @integer 1~4</pluralRule>
             <pluralRule count="other"> @integer 0, 5~19, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
+        </pluralRules>
+        <pluralRules locales="es">
+            <pluralRule count="one">n % 10 = 1,3 and n % 100 != 11 @integer 1, 3, 13, 21, 23, 31, 33, 41, 43, 51, 53, 101, 103, 1001, 1003, …</pluralRule>
+            <pluralRule count="other"> @integer 0, 2, 4~12, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 
         <!-- 2: few,other -->


### PR DESCRIPTION
CLDR-16292

This is a revised submission of #2769. It changes RBNF to use the new plural format values.

- [x] This PR completes the ticket.