### PR TITLE
CLDR-18977 generate minimal pairs automatically for plurals, ordinals

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GeneratePluralRanges.java
@@ -246,7 +246,7 @@ public class GeneratePluralRanges {
         String samplePattern;
         try {
             samplePattern =
-                    samplePatterns.get(
+                    samplePatterns.getSample(
                             PluralRules.PluralType.CARDINAL,
                             r); // CldrUtility.get(samplePatterns.keywordToPattern, r);
         } catch (Exception e) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PluralMinimalPairs.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PluralMinimalPairs.java
@@ -20,20 +20,20 @@ public class PluralMinimalPairs {
 
     private PluralMinimalPairs() {}
 
-    private static Map<String, PluralMinimalPairs> cache = new ConcurrentHashMap<>();
-    public static PluralMinimalPairs EMPTY = new PluralMinimalPairs().freeze();
+    private static final Map<String, PluralMinimalPairs> cache = new ConcurrentHashMap<>();
+    public static final PluralMinimalPairs EMPTY = new PluralMinimalPairs().freeze();
 
-    // TODO should use builder pattern
     public static PluralMinimalPairs getInstance(String ulocale) {
-        PluralMinimalPairs samplePatterns = cache.get(ulocale);
-        if (samplePatterns != null) {
-            return samplePatterns;
-        }
+        return cache.computeIfAbsent(ulocale, x -> getUncachedSamples(factory.make(ulocale, true)));
+    }
+
+    private static Factory factory = CLDRConfig.getInstance().getCldrFactory();
+
+    public static PluralMinimalPairs getUncachedSamples(CLDRFile cldrFile) {
+        PluralMinimalPairs samplePatterns;
         // don't care if we put it in twice, better than locking
-        Factory factory = CLDRConfig.getInstance().getFullCldrFactory();
         try {
             samplePatterns = new PluralMinimalPairs();
-            CLDRFile cldrFile = factory.make(ulocale, true);
             for (Iterator<String> it = cldrFile.iterator("//ldml/numbers/minimalPairs/");
                     it.hasNext(); ) {
                 String path = it.next();
@@ -62,7 +62,7 @@ public class PluralMinimalPairs {
                 if (category == null || type == null) {
                     throw new IllegalArgumentException("Bad plural info");
                 }
-                samplePatterns.put(ulocale, type, category, sample);
+                samplePatterns.put(cldrFile.getLocaleID(), type, category, sample);
             }
             if (samplePatterns.typeToCountToSample.isEmpty()) {
                 samplePatterns = EMPTY;
@@ -72,11 +72,10 @@ public class PluralMinimalPairs {
         } catch (Exception e) {
             samplePatterns = EMPTY;
         }
-        cache.put(ulocale, samplePatterns);
         return samplePatterns;
     }
 
-    public void put(String locale, PluralType type, Count count, String sample) {
+    private void put(String locale, PluralType type, Count count, String sample) {
         Map<Count, String> countToSample = typeToCountToSample.get(type);
         if (countToSample == null) {
             typeToCountToSample.put(type, countToSample = new EnumMap<>(Count.class));
@@ -84,7 +83,7 @@ public class PluralMinimalPairs {
         countToSample.put(count, sample);
     }
 
-    public String get(PluralType type, Count count) {
+    public String getSample(PluralType type, Count count) {
         Map<Count, String> countToSample = typeToCountToSample.get(type);
         return countToSample == null ? null : countToSample.get(count);
     }
@@ -94,7 +93,7 @@ public class PluralMinimalPairs {
         return countToSample == null ? null : typeToCountToSample.get(type).keySet();
     }
 
-    public PluralMinimalPairs freeze() {
+    private PluralMinimalPairs freeze() {
         typeToCountToSample = CldrUtility.protectCollection(typeToCountToSample);
         return this;
     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PluralRulesFactory.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/PluralRulesFactory.java
@@ -160,7 +160,7 @@ public abstract class PluralRulesFactory extends PluralRules.Factory {
     public static String getSamplePattern(String uLocale, PluralType type, Count count) {
         PluralMinimalPairs samplePatterns = PluralMinimalPairs.getInstance(uLocale);
         if (samplePatterns != null) {
-            String result = samplePatterns.get(type, count);
+            String result = samplePatterns.getSample(type, count);
             if (result != null) {
                 return result;
             }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/ShowPlurals.java
@@ -248,7 +248,7 @@ public class ShowPlurals {
                     String sample = counts.size() == 1 ? NO_PLURAL_DIFFERENCES : NOT_AVAILABLE;
                     if (samplePatterns != null) {
                         String samplePattern =
-                                samplePatterns.get(
+                                samplePatterns.getSample(
                                         pluralType.standardType,
                                         Count.valueOf(
                                                 keyword)); // CldrUtility.get(samplePatterns.keywordToPattern, Count.valueOf(keyword));

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/WritePluralRulesSpreadsheets.java
@@ -136,7 +136,7 @@ public class WritePluralRulesSpreadsheets {
 
             for (DecimalQuantity number : samples) {
                 String cat = rules.select(number);
-                String sample = samplePatterns.get(PluralType.CARDINAL, Count.valueOf(cat));
+                String sample = samplePatterns.getSample(PluralType.CARDINAL, Count.valueOf(cat));
                 System.out.print(
                         locale
                                 + "\t"
@@ -150,7 +150,7 @@ public class WritePluralRulesSpreadsheets {
                                 + "«replace if Sample wrong»");
                 for (String keyword : keywords) {
                     String sample2 =
-                            samplePatterns.get(PluralType.CARDINAL, Count.valueOf(keyword));
+                            samplePatterns.getSample(PluralType.CARDINAL, Count.valueOf(keyword));
                     System.out.print("\t" + sample2.replace("{0}", number.toString()));
                 }
                 System.out.println();
@@ -257,7 +257,7 @@ public class WritePluralRulesSpreadsheets {
     }
 
     private static String getSamplePattern(PluralMinimalPairs samplePatterns, String start) {
-        String result = samplePatterns.get(PluralType.CARDINAL, Count.valueOf(start));
+        String result = samplePatterns.getSample(PluralType.CARDINAL, Count.valueOf(start));
         return result == null ? "N/A" : result;
     }
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -15,6 +15,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import org.unicode.cldr.test.CheckMetazones;
+import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
 
 public class ExtraPaths {
@@ -356,7 +357,9 @@ public class ExtraPaths {
             Set<String> toAddTo, Iterable<String> file, String localeID) {
         SupplementalDataInfo.PluralInfo plurals =
                 supplementalData.getPlurals(SupplementalDataInfo.PluralType.cardinal, localeID);
-        if (plurals == null && DEBUG) {
+        SupplementalDataInfo.PluralInfo ordinals =
+                supplementalData.getPlurals(SupplementalDataInfo.PluralType.ordinal, localeID);
+        if (DEBUG && (plurals == null || ordinals == null)) {
             System.err.println(
                     "No "
                             + SupplementalDataInfo.PluralType.cardinal
@@ -365,6 +368,8 @@ public class ExtraPaths {
                             + " in "
                             + supplementalData.getDirectory().getAbsolutePath());
         }
+
+        addMinimalPairs(toAddTo, plurals, ordinals);
         Set<SupplementalDataInfo.PluralInfo.Count> pluralCounts =
                 Count.LOCALES_USING_OTHER_ONLY_HACK.contains(localeID)
                         ? Collections.emptySet()
@@ -373,6 +378,28 @@ public class ExtraPaths {
         addDayPlurals(toAddTo, localeID);
         addCurrencies(toAddTo, pluralCounts);
         addGrammar(toAddTo, pluralCounts, localeID);
+    }
+
+    private static void addMinimalPairs(
+            Set<String> toAddTo, PluralInfo plurals, PluralInfo ordinals) {
+        if (plurals != null) {
+            plurals.getCounts().stream()
+                    .forEach(
+                            x ->
+                                    toAddTo.add(
+                                            "//ldml/numbers/minimalPairs/pluralMinimalPairs[@count=\""
+                                                    + x
+                                                    + "\"]"));
+        }
+        if (ordinals != null) {
+            ordinals.getCounts().stream()
+                    .forEach(
+                            x ->
+                                    toAddTo.add(
+                                            "//ldml/numbers/minimalPairs/ordinalMinimalPairs[@ordinal=\""
+                                                    + x
+                                                    + "\"]"));
+        }
     }
 
     private static void addUnitPlurals(

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestSupplementalInfo.java
@@ -267,7 +267,7 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                 } else {
                     for (Count result : found) {
                         String samplePattern =
-                                samplePatterns.get(PluralRules.PluralType.CARDINAL, result);
+                                samplePatterns.getSample(PluralRules.PluralType.CARDINAL, result);
                         if (samplePattern != null && !samplePattern.contains("{0}")) {
                             errln(
                                     "Plural Ranges cannot have results that don't use {0} in samples: "
@@ -342,12 +342,12 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         if (samplePatterns != null) {
             example = "";
             if (result != null) {
-                String pat = samplePatterns.get(PluralRules.PluralType.CARDINAL, result);
+                String pat = samplePatterns.getSample(PluralRules.PluralType.CARDINAL, result);
                 example +=
                         "«" + (pat == null ? "MISSING-PATTERN" : pat.replace("{0}", range)) + "»";
             } else {
                 for (Count c : new TreeSet<>(Arrays.asList(start, end, Count.other))) {
-                    String pat = samplePatterns.get(PluralRules.PluralType.CARDINAL, c);
+                    String pat = samplePatterns.getSample(PluralRules.PluralType.CARDINAL, c);
                     example +=
                             c
                                     + ":«"
@@ -396,7 +396,11 @@ public class TestSupplementalInfo extends TestFmwkPlus {
         }
     }
 
-    public void TestPluralSamples2() {
+    // this is in the Checks, so we don't need it here.
+    // That is, the ordinals will show up as missing in the Survey Tool
+    // Retaining the code for now in case we want to add more to Checks
+
+    public void oldTestPluralSamples2() {
         PluralRulesFactory prf = PluralRulesFactory.getInstance(SUPPLEMENTAL);
         for (String locale : prf.getLocales()) {
             if (locale.equals(LocaleNames.UND)) {
@@ -417,11 +421,11 @@ public class TestSupplementalInfo extends TestFmwkPlus {
                 Multimap<String, Count> sampleToCount = TreeMultimap.create();
 
                 for (Count count : rules.getCounts()) {
-                    String sample = samplePatterns.get(type, count);
+                    String sample = samplePatterns.getSample(type, count);
                     if (sample == null) {
                         errOrLog(
                                 CoverageIssue.error,
-                                locale + "\t" + type + " \tmissing samples for " + count,
+                                "\t" + locale + "\t" + type + " \tmissing samples for " + count,
                                 "cldrbug:7075",
                                 "Missing ordinal minimal pairs");
                     } else {


### PR DESCRIPTION
CLDR-18977

The main change is in ExtraPaths.java — both minimal pairs for both plurals and ordinals are automatically generated.

As a part of this, I did some cleanup on PluralMinimalPairs.java, including a name change that triggered small changes in a few files. 

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
