### PR TITLE
CLDR-7408 Ordinal days-of-week

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -867,7 +867,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
     <!--@DEPRECATED-->
 
-<!ELEMENT calendar ( alias | ( months?, monthNames?, monthAbbr?, monthPatterns?, days?, dayNames?, dayAbbr?, quarters?, week?, am*, pm*, dayPeriods?, eras?, cyclicNameSets?, dateFormats?, timeFormats?, dateTimeFormats?, fields*, special* ) ) >
+<!ELEMENT calendar ( alias | ( months?, monthNames?, monthAbbr?, monthPatterns?, dayOfMonths?, days?, dayNames?, dayAbbr?, quarters?, week?, am*, pm*, dayPeriods?, eras?, cyclicNameSets?, dateFormats?, timeFormats?, dateTimeFormats?, fields*, special* ) ) >
     <!-- use of fields is deprecated here -->
 <!ATTLIST calendar type NMTOKEN #REQUIRED >
     <!--@MATCH:bcp47/ca-->
@@ -1000,6 +1000,28 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@METADATA-->
 <!ATTLIST monthPattern references CDATA #IMPLIED >
     <!--@METADATA-->
+
+<!ELEMENT dayOfMonths ( alias | ( default*, dayOfMonthContext*, special* ) ) >
+<!ATTLIST dayOfMonths alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+
+<!ELEMENT dayOfMonthContext ( alias | ( default*, dayOfMonthWidth*, special* ) ) >
+<!ATTLIST dayOfMonthContext type (format | stand-alone) #REQUIRED >
+<!ATTLIST dayOfMonthContext alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+
+<!ELEMENT dayOfMonthWidth ( alias | ( dayOfMonth*, special* ) ) >
+<!ATTLIST dayOfMonthWidth type (abbreviated | narrow | short | wide) #REQUIRED >
+<!ATTLIST dayOfMonthWidth alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+
+<!ELEMENT dayOfMonth ( #PCDATA ) >
+	<!-- There must be at least one of type or ordinal, but that constraint can't be expressed in the DTD -->
+<!ATTLIST dayOfMonth type NMTOKEN #IMPLIED >
+    <!--@MATCH:literal/1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32-->
+<!ATTLIST dayOfMonth ordinal (zero | one | two | few | many | other) #IMPLIED>
+<!ATTLIST dayOfMonth alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
 
 <!ELEMENT days ( alias | ( default*, dayContext*, special* ) ) >
 <!ATTLIST days alt NMTOKENS #IMPLIED >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1022,6 +1022,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST dayOfMonth ordinal (zero | one | two | few | many | other) #IMPLIED>
 <!ATTLIST dayOfMonth alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
+<!ATTLIST dayOfMonth draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >
+    <!--@METADATA-->
 
 <!ELEMENT days ( alias | ( default*, dayContext*, special* ) ) >
 <!ATTLIST days alt NMTOKENS #IMPLIED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2536,6 +2536,24 @@ annotations.
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<dayOfMonthContext type="format">
+						<dayOfMonthWidth type="abbreviated">
+							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
+							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
+							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
+							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
+						</dayOfMonthWidth>
+					</dayOfMonthContext>
+					<dayOfMonthContext type="stand-alone">
+						<dayOfMonthWidth type="abbreviated">
+							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
+							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
+							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
+							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
+						</dayOfMonthWidth>
+					</dayOfMonthContext>
+				</dayOfMonths>
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2160,6 +2160,24 @@ annotations.
 				</eras>
 			</calendar>
 			<calendar type="generic">
+				<dayOfMonths>
+					<dayOfMonthContext type="format">
+						<dayOfMonthWidth type="abbreviated">
+							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
+							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
+							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
+							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
+						</dayOfMonthWidth>
+					</dayOfMonthContext>
+					<dayOfMonthContext type="stand-alone">
+						<dayOfMonthWidth type="abbreviated">
+							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
+							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
+							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
+							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
+						</dayOfMonthWidth>
+					</dayOfMonthContext>
+				</dayOfMonths>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1225,6 +1225,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<dayOfMonthContext type="stand-alone">
+						<alias source="locale" path="../dayOfMonthContext[@type='format']"/>
+					</dayOfMonthContext>
+				</dayOfMonths>
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -387,6 +387,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel	value="moderate"	inTerritory="%islamicCalendarTerritories"	match="dates/calendars/calendar[@type='islamic']/months/monthContext[@type='%contextTypes']/monthWidth[@type='%allWidths']/month[@type='%monthTypes']"/>
 		<coverageLevel	value="moderate"	inTerritory="%persianCalendarTerritories"	match="dates/calendars/calendar[@type='persian']/months/monthContext[@type='%contextTypes']/monthWidth[@type='%allWidths']/month[@type='%monthTypes']"/>
 
+		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/dayOfMonths/dayOfMonthContext[@type='%A']/dayOfMonthWidth[@type='%A']/dayOfMonth[@ordinal='%A']"/>
+		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='generic']/dayOfMonths/dayOfMonthContext[@type='%A']/dayOfMonthWidth[@type='%A']/dayOfMonth[@ordinal='%A']"/>
+
 		<coverageLevel	value="basic"		match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='format']/dayWidth[@type='wide']/day[@type='%dayTypes']"/>
 		<coverageLevel	value="moderate"		match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='format']/dayWidth[@type='%wideAbbr']/day[@type='%dayTypes']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/days/dayContext[@type='format']/dayWidth[@type='narrow']/day[@type='%dayTypes']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -573,6 +573,8 @@ public class ExampleGenerator {
             handleRelative(xpath, parts, value, examples);
         } else if (parts.contains("dayPeriods")) {
             handleDayPeriod(parts, value, examples);
+        } else if (parts.contains("dayOfMonths")) {
+            handleDayOfMonths(parts, value, examples);
         } else if (parts.contains("monthContext")) {
             handleDateSymbol(parts, value, examples);
         } else if (parts.contains("pattern") || parts.contains("dateFormatItem")) {
@@ -1237,6 +1239,19 @@ public class ExampleGenerator {
         dfs.setMonths(monthNames, DateFormatSymbols.STANDALONE, DateFormatSymbols.ABBREVIATED);
         sdf.setDateFormatSymbols(dfs);
         examples.add(sdf.format(DATE_SAMPLE));
+    }
+
+    private void handleDayOfMonths(XPathParts parts, String value, List<String> examples) {
+        // ldml/dates/☹calendars/calendar[@type="gregorian"]/dayOfMonths/dayOfMonthContext[@type="format"]/dayOfMonthWidth[@type="abbreviated"]/dayOfMonth[@ordinal="few"]
+        String ordinal = parts.getAttributeValue(-1, "ordinal");
+        String type = parts.getAttributeValue(-1, "type"); // constants
+        if (ordinal == null) {
+            return; // no example needed
+        }
+        String sample =
+                bestMinimalPairSamples.getPluralOrOrdinalSample(PluralType.ordinal, ordinal);
+        String formattedUnit = format(value, backgroundStartSymbol + sample + backgroundEndSymbol);
+        examples.add(formattedUnit);
     }
 
     private void handleMinimalPairs(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -401,7 +401,7 @@ public class ExtraPaths {
             Count ordinal, String calendar, String context, String width) {
         return "//ldml/dates/calendars/calendar[@type=\""
                 + calendar
-                + "\"]/dayOfMonthContext[@type=\""
+                + "\"]/dayOfMonths/dayOfMonthContext[@type=\""
                 + context
                 + "\"]/dayOfMonthWidth[@type=\""
                 + width

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -369,6 +369,7 @@ public class ExtraPaths {
                             + supplementalData.getDirectory().getAbsolutePath());
         }
 
+        addDayOfMonthPaths(toAddTo, ordinals);
         addMinimalPairs(toAddTo, plurals, ordinals);
         Set<SupplementalDataInfo.PluralInfo.Count> pluralCounts =
                 Count.LOCALES_USING_OTHER_ONLY_HACK.contains(localeID)
@@ -378,6 +379,35 @@ public class ExtraPaths {
         addDayPlurals(toAddTo, localeID);
         addCurrencies(toAddTo, pluralCounts);
         addGrammar(toAddTo, pluralCounts, localeID);
+    }
+
+    private static void addDayOfMonthPaths(Set<String> toAddTo, PluralInfo ordinals) {
+        if (ordinals != null) {
+            ordinals.getCounts().stream()
+                    .forEach(
+                            ordinal -> {
+                                for (String calendar : List.of("gregorian", "generic")) {
+                                    for (String context : List.of("format", "stand-alone")) {
+                                        toAddTo.add(
+                                                dayOfMonthPath(
+                                                        ordinal, calendar, context, "abbreviated"));
+                                    }
+                                }
+                            });
+        }
+    }
+
+    private static String dayOfMonthPath(
+            Count ordinal, String calendar, String context, String width) {
+        return "//ldml/dates/calendars/calendar[@type=\""
+                + calendar
+                + "\"]/dayOfMonthContext[@type=\""
+                + context
+                + "\"]/dayOfMonthWidth[@type=\""
+                + width
+                + "\"]/dayOfMonth[@ordinal=\""
+                + ordinal
+                + "\"]";
     }
 
     private static void addMinimalPairs(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/PatternPlaceholders.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/PatternPlaceholders.java
@@ -3,10 +3,14 @@ package org.unicode.cldr.util;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.ibm.icu.text.Transform;
+import com.ibm.icu.util.Output;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.unicode.cldr.test.CheckCLDR.CheckStatus.Subtype;
+import org.unicode.cldr.util.RegexLookup.Finder;
 import org.unicode.cldr.util.RegexLookup.Merger;
 
 public class PatternPlaceholders {
@@ -160,9 +164,28 @@ public class PatternPlaceholders {
     }
 
     public PlaceholderStatus getStatus(String path) {
+        return getStatus(path, false);
+    }
+
+    public PlaceholderStatus getStatus(String path, boolean debug) {
         // TODO change the original map to be unmodifiable, to avoid this step. Need to add a
         // "finalize" to the lookup.
-        final PlaceholderData map = patternPlaceholders.get(path);
+        final PlaceholderData map;
+        if (!debug) {
+            map = patternPlaceholders.get(path);
+        } else {
+            Output<String[]> arguments = new Output<>();
+            Output<Finder> matcherFound = new Output<>();
+            Collection<String> failures = new ArrayList<>();
+            map = patternPlaceholders.get(path, "", arguments, matcherFound, failures);
+            System.out.println(
+                    "\narguments:\t"
+                            + arguments
+                            + "\nmatcherFound:\t"
+                            + matcherFound
+                            + "\nfailures:\t");
+            failures.stream().forEach(System.out::println);
+        }
         return map == null ? PlaceholderStatus.DISALLOWED : map.status;
     }
 }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathDescriptions.md
@@ -837,6 +837,14 @@ Provide the {3}, {2} version of the name for the day period code “{4}”. To s
 
 ###
 
+- `dates/calendars/calendar[@type="%A"]/dayOfMonths/dayOfMonthContext[@type="%A"]/dayOfMonthWidth[@type="%A"]/dayOfMonth[@ordinal="%A"]`
+
+Provide the {2} and {3} version of the name for day-of-the-month {4}.
+Some locales/calendars may require formats for specific days (like day 1 of the month), which can be arranged.
+For more information, please see [Date Time Names].
+
+###
+
 - `dates/calendars/calendar[@type="%anyAttribute"]/days/dayContext[@type="%anyAttribute"]/dayWidth[@type="%anyAttribute"]/day[@type="%anyAttribute"]`
 
 Provide the {2} and {3} version of the name for day-of-the-week {4}. For more information, please see [Date Time Names].

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -98,6 +98,10 @@
 //ldml/dates/calendars/calendar[@type="%A"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"][@yeartype="%A"]  ; Special  ; Suppress ;  &calendar($1) ; &calField(Months:$3:$2)-M$4 (leap) ; HIDE
 //ldml/dates/calendars/calendar[@type="%A"]/months/monthContext[@type="%A"]/monthWidth[@type="%A"]/month[@type="%A"]            ; Special  ; Suppress ;  &calendar($1) ; &calField(Months:$3:$2)-M$4 ; HIDE
 
+//ldml/dates/calendars/calendar[@type="%A"]/dayOfMonths/dayOfMonthContext[@type="%A"]/dayOfMonthWidth[@type="%A"]/dayOfMonth[@ordinal="%A"]                    ; DateTime ; &calendar($1) ; &calField(DayOfMonth:$3:$2) ; $4
+//ldml/dates/calendars/calendar[@type="%A"]/dayOfMonths/dayOfMonthContext[@type="%A"]/dayOfMonthWidth[@type="%A"]/dayOfMonth[@type="%A"]                    ; DateTime ; &calendar($1) ; &calField(DayOfMonth:$3:$2) ; $4
+//ldml/dates/calendars/calendar[@type="%A"]/dayOfMonthContext[@type="%A"]/dayOfMonthWidth[@type="%A"]/dayOfMonth[@ordinal="%A"]                    ; Special  ; Suppress ; &calendar($1) ; &calField(Days:$3:$2)-&day($4) ; HIDE
+
 //ldml/dates/calendars/calendar[@type="gregorian"]/days/dayContext[@type="%A"]/dayWidth[@type="%A"]/day[@type="%A"]                    ; DateTime ; &calendar(gregorian) ; &calField(Days:$2:$1) ; &day($3)
 //ldml/dates/calendars/calendar[@type="%A"]/days/dayContext[@type="%A"]/dayWidth[@type="%A"]/day[@type="%A"]                    ; Special  ; Suppress ; &calendar($1) ; &calField(Days:$3:$2)-&day($4) ; HIDE
 

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -6,6 +6,8 @@
 #	multiple: there may be zero or more placeholders (normally only in count or ordinal minimalPairs)
 #	optional: there may be one or more placeholders; and they have alpha ids, not numeric ids.
 
+# IMPORTANT: the [ must be quoted; the call on RegexLookup needs to be fixed to make that automatic.
+
 %A = [^"]*+
 %L = (long|short|narrow)
 
@@ -88,6 +90,8 @@
 #
 #^//ldml/dates/.*(pattern|available|intervalFormatItem) ; VVVV=TIMEZONE_GENERIC_LOCATION United States (Los Angeles) Time
 #^//ldml/dates/.*(pattern|available|intervalFormatItem) ; V=TIMEZONE_SPECIFIC_NON_LOCATION_SHORT_FORCED PDT
+
+^//ldml/dates/calendars/calendar\[@type="%A"]/dayOfMonths/dayOfMonthContext\[@type="%A"]/dayOfMonthWidth\[@type="%A"]/dayOfMonth\[@ordinal="%A"] ; locale ; {0}=DIGITS 1
 
 ^//ldml/dates/fields/field\[@type="day"]/relativeTime\[@type="(future|past)"]/relativeTimePattern\[@count="\w+"] ; locale ; {0}=NUMBER_OF_DAYS 3
 ^//ldml/dates/fields/field\[@type="day-short"]/relativeTime\[@type="(future|past)"]/relativeTimePattern\[@count="\w+"] ; locale ; {0}=NUMBER_OF_DAYS 3

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCheckCLDR.java
@@ -421,6 +421,7 @@ public class TestCheckCLDR extends TestFmwk {
                                     + placeholderStatus
                                     + "»\t"
                                     + path);
+                    patternPlaceholders.getStatus(path, true); // for debugging
                     continue;
                 }
             } else { // not disallowed


### PR DESCRIPTION
CLDR-7408

- [ ] This PR completes the ticket.

Notes: 
These will not appear in root, except for an alias for the stand-alone forms. Instead, they will be added in ExtraPaths, which has the code to add the paths according to the ordinal forms. They will not be visible in the ST for locales that don't have ordinal forms.

At this point, I'm working on supporting them in gregorian and generic.

TODOs:
- Add to other calendars
- Add to info hub, and to the date/time page for vetters
- Add to spec.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
