### PR TITLE
CLDR-18759 Do not use non-winning inherited empty exemplar set as a candidate item

### DIFF
--- a/tools/cldr-apps/js/src/views/InfoSelectedItem.vue
+++ b/tools/cldr-apps/js/src/views/InfoSelectedItem.vue
@@ -5,7 +5,8 @@
         {{ getTitle() }}
       </div></template
     >
-    <div class="info-selected-item" v-if="displayValue && description">
+    <!-- displayValue may be ""; still display the item if valueClass and description have been set -->
+    <div class="info-selected-item" v-if="valueClass && description">
       <div>
         Value:
         <span :class="valueClass" :lang="language" :dir="direction">{{

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -804,7 +804,11 @@ public class DataPage {
                     new Output<>(); // may be used to construct inheritedLocale
             inheritedValue =
                     ourSrc.getBaileyValue(xpath, inheritancePathWhereFound, localeWhereFound);
-
+            if (UnicodeSetPrettyPrinter.EMPTY_SET.equals(inheritedValue)
+                    && xpath.contains("exemplarCharacters")) {
+                // Do not treat inherited empty exemplar set "[]" as a candidate item
+                inheritedValue = null;
+            }
             if (TRACE_TIME) {
                 System.err.println("@@1:" + (System.currentTimeMillis() - lastTime));
             }

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/DataPage.java
@@ -804,11 +804,6 @@ public class DataPage {
                     new Output<>(); // may be used to construct inheritedLocale
             inheritedValue =
                     ourSrc.getBaileyValue(xpath, inheritancePathWhereFound, localeWhereFound);
-            if (UnicodeSetPrettyPrinter.EMPTY_SET.equals(inheritedValue)
-                    && xpath.contains("exemplarCharacters")) {
-                // Do not treat inherited empty exemplar set "[]" as a candidate item
-                inheritedValue = null;
-            }
             if (TRACE_TIME) {
                 System.err.println("@@1:" + (System.currentTimeMillis() - lastTime));
             }
@@ -873,14 +868,38 @@ public class DataPage {
                 if (TRACE_TIME) {
                     System.err.println("@@6:" + (System.currentTimeMillis() - lastTime));
                 }
-
                 if (!iTests.isEmpty()) {
-                    inheritedItem.setTests(iTests);
+                    if (!CldrUtility.INHERITANCE_MARKER.equals(winningValue)
+                            && testsExcludeCandidateItem(iTests)) {
+                        inheritedItem = null;
+                        inheritedValue = inheritedDisplayValue = null;
+                        inheritedLocale = null;
+                    } else {
+                        inheritedItem.setTests(iTests);
+                    }
                 }
             }
             if (TRACE_TIME) {
                 System.err.println("@@7:" + (System.currentTimeMillis() - lastTime));
             }
+        }
+
+        /**
+         * Do the given test results imply that the value should not be shown as a candidate item?
+         * (If the item is winning, this method is not called.)
+         *
+         * @param tests the test results
+         * @return true if the value should be excluded
+         */
+        private boolean testsExcludeCandidateItem(List<CheckStatus> tests) {
+            for (CheckStatus test : tests) {
+                // Do not treat inherited empty exemplar set "[]" as a candidate item (unless
+                // winning)
+                if (test.getSubtype() == CheckCLDR.CheckStatus.Subtype.missingMainExemplars) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /**

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/draft/UnicodeSetFormat.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/draft/UnicodeSetFormat.java
@@ -13,6 +13,7 @@ import java.util.BitSet;
 import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.draft.PatternFixer.Target;
+import org.unicode.cldr.util.UnicodeSetPrettyPrinter;
 
 public class UnicodeSetFormat extends Format {
 
@@ -33,7 +34,7 @@ public class UnicodeSetFormat extends Format {
         // API for Format calls for StringBuffer, but should update to StringBuilder
         int startPos = toAppendTo.length();
         Set<String> strings = null;
-        toAppendTo.append('[');
+        toAppendTo.append(UnicodeSetPrettyPrinter.SET_OPEN);
         for (UnicodeSetIterator it = new UnicodeSetIterator((UnicodeSet) obj); it.nextRange(); ) {
             if (it.codepoint == UnicodeSetIterator.IS_STRING) {
                 if (strings == null) {
@@ -47,7 +48,7 @@ public class UnicodeSetFormat extends Format {
                 appendQuoted(toAppendTo.append('-'), it.codepointEnd);
             }
         }
-        toAppendTo.append(']');
+        toAppendTo.append(UnicodeSetPrettyPrinter.SET_CLOSE);
         if (strings != null) { // edge case
             StringBuffer extras = new StringBuffer("(?:");
             for (String string : strings) {
@@ -63,8 +64,8 @@ public class UnicodeSetFormat extends Format {
     // and (possibly) the given location in the character class
     private StringBuffer appendQuoted(StringBuffer target, int codePoint) {
         switch (codePoint) {
-            case '[': // SET_OPEN:
-            case ']': // SET_CLOSE:
+            case UnicodeSetPrettyPrinter.SET_OPEN:
+            case UnicodeSetPrettyPrinter.SET_CLOSE:
             case '-': // HYPHEN:
             case '^': // COMPLEMENT:
             case '&': // INTERSECTION:

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
@@ -28,7 +28,6 @@ import java.util.TreeSet;
 public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
     public static final char SET_OPEN = '[';
     public static final char SET_CLOSE = ']';
-    public static final String EMPTY_SET = "[]";
 
     private static final StringComparator CODEPOINT_ORDER =
             new UTF16.StringComparator(true, false, 0);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/UnicodeSetPrettyPrinter.java
@@ -26,6 +26,10 @@ import java.util.TreeSet;
  * For the Survey Tool, should use SimpleUnicodeSetFormatter.java
  */
 public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
+    public static final char SET_OPEN = '[';
+    public static final char SET_CLOSE = ']';
+    public static final String EMPTY_SET = "[]";
+
     private static final StringComparator CODEPOINT_ORDER =
             new UTF16.StringComparator(true, false, 0);
     private static final UnicodeSet PATTERN_WHITESPACE =
@@ -37,7 +41,7 @@ public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
             new UnicodeSet("[\\[\\]\\-\\^\\&\\\\\\{\\}\\$\\:]").addAll(PATTERN_WHITESPACE).freeze();
 
     private boolean first = true;
-    private StringBuffer target = new StringBuffer();
+    private final StringBuffer target = new StringBuffer();
     private int firstCodePoint = -2;
     private int lastCodePoint = -2;
     private boolean compressRanges = true;
@@ -178,7 +182,7 @@ public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
                 }
             }
             target.setLength(0);
-            target.append("[");
+            target.append(SET_OPEN);
             for (String item : orderedStrings) {
                 appendUnicodeSetItem(item);
             }
@@ -190,7 +194,7 @@ public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
                 // is safe
             }
             flushLast();
-            target.append("]");
+            target.append(SET_CLOSE);
             String sresult = target.toString();
 
             return sresult;
@@ -290,8 +294,8 @@ public class UnicodeSetPrettyPrinter implements FormatterParser<UnicodeSet> {
             return this;
         }
         switch (codePoint) {
-            case '[': // SET_OPEN:
-            case ']': // SET_CLOSE:
+            case SET_OPEN:
+            case SET_CLOSE:
             case '-': // HYPHEN:
             case '^': // COMPLEMENT:
             case '&': // INTERSECTION:


### PR DESCRIPTION
-Skip inherited item if it has error missingMainExemplars and is not winning

-New method DataRow.testsExcludeCandidateItem

-Fix front end to display selected item even if displayValue is empty/falsy

-Encapsulate brackets as UnicodeSetPrettyPrinter.SET_OPEN/SET_CLOSE

-Make UnicodeSetPrettyPrinter.target final (fixing compiler warning)

CLDR-18759

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
