### PR TITLE
CLDR-16859 docker: webdriver test summary, first few sanity checks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -337,7 +337,7 @@ jobs:
         # docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
         cat target/webdriver-output/summary.md >> $GITHUB_STEP_SUMMARY
         echo >> $GITHUB_STEP_SUMMARY
-        echo '- Tip: Need more details? See artifact cldr-apps-docker'">> $GITHUB_STEP_SUMMARY
+        echo '- Tip: Need more details? See artifact: cldr-apps-docker'>> $GITHUB_STEP_SUMMARY
       working-directory: tools/cldr-apps
     - name: Shut down containers
       run: docker compose stop || true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -295,9 +295,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-mavencheck-${{ hashFiles('tools/**/pom.xml') }}
+        key: ${{ runner.os }}-servertest-${{ hashFiles('tools/**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-mavencheck-
+          ${{ runner.os }}-servertest-
+          servertest-
     - name: Cache local npm repository
       uses: actions/cache@v4
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -332,8 +332,8 @@ jobs:
       working-directory: tools/cldr-apps
     - name: Collect Webdriver Output
       run: |
-        docker compose exec cldr-apps chmod a+r /logs/messages.log
-        docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
+        # docker compose exec cldr-apps chmod a+r /logs/messages.log
+        # docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
         cat target/webdriver-output/summary.md >> $GITHUB_STEP_SUMMARY
         echo >> $GITHUB_STEP_SUMMARY
         echo "_Need more details? See artifact `cldr-apps-docker`_" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -332,11 +332,12 @@ jobs:
       working-directory: tools/cldr-apps
     - name: Collect Webdriver Output
       run: |
+        ## TODO CLDR-16859 permissions are preventing this from working on linux
         # docker compose exec cldr-apps chmod a+r /logs/messages.log
         # docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
         cat target/webdriver-output/summary.md >> $GITHUB_STEP_SUMMARY
         echo >> $GITHUB_STEP_SUMMARY
-        echo "_Need more details? See artifact `cldr-apps-docker`_" >> $GITHUB_STEP_SUMMARY
+        echo '- Tip: Need more details? See artifact cldr-apps-docker'">> $GITHUB_STEP_SUMMARY
       working-directory: tools/cldr-apps
     - name: Shut down containers
       run: docker compose stop || true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -332,6 +332,7 @@ jobs:
       working-directory: tools/cldr-apps
     - name: Collect Webdriver Output
       run: |
+        docker compose exec cldr-apps chmod a+r /logs/messages.log
         docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
         cat target/webdriver-output/summary.md >> $GITHUB_STEP_SUMMARY
         echo >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -321,6 +321,7 @@ jobs:
     - name: Test with Webdriver
       # See tools/cldr-apps/README.md
       run: >
+        rm -rf target/webdriver-output &&
         docker compose run -v ~/.m2/repository:/root/.m2/repository:rw --rm webdriver || ( docker compose exec -it cldr-apps tail /logs/messages.log ; true )
       working-directory: tools/cldr-apps
     - name: Prepare client tests
@@ -329,9 +330,21 @@ jobs:
     - name: Run client tests against ST
       run: docker compose run --rm client-test || ( docker compose exec -it cldr-apps tail /logs/messages.log ; false )
       working-directory: tools/cldr-apps
+    - name: Collect Webdriver Output
+      run: |
+        docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
+        cat target/webdriver-output/summary.md >> $GITHUB_STEP_SUMMARY
+        echo >> $GITHUB_STEP_SUMMARY
+        echo "_Need more details? See artifact `cldr-apps-docker`_" >> $GITHUB_STEP_SUMMARY
+      working-directory: tools/cldr-apps
     - name: Shut down containers
       run: docker compose stop || true
       working-directory: tools/cldr-apps
+    - name: Upload cldr-apps-docker.zip
+      uses: actions/upload-artifact@v7
+      with:
+        name: cldr-apps-docker
+        path: tools/cldr-apps/target/webdriver-output
   deploy:
     name: "Deploy to cldr-smoke for testing"
     # don't run deploy on manual builds!

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -333,8 +333,7 @@ jobs:
     - name: Collect Webdriver Output
       run: |
         ## TODO CLDR-16859 permissions are preventing this from working on linux
-        # docker compose exec cldr-apps chmod a+r /logs/messages.log
-        # docker compose cp cldr-apps:/logs/messages.log target/webdriver-output/cldr-apps-messages.log
+        docker compose cp cldr-apps:/logs target/cldr-apps-logs
         cat target/webdriver-output/summary.md >> $GITHUB_STEP_SUMMARY
         echo >> $GITHUB_STEP_SUMMARY
         echo '- Tip: Need more details? See artifact: cldr-apps-docker'>> $GITHUB_STEP_SUMMARY
@@ -347,6 +346,11 @@ jobs:
       with:
         name: cldr-apps-docker
         path: tools/cldr-apps/target/webdriver-output
+    - name: Upload cldr-apps-logs.zip
+      uses: actions/upload-artifact@v7
+      with:
+        name: cldr-apps-logs
+        path: tools/cldr-apps/target/cldr-apps-logs
   deploy:
     name: "Deploy to cldr-smoke for testing"
     # don't run deploy on manual builds!

--- a/tools/cldr-apps-webdriver/.gitignore
+++ b/tools/cldr-apps-webdriver/.gitignore
@@ -2,3 +2,4 @@
 /target
 surveydriver.properties
 scripts/selenium-server.jar
+/.settings

--- a/tools/cldr-apps-webdriver/README.md
+++ b/tools/cldr-apps-webdriver/README.md
@@ -1,7 +1,46 @@
 # CLDR Survey Tool `tools/cldr-apps-webdriver` directory
 
-Survey Tool WebDriver Test Framework: automated tests for the Survey Tool to ensure that it remains operational
+Survey Tool WebDriver Test Framework: automated tests for the Survey Tool to ensure that it remains operational.
 
-https://www.w3.org/TR/webdriver/ “WebDriver is a remote control interface that enables introspection and control of user agents”
+> “[WebDriver] is a remote control interface that enables introspection and control of user agents”
+
+See [cldr-apps/README.md#docker-testing](../cldr-apps/README.md#docker-testing) for details on how to use this.
+
+## Configuration
+
+Configuration is via the `surveydriver.properties` file. You can see the [`surveydriver-docker.properties`](./surveydriver-docker.properties) file, which is used in the automated build for an example.
+
+```properties
+# This must be identical to the cldr.properties property CLDR_WEBDRIVER_PASSWORD=SomeRandomId
+# and it grants special access to the test. As you might expect, this property is ignored
+# in production.
+WEBDRIVER_PASSWORD=SomeRandomId
+# This tells the webdriver which instance to connect to.
+SURVEYTOOL_URL=http://localhost:9080
+# This is the URL of the selenium grid.
+WEBDRIVER_URL=http://localhost:4444
+# This is an optional parameter for detailed test output. See Output below
+WEBDRIVER_OUTPUT=/tmp/webdriver-output/
+# General timeout in seconds for Survey Tool startup. Bump this up if failures
+# happen before the tool starts. However, if it's too long, it will delay the test
+# when there's a problem.
+TIME_OUT_SECONDS=120
+```
+
+### Output
+
+If `WEBDRIVER_OUTPUT` is set and a directory, its contents will be cleared at the beginning of the test, and the following will be added (assuming test success). Not all components will be present depending on test status.
+
+- `summary.md` - this summarizes the output and is suitable for appending to [`GITHUB_STEP_SUMMARY`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary)
+- `screenshots/` - this may contain screenshots at various steps.
+- `data/` - this may contain any other downloadable content.
+- `logs/` - additional logs, including those from the server
+
+In CI, the entire `WEBDRIVER_OUTPUT` is also attached to the job.
+
+
+## More details
 
 For copyright, terms of use, and further details, see the top [README](../../README.md).
+
+[WebDriver]: https://www.w3.org/TR/webdriver/

--- a/tools/cldr-apps-webdriver/pom.xml
+++ b/tools/cldr-apps-webdriver/pom.xml
@@ -27,8 +27,8 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.32.0</version>
-    </dependency>    
+      <version>4.43.0</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/AppTest.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/AppTest.java
@@ -1,10 +1,12 @@
 package org.unicode.cldr.surveydriver;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 public class AppTest {
     @Test
     public void shouldDrive() {
-        SurveyDriver.runTests();
+        assertTrue(SurveyDriver.runTests());
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -100,6 +100,9 @@ public class SurveyDriver {
     private boolean gotComprehensiveCoverage = false;
 
     public static void runTests() {
+
+        SurveyDriverLog.printlnSummary("### Web Driver starting");
+
         SurveyDriver s = new SurveyDriver();
         s.setUp();
         try {
@@ -123,6 +126,7 @@ public class SurveyDriver {
             }
         } finally {
             s.tearDown();
+            SurveyDriverLog.printlnSummary("#### Web Driver Stopping");
         }
     }
 

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -12,12 +12,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -83,6 +85,7 @@ public class SurveyDriver {
     // static final String BASE_URL = "https://cldr-staging.unicode.org/cldr-apps/";
 
     static final long TIME_OUT_SECONDS = SurveyDriverCredentials.getTimeOut();
+    static final long TIME_OUT_QUICK_SECONDS = SurveyDriverCredentials.getQuickTimeOut();
     static final long SLEEP_MILLISECONDS = 100;
 
     /*
@@ -96,7 +99,13 @@ public class SurveyDriver {
     static final String REMOTE_WEBDRIVER_URL = SurveyDriverCredentials.getWebdriverUrl();
 
     public WebDriver driver;
+
+    /** longer wait such as ST startup */
     public WebDriverWait wait;
+
+    /** shorter wait such as page flipping */
+    public WebDriverWait quickWait;
+
     private SessionId sessionId = null;
 
     /**
@@ -113,11 +122,19 @@ public class SurveyDriver {
             System.err.println("No screenshot (set WEBDRIVER_OUTPUT) - " + imageComment + ".jpg");
             return null;
         }
+        int n = 0;
         try {
             File outputFile = SurveyDriverCredentials.getScreenshotFile(imageComment + ".jpg");
+            while (outputFile.exists() && n < 20) {
+                outputFile =
+                        SurveyDriverCredentials.getScreenshotFile(imageComment + "-" + n + ".jpg");
+                n++;
+            }
+            while (outputFile.exists())
+                ;
             File tmpFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
             Files.copy(tmpFile.toPath(), outputFile.toPath());
-            SurveyDriverLog.printlnSummary("- Screenshot: " + outputFile.toString());
+            SurveyDriverLog.printlnSummary("- :tv: Screenshot: " + outputFile.toString());
             return outputFile;
         } catch (IOException ioe) {
             SurveyDriverLog.println(ioe);
@@ -230,6 +247,11 @@ public class SurveyDriver {
                 new WebDriverWait(
                         driver,
                         Duration.ofSeconds(TIME_OUT_SECONDS),
+                        Duration.ofMillis(SLEEP_MILLISECONDS));
+        quickWait =
+                new WebDriverWait(
+                        driver,
+                        Duration.ofSeconds(TIME_OUT_QUICK_SECONDS),
                         Duration.ofMillis(SLEEP_MILLISECONDS));
         if (USE_REMOTE_WEBDRIVER) {
             userIndex = getUserIndexFromGrid(sessionId);
@@ -837,13 +859,14 @@ public class SurveyDriver {
                                     (Objects.requireNonNull(webDriver).getTitle().contains(s)));
         } catch (Exception e) {
             SurveyDriverLog.println(e);
-            SurveyDriverLog.println(
-                    "❌ Test failed, maybe timed out, waiting for title to contain "
+            printlnSummary(
+                    "  - ❌ Test failed, maybe timed out, waiting for title to contain "
                             + s
                             + " in "
                             + url);
             return false;
         }
+        printlnSummary("  - OK: url = " + driver.getCurrentUrl());
         return true;
     }
 
@@ -1301,12 +1324,233 @@ public class SurveyDriver {
             takeSnapShot("fail-sanity-login");
             return false;
         }
+        closeAntNotification();
         takeSnapShot("sanity-login");
 
+        /// ----- OK. now start the steps
+        /// 10. CLA
         result = testCla() && result;
 
-        printSection("Sanity Test: " + getResult(result));
+        result = testVoting() && result;
+
+        printSection("Overall Sanity Test: " + getResult(result));
         return result;
+    }
+
+    boolean testVoting() {
+        boolean result = true;
+        printSection("Voting");
+
+        result = testOpenLocale("fr", "French") && result;
+        result = testNavigateDashboard() && result;
+        result = testWarningClick() && result;
+
+        printSubSection("Overall Voting: " + getResult(result));
+        return result;
+    }
+
+    boolean testOpenLocale(final String locale, final String locName) {
+        boolean result = true;
+        printSubSection("Open Locale: " + locale);
+
+        try {
+            // the locale list
+            {
+                String url = BASE_URL + "v#locales///";
+                driver.get(url);
+                waitForTitle("Locale List", url);
+            }
+
+            // pop open left side
+            {
+                final WebElement leftSidebar = driver.findElement(By.id("left-sidebar"));
+                // final Point  p = leftSidebar.getLocation();
+                leftSidebar.click();
+                final String linkToLocale = "#/" + locale + "//";
+
+                // TODO CLDR-16859 sidebar click wasn't working...
+                // now, look for a visible link
+                // final WebElement theLocale = findLocaleLink(locale, locName);
+                // if (theLocale == null) {
+                //     SurveyDriverLog.printlnSummary("- :x: could not find locale link");
+                //     takeSnapShot("open-" + locale);
+                //     return false;
+                // }
+                // theLocale.click();
+
+                // Go over to the locale's page
+                {
+                    String url = BASE_URL + "v#/" + locale + "//";
+                    driver.get(url);
+                }
+
+                waitForTitle(locName, BASE_URL + "v" + linkToLocale);
+            }
+
+            takeSnapShot("open-" + locale);
+        } catch (Throwable t) {
+            takeSnapShot("open-" + locale + "-exception");
+            SurveyDriverLog.println(t);
+            result = false;
+        }
+
+        printSubSubSection("Overall Open Locale: " + getResult(result));
+        return result;
+    }
+
+    boolean testDashboardCategory(String category, String catchar, boolean okToSkip) {
+        printSubSubSection("Navigate to: " + category + " - " + catchar);
+        final WebElement btn = findDashboardCategoryButton(category, okToSkip);
+        if (btn == null) {
+            takeSnapShot("navigate-dashboard-nobutton-" + category);
+            return okToSkip;
+        } else {
+            btn.click();
+        }
+        takeSnapShot("navigate-dashboard-" + category);
+
+        final WebElement visibleItemInCat = findVisibleItemInCategory(catchar);
+
+        if (visibleItemInCat == null) {
+            printlnSummary("- " + getResult(false) + " - found no visible items for " + catchar);
+            return false;
+        }
+
+        printlnSummary("- " + getResult(true) + " - found visible item " + catchar);
+
+        return true;
+    }
+
+    final WebElement findVisibleItemInCategory(String catchar) {
+        final WebElement scroller = driver.findElement(By.id("DashboardScroller"));
+
+        for (final WebElement e : scroller.findElements(By.className("category"))) {
+            if (e.getText().startsWith(catchar) && e.isDisplayed()) {
+                return e;
+            }
+        }
+        return null;
+    }
+
+    boolean testNavigateDashboard() {
+        boolean result = true;
+        printSubSection("Navigate Dashboard");
+        try {
+            if (!waitUntilIdExists("DashboardScroller", true, driver.getCurrentUrl())) {
+                result = false;
+                printlnSummary("- :x: could not find DashboardScroller");
+            }
+
+            result = testDashboardCategory("Missing", "M", true) && result;
+            result = testDashboardCategory("Provisional", "P", true) && result;
+            result = testDashboardCategory("Warning", "W", false) && result;
+            result = testDashboardCategory("Reports", "R", false) && result;
+            // leave Warning as clicked for the next test.
+        } catch (Throwable t) {
+            takeSnapShot("navigate-dashboard-exception");
+            SurveyDriverLog.println(t);
+            result = false;
+        }
+        printSubSubSection("Navigate Dashboard: " + getResult(result));
+        return result;
+    }
+
+    private WebElement findDashboardCategoryButton(String category, boolean okToSkip) {
+        for (final WebElement e : driver.findElements(By.tagName("BUTTON"))) {
+            if (e.getText().startsWith(category)) {
+                if (!e.isDisplayed()) {
+                    SurveyDriverLog.printlnSummary(
+                            "- warning: button " + category + " is found but not displayed");
+                } else {
+                    return e;
+                }
+            }
+        }
+        if (okToSkip) {
+            printlnSummary("- :arrow_lower_right: skip " + category + " - not found");
+        } else {
+            printlnSummary("- :x: could not find category button " + category);
+        }
+        return null;
+    }
+
+    // private WebElement findLocaleLink(String locale, String locName) {
+    //     for (final WebElement e : driver.findElements(By.className("locName"))) {
+    //         if (e.getText().equals(locName)) {
+    //             if (!e.isDisplayed()) {
+    //                 SurveyDriverLog.printlnSummary("- :x: locale name is found but not
+    // displayed");
+    //                 return null;
+    //             }
+    //             return e;
+    //         }
+    //     }
+    //     return null;
+    // }
+
+    boolean testWarningClick() {
+        boolean result = true;
+        printSubSection("Click on Warning");
+        try {
+            // make sure we're still OK
+            if (!waitUntilIdExists("DashboardScroller", true, driver.getCurrentUrl())) {
+                result = false;
+                printlnSummary("- :x: could not find DashboardScroller");
+                return result;
+            }
+
+            // rerun this test
+            testDashboardCategory("Warning", "W", true);
+
+            final WebElement clickItem = findVisibleItemInCategory("W");
+            if (clickItem == null) {
+                printlnSummary("- :x: could not find item in W");
+                result = false;
+                return result;
+            }
+
+            printlnSummary("- Clicking the dashboard item");
+            clickItem.click();
+
+            printlnSummary("- Waiting until the dashboard item shows up");
+            // wait until the clicked item shows up
+            if (!waitUntilUrlMatches("^.*v#\\/[a-z_A-Z]+\\/[A-Za-z0-9_]+\\/[a-f0-9]+$")) {
+                return false;
+            }
+            printlnSummary("- ended up at " + driver.getTitle() + " - " + driver.getCurrentUrl());
+
+            // make sure infoPanel is there
+            if (!waitUntilIdExists("info-panel-help", true, driver.getCurrentUrl())) {
+                printlnSummary("- :x: Info panel didn't showup");
+                return false;
+            }
+            printlnSummary("- got InfoPanel OK");
+
+            takeSnapShot("click-warning");
+        } catch (Throwable t) {
+            takeSnapShot("click-warning-exception");
+            SurveyDriverLog.println(t);
+            result = false;
+        }
+        printSubSubSection("Click on Warning: " + getResult(result));
+        return result;
+    }
+
+    private boolean waitUntilUrlMatches(final String regex) {
+        final Pattern pat = Pattern.compile(regex);
+        try {
+            quickWait.until(
+                    (ExpectedCondition<Boolean>)
+                            webDriver -> pat.matcher(driver.getCurrentUrl()).matches());
+            return true;
+        } catch (TimeoutException e) {
+            printlnSummary(
+                    "- :x: failed, timed out waiting for URL to match "
+                            + regex
+                            + " - final url "
+                            + driver.getCurrentUrl());
+            return false;
+        }
     }
 
     boolean testCla() {
@@ -1333,5 +1577,16 @@ public class SurveyDriver {
             if (e.getText().contains(subText)) return true;
         }
         return false;
+    }
+
+    void closeAntNotification() {
+        try {
+            final WebElement el = driver.findElement(By.className("ant-notification-notice-close"));
+            if (el != null) {
+                el.click();
+            }
+        } catch (Throwable t) {
+            // ...
+        }
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -1563,7 +1563,7 @@ public class SurveyDriver {
         driver.get(url);
         waitForTitle("Contributor License Agreement", url);
         boolean hasSignedCorpCla =
-                haveElementWithClassAndSubtext(
+                waitForElementWithClassAndSubtext(
                         "ant-alert-message",
                         "Your organization has signed a Unicode Corporate CLA");
         printlnSummary("- Has signed corp CLA: " + getResult(hasSignedCorpCla));

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -1363,12 +1363,13 @@ public class SurveyDriver {
 
             // pop open left side
             {
-                final WebElement leftSidebar = driver.findElement(By.id("left-sidebar"));
-                // final Point  p = leftSidebar.getLocation();
-                leftSidebar.click();
-                final String linkToLocale = "#/" + locale + "//";
-
                 // TODO CLDR-16859 sidebar click wasn't working...
+                final WebElement leftSidebar = driver.findElement(By.id("left-sidebar"));
+                // For now just confirm that leftSidebar is preent.
+                // // final Point  p = leftSidebar.getLocation();
+                // leftSidebar.click();
+                // final String linkToLocale = "#/" + locale + "//";
+
                 // now, look for a visible link
                 // final WebElement theLocale = findLocaleLink(locale, locName);
                 // if (theLocale == null) {
@@ -1381,10 +1382,11 @@ public class SurveyDriver {
                 // Go over to the locale's page
                 {
                     String url = BASE_URL + "v#/" + locale + "//";
+                    printlnSummary("- go to locale page " + locale);
                     driver.get(url);
                 }
 
-                waitForTitle(locName, BASE_URL + "v" + linkToLocale);
+                waitForTitle(locName, driver.getCurrentUrl());
             }
 
             takeSnapShot("open-" + locale);

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -130,10 +130,9 @@ public class SurveyDriver {
                         SurveyDriverCredentials.getScreenshotFile(imageComment + "-" + n + ".jpg");
                 n++;
             }
-            while (outputFile.exists())
-                ;
             File tmpFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
             Files.copy(tmpFile.toPath(), outputFile.toPath());
+            outputFile.toPath();
             SurveyDriverLog.printlnSummary("- :tv: Screenshot: " + outputFile.toString());
             return outputFile;
         } catch (IOException ioe) {
@@ -215,6 +214,7 @@ public class SurveyDriver {
         } finally {
             tearDown();
             printSection("Web Driver Stopping");
+            SurveyDriverCredentials.finalizeOutputDir(); // so output is all world readable
         }
         return true;
     }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -1581,6 +1581,17 @@ public class SurveyDriver {
         return false;
     }
 
+    boolean waitForElementWithClassAndSubtext(final String className, final String subText) {
+        try {
+            quickWait.until(
+                    (ExpectedCondition<Boolean>)
+                            webDriver -> haveElementWithClassAndSubtext(className, subText));
+            return true;
+        } catch (TimeoutException t) {
+            return false;
+        }
+    }
+
     void closeAntNotification() {
         try {
             final WebElement el = driver.findElement(By.className("ant-notification-notice-close"));

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriver.java
@@ -2,8 +2,11 @@ package org.unicode.cldr.surveydriver;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -12,7 +15,9 @@ import java.util.logging.Level;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -58,13 +63,17 @@ public class SurveyDriver {
 
     /*
      * Enable/disable specific tests using these booleans
+     *
+     * Most of these are the original (non sanity test) tests
      */
     static final boolean TEST_VETTING_TABLE = false;
     static final boolean TEST_FAST_VOTING = false;
     static final boolean TEST_LOCALES_AND_PAGES = false;
     static final boolean TEST_ANNOTATION_VOTING = false;
     static final boolean TEST_XML_UPLOADER = false;
-    static final boolean TEST_DASHBOARD = true;
+    static final boolean TEST_DASHBOARD = false;
+    // the sanity test
+    static final boolean TEST_SANITY = true;
 
     /*
      * Configure for Survey Tool server, which can be localhost, cldr-smoke, cldr-staging, ...
@@ -99,35 +108,98 @@ public class SurveyDriver {
 
     private boolean gotComprehensiveCoverage = false;
 
-    public static void runTests() {
+    public File takeSnapShot(final String imageComment) {
+        if (!SurveyDriverCredentials.haveOutputDir()) {
+            System.err.println("No screenshot (set WEBDRIVER_OUTPUT) - " + imageComment + ".jpg");
+            return null;
+        }
+        try {
+            File outputFile = SurveyDriverCredentials.getScreenshotFile(imageComment + ".jpg");
+            File tmpFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            Files.copy(tmpFile.toPath(), outputFile.toPath());
+            SurveyDriverLog.printlnSummary("- Screenshot: " + outputFile.toString());
+            return outputFile;
+        } catch (IOException ioe) {
+            SurveyDriverLog.println(ioe);
+            return null;
+        }
+    }
 
-        SurveyDriverLog.printlnSummary("### Web Driver starting");
+    public static void printSection(String s) {
+        SurveyDriverLog.printlnSummary("");
+        SurveyDriverLog.printlnSummary("## " + s);
+        SurveyDriverLog.printlnSummary("");
+    }
 
-        SurveyDriver s = new SurveyDriver();
-        s.setUp();
+    public static void printSubSection(String s) {
+        SurveyDriverLog.printlnSummary("");
+        SurveyDriverLog.printlnSummary("### " + s);
+        SurveyDriverLog.printlnSummary("");
+    }
+
+    public static void printSubSubSection(String s) {
+        SurveyDriverLog.printlnSummary("");
+        SurveyDriverLog.printlnSummary("#### " + s);
+        SurveyDriverLog.printlnSummary("");
+    }
+
+    /** redirect this as it will be commonly used */
+    public static final void printlnSummary(String s) {
+        SurveyDriverLog.printlnSummary(s);
+    }
+
+    public static String getResult(boolean pass) {
+        return "Result: " + (pass ? ":white_check_mark: PASS" : ":x: FAIL");
+    }
+
+    public static boolean runTests() {
+        boolean result = new SurveyDriver().runAllTests();
+        SurveyDriverLog.printlnSummary("#### " + getResult(result));
+        return result;
+    }
+
+    public boolean runAllTests() {
+        SurveyDriverLog.printlnSummary("# Web Driver starting");
+
+        setUp();
+        takeSnapShot("setup-complete");
+
         try {
             if (TEST_VETTING_TABLE) {
-                assertTrue(SurveyDriverVettingTable.testVettingTable(s));
+                printSection("Test Vetting Table");
+                assertTrue(SurveyDriverVettingTable.testVettingTable(this));
             }
             if (TEST_FAST_VOTING) {
-                assertTrue(s.testFastVoting());
+                printSection("Test Fast Voting");
+                assertTrue(testFastVoting());
             }
             if (TEST_LOCALES_AND_PAGES) {
-                assertTrue(s.testAllLocalesAndPages());
+                printSection("Test Locales and Pages");
+                assertTrue(testAllLocalesAndPages());
             }
             if (TEST_ANNOTATION_VOTING) {
-                assertTrue(s.testAnnotationVoting());
+                printSection("Test Annotation Voting");
+                assertTrue(testAnnotationVoting());
             }
             if (TEST_XML_UPLOADER) {
-                assertTrue(new SurveyDriverXMLUploader(s).testXMLUploader());
+                printSection("Test XML Uploader");
+                assertTrue(new SurveyDriverXMLUploader(this).testXMLUploader());
             }
             if (TEST_DASHBOARD) {
-                assertTrue(new SurveyDriverDashboard(s).test());
+                printSection("Test Dashboard");
+                assertTrue(new SurveyDriverDashboard(this).test());
             }
+            if (TEST_SANITY) {
+                return testSanity();
+            }
+        } catch (Throwable t) {
+            SurveyDriverLog.println(t);
+            return false;
         } finally {
-            s.tearDown();
-            SurveyDriverLog.printlnSummary("#### Web Driver Stopping");
+            tearDown();
+            printSection("Web Driver Stopping");
         }
+        return true;
     }
 
     /** Set up the driver and its "wait" object. */
@@ -469,7 +541,7 @@ public class SurveyDriver {
     /** Log into Survey Tool. */
     public boolean login() {
         final String url = BASE_URL;
-        SurveyDriverLog.println("Logging in to " + url);
+        SurveyDriverLog.println("Logging in to " + url + " as #" + userIndex);
         driver.get(url);
 
         /*
@@ -757,6 +829,7 @@ public class SurveyDriver {
      * @return true for success, false for failure
      */
     public boolean waitForTitle(String s, String url) {
+        printlnSummary("- Waiting for title: " + s);
         try {
             wait.until(
                     (ExpectedCondition<Boolean>)
@@ -1213,5 +1286,52 @@ public class SurveyDriver {
                             + url);
         }
         return uIndex;
+    }
+
+    /**
+     * @returns true if sanity test passes
+     */
+    boolean testSanity() {
+        boolean result = true;
+
+        printSection("Sanity Login");
+        userIndex = SurveyDriverCredentials.SANITY_USER_INDEX;
+        if (!login()) {
+            printSubSection("Sanity Login failed.");
+            takeSnapShot("fail-sanity-login");
+            return false;
+        }
+        takeSnapShot("sanity-login");
+
+        result = testCla() && result;
+
+        printSection("Sanity Test: " + getResult(result));
+        return result;
+    }
+
+    boolean testCla() {
+        boolean result = true;
+        printSection("CLA");
+
+        String url = BASE_URL + "v#cla///";
+        driver.get(url);
+        waitForTitle("Contributor License Agreement", url);
+        boolean hasSignedCorpCla =
+                haveElementWithClassAndSubtext(
+                        "ant-alert-message",
+                        "Your organization has signed a Unicode Corporate CLA");
+        printlnSummary("- Has signed corp CLA: " + getResult(hasSignedCorpCla));
+        result = hasSignedCorpCla && result;
+        takeSnapShot("sanity-cla");
+
+        printSubSection("CLA: " + getResult(result));
+        return result;
+    }
+
+    boolean haveElementWithClassAndSubtext(final String className, final String subText) {
+        for (final WebElement e : driver.findElements(By.className(className))) {
+            if (e.getText().contains(subText)) return true;
+        }
+        return false;
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
@@ -35,6 +35,8 @@ public class SurveyDriverCredentials {
         this.email = email;
     }
 
+    public static final int SANITY_USER_INDEX = 1000; // see AuthSurveyDriver.java
+
     /**
      * Get credentials for logging in as a particular user depending on which Selenium slot we're
      * running on.
@@ -196,5 +198,12 @@ public class SurveyDriverCredentials {
         if (!haveOutputDir()) return null;
 
         return new File(getOutputDir(), "summary.md");
+    }
+
+    public static final File getScreenshotFile(String d) {
+        if (!haveOutputDir()) return null;
+
+        final File sub = new File(getOutputDir(SCREENSHOTS_SUBDIR), d);
+        return sub;
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
@@ -1,5 +1,6 @@
 package org.unicode.cldr.surveydriver;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +25,8 @@ public class SurveyDriverCredentials {
     private static final String PROPS_URL_KEY = "SURVEYTOOL_URL";
 
     private static final Object PROPS_WEBDRIVER_KEY = "WEBDRIVER_URL";
+    private static final String PROPS_WEBDRIVER_OUTPUT = "WEBDRIVER_OUTPUT";
+
     private static String webdriverPassword = null;
 
     private final String email;
@@ -47,10 +50,22 @@ public class SurveyDriverCredentials {
 
     private static final class PropsHelper {
         public final Properties props = new java.util.Properties();
+        public final File outputDir;
 
         PropsHelper() {
             if (!tryFromFile()) {
                 tryFromResource();
+            }
+            final String outputPath = props.getOrDefault(PROPS_WEBDRIVER_OUTPUT, "").toString();
+            if (!setupOutputDir(outputPath)) {
+                System.err.println(
+                        "Warning: WEBDRIVER_OUTPUT=" + outputPath + " not set or not usable.");
+                // remove this property so it doesn't get used.
+                props.remove(PROPS_WEBDRIVER_OUTPUT);
+                outputDir = null;
+            } else {
+                System.out.println("# WEBDRIVER_OUTPUT=" + outputPath);
+                outputDir = new File(outputPath);
             }
         }
 
@@ -122,5 +137,64 @@ public class SurveyDriverCredentials {
         }
         System.out.println("TIME_OUT_SECONDS=" + s);
         return Integer.parseInt(s);
+    }
+
+    // output dir
+
+    private static final String LOGS_SUBDIR = "logs/";
+    private static final String DATA_SUBDIR = "data/";
+    private static final String SCREENSHOTS_SUBDIR = "screenshots/";
+
+    /**
+     * @returns true if output dir was setup and cleared
+     */
+    private static final boolean setupOutputDir(final String dir) {
+        if (dir == null || dir.isBlank()) return false;
+        final File f = new File(dir);
+        if (!f.isDirectory()) return false;
+
+        // make directories ahead of time
+        new File(f, LOGS_SUBDIR).mkdirs();
+        new File(f, DATA_SUBDIR).mkdirs();
+        new File(f, SCREENSHOTS_SUBDIR).mkdirs();
+
+        return true; // OK for now
+    }
+
+    /**
+     * @returns a FILE with the WEBDRIVER_OUTPUT dir, or null
+     */
+    public static final File getOutputDir() {
+        return PropsHelper.INSTANCE.outputDir;
+    }
+
+    /**
+     * @returns true if WEBDRIVER_OUTPUT is usable
+     */
+    public static final boolean haveOutputDir() {
+        return getOutputDir() != null;
+    }
+
+    /**
+     * @returns path to a new subdirectory
+     */
+    public static final File getOutputDir(String d) {
+        if (!haveOutputDir()) return null;
+
+        final File sub = new File(getOutputDir(), d);
+        sub.mkdirs(); // always initialize the subdir
+        return sub;
+    }
+
+    public static final File getDriverLogFile() {
+        if (!haveOutputDir()) return null;
+
+        return new File(getOutputDir(LOGS_SUBDIR), "webdriverlog.txt");
+    }
+
+    public static final File getDriverSummaryFile() {
+        if (!haveOutputDir()) return null;
+
+        return new File(getOutputDir(), "summary.md");
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
@@ -146,7 +146,7 @@ public class SurveyDriverCredentials {
     private static final String SCREENSHOTS_SUBDIR = "screenshots/";
 
     /**
-     * @returns true if output dir was setup and cleared
+     * @returns true if output dir was setup
      */
     private static final boolean setupOutputDir(final String dir) {
         if (dir == null || dir.isBlank()) return false;

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
@@ -4,7 +4,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Properties;
+import java.util.Set;
 
 public class SurveyDriverCredentials {
     /**
@@ -214,5 +218,31 @@ public class SurveyDriverCredentials {
 
         final File sub = new File(getOutputDir(SCREENSHOTS_SUBDIR), d);
         return sub;
+    }
+
+    /** fix up permissions */
+    public static void finalizeOutputDir() {
+        if (!haveOutputDir()) return;
+        try {
+            Files.walk(getOutputDir().toPath())
+                    .forEach(
+                            path -> {
+                                Set<PosixFilePermission> oldPerm;
+                                try {
+                                    oldPerm =
+                                            Files.getPosixFilePermissions(
+                                                    path, LinkOption.NOFOLLOW_LINKS);
+                                    if (oldPerm.add(PosixFilePermission.OTHERS_READ)
+                                            || oldPerm.add(PosixFilePermission.GROUP_READ)
+                                            || oldPerm.add(PosixFilePermission.OWNER_READ)) {
+                                        Files.setPosixFilePermissions(path, oldPerm);
+                                    }
+                                } catch (IOException e) {
+                                    e.printStackTrace();
+                                }
+                            });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverCredentials.java
@@ -141,6 +141,15 @@ public class SurveyDriverCredentials {
         return Integer.parseInt(s);
     }
 
+    public static int getQuickTimeOut() {
+        String s = getProperties().getOrDefault("TIME_OUT_QUICK_SECONDS", "5").toString();
+        if (s == null || s.isEmpty()) {
+            s = "5";
+        }
+        System.out.println("TIME_OUT_QUICK_SECONDS=" + s);
+        return Integer.parseInt(s);
+    }
+
     // output dir
 
     private static final String LOGS_SUBDIR = "logs/";

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverLog.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverLog.java
@@ -1,5 +1,9 @@
 package org.unicode.cldr.surveydriver;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.logging.*;
 
 public class SurveyDriverLog {
@@ -12,6 +16,36 @@ public class SurveyDriverLog {
         ConsoleHandler handler = new ConsoleHandler();
         handler.setFormatter(formatter);
         logger.addHandler(handler);
+        // add a handler that appends to a flat log
+        logger.addHandler(
+                new Handler() {
+                    @Override
+                    public void close() {}
+
+                    @Override
+                    public void flush() throws SecurityException {
+                        // auto flush
+                    }
+
+                    @Override
+                    public void publish(LogRecord record) {
+                        // check each time
+                        if (SurveyDriverCredentials.haveOutputDir()) {
+                            try {
+                                printlnFile(
+                                        SurveyDriverCredentials.getDriverLogFile(),
+                                        record.getMessage());
+                            } catch (IOException ioe) {
+                                ioe.printStackTrace();
+                                System.err.println(
+                                        "Could not write to log: "
+                                                + ioe.getMessage()
+                                                + " - "
+                                                + record.getMessage());
+                            }
+                        }
+                    }
+                });
     }
 
     public static void println(Exception e) {
@@ -27,5 +61,24 @@ public class SurveyDriverLog {
         public String format(LogRecord record) {
             return formatMessage(record) + "\n";
         }
+    }
+
+    // helper function
+    private static final void printlnFile(final File f, final String str) throws IOException {
+        try (final Writer out = new FileWriter(f, true)) {
+            out.append(str).append('\n');
+        }
+    }
+
+    /** print to summary.md */
+    public static void printlnSummary(final String s) {
+        if (SurveyDriverCredentials.haveOutputDir()) {
+            try {
+                printlnFile(SurveyDriverCredentials.getDriverSummaryFile(), s);
+            } catch (IOException ioe) {
+                System.err.println("%% Could not write to summary file");
+            }
+        }
+        System.out.println("%% " + s);
     }
 }

--- a/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverLog.java
+++ b/tools/cldr-apps-webdriver/src/test/java/org/unicode/cldr/surveydriver/SurveyDriverLog.java
@@ -48,7 +48,7 @@ public class SurveyDriverLog {
                 });
     }
 
-    public static void println(Exception e) {
+    public static void println(Throwable e) {
         logger.severe("Exception: " + e);
     }
 

--- a/tools/cldr-apps-webdriver/surveydriver-docker.properties
+++ b/tools/cldr-apps-webdriver/surveydriver-docker.properties
@@ -1,4 +1,5 @@
 WEBDRIVER_PASSWORD=pw-for-docker-webdriver
 SURVEYTOOL_URL=http://cldr-apps:9080
 WEBDRIVER_URL=http://selenium:4444
+WEBDRIVER_OUTPUT=/workarea/webdriver-output
 TIME_OUT_SECONDS=120

--- a/tools/cldr-apps/docker-compose.yml
+++ b/tools/cldr-apps/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       # cache these two
       - mavencache:/root/.m2
       - webdrivertarget:/workarea/target
+      - ./target/webdriver-output:/workarea/webdriver-output
   selenium:
     image: selenium/standalone-chrome:latest
     shm_size: 2gb

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AuthSurveyDriver.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/AuthSurveyDriver.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import org.unicode.cldr.util.CLDRConfig;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.util.StandardCodes;
+import org.unicode.cldr.util.VoteResolver.Level;
 import org.unicode.cldr.web.UserRegistry.User;
 
 public class AuthSurveyDriver {
@@ -94,13 +95,28 @@ public class AuthSurveyDriver {
         u.name = EMAIL_PREFIX + userIndex;
         Organization[] orgArray = Organization.values();
         u.org = orgArray[userIndex % orgArray.length].name();
+        // Special users
+        if (userIndex == 1000) {
+            // French TC vetter
+            u.org = Organization.microsoft.name();
+            u.setLocales("fr");
+            u.userlevel = UserRegistry.VETTER;
+        }
         u.setPassword(password);
         User registeredUser = reg.newUser(null, u);
         if (registeredUser == null || registeredUser.id <= 0) {
             logger.severe("Failed to add webdriver simulated user " + email);
             return null;
         }
-        logger.info("Added webdriver simulated user " + email);
+        logger.info(
+                "Added webdriver simulated user "
+                        + email
+                        + " as "
+                        + Level.fromSTLevel(u.userlevel)
+                        + " "
+                        + u.getLocales()
+                        + " in "
+                        + u.org);
         return registeredUser;
     }
 }


### PR DESCRIPTION
CLDR-16859

- [ ] This PR completes the ticket.


- Supports first few items of Sanity Check automatically
- for now, disabled the existing webdriver tests (may bring them back by default)
- Summary file [see example](https://github.com/unicode-org/cldr/actions/runs/24298408899#summary-70947450242) , uploaded screenshots, uploaded server logs— all in the Summary page of the Maven build
- updated docs

<img width="937" height="895" alt="click-warning" src="https://github.com/user-attachments/assets/5f1de4c4-25ad-466f-bb4b-b210640f9eba" />


<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
