### PR TITLE
CLDR-18913 Revise locale setting for Add User

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAddUser.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddUser.mjs
@@ -4,6 +4,7 @@
 import * as cldrAccount from "./cldrAccount.mjs";
 import * as cldrAjax from "./cldrAjax.mjs";
 import * as cldrLoad from "./cldrLoad.mjs";
+import * as cldrLocales from "./cldrLocales.mjs";
 import * as cldrOrganizations from "./cldrOrganizations.mjs";
 import * as cldrStatus from "./cldrStatus.mjs";
 import * as cldrUserLevels from "./cldrUserLevels.mjs";
@@ -84,7 +85,7 @@ function setOrgLocales(orgName, json) {
   }
   const orgLocales =
     json.locales == ALL_LOCALES
-      ? Object.keys(cldrLoad.getTheLocaleMap().locmap.locales).join(" ")
+      ? cldrLocales.getAllVotable().join(" ")
       : json.locales;
   callbackToSetData({
     orgName,
@@ -114,7 +115,7 @@ async function validateLocales(
     locs: newUserLocales,
     org: orgForValidation,
   });
-  const resource = makeApiUrl("locales/normalize", p);
+  const resource = cldrAjax.makeApiUrl("locales/normalize", p);
   await cldrAjax
     .doFetch(resource)
     .then(cldrAjax.handleFetchErrors)

--- a/tools/cldr-apps/js/src/esm/cldrLocales.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrLocales.mjs
@@ -150,4 +150,27 @@ function validateAllLocales(locales) {
   }
 }
 
-export { fetchMap, isValid, load, parseHash, USER_LOCALE_ID };
+/**
+ * Get all the locale IDs that allow voting.
+ * Filter the list of all locales to exclude read-only, default-content, scratch.
+ * (See LocaleNormalizer.LocaleRejection on the back end.)
+ * When setting a user's locales, if their org has "*" for locales, meaning "all locales",
+ * this is the list to choose from.
+ *
+ * @returns {Array} the filtered list of locale IDs
+ */
+function getAllVotable() {
+  const locMap = cldrLoad.getTheLocaleMap();
+  const allLocs = Object.keys(locMap.locmap.locales);
+  let filtered = [];
+  for (const loc of allLocs) {
+    const locInfo = locMap.getLocaleInfo(loc);
+    // readonly includes default-content; special_type includes scratch
+    if (!locInfo.readonly && !locInfo.special_type) {
+      filtered.push(loc);
+    }
+  }
+  return filtered;
+}
+
+export { fetchMap, getAllVotable, isValid, load, parseHash, USER_LOCALE_ID };

--- a/tools/cldr-apps/js/src/views/AddUser.vue
+++ b/tools/cldr-apps/js/src/views/AddUser.vue
@@ -79,7 +79,7 @@
             </a-select>
           </td>
         </tr>
-        <template v-if="localesAreRequired()">
+        <template v-if="!localesAreRequired()">
           <tr>
             <th><label for="radio_head"> </label></th>
             <td>
@@ -89,7 +89,9 @@
               </a-radio-group>
             </td>
           </tr>
-          <tr v-if="!allLocales">
+        </template>
+        <template v-if="!allLocales">
+          <tr>
             <th><label for="new_locales">Locales:</label></th>
             <td>
               <a-select

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/AddUser.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/AddUser.java
@@ -10,7 +10,6 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.unicode.cldr.util.EmailValidator;
-import org.unicode.cldr.util.LocaleNames;
 import org.unicode.cldr.util.LocaleNormalizer;
 import org.unicode.cldr.util.Organization;
 import org.unicode.cldr.web.CookieSession;
@@ -126,11 +125,7 @@ public class AddUser {
     }
 
     private String getNewUserLocales(String requestLocales) {
-        requestLocales = LocaleNormalizer.normalizeQuietly(requestLocales);
-        if (requestLocales.isEmpty()) {
-            return LocaleNames.MUL;
-        }
-        return requestLocales;
+        return LocaleNormalizer.normalizeQuietlyDisallowDefaultContent(requestLocales);
     }
 
     private String getNewUserOrg(String requestOrg, User me) {


### PR DESCRIPTION
-If organization for new user covers all locales, filter to exclude readonly/scratch; new method cldrLocales.getAllVotable

-Fix call to makeApiUrl for locales/normalize; it was missing module name cldrAjax

-Make the All Locales option available for manager and stronger, not for vetter and weaker; it was the other way around

-In AddUser.java, getNewUserLocales, disallow default-content, and do not substitute LocaleNames.MUL for a set that would otherwise be empty

CLDR-18913

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
