### PR TITLE
CLDR-7408 Ordinal dates Part2

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1613,7 +1613,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT dateFormatItem ( #PCDATA ) >
 <!ATTLIST dateFormatItem id CDATA #REQUIRED >
-    <!--@MATCH:regex/((E|EEEE)?(H|HH|h|hh|Bh)(m|ms|mm|mmss)?(v|vvvv)?)|(ms|mmss)|((G|GGGGG)?(y|yy|yyyy)((M{1,4}((E|EEEE|cccc)?(d|dd))?)|(w|Q|QQQ|QQQQ))?)|(U(M|MMM)d?)|(M{1,4}(((E|EEEE|cccc)?(d|dd))|W)?)|((E|EEEE)?d)|(E|EEEE)-->
+    <!--@MATCH:regex/((E|EEEE)?(H|HH|h|hh|Bh)(m|ms|mm|mmss)?(v|vvvv)?)|(ms|mmss)|((G|GGGGG)?(y|yy|yyyy)((M{1,4}((E|EEEE|cccc)?(d{1,3}))?)|(w|Q|QQQ|QQQQ))?)|(U(M|MMM)d?)|(M{1,4}(((E|EEEE|cccc)?(d{1,3}))|W)?)|((E|EEEE)?d)|(E|EEEE)-->
 <!ATTLIST dateFormatItem count (zero | one | two | few | many | other) #IMPLIED >
 <!ATTLIST dateFormatItem alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/ascii, variant-->

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1006,12 +1006,12 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@MATCH:literal/variant-->
 
 <!ELEMENT dayOfMonthContext ( alias | ( default*, dayOfMonthWidth*, special* ) ) >
-<!ATTLIST dayOfMonthContext type (format | stand-alone) #REQUIRED >
+<!ATTLIST dayOfMonthContext type (format) #REQUIRED >
 <!ATTLIST dayOfMonthContext alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 
 <!ELEMENT dayOfMonthWidth ( alias | ( dayOfMonth*, special* ) ) >
-<!ATTLIST dayOfMonthWidth type (abbreviated | narrow | short | wide) #REQUIRED >
+<!ATTLIST dayOfMonthWidth type (abbreviated | wide) #REQUIRED >
 <!ATTLIST dayOfMonthWidth alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2295,6 +2295,7 @@ annotations.
 						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
@@ -2305,6 +2306,7 @@ annotations.
 						<dateFormatItem id="yyyyMEd">E, M/d/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMddd">MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
@@ -2312,7 +2314,7 @@ annotations.
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0} {1}</appendItem>
+						<appendItem request="Day-Of-Week">{0}, {1}</appendItem>
 						<appendItem request="Era">{0} {1}</appendItem>
 						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
 						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
@@ -2941,6 +2943,7 @@ annotations.
 						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="one">'week' W 'of' MMMM</dateFormatItem>
@@ -2952,6 +2955,7 @@ annotations.
 						<dateFormatItem id="yMEd">E, M/d/y</dateFormatItem>
 						<dateFormatItem id="yMMM">MMM y</dateFormatItem>
 						<dateFormatItem id="yMMMd">MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMddd">MMM ddd, y</dateFormatItem>
 						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
 						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
@@ -2961,7 +2965,7 @@ annotations.
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0} {1}</appendItem>
+						<appendItem request="Day-Of-Week">{0}, {1}</appendItem>
 						<appendItem request="Era">{0} {1}</appendItem>
 						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
 						<appendItem request="Minute">{0} ({2}: {1})</appendItem>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2160,16 +2160,6 @@ annotations.
 				</eras>
 			</calendar>
 			<calendar type="generic">
-				<dayOfMonths>
-					<dayOfMonthContext type="format">
-						<dayOfMonthWidth type="abbreviated">
-							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
-							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
-							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
-							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
-						</dayOfMonthWidth>
-					</dayOfMonthContext>
-				</dayOfMonths>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
@@ -2903,7 +2893,9 @@ annotations.
 						<dateFormatItem id="GyMEd">E, M/d/y G</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMddd">MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEddd">E, MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="h" alt="ascii">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
@@ -2929,7 +2921,9 @@ annotations.
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
 						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEddd">E, MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMddd">MMMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="one">'week' W 'of' MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">'week' W 'of' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
@@ -2941,6 +2935,7 @@ annotations.
 						<dateFormatItem id="yMMMd">MMM d, y</dateFormatItem>
 						<dateFormatItem id="yMMMddd">MMM ddd, y</dateFormatItem>
 						<dateFormatItem id="yMMMEd">E, MMM d, y</dateFormatItem>
