### PR TITLE
CLDR-19372 Remove %%lenient-parse rules from RBNF

### DIFF
--- a/common/rbnf/es.xml
+++ b/common/rbnf/es.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 x.x: =0.0=;
 0: =%spellout-numbering=;

--- a/common/rbnf/fr.xml
+++ b/common/rbnf/fr.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 -x: moins >>;
 x.x: =0.0=;

--- a/common/rbnf/fr_BE.xml
+++ b/common/rbnf/fr_BE.xml
@@ -14,8 +14,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 -x: moins >>;
 x.x: =0.0=;

--- a/common/rbnf/fr_CH.xml
+++ b/common/rbnf/fr_CH.xml
@@ -14,8 +14,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 -x: moins >>;
 x.x: =0.0=;

--- a/common/rbnf/ga.xml
+++ b/common/rbnf/ga.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-& ' ' , ',' ;
 %spellout-numbering-year:
 -x: míneas >>;
 x.x: =0.0=;

--- a/common/rbnf/it.xml
+++ b/common/rbnf/it.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 x.x: =0.0=;
 0: =%spellout-numbering=;

--- a/common/rbnf/km.xml
+++ b/common/rbnf/km.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << '​' << '­';
 %spellout-numbering-year:
 0: =%spellout-numbering=;
 %spellout-numbering:

--- a/common/rbnf/mt.xml
+++ b/common/rbnf/mt.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 x.x: =0.0=;
 0: =%spellout-numbering=;

--- a/common/rbnf/pt.xml
+++ b/common/rbnf/pt.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 x.x: =0.0=;
 0: =%spellout-numbering=;

--- a/common/rbnf/pt_PT.xml
+++ b/common/rbnf/pt_PT.xml
@@ -14,8 +14,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 x.x: =0.0=;
 0: =%spellout-numbering=;

--- a/common/rbnf/sv.xml
+++ b/common/rbnf/sv.xml
@@ -13,8 +13,6 @@ For terms of use, see http://www.unicode.org/copyright.html
     <rbnf>
         <rulesetGrouping type="SpelloutRules">
             <rbnfRules><![CDATA[
-%%lenient-parse:
-&[last primary ignorable ] << ' ' << ',' << '-' << '­';
 %spellout-numbering-year:
 -x: minus >>;
 x.x: =0.0=;


### PR DESCRIPTION
CLDR-19372

ICU-23358 will be removing the unnecessary %%lenient-parse rules. Removing them will reduce the size of the rules, and improve the lenient parsing speed without using a collator.

CLDR occasionally defines this rule, but it’s inconsistently defined. All of the ones in CLDR are used to define ignorable characters for lenient parsing. We should remove these rules once https://github.com/unicode-org/icu/pull/3926 is merged into ICU.

- [x] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
