### PR TITLE
CLDR-18414 st: add AM/PM to Date report

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrDom.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrDom.mjs
@@ -237,7 +237,7 @@ function parentOfType(tag, obj) {
   return parentOfType(tag, obj.parentElement);
 }
 
-/** CLDR conventional target= for documentation */
+/** CLDR conventional target= for documentation. See CLDRURLS.TARGET_DOCS */
 const TARGET_DOCS = "CLDR-ST-DOCS";
 
 /** set target=TARGET_DOCS on all <a< nodes */

--- a/tools/cldr-apps/src/main/webapp/surveytool.css
+++ b/tools/cldr-apps/src/main/webapp/surveytool.css
@@ -3279,3 +3279,7 @@ div.thinUser {
 .sidebyside-narrow a[href] {
 	word-wrap: break-word;
 }
+
+footer {
+	margin-top: 1em;
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CLDRURLS.java
@@ -54,6 +54,9 @@ public abstract class CLDRURLS {
 
     public static final String TOOLSURL = "http://cldr.unicode.org/tools/";
 
+    /** Link target for docs */
+    public static final String TARGET_DOCS = "CLDR-ST-DOCS";
+
     /**
      * "special" pages
      *
@@ -117,6 +120,8 @@ public abstract class CLDRURLS {
             "https://cldr.unicode.org/translation/date-time/date-time-patterns";
     public static final String DATE_TIME_PATTERNS_URL =
             "https://cldr.unicode.org/translation/date-time/date-time-patterns";
+    public static final String DATE_TIME_AMPM_URL =
+            "https://cldr.unicode.org/translation/date-time/date-time-names#day-periods-am-pm-etc";
     public static final String ERRORS_URL =
             "https://cldr.unicode.org/translation/error-and-warning-codes";
     public static final String EXEMPLAR_CHARACTERS =
@@ -428,5 +433,16 @@ public abstract class CLDRURLS {
                 + ".vvd {}\n"
                 + ".vvo {}\n"
                 + "</style>";
+    }
+
+    /**
+     * Emit a link to part of the docs
+     *
+     * @param url the URL (use a CLDRURLS constant or function)
+     * @param title link title
+     * @return
+     */
+    public static final String docLink(String url, String title) {
+        return String.format("<a target=\"%s\" href=\"%s\">%s</a>", TARGET_DOCS, url, title);
     }
 }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -40,6 +40,7 @@ import org.unicode.cldr.tool.FormattedFileWriter;
 import org.unicode.cldr.tool.Option;
 import org.unicode.cldr.tool.Option.Options;
 import org.unicode.cldr.tool.ShowData;
+import org.unicode.cldr.util.DayPeriodInfo.DayPeriod;
 import org.unicode.cldr.util.ICUServiceBuilder.Context;
 import org.unicode.cldr.util.ICUServiceBuilder.Width;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
@@ -1230,7 +1231,8 @@ public class DateTimeFormats {
                             + ".</p>\n");
             output.append(
                     "<table class='dtf-table'>\n"
-                            + "<tr>"
+                            + "<thead>\n"
+                            + "<tr>\n"
                             + "<th class='dtf-th' rowSpan='3'>DayPeriodID</th>"
                             + "<th class='dtf-th' rowSpan='3'>Time Span(s)</th>"
                             + "<th class='dtf-th' colSpan='4'>Format</th>"
@@ -1253,70 +1255,116 @@ public class DateTimeFormats {
                             + "<th class='dtf-th'>Native</th>"
                             + "<th class='dtf-th'>Native</th>"
                             + "<th class='dtf-th'>Native</th>"
-                            + "</tr>\n");
+                            + "</tr>\n"
+                            + "</thead>\n");
             DayPeriodInfo dayPeriodInfo =
                     sdi.getDayPeriods(DayPeriodInfo.Type.format, file.getLocaleID());
             Set<DayPeriodInfo.DayPeriod> dayPeriods =
                     new LinkedHashSet<>(dayPeriodInfo.getPeriods());
             DayPeriodInfo dayPeriodInfo2 = sdi.getDayPeriods(DayPeriodInfo.Type.format, "en");
+            DayPeriodInfo dayPeriodInfoRoot = sdi.getDayPeriods(DayPeriodInfo.Type.format, "root");
+            final boolean isRootPeriods =
+                    dayPeriodInfoRoot.equals(dayPeriodInfo); // true if it's the root periods
             Set<DayPeriodInfo.DayPeriod> eDayPeriods = EnumSet.copyOf(dayPeriodInfo2.getPeriods());
             Output<Boolean> real = new Output<>();
             Output<Boolean> realEnglish = new Output<>();
 
+            output.append("<tbody>\n");
             for (DayPeriodInfo.DayPeriod period : dayPeriods) {
-                R3<Integer, Integer, Boolean> first = dayPeriodInfo.getFirstDayPeriodInfo(period);
-                int midPoint = (first.get0() + first.get1()) / 2;
-                output.append("<tr>");
-                output.append("<th class='dtf-left'>")
-                        .append(TransliteratorUtilities.toHTML.transform(period.toString()))
-                        .append("</th>\n");
-                String periods = dayPeriodInfo.toString(period);
-                output.append("<th class='dtf-left'>")
-                        .append(TransliteratorUtilities.toHTML.transform(periods))
-                        .append("</th>\n");
-                for (Context context : Context.values()) {
-                    for (Width width : Width.values()) {
-                        final String dayPeriodPath =
-                                ICUServiceBuilder.getDayPeriodPath(period, context, width);
-                        if (width == Width.wide) {
-                            String englishValue;
-                            if (context == Context.format) {
-                                englishValue =
-                                        icuServiceBuilderEnglish.formatDayPeriod(
-                                                midPoint, context, width);
-                                realEnglish.value = true;
-                            } else {
-                                englishValue =
-                                        icuServiceBuilderEnglish.getDayPeriodValue(
-                                                dayPeriodPath, null, realEnglish);
-                            }
-                            output.append(
-                                            "<th class='dtf-left"
-                                                    + (realEnglish.value ? "" : " dtf-gray")
-                                                    + "'"
-                                                    + ">")
-                                    .append(getCleanValue(englishValue, width, "<i>unused</i>"))
-                                    .append("</th>\n");
-                        }
-                        String nativeValue =
-                                icuServiceBuilder.getDayPeriodValue(dayPeriodPath, "�", real);
-                        if (context == Context.format) {
-                            nativeValue = icuServiceBuilder.formatDayPeriod(midPoint, nativeValue);
-                        }
-                        output.append(
-                                        "<td class='dtf-left"
-                                                + (real.value ? "" : " dtf-gray")
-                                                + "'>")
-                                .append(getCleanValue(nativeValue, width, "<i>missing</i>"))
-                                .append("</td>\n");
-                    }
-                }
-                output.append("</tr>\n");
+                outputPeriod(output, dayPeriodInfo, real, realEnglish, period);
             }
+            output.append("</tbody>\n");
+
+            if (!isRootPeriods) {
+                output.append("<tbody>\n")
+                        .append("<tr>\n")
+                        .append("<th colspan='10' scope='rowgroup'><center><i>\n")
+                        .append(
+                                "Even if AM/PM is not normally used, please ensure the following are correct.")
+                        .append("</i></center></th></tr>\n")
+                        .append("</tbody>\n");
+
+                // we double check, just in case AM/PM were already shown above.
+                if (!dayPeriodInfo.has(DayPeriod.am)) {
+                    outputPeriod(output, dayPeriodInfo, real, realEnglish, DayPeriod.am);
+                }
+                if (!dayPeriodInfo.has(DayPeriod.pm)) {
+                    outputPeriod(output, dayPeriodInfo, real, realEnglish, DayPeriod.pm);
+                }
+                output.append("</tbody>");
+            } else {
+                output.append("<tfoot>\n")
+                        .append("<tr>\n")
+                        .append("<th colspan='10' scope='rowgroup'><center><i>\n")
+                        .append("This locale does not have dayPeriods defined. To fix, see ")
+                        .append(
+                                CLDRURLS.docLink(
+                                        "https://unicode.org/reports/tr35/tr35-dates.html#Day_Period_Rules",
+                                        "UTS#35"))
+                        .append(
+                                " and <a target='ticket' href='"
+                                        + CLDRURLS.CLDR_NEWTICKET_URL
+                                        + "'>file a ticket</a>")
+                        .append("</i></center></th></tr>\n</tfoot>\n");
+                // TODO: CLDR-18414 add a link suggesting checking dayperiods!
+            }
+
             output.append("</table>\n");
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
+    }
+
+    private void outputPeriod(
+            Appendable output,
+            DayPeriodInfo dayPeriodInfo,
+            Output<Boolean> real,
+            Output<Boolean> realEnglish,
+            DayPeriodInfo.DayPeriod period)
+            throws IOException {
+        R3<Integer, Integer, Boolean> first = dayPeriodInfo.getFirstDayPeriodInfo(period);
+        int midPoint = (first.get0() + first.get1()) / 2;
+        output.append("<tr>");
+        output.append("<th class='dtf-left'>")
+                .append(TransliteratorUtilities.toHTML.transform(period.toString()))
+                .append("</th>\n");
+        String periods = dayPeriodInfo.toString(period);
+        output.append("<th class='dtf-left'>")
+                .append(TransliteratorUtilities.toHTML.transform(periods))
+                .append("</th>\n");
+        for (Context context : Context.values()) {
+            for (Width width : Width.values()) {
+                final String dayPeriodPath =
+                        ICUServiceBuilder.getDayPeriodPath(period, context, width);
+                if (width == Width.wide) {
+                    String englishValue;
+                    if (context == Context.format) {
+                        englishValue =
+                                icuServiceBuilderEnglish.formatDayPeriod(midPoint, context, width);
+                        realEnglish.value = true;
+                    } else {
+                        englishValue =
+                                icuServiceBuilderEnglish.getDayPeriodValue(
+                                        dayPeriodPath, null, realEnglish);
+                    }
+                    output.append(
+                                    "<th class='dtf-left"
+                                            + (realEnglish.value ? "" : " dtf-gray")
+                                            + "'"
+                                            + ">")
+                            .append(getCleanValue(englishValue, width, "<i>unused</i>"))
+                            .append("</th>\n");
+                }
+                String nativeValue = icuServiceBuilder.getDayPeriodValue(dayPeriodPath, "�", real);
+                if (context == Context.format) {
+                    nativeValue = icuServiceBuilder.formatDayPeriod(midPoint, nativeValue);
+                }
+                output.append("<td class='dtf-left" + (real.value ? "" : " dtf-gray") + "'>")
+                        .append(getCleanValue(nativeValue, width, "<i>missing</i>"))
+                        .append("</td>\n");
+            }
+        }
+        output.append("</tr>\n");
     }
 
     private String getCleanValue(String evalue, Width width, String fallback) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -1225,7 +1225,9 @@ public class DateTimeFormats {
                                             DayPeriodInfo.DayPeriod.am, Context.format, Width.wide))
                             + " and following. "
                             + "<b>Note: </b>Day Periods can be a bit tricky; "