+						<dateFormatItem id="yMMMEddd">E, MMM ddd, y</dateFormatItem>
 						<dateFormatItem id="yMMMM">MMMM y</dateFormatItem>
 						<dateFormatItem id="yQQQ">QQQ y</dateFormatItem>
 						<dateFormatItem id="yQQQQ">QQQQ y</dateFormatItem>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2906,7 +2906,7 @@ annotations.
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMddd">MMM ddd, y G</dateFormatItem>
-						<dateFormatItem id="GyMMMMddd">E, MMM ddd, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMddd">MMMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEddd">E, MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMMEddd">E, MMM ddd, y G</dateFormatItem>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2160,6 +2160,16 @@ annotations.
 				</eras>
 			</calendar>
 			<calendar type="generic">
+				<dayOfMonths>
+					<dayOfMonthContext type="format">
+						<dayOfMonthWidth type="abbreviated">
+							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
+							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
+							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
+							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
+						</dayOfMonthWidth>
+					</dayOfMonthContext>
+				</dayOfMonths>
 				<dateFormats>
 					<dateFormatLength type="full">
 						<dateFormat>
@@ -2259,7 +2269,9 @@ annotations.
 						<dateFormatItem id="GyMEd">E, M/d/y G</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMddd">MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEddd">E, MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="h" alt="ascii">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
@@ -2549,10 +2561,10 @@ annotations.
 				<dayOfMonths>
 					<dayOfMonthContext type="format">
 						<dayOfMonthWidth type="abbreviated">
-							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
-							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
 							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
+							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
 							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
+							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
 						</dayOfMonthWidth>
 					</dayOfMonthContext>
 				</dayOfMonths>
@@ -2894,8 +2906,10 @@ annotations.
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMddd">MMM ddd, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMddd">E, MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
 						<dateFormatItem id="GyMMMEddd">E, MMM ddd, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMMEddd">E, MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="h" alt="ascii">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
@@ -2924,6 +2938,7 @@ annotations.
 						<dateFormatItem id="MMMEddd">E, MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="MMMMddd">MMMM ddd</dateFormatItem>
+						<dateFormatItem id="MMMMEddd">E, MMMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="one">'week' W 'of' MMMM</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">'week' W 'of' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
@@ -3431,14 +3446,19 @@ annotations.
 						<dateFormatItem id="GyMEd">E, M/d/y G</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMddd">G y MMM ddd</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="M">L</dateFormatItem>
 						<dateFormatItem id="Md">M/d</dateFormatItem>
 						<dateFormatItem id="MEd">E, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEddd">MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMddd">MMMM ddd</dateFormatItem>
 						<dateFormatItem id="y">y G</dateFormatItem>
 						<dateFormatItem id="yyyy">y G</dateFormatItem>
 						<dateFormatItem id="yyyyM">M/y G</dateFormatItem>
@@ -3446,7 +3466,9 @@ annotations.
 						<dateFormatItem id="yyyyMEd">E, M/d/y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMddd">MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQQ">QQQQ y G</dateFormatItem>
@@ -3536,7 +3558,9 @@ annotations.
 						<dateFormatItem id="GyMEd">E, M/d/y GGGGG</dateFormatItem>
 						<dateFormatItem id="GyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="GyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMddd">G y MMM ddd</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="GyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="GyMMMEEEEd">EEEE, MMM d, y G</dateFormatItem>
 						<dateFormatItem id="h">↑↑↑</dateFormatItem>
 						<dateFormatItem id="H">↑↑↑</dateFormatItem>
@@ -3550,9 +3574,12 @@ annotations.
 						<dateFormatItem id="MEEEEd">EEEE, M/d</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">E, MMM d</dateFormatItem>
+						<dateFormatItem id="MMMEddd">MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="MMMEEEEd">EEEE, MMM d</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMddd">MMMM ddd</dateFormatItem>
 						<dateFormatItem id="ms">↑↑↑</dateFormatItem>
 						<dateFormatItem id="y">y G</dateFormatItem>
 						<dateFormatItem id="yyyy">y G</dateFormatItem>
@@ -3563,7 +3590,9 @@ annotations.
 						<dateFormatItem id="yyyyMM">MM y GGGGG</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">MMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMddd">MMM ddd, y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">E, MMM d, y G</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEEEEd">EEEE, MMMM d, y G</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">MMMM y G</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">QQQ y G</dateFormatItem>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2169,14 +2169,6 @@ annotations.
 							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
 						</dayOfMonthWidth>
 					</dayOfMonthContext>
-					<dayOfMonthContext type="stand-alone">
-						<dayOfMonthWidth type="abbreviated">
-							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
-							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
-							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
-							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
-						</dayOfMonthWidth>
-					</dayOfMonthContext>
 				</dayOfMonths>
 				<dateFormats>
 					<dateFormatLength type="full">
@@ -2566,14 +2558,6 @@ annotations.
 				</months>
 				<dayOfMonths>
 					<dayOfMonthContext type="format">
