### PR TITLE
CLDR-19090 Ordinal plural rules are missing for af and bg

### DIFF
--- a/common/rbnf/af.xml
+++ b/common/rbnf/af.xml
@@ -170,27 +170,14 @@ x.x: =#,##0.#=;
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%digits-ordinal-indicator:
-0: ste;
-1: ste;
-2: de;
-20: ste;
-100: >>;
 %digits-ordinal:
 -x: −>>;
-0: =#,##0==%%digits-ordinal-indicator=;
+0: =#,##0=$(ordinal,few{de}other{ste})$;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="digits-ordinal-indicator" access="private">
-                <rbnfrule value="0">ste;</rbnfrule>
-                <rbnfrule value="1">ste;</rbnfrule>
-                <rbnfrule value="2">de;</rbnfrule>
-                <rbnfrule value="20">ste;</rbnfrule>
-                <rbnfrule value="100">→→;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0==%%digits-ordinal-indicator=;</rbnfrule>
+                <rbnfrule value="0">=#,##0=$(ordinal,few{de}other{ste})$;</rbnfrule>
             </ruleset>
         </rulesetGrouping>
     </rbnf>

--- a/common/rbnf/bg.xml
+++ b/common/rbnf/bg.xml
@@ -1027,114 +1027,30 @@ x.x: =#,##0.#=;
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">
             <rbnfRules><![CDATA[
-%%digits-ordinal-masculine-larger-suffix:
-0: тен;
-1: >%%digits-ordinal-masculine-suffix>;
-100: >>;
-%%digits-ordinal-masculine-suffix:
-0: и;
-1: ви;
-2: ри;
-3: ти;
-5: и;
-20: >>;
-100: >%%digits-ordinal-masculine-larger-suffix>;
-1000: >>;
 %digits-ordinal-masculine:
 -x: −>>;
-0: =#,##0=-=%%digits-ordinal-masculine-suffix=;
-%%digits-ordinal-feminine-larger-suffix:
-0: тна;
-1: >%%digits-ordinal-feminine-suffix>;
-100: >>;
-%%digits-ordinal-feminine-suffix:
-0: а;
-1: ва;
-2: ра;
-3: та;
-5: а;
-20: >>;
-100: >%%digits-ordinal-feminine-larger-suffix>;
-1000: >>;
+0: =#,##0=-$(ordinal,zero{тен}one{ви}two{ри}few{ти}many{ми}other{и})$;
 %digits-ordinal-feminine:
 -x: −>>;
-0: =#,##0=-=%%digits-ordinal-feminine-suffix=;
-%%digits-ordinal-neuter-larger-suffix:
-0: тно;
-1: >%%digits-ordinal-neuter-suffix>;
-100: >>;
-%%digits-ordinal-neuter-suffix:
-0: o;
-1: вo;
-2: рo;
-3: тo;
-5: o;
-20: >>;
-100: >%%digits-ordinal-neuter-larger-suffix>;
-1000: >>;
+0: =#,##0=-$(ordinal,zero{тна}one{ва}two{ра}few{та}many{ма}other{а})$;
 %digits-ordinal-neuter:
 -x: −>>;
-0: =#,##0=-=%%digits-ordinal-neuter-suffix=;
+0: =#,##0=-$(ordinal,zero{тно}one{вo}two{рo}few{тo}many{мо}other{o})$;
 %digits-ordinal:
 0: =%digits-ordinal-masculine=;
 ]]></rbnfRules>
             <!-- The following redundant ruleset elements have been deprecated and will be removed in the next release. Please use the rbnfRules contents instead. -->
-            <ruleset type="digits-ordinal-masculine-larger-suffix" access="private">
-                <rbnfrule value="0">тен;</rbnfrule>
-                <rbnfrule value="1">→%%digits-ordinal-masculine-suffix→;</rbnfrule>
-                <rbnfrule value="100">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="digits-ordinal-masculine-suffix" access="private">
-                <rbnfrule value="0">и;</rbnfrule>
-                <rbnfrule value="1">ви;</rbnfrule>
-                <rbnfrule value="2">ри;</rbnfrule>
-                <rbnfrule value="3">ти;</rbnfrule>
-                <rbnfrule value="5">и;</rbnfrule>
-                <rbnfrule value="20">→→;</rbnfrule>
-                <rbnfrule value="100">→%%digits-ordinal-masculine-larger-suffix→;</rbnfrule>
-                <rbnfrule value="1000">→→;</rbnfrule>
-            </ruleset>
             <ruleset type="digits-ordinal-masculine">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=-=%%digits-ordinal-masculine-suffix=;</rbnfrule>
