### PR TITLE
CLDR-19252 move core types to comprehensive if the key has a digit

### DIFF
--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -287,11 +287,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/measurementSystemNames/measurementSystemName[@type='(metric|UK|US)']"/>
 
-		<!-- all types with a digit in the key need to be comprehensive-->
-		<coverageLevel value="comprehensive" match="localeDisplayNames/types/type[@key='[a-z][0]'][@type='%A'][@scope='core']"/>
-
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/annotationPatterns/annotationPattern[@type='(flag|keycap|emoji|combined)']"/>
-		<coverageLevel  value="modern" 			match="localeDisplayNames/types/type[@key='%anyAttribute'][@type='%anyAttribute'][@scope='core']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/localeDisplayPattern/localeKeyTypePattern"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/types/type[@key='calendar'][@type='${Calendar-List}'][@scope='%A']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/types/type[@key='calendar'][@type='${Calendar-List}']"/>
@@ -1114,6 +1110,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='t0'][@type='%t0Types80']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='kr'][@type='(currency|digit|punct|space|symbol)'][@scope='%A']"/>
 		<coverageLevel value="modern" match="localeDisplayNames/types/type[@key='kr'][@type='(currency|digit|punct|space|symbol)']"/>
+		<!-- all other types with a digit in the key need to be comprehensive-->
+		<coverageLevel value="comprehensive"	match="localeDisplayNames/types/type[@key='[a-z][0-9]'][@type='%A'][@scope='core']"/>
+		<!-- all other types get modern -->
+		<coverageLevel  value="modern" 			match="localeDisplayNames/types/type[@key='%anyAttribute'][@type='%anyAttribute'][@scope='core']"/>
+
 		<coverageLevel value="modern" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="modern" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatItem[@id='%intervalFormatTimeItemsDayPer']/greatestDifference[@id='%intervalFormatGDiff']"/>
 		<coverageLevel value="modern" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%timeFormatItemsDayPer']"/>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -287,6 +287,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="localeDisplayNames/measurementSystemNames/measurementSystemName[@type='(metric|UK|US)']"/>
 
+		<!-- all types with a digit in the key need to be comprehensive-->
+		<coverageLevel value="comprehensive" match="localeDisplayNames/types/type[@key='[a-z][0]'][@type='%A'][@scope='core']"/>
+
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/annotationPatterns/annotationPattern[@type='(flag|keycap|emoji|combined)']"/>
 		<coverageLevel  value="modern" 			match="localeDisplayNames/types/type[@key='%anyAttribute'][@type='%anyAttribute'][@scope='core']"/>
 		<coverageLevel	value="moderate"	 	match="localeDisplayNames/localeDisplayPattern/localeKeyTypePattern"/>

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCoverageLevel.java
@@ -735,6 +735,10 @@ public class TestCoverageLevel extends TestFmwkPlus {
                 }
             } else if (xpp.contains("posix")) {
                 continue;
+            } else if (path.equals(
+                            "//ldml/localeDisplayNames/types/type[@key=\"t0\"][@type=\"und\"][@scope=\"core\"]")
+                    && logKnownIssue("CLDR-19252", "comprehensive path: " + path)) {
+                continue;
             }
 
             errln("Comprehensive & no exception for path =>\t" + path);

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
@@ -194,7 +194,8 @@ public class TestExtraPaths {
             final String path = i.next();
             final Level l = cov.getLevel(path);
             if (path.endsWith("[@scope=\"core\"]")) {
-                assertEquals(Level.MODERN, l, () -> localeId + ":" + path);
+                // should be modern or lower. Some were already lower.
+                assertTrue(Level.MODERN.isAtLeast(l), () -> l + "=" + localeId + ":" + path);
             }
         }
     }
@@ -247,6 +248,13 @@ public class TestExtraPaths {
                             Level.COMPREHENSIVE,
                             l,
                             () -> localeId + ":" + path + " - expect comprehensive");
+                }
+            } else {
+                if (l48 != null && l48 != Level.COMPREHENSIVE) {
+                    // present in v48
+                    assertEquals(l48, l, () -> localeId + ": vs v48 " + path);
+                } else {
+                    assertEquals(Level.MODERN, l, () -> localeId + ": (not in v48)" + path);
                 }
             }
         }


### PR DESCRIPTION
example `//ldml/localeDisplayNames/types/type[@key="d0"][@type="hwidth"][@scope="core"]`

CLDR-19252

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