-						<dayOfMonthWidth type="abbreviated">
-							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
-							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>
-							<dayOfMonth ordinal="few">{0}rd</dayOfMonth>
-							<dayOfMonth ordinal="other">{0}th</dayOfMonth>
-						</dayOfMonthWidth>
-					</dayOfMonthContext>
-					<dayOfMonthContext type="stand-alone">
 						<dayOfMonthWidth type="abbreviated">
 							<dayOfMonth ordinal="one">{0}st</dayOfMonth>
 							<dayOfMonth ordinal="two">{0}nd</dayOfMonth>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -95,6 +95,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<alias source="locale" path="../../calendar[@type='gregorian']/months"/>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -201,6 +204,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthPatternWidth>
 					</monthPatternContext>
 				</monthPatterns>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -656,6 +662,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -764,6 +773,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -998,7 +1010,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="GyMEd">G y-MM-dd, E</dateFormatItem>
 						<dateFormatItem id="GyMMM">G y MMM</dateFormatItem>
 						<dateFormatItem id="GyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMddd">G y MMM ddd</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">G y MMM d, E</dateFormatItem>
+						<dateFormatItem id="GyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
 						<dateFormatItem id="hm">h:mm a</dateFormatItem>
@@ -1014,7 +1028,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
 						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMEddd">MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMddd">MMMM ddd</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">G y</dateFormatItem>
 						<dateFormatItem id="yyyy">G y</dateFormatItem>
@@ -1025,6 +1041,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
 						<dateFormatItem id="yyyyMMMddd">G y MMM ddd</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">G y MMM d, E</dateFormatItem>
+						<dateFormatItem id="yyyyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">G y MMMM</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
 						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
@@ -1468,10 +1485,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="GyMEd">G y-MM-dd, E</dateFormatItem>
 						<dateFormatItem id="GyMMM">G y MMM</dateFormatItem>
 						<dateFormatItem id="GyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMddd">G y MMM ddd</dateFormatItem>
 						<dateFormatItem id="GyMMMEd">G y MMM d, E</dateFormatItem>
+						<dateFormatItem id="GyMMMEddd">G y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="GyMMMM">G y MMMM</dateFormatItem>
 						<dateFormatItem id="GyMMMMd">G y MMMM d</dateFormatItem>
+						<dateFormatItem id="GyMMMMddd">G y MMMM ddd</dateFormatItem>
 						<dateFormatItem id="GyMMMMEd">G y MMMM d, E</dateFormatItem>
+						<dateFormatItem id="GyMMMMEddd">G y MMMM ddd, E</dateFormatItem>
 						<dateFormatItem id="h">h a</dateFormatItem>
 						<dateFormatItem id="H">HH</dateFormatItem>
 						<dateFormatItem id="hm">h:mm a</dateFormatItem>
@@ -1490,9 +1511,13 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
 						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMEddd">MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
+						<dateFormatItem id="MMMMddd">MMMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMMEd">MMMM d, E</dateFormatItem>
+						<dateFormatItem id="MMMMEddd">MMMM ddd, E</dateFormatItem>
 						<dateFormatItem id="MMMMW" count="other">'week' W 'of' MMMM</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
 						<dateFormatItem id="y">y</dateFormatItem>
@@ -1503,9 +1528,12 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yMMMd">y MMM d</dateFormatItem>
 						<dateFormatItem id="yMMMddd">y MMM ddd</dateFormatItem>
 						<dateFormatItem id="yMMMEd">y MMM d, E</dateFormatItem>
+						<dateFormatItem id="yMMMEddd">y MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yMMMM">y MMMM</dateFormatItem>
 						<dateFormatItem id="yMMMMd">y MMMM d</dateFormatItem>
+						<dateFormatItem id="yMMMMddd">y MMMM ddd</dateFormatItem>
 						<dateFormatItem id="yMMMMEd">y MMMM d, E</dateFormatItem>
+						<dateFormatItem id="yMMMMEddd">y MMMM ddd, E</dateFormatItem>
 						<dateFormatItem id="yQQQ">y QQQ</dateFormatItem>
 						<dateFormatItem id="yQQQQ">y QQQQ</dateFormatItem>
 						<dateFormatItem id="yw" count="other">'week' w 'of' Y</dateFormatItem>
@@ -1722,6 +1750,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -1799,6 +1830,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -1887,6 +1921,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -2026,6 +2063,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<alias source="locale" path="../../calendar[@type='gregorian']/months"/>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -2333,6 +2373,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<alias source="locale" path="../../calendar[@type='gregorian']/months"/>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -2418,6 +2461,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -2452,6 +2498,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<months>
 					<alias source="locale" path="../../calendar[@type='gregorian']/months"/>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1511,7 +1511,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
 						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
-						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
 						<dateFormatItem id="MMMEddd">MMM ddd, E</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1009,6 +1009,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MEd">MM-dd, E</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="ms">mm:ss</dateFormatItem>
@@ -1019,6 +1020,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyMEd">G y-MM-dd, E</dateFormatItem>
 						<dateFormatItem id="yyyyMMM">G y MMM</dateFormatItem>
 						<dateFormatItem id="yyyyMMMd">G y MMM d</dateFormatItem>
