### PR TITLE
CLDR-19169 Refinements for new keyboard layouts for Sanskrit, Tibetan, and Gandhari 

### DIFF
--- a/keyboards/3.0/pgd-Khar-t-k0-qwerty.md
+++ b/keyboards/3.0/pgd-Khar-t-k0-qwerty.md
@@ -1,0 +1,235 @@
+# Gandhari (Phonetic) Keyboard
+
+A QWERTY-based phonetic keyboard layout for typing Gandhari using the Kharoshthi script.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| **Locale** | `pgd-Khar` (Gandhari language, Kharoshthi script) |
+| **Layout** | QWERTY Phonetic |
+| **Author** | Andrew Glass |
+| **Version** | 1.0.2 |
+| **Keyboard Indicator** | 𐨒𐨎 (U+10A12 U+10A0E) |
+| **CLDR Conformance** | CLDR 47 |
+| **Draft Status** | Contributed |
+| **Form Factors** | US hardware keyboard |
+
+## About Gandhari and Kharoshthi
+
+Gandhari (also known as Gāndhārī Prakrit) was a Middle Indo-Aryan language used in the region of Gandhara (modern-day northwestern Pakistan and eastern Afghanistan) from approximately the 3rd century BCE to the 4th century CE. The Kharoshthi script was the primary writing system used to record Gandhari texts, particularly Buddhist manuscripts.
+
+The Kharoshthi script (Unicode range U+10A00–U+10A5F) is an ancient Indic script that was used in the northwestern regions of the Indian subcontinent. It is written from right to left, unlike most other Indic scripts.
+
+## Keyboard Layers
+
+This keyboard defines six layers based on modifier key combinations:
+
+| Layer | Modifiers | Description |
+|-------|-----------|-------------|
+| Base | None | Primary consonants, vowels, numbers, punctuation |
+| Shift | Shift | Aspirated consonants, additional punctuation |
+| Caps | Caps Lock | Same as Shift layer (aspirates and long vowels) |
+| Shift+Caps | Shift + Caps Lock | Inverted caps behavior |
+| AltGr | Right Alt | Vowel modifiers, retroflex consonants, special characters |
+| Shift+AltGr | Shift + Right Alt | Additional modifiers |
+
+## Character Mapping
+
+### Numbers (Row 1)
+
+Kharoshthi numbers use a additive-multiplicative system. This keyboard implements number composition through transform rules so that input can be done using key sequences based on the decimal place value.
+
+| Keypress | Result | Unicode | Notes |
+|----------|--------|---------|-------------|
+| 0        |        | N/A     | Invokes transform to decade / hundred / thousand |
+| 1 | 𐩀 | U+10A40 | Kharoshthi Digit One |
+| 2 | 𐩁 | U+10A41 | Kharoshthi Digit Two |
+| 3 | 𐩂 | U+10A42 | Kharoshthi Digit Three |
+| 4 | 𐩃 | U+10A43 | Kharoshthi Digit Four |
+| 5 | 𐩃𐩀 | U+10A40 U+10A43 | Composite output via transform |
+| 6 | 𐩃𐩁 | U+10A41 U+10A43 | Composite output via transform |
+| 7 | 𐩃𐩂 | U+10A42 U+10A43 | Composite output via transform |
+| 8 | 𐩃𐩃 | U+10A43 U+10A43 | Composite output via transform |
+| 9 | 𐩃𐩃𐩀 | U+10A40 U+10A43 U+10A43 | Composite output via transform |
+| 10 | 𐩄 | U+10A44 | Kharoshthi Numeral Ten |
+| 20 | 𐩄 | U+10A45 | Kharoshthi Numeral Twenty |
+| 30 | 𐩅𐩄 | U+10A45 U+10A44 | Composite output via transform |
+| 100 | 𐩆 | U+10A46 | Kharoshthi Numeral Hundred |
+| 200 | 𐩁𐩆 | U+10A41 U+10A46 | Composite output via transform |
+| 201 | 𐩁𐩆𐩀 | U+10A41 U+10A46 U+10A40 | Composite output via transform |
+| 1000 | 𐩇 | U+10A47 | Kharoshthi Numeral Thousand |
+| 2000 | 𐩁𐩇 | U+10A41 U+10A47 | Composite output via transform |
+| 2001 | 𐩁𐩇𐩀 | U+10A41 U+10A47 U+10A40 | Composite output via transform |
+
+### Vowels
+Full vowels and dependent vowels are entered using the
+same keys. Context determines whether the full or dependent
+form is entered. Dependent forms are entered immediately
+after a consonant. Full forms are entered otherwise.
+
+| Keypress | Transliteration | Full | Unicode                 | Dependent | Unicode         |
+|---------|-----------------|------|-------------------------|-----------|-----------------|
+| a       | a               | 𐨀    | U+10A00                 |           |                 |
+| A       | ā               | 𐨀𐨌    | U+10A00 U+10A0C         |  𐨌        | U+10A0C         |
+| i       | i               | 𐨀𐨁    | U+10A00 U+10A01         |  𐨁        | U+10A01         |
+| I       | ī               | 𐨀𐨁𐨌    | U+10A00 U+10A01 U+10A0C |  𐨁𐨌        | U+10A01 U+10A0C |
+| u       | u               | 𐨀𐨂    | U+10A00 U+10A02         |  𐨂        | U+10A02         |
+| U       | ū               | 𐨀𐨂𐨌    | U+10A00 U+10A02 U+10A0C |  𐨂𐨌        | U+10A02 U+10A0C |
+| AltGr+r | r̥               | 𐨀𐨃    | U+10A00 U+10A03         |  𐨃        | U+10A03         |
+| AltGr+R | r̥̄               | 𐨀𐨃𐨌    | U+10A00 U+10A03 U+10A0C |  𐨃𐨌        | U+10A03 U+10A0C |
+| e       | e               | 𐨀𐨅    | U+10A00 U+10A05         |  𐨅        | U+10A05         |
+| E       | ai              | 𐨀𐨅𐨌    | U+10A00 U+10A05 U+10A0C |  𐨅𐨌        | U+10A05 U+10A0C |
+| o       | o               | 𐨀𐨆    | U+10A00 U+10A06         |  𐨆        | U+10A06         |
+| O       | au              | 𐨀𐨆𐨌    | U+10A00 U+10A06 U+10A0C |  𐨆𐨌        | U+10A06 U+10A0C |
+
+#### Dependent Vowels (AltGr Layer)
+Direct entry of dependent vowel forms may be done to bypass
+contextual transformation rules.
+
+| Keypress | Transliteration | Result | Unicode |
+|----------|---|--------|---------|
+| AltGr+a  | &#x25CC; ̄  | 𐨌      | U+10A0C |
+| AltGr+i  | i | 𐨁      | U+10A01 |
+| AltGr+u  | u | 𐨂      | U+10A02 |
+| AltGr+r  | r̥ | 𐨃      | U+10A03 |
+| AltGr+e  | e | 𐨅      | U+10A05 |
+| AltGr+o  | o | 𐨆      | U+10A06 |
+
+#### Vowel Modifiers
+
+| Keypress    | Transliteration | Result | Unicode | Description |
+|-------------|---|--------|---------|-------------|
+| M | ṃ | 𐨎 | U+10A0E | Anusvara |
+| H | ḥ | 𐨏 | U+10A0F | Visarga |
+| AltGr+8     | &#x25CC; ͚  | 𐨍 | U+10A0D | Double ring below |
+
+### Consonants
+
+#### Basic Consonants
+Consonants are entered with the inherant vowel invisibly suppressed. Pressing the key |a| provides the inherent vowel. If a consonant is pressed directly after another consontant, a conjuct form may result, unless the combination matches a diagraph form, see below.
+
+| Keypress | Transliteration |Result | Unicode |
+|-----|--------|---------|-----------------|
+| k | k | 𐨐 | U+10A10 |
+| K | kh | 𐨑 | U+10A11 |
+| g | g | 𐨒 | U+10A12 |
+| G | gh | 𐨓 | U+10A13 |
+| c | c | 𐨕 | U+10A15 |
+| C | ch | 𐨖 | U+10A16 |
+| j | j | 𐨗 | U+10A17 |
+| N | ṇ | 𐨞 | U+10A1E |
+| t | t | 𐨟 | U+10A1F |
+| T | th | 𐨠 | U+10A20 |
+| d | d | 𐨡 | U+10A21 |
+| D | dh | 𐨢 | U+10A22 |
+| n | n | 𐨣 | U+10A23 |
+| p | p | 𐨤 | U+10A24 |
+| f | ph | 𐨥 | U+10A25 |
+| b | b | 𐨦 | U+10A26 |
+| B | bh | 𐨧 | U+10A27 |
+| m | m | 𐨨 | U+10A28 |
+| y | y | 𐨩 | U+10A29 |
+| r | r | 𐨪 | U+10A2A |
+| l | l | 𐨫 | U+10A2B |
+| v | v | 𐨬 | U+10A2C |
+| w | ś | 𐨭 | U+10A2D |
+| x | ṣ | 𐨮 | U+10A2E |
+| s | s | 𐨯 | U+10A2F |
+| z | z | 𐨰 | U+10A30 |
+| h | h | 𐨱 | U+10A31 |
+
+#### Digraphs
+Consonants normally transcribed with digraphs can
+be entered by typing the usual diagraph or an approximation.
+
+| Keypresses | Transliteration | Result | Unicode |
+|------------|-----------------|--------|---------|
+| k h | kh | &#x10A11; | U+10A11 |
+| k ' | ḱ | &#x10A32; | U+10A32 |
+| g h | gh | &#x10A13; | U+10A13 |
+| c h | ch | &#x10A16; | U+10A16 |
+| AltGr+t h | ṭh | &#x10A1B; | U+10A1B |
+| AltGr+t h h | ṭ́h | &#x10A33; | U+10A33 |
+| AltGr+t h' | ṭ́h | &#x10A33; | U+10A33 |
+| AltGr+d h | ḍh | &#x10A1D; | U+10A1D |
+| t h | th | &#x10A20; | U+10A20 |
+| d h | dh | &#x10A22; | U+10A22 |
+| p h | ph | &#x10A25; | U+10A25 |
+| b h | bh | &#x10A27; | U+10A27 |
+| s h | ś | &#x10A2D; | U+10A2D |
+| AltGr+t ' | ṭ́ | &#x10A34; | U+10A34 |
+| v h | vh | &#x10A35; | U+10A35 |
+
+#### Consonants via AltGr
+Consonants normally transcribed with diacritics can
+be accessed using AltGr with a related key.
+
+| Keypress | Transliteration | Result | Unicode |
+|-----|--------|---------|-----------------|
+| AltGr+y | ñ | 𐨙 | U+10A19 |
+| AltGr+t | ṭ | 𐨚 | U+10A1A |
+| AltGr+T | ṭh | 𐨛 | U+10A1B |
+| AltGr+d | ḍ | 𐨜 | U+10A1C |
+| AltGr+D | ḍh | 𐨝 | U+10A1D |
+| AltGr+n | ṇ | 𐨞 | U+10A1E |
+| AltGr+S | ś | 𐨭 | U+10A2D |
+| AltGr+k | ḱ | 𐨲 | U+10A32 |
+
+#### Special Consonants
+
+| Key | Transliteration | Result | Unicode |
+|-----|--------|---------|-----------------|
+| X | kṣ | 𐨐𐨿𐨮 | U+10A10 U+10A3F U+10A2E |
+| V | vh | 𐨵 | U+10A35 |
+
+### Consonant Modifiers
+
+| Keypress | Result | Unicode | Description |
+|-----|--------|---------|-------------|
+| - | 𐨸 | U+10A38 | Hyphen enters bar above a preceding consonant |
+| _ | 𐨹 | U+10A39 | Underscore enters cauda below a preceding consonant |
+| AltGr+. | 𐨺 | U+10A3A | Dot below |
+| AltGr+/ | 𐨿 | U+10A3F | Enter the explicit virama and  render the preceding consonant in subscript form |
+
+### Punctuation
+
+| Keypress | Result | Unicode | Description |
+|-----|--------|---------|-------------|
+| . | 𐩐 | U+10A50 | Punctuation dot |
+| Shift+. (>) | 𐩑 | U+10A51 | Punctuation small circle |
+| ; | 𐩒 | U+10A52 | Punctuation circle |
+| Shift+; (:) | 𐩓 | U+10A53 | Punctuation crescent bar |
+| , | 𐩔 | U+10A54 | Punctuation mangalam |
+| Shift+, (<) | 𐩕 | U+10A55 | Punctuation lotus |
+| \ | 𐩖 | U+10A56 | Punctuation danda |
+| Shift+\ (\|) | 𐩗 | U+10A57 | Punctuation double danda |
+| = | 𐩘 | U+10A58 | Punctuation lines |
+| ½ (half) | 𐩈 | U+10A48 | Fraction half |
+| \| \| | 𐩗 | U+10A57 | Two single dandas transform to a double danda |
+
+## Backspace Behavior
+
+The keyboard implements intelligent backspace handling:
+
+1. **Full vowel deletion**: Deleting a full vowel (base + vowel sign) removes both characters
+2. **Vowel sign restoration**: Deleting a vowel sign after a consonant restores the inherent 'a'
+3. **Vowel modifier handling**: Deleting a vowel modifier after a consonant restores the consonant state
+4. **Conjunct dissolution**: Deleting a virama+consonant sequence removes the entire conjunct portion
+
+## Technical Notes
+
+- **LDML Version**: This keyboard conforms to CLDR Keyboard 3.0 specification (CLDR 47)
+- **DTD**: `ldmlKeyboard3.dtd`
+- **Form Factor**: Designed for US ANSI 101-key hardware keyboard layout
+- **Imports**: Uses standard CLDR punctuation and currency key definitions
+
+## References
+
+- [Unicode Kharoshthi Block](https://www.unicode.org/charts/PDF/U10A00.pdf) (U+10A00–U+10A5F)
+- [CLDR Keyboard Specification](https://www.unicode.org/reports/tr35/tr35-keyboards.html) (UTS #35 Part 7)
+- [Kharoshthi Script in Unicode](https://www.unicode.org/versions/Unicode15.0.0/ch14.pdf) (Chapter 14, The Unicode Standard)
+
+## License
+
+This keyboard layout is part of the Unicode CLDR project and is subject to the [Unicode License Agreement](https://www.unicode.org/copyright.html).

--- a/keyboards/3.0/pgd-Khar-t-k0-qwerty.xml
+++ b/keyboards/3.0/pgd-Khar-t-k0-qwerty.xml
@@ -3,7 +3,7 @@
   conformsTo="47" draft="contributed" >
   <info author="Andrew Glass" name="Gandhari (Phonetic)"
     layout="QWERTY" indicator="\u{10A12}\u{10A0E}" />
-  <version number="1.0.1"/>
+  <version number="1.0.2"/>
 
   <keys>
     <import base="cldr" path="47/keys-Zyyy-punctuation.xml"/>
@@ -18,7 +18,7 @@
       <key id="3"          output="\u{10A42}" /> <!-- Three -->
       <key id="4"          output="\u{10A43}" /> <!-- Four -->
       <key id="5"          output="\m{FIVE}"  /> <!-- Five -->
-      <key id="6"          output="\m{SIXX}"  /> <!-- Six -->
+      <key id="6"          output="\m{SIX}"   /> <!-- Six -->
       <key id="7"          output="\m{SEVE}"  /> <!-- Seven -->
       <key id="8"          output="\m{EIGH}"  /> <!-- Eight -->
       <key id="9"          output="\m{NINE}"  /> <!-- Nine -->
@@ -59,13 +59,13 @@
       <key id="alt_k"      output="\u{10A32}\m{A}" />
       <key id="K"          output="\u{10A11}\m{A}" />
       <key id="q"          output="\u{10A11}\m{A}" />
-      <key id="Q"          output="\u{10A11}\m{A}" />
+      <key id="Q"          output="\u{10A11}\m{A}" /> <!--intentional duplicate -->
       <key id="g"          output="\u{10A12}\m{A}" />
       <key id="G"          output="\u{10A13}\m{A}" />
       <key id="c"          output="\u{10A15}\m{A}" />
       <key id="C"          output="\u{10A16}\m{A}" />
       <key id="j"          output="\u{10A17}\m{A}" />
-      <key id="J"          output="\u{10A17}\m{A}" />
+      <key id="J"          output="\u{10A17}\m{A}" /> <!--intentional duplicate -->
       <key id="alt_y"      output="\u{10A19}\m{A}" />
       <key id="alt_t"      output="\u{10A1A}\m{A}" />
       <key id="alt_T"      output="\u{10A1B}\m{A}" />
@@ -77,41 +77,52 @@
       <key id="d"          output="\u{10A21}\m{A}" />
       <key id="D"          output="\u{10A22}\m{A}" />
       <key id="n"          output="\u{10A23}\m{A}" />
+      <key id="N"          output="\u{10A1E}\m{A}" />
       <key id="p"          output="\u{10A24}\m{A}" />
       <key id="P"          output="\u{10A25}\m{A}" />
       <key id="f"          output="\u{10A25}\m{A}" />
-      <key id="F"          output="\u{10A25}\m{A}" />
+      <key id="F"          output="\u{10A25}\m{A}" /> <!--intentional duplicate -->
       <key id="b"          output="\u{10A26}\m{A}" />
       <key id="B"          output="\u{10A27}\m{A}" />
       <key id="m"          output="\u{10A28}\m{A}" />
+      <key id="M"          output="\u{10A0E}" />
       <key id="y"          output="\u{10A29}\m{A}" />
+      <key id="Y"          output="\m{C}\u{10A29}\m{A}" /> <!--full ya -->
       <key id="r"          output="\u{10A2A}\m{A}" />
+      <key id="R"          output="\u{10A2A}\m{A}" /> <!--intentional duplicate -->
       <key id="l"          output="\u{10A2B}\m{A}" />
+      <key id="L"          output="\u{10A2B}\m{A}" /> <!--intentional duplicate -->
       <key id="v"          output="\u{10A2C}\m{A}" />
-      <key id="w"          output="\u{10A2C}\m{A}" />
+      <key id="V"          output="\u{10A35}\m{A}" />
+      <key id="w"          output="\u{10A2D}\m{A}" />
+      <key id="W"          output="\u{10A2D}\m{A}" /> <!--intentional duplicate -->
       <key id="alt_s"      output="\u{10A2D}\m{A}" />
       <key id="x"          output="\u{10A2E}\m{A}" />
+      <key id="X"          output="\u{10A10}\u{10A3F}\u{10A2E}\m{A}" />
       <key id="s"          output="\u{10A2F}\m{A}" />
+      <key id="S"          output="\u{10A2D}\m{A}" />
       <key id="z"          output="\u{10A30}\m{A}" />
+      <key id="Z"          output="\u{10A30}\m{A}" /> <!--intentional duplicate -->
       <key id="h"          output="\u{10A31}\m{A}" />
+      <key id="H"          output="\u{10A0F}" />
 
     <!-- Consonant modifiers -->
       <key id="barabove"   output="\u{10A38}" />
       <key id="cauda"      output="\u{10A39}" />
       <key id="dotbelow"   output="\u{10A3A}" />
       <key id="virama"     output="\u{10A3F}" />
-      <key id="apos"       output="\m{nobar}" />
+      <key id="apos"       output="\m{special}" />
 
     <!-- Punctuation -->
-      <key id="comma"      output="\u{10A50}" />
-      <key id="period"     output="\u{10A51}" />
-      <key id="semi-colon" output="\u{10A52}" />
-      <key id="colon"      output="\u{10A53}" />
-      <key id="alt_comma"  output="\u{10A54}" />
-      <key id="alt_period" output="\u{10A55}" />
-      <key id="pipe"       output="\u{10A56}" />
-      <key id="alt_pipe"   output="\u{10A57}" />
-      <key id="equal"      output="\u{10A58}" />
+      <key id="period"      output="\u{10A50}" />
+      <key id="close-angle" output="\u{10A51}" />
+      <key id="semi-colon"  output="\u{10A52}" />
+      <key id="colon"       output="\u{10A53}" />
+      <key id="comma"       output="\u{10A54}" />
+      <key id="open-angle"  output="\u{10A55}" />
+      <key id="pipe"        output="\u{10A56}" />
+      <key id="alt_pipe"    output="\u{10A57}" />
+      <key id="equal"       output="\u{10A58}" />
   </keys>
 
   <layers formId="us">
@@ -119,7 +130,7 @@
       <row keys="grave 1 2 3 4 5 6 7 8 9 0 barabove equal"/>
       <row keys="q w e r t y u i o p open-square close-square backslash"/>
       <row keys="a s d f g h j k l semi-colon apos"/>
-      <row keys="z x c v b n m comma period virama"/>
+      <row keys="z x c v b n m comma period slash"/>
       <row keys="space"/>
     </layer>
     <layer modifiers="shift">
@@ -147,17 +158,24 @@
       <row keys="gap half gap gap gap gap gap gap alt_8 gap gap gap gap"/>
       <row keys="gap gap alt_e alt_r alt_t alt_y alt_u alt_i alt_o gap gap gap gap"/>
       <row keys="alt_a alt_s alt_d gap gap alt_h gap alt_k gap gap gap"/>
-      <row keys="gap gap gap gap gap alt_n alt_m alt_comma alt_period gap"/>
+      <row keys="gap gap gap gap gap alt_n alt_m gap dotbelow virama"/>
       <row keys="space"/>
     </layer>
     <layer modifiers="shift altR">
-      <row keys="gap gap gap gap gap gap gap gap gap gap gap dotbelow gap"/>
+      <row keys="gap gap gap gap gap gap gap gap gap gap gap gap gap"/>
       <row keys="gap gap gap alt_R alt_T gap gap gap gap gap gap gap alt_pipe"/>
       <row keys="alt_A gap alt_D gap gap alt_H gap gap gap gap gap"/>
       <row keys="gap gap gap gap gap gap alt_M gap gap gap"/>
       <row keys="gap"/>
     </layer>
   </layers>
+
+  <variables>
+    <uset id="vowels"            value="[\u{10A01}-\u{10A03} \u{10A05}-\u{10A06}]" />
+    <set id="vowelmodifiers"     value="\u{10A0C} \u{10A0D} \u{10A0E} \u{10A0F}" />
+    <uset id="consonants"        value="[\u{10A10}-\u{10A13} \u{10A15}-\u{10A17} \u{10A19}-\u{10A35}]" />
+    <set id="consonantmodifiers" value="\u{10A38} \u{10A39} \u{10A3A}" />
+  </variables>
 
   <transforms type="simple">
     <transformGroup> <!-- Numbers -->
@@ -198,86 +216,108 @@
       <transform from="\m{NINE}"                                     to="\u{10A43}\u{10A43}\u{10A40}" />                   <!-- Four Four One -->
       <transform from="\m{EIGH}"                                     to="\u{10A43}\u{10A43}" />                            <!-- Four Four -->
       <transform from="\m{SEVE}"                                     to="\u{10A43}\u{10A42}" />                            <!-- Four Three -->
-      <transform from="\m{SIXX}"                                     to="\u{10A43}\u{10A41}" />                            <!-- Four Two -->
+      <transform from="\m{SIX}"                                      to="\u{10A43}\u{10A41}" />                            <!-- Four Two -->
       <transform from="\m{FIVE}"                                     to="\u{10A43}\u{10A40}" />                            <!-- Four One -->
       <transform from="\m{ZERO}"                                     to="0" />                                             <!-- Four One -->
     </transformGroup>
 
     <transformGroup> <!-- Derived consonants -->
-      <transform from="\u{10A10}\m{A}\u{10A31}\m{A}"     to="\u{10A11}\m{A}" />
-      <transform from="\u{10A12}\m{A}\u{10A31}\m{A}"     to="\u{10A13}\m{A}" />
-      <transform from="\u{10A15}\m{A}\u{10A31}\m{A}"     to="\u{10A16}\m{A}" />
-      <transform from="\u{10A1A}\m{A}\u{10A31}\m{A}"     to="\u{10A1B}\m{A}" />
-      <transform from="\u{10A1B}\m{A}\u{10A31}\m{A}"     to="\u{10A33}\m{A}" />  <!-- ṭh h to ṭ́h -->
-      <transform from="\u{10A1C}\m{A}\u{10A31}\m{A}"     to="\u{10A1D}\m{A}" />
-      <transform from="\u{10A1F}\m{A}\u{10A31}\m{A}"     to="\u{10A20}\m{A}" />
-      <transform from="\u{10A21}\m{A}\u{10A31}\m{A}"     to="\u{10A22}\m{A}" />
-      <transform from="\u{10A24}\m{A}\u{10A31}\m{A}"     to="\u{10A25}\m{A}" />
-      <transform from="\u{10A26}\m{A}\u{10A31}\m{A}"     to="\u{10A27}\m{A}" />
-      <transform from="\u{10A2F}\m{A}\u{10A31}\m{A}"     to="\u{10A2D}\m{A}" />  <!-- S H to Ś -->
-      <transform from="\u{10A1A}\m{A}\m{nobar}"          to="\u{10A34}\m{A}" />  <!-- ṭ ' to ṭ́ -->
-      <transform from="\u{10A2C}\m{A}\u{10A31}\m{A}"     to="\u{10A35}\m{A}" />  <!-- V H to VH -->
-      <transform from="\u{10A2B}\m{A}\u{10A19}\m{A}"     to="\u{10A2B}\u{200D}\u{10A3F}\u{10A29}\m{A}" />  <!-- V H to VH -->
-      <transform from="\m{nobar}"                        to="\u{0027}" />  <!-- ṭ ' to ṭ́ -->
+      <transform from="\u{10A10}\m{A}\u{10A31}\m{A}"      to="\u{10A11}\m{A}" />  <!-- kh -->
+      <transform from="\u{10A10}\m{A}\m{special}"         to="\u{10A32}\m{A}" />  <!-- k ' > ḱ -->
+      <transform from="\u{10A12}\m{A}\u{10A31}\m{A}"      to="\u{10A13}\m{A}" />  <!-- gh -->
+      <transform from="\u{10A15}\m{A}\u{10A31}\m{A}"      to="\u{10A16}\m{A}" />  <!-- ch -->
+      <transform from="\u{10A1A}\m{A}\u{10A31}\m{A}"      to="\u{10A1B}\m{A}" />  <!-- ṭh -->
+      <transform from="\u{10A1B}\m{A}\u{10A31}\m{A}"      to="\u{10A33}\m{A}" />  <!-- ṭh h to ṭ́h -->
+      <transform from="\u{10A1B}\m{A}\m{special}"         to="\u{10A33}\m{A}" />  <!-- ṭh ' to ṭ́h -->
+      <transform from="\u{10A1C}\m{A}\u{10A31}\m{A}"      to="\u{10A1D}\m{A}" />  <!-- ḍh -->
+      <transform from="\u{10A1F}\m{A}\u{10A31}\m{A}"      to="\u{10A20}\m{A}" />  <!-- th -->
+      <transform from="\u{10A21}\m{A}\u{10A31}\m{A}"      to="\u{10A22}\m{A}" />  <!-- dh -->
+      <transform from="\u{10A24}\m{A}\u{10A31}\m{A}"      to="\u{10A25}\m{A}" />  <!-- ph -->
+      <transform from="\u{10A26}\m{A}\u{10A31}\m{A}"      to="\u{10A27}\m{A}" />  <!-- bh -->
+      <transform from="\u{10A2F}\m{A}\u{10A31}\m{A}"      to="\u{10A2D}\m{A}" />  <!-- s h to ś -->
+      <transform from="\u{10A1A}\m{A}\m{special}"         to="\u{10A34}\m{A}" />  <!-- ṭ ' to ṭ́ -->
+      <transform from="\u{10A2C}\m{A}\u{10A31}\m{A}"      to="\u{10A35}\m{A}" />  <!-- v h to vh -->
+      <transform from="\u{10A2C}\m{A}\m{special}"         to="\u{10A35}\m{A}" />  <!-- ṭ ' to ṭ́ -->
+      <transform from="\m{special}"                       to="\u{0027}" />  <!-- ṭ ' to ṭ́ -->
+      <transform from="\u{10A2B}\m{A}\m{C}\u{10A29}\m{A}" to="\u{10A2B}\u{200D}\u{10A3F}\u{10A29}\m{A}" />  <!-- l'ya -->
     </transformGroup>
 
     <transformGroup> <!-- Derived punctuation -->
-      <transform from="\u{10A56}\u{10A56}"               to="\u{10A57}" />  <!-- Double danda -->
+      <transform from="\m{A}\u{0020}"                     to="" />           <!-- Cancel halant -->
+      <transform from="\u{10A56}\u{10A56}"                to="\u{10A57}" />  <!-- Double danda -->
     </transformGroup>
 
     <transformGroup> <!-- Dependent vowels -->
-      <transform from="\m{A}\u{10A00}"                   to="" />
-      <transform from="\m{A}\u{10A00}\u{10A0C}"          to="\u{10A0C}" />
-      <transform from="\m{A}\u{10A00}\u{10A01}"          to="\u{10A01}" />
-      <transform from="\m{A}\u{10A00}\u{10A01}\u{10A0C}" to="\u{10A01}\u{10A0C}" />
-      <transform from="\m{A}\u{10A00}\u{10A02}"          to="\u{10A02}" />
-      <transform from="\m{A}\u{10A00}\u{10A02}\u{10A0C}" to="\u{10A02}\u{10A0C}" />
-      <transform from="\m{A}\u{10A00}\u{10A03}"          to="\u{10A03}" />
-      <transform from="\m{A}\u{10A00}\u{10A03}\u{10A0C}" to="\u{10A03}\u{10A0C}" />
-      <transform from="\m{A}\u{10A00}\u{10A05}"          to="\u{10A05}" />
-      <transform from="\m{A}\u{10A00}\u{10A05}\u{10A0C}" to="\u{10A05}\u{10A0C}" />
-      <transform from="\m{A}\u{10A00}\u{10A06}"          to="\u{10A06}" />
-      <transform from="\m{A}\u{10A00}\u{10A06}\u{10A0C}" to="\u{10A06}\u{10A0C}" />
+      <transform from="\m{A}\u{10A00}"                    to="\m{B}" />
+      <transform from="\m{A}\u{10A00}\u{10A0C}"           to="\u{10A0C}" />
+      <transform from="\m{A}\u{10A00}\u{10A01}"           to="\u{10A01}" />
+      <transform from="\m{A}\u{10A00}\u{10A01}\u{10A0C}"  to="\u{10A01}\u{10A0C}" />
+      <transform from="\m{A}\u{10A00}\u{10A02}"           to="\u{10A02}" />
+      <transform from="\m{A}\u{10A00}\u{10A02}\u{10A0C}"  to="\u{10A02}\u{10A0C}" />
+      <transform from="\m{A}\u{10A00}\u{10A03}"           to="\u{10A03}" />
+      <transform from="\m{A}\u{10A00}\u{10A03}\u{10A0C}"  to="\u{10A03}\u{10A0C}" />
+      <transform from="\m{A}\u{10A00}\u{10A05}"           to="\u{10A05}" />
+      <transform from="\m{A}\u{10A00}\u{10A05}\u{10A0C}"  to="\u{10A05}\u{10A0C}" />
+      <transform from="\m{A}\u{10A00}\u{10A06}"           to="\u{10A06}" />
+      <transform from="\m{A}\u{10A00}\u{10A06}\u{10A0C}"  to="\u{10A06}\u{10A0C}" />
+    </transformGroup>
+
+    <transformGroup> <!-- Modifiers -->
+      <transform from="\m{A}($[vowelmodifiers])"          to="$1" />
+      <transform from="\m{A}($[consonantmodifiers])"      to="$1\m{A}" />
+    </transformGroup>
+
+    <transformGroup> <!-- Virama -->
+      <transform from="\m{A}\u{10A3F}"                    to="\u{10A3F}" />
     </transformGroup>
 
     <transformGroup> <!-- Virama consonants -->
-      <transform from="\m{A}\u{10A10}\m{A}"              to="\u{10A3F}\u{10A10}\m{A}" />
-      <transform from="\m{A}\u{10A32}\m{A}"              to="\u{10A3F}\u{10A32}\m{A}" />
-      <transform from="\m{A}\u{10A11}\m{A}"              to="\u{10A3F}\u{10A11}\m{A}" />
-      <transform from="\m{A}\u{10A12}\m{A}"              to="\u{10A3F}\u{10A12}\m{A}" />
-      <transform from="\m{A}\u{10A13}\m{A}"              to="\u{10A3F}\u{10A13}\m{A}" />
-      <transform from="\m{A}\u{10A15}\m{A}"              to="\u{10A3F}\u{10A15}\m{A}" />
-      <transform from="\m{A}\u{10A16}\m{A}"              to="\u{10A3F}\u{10A16}\m{A}" />
-      <transform from="\m{A}\u{10A17}\m{A}"              to="\u{10A3F}\u{10A17}\m{A}" />
-      <transform from="\m{A}\u{10A17}\m{A}"              to="\u{10A3F}\u{10A17}\m{A}" />
-      <transform from="\m{A}\u{10A19}\m{A}"              to="\u{10A3F}\u{10A19}\m{A}" />
-      <transform from="\m{A}\u{10A1A}\m{A}"              to="\u{10A3F}\u{10A1A}\m{A}" />
-      <transform from="\m{A}\u{10A1B}\m{A}"              to="\u{10A3F}\u{10A1B}\m{A}" />
-      <transform from="\m{A}\u{10A1C}\m{A}"              to="\u{10A3F}\u{10A1C}\m{A}" />
-      <transform from="\m{A}\u{10A1D}\m{A}"              to="\u{10A3F}\u{10A1D}\m{A}" />
-      <transform from="\m{A}\u{10A1E}\m{A}"              to="\u{10A3F}\u{10A1E}\m{A}" />
-      <transform from="\m{A}\u{10A1F}\m{A}"              to="\u{10A3F}\u{10A1F}\m{A}" />
-      <transform from="\m{A}\u{10A20}\m{A}"              to="\u{10A3F}\u{10A20}\m{A}" />
-      <transform from="\m{A}\u{10A21}\m{A}"              to="\u{10A3F}\u{10A21}\m{A}" />
-      <transform from="\m{A}\u{10A22}\m{A}"              to="\u{10A3F}\u{10A22}\m{A}" />
-      <transform from="\m{A}\u{10A23}\m{A}"              to="\u{10A3F}\u{10A23}\m{A}" />
-      <transform from="\m{A}\u{10A24}\m{A}"              to="\u{10A3F}\u{10A24}\m{A}" />
-      <transform from="\m{A}\u{10A25}\m{A}"              to="\u{10A3F}\u{10A25}\m{A}" />
-      <transform from="\m{A}\u{10A26}\m{A}"              to="\u{10A3F}\u{10A26}\m{A}" />
-      <transform from="\m{A}\u{10A27}\m{A}"              to="\u{10A3F}\u{10A27}\m{A}" />
-      <transform from="\m{A}\u{10A28}\m{A}"              to="\u{10A3F}\u{10A28}\m{A}" />
-      <transform from="\m{A}\u{10A29}\m{A}"              to="\u{10A3F}\u{10A29}\m{A}" />
-      <transform from="\m{A}\u{10A2A}\m{A}"              to="\u{10A3F}\u{10A2A}\m{A}" />
-      <transform from="\m{A}\u{10A2B}\m{A}"              to="\u{10A3F}\u{10A2B}\m{A}" />
-      <transform from="\m{A}\u{10A2C}\m{A}"              to="\u{10A3F}\u{10A2C}\m{A}" />
-      <transform from="\m{A}\u{10A2C}\m{A}"              to="\u{10A3F}\u{10A2C}\m{A}" />
-      <transform from="\m{A}\u{10A2D}\m{A}"              to="\u{10A3F}\u{10A2D}\m{A}" />
-      <transform from="\m{A}\u{10A2E}\m{A}"              to="\u{10A3F}\u{10A2E}\m{A}" />
-      <transform from="\m{A}\u{10A2F}\m{A}"              to="\u{10A3F}\u{10A2F}\m{A}" />
-      <transform from="\m{A}\u{10A30}\m{A}"              to="\u{10A3F}\u{10A30}\m{A}" />
-      <transform from="\m{A}\u{10A31}\m{A}"              to="\u{10A3F}\u{10A31}\m{A}" />
+      <transform from="\m{A}\u{10A10}\m{A}"               to="\u{10A3F}\u{10A10}\m{A}" />
+      <transform from="\m{A}\u{10A32}\m{A}"               to="\u{10A3F}\u{10A32}\m{A}" />
+      <transform from="\m{A}\u{10A11}\m{A}"               to="\u{10A3F}\u{10A11}\m{A}" />
+      <transform from="\m{A}\u{10A12}\m{A}"               to="\u{10A3F}\u{10A12}\m{A}" />
+      <transform from="\m{A}\u{10A13}\m{A}"               to="\u{10A3F}\u{10A13}\m{A}" />
+      <transform from="\m{A}\u{10A15}\m{A}"               to="\u{10A3F}\u{10A15}\m{A}" />
+      <transform from="\m{A}\u{10A16}\m{A}"               to="\u{10A3F}\u{10A16}\m{A}" />
+      <transform from="\m{A}\u{10A17}\m{A}"               to="\u{10A3F}\u{10A17}\m{A}" />
+      <transform from="\m{A}\u{10A17}\m{A}"               to="\u{10A3F}\u{10A17}\m{A}" />
+      <transform from="\m{A}\u{10A19}\m{A}"               to="\u{10A3F}\u{10A19}\m{A}" />
+      <transform from="\m{A}\u{10A1A}\m{A}"               to="\u{10A3F}\u{10A1A}\m{A}" />
+      <transform from="\m{A}\u{10A1B}\m{A}"               to="\u{10A3F}\u{10A1B}\m{A}" />
+      <transform from="\m{A}\u{10A1C}\m{A}"               to="\u{10A3F}\u{10A1C}\m{A}" />
+      <transform from="\m{A}\u{10A1D}\m{A}"               to="\u{10A3F}\u{10A1D}\m{A}" />
+      <transform from="\m{A}\u{10A1E}\m{A}"               to="\u{10A3F}\u{10A1E}\m{A}" />
+      <transform from="\m{A}\u{10A1F}\m{A}"               to="\u{10A3F}\u{10A1F}\m{A}" />
+      <transform from="\m{A}\u{10A20}\m{A}"               to="\u{10A3F}\u{10A20}\m{A}" />
+      <transform from="\m{A}\u{10A21}\m{A}"               to="\u{10A3F}\u{10A21}\m{A}" />
+      <transform from="\m{A}\u{10A22}\m{A}"               to="\u{10A3F}\u{10A22}\m{A}" />
+      <transform from="\m{A}\u{10A23}\m{A}"               to="\u{10A3F}\u{10A23}\m{A}" />
+      <transform from="\m{A}\u{10A24}\m{A}"               to="\u{10A3F}\u{10A24}\m{A}" />
+      <transform from="\m{A}\u{10A25}\m{A}"               to="\u{10A3F}\u{10A25}\m{A}" />
+      <transform from="\m{A}\u{10A26}\m{A}"               to="\u{10A3F}\u{10A26}\m{A}" />
+      <transform from="\m{A}\u{10A27}\m{A}"               to="\u{10A3F}\u{10A27}\m{A}" />
+      <transform from="\m{A}\u{10A28}\m{A}"               to="\u{10A3F}\u{10A28}\m{A}" />
+      <transform from="\m{A}\u{10A29}\m{A}"               to="\u{10A3F}\u{10A29}\m{A}" />
+      <transform from="\m{A}\u{10A2A}\m{A}"               to="\u{10A3F}\u{10A2A}\m{A}" />
+      <transform from="\m{A}\u{10A2B}\m{A}"               to="\u{10A3F}\u{10A2B}\m{A}" />
+      <transform from="\m{A}\u{10A2C}\m{A}"               to="\u{10A3F}\u{10A2C}\m{A}" />
+      <transform from="\m{A}\u{10A2C}\m{A}"               to="\u{10A3F}\u{10A2C}\m{A}" />
+      <transform from="\m{A}\u{10A2D}\m{A}"               to="\u{10A3F}\u{10A2D}\m{A}" />
+      <transform from="\m{A}\u{10A2E}\m{A}"               to="\u{10A3F}\u{10A2E}\m{A}" />
+      <transform from="\m{A}\u{10A2F}\m{A}"               to="\u{10A3F}\u{10A2F}\m{A}" />
+      <transform from="\m{A}\u{10A30}\m{A}"               to="\u{10A3F}\u{10A30}\m{A}" />
+      <transform from="\m{A}\u{10A31}\m{A}"               to="\u{10A3F}\u{10A31}\m{A}" />
     </transformGroup>
+  </transforms>
 
+  <transforms type="backspace">
+    <transformGroup>
+      <transform from="\u{10A00}$[vowels]"                to="" />
+      <transform from="$[vowels]"                         to="\m{A}" />
+      <transform from="($[consonants])$[vowelmodifiers]"  to="$1\m{A}" />
+      <transform from="\u{10A3F}$[consonants]\m{A}"       to="\m{A}" />
+      <transform from="\m{B}"                             to="\m{A}" />
+    </transformGroup>
   </transforms>
 
 </keyboard3>

--- a/keyboards/3.0/pgd-Khar-t-k0-qwerty.xml
+++ b/keyboards/3.0/pgd-Khar-t-k0-qwerty.xml
@@ -59,13 +59,13 @@
       <key id="alt_k"      output="\u{10A32}\m{A}" />
       <key id="K"          output="\u{10A11}\m{A}" />
       <key id="q"          output="\u{10A11}\m{A}" />
-      <key id="Q"          output="\u{10A11}\m{A}" /> <!--intentional duplicate -->
+      <key id="Q"          output="\u{10A11}\m{A}" /> <!--q and Q intentionally produce the same output -->
       <key id="g"          output="\u{10A12}\m{A}" />
       <key id="G"          output="\u{10A13}\m{A}" />
       <key id="c"          output="\u{10A15}\m{A}" />
       <key id="C"          output="\u{10A16}\m{A}" />
       <key id="j"          output="\u{10A17}\m{A}" />
-      <key id="J"          output="\u{10A17}\m{A}" /> <!--intentional duplicate -->
+      <key id="J"          output="\u{10A17}\m{A}" /> <!--j and J intentionally produce the same output -->
       <key id="alt_y"      output="\u{10A19}\m{A}" />
       <key id="alt_t"      output="\u{10A1A}\m{A}" />
       <key id="alt_T"      output="\u{10A1B}\m{A}" />
@@ -81,28 +81,28 @@
       <key id="p"          output="\u{10A24}\m{A}" />
       <key id="P"          output="\u{10A25}\m{A}" />
       <key id="f"          output="\u{10A25}\m{A}" />
-      <key id="F"          output="\u{10A25}\m{A}" /> <!--intentional duplicate -->
+      <key id="F"          output="\u{10A25}\m{A}" /> <!--f and F intentionally produce the same output -->
       <key id="b"          output="\u{10A26}\m{A}" />
       <key id="B"          output="\u{10A27}\m{A}" />
       <key id="m"          output="\u{10A28}\m{A}" />
       <key id="M"          output="\u{10A0E}" />
       <key id="y"          output="\u{10A29}\m{A}" />
-      <key id="Y"          output="\m{C}\u{10A29}\m{A}" /> <!--full ya -->
+      <key id="Y"          output="\m{C}\u{10A29}\m{A}" />
       <key id="r"          output="\u{10A2A}\m{A}" />
-      <key id="R"          output="\u{10A2A}\m{A}" /> <!--intentional duplicate -->
+      <key id="R"          output="\u{10A2A}\m{A}" /> <!--r and R intentionally produce the same output -->
       <key id="l"          output="\u{10A2B}\m{A}" />
-      <key id="L"          output="\u{10A2B}\m{A}" /> <!--intentional duplicate -->
+      <key id="L"          output="\u{10A2B}\m{A}" /> <!--l and L intentionally produce the same output -->
       <key id="v"          output="\u{10A2C}\m{A}" />
       <key id="V"          output="\u{10A35}\m{A}" />
       <key id="w"          output="\u{10A2D}\m{A}" />
-      <key id="W"          output="\u{10A2D}\m{A}" /> <!--intentional duplicate -->
+      <key id="W"          output="\u{10A2D}\m{A}" /> <!--w and W intentionally produce the same output -->
       <key id="alt_s"      output="\u{10A2D}\m{A}" />
       <key id="x"          output="\u{10A2E}\m{A}" />
       <key id="X"          output="\u{10A10}\u{10A3F}\u{10A2E}\m{A}" />
       <key id="s"          output="\u{10A2F}\m{A}" />
       <key id="S"          output="\u{10A2D}\m{A}" />
       <key id="z"          output="\u{10A30}\m{A}" />
-      <key id="Z"          output="\u{10A30}\m{A}" /> <!--intentional duplicate -->
+      <key id="Z"          output="\u{10A30}\m{A}" /> <!--z and Z intentionally produce the same output -->
       <key id="h"          output="\u{10A31}\m{A}" />
       <key id="H"          output="\u{10A0F}" />
 

--- a/keyboards/3.0/sa-Deva-t-k0-qwerty.xml
+++ b/keyboards/3.0/sa-Deva-t-k0-qwerty.xml
@@ -8,7 +8,7 @@
     <import base="cldr" path="47/keys-Zyyy-punctuation.xml"/>
     <import base="cldr" path="47/keys-Zyyy-currency.xml"/>
     <!-- \m{A} — Holds the inherent vowel during normal input -->
-    <!-- \m{B} — The inherent vowel that arrises from deleting a dependent vowel -->
+    <!-- \m{B} — The inherent vowel that arises from deleting a dependent vowel -->
 
     <!-- gap -->
       <key id="gap" gap="true" width="1" />
@@ -164,6 +164,8 @@
     <set id="dependentvowels" value="\u{093E} \u{093F} \u{0940} \u{0941} \u{0942} \u{0943} \u{0944} \u{0962} \u{0963} \u{0947} \u{0948} \u{094B} \u{094C}" />
     <set id="aspirates"       value="\u{0916}\u{094D} \u{0918}\u{094D} \u{091B}\u{094D} \u{091D}\u{094D} \u{0920}\u{094D} \u{0922}\u{094D} \u{0925}\u{094D} \u{0927}\u{094D} \u{092B}\u{094D} \u{092D}\u{094D} \u{0937}\u{094D}" />
     <set id="unaspirates"     value="\u{0915} \u{0917} \u{091A} \u{091C} \u{091F} \u{0921} \u{0924} \u{0926} \u{092A} \u{092C} \u{0938}" />
+    <set id="cantillation_bases" value="\u{0966} \u{0967} \u{0968} \u{0969} \u{096A} \u{096B} \u{096C} \u{096D} \u{096E} \u{096F} \u{0905} \u{0909} \u{0915}\u{094D} \u{0928}\u{094D} \u{092A}\u{094D} \u{0930}\u{094D} \u{0935}\u{094D} \u{0027}" />
+    <set id="cantillation_marks" value="\u{A8E0} \u{A8E1} \u{A8E2} \u{A8E3} \u{A8E4} \u{A8E5} \u{A8E6} \u{A8E7} \u{A8E8} \u{A8E9} \u{A8EA} \u{A8EB} \u{A8EC} \u{A8ED} \u{A8EE} \u{A8EF} \u{A8F0} \u{A8F1}" />
 
     <uset id="vowelmodifiers" value="[\u{0901}-\u{0903} \u{093C} \u{094D}]" />
     <uset id="consonants"     value="[\u{0915}-\u{0928} \u{092A}-\u{0930} \u{0932} \u{0933} \u{0935}-\u{0939}]" />
@@ -176,7 +178,7 @@
     </transformGroup>
 
     <transformGroup> <!-- Candrabindu -->
-      <transform from="\u{0020}\u{0901}"  to="\u{A8F2}" /> 
+      <transform from="\u{0020}\u{0901}"  to="\u{A8F2}" />
       <transform from="\m{SUPER}\u{0901}" to="\u{A8F2}" />
       <transform from="\u{A8F2}\u{094D}"  to="\u{A8F3}" />
       <transform from="\u{A8F2}\u{0901}"  to="\u{A8F4}" />
@@ -218,7 +220,7 @@
     <transformGroup> <!-- Dependent vowels not a-->
       <transform from="\u{094D}($[fullvowels])" to="$[1:dependentvowels]" />
       <transform from="\m{B}($[fullvowels])" to="$[1:dependentvowels]" />
-      <transform from="($[consonants])\u{0906}" to="$1\u{093E}" /> <!--Not working with map-->
+      <transform from="($[consonants])\u{0906}" to="$1\u{093E}" />
       <transform from="($[consonants])\u{0907}" to="$1\u{093F}" />
       <transform from="($[consonants])\u{0908}" to="$1\u{0940}" />
       <transform from="($[consonants])\u{0909}" to="$1\u{0941}" />
@@ -249,24 +251,8 @@
     </transformGroup>
 
     <transformGroup> <!-- Cantillation marks -->
-      <transform from="\m{SUPER}\u{0966}" to="\u{A8E0}" />          <!-- 0 -->
-      <transform from="\m{SUPER}\u{0967}" to="\u{A8E1}" />          <!-- 1 -->
-      <transform from="\m{SUPER}\u{0968}" to="\u{A8E2}" />          <!-- 2 -->
-      <transform from="\m{SUPER}\u{0969}" to="\u{A8E3}" />          <!-- 3 -->
-      <transform from="\m{SUPER}\u{096A}" to="\u{A8E4}" />          <!-- 4 -->
-      <transform from="\m{SUPER}\u{096B}" to="\u{A8E5}" />          <!-- 5 -->
-      <transform from="\m{SUPER}\u{096C}" to="\u{A8E6}" />          <!-- 6 -->
-      <transform from="\m{SUPER}\u{096D}" to="\u{A8E7}" />          <!-- 7 -->
-      <transform from="\m{SUPER}\u{096E}" to="\u{A8E8}" />          <!-- 8 -->
-      <transform from="\m{SUPER}\u{096F}" to="\u{A8E9}" />          <!-- 9 -->
-      <transform from="\m{SUPER}\u{0905}" to="\u{A8EA}" />          <!-- A -->
-      <transform from="\m{SUPER}\u{0909}" to="\u{A8EB}" />          <!-- U -->
-      <transform from="\m{SUPER}\u{0915}\u{094D}" to="\u{A8EC}" />  <!-- KA -->
-      <transform from="\m{SUPER}\u{0928}\u{094D}" to="\u{A8ED}" />  <!-- NA -->
-      <transform from="\m{SUPER}\u{092A}\u{094D}" to="\u{A8EE}" />  <!-- PA -->
-      <transform from="\m{SUPER}\u{0930}\u{094D}" to="\u{A8EF}" />  <!-- RA -->
-      <transform from="\m{SUPER}\u{0935}\u{094D}" to="\u{A8F0}" />  <!-- VI -->
-      <transform from="\m{SUPER}\u{0027}" to="\u{A8F1}" />          <!-- Avagraha -->
+      <transform from="\m{A}\m{SUPER}($[cantillation_bases])" to="$[1:cantillation_marks]" />
+      <transform from="\m{SUPER}($[cantillation_bases])" to="$[1:cantillation_marks]" />
     </transformGroup>
   </transforms>
 

--- a/keyboards/3.0/sa-Deva-t-k0-qwerty.xml
+++ b/keyboards/3.0/sa-Deva-t-k0-qwerty.xml
@@ -3,112 +3,120 @@
   conformsTo="47" draft="contributed" >
   <info author="Andrew Glass" name="Sanskrit (Phonetic)"
     layout="QWERTY" indicator="\u{0938}\u{0902}" />
-  <version number="1.0.1"/>
+  <version number="1.0.2"/>
   <keys>
     <import base="cldr" path="47/keys-Zyyy-punctuation.xml"/>
     <import base="cldr" path="47/keys-Zyyy-currency.xml"/>
+    <!-- \m{A} — Holds the inherent vowel during normal input -->
+    <!-- \m{B} — The inherent vowel that arrises from deleting a dependent vowel -->
 
     <!-- gap -->
       <key id="gap" gap="true" width="1" />
 
     <!-- Special -->
-      <key id="q"          output="\u{0950}" />
-      <key id="Q"          output="\u{0950}" />
+      <key id="q"            output="\u{0950}" />
+      <key id="Q"            output="\u{0950}" />
 
     <!-- Full vowels -->
-      <key id="a"          output="\u{0905}" />
-      <key id="A"          output="\u{0906}" />
-      <key id="i"          output="\u{0907}" />
-      <key id="I"          output="\u{0908}" />
-      <key id="u"          output="\u{0909}" />
-      <key id="U"          output="\u{090A}" />
-      <key id="alt_r"      output="\u{090B}" />
-      <key id="alt_R"      output="\u{0960}" />
-      <key id="alt_l"      output="\u{090C}" />
-      <key id="alt_L"      output="\u{0961}" />
-      <key id="e"          output="\u{090F}" />
-      <key id="E"          output="\u{0910}" />
-      <key id="o"          output="\u{0913}" />
-      <key id="O"          output="\u{0914}" />
+      <key id="a"            output="\u{0905}" />
+      <key id="A"            output="\u{0906}" />
+      <key id="i"            output="\u{0907}" />
+      <key id="I"            output="\u{0908}" />
+      <key id="u"            output="\u{0909}" />
+      <key id="U"            output="\u{090A}" />
+      <key id="alt_r"        output="\u{090B}" />
+      <key id="alt_R"        output="\u{0960}" />
+      <key id="alt_l"        output="\u{090C}" />
+      <key id="alt_L"        output="\u{0961}" />
+      <key id="e"            output="\u{090F}" />
+      <key id="E"            output="\u{0910}" />
+      <key id="o"            output="\u{0913}" />
+      <key id="O"            output="\u{0914}" />
 
     <!-- Vowel modifiers -->
-      <key id="alt_M"      output="\u{0901}" />
-      <key id="alt_m"      output="\u{0902}" />
-      <key id="virama"     output="\u{0903}" />
-      <key id="alt_comma"  output="\u{094D}" />
-      <key id="alt_period" output="\u{093C}" />
+      <key id="alt_M"        output="\u{0901}" />
+      <key id="alt_m"        output="\u{0902}" />
+      <key id="M"            output="\u{0902}" />
+      <key id="virama"       output="\u{0903}" />
+      <key id="H"            output="\u{0903}" />
+      <key id="alt_comma"    output="\u{094D}" />
+      <key id="alt_period"   output="\u{093C}" />
 
     <!-- Consonants -->
-      <key id="k"          output="\u{0915}\u{094D}" />
-      <key id="K"          output="\u{0916}\u{094D}" />
-      <key id="g"          output="\u{0917}\u{094D}" />
-      <key id="G"          output="\u{0918}\u{094D}" />
-      <key id="alt_g"      output="\u{0919}\u{094D}" />
-      <key id="c"          output="\u{091A}\u{094D}" />
-      <key id="alt_c"      output="\u{A8F8}" />
-      <key id="C"          output="\u{091B}\u{094D}" />
-      <key id="j"          output="\u{091C}\u{094D}" />
-      <key id="J"          output="\u{091D}\u{094D}" />
-      <key id="alt_y"      output="\u{091E}\u{094D}" />
-      <key id="alt_t"      output="\u{091F}\u{094D}" />
-      <key id="alt_T"      output="\u{0920}\u{094D}" />
-      <key id="alt_d"      output="\u{0921}\u{094D}" />
-      <key id="alt_D"      output="\u{0922}\u{094D}" />
-      <key id="alt_n"      output="\u{0923}\u{094D}" />
-      <key id="t"          output="\u{0924}\u{094D}" />
-      <key id="T"          output="\u{0925}\u{094D}" />
-      <key id="d"          output="\u{0926}\u{094D}" />
-      <key id="D"          output="\u{0927}\u{094D}" />
-      <key id="n"          output="\u{0928}\u{094D}" />
-      <key id="p"          output="\u{092A}\u{094D}" />
-      <key id="P"          output="\u{092B}\u{094D}" />
-      <key id="b"          output="\u{092C}\u{094D}" />
-      <key id="B"          output="\u{092D}\u{094D}" />
-      <key id="m"          output="\u{092E}\u{094D}" />
-      <key id="y"          output="\u{092F}\u{094D}" />
-      <key id="r"          output="\u{0930}\u{094D}" />
-      <key id="l"          output="\u{0932}\u{094D}" />
-      <key id="L"          output="\u{0933}\u{094D}" />
-      <key id="v"          output="\u{0935}\u{094D}" />
-      <key id="w"          output="\u{0935}\u{094D}" />
-      <key id="alt_s"      output="\u{0936}\u{094D}" />
-      <key id="alt_x"      output="\u{0937}\u{094D}" />
-      <key id="s"          output="\u{0938}\u{094D}" />
-      <key id="h"          output="\u{0939}\u{094D}" />
+      <key id="k"            output="\u{0915}\u{094D}" />
+      <key id="K"            output="\u{0916}\u{094D}" />
+      <key id="g"            output="\u{0917}\u{094D}" />
+      <key id="G"            output="\u{0918}\u{094D}" />
+      <key id="alt_g"        output="\u{0919}\u{094D}" />
+      <key id="c"            output="\u{091A}\u{094D}" />
+      <key id="alt_c"        output="\u{A8F8}" />
+      <key id="C"            output="\u{091B}\u{094D}" />
+      <key id="j"            output="\u{091C}\u{094D}" />
+      <key id="J"            output="\u{091D}\u{094D}" />
+      <key id="alt_y"        output="\u{091E}\u{094D}" />
+      <key id="alt_t"        output="\u{091F}\u{094D}" />
+      <key id="alt_T"        output="\u{0920}\u{094D}" />
+      <key id="alt_d"        output="\u{0921}\u{094D}" />
+      <key id="alt_D"        output="\u{0922}\u{094D}" />
+      <key id="N"            output="\u{0923}\u{094D}" />
+      <key id="alt_n"        output="\u{0923}\u{094D}" />
+      <key id="t"            output="\u{0924}\u{094D}" />
+      <key id="T"            output="\u{0925}\u{094D}" />
+      <key id="d"            output="\u{0926}\u{094D}" />
+      <key id="D"            output="\u{0927}\u{094D}" />
+      <key id="n"            output="\u{0928}\u{094D}" />
+      <key id="p"            output="\u{092A}\u{094D}" />
+      <key id="P"            output="\u{092B}\u{094D}" />
+      <key id="b"            output="\u{092C}\u{094D}" />
+      <key id="B"            output="\u{092D}\u{094D}" />
+      <key id="m"            output="\u{092E}\u{094D}" />
+      <key id="y"            output="\u{092F}\u{094D}" />
+      <key id="r"            output="\u{0930}\u{094D}" />
+      <key id="l"            output="\u{0932}\u{094D}" />
+      <key id="L"            output="\u{0933}\u{094D}" />
+      <key id="v"            output="\u{0935}\u{094D}" />
+      <key id="w"            output="\u{0935}\u{094D}" />
+      <key id="S"            output="\u{0936}\u{094D}" />
+      <key id="alt_s"        output="\u{0936}\u{094D}" />
+      <key id="x"            output="\u{0937}\u{094D}" />
+      <key id="X"            output="\u{0915}\u{094D}\u{0937}\u{094D}" />
+      <key id="alt_x"        output="\u{0937}\u{094D}" />
+      <key id="s"            output="\u{0938}\u{094D}" />
+      <key id="h"            output="\u{0939}\u{094D}" />
 
     <!-- Digits -->
-      <key id="0"          output="\u{0966}" />
-      <key id="1"          output="\u{0967}" />
-      <key id="2"          output="\u{0968}" />
-      <key id="3"          output="\u{0969}" />
-      <key id="4"          output="\u{096A}" />
-      <key id="5"          output="\u{096B}" />
-      <key id="6"          output="\u{096C}" />
-      <key id="7"          output="\u{096D}" />
-      <key id="8"          output="\u{096E}" />
-      <key id="9"          output="\u{096F}" />
+      <key id="0"            output="\u{0966}" />
+      <key id="1"            output="\u{0967}" />
+      <key id="2"            output="\u{0968}" />
+      <key id="3"            output="\u{0969}" />
+      <key id="4"            output="\u{096A}" />
+      <key id="5"            output="\u{096B}" />
+      <key id="6"            output="\u{096C}" />
+      <key id="7"            output="\u{096D}" />
+      <key id="8"            output="\u{096E}" />
+      <key id="9"            output="\u{096F}" />
 
     <!-- Punctuation -->
-      <key id="alt_a"      output="\u{093D}" />
-      <key id="pipe"       output="\u{0964}" />
-      <key id="alt_0"      output="\u{0970}" />
-      <key id="alt_slash"  output="\u{221A}" />
-      <key id="alt_pipe"   output="\u{0951}" />
-      <key id="alt_hyphen" output="\u{0952}" />
-      <key id="nbsp"       output="\u{00A0}" />
-      <key id="shftalt_0"  output="\u{A8F9}" />
-      <key id="shftalt_6"  output="\u{A8FA}" />
-      <key id="alt_hyphen" output="\u{A8FB}" />
-      <key id="siddham"    output="\u{A8FC}" />
-      <key id="alt_grave"  output="\u{A8FD}" />
+      <key id="alt_a"        output="\u{093D}" />
+      <key id="pipe"         output="\u{0964}" />
+      <key id="alt_0"        output="\u{0970}" />
+      <key id="alt_slash"    output="\u{221A}" />
+      <key id="alt_pipe"     output="\u{0951}" />
+      <key id="alt_underbar" output="\u{0952}" />
+      <key id="alt_space"    output="\u{00A0}" />
+      <key id="shftalt_0"    output="\u{A8F9}" />
+      <key id="shftalt_6"    output="\u{A8FA}" />
+      <key id="alt_hyphen"   output="\u{A8FB}" />
+      <key id="alt_tilde"    output="\u{A8FC}" />
+      <key id="alt_grave"    output="\u{A8FD}" />
 
     <!-- Mark -->
-      <key id="alt_apos"   output="\m{SUPER}" />
+      <key id="alt_apos"     output="\m{SUPER}" />
   </keys>
 
   <layers formId="us">
     <layer modifiers="none">
-      <row keys="siddham 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
+      <row keys="alt_tilde 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
       <row keys="q w e r t y u i o p open-square close-square pipe"/>
       <row keys="a s d f g h j k l virama apos"/>
       <row keys="z x c v b n m comma period slash"/>
@@ -122,7 +130,7 @@
       <row keys="space"/>
     </layer>
     <layer modifiers="caps">
-      <row keys="siddham 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
+      <row keys="alt_tilde 1 2 3 4 5 6 7 8 9 0 hyphen equal"/>
       <row keys="Q W E R T Y U I O P open-square close-square backslash"/>
       <row keys="A S D F G H J K L semi-colon apos"/>
       <row keys="Z X C V B N M comma period slash"/>
@@ -140,10 +148,10 @@
       <row keys="gap gap gap alt_r alt_t alt_y gap gap gap gap gap gap alt_pipe"/>
       <row keys="alt_a alt_s alt_d gap alt_g virama gap gap alt_l gap alt_apos"/>
       <row keys="gap alt_x alt_c gap gap alt_n alt_m alt_comma alt_period alt_slash"/>
-      <row keys="nbsp"/>
+      <row keys="alt_space"/>
     </layer>
     <layer modifiers="shift altR">
-      <row keys="gap gap gap gap gap gap shftalt_6 gap gap gap shftalt_0 alt_hyphen gap"/>
+      <row keys="gap gap gap gap gap gap shftalt_6 gap gap gap shftalt_0 alt_underbar gap"/>
       <row keys="gap gap gap alt_R gap gap gap gap gap gap gap gap alt_pipe"/>
       <row keys="gap gap gap gap gap gap gap gap alt_L gap gap"/>
       <row keys="gap gap alt_c gap gap gap alt_M gap gap gap"/>
@@ -152,17 +160,23 @@
   </layers>
 
   <variables>
-    <uset id="consonants" value="[\u{0915}-\u{0928} \u{092A}-\u{0930} \u{0932} \u{0933} \u{0935}-\u{0939}]"/>
+    <set id="fullvowels"      value="\u{0906} \u{0907} \u{0908} \u{0909} \u{090A} \u{090B} \u{0960} \u{090C} \u{0961} \u{090F} \u{0910} \u{0913} \u{0914}" />
+    <set id="dependentvowels" value="\u{093E} \u{093F} \u{0940} \u{0941} \u{0942} \u{0943} \u{0944} \u{0962} \u{0963} \u{0947} \u{0948} \u{094B} \u{094C}" />
+    <set id="aspirates"       value="\u{0916}\u{094D} \u{0918}\u{094D} \u{091B}\u{094D} \u{091D}\u{094D} \u{0920}\u{094D} \u{0922}\u{094D} \u{0925}\u{094D} \u{0927}\u{094D} \u{092B}\u{094D} \u{092D}\u{094D} \u{0937}\u{094D}" />
+    <set id="unaspirates"     value="\u{0915} \u{0917} \u{091A} \u{091C} \u{091F} \u{0921} \u{0924} \u{0926} \u{092A} \u{092C} \u{0938}" />
+
+    <uset id="vowelmodifiers" value="[\u{0901}-\u{0903} \u{093C} \u{094D}]" />
+    <uset id="consonants"     value="[\u{0915}-\u{0928} \u{092A}-\u{0930} \u{0932} \u{0933} \u{0935}-\u{0939}]" />
   </variables>
 
   <transforms type="simple">
     <transformGroup> <!-- Avagraha -->
-      <transform from="\u{0947} \u{0905}" to="\u{0947} \u{093D}" />
-      <transform from="\u{094B} \u{0905}" to="\u{094B} \u{093D}" />
+      <transform from="\u{0947} \u{0905}" to="\u{0947} \u{093D}" /> <!-- े अ >>> े ऽ -->
+      <transform from="\u{094B} \u{0905}" to="\u{094B} \u{093D}" /> <!-- ो अ >>> ो ऽ -->
     </transformGroup>
 
     <transformGroup> <!-- Candrabindu -->
-      <transform from="\u{0020}\u{0901}"  to="\u{A8F2}" />
+      <transform from="\u{0020}\u{0901}"  to="\u{A8F2}" /> 
       <transform from="\m{SUPER}\u{0901}" to="\u{A8F2}" />
       <transform from="\u{A8F2}\u{094D}"  to="\u{A8F3}" />
       <transform from="\u{A8F2}\u{0901}"  to="\u{A8F4}" />
@@ -180,12 +194,17 @@
       <transform from="\u{0905}\u{0909}" to="\u{0914}" />
       <transform from="\u{090F}\u{090F}" to="\u{0910}" />
       <transform from="\u{0913}\u{0913}" to="\u{0914}" />
-
       <transform from="\u{093F}\u{0907}" to="\u{0940}" />
       <transform from="\u{0941}\u{0909}" to="\u{0942}" />
       <transform from="\u{0943}\u{090B}" to="\u{0944}" />
       <transform from="\u{0947}\u{090F}" to="\u{0948}" />
       <transform from="\u{094B}\u{0913}" to="\u{094C}" />
+    </transformGroup>
+
+    <transformGroup>  <!-- Clean up mark -->
+      <transform from="\m{A}($[consonants]\u{094D})" to="$1" />
+      <transform from="\m{B}($[consonants]\u{094D})" to="$1" />
+      <transform from="\m{B}\u{0905}"                to="\m{A}" />
     </transformGroup>
 
     <transformGroup> <!-- Dependent vowel a-->
@@ -197,32 +216,32 @@
     </transformGroup>
 
     <transformGroup> <!-- Dependent vowels not a-->
-      <transform from="\u{094D}\u{0906}" to="\u{093E}" />
-      <transform from="\u{094D}\u{0907}" to="\u{093F}" />
-      <transform from="\u{094D}\u{0908}" to="\u{0940}" />
-      <transform from="\u{094D}\u{0909}" to="\u{0941}" />
-      <transform from="\u{094D}\u{090A}" to="\u{0942}" />
-      <transform from="\u{094D}\u{090B}" to="\u{0943}" />
-      <transform from="\u{094D}\u{0960}" to="\u{0944}" />
-      <transform from="\u{094D}\u{090C}" to="\u{0962}" />
-      <transform from="\u{094D}\u{0961}" to="\u{0963}" />
-      <transform from="\u{094D}\u{090F}" to="\u{0947}" />
-      <transform from="\u{094D}\u{0910}" to="\u{0948}" />
-      <transform from="\u{094D}\u{0913}" to="\u{094B}" />
-      <transform from="\u{094D}\u{0914}" to="\u{094C}" />
+      <transform from="\u{094D}($[fullvowels])" to="$[1:dependentvowels]" />
+      <transform from="\m{B}($[fullvowels])" to="$[1:dependentvowels]" />
+      <transform from="($[consonants])\u{0906}" to="$1\u{093E}" /> <!--Not working with map-->
+      <transform from="($[consonants])\u{0907}" to="$1\u{093F}" />
+      <transform from="($[consonants])\u{0908}" to="$1\u{0940}" />
+      <transform from="($[consonants])\u{0909}" to="$1\u{0941}" />
+      <transform from="($[consonants])\u{090A}" to="$1\u{0942}" />
+      <transform from="($[consonants])\u{090B}" to="$1\u{0943}" />
+      <transform from="($[consonants])\u{0960}" to="$1\u{0944}" />
+      <transform from="($[consonants])\u{090C}" to="$1\u{0962}" />
+      <transform from="($[consonants])\u{0961}" to="$1\u{0963}" />
+      <transform from="($[consonants])\u{090F}" to="$1\u{0947}" />
+      <transform from="($[consonants])\u{0910}" to="$1\u{0948}" />
+      <transform from="($[consonants])\u{0913}" to="$1\u{094B}" />
+      <transform from="($[consonants])\u{0914}" to="$1\u{094C}" />
+    </transformGroup>
+
+    <transformGroup>
+        <!-- Vowel modifiers -->
+      <transform from="\m{A}($[vowelmodifiers])"    to="$1" />
+      <transform from="\m{B}($[vowelmodifiers])"    to="$1" />
+      <transform from="\u{094D}($[vowelmodifiers])" to="$1" />
     </transformGroup>
 
     <transformGroup> <!-- Aspirated consonants -->
-      <transform from="\u{0915}\u{094D}\u{0939}\u{094D}" to="\u{0916}\u{094D}" /> <!-- kh -->
-      <transform from="\u{0917}\u{094D}\u{0939}\u{094D}" to="\u{0918}\u{094D}" /> <!-- gh --> 
-      <transform from="\u{091A}\u{094D}\u{0939}\u{094D}" to="\u{091B}\u{094D}" /> <!-- ch -->
-      <transform from="\u{091C}\u{094D}\u{0939}\u{094D}" to="\u{091D}\u{094D}" /> <!-- jh -->
-      <transform from="\u{091F}\u{094D}\u{0939}\u{094D}" to="\u{0920}\u{094D}" /> <!-- ṭh -->
-      <transform from="\u{0921}\u{094D}\u{0939}\u{094D}" to="\u{0922}\u{094D}" /> <!-- ḍh -->
-      <transform from="\u{0924}\u{094D}\u{0939}\u{094D}" to="\u{0925}\u{094D}" /> <!-- th -->
-      <transform from="\u{0926}\u{094D}\u{0939}\u{094D}" to="\u{0927}\u{094D}" /> <!-- dh -->
-      <transform from="\u{092A}\u{094D}\u{0939}\u{094D}" to="\u{092B}\u{094D}" /> <!-- ph -->
-      <transform from="\u{092C}\u{094D}\u{0939}\u{094D}" to="\u{092D}\u{094D}" /> <!-- bh -->
+      <transform from="($[unaspirates])\u{094D}\u{0939}\u{094D}" to="$[1:aspirates]" />
     </transformGroup>
 
     <transformGroup> <!-- Punctuation -->
@@ -230,25 +249,36 @@
     </transformGroup>
 
     <transformGroup> <!-- Cantillation marks -->
-      <transform from="\m{SUPER}\u{0966}" to="\u{A8E0}" /> <!-- 0 -->
-      <transform from="\m{SUPER}\u{0967}" to="\u{A8E1}" /> <!-- 1 -->
-      <transform from="\m{SUPER}\u{0968}" to="\u{A8E2}" /> <!-- 2 -->
-      <transform from="\m{SUPER}\u{0969}" to="\u{A8E3}" /> <!-- 3 -->
-      <transform from="\m{SUPER}\u{096A}" to="\u{A8E4}" /> <!-- 4 -->
-      <transform from="\m{SUPER}\u{096B}" to="\u{A8E5}" /> <!-- 5 -->
-      <transform from="\m{SUPER}\u{096C}" to="\u{A8E6}" /> <!-- 6 -->
-      <transform from="\m{SUPER}\u{096D}" to="\u{A8E7}" /> <!-- 7 -->
-      <transform from="\m{SUPER}\u{096E}" to="\u{A8E8}" /> <!-- 8 -->
-      <transform from="\m{SUPER}\u{096F}" to="\u{A8E9}" /> <!-- 9 -->
-      <transform from="\m{SUPER}\u{0905}" to="\u{A8EA}" /> <!-- A -->
-      <transform from="\m{SUPER}\u{0909}" to="\u{A8EB}" /> <!-- U -->
-      <transform from="\m{SUPER}\u{0915}" to="\u{A8EC}" /> <!-- KA -->
-      <transform from="\m{SUPER}\u{0928}" to="\u{A8ED}" /> <!-- NA -->
-      <transform from="\m{SUPER}\u{092A}" to="\u{A8EE}" /> <!-- PA -->
-      <transform from="\m{SUPER}\u{0930}" to="\u{A8EF}" /> <!-- RA -->
-      <transform from="\m{SUPER}\u{0935}" to="\u{A8F0}" /> <!-- VI -->
-      <transform from="\m{SUPER}\u{093D}" to="\u{A8F1}" /> <!-- Avagraha -->
+      <transform from="\m{SUPER}\u{0966}" to="\u{A8E0}" />          <!-- 0 -->
+      <transform from="\m{SUPER}\u{0967}" to="\u{A8E1}" />          <!-- 1 -->
+      <transform from="\m{SUPER}\u{0968}" to="\u{A8E2}" />          <!-- 2 -->
+      <transform from="\m{SUPER}\u{0969}" to="\u{A8E3}" />          <!-- 3 -->
+      <transform from="\m{SUPER}\u{096A}" to="\u{A8E4}" />          <!-- 4 -->
+      <transform from="\m{SUPER}\u{096B}" to="\u{A8E5}" />          <!-- 5 -->
+      <transform from="\m{SUPER}\u{096C}" to="\u{A8E6}" />          <!-- 6 -->
+      <transform from="\m{SUPER}\u{096D}" to="\u{A8E7}" />          <!-- 7 -->
+      <transform from="\m{SUPER}\u{096E}" to="\u{A8E8}" />          <!-- 8 -->
+      <transform from="\m{SUPER}\u{096F}" to="\u{A8E9}" />          <!-- 9 -->
+      <transform from="\m{SUPER}\u{0905}" to="\u{A8EA}" />          <!-- A -->
+      <transform from="\m{SUPER}\u{0909}" to="\u{A8EB}" />          <!-- U -->
+      <transform from="\m{SUPER}\u{0915}\u{094D}" to="\u{A8EC}" />  <!-- KA -->
+      <transform from="\m{SUPER}\u{0928}\u{094D}" to="\u{A8ED}" />  <!-- NA -->
+      <transform from="\m{SUPER}\u{092A}\u{094D}" to="\u{A8EE}" />  <!-- PA -->
+      <transform from="\m{SUPER}\u{0930}\u{094D}" to="\u{A8EF}" />  <!-- RA -->
+      <transform from="\m{SUPER}\u{0935}\u{094D}" to="\u{A8F0}" />  <!-- VI -->
+      <transform from="\m{SUPER}\u{0027}" to="\u{A8F1}" />          <!-- Avagraha -->
+    </transformGroup>
+  </transforms>
+
+  <transforms type="backspace">
+    <transformGroup>   <!-- Clear base consonant with virama -->
+      <transform from="($[consonants])\m{A}" to="$1\u{094D}"/>
+      <transform from="($[consonants])\m{B}" to=""/>
+      <transform from="($[consonants])\u{094D}" to=""/>
     </transformGroup>
 
+    <transformGroup> <!-- Dependent vowels not a-->
+      <transform from="$[dependentvowels]" to="\m{B}" />
+    </transformGroup>
   </transforms>
 </keyboard3>

--- a/keyboards/3.0/xct-Tibt-t-k0-qwerty.xml
+++ b/keyboards/3.0/xct-Tibt-t-k0-qwerty.xml
@@ -3,7 +3,7 @@
   conformsTo="47" draft="contributed" >
   <info author="Andrew Glass" name="Classical Tibetan (Phonetic)"
     layout="QWERTY" indicator="\u{0F56}\u{0F7C}\u{0F51}" />
-  <version number="1.0.1"/>
+  <version number="1.0.2"/>
 
   <keys>
     <import base="cldr" path="45/keys-Zyyy-punctuation.xml"/>
@@ -51,105 +51,105 @@
       <key id="tsaphru"      output="\m{TSAPHRU}" />
 
     <!-- full_vowels -->
-      <key id="a"     output="\u{0F68}" />
-      <key id="A"     output="\u{0F68}\u{0F71}" />
-      <key id="alt_a" output="\u{0F68}\u{0F71}" />
-      <key id="alt_A" output="\u{0F68}\u{0F71}" />
-      <key id="i"     output="\u{0F68}\u{0F72}" />
-      <key id="I"     output="\u{0F68}\u{0F72}" />
-      <key id="alt_i" output="\u{0F68}\u{0F71}\u{0F72}" />
-      <key id="alt_I" output="\u{0F68}\u{0F71}\u{0F72}" />
-      <key id="u"     output="\u{0F68}\u{0F74}" />
-      <key id="U"     output="\u{0F68}\u{0F74}" />
-      <key id="alt_u" output="\u{0F68}\u{0F71}\u{0F74}" />
-      <key id="alt_U" output="\u{0F68}\u{0F71}\u{0F74}" />
-      <key id="alt_r" output="\u{0F62}\u{0FB2}\u{0F80}" />
-      <key id="alt_R" output="\u{0F62}\u{0FB2}\u{0F71}\u{0F80}" />
-      <key id="alt_l" output="\u{0F62}\u{0FB3}\u{0F80}" />
-      <key id="alt_L" output="\u{0F62}\u{0FB3}\u{0F71}\u{0F80}" />
-      <key id="e"     output="\u{0F68}\u{0F7A}" />
-      <key id="E"     output="\u{0F68}\u{0F7A}" />
-      <key id="alt_e" output="\u{0F68}\u{0F7B}" />
-      <key id="alt_E" output="\u{0F68}\u{0F7B}" />
-      <key id="o"     output="\u{0F68}\u{0F7C}" />
-      <key id="O"     output="\u{0F68}\u{0F7C}" />
-      <key id="alt_o" output="\u{0F68}\u{0F7D}" />
-      <key id="alt_O" output="\u{0F68}\u{0F7D}" />
+      <key id="a"            output="\u{0F68}" />
+      <key id="A"            output="\u{0F68}\u{0F71}" />
+      <key id="alt_a"        output="\u{0F68}\u{0F71}" />
+      <key id="alt_A"        output="\u{0F68}\u{0F71}" />
+      <key id="i"            output="\u{0F68}\u{0F72}" />
+      <key id="I"            output="\u{0F68}\u{0F71}\u{0F72}" />
+      <key id="alt_i"        output="\u{0F68}\u{0F71}\u{0F72}" />
+      <key id="alt_I"        output="\u{0F68}\u{0F71}\u{0F72}" />
+      <key id="u"            output="\u{0F68}\u{0F74}" />
+      <key id="U"            output="\u{0F68}\u{0F7}\u{0F74}" />
+      <key id="alt_u"        output="\u{0F68}\u{0F71}\u{0F74}" />
+      <key id="alt_U"        output="\u{0F68}\u{0F71}\u{0F74}" />
+      <key id="alt_r"        output="\u{0F62}\u{0FB2}\u{0F80}" />
+      <key id="alt_R"        output="\u{0F62}\u{0FB2}\u{0F71}\u{0F80}" />
+      <key id="alt_l"        output="\u{0F62}\u{0FB3}\u{0F80}" />
+      <key id="alt_L"        output="\u{0F62}\u{0FB3}\u{0F71}\u{0F80}" />
+      <key id="e"            output="\u{0F68}\u{0F7A}" />
+      <key id="E"            output="\u{0F68}\u{0F7B}" />
+      <key id="alt_e"        output="\u{0F68}\u{0F7B}" />
+      <key id="alt_E"        output="\u{0F68}\u{0F7B}" />
+      <key id="o"            output="\u{0F68}\u{0F7C}" />
+      <key id="O"            output="\u{0F68}\u{0F7D}" />
+      <key id="alt_o"        output="\u{0F68}\u{0F7D}" />
+      <key id="alt_O"        output="\u{0F68}\u{0F7D}" />
 
     <!-- vowel modifiers -->
-      <key id="M"        output="\u{0F7E}" />
-      <key id="alt_m"    output="\u{0F7E}" />
-      <key id="H"        output="\u{0F7F}" />
-      <key id="alt_h"    output="\u{0F7F}" />
-      <key id="halanta"  output="\u{0F84}" />
-      <key id="alt_hash" output="\u{0F85}" />
+      <key id="M"            output="\u{0F7E}" />
+      <key id="alt_m"        output="\u{0F7E}" />
+      <key id="H"            output="\u{0F7F}" />
+      <key id="alt_h"        output="\u{0F7F}" />
+      <key id="halanta"      output="\u{0F84}" />
+      <key id="alt_hash"     output="\u{0F85}" />
 
     <!-- consonants -->
-      <key id="k"     output="\u{0F40}" />
-      <key id="K"     output="\u{0F41}" />
-      <key id="g"     output="\u{0F42}" />
-      <key id="alt_g" output="\u{0F44}" />
-      <key id="c"     output="\u{0F45}" />
-      <key id="C"     output="\u{0F46}" />
-      <key id="j"     output="\u{0F47}" />
-      <key id="alt_y" output="\u{0F49}" />
-      <key id="alt_t" output="\u{0F4A}" />
-      <key id="alt_T" output="\u{0F4B}" />
-      <key id="alt_d" output="\u{0F4C}" />
-      <key id="alt_n" output="\u{0F4E}" />
-      <key id="N"     output="\u{0F4E}" />
-      <key id="t"     output="\u{0F4F}" />
-      <key id="T"     output="\u{0F50}" />
-      <key id="d"     output="\u{0F51}" />
-      <key id="n"     output="\u{0F53}" />
-      <key id="p"     output="\u{0F54}" />
-      <key id="P"     output="\u{0F55}" />
-      <key id="b"     output="\u{0F56}" />
-      <key id="m"     output="\u{0F58}" />
-      <key id="w"     output="\u{0F5D}" />
-      <key id="v"     output="\u{0F5D}" />
-      <key id="Z"     output="\u{0F5E}" />
-      <key id="z"     output="\u{0F5F}" />
-      <key id="apos"  output="\u{0F60}" />
-      <key id="y"     output="\u{0F61}" />
-      <key id="Y"     output="\m{fullYa}"/>
-      <key id="r"     output="\u{0F62}" />
-      <key id="R"     output="\u{0F6A}" />
-      <key id="l"     output="\u{0F63}" />
-      <key id="alt_s" output="\u{0F64}" />
-      <key id="S"     output="\u{0F65}" />
-      <key id="alt_x" output="\u{0F65}" />
-      <key id="s"     output="\u{0F66}" />
-      <key id="h"     output="\u{0F67}" />
+      <key id="k"            output="\u{0F40}" />
+      <key id="K"            output="\u{0F41}" />
+      <key id="g"            output="\u{0F42}" />
+      <key id="alt_g"        output="\u{0F44}" />
+      <key id="c"            output="\u{0F45}" />
+      <key id="C"            output="\u{0F46}" />
+      <key id="j"            output="\u{0F47}" />
+      <key id="alt_y"        output="\u{0F49}" />
+      <key id="alt_t"        output="\u{0F4A}" />
+      <key id="alt_T"        output="\u{0F4B}" />
+      <key id="alt_d"        output="\u{0F4C}" />
+      <key id="alt_n"        output="\u{0F4E}" />
+      <key id="N"            output="\u{0F4E}" />
+      <key id="t"            output="\u{0F4F}" />
+      <key id="T"            output="\u{0F50}" />
+      <key id="d"            output="\u{0F51}" />
+      <key id="n"            output="\u{0F53}" />
+      <key id="p"            output="\u{0F54}" />
+      <key id="P"            output="\u{0F55}" />
+      <key id="b"            output="\u{0F56}" />
+      <key id="m"            output="\u{0F58}" />
+      <key id="w"            output="\u{0F5D}" />
+      <key id="v"            output="\u{0F5D}" />
+      <key id="Z"            output="\u{0F5E}" />
+      <key id="z"            output="\u{0F5F}" />
+      <key id="apos"         output="\u{0F60}" />
+      <key id="y"            output="\u{0F61}" />
+      <key id="Y"            output="\m{fullYa}"/>
+      <key id="r"            output="\u{0F62}" />
+      <key id="R"            output="\u{0F6A}" />
+      <key id="l"            output="\u{0F63}" />
+      <key id="alt_s"        output="\u{0F64}" />
+      <key id="S"            output="\u{0F65}" />
+      <key id="alt_x"        output="\u{0F65}" />
+      <key id="s"            output="\u{0F66}" />
+      <key id="h"            output="\u{0F67}" />
 
     <!-- specials -->
-      <key id="f"     output="\m{STACK}" />
-      <key id="F"     output="\m{STACK}" />
-      <key id="cycle" output="\m{CYCLE}" />
+      <key id="f"            output="\m{STACK}" />
+      <key id="F"            output="\m{STACK}" />
+      <key id="cycle"        output="\m{CYCLE}" />
 
     <!-- digits -->
-      <key id="1"     output="\u{0F21}" />
-      <key id="2"     output="\u{0F22}" />
-      <key id="3"     output="\u{0F23}" />
-      <key id="4"     output="\u{0F24}" />
-      <key id="5"     output="\u{0F25}" />
-      <key id="6"     output="\u{0F26}" />
-      <key id="7"     output="\u{0F27}" />
-      <key id="8"     output="\u{0F28}" />
-      <key id="9"     output="\u{0F29}" />
-      <key id="0"     output="\u{0F20}" />
+      <key id="1"            output="\u{0F21}" />
+      <key id="2"            output="\u{0F22}" />
+      <key id="3"            output="\u{0F23}" />
+      <key id="4"            output="\u{0F24}" />
+      <key id="5"            output="\u{0F25}" />
+      <key id="6"            output="\u{0F26}" />
+      <key id="7"            output="\u{0F27}" />
+      <key id="8"            output="\u{0F28}" />
+      <key id="9"            output="\u{0F29}" />
+      <key id="0"            output="\u{0F20}" />
 
     <!-- digits minus half -->
-      <key id="alt_1" output="\u{0F2A}" />  
-      <key id="alt_2" output="\u{0F2B}" />  
-      <key id="alt_3" output="\u{0F2C}" />  
-      <key id="alt_4" output="\u{0F2D}" /> 
-      <key id="alt_5" output="\u{0F2E}" /> 
-      <key id="alt_6" output="\u{0F2F}" /> 
-      <key id="alt_7" output="\u{0F30}" /> 
-      <key id="alt_8" output="\u{0F31}" /> 
-      <key id="alt_9" output="\u{0F32}" /> 
-      <key id="alt_0" output="\u{0F33}" /> 
+      <key id="alt_1"        output="\u{0F2A}" />  
+      <key id="alt_2"        output="\u{0F2B}" />  
+      <key id="alt_3"        output="\u{0F2C}" />  
+      <key id="alt_4"        output="\u{0F2D}" /> 
+      <key id="alt_5"        output="\u{0F2E}" /> 
+      <key id="alt_6"        output="\u{0F2F}" /> 
+      <key id="alt_7"        output="\u{0F30}" /> 
+      <key id="alt_8"        output="\u{0F31}" /> 
+      <key id="alt_9"        output="\u{0F32}" /> 
+      <key id="alt_0"        output="\u{0F33}" /> 
   </keys>
 
   <layers formId="us">
@@ -204,10 +204,10 @@
       \u{0F90}-\u{0F92} \u{0F94}-\u{0F97} \u{0F99}-\u{0F9C} \u{0F9E}-\u{0FA1}
       \u{0FA3}-\u{0FA6} \u{0FA8}-\u{0FAB} \u{0FAD}-\u{0FB8} \u{0FBA}-\u{0FBC}]" />
     
-    <set id="suby" value="\u{0F40} \u{0F41} \u{0F42} \u{0F54} \u{0F55} \u{0F56} \u{0F58} \u{0F90} \u{0F91} \u{0F92} \u{0FA4} \u{0FA6} \u{0FA8}" />
-    <set id="subr" value="\u{0F40} \u{0F41} \u{0F42} \u{0F4F} \u{0F50} \u{0F51} \u{0F53} \u{0F54} \u{0F55} \u{0F56} \u{0F58} \u{0F64} \u{0F66} \u{0F67} \u{0F90} \u{0F91} \u{0F92} \u{0F9F} \u{0FA0} \u{0FA1} \u{0FA3} \u{0FA4} \u{0FA5} \u{0FA6} \u{0FA8} \u{0FB4} \u{0FB6} \u{0FB7}" />
-    <set id="subl" value="\u{0F40} \u{0F42} \u{0F56} \u{0F5F} \u{0F62} \u{0F66} \u{0F90} \u{0F92} \u{0FA6} \u{0FAF} \u{0FB6}" />
-    <set id="subw" value="\u{0F40} \u{0F41} \u{0F42} \u{0F45} \u{0F49} \u{0F4F} \u{0F51} \u{0F59} \u{0F5A} \u{0F5E} \u{0F5F} \u{0F62} \u{0F63} \u{0F64} \u{0F66} \u{0F67} \u{0F90} \u{0F91} \u{0F92} \u{0F95} \u{0F99} \u{0F9F} \u{0FA1} \u{0FA9} \u{0FAA} \u{0FAE} \u{0FAF} \u{0FB2} \u{0FB3} \u{0FB4} \u{0FB6} \u{0FB7}" />
+    <set id="suby" value="\u{0F40} \u{0F41} \u{0F42} \u{0F54} \u{0F55} \u{0F56} \u{0F58} \u{0F62} \u{0F63} \u{0F90} \u{0F91} \u{0F92} \u{0FA4} \u{0FA6} \u{0FA8}" />
+    <set id="subr" value="\u{0F40} \u{0F41} \u{0F42} \u{0F4F} \u{0F50} \u{0F51} \u{0F53} \u{0F54} \u{0F55} \u{0F56} \u{0F58} \u{0F61} \u{0F63} \u{0F64} \u{0F66} \u{0F67} \u{0F90} \u{0F91} \u{0F92} \u{0F9F} \u{0FA0} \u{0FA1} \u{0FA3} \u{0FA4} \u{0FA5} \u{0FA6} \u{0FA8} \u{0FB4} \u{0FB6} \u{0FB7}" />
+    <set id="subl" value="\u{0F40} \u{0F42} \u{0F56} \u{0F5F} \u{0F61} \u{0F62} \u{0F66} \u{0F90} \u{0F92} \u{0FA6} \u{0FAF} \u{0FB6}" />
+    <set id="subw" value="\u{0F40} \u{0F41} \u{0F42} \u{0F45} \u{0F49} \u{0F4F} \u{0F51} \u{0F59} \u{0F5A} \u{0F5E} \u{0F5F} \u{0F61} \u{0F62} \u{0F63} \u{0F64} \u{0F66} \u{0F67} \u{0F90} \u{0F91} \u{0F92} \u{0F95} \u{0F99} \u{0F9F} \u{0FA1} \u{0FA9} \u{0FAA} \u{0FAE} \u{0FAF} \u{0FB2} \u{0FB3} \u{0FB4} \u{0FB6} \u{0FB7}" />
   </variables>
 
   <transforms type="simple">
@@ -262,6 +262,16 @@
       <transform from="($[consonants])\u{0F68}(\u{0F7C})"                 to="$1$2" />       <!-- o -->
       <transform from="($[consonants])\u{0F68}(\u{0F7D})"                 to="$1$2" />       <!-- au -->
       <transform from="($[consonants])\m{A}\u{0F68}\u{0F74}"              to="$1\u{0F7D}" /> <!-- au -->
+    </transformGroup>
+
+    <transformGroup> <!-- long vowels -->
+      <transform from="\m{A}\u{0F68}" to="\u{0F71}" />
+      <transform from="\u{0F72}\u{0F68}\u{0F72}" to="\u{0F71}\u{0F72}" />
+      <transform from="\u{0F74}\u{0F68}\u{0F74}" to="\u{0F71}\u{0F74}" />
+      <transform from="\u{0FB2}\u{0F80}\u{0F62}\u{0FB2}\u{0F80}" to="\u{0FB2}\u{0F71}\u{0F80}" />
+      <transform from="\u{0FB3}\u{0F80}\u{0F62}\u{0FB3}\u{0F80}" to="\u{0FB3}\u{0F71}\u{0F80}" />
+      <transform from="\u{0F7A}\u{0F68}\u{0F7A}" to="\u{0F7B}" />
+      <transform from="\u{0F7C}\u{0F68}\u{0F7C}" to="\u{0F7D}" />
     </transformGroup>
 
     <transformGroup> <!-- subscript consonants -->
@@ -418,6 +428,7 @@
       <transform from="\u{0F56}\u{0F62}\u{0FA3}\u{0F61}" to="\u{0F56}\u{0F62}\u{0F99}" /> <!-- NY -->
       <transform from="\u{0F56}\u{0F62}\u{0F9F}\u{0F66}" to="\u{0F56}\u{0F62}\u{0FA9}" /> <!-- TS -->
       <transform from="\u{0F56}\u{0F62}\u{0FA1}\u{0F5F}" to="\u{0F56}\u{0F62}\u{0FAB}" /> <!-- DZ -->
+      <transform from="\u{0F56}\u{0FB2}\u{0F63}"         to="\u{0F56}\u{0F62}\u{0FB3}" /> <!-- BRL -->
     </transformGroup>
 
     <transformGroup> <!-- head bs -->
@@ -434,14 +445,14 @@
     </transformGroup>
 
     <transformGroup> <!-- exceptions -->
-      <transform from="\u{0F42}\u{002E}\u{0F61}" to="\u{0F42}\m{fullYa}\u{0F61}" />
-      <transform from="\u{0F42}\m{fullYa}"       to="\u{0F42}\m{fullYa}\u{0F61}" />
+      <transform from="\u{0F42}\u{002E}\u{0F61}"   to="\u{0F42}\m{fullYa}\u{0F61}" /> <!-- g.y -->
+      <transform from="\m{fullYa}"                 to="\u{0F61}" /> <!-- Y > y  -->
     </transformGroup>
 
     <transformGroup> <!-- ligatures -->
-      <transform from="\u{0F60}\u{0F74}\u{0F7F}" to="\u{0F02}" />
-      <transform from="\u{0F02}\u{002D}"         to="\u{0F03}" />
-      <transform from="\u{0F68}\u{0F7C}\u{0F7E}" to="\u{0F00}" />
+      <transform from="\u{0F60}\u{0F74}\u{0F7F}"   to="\u{0F02}" />
+      <transform from="\u{0F02}\u{002D}"           to="\u{0F03}" />
+      <transform from="\u{0F68}\u{0F7C}\u{0F7E}"   to="\u{0F00}" />
     </transformGroup>
 
     <transformGroup> <!-- lenition -->
@@ -449,20 +460,20 @@
     </transformGroup>
 
     <transformGroup> <!-- cycles -->
-      <transform from="\u{0F00}\m{CYCLE}"  to="\u{0F01}" />
-      <transform from="\u{0F01}\m{CYCLE}"  to="\u{0F00}" />
-      <transform from="\u{0F60}\m{CYCLE}"  to="\u{0F02}" />
-      <transform from="\u{0F02}\m{CYCLE}"  to="\u{0F03}" />
-      <transform from="\u{0F03}\m{CYCLE}"  to="\u{0F60}" />
-      <transform from="\u{0F04}\m{CYCLE}"  to="\u{0F06}" />
-      <transform from="\m{CYCLE}\m{CYCLE}" to="\u{002F}" />
-      <transform from="\u{002F}\m{CYCLE}"  to="\u{002F}\u{002F}" />
+      <transform from="\u{0F00}\m{CYCLE}"          to="\u{0F01}" />
+      <transform from="\u{0F01}\m{CYCLE}"          to="\u{0F00}" />
+      <transform from="\u{0F60}\m{CYCLE}"          to="\u{0F02}" />
+      <transform from="\u{0F02}\m{CYCLE}"          to="\u{0F03}" />
+      <transform from="\u{0F03}\m{CYCLE}"          to="\u{0F60}" />
+      <transform from="\u{0F04}\m{CYCLE}"          to="\u{0F06}" />
+      <transform from="\m{CYCLE}\m{CYCLE}"         to="\u{002F}" />
+      <transform from="\u{002F}\m{CYCLE}"          to="\u{002F}\u{002F}" />
 
-      <transform from="\u{0F0D}\m{CYCLE}"  to="\u{0F0F}" />
-      <transform from="\u{0F0F}\m{CYCLE}"  to="\u{0F10}" />
-      <transform from="\u{0F10}\m{CYCLE}"  to="\u{0F11}" />
-      <transform from="\u{0F11}\m{CYCLE}"  to="\u{0F12}" />
-      <transform from="\u{0F11}\m{CYCLE}"  to="\u{0F0D}" />
+      <transform from="\u{0F0D}\m{CYCLE}"          to="\u{0F0F}" />
+      <transform from="\u{0F0F}\m{CYCLE}"          to="\u{0F10}" />
+      <transform from="\u{0F10}\m{CYCLE}"          to="\u{0F11}" />
+      <transform from="\u{0F11}\m{CYCLE}"          to="\u{0F12}" />
+      <transform from="\u{0F11}\m{CYCLE}"          to="\u{0F0D}" />
 
       <transform from="\u{0F20}\m{CYCLE}"          to="\u{0F20}\u{0F18}" />
       <transform from="\u{0F20}\u{0F18}\m{CYCLE}"  to="\u{0F20}\u{0F19}" />
@@ -507,10 +518,9 @@
       <transform from="\u{0F09}\m{CYCLE}"          to="\u{0F0A}" />
       <transform from="\u{0F0A}\m{CYCLE}"          to="\u{0F09}" />
 
-      <transform from="\u{0F8E}\m{CYCLE}" to="\u{0F8F}" />
-      <transform from="\u{0F8F}\m{CYCLE}" to="\u{0F8E}" />
+      <transform from="\u{0F8E}\m{CYCLE}"          to="\u{0F8F}" />
+      <transform from="\u{0F8F}\m{CYCLE}"          to="\u{0F8E}" />
 
-    </transformGroup>
-    
+    </transformGroup>   
   </transforms>
 </keyboard3>

--- a/keyboards/3.0/xct-Tibt-t-k0-qwerty.xml
+++ b/keyboards/3.0/xct-Tibt-t-k0-qwerty.xml
@@ -60,7 +60,7 @@
       <key id="alt_i"        output="\u{0F68}\u{0F71}\u{0F72}" />
       <key id="alt_I"        output="\u{0F68}\u{0F71}\u{0F72}" />
       <key id="u"            output="\u{0F68}\u{0F74}" />
-      <key id="U"            output="\u{0F68}\u{0F7}\u{0F74}" />
+      <key id="U"            output="\u{0F68}\u{0F71}\u{0F74}" />
       <key id="alt_u"        output="\u{0F68}\u{0F71}\u{0F74}" />
       <key id="alt_U"        output="\u{0F68}\u{0F71}\u{0F74}" />
       <key id="alt_r"        output="\u{0F62}\u{0FB2}\u{0F80}" />
@@ -140,16 +140,16 @@
       <key id="0"            output="\u{0F20}" />
 
     <!-- digits minus half -->
-      <key id="alt_1"        output="\u{0F2A}" />  
-      <key id="alt_2"        output="\u{0F2B}" />  
-      <key id="alt_3"        output="\u{0F2C}" />  
-      <key id="alt_4"        output="\u{0F2D}" /> 
-      <key id="alt_5"        output="\u{0F2E}" /> 
-      <key id="alt_6"        output="\u{0F2F}" /> 
-      <key id="alt_7"        output="\u{0F30}" /> 
-      <key id="alt_8"        output="\u{0F31}" /> 
-      <key id="alt_9"        output="\u{0F32}" /> 
-      <key id="alt_0"        output="\u{0F33}" /> 
+      <key id="alt_1"        output="\u{0F2A}" />
+      <key id="alt_2"        output="\u{0F2B}" />
+      <key id="alt_3"        output="\u{0F2C}" />
+      <key id="alt_4"        output="\u{0F2D}" />
+      <key id="alt_5"        output="\u{0F2E}" />
+      <key id="alt_6"        output="\u{0F2F}" />
+      <key id="alt_7"        output="\u{0F30}" />
+      <key id="alt_8"        output="\u{0F31}" />
+      <key id="alt_9"        output="\u{0F32}" />
+      <key id="alt_0"        output="\u{0F33}" />
   </keys>
 
   <layers formId="us">
@@ -203,7 +203,7 @@
       \u{0F53}-\u{0F56} \u{0F58}-\u{0F5B} \u{0F5D}-\u{0F68} \u{0F6A}
       \u{0F90}-\u{0F92} \u{0F94}-\u{0F97} \u{0F99}-\u{0F9C} \u{0F9E}-\u{0FA1}
       \u{0FA3}-\u{0FA6} \u{0FA8}-\u{0FAB} \u{0FAD}-\u{0FB8} \u{0FBA}-\u{0FBC}]" />
-    
+
     <set id="suby" value="\u{0F40} \u{0F41} \u{0F42} \u{0F54} \u{0F55} \u{0F56} \u{0F58} \u{0F62} \u{0F63} \u{0F90} \u{0F91} \u{0F92} \u{0FA4} \u{0FA6} \u{0FA8}" />
     <set id="subr" value="\u{0F40} \u{0F41} \u{0F42} \u{0F4F} \u{0F50} \u{0F51} \u{0F53} \u{0F54} \u{0F55} \u{0F56} \u{0F58} \u{0F61} \u{0F63} \u{0F64} \u{0F66} \u{0F67} \u{0F90} \u{0F91} \u{0F92} \u{0F9F} \u{0FA0} \u{0FA1} \u{0FA3} \u{0FA4} \u{0FA5} \u{0FA6} \u{0FA8} \u{0FB4} \u{0FB6} \u{0FB7}" />
     <set id="subl" value="\u{0F40} \u{0F42} \u{0F56} \u{0F5F} \u{0F61} \u{0F62} \u{0F66} \u{0F90} \u{0F92} \u{0FA6} \u{0FAF} \u{0FB6}" />
@@ -310,7 +310,7 @@
       <transform from="\m{STACK}\u{0F66}"         to="\u{0FB6}" />
       <transform from="\m{STACK}\u{0F67}"         to="\u{0FB7}" />
       <transform from="\m{STACK}\u{0F68}"         to="\u{0FB8}" />
-      <transform from="\m{STACK}\u{0F0D}"         to="\u{0F19}" />    
+      <transform from="\m{STACK}\u{0F0D}"         to="\u{0F19}" />
     </transformGroup>
 
     <transformGroup> <!-- nasals -->
@@ -386,7 +386,7 @@
     </transformGroup>
 
     <transformGroup> <!-- head l -->
-      <transform from="\u{0F63}\u{0F40}"         to="\u{0F63}\u{0F90}" /> <!-- K --> 
+      <transform from="\u{0F63}\u{0F40}"         to="\u{0F63}\u{0F90}" /> <!-- K -->
       <transform from="\u{0F63}\u{0F42}"         to="\u{0F63}\u{0F92}" /> <!-- G -->
       <transform from="\u{0F63}\u{0F44}"         to="\u{0F63}\u{0F94}" /> <!-- NG -->
       <transform from="\u{0F63}\u{0F45}"         to="\u{0F63}\u{0F95}" /> <!-- C -->
@@ -521,6 +521,6 @@
       <transform from="\u{0F8E}\m{CYCLE}"          to="\u{0F8F}" />
       <transform from="\u{0F8F}\m{CYCLE}"          to="\u{0F8E}" />
 
-    </transformGroup>   
+    </transformGroup>
   </transforms>
 </keyboard3>


### PR DESCRIPTION
CLDR-19169

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true

These keyboard updates implement refinements for new LDML layouts for Sanskrit, Tibetan, and Gandhari including introducing backspace transforms and better use of set/uset.