### PR TITLE
CLDR-19226 Add more specificity around using appendItems in date+time patterns

### DIFF
--- a/docs/ldml/tr35-dates.md
+++ b/docs/ldml/tr35-dates.md
@@ -838,7 +838,11 @@ Finally: If the requested skeleton included both seconds and fractional seconds 
 If a client-requested set of fields includes both date and time fields, and if the `availableFormats` data does not include a `dateFormatItem` whose skeleton matches the same set of fields, then the request should be handled as follows:
 
 1. Divide the request into a date fields part and a time fields part.
+    * Date fields are: [year](#dfst-year), [month](#dfst-month), [day](#dfst-day), [era](#dfst-era), [week](#dfst-week), [quarter](#dfst-quarter), and [week day](#dfst-weekday).
+    * Time fields are: [hour](#dfst-hour), [minute](#dfst-minute), [second](#dfst-second), [period](#dfst-period), and [zone](#dfst-zone).
 2. For each part, find the matching `dateFormatItem`, and expand the pattern as above.
+    * If there is still no `dateFormatItem` whose skeleton matches the same set of fields, select the one with the greatest number of matching fields (but no extra fields), then use `appendItems` to append any missing fields (see below).
+    * If multiple `dateFormatItem`s with missing fields have the same distance, rank them by their matching fields in the order listed in step 1. For example, if the request is for "HBv", and the locale has `dateFormatItem`s for only "HB" and "Hv", select the "HB" pattern, because "B" has a higher weight than "v", and then use the `appendItem` for "v" (time zone).
 3. Combine the patterns for the two `dateFormatItem`s using the appropriate dateTimeFormat pattern, determined as follows from the requested date fields:
    * If the requested date fields include wide month (MMMM, LLLL) and weekday name of any length (e.g. E, EEEE, c, cccc), use `<dateTimeFormatLength type="full">`
    * Otherwise, if the requested date fields include wide month, use `<dateTimeFormatLength type="long">`
@@ -852,6 +856,8 @@ If a client-requested set of fields includes both date and time fields, and if t
 ```
 
 In case the best match does not include all the requested calendar fields, the `appendItems` element describes how to append needed fields to one of the existing formats. Each `appendItem` element covers a single calendar field. In the pattern, {0} represents the format string, {1} the data content of the field, and {2} the display name of the field (see [Calendar Fields](#Calendar_Fields)).
+
+Note: as described above `appendItems` for date fields should be appended to the date, and `appendItems` for time fields should be appended to the time, _before_ combining them with the `dateTimeFormat`.
 
 #### <a name="intervalFormats" href="#intervalFormats">Element intervalFormats</a>
 

--- a/docs/ldml/tr35-modifications.md
+++ b/docs/ldml/tr35-modifications.md
@@ -43,6 +43,10 @@ This is a partial document, describing only the changes to the LDML since the pr
 * [Locale Display Name Algorithm](tr35-general.html#locale_display_name_algorithm) updated to use the nested bracket replacement data and avoid nested parentheses by flattening `-t-` (transform) language names
 * The section "Enhanced Language Matching" is retitled as [Language Matching Variables](tr35.html#enhanced-language-matching) and clarified.
 
+**Changes in LDML Version 49 (Differences from Version 48.2)**
+* Clarified the process of selecting the best `dateFormatItem` when there is no exact match, and how to use `appendItems` to add missing fields. This includes a clarification of what are date fields and what are time fields, and a note that `appendItems` for date and time fields should be appended before combining them.
+<!-- Updated spec date -->
+
 ### MessageFormat
 
 * The `:currency` and `:percent` functions are now Stable, with the same implementations as previously.

--- a/docs/ldml/tr35.md
+++ b/docs/ldml/tr35.md
@@ -5,7 +5,7 @@
 |Version|49 (draft)|
 |-------|----------|
 |Editors|Mark Davis (<a href="mailto:markdavis@google.com">markdavis@google.com</a>) and <a href="tr35-acknowledgments.md#acknowledgments">other CLDR committee members</a>|
-|Date|2026-02-09|
+|Date|2026-02-23|
 |This Version| https://www.unicode.org/reports/tr35/tr35-79/tr35.html |
 |Previous Version| https://www.unicode.org/reports/tr35/tr35-78/tr35.html |
 |Latest Version| https://www.unicode.org/reports/tr35/ |

--- a/docs/site/downloads/cldr-49.md
+++ b/docs/site/downloads/cldr-49.md
@@ -51,7 +51,7 @@ For a full listing, see [Coverage Levels](https://unicode.org/cldr/charts/dev/su
 
 The following are the most significant changes to the specification (LDML).
 
-- TBD
+- Clarified the process of selecting the best `dateFormatItem` when there is no exact match, and how to use `appendItems` to add missing fields. This includes a clarification of what are date fields and what are time fields, and a note that `appendItems` for date and time fields should be appended before combining them.
 
 There are many more changes that are important to implementations, such as changes to certain identifier syntax and various algorithms.
 See the [Modifications section](https://www.unicode.org/reports/tr35/proposed.html#Modifications) of the specification for details.


### PR DESCRIPTION
CLDR-19226

- [ ] This PR completes the ticket.

This adds the spec. We should update the CLDR code and add lots and lots _and lots_ of tests, since this algorithm has lots of edge cases. I think this code uses ICU4J DateTimePatternGenerator so we would need to either implement this over there or make a new DTPG in CLDR code before we can add more test data. (Thought: An AI might be able to do a decent job of generating a cleanroom DTPG in CLDR Java.)

ALLOW_MANY_COMMITS=true