### PR TITLE
CLDR-19089 Improve parsing of numbers with Irish RBNF rules

### DIFF
--- a/common/rbnf/ga.xml
+++ b/common/rbnf/ga.xml
@@ -15,31 +15,10 @@ For terms of use, see http://www.unicode.org/copyright.html
             <rbnfRules><![CDATA[
 %%lenient-parse:
 & ' ' , ',' ;
-%%2d-year:
-0: agus =%spellout-numbering=;
-10: =%%spellout-numbering-no-a=;
 %spellout-numbering-year:
 -x: míneas >>;
 x.x: =0.0=;
 0: =%spellout-numbering=;
-1000/100: <%%spellout-numbering-no-a< >%%2d-year>;
-10000: =%spellout-numbering=;
-%%spellout-numbering-no-a:
-0: náid;
-1: aon;
-2: dó;
-3: trí;
-4: ceathair;
-5: cúig;
-6: sé;
-7: seacht;
-8: ocht;
-9: naoi;
-10: deich;
-11: >> déag;
-12: >> dhéag;
-13: >> déag;
-20: =%spellout-numbering=;
 %spellout-numbering:
 -x: míneas >>;
 x.x: << pointe >>;
@@ -54,9 +33,7 @@ x.x: << pointe >>;
 8: a hocht;
 9: a naoi;
 10: a deich;
-11: >> déag;
-12: >> dhéag;
-13: >> déag;
+11: >> $(cardinal,two{dhéag}other{déag})$;
 20: fiche[ >>];
 30: tríocha[ >>];
 40: daichead[ >>];
@@ -65,27 +42,33 @@ x.x: << pointe >>;
 70: seachtó[ >>];
 80: ochtó[ >>];
 90: nócha[ >>];
-100: <%%hundreds<[>%%is-number>];
-1000: <%%thousands<[, >%spellout-numbering>];
-1000000: <%%millions<[, >%spellout-numbering>];
-1000000000: <%%billions<[, >%spellout-numbering>];
-1000000000000: <%%trillions<[, >%spellout-numbering>];
-1000000000000000: <%%quadrillions<[, >%spellout-numbering>];
+100: céad[ is >>];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$[ is >>];
+1000: <%%thousands<[ >>];
+1000000: <%%millions<[ >>];
+1000000000: <%%billions<[ >>];
+1000000000000: <%%trillions<[ >>];
+1000000000000000: <%%quadrillions<[ >>];
 1000000000000000000: =#,##0=;
-%%is-number:
-0: ' is =%spellout-numbering=;
-1: ' =%spellout-numbering=;
-%%is-numberp:
-0: ' is =%%numberp=;
-1: ' =%%numberp=;
-%%numberp:
-0: =%%spellout-cardinal-prefixpart=;
-12: dó dhéag;
-13: =%%spellout-cardinal-prefixpart= déag;
-20: =%%spellout-cardinal-prefixpart=;
 %spellout-cardinal:
-0: =%spellout-numbering=;
-%%spellout-cardinal-prefixpart:
+-x: míneas >>;
+x.x: << pointe >>;
+0: náid;
+1: aon;
+2: dó;
+3: trí;
+4: ceathair;
+5: cúig;
+6: sé;
+7: seacht;
+8: ocht;
+9: naoi;
+10: deich;
+11: >> $(cardinal,two{dhéag}other{déag})$;
+20: =%spellout-numbering=;
+%%is-number-attributive:
+0: [ | is ]=%%spellout-cardinal-attributive=;
+%%spellout-cardinal-attributive:
 0: náid;
 1: aon;
 2: dhá;
@@ -97,7 +80,7 @@ x.x: << pointe >>;
 8: ocht;
 9: naoi;
 10: deich;
-11: >>;
+11: >> $(cardinal,two{dhéag}other{déag})$;
 20: fiche[ is >>];
 30: tríocha[ is >>];
 40: daichead[ is >>];
@@ -106,135 +89,53 @@ x.x: << pointe >>;
 70: seachtó[ is >>];
 80: ochtó[ is >>];
 90: nócha[ is >>];
-100: <%%hundreds<[>%%is-numberp>];
-1000: <%%thousands<[, >%%numberp>];
-1000000: <%%millions<[, >%%numberp>];
-1000000000: <%%billions<[, >%%numberp>];
-1000000000000: <%%trillions<[, >%%numberp>];
-1000000000000000: <%%quadrillions<[, >%%numberp>];
-1000000000000000000: =#,##0=;
-%%is:
-0: ' is;
-1: ;
-10: >>;
-%%hundreds:
-1: céad;
-2: dhá chéad;
-3: trí chéad;
-4: ceithre chéad;
-5: cúig chéad;
-6: sé chéad;
-7: seacht gcéad;
-8: ocht gcéad;
-9: naoi gcéad;
+100: céad[ is >>];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$[>%%is-number-attributive>];
+1000: =%spellout-numbering=;
 %%thousands:
 1: míle;
-2: =%%spellout-cardinal-prefixpart= =%%thousandp=;
-100: <%%hundreds<>%%is-thousands>;
-%%thousandp:
-2: =%%thousand=;
-11: =%%thousand= dhéag;
-20: =%%thousand=;
-%%thousand:
-0: míle;
-1: mhíle;
-7: míle;
-11: >>;
-%%is-thousands:
-0: ' =%%thousand=;
-1: ' is =%%spellout-cardinal-prefixpart= =%%thousand=;
-11: ' is =%%thousands=;
-20: =%%is= =%%thousands=;
+2: =%%spellout-cardinal-attributive= $(cardinal,many{míle}other{mhíle})$;
+11: >%%spellout-cardinal-attributive> mhíle dhéag;
+20: =%%spellout-cardinal-attributive= mhíle;
+100: céad [>>|míle];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$ [>>|míle];
 %%millions:
 1: milliún;
-2: =%%spellout-cardinal-prefixpart= =%%millionsp=;
-100: <%%hundreds<>%%is-millions>;
-%%millionsp:
-2: =%%million=;
-11: =%%million= déag;
-20: =%%million=;
-%%million:
-0: milliún;
-1: mhilliún;
-7: milliún;
-11: >>;
-%%is-millions:
-0: ' =%%million=;
-1: ' is =%%spellout-cardinal-prefixpart= =%%million=;
-11: ' is =%%millions=;
-20: =%%is= =%%millions=;
+2: =%%spellout-cardinal-attributive= $(cardinal,many{milliún}other{mhilliún})$;
+11: >%%spellout-cardinal-attributive> mhilliún dhéag;
+20: =%%spellout-cardinal-attributive= mhilliún;
+100: céad [>>|milliún];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$ [>>|milliún];
 %%billions:
 1: billiún;
-2: =%%spellout-cardinal-prefixpart= billiún;
-11: =%%spellout-cardinal-prefixpart= billiún déag;
-20: =%%spellout-cardinal-prefixpart= billiún;
-100: <%%hundreds<>%%is-billions>;
-%%is-billions:
-0: ' billiún;
-1: ' is =%%spellout-cardinal-prefixpart= billiún;
-11: ' is =%%billions=;
-20: =%%is= =%%billions=;
+2: =%%spellout-cardinal-attributive= billiún;
+11: >%%spellout-cardinal-attributive> billiún déag;
+20: =%%spellout-cardinal-attributive= billiún;
+100: céad [>>|billiún];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$ [>>|billiún];
 %%trillions:
 1: thrilliún;
-2: =%%spellout-cardinal-prefixpart= =%%trillionsp=;
-100: <%%hundreds<>%%is-trillions>;
-%%trillionsp:
-2: =%%trillion=;
-11: =%%trillion= déag;
-20: =%%trillion=;
-%%trillion:
-0: dtrilliún;
-1: thrilliún;
-7: dtrilliún;
-11: >>;
-%%is-trillions:
-0: ' =%%trillion=;
-1: ' is =%%spellout-cardinal-prefixpart= =%%trillion=;
-11: ' is =%%trillions=;
-20: =%%is= =%%trillions=;
+2: =%%spellout-cardinal-attributive= $(cardinal,many{dtrilliún}other{thrilliún})$;
+11: >%%spellout-cardinal-attributive> thrilliún dhéag;
+20: =%%spellout-cardinal-attributive= thrilliún;
+100: céad [>>|thrilliún];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$ [>>|thrilliún];
 %%quadrillions:
 1: quadrilliún;
-2: =%%spellout-cardinal-prefixpart= quadrilliún;
-11: =%%spellout-cardinal-prefixpart= quadrilliún déag;
-20: =%%spellout-cardinal-prefixpart= quadrilliún;
-100: <%%hundreds<>%%is-quadrillions>;
-%%is-quadrillions:
-0: ' quadrilliún;
-1: ' is =%%spellout-cardinal-prefixpart= quadrilliún;
-11: ' is =%%quadrillions=;
-20: =%%is= =%%quadrillions=;
+2: =%%spellout-cardinal-attributive= quadrilliún;
+11: >%%spellout-cardinal-attributive> quadrilliún déag;
+20: =%%spellout-cardinal-attributive= quadrilliún;
+100: céad [>>|quadrilliún];
+200: <%%spellout-cardinal-attributive< $(cardinal,many{gcéad}other{chéad})$ [>>|quadrilliún];
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
             <ruleset type="lenient-parse" access="private">
                 <rbnfrule value="0">&amp; ' ' , ',' ;</rbnfrule>
             </ruleset>
-            <ruleset type="2d-year" access="private">
-                <rbnfrule value="0">agus =%spellout-numbering=;</rbnfrule>
-                <rbnfrule value="10">=%%spellout-numbering-no-a=;</rbnfrule>
-            </ruleset>
             <ruleset type="spellout-numbering-year">
                 <rbnfrule value="-x">míneas →→;</rbnfrule>
                 <rbnfrule value="x.x">=0.0=;</rbnfrule>
                 <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
-                <rbnfrule value="1000" radix="100">←%%spellout-numbering-no-a← →%%2d-year→;</rbnfrule>
-                <rbnfrule value="10000">=%spellout-numbering=;</rbnfrule>
-            </ruleset>
-            <ruleset type="spellout-numbering-no-a" access="private">
-                <rbnfrule value="0">náid;</rbnfrule>
-                <rbnfrule value="1">aon;</rbnfrule>
-                <rbnfrule value="2">dó;</rbnfrule>
-                <rbnfrule value="3">trí;</rbnfrule>
-                <rbnfrule value="4">ceathair;</rbnfrule>
-                <rbnfrule value="5">cúig;</rbnfrule>
-                <rbnfrule value="6">sé;</rbnfrule>
-                <rbnfrule value="7">seacht;</rbnfrule>
-                <rbnfrule value="8">ocht;</rbnfrule>
-                <rbnfrule value="9">naoi;</rbnfrule>
-                <rbnfrule value="10">deich;</rbnfrule>
-                <rbnfrule value="11">→→ déag;</rbnfrule>
-                <rbnfrule value="12">→→ dhéag;</rbnfrule>
-                <rbnfrule value="13">→→ déag;</rbnfrule>
-                <rbnfrule value="20">=%spellout-numbering=;</rbnfrule>
             </ruleset>
             <ruleset type="spellout-numbering">
                 <rbnfrule value="-x">míneas →→;</rbnfrule>
@@ -250,9 +151,7 @@ x.x: << pointe >>;
                 <rbnfrule value="8">a hocht;</rbnfrule>
                 <rbnfrule value="9">a naoi;</rbnfrule>
                 <rbnfrule value="10">a deich;</rbnfrule>
-                <rbnfrule value="11">→→ déag;</rbnfrule>
-                <rbnfrule value="12">→→ dhéag;</rbnfrule>
-                <rbnfrule value="13">→→ déag;</rbnfrule>
+                <rbnfrule value="11">→→ $(cardinal,two{dhéag}other{déag})$;</rbnfrule>
                 <rbnfrule value="20">fiche[ →→];</rbnfrule>
                 <rbnfrule value="30">tríocha[ →→];</rbnfrule>
                 <rbnfrule value="40">daichead[ →→];</rbnfrule>
@@ -261,32 +160,36 @@ x.x: << pointe >>;
                 <rbnfrule value="70">seachtó[ →→];</rbnfrule>
                 <rbnfrule value="80">ochtó[ →→];</rbnfrule>
                 <rbnfrule value="90">nócha[ →→];</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←[→%%is-number→];</rbnfrule>
-                <rbnfrule value="1000">←%%thousands←[, →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000">←%%millions←[, →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000">←%%billions←[, →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000">←%%trillions←[, →%spellout-numbering→];</rbnfrule>
-                <rbnfrule value="1000000000000000">←%%quadrillions←[, →%spellout-numbering→];</rbnfrule>
+                <rbnfrule value="100">céad[ is →→];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$[ is →→];</rbnfrule>
+                <rbnfrule value="1000">←%%thousands←[ →→];</rbnfrule>
+                <rbnfrule value="1000000">←%%millions←[ →→];</rbnfrule>
+                <rbnfrule value="1000000000">←%%billions←[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000">←%%trillions←[ →→];</rbnfrule>
+                <rbnfrule value="1000000000000000">←%%quadrillions←[ →→];</rbnfrule>
                 <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
             </ruleset>
-            <ruleset type="is-number" access="private">
-                <rbnfrule value="0">' is =%spellout-numbering=;</rbnfrule>
-                <rbnfrule value="1">' =%spellout-numbering=;</rbnfrule>
-            </ruleset>
-            <ruleset type="is-numberp" access="private">
-                <rbnfrule value="0">' is =%%numberp=;</rbnfrule>
-                <rbnfrule value="1">' =%%numberp=;</rbnfrule>
-            </ruleset>
-            <ruleset type="numberp" access="private">
-                <rbnfrule value="0">=%%spellout-cardinal-prefixpart=;</rbnfrule>
-                <rbnfrule value="12">dó dhéag;</rbnfrule>
-                <rbnfrule value="13">=%%spellout-cardinal-prefixpart= déag;</rbnfrule>
-                <rbnfrule value="20">=%%spellout-cardinal-prefixpart=;</rbnfrule>
-            </ruleset>
             <ruleset type="spellout-cardinal">
-                <rbnfrule value="0">=%spellout-numbering=;</rbnfrule>
+                <rbnfrule value="-x">míneas →→;</rbnfrule>
+                <rbnfrule value="x.x">←← pointe →→;</rbnfrule>
+                <rbnfrule value="0">náid;</rbnfrule>
+                <rbnfrule value="1">aon;</rbnfrule>
+                <rbnfrule value="2">dó;</rbnfrule>
+                <rbnfrule value="3">trí;</rbnfrule>
+                <rbnfrule value="4">ceathair;</rbnfrule>
+                <rbnfrule value="5">cúig;</rbnfrule>
+                <rbnfrule value="6">sé;</rbnfrule>
+                <rbnfrule value="7">seacht;</rbnfrule>
+                <rbnfrule value="8">ocht;</rbnfrule>
+                <rbnfrule value="9">naoi;</rbnfrule>
+                <rbnfrule value="10">deich;</rbnfrule>
+                <rbnfrule value="11">→→ $(cardinal,two{dhéag}other{déag})$;</rbnfrule>
+                <rbnfrule value="20">=%spellout-numbering=;</rbnfrule>
             </ruleset>
-            <ruleset type="spellout-cardinal-prefixpart" access="private">
+            <ruleset type="is-number-attributive" access="private">
+                <rbnfrule value="0">[ | is ]=%%spellout-cardinal-attributive=;</rbnfrule>
+            </ruleset>
+            <ruleset type="spellout-cardinal-attributive" access="private">
                 <rbnfrule value="0">náid;</rbnfrule>
                 <rbnfrule value="1">aon;</rbnfrule>
                 <rbnfrule value="2">dhá;</rbnfrule>
@@ -298,7 +201,7 @@ x.x: << pointe >>;
                 <rbnfrule value="8">ocht;</rbnfrule>
                 <rbnfrule value="9">naoi;</rbnfrule>
                 <rbnfrule value="10">deich;</rbnfrule>
-                <rbnfrule value="11">→→;</rbnfrule>
+                <rbnfrule value="11">→→ $(cardinal,two{dhéag}other{déag})$;</rbnfrule>
                 <rbnfrule value="20">fiche[ is →→];</rbnfrule>
                 <rbnfrule value="30">tríocha[ is →→];</rbnfrule>
                 <rbnfrule value="40">daichead[ is →→];</rbnfrule>
@@ -307,121 +210,49 @@ x.x: << pointe >>;
                 <rbnfrule value="70">seachtó[ is →→];</rbnfrule>
                 <rbnfrule value="80">ochtó[ is →→];</rbnfrule>
                 <rbnfrule value="90">nócha[ is →→];</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←[→%%is-numberp→];</rbnfrule>
-                <rbnfrule value="1000">←%%thousands←[, →%%numberp→];</rbnfrule>
-                <rbnfrule value="1000000">←%%millions←[, →%%numberp→];</rbnfrule>
-                <rbnfrule value="1000000000">←%%billions←[, →%%numberp→];</rbnfrule>
-                <rbnfrule value="1000000000000">←%%trillions←[, →%%numberp→];</rbnfrule>
-                <rbnfrule value="1000000000000000">←%%quadrillions←[, →%%numberp→];</rbnfrule>
-                <rbnfrule value="1000000000000000000">=#,##0=;</rbnfrule>
-            </ruleset>
-            <ruleset type="is" access="private">
-                <rbnfrule value="0">' is;</rbnfrule>
-                <rbnfrule value="1">;</rbnfrule>
-                <rbnfrule value="10">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="hundreds" access="private">
-                <rbnfrule value="1">céad;</rbnfrule>
-                <rbnfrule value="2">dhá chéad;</rbnfrule>
-                <rbnfrule value="3">trí chéad;</rbnfrule>
-                <rbnfrule value="4">ceithre chéad;</rbnfrule>
-                <rbnfrule value="5">cúig chéad;</rbnfrule>
-                <rbnfrule value="6">sé chéad;</rbnfrule>
-                <rbnfrule value="7">seacht gcéad;</rbnfrule>
-                <rbnfrule value="8">ocht gcéad;</rbnfrule>
-                <rbnfrule value="9">naoi gcéad;</rbnfrule>
+                <rbnfrule value="100">céad[ is →→];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$[→%%is-number-attributive→];</rbnfrule>
+                <rbnfrule value="1000">=%spellout-numbering=;</rbnfrule>
             </ruleset>
             <ruleset type="thousands" access="private">
                 <rbnfrule value="1">míle;</rbnfrule>
-                <rbnfrule value="2">=%%spellout-cardinal-prefixpart= =%%thousandp=;</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←→%%is-thousands→;</rbnfrule>
-            </ruleset>
-            <ruleset type="thousandp" access="private">
-                <rbnfrule value="2">=%%thousand=;</rbnfrule>
-                <rbnfrule value="11">=%%thousand= dhéag;</rbnfrule>
-                <rbnfrule value="20">=%%thousand=;</rbnfrule>
-            </ruleset>
-            <ruleset type="thousand" access="private">
-                <rbnfrule value="0">míle;</rbnfrule>
-                <rbnfrule value="1">mhíle;</rbnfrule>
-                <rbnfrule value="7">míle;</rbnfrule>
-                <rbnfrule value="11">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="is-thousands" access="private">
-                <rbnfrule value="0">' =%%thousand=;</rbnfrule>
-                <rbnfrule value="1">' is =%%spellout-cardinal-prefixpart= =%%thousand=;</rbnfrule>
-                <rbnfrule value="11">' is =%%thousands=;</rbnfrule>
-                <rbnfrule value="20">=%%is= =%%thousands=;</rbnfrule>
+                <rbnfrule value="2">=%%spellout-cardinal-attributive= $(cardinal,many{míle}other{mhíle})$;</rbnfrule>
+                <rbnfrule value="11">→%%spellout-cardinal-attributive→ mhíle dhéag;</rbnfrule>
+                <rbnfrule value="20">=%%spellout-cardinal-attributive= mhíle;</rbnfrule>
+                <rbnfrule value="100">céad [→→|míle];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$ [→→|míle];</rbnfrule>
             </ruleset>
             <ruleset type="millions" access="private">
                 <rbnfrule value="1">milliún;</rbnfrule>
-                <rbnfrule value="2">=%%spellout-cardinal-prefixpart= =%%millionsp=;</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←→%%is-millions→;</rbnfrule>
-            </ruleset>
-            <ruleset type="millionsp" access="private">
-                <rbnfrule value="2">=%%million=;</rbnfrule>
-                <rbnfrule value="11">=%%million= déag;</rbnfrule>
-                <rbnfrule value="20">=%%million=;</rbnfrule>
-            </ruleset>
-            <ruleset type="million" access="private">
-                <rbnfrule value="0">milliún;</rbnfrule>
-                <rbnfrule value="1">mhilliún;</rbnfrule>
-                <rbnfrule value="7">milliún;</rbnfrule>
-                <rbnfrule value="11">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="is-millions" access="private">
-                <rbnfrule value="0">' =%%million=;</rbnfrule>
-                <rbnfrule value="1">' is =%%spellout-cardinal-prefixpart= =%%million=;</rbnfrule>
-                <rbnfrule value="11">' is =%%millions=;</rbnfrule>
-                <rbnfrule value="20">=%%is= =%%millions=;</rbnfrule>
+                <rbnfrule value="2">=%%spellout-cardinal-attributive= $(cardinal,many{milliún}other{mhilliún})$;</rbnfrule>
+                <rbnfrule value="11">→%%spellout-cardinal-attributive→ mhilliún dhéag;</rbnfrule>
+                <rbnfrule value="20">=%%spellout-cardinal-attributive= mhilliún;</rbnfrule>
+                <rbnfrule value="100">céad [→→|milliún];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$ [→→|milliún];</rbnfrule>
             </ruleset>
             <ruleset type="billions" access="private">
                 <rbnfrule value="1">billiún;</rbnfrule>
-                <rbnfrule value="2">=%%spellout-cardinal-prefixpart= billiún;</rbnfrule>
-                <rbnfrule value="11">=%%spellout-cardinal-prefixpart= billiún déag;</rbnfrule>
-                <rbnfrule value="20">=%%spellout-cardinal-prefixpart= billiún;</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←→%%is-billions→;</rbnfrule>
-            </ruleset>
-            <ruleset type="is-billions" access="private">
-                <rbnfrule value="0">' billiún;</rbnfrule>
-                <rbnfrule value="1">' is =%%spellout-cardinal-prefixpart= billiún;</rbnfrule>
-                <rbnfrule value="11">' is =%%billions=;</rbnfrule>
-                <rbnfrule value="20">=%%is= =%%billions=;</rbnfrule>
+                <rbnfrule value="2">=%%spellout-cardinal-attributive= billiún;</rbnfrule>
+                <rbnfrule value="11">→%%spellout-cardinal-attributive→ billiún déag;</rbnfrule>
+                <rbnfrule value="20">=%%spellout-cardinal-attributive= billiún;</rbnfrule>
+                <rbnfrule value="100">céad [→→|billiún];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$ [→→|billiún];</rbnfrule>
             </ruleset>
             <ruleset type="trillions" access="private">
                 <rbnfrule value="1">thrilliún;</rbnfrule>
-                <rbnfrule value="2">=%%spellout-cardinal-prefixpart= =%%trillionsp=;</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←→%%is-trillions→;</rbnfrule>
-            </ruleset>
-            <ruleset type="trillionsp" access="private">
-                <rbnfrule value="2">=%%trillion=;</rbnfrule>
-                <rbnfrule value="11">=%%trillion= déag;</rbnfrule>
-                <rbnfrule value="20">=%%trillion=;</rbnfrule>
-            </ruleset>
-            <ruleset type="trillion" access="private">
-                <rbnfrule value="0">dtrilliún;</rbnfrule>
-                <rbnfrule value="1">thrilliún;</rbnfrule>
-                <rbnfrule value="7">dtrilliún;</rbnfrule>
-                <rbnfrule value="11">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="is-trillions" access="private">
-                <rbnfrule value="0">' =%%trillion=;</rbnfrule>
-                <rbnfrule value="1">' is =%%spellout-cardinal-prefixpart= =%%trillion=;</rbnfrule>
-                <rbnfrule value="11">' is =%%trillions=;</rbnfrule>
-                <rbnfrule value="20">=%%is= =%%trillions=;</rbnfrule>
+                <rbnfrule value="2">=%%spellout-cardinal-attributive= $(cardinal,many{dtrilliún}other{thrilliún})$;</rbnfrule>
+                <rbnfrule value="11">→%%spellout-cardinal-attributive→ thrilliún dhéag;</rbnfrule>
+                <rbnfrule value="20">=%%spellout-cardinal-attributive= thrilliún;</rbnfrule>
+                <rbnfrule value="100">céad [→→|thrilliún];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$ [→→|thrilliún];</rbnfrule>
             </ruleset>
             <ruleset type="quadrillions" access="private">
                 <rbnfrule value="1">quadrilliún;</rbnfrule>
-                <rbnfrule value="2">=%%spellout-cardinal-prefixpart= quadrilliún;</rbnfrule>
-                <rbnfrule value="11">=%%spellout-cardinal-prefixpart= quadrilliún déag;</rbnfrule>
-                <rbnfrule value="20">=%%spellout-cardinal-prefixpart= quadrilliún;</rbnfrule>
-                <rbnfrule value="100">←%%hundreds←→%%is-quadrillions→;</rbnfrule>
-            </ruleset>
-            <ruleset type="is-quadrillions" access="private">
-                <rbnfrule value="0">' quadrilliún;</rbnfrule>
-                <rbnfrule value="1">' is =%%spellout-cardinal-prefixpart= quadrilliún;</rbnfrule>
-                <rbnfrule value="11">' is =%%quadrillions=;</rbnfrule>
-                <rbnfrule value="20">=%%is= =%%quadrillions=;</rbnfrule>
+                <rbnfrule value="2">=%%spellout-cardinal-attributive= quadrilliún;</rbnfrule>
+                <rbnfrule value="11">→%%spellout-cardinal-attributive→ quadrilliún déag;</rbnfrule>
+                <rbnfrule value="20">=%%spellout-cardinal-attributive= quadrilliún;</rbnfrule>
+                <rbnfrule value="100">céad [→→|quadrilliún];</rbnfrule>
+                <rbnfrule value="200">←%%spellout-cardinal-attributive← $(cardinal,many{gcéad}other{chéad})$ [→→|quadrilliún];</rbnfrule>
             </ruleset>
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">


### PR DESCRIPTION
CLDR-19089

While these changes don't fully fix parsing with Irish RBNF rules. It's one step closer. I tested these rules with [Number Format Tester](https://st.unicode.org/cldr-apps/numbers.jsp?locale=ga).

Here are the important changes:

* The year is now pronounced correctly. It's not supposed to use English style spelling. It uses a more traditional form.
* The cardinals are now separated from counting numbers.
* Numbers like 2000 and 2001 are now correctly parsing, but numbers like 212212 still struggle to parse correctly. It's due to Irish's unusual ordering for the tens range to have the tens after the unit.  The order is like "two hundred two thousand ten two hundred two ten" for the value 212212.

- [x] This PR completes the ticket.