### PR TITLE
CLDR-19352 updates for bcp47 key/type core values and tests

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1458,10 +1458,15 @@ annotations.
 			<type key="colReorder" type="space">Whitespace</type>
 			<type key="colReorder" type="symbol">Symbol</type>
 			<type key="colStrength" type="identical">Sort All</type>
+			<type key="colStrength" type="identical" scope="core">All</type>
 			<type key="colStrength" type="primary">Sort Base Letters Only</type>
+			<type key="colStrength" type="primary" scope="core">Base Letters Only</type>
 			<type key="colStrength" type="quaternary">Sort Accents/Case/Width/Kana</type>
+			<type key="colStrength" type="quaternary" scope="core">Base, Accents, Case, Variants, Kana</type>
 			<type key="colStrength" type="secondary">Sort Accents</type>
+			<type key="colStrength" type="secondary" scope="core">Base, Accents</type>
 			<type key="colStrength" type="tertiary">Sort Accents/Case/Width</type>
+			<type key="colStrength" type="tertiary" scope="core">Base, Accents, Case, Variants</type>
 			<type key="d0" type="accents">To Accented Characters From ASCII Sequence</type>
 			<type key="d0" type="ascii">To ASCII</type>
 			<type key="d0" type="casefold">To Casefolded</type>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1414,8 +1414,11 @@ annotations.
 			<type key="colBackwards" type="no">Sort Accents Normally</type>
 			<type key="colBackwards" type="yes">Sort Accents Reversed</type>
 			<type key="colCaseFirst" type="lower">Sort Lowercase First</type>
+			<type key="colCaseFirst" type="lower" scope="core">Lowercase</type>
 			<type key="colCaseFirst" type="no">Sort Normal Case Order</type>
+			<type key="colCaseFirst" type="no" scope="core">Sort Normal Case Order</type>
 			<type key="colCaseFirst" type="upper">Sort Uppercase First</type>
+			<type key="colCaseFirst" type="upper" scope="core">Uppercase</type>
 			<type key="colCaseLevel" type="no">Sort Case Insensitive</type>
 			<type key="colCaseLevel" type="yes">Sort Case Sensitive</type>
 			<type key="collation" type="compat">Previous Sort Order, for compatibility</type>
@@ -1457,6 +1460,11 @@ annotations.
 			<type key="colReorder" type="punct">Punctuation</type>
 			<type key="colReorder" type="space">Whitespace</type>
 			<type key="colReorder" type="symbol">Symbol</type>
+			<type key="colReorder" type="currency" scope="core">Currency</type>
+			<type key="colReorder" type="digit" scope="core">Digits</type>
+			<type key="colReorder" type="punct" scope="core">Punctuation</type>
+			<type key="colReorder" type="space" scope="core">Whitespace</type>
+			<type key="colReorder" type="symbol" scope="core">Symbol</type>
 			<type key="colStrength" type="identical">Sort All</type>
 			<type key="colStrength" type="identical" scope="core">All</type>
 			<type key="colStrength" type="primary">Sort Base Letters Only</type>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -1416,7 +1416,7 @@ annotations.
 			<type key="colCaseFirst" type="lower">Sort Lowercase First</type>
 			<type key="colCaseFirst" type="lower" scope="core">Lowercase</type>
 			<type key="colCaseFirst" type="no">Sort Normal Case Order</type>
-			<type key="colCaseFirst" type="no" scope="core">Sort Normal Case Order</type>
+			<type key="colCaseFirst" type="no" scope="core">Lowercase</type>
 			<type key="colCaseFirst" type="upper">Sort Uppercase First</type>
 			<type key="colCaseFirst" type="upper" scope="core">Uppercase</type>
 			<type key="colCaseLevel" type="no">Sort Case Insensitive</type>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -227,6 +227,29 @@ public class ExtraPaths {
                         "timezone" // ldml/dates/timeZoneNames
                         );
 
