### PR TITLE
CLDR-19352 remove core key/types for now as they aren't in English

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -227,6 +227,29 @@ public class ExtraPaths {
                         "timezone" // ldml/dates/timeZoneNames
                         );
 
+        // skip these core 'keys' entirely from extraPaths
+        private static final Set<String> skipCoreKeys =
+                ImmutableSet.of(
+                        "fw",
+                        "numbers",
+                        "t0",
+                        "colAlternate",
+                        "colBackwards",
+                        "colCaseFirst",
+                        "colCaseLevel",
+                        "colNormalization",
+                        "colNumeric",
+                        "colReorder",
+                        "colStrength",
+                        "d0",
+                        "k0",
+                        "h0",
+                        "i0",
+                        "m0",
+                        "mu",
+                        "numbers",
+                        "s0");
+
         /** add BCP47 keys */
         private void addBcp47Keys() {
             final Relation<String, String> bcp47Keys = supplementalData.getBcp47Keys();
@@ -346,8 +369,10 @@ public class ExtraPaths {
                     final String typeKeyTypePath =
                             typeKeyPath + String.format("[@type=\"%s\"]", type);
                     pathsTemp.add(typeKeyTypePath);
-                    // add all of these with [@scope="core"]
-                    pathsTemp.add(typeKeyTypePath + SCOPE_CORE);
+                    // add some of these with [@scope="core"]
+                    if (!skipCoreKeys.contains(k)) {
+                        pathsTemp.add(typeKeyTypePath + SCOPE_CORE);
+                    }
                 }
             }
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
@@ -35,10 +35,6 @@ public class TestEnInheritance extends TestWithKnownIssues {
                     // //ldml/dates/timeZoneNames/metazone[@type="Gulf"]/short/standard
                     if (!cldrFile.getExtraPaths().contains(path)
                             || !TestPaths.extraPathAllowsNullValue(path)) {
-                        // if (path.endsWith("[@scope=\"core\"]")
-                        //         && logKnownIssue("CLDR-19352", "Missing in en.xml: " + path)) {
-                        //     continue; // skip for now
-                        // }
                         complain("null value", ++pathsWithNullValue, path);
                     }
                 } else if (CldrUtility.INHERITANCE_MARKER.equals(value)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
@@ -35,10 +35,10 @@ public class TestEnInheritance extends TestWithKnownIssues {
                     // //ldml/dates/timeZoneNames/metazone[@type="Gulf"]/short/standard
                     if (!cldrFile.getExtraPaths().contains(path)
                             || !TestPaths.extraPathAllowsNullValue(path)) {
-                        if (path.endsWith("[@scope=\"core\"]")
-                                && logKnownIssue("CLDR-19352", "Missing in en.xml: " + path)) {
-                            continue; // skip for now
-                        }
+                        // if (path.endsWith("[@scope=\"core\"]")
+                        //         && logKnownIssue("CLDR-19352", "Missing in en.xml: " + path)) {
+                        //     continue; // skip for now
+                        // }
                         complain("null value", ++pathsWithNullValue, path);
                     }
                 } else if (CldrUtility.INHERITANCE_MARKER.equals(value)) {


### PR DESCRIPTION
CLDR-19352

Remove most key/types which are core from extraPaths

These aren't in English now, so should at least be in English before re-adding.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