-            </ruleset>
-            <ruleset type="digits-ordinal-feminine-larger-suffix" access="private">
-                <rbnfrule value="0">тна;</rbnfrule>
-                <rbnfrule value="1">→%%digits-ordinal-feminine-suffix→;</rbnfrule>
-                <rbnfrule value="100">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="digits-ordinal-feminine-suffix" access="private">
-                <rbnfrule value="0">а;</rbnfrule>
-                <rbnfrule value="1">ва;</rbnfrule>
-                <rbnfrule value="2">ра;</rbnfrule>
-                <rbnfrule value="3">та;</rbnfrule>
-                <rbnfrule value="5">а;</rbnfrule>
-                <rbnfrule value="20">→→;</rbnfrule>
-                <rbnfrule value="100">→%%digits-ordinal-feminine-larger-suffix→;</rbnfrule>
-                <rbnfrule value="1000">→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-$(ordinal,zero{тен}one{ви}two{ри}few{ти}many{ми}other{и})$;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal-feminine">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=-=%%digits-ordinal-feminine-suffix=;</rbnfrule>
-            </ruleset>
-            <ruleset type="digits-ordinal-neuter-larger-suffix" access="private">
-                <rbnfrule value="0">тно;</rbnfrule>
-                <rbnfrule value="1">→%%digits-ordinal-neuter-suffix→;</rbnfrule>
-                <rbnfrule value="100">→→;</rbnfrule>
-            </ruleset>
-            <ruleset type="digits-ordinal-neuter-suffix" access="private">
-                <rbnfrule value="0">o;</rbnfrule>
-                <rbnfrule value="1">вo;</rbnfrule>
-                <rbnfrule value="2">рo;</rbnfrule>
-                <rbnfrule value="3">тo;</rbnfrule>
-                <rbnfrule value="5">o;</rbnfrule>
-                <rbnfrule value="20">→→;</rbnfrule>
-                <rbnfrule value="100">→%%digits-ordinal-neuter-larger-suffix→;</rbnfrule>
-                <rbnfrule value="1000">→→;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-$(ordinal,zero{тна}one{ва}two{ра}few{та}many{ма}other{а})$;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal-neuter">
                 <rbnfrule value="-x">−→→;</rbnfrule>
-                <rbnfrule value="0">=#,##0=-=%%digits-ordinal-neuter-suffix=;</rbnfrule>
+                <rbnfrule value="0">=#,##0=-$(ordinal,zero{тно}one{вo}two{рo}few{тo}many{мо}other{o})$;</rbnfrule>
             </ruleset>
             <ruleset type="digits-ordinal">
                 <rbnfrule value="0">=%digits-ordinal-masculine=;</rbnfrule>

--- a/common/supplemental/ordinals.xml
+++ b/common/supplemental/ordinals.xml
@@ -13,7 +13,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 1: other -->
 
-        <pluralRules locales="af am an ar ast bg bs ce cs cv da de dsb el es et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
+        <pluralRules locales="am an ar ast bs ce cs cv da de dsb el es et eu fa fi fy gl gsw he hr hsb ia id ie in is iw ja km kn ko ky lt lv ml mn my nb nl no pa pl prg ps pt root ru sd sh si sk sl sr sw ta te th tpi tr ur uz yue zh zu">
             <pluralRule count="other"> @integer 0~15, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
         </pluralRules>
 
@@ -38,6 +38,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 2: few,other -->
 
+        <pluralRules locales="af">
+            <pluralRule count="few">i % 100 = 2..19 @integer 2~19, 102~119, 202~219, 1002, 10002, 100002, 1000002, …</pluralRule>
+            <pluralRule count="other"> @integer 0~1, 20~30, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
+        </pluralRules>
         <pluralRules locales="be">
             <pluralRule count="few">n % 10 = 2,3 and n % 100 != 12,13 @integer 2, 3, 22, 23, 32, 33, 42, 43, 52, 53, 62, 63, 72, 73, 82, 83, 102, 1002, …</pluralRule>
             <pluralRule count="other"> @integer 0, 1, 4~17, 100, 1000, 10000, 100000, 1000000, …</pluralRule>
@@ -164,6 +168,14 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
         <!-- 6: zero,one,two,few,many,other -->
 
+        <pluralRules locales="bg">
+            <pluralRule count="zero">i % 100 = 0 and i != 0 @integer 100, 200, 300, 1000, 10000, 100000, 1000000, …</pluralRule>
+            <pluralRule count="one">i % 10 = 1 and i % 100 != 11 @integer 1, 21, 31, 101, 201, 1001, …</pluralRule>
+            <pluralRule count="two">i % 10 = 2 and i % 100 != 12 @integer 2, 22, 32, 102, 202, 1002, …</pluralRule>
+            <pluralRule count="few">i % 10 = 3,4 and i % 100 != 13,14 @integer 3, 4, 23, 24, 33, 34, 103, 104, 123, 124, 203, 204, 1003, 1004, …</pluralRule>
+            <pluralRule count="many">i % 10 = 7,8 and i % 100 != 17,18 @integer 7, 8, 27, 28, 107, 108, 207, 208, …</pluralRule>
+            <pluralRule count="other"> @integer 5~6, 9~20, 1005, 10005, 100005, 1000005, …</pluralRule>
+        </pluralRules>
         <pluralRules locales="cy">
             <pluralRule count="zero">n = 0,7,8,9 @integer 0, 7~9</pluralRule>
             <pluralRule count="one">n = 1 @integer 1</pluralRule>


### PR DESCRIPTION
CLDR-19090

Afrikaans and Bulgarian are missing the following plural rules. Afrikaans mirrors the current RBNF ordinal rules. Bulgarian is similar to the current RBNF rules, but it follows the more grammatically correct/explicit forms for 7th, and 8th.

Bulgarian also has additional grammatical states for thousands, millions, billions, trillions and quadrillions. Unfortunately that's too many states for plural format. The revised rules aren't any worse than the current rules. It should provide the same formatted results, but the parsing work.

These updates are needed to allow the RBNF ordinal rules to roundtrip with formatting and parsing. RBNF also needs to be updated to use these new rules.

- [x] This PR completes the ticket.