-                            + "for more information, see <a target='CLDR-ST-DOCS' href='http://cldr.unicode.org/translation/date-time-names#TOC-Day-Periods-AM-and-PM-'>Day Periods</a>.</p>\n");
+                            + "for more information, see "
+                            + CLDRURLS.docLink(CLDRURLS.DATE_TIME_AMPM_URL, "Day Periods")
+                            + ".</p>\n");
             output.append(
                     "<table class='dtf-table'>\n"
                             + "<tr>"

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DayPeriodInfo.java
@@ -251,6 +251,13 @@ public class DayPeriodInfo implements Comparable<DayPeriodInfo> {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof DayPeriodInfo)) return false;
+        return compareTo((DayPeriodInfo) obj) == 0;
+    }
+
+    @Override
     public int compareTo(DayPeriodInfo o) {
         int result;
         int thisSpanCount = spans.length;
@@ -317,6 +324,13 @@ public class DayPeriodInfo implements Comparable<DayPeriodInfo> {
             default:
                 return dayPeriodsToSpans.get(dayPeriod);
         }
+    }
+
+    /**
+     * @returns true if this dayPeriod is present
+     */
+    public boolean has(DayPeriod dayPeriod) {
+        return dayPeriodsToSpans.containsKey(dayPeriod);
     }
 
     /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ICUServiceBuilder.java
