### PR TITLE
CLDR-19293 Improve English RBNF rules

### DIFF
--- a/common/rbnf/en.xml
+++ b/common/rbnf/en.xml
@@ -120,12 +120,8 @@ NaN: not a number;
 1000000000000: << trillion[>%%commas>];
 1000000000000000: << quadrillion[>%%commas>];
 1000000000000000000: =#,##0=;
-%%tieth:
-0: tieth;
-1: ty-=%spellout-ordinal=;
-%%th:
-0: th;
-1: ' =%spellout-ordinal=;
+%%digits-ordinal:
+0: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
 %spellout-ordinal:
 -x: minus >>;
 x.x: =#,##0.#=;
@@ -144,21 +140,21 @@ Inf: infinitieth;
 11: eleventh;
 12: twelfth;
 13: =%spellout-numbering=th;
-20: twen>%%tieth>;
-30: thir>%%tieth>;
-40: for>%%tieth>;
-50: fif>%%tieth>;
-60: six>%%tieth>;
-70: seven>%%tieth>;
-80: eigh>%%tieth>;
-90: nine>%%tieth>;
-100: <%spellout-numbering< hundred>%%th>;
-1000: <%spellout-numbering< thousand>%%th>;
-1000000: <%spellout-numbering< million>%%th>;
-1000000000: <%spellout-numbering< billion>%%th>;
-1000000000000: <%spellout-numbering< trillion>%%th>;
-1000000000000000: <%spellout-numbering< quadrillion>%%th>;
-1000000000000000000: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
+20: twent[y->>|ieth];
+30: thirt[y->>|ieth];
+40: fort[y->>|ieth];
+50: fift[y->>|ieth];
+60: sixt[y->>|ieth];
+70: sevent[y->>|ieth];
+80: eight[y->>|ieth];
+90: ninet[y->>|ieth];
+100: <%spellout-numbering< hundred[ >>|th];
+1000: <%spellout-numbering< thousand[ >>|th];
+1000000: <%spellout-numbering< million[ >>|th];
+1000000000: <%spellout-numbering< billion[ >>|th];
+1000000000000: <%spellout-numbering< trillion[ >>|th];
+1000000000000000: <%spellout-numbering< quadrillion[ >>|th];
+1000000000000000000: =%%digits-ordinal=;
 %%and-o:
 0: th;
 1: ' and =%spellout-ordinal-verbose=;
@@ -181,7 +177,7 @@ Inf: infinitieth;
 1000000000: <%spellout-numbering-verbose< billion>%%commas-o>;
 1000000000000: <%spellout-numbering-verbose< trillion>%%commas-o>;
 1000000000000000: <%spellout-numbering-verbose< quadrillion>%%commas-o>;
-1000000000000000000: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
+1000000000000000000: =%%digits-ordinal=;
 ]]></rbnfRules>
         </rulesetGrouping>
         <rulesetGrouping type="OrdinalRules">

--- a/common/rbnf/en.xml
+++ b/common/rbnf/en.xml
@@ -19,7 +19,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 10: =%spellout-numbering=;
 %spellout-numbering-year:
 -x: minus >>;
-x.x: =#,##0.#=;
+x.x: =0.#=;
 0: =%spellout-numbering=;
 1010/100: << >%%2d-year>;
 1100/100: << >%%2d-year>;
@@ -124,7 +124,7 @@ NaN: not a number;
 0: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
 %spellout-ordinal:
 -x: minus >>;
-x.x: =#,##0.#=;
+x.x: =0.#=;
 Inf: infinitieth;
 0: zeroth;
 1: first;
@@ -167,7 +167,7 @@ Inf: infinitieth;
 1000000: , =%spellout-ordinal-verbose=;
 %spellout-ordinal-verbose:
 -x: minus >>;
-x.x: =#,##0.#=;
+x.x: =0.#=;
 Inf: infinitieth;
 0: =%spellout-ordinal=;
 100: <%spellout-numbering-verbose< hundred>%%and-o>;

--- a/common/rbnf/en_IN.xml
+++ b/common/rbnf/en_IN.xml
@@ -20,7 +20,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 10: =%spellout-numbering=;
 %spellout-numbering-year:
 -x: minus >>;
