### PR TITLE
CLDR-19258 Update datetime test data after icu4j version bump

### DIFF
--- a/common/testData/datetime/datetime.json
+++ b/common/testData/datetime/datetime.json
@@ -201,7 +201,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
-    "expected": "Saturday, January 1, 2000"
+    "expected": "2000 January 1, Saturday"
   },
   {
     "semanticSkeleton": "YMDE",
@@ -210,7 +210,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
-    "expected": "Monday, July 1, 2024"
+    "expected": "2024 July 1, Monday"
   },
   {
     "semanticSkeleton": "YMDE",
@@ -219,7 +219,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
-    "expected": "Tuesday, July 15, 2014"
+    "expected": "2014 July 15, Tuesday"
   },
   {
     "semanticSkeleton": "YMDE",
@@ -289,7 +289,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2000-01-01T00:00Z[Etc/GMT]",
-    "expected": "Saturday, January 1, 2000 AD"
+    "expected": "AD 2000 January 1, Saturday"
   },
   {
     "semanticSkeleton": "YMDE",
@@ -299,7 +299,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2024-07-01T08:50:07Z[Etc/GMT]",
-    "expected": "Monday, July 1, 2024 AD"
+    "expected": "AD 2024 July 1, Monday"
   },
   {
     "semanticSkeleton": "YMDE",
@@ -309,7 +309,7 @@
     "calendar": "gregorian",
     "locale": "en",
     "input": "2014-07-15T12:00Z[Etc/GMT]",
-    "expected": "Tuesday, July 15, 2014 AD"
+    "expected": "AD 2014 July 15, Tuesday"
   },
   {
     "semanticSkeleton": "Z",


### PR DESCRIPTION
~Follow-up to #5598~

~The previous commit (9ffad5d0b7) disabled stock patterns by default in DateTimeFormats. This change updates the generated test data to reflect the new behavior, where expected strings are synthesized from skeletons without falling back to stock patterns.~

EDIT: The culprit is https://github.com/unicode-org/cldr/commit/09e74533a67c3a316f9ffb4d78f56f2b49d0b972. The datetime test data was not updated when icu4j was updated.

CLDR-19258

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