@@ -1071,7 +1071,7 @@ public class ICUServiceBuilder {
 
     private String formatDayPeriod(int timeInDay, DayPeriod period, String dayPeriodFormatString) {
         String pattern = null;
-        if ((timeInDay % 6) != 0) { // need a better way to test for this
+        if ((timeInDay % 6) != 0) { // TODO CLDR-19377: need a better way to test for this
             // dayPeriods other than am, pm, noon, midnight (want patterns with B)
             pattern = cldrFile.getStringValue(BHM_PATH);
             if (pattern != null) {


### PR DESCRIPTION
CLDR-18414

- [ ] This PR completes the ticket.

See images below.
If AM/PM aren't otherwise shown in dayperiods, show them (with a note). 

### Also:
- Some minor updates to the URL generation machinery
- added a TODO in ICUServiceBuilder

### Review Images

#### Greek (`el`)

Note the "Even if AM/PM is not used.." message at the bottom

<img width="1003" height="508" alt="image" src="https://github.com/user-attachments/assets/d60a5ca0-66ed-4f7a-8814-01014f527759" />

#### Adyghe ('ady')

DDL, dayPeriods inherit from root. Suggests filing a ticket.

<img width="1011" height="308" alt="image" src="https://github.com/user-attachments/assets/c108d41a-d38a-4cee-8dff-4a41b8665d41" />

Also note the little gap between the copyright footer and the bottom of the text. That's updated in this CSS. Otherwise the bottom of the table was bumping into the footer.



ALLOW_MANY_COMMITS=true
