### PR TITLE
CLDR-19258 Disable stock patterns by default in DateTimeFormats

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/DateTimeFormats.java
@@ -153,7 +153,7 @@ public class DateTimeFormats {
             CONFIG.getProperty("CLDR_SURVEY_URL", "http://st.unicode.org/cldr-apps/survey");
 
     public DateTimeFormats(CLDRFile file, String calendarID) {
-        this(file, calendarID, true);
+        this(file, calendarID, false);
     }
 
     /**


### PR DESCRIPTION
Change the default behavior of DateTimeFormats to not include stock patterns. This ensures that UI and Chart examples are generated using availableFormats skeletons alone, while preserving stock pattern usage in consistency checking tools.

I used Gemini to research all the call sites of stock patterns in DTPG and it thinks this is the only one that isn't about testing.

CLDR-19258

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