+						<dateFormatItem id="yyyyMMMddd">G y MMM ddd</dateFormatItem>
 						<dateFormatItem id="yyyyMMMEd">G y MMM d, E</dateFormatItem>
 						<dateFormatItem id="yyyyMMMM">G y MMMM</dateFormatItem>
 						<dateFormatItem id="yyyyQQQ">G y QQQ</dateFormatItem>
@@ -1489,6 +1491,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="MEd">MM-dd, E</dateFormatItem>
 						<dateFormatItem id="MMM">LLL</dateFormatItem>
 						<dateFormatItem id="MMMd">MMM d</dateFormatItem>
+						<dateFormatItem id="MMMddd">MMM ddd</dateFormatItem>
 						<dateFormatItem id="MMMEd">MMM d, E</dateFormatItem>
 						<dateFormatItem id="MMMMd">MMMM d</dateFormatItem>
 						<dateFormatItem id="MMMMEd">MMMM d, E</dateFormatItem>
@@ -1500,6 +1503,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yMEd">y-MM-dd, E</dateFormatItem>
 						<dateFormatItem id="yMMM">y MMM</dateFormatItem>
 						<dateFormatItem id="yMMMd">y MMM d</dateFormatItem>
+						<dateFormatItem id="yMMMddd">y MMM ddd</dateFormatItem>
 						<dateFormatItem id="yMMMEd">y MMM d, E</dateFormatItem>
 						<dateFormatItem id="yMMMM">y MMMM</dateFormatItem>
 						<dateFormatItem id="yMMMMd">y MMMM d</dateFormatItem>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -876,6 +876,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
+				<dayOfMonths>
+					<alias source="locale" path="../../calendar[@type='gregorian']/dayOfMonths"/>
+				</dayOfMonths>
 				<days>
 					<alias source="locale" path="../../calendar[@type='gregorian']/days"/>
 				</days>
@@ -1234,11 +1237,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</monthWidth>
 					</monthContext>
 				</months>
-				<dayOfMonths>
-					<dayOfMonthContext type="stand-alone">
-						<alias source="locale" path="../dayOfMonthContext[@type='format']"/>
-					</dayOfMonthContext>
-				</dayOfMonths>
 				<days>
 					<dayContext type="format">
 						<dayWidth type="abbreviated">

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -73,8 +73,8 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageVariable key="%currency100" value="(AFA|ADP|ALK|AO[KNR]|AR[ALMP]|ATS|AZM|BA[DN]|BE[CFL]|BG[LM]|BGO|BO[LPV]|BR[BCENRZ]|BUK|BY[BR]|CH[EW]|CL[EF]|CNX|COU|CS[DK]|CYP|DDM|DEM|EC[SV]|EEK|ES[ABP]|FIM|FRF|GEK|GHC|GNS|GQE|GRD|GW[EP]|HRD|IEP|IL[PR]|ISJ|ITL|KR[HO]|LT[LT]|LU[CFL]|LV[LR]|MAF|MCF|MDC|MGF|MKN|MLF|MRO|MT[LP]|MVP|MX[PV]|MZ[EM]|NIC|NLG|PE[IS]|PLZ|PTE|RHD|ROL|RUR|SD[DP]|SIT|SKK|SRG|STD|SUR|SVC|TJR|TMM|TPE|TRL|UAK|UGS|US[NS]|UY[IPW]|VE[BF]|VNN|XA[GU]|XB[ABCD]|XDR|XEU|XF[OU]|XP[DT]|XRE|XSU|XTS|XUA|YDD|YU[DMNR]|ZAL|ZMK|ZR[NZ]|ZW[DLR])"/>
 		<coverageVariable key="%cyclicNameTypes" value="([1-9]?[0-9])"/>
 		<coverageVariable key="%d0Types80" value="(ascii|fwidth|hwidth|lower|title|upper)"/>
-		<coverageVariable key="%dateFormatItems" value="((E|d|Ed|EEEEd)|((Gy|y|yyyy|U)?(M|Md|MEd|MEEEEd|MMM|MMMd|MMMEd|MMMEEEEd|MMMM|MMMMd|MMMMEd|MMMMEEEEd))|((Gy|y|yyyy)(QQQ|QQQQ)?))"/>
-		<coverageVariable key="%dateFormatItemsAll" value="(G{0,5}(y|U){0,4}Q{0,4}(M|L){0,5}(E|c){0,5}d{0,2}(H|h){0,2}m{0,2}s{0,2}(v|z|Z){0,4})"/>
+		<coverageVariable key="%dateFormatItems" value="((E|d|Ed|EEEEd)|((Gy|y|yyyy|U)?(M|Md|MEd|MEEEEd|MMM|MMMd{1,3}|MMMEd{1,3}|MMMEEEEd{1,3}|MMMM|MMMMd{1,3}|MMMMEd{1,3}|MMMMEEEEd{1,3}))|((Gy|y|yyyy)(QQQ|QQQQ)?))"/>
+		<coverageVariable key="%dateFormatItemsAll" value="(G{0,5}(y|U){0,4}Q{0,4}(M|L){0,5}(E|c){0,5}d{0,3}(H|h){0,2}m{0,2}s{0,2}(v|z|Z){0,4})"/>
 		<coverageVariable key="%dateTimeFormatLengths" value="(full|long|medium|short)"/>
 		<coverageVariable key="%emTypes" value="(default|emoji|text)"/>
 		<coverageVariable key="%fullMedium" value="(full|medium)"/>