+        // skip these core 'keys' entirely from extraPaths
+        private static final Set<String> skipCoreKeys =
+                ImmutableSet.of(
+                        "fw",
+                        "numbers",
+                        "t0",
+                        "colAlternate",
+                        "colBackwards",
+                        "colCaseFirst",
+                        "colCaseLevel",
+                        "colNormalization",
+                        "colNumeric",
+                        "colReorder",
+                        "colStrength",
+                        "d0",
+                        "k0",
+                        "h0",
+                        "i0",
+                        "m0",
+                        "mu",
+                        "numbers",
+                        "s0");
+
         /** add BCP47 keys */
         private void addBcp47Keys() {
             final Relation<String, String> bcp47Keys = supplementalData.getBcp47Keys();
@@ -346,8 +369,10 @@ public class ExtraPaths {
                     final String typeKeyTypePath =
                             typeKeyPath + String.format("[@type=\"%s\"]", type);
                     pathsTemp.add(typeKeyTypePath);
-                    // add all of these with [@scope="core"]
-                    pathsTemp.add(typeKeyTypePath + SCOPE_CORE);
+                    // add some of these with [@scope="core"]
+                    if (!skipCoreKeys.contains(k)) {
+                        pathsTemp.add(typeKeyTypePath + SCOPE_CORE);
+                    }
                 }
             }
         }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import org.unicode.cldr.test.CheckMetazones;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
@@ -227,29 +228,6 @@ public class ExtraPaths {
                         "timezone" // ldml/dates/timeZoneNames
                         );
 
-        // skip these core 'keys' entirely from extraPaths
-        private static final Set<String> skipCoreKeys =
-                ImmutableSet.of(
-                        "fw",
-                        "numbers",
-                        "t0",
-                        "colAlternate",
-                        "colBackwards",
-                        "colCaseFirst",
-                        "colCaseLevel",
-                        "colNormalization",
-                        "colNumeric",
-                        "colReorder",
-                        "colStrength",
-                        "d0",
-                        "k0",
-                        "h0",
-                        "i0",
-                        "m0",
-                        "mu",
-                        "numbers",
-                        "s0");
-
         /** add BCP47 keys */
         private void addBcp47Keys() {
             final Relation<String, String> bcp47Keys = supplementalData.getBcp47Keys();
@@ -370,11 +348,50 @@ public class ExtraPaths {
                             typeKeyPath + String.format("[@type=\"%s\"]", type);
                     pathsTemp.add(typeKeyTypePath);
                     // add some of these with [@scope="core"]
-                    if (!skipCoreKeys.contains(k)) {
+                    if (!skipCoreType(k, t)) {
                         pathsTemp.add(typeKeyTypePath + SCOPE_CORE);
                     }
                 }
             }
+        }
+
+        // skip these core 'keys' entirely from extraPaths - they are constructed
+        private static final Set<String> skipCoreKeys =
+                ImmutableSet.of(
+                        // Skip items that are constructed:
+                        // "numbers", Numbers will get special treatment
+                        "fw", // uses calendar data
+                        "sd", // subdivision
+                        "currency",
+                        "dx", // scripts
+                        "mu", // units
+                        "rg", // region names
+                        "colAlternate", // On/Off
+                        "colBackwards", // On/Off
+                        "colCaseLevel", // On/Off
+                        "colNormalization", // On/Off
+                        "colNumeric", // On/Off
+
+                        // all of the transforms
+                        "d0",
+                        "h0",
+                        "i0",
+                        "k0",
+                        "m0",
+                        "mu",
+                        "s0",
+                        "t0");
+
+        static final Pattern MATCH_LOWERCASE_SCRIPT_CODE = PatternCache.get("^[a-z]{4}$");
+
+        private static final boolean skipCoreType(final String k, String t) {
+            // always skip these
+            if (skipCoreKeys.contains(k)) return true;
+            // skip numbers that are just script codes (will be constructed)
+            if (k.equals("numbers") && MATCH_LOWERCASE_SCRIPT_CODE.matcher(t).matches())
+                return true;
+            // otherwise, don't skip
+            return false;
         }
     }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
