### PR TITLE
CLDR-14273 Handle logical group errors with Vietnamese plurals

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -15,6 +15,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.test.CheckMetazones;
+import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 
 public class ExtraPaths {
     private static final boolean DEBUG = false;
@@ -351,8 +352,6 @@ public class ExtraPaths {
         }
     }
 
-    static final Set<String> SKIP_PLURALS = Set.of("vi", "vi_VN");
-
     public static void addLocaleDependent(
             Set<String> toAddTo, Iterable<String> file, String localeID) {
         SupplementalDataInfo.PluralInfo plurals =
@@ -367,7 +366,7 @@ public class ExtraPaths {
                             + supplementalData.getDirectory().getAbsolutePath());
         }
         Set<SupplementalDataInfo.PluralInfo.Count> pluralCounts =
-                SKIP_PLURALS.contains(localeID)
+                Count.LOCALES_USING_OTHER_ONLY_HACK.contains(localeID)
                         ? Collections.emptySet()
                         : (plurals != null) ? plurals.getAdjustedCounts() : Collections.emptySet();
         addUnitPlurals(toAddTo, file, plurals, pluralCounts);

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/LogicalGrouping.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/LogicalGrouping.java
@@ -324,6 +324,12 @@ public class LogicalGrouping {
         }
     }
 
+    private static Set<Count> getCounts(CLDRFile cldrFile) {
+        return PluralInfo.Count.LOCALES_USING_OTHER_ONLY_HACK.contains(cldrFile.getLocaleID())
+                ? Count.OTHER_ONLY
+                : getPluralInfo(cldrFile).getCounts();
+    }
+
     /** Path types for logical groupings */
     public enum PathType {
         SINGLETON { // no logical groups for singleton paths
@@ -508,7 +514,7 @@ public class LogicalGrouping {
                     addCaseOnly(set, cldrFile, parts);
                     return;
                 }
-                Set<Count> pluralTypes = getPluralInfo(cldrFile).getCounts();
+                Set<Count> pluralTypes = getCounts(cldrFile);
                 Collection<String> rawCases =
                         grammarInfo.get(
                                 GrammaticalTarget.nominal,
@@ -530,7 +536,7 @@ public class LogicalGrouping {
                     addCaseOnly(set, cldrFile, parts);
                     return;
                 }
-                Set<Count> pluralTypes = getPluralInfo(cldrFile).getCounts();
+                Set<Count> pluralTypes = getCounts(cldrFile);
                 Collection<String> rawCases =
                         grammarInfo.get(
                                 GrammaticalTarget.nominal,
@@ -548,7 +554,7 @@ public class LogicalGrouping {
         abstract void addPaths(Set<String> set, CLDRFile cldrFile, String path, XPathParts parts);
 
         public void addCaseOnly(Set<String> set, CLDRFile cldrFile, XPathParts parts) {
-            Set<Count> pluralTypes = getPluralInfo(cldrFile).getCounts();
+            Set<Count> pluralTypes = getCounts(cldrFile);
             for (Count count : pluralTypes) {
                 parts.setAttribute(-1, "count", count.toString());
                 set.add(parts.toString());

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/SupplementalDataInfo.java
@@ -4079,6 +4079,8 @@ public class SupplementalDataInfo {
             public static final int LENGTH = Count.values().length;
             public static final List<Count> VALUES =
                     Collections.unmodifiableList(Arrays.asList(values()));
+            public static final Set<Count> OTHER_ONLY = Set.of(Count.other);
+            public static final Set<String> LOCALES_USING_OTHER_ONLY_HACK = Set.of("vi", "vi_VN");
         }
 
         static final Pattern pluralPaths = PatternCache.get(".*pluralRule.*");

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPluralRuleGeneration.java
@@ -423,4 +423,10 @@ public class TestPluralRuleGeneration extends TestFmwkPlus {
         buffer.append(pr.select(formatted));
         return buffer;
     }
+
+    public void TestSpecialPlurals() {
+        logKnownIssue(
+                "CLDR-15634",
+                "Fix the hack for Vietnamese plurals to be more generate. Should replace Count.LOCALES_USING_OTHER_ONLY_HACK");
+    }
 }


### PR DESCRIPTION
CLDR-14273

The skipping plurals for Vietnamese needs a fix also for LogicalGroup errors. 

This also makes it a bit more clear that this is a hack that needs to be replaced and adds a logKnownIssue.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