--- a/docs/site/translation.md
+++ b/docs/site/translation.md
@@ -58,7 +58,39 @@ We are reviewing new locale requests for inclusion in CLDR 49. See [how to add a
 
 🆕 2026-04-15 — Added long display names for the territories "St. Helena, Ascension & Tristan da Cunha" (`SH`), "French Southern and Antarctic Lands" (`TF`), and "Heard Island & McDonald Islands" (`HM`). The previous names were moved to `alt="short"`.
 
-### New emoji
+### Dates and times
+
+#### Ordinal dates
+
+🆕 2026-04-18
+
+In some locales, ordinal numbers (such as 1st, 2nd, …) can be used in dates. 
+For example, ordinal: "March 3rd, 2026" compared to cardinal: "March 3, 2026". 
+There are now two new types of data items to support this.
+* Date & Time | Gregorian | DayOfMonth-abbreviated-Formatting | few — English: `{0}rd`
+   * The value substituted for `{0}` will always be an integer, such as English "**3**rd".
+   * The exact items will depend on the locale: many locales have a "constant" pattern, such as German.
+In that case only the `other` code will appear.
+   * A few locales didn't have ordinal categories, just plural categories. That is being corrected in this release.
+* Date & Time | Gregorian | Formats-Flexible-Date_Formats | yMMMddd — English: `MMM ddd, y`
+   * The symbol `ddd` in this pattern will be replaced by an ordinal, resulting in something like "Sep **3rd**, 1999"
+   
+##### Guidelines
+
+* The `ddd` is ignored in any pattern with a numeric month.
+* These ordinal forms are _specific to dates_; they are _not_ general-purpose.
+    * They should have the appropriate grammatical form for a nominative date.
+    * They might not be the same as general-purpose ordinals.
+        * For example, suppose that your locale uses a "er" suffix just on `one` in dates. 
+        * In that case, the `one` form would be {0}er, but all other forms would have just {0}.
+* If your locale _never_ uses ordinals in dates, then:
+    * Set all the dayOfMonth patterns (`one`, `other`, …) to a constant {0}.
+* If your locale _always_ uses ordinals in certain kinds of dates (with non-numeric months), then make sure the patterns where they are used have `ddd` in them (instead of `d` or `dd`).
+    * For example, suppose that a form like "March 3, 2026" is not acceptable, just a form like "March 3rd, 2026".
+In that case, for the code `yMMMMd` you would change its pattern to have `ddd` in it to force the use of ordinals, something like: "MMMM ddd, y"
+
+
+### New emojii
 
 TBA - Section will be updated when Unicode 18 emoji keywords are added to the Survey Tool for localization
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/BestMinimalPairSamples.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/BestMinimalPairSamples.java
@@ -61,6 +61,7 @@ public class BestMinimalPairSamples {
     private Multimap<Integer, String> uniqueCaseAndCountToUnits;
     private Multimap<String, String> distinctNominativeCaseToUnit;
     private final boolean gatherStats;
+    private final Multimap<Count, Integer> dayOfMonthSamples;
 
     public BestMinimalPairSamples(
             CLDRFile cldrFile, ICUServiceBuilder icuServiceBuilder, boolean gatherStats) {
@@ -74,6 +75,13 @@ public class BestMinimalPairSamples {
                 supplementalDataInfo
                         .getPlurals(PluralType.ordinal, cldrFile.getLocaleID())
                         .getPluralRules();
+
+        Multimap<Count, Integer> dayOfMonthSamples_ = TreeMultimap.create();
+        for (int i = 1; i <= 32; ++i) {
+            dayOfMonthSamples_.put(Count.valueOf(ordinalInfo.select(i, 0, 0)), Integer.valueOf(i));
+        }
+        dayOfMonthSamples = ImmutableMultimap.copyOf(dayOfMonthSamples_);
+
         this.icuServiceBuilder = icuServiceBuilder;
         genderToUnits = TreeMultimap.create();
         uniqueCaseAndCountToUnits = TreeMultimap.create();
@@ -408,6 +416,10 @@ public class BestMinimalPairSamples {
             return 2;
         }
         return 999;
+    }
+
+    public Multimap<Count, Integer> getDayOfMonthSamples() {
+        return dayOfMonthSamples;
     }
 
     public String getPluralOrOrdinalSample(PluralType pluralType, String code) {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -3,6 +3,7 @@ package org.unicode.cldr.test;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
 import com.ibm.icu.impl.Row.R3;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.impl.number.DecimalQuantity;
@@ -57,6 +58,7 @@ import org.unicode.cldr.util.CLDRFile;
 import org.unicode.cldr.util.CLDRFile.WinningChoice;
 import org.unicode.cldr.util.CLDRFileOverride;
 import org.unicode.cldr.util.CLDRLocale;
+import org.unicode.cldr.util.CldrPathUtilities;
 import org.unicode.cldr.util.CldrUtility;
 import org.unicode.cldr.util.CodePointEscaper;
 import org.unicode.cldr.util.DateConstants;
@@ -1245,15 +1247,51 @@ public class ExampleGenerator {
 
     private void handleDayOfMonths(XPathParts parts, String value, List<String> examples) {
         // ldml/dates/☹calendars/calendar[@type="gregorian"]/dayOfMonths/dayOfMonthContext[@type="format"]/dayOfMonthWidth[@type="abbreviated"]/dayOfMonth[@ordinal="few"]
-        String ordinal = parts.getAttributeValue(-1, "ordinal");
-        String type = parts.getAttributeValue(-1, "type"); // constants
-        if (ordinal == null) {
-            return; // no example needed
+        String rawOrdinal = parts.getAttributeValue(-1, "ordinal");
+        if (rawOrdinal == null) {
+            return; // no example can be created
         }
-        String sample =
-                bestMinimalPairSamples.getPluralOrOrdinalSample(PluralType.ordinal, ordinal);
-        String formattedUnit = format(value, backgroundStartSymbol + sample + backgroundEndSymbol);
-        examples.add(formattedUnit);
+        Count ordinal = Count.valueOf(rawOrdinal);
+        Multimap<Count, Integer> sampleMap = bestMinimalPairSamples.getDayOfMonthSamples();
+        Collection<Integer> samples = sampleMap.get(ordinal);
+        if (samples.isEmpty()) {
+            return; // no example can be created for this ordinal.
+            // TODO limit the ordinal strings vetters need to just ones with samples
+        }
+        String calendarId = parts.getAttributeValue(3, "type");
+        if (!calendarId.equals("gregorian")) {
+            int debug = 0;
+        }
+        String pattern1 =
+                cldrFile.getStringValueWithBailey(getAvailablePath(calendarId, "yMMMddd"));
+        if (pattern1 == null) {
+            pattern1 =
+                    cldrFile.getStringValueWithBailey(getAvailablePath(calendarId, "yyyyMMMddd"));
+        }
+        String pattern = pattern1;
+        samples.stream()
+                .limit(2)
+                .forEach(
+                        x -> {
+                            String formattedOrdinal =
+                                    format(value, backgroundStartSymbol + x + backgroundEndSymbol);
+                            examples.add(formattedOrdinal);
+                            // HACK to replace ddd until it is supported.
+                            // The background stuff will still be necessary
+                            String pattern2 =
+                                    backgroundStartSymbol
+                                            + pattern.replace(
+                                                    "ddd",
+                                                    "'"
+                                                            + backgroundEndSymbol
+                                                            + formattedOrdinal
+                                                            + backgroundStartSymbol
+                                                            + "'")
+                                            + backgroundEndSymbol;
+                            SimpleDateFormat format =
+                                    icuServiceBuilder.getDateFormat(calendarId, pattern2);
+                            examples.add(format.format(DATE_SAMPLE));
+                        });
     }
 
     private void handleMinimalPairs(
@@ -2666,9 +2704,11 @@ public class ExampleGenerator {
                             "//ldml/dates/fields/field[@type=\"day\"]/relative[@type=\"0\"]");
             String relativeDayValue = cldrFile.getWinningValue(relativeDayXPath);
 
-            String dfResult = df.format(DATE_SAMPLE);
-            String tlfResult = tlf.format(DATE_SAMPLE);
-            String tsfResult = tsf.format(DATE_SAMPLE); // DATE_SAMPLE is in the afternoon
+            String dfResult = formatWithOrdinalHack(df, calendar, DATE_SAMPLE);
+            String tlfResult = formatWithOrdinalHack(tlf, calendar, DATE_SAMPLE);
+            String tsfResult =
+                    formatWithOrdinalHack(
+                            tsf, calendar, DATE_SAMPLE); // DATE_SAMPLE is in the afternoon
 
             if (!formatType.contentEquals("relative")) {
                 // Handle date plus a single full time.
@@ -2746,7 +2786,7 @@ public class ExampleGenerator {
             }
 
             return;
-        } else {
+        } else { // availableFormats
             String id = parts.findAttributeValue("dateFormatItem", "id");
             if ("NEW".equals(id) || value == null) {
                 examples.add(startItalicSymbol + "n/a" + endItalicSymbol);
@@ -2770,7 +2810,7 @@ public class ExampleGenerator {
                     // Standard date/time format, or availableFormat without dayPeriod
                     if (value.contains("MMM") || value.contains("LLL")) {
                         // alpha month, do not need context examples
-                        examples.add(sdf.format(DATE_SAMPLE));
+                        examples.add(formatWithOrdinalHack(sdf, calendar, DATE_SAMPLE));
                         addRelatedAvailable(parts, calendar, numbersOverride, dfs, examples);
                         return;
                     } else {
@@ -2781,8 +2821,9 @@ public class ExampleGenerator {
                                                 + contextheader
                                                 + exampleEndSymbol
                                         : "";
-                        String sup_twelve_example = sdf.format(DATE_SAMPLE);
-                        String sub_ten_example = sdf.format(DATE_SAMPLE5);
+                        String sup_twelve_example =
+                                formatWithOrdinalHack(sdf, calendar, DATE_SAMPLE);
+                        String sub_ten_example = formatWithOrdinalHack(sdf, calendar, DATE_SAMPLE5);
                         example = addExampleResult(sup_twelve_example, example, showContexts);
                         if (!sup_twelve_example.equals(sub_ten_example)) {
                             example = addExampleResult(sub_ten_example, example, showContexts);
@@ -2818,6 +2859,36 @@ public class ExampleGenerator {
         }
     }
 
+    private String formatWithOrdinalHack(SimpleDateFormat sdf, String calendar, Date date) {
+        String pattern = sdf.toPattern();
+        if (!pattern.contains("ddd")) {
+            return sdf.format(date);
+        }
+        PluralRules ordinalRules =
+                supplementalDataInfo.getPluralRules(
+                        cldrFile.getLocaleID(), PluralRules.PluralType.ORDINAL);
+        if (ordinalRules == null) {
+            return sdf.format(date);
+        }
+        int dayOfMonth = date.getDate();
+        String keyword = ordinalRules.select(dayOfMonth, 0, 0);
+        String path =
+                CldrPathUtilities.dayOfMonthPath(
+                        Count.valueOf(keyword), calendar, "format", "abbreviated");
+        String ordinalPattern = cldrFile.getStringValueWithBailey(path);
+        if (ordinalPattern == null) {
+            ordinalPattern = "{0}missing";
+        }
+        String ordinalString =
+                ordinalPattern.replace(
+                        "{0}", String.valueOf(dayOfMonth)); // TODO fix for native digits
+        // quote to prevent substitutions within the pattern.
+        String newPattern = pattern.replace("ddd", "'" + ordinalString + "'");
+        SimpleDateFormat sdf2 = sdf.clone();
+        sdf2.applyLocalizedPattern(newPattern);
+        return sdf2.format(date);
+    }
+
     private void addRelatedAvailable(
             XPathParts parts,
             String calendar,
@@ -2835,7 +2906,8 @@ public class ExampleGenerator {
                                                 calendar, x, numbersOverride);
                                 sdf2.setDateFormatSymbols(dfs);
                                 sdf2.setTimeZone(ZONE_SAMPLE);
-                                String example2 = sdf2.format(DATE_SAMPLE);
+                                String example2 =
+                                        formatWithOrdinalHack(sdf2, calendar, DATE_SAMPLE);
                                 if (!examples.contains(example2)) {
                                     examples.add(example2);
                                 }
@@ -3316,12 +3388,8 @@ public class ExampleGenerator {
         final Date sample = sampleDate.getTime();
 
         String skeleton = "Gy";
-        String checkPath =
-                "//ldml/dates/calendars/calendar[@type=\""
-                        + calendarId
-                        + "\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\""
-                        + skeleton
-                        + "\"]";
+        String checkPath = getAvailablePath(calendarId, skeleton);
+
         String dateFormat = cldrFile.getWinningValue(checkPath);
         SimpleDateFormat sdf = icuServiceBuilder.getDateFormat(calendarId, dateFormat);
         DateFormatSymbols dfs = sdf.getDateFormatSymbols();
@@ -3330,6 +3398,14 @@ public class ExampleGenerator {
         dfs.setEras(eraNames);
         sdf.setDateFormatSymbols(dfs);
         examples.add(sdf.format(sample));
+    }
+
+    private String getAvailablePath(String calendarId, String skeleton) {
+        return "//ldml/dates/calendars/calendar[@type=\""
+                + calendarId
+                + "\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\""
+                + skeleton
+                + "\"]";
     }
 
     /**
@@ -3349,12 +3425,7 @@ public class ExampleGenerator {
         String type = parts.getAttributeValue(-1, "type"); // 1-indexed
         int quarterIndex = Integer.parseInt(type) - 1;
         String skeleton = (width.equals("wide")) ? "yQQQQ" : "yQQQ";
-        String checkPath =
-                "//ldml/dates/calendars/calendar[@type=\""
-                        + calendarId
-                        + "\"]/dateTimeFormats/availableFormats/dateFormatItem[@id=\""
-                        + skeleton
-                        + "\"]";
+        String checkPath = getAvailablePath(calendarId, skeleton);
         String dateFormat = cldrFile.getWinningValue(checkPath);
         SimpleDateFormat sdf = icuServiceBuilder.getDateFormat(calendarId, dateFormat);
         DateFormatSymbols dfs = sdf.getDateFormatSymbols();
@@ -3397,7 +3468,7 @@ public class ExampleGenerator {
                         + "\"]";
         String dateFormat = cldrFile.getWinningValue(availableFormatPath);
         SimpleDateFormat sdf = icuServiceBuilder.getDateFormat("gregorian", dateFormat);
-        String sampleDate = sdf.format(DATE_SAMPLE);
+        String sampleDate = formatWithOrdinalHack(sdf, "gregorian", DATE_SAMPLE);
 
         String contextTransformPath =
                 "//ldml/contextTransforms/contextTransformUsage[@type=\"relative\"]/contextTransform[@type=\"stand-alone\"]";

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -1278,6 +1278,9 @@ public class ExampleGenerator {
                             examples.add(formattedOrdinal);
                             // HACK to replace ddd until it is supported.
                             // The background stuff will still be necessary
+                            if (pattern == null) {
+                                return;
+                            }
                             String pattern2 =
                                     backgroundStartSymbol
                                             + pattern.replace(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrPathUtilities.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CldrPathUtilities.java
@@ -1,0 +1,19 @@
+package org.unicode.cldr.util;
+
+import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
+
+public class CldrPathUtilities {
+
+    public static String dayOfMonthPath(
+            Count ordinal, String calendar, String context, String width) {
+        return "//ldml/dates/calendars/calendar[@type=\""
+                + calendar
+                + "\"]/dayOfMonths/dayOfMonthContext[@type=\""
+                + context
+                + "\"]/dayOfMonthWidth[@type=\""
+                + width
+                + "\"]/dayOfMonth[@ordinal=\""
+                + ordinal
+                + "\"]";
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -387,11 +387,10 @@ public class ExtraPaths {
                     .forEach(
                             ordinal -> {
                                 for (String calendar : List.of("gregorian", "generic")) {
-                                    for (String context : List.of("format", "stand-alone")) {
                                         toAddTo.add(
                                                 dayOfMonthPath(
-                                                        ordinal, calendar, context, "abbreviated"));
-                                    }
+                                                        ordinal, calendar, "stand-alone", "abbreviated"));
+                                    
                                 }
                             });
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -388,27 +388,11 @@ public class ExtraPaths {
                             ordinal -> {
                                 for (String calendar : List.of("gregorian", "generic")) {
                                     toAddTo.add(
-                                            dayOfMonthPath(
-                                                    ordinal,
-                                                    calendar,
-                                                    "stand-alone",
-                                                    "abbreviated"));
+                                            CldrPathUtilities.dayOfMonthPath(
+                                                    ordinal, calendar, "format", "abbreviated"));
                                 }
                             });
         }
-    }
-
-    private static String dayOfMonthPath(
-            Count ordinal, String calendar, String context, String width) {
-        return "//ldml/dates/calendars/calendar[@type=\""
-                + calendar
-                + "\"]/dayOfMonths/dayOfMonthContext[@type=\""
-                + context
-                + "\"]/dayOfMonthWidth[@type=\""
-                + width
-                + "\"]/dayOfMonth[@ordinal=\""
-                + ordinal
-                + "\"]";
     }
 
     private static void addMinimalPairs(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -387,10 +387,12 @@ public class ExtraPaths {
                     .forEach(
                             ordinal -> {
                                 for (String calendar : List.of("gregorian", "generic")) {
-                                        toAddTo.add(
-                                                dayOfMonthPath(
-                                                        ordinal, calendar, "stand-alone", "abbreviated"));
-                                    
+                                    toAddTo.add(
+                                            dayOfMonthPath(
+                                                    ordinal,
+                                                    calendar,
+                                                    "stand-alone",
+                                                    "abbreviated"));
                                 }
                             });
         }

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestPaths.java
@@ -813,7 +813,7 @@ public class TestPaths extends TestFmwkPlus {
                     gregorian,
                     id2,
                     id -> id.contains("d") && !id.contains("E"),
-                    id -> id.replace("d", "Ed"));
+                    id -> id.replaceFirst("d", "Ed"));
             checkCondition(
                     gregorian,
                     id2,


### PR DESCRIPTION
CLDR-7408

Continuing work started in https://github.com/unicode-org/cldr/pull/5590

- add date patterns: instances of MMME+d were duplicated with ddd in the id and pattern (root and English)
- fixed problems Rich noted: only format, only abbreviated
- adjusted for coverage problems
- for English, added comma for the fallback dow format. 
- added many aliases in root, so the calendars inherit dayOfMonths
- documented in Info Hub (I expected it will take further enhancement, I'd like to do in subsequent PR).
- added/refined ExampleGenerator for the new paths.
    - For the samples for date ordinals, confined to numbers from 1 to 32
    - Added 2 hacks to support "ddd" in examples until ICU supports it (`formatWithOrdinalHack`). @sffc, along with your 'cleanroom' DatetimePatternGenerator, we might want to do something similar for formatting, so that we have it for both examples and for generating test data.
    - Created a CldrPathUtilities.java with utilities for dealing with paths (right now we have these scattered over different files)
 - Fixed a couple of tests

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