@@ -35,10 +35,6 @@ public class TestEnInheritance extends TestWithKnownIssues {
                     // //ldml/dates/timeZoneNames/metazone[@type="Gulf"]/short/standard
                     if (!cldrFile.getExtraPaths().contains(path)
                             || !TestPaths.extraPathAllowsNullValue(path)) {
-                        // if (path.endsWith("[@scope=\"core\"]")
-                        //         && logKnownIssue("CLDR-19352", "Missing in en.xml: " + path)) {
-                        //     continue; // skip for now
-                        // }
                         complain("null value", ++pathsWithNullValue, path);
                     }
                 } else if (CldrUtility.INHERITANCE_MARKER.equals(value)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/test/TestEnInheritance.java
@@ -35,10 +35,10 @@ public class TestEnInheritance extends TestWithKnownIssues {
                     // //ldml/dates/timeZoneNames/metazone[@type="Gulf"]/short/standard
                     if (!cldrFile.getExtraPaths().contains(path)
                             || !TestPaths.extraPathAllowsNullValue(path)) {
-                        if (path.endsWith("[@scope=\"core\"]")
-                                && logKnownIssue("CLDR-19352", "Missing in en.xml: " + path)) {
-                            continue; // skip for now
-                        }
+                        // if (path.endsWith("[@scope=\"core\"]")
+                        //         && logKnownIssue("CLDR-19352", "Missing in en.xml: " + path)) {
+                        //     continue; // skip for now
+                        // }
                         complain("null value", ++pathsWithNullValue, path);
                     }
                 } else if (CldrUtility.INHERITANCE_MARKER.equals(value)) {

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
@@ -201,7 +201,7 @@ public class TestExtraPaths {
     }
 
     @ParameterizedTest(name = "{index} locale={0}.xml")
-    @ValueSource(strings = {"de", "ru"})
+    @ValueSource(strings = {"en", "de", "ru"})
     public void testTypeCoverageVs48(final String localeId) {
         assumeTrue(TestCLDRPaths.canUseArchiveDirectory(), "Skip if CLDR Archive not present");
         final String CLDR48 = ToolConstants.getBaseDirectory(VersionInfo.getInstance(48));
@@ -210,7 +210,9 @@ public class TestExtraPaths {
         assertTrue(
                 commonMain48Path.toFile().isDirectory(),
                 () -> "Can’t read CLDR 48: " + commonMain48Path);
-        final CLDRFile root48 = Factory.make(commonMain48Path.toString(), ".*").make("root", true);
+        Factory factory48 = Factory.make(commonMain48Path.toString(), ".*");
+        final CLDRFile root48 = factory48.make("root", true);
+        final CLDRFile en48 = factory48.make("en", true);
 
         CoverageLevel2 cov =
                 CoverageLevel2.getInstance(
@@ -232,10 +234,9 @@ public class TestExtraPaths {
             final Level l = cov.getLevel(path);
             final Level l48 = cov48.getLevel(path);
             if (!path.endsWith("[@scope=\"core\"]")) {
-                if (root48.isHere(path)) {
-                    // in 48 root - so, MODERN
-                    assertEquals(Level.MODERN, l, () -> localeId + ":" + path);
-                } else if (l48 != null && l48 != Level.COMPREHENSIVE) {
+                // non core
+                if ((root48.isHere(path)
+                        || en48.isHere(path) && (l48 != null && Level.MODERN.isAtLeast(l48)))) {
                     // Was in 48 and not comprehensive there - expect it to match identically (for
                     // now)
                     assertEquals(
@@ -250,6 +251,7 @@ public class TestExtraPaths {
                             () -> localeId + ":" + path + " - expect comprehensive");
                 }
             } else {
+                // CORE
                 if (l48 != null && l48 != Level.COMPREHENSIVE) {
                     // present in v48
                     assertEquals(l48, l, () -> localeId + ": vs v48 " + path);


### PR DESCRIPTION
CLDR-19352

- [ ] This PR completes the ticket.

What's in the box:
- update english names for core from the spreadsheet linked below
- filter which extraPaths are added 
- update tests to conform with requirements
- don't generate constructed types as ExtraPaths

> Note: 👉 see also  #5606 which updates PathDescription for core types

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