-x.x: =#,##0.#=;
+x.x: =0.#=;
 0: =%spellout-numbering=;
 1010/100: << >%%2d-year>;
 1100/100: << >%%2d-year>;
@@ -120,15 +120,11 @@ NaN: not a number;
 1000000000000: << trillion[>%%commas>];
 1000000000000000: << quadrillion[>%%commas>];
 1000000000000000000: =#,##0=;
-%%tieth:
-0: tieth;
-1: ty-=%spellout-ordinal=;
-%%th:
-0: th;
-1: ' =%spellout-ordinal=;
+%%digits-ordinal:
+0: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
 %spellout-ordinal:
 -x: minus >>;
-x.x: =#,##0.#=;
+x.x: =0.#=;
 Inf: infinitieth;
 0: zeroth;
 1: first;
@@ -144,21 +140,21 @@ Inf: infinitieth;
 11: eleventh;
 12: twelfth;
 13: =%spellout-numbering=th;
-20: twen>%%tieth>;
-30: thir>%%tieth>;
-40: for>%%tieth>;
-50: fif>%%tieth>;
-60: six>%%tieth>;
-70: seven>%%tieth>;
-80: eigh>%%tieth>;
-90: nine>%%tieth>;
-100: <%spellout-numbering< hundred>%%th>;
-1000: <%spellout-numbering< thousand>%%th>;
-1000000: <%spellout-numbering< million>%%th>;
-1000000000: <%spellout-numbering< billion>%%th>;
-1000000000000: <%spellout-numbering< trillion>%%th>;
-1000000000000000: <%spellout-numbering< quadrillion>%%th>;
-1000000000000000000: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
+20: twent[y->>|ieth];
+30: thirt[y->>|ieth];
+40: fort[y->>|ieth];
+50: fift[y->>|ieth];
+60: sixt[y->>|ieth];
+70: sevent[y->>|ieth];
+80: eight[y->>|ieth];
+90: ninet[y->>|ieth];
+100: <%spellout-numbering< hundred[ >>|th];
+1000: <%spellout-numbering< thousand[ >>|th];
+1000000: <%spellout-numbering< million[ >>|th];
+1000000000: <%spellout-numbering< billion[ >>|th];
+1000000000000: <%spellout-numbering< trillion[ >>|th];
+1000000000000000: <%spellout-numbering< quadrillion[ >>|th];
+1000000000000000000: =%%digits-ordinal=;
 %%and-o:
 0: th;
 1: ' and =%spellout-ordinal-verbose=;
@@ -171,7 +167,7 @@ Inf: infinitieth;
 1000000: , =%spellout-ordinal-verbose=;
 %spellout-ordinal-verbose:
 -x: minus >>;
-x.x: =#,##0.#=;
+x.x: =0.#=;
 Inf: infinitieth;
 0: =%spellout-ordinal=;
 100: <%spellout-numbering-verbose< hundred>%%and-o>;
@@ -181,7 +177,7 @@ Inf: infinitieth;
 1000000000: <%spellout-numbering-verbose< billion>%%commas-o>;
 1000000000000: <%spellout-numbering-verbose< trillion>%%commas-o>;
 1000000000000000: <%spellout-numbering-verbose< quadrillion>%%commas-o>;
-1000000000000000000: =#,##0=$(ordinal,one{st}two{nd}few{rd}other{th})$;
+1000000000000000000: =%%digits-ordinal=;
 ]]></rbnfRules>
         </rulesetGrouping>
     </rbnf>


### PR DESCRIPTION
CLDR-19293

There are some improvements that can be made for English RBNF.

This very large ordinal digit rule doesn’t work because it’s not using the whole number for the ordinal plural rules. This is only an issue for very large ordinals, like a quintillionth or larger. For a quintillionth, it returns `st` instead of the desired `th`. Now it returns `th` for the same value, and `st` for a quintillion first.

Since several contributors use English as a way to write rules for a new language, we should also convert the ordinal rules to use the new or pipe operator syntax used in the optional brackets. The verbose form can't use this revised syntax because it's intermittently inserting commas and "and".

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
