### PR TITLE
CLDR-19258 Generate test data in cldr-modify task in GitHub Actions

### DIFF
--- a/.github/workflows/cldr-modify.yml
+++ b/.github/workflows/cldr-modify.yml
@@ -69,6 +69,12 @@ jobs:
         env:
           CLDR_DIR: ${{ github.workspace }}
           LANG: en_US.UTF-8
+      - name: Run GenerateTestData
+        run: >
+          mvn -s .github/workflows/mvn-settings.xml -B --file tools/pom.xml -pl cldr-code
+          exec:java -Dexec.mainClass=org.unicode.cldr.tool.GenerateTestData
+          -Dexec.cleanupDaemonThreads=false
+          -DCLDR_DIR=$(pwd)
       - name: Verify git Changes
         id: gitstatus
         run: |
@@ -86,6 +92,7 @@ jobs:
           git config user.name 'cldr-modify.yml [bot]'
           git config user.email 'unicode-org@users.noreply.github.com'
           git add common/main
+          git add common/testData
           bash .github/workflows/cldr-modify-commit.sh cldr-modify.yml CLDRModify
           git checkout -b ${AUTO_BRANCH}
           # reset origin using token

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTestData.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/GenerateTestData.java
@@ -9,5 +9,6 @@ public class GenerateTestData {
         GeneratePersonNameTestData.main(args);
         GenerateUnitTestData.main(args);
         GenerateDateTimeTestData.main(args);
+        GenerateRBNFTestData.main(args);
     }
 }


### PR DESCRIPTION
This commit introduces a new 'data-check' job in the Maven workflow that executes 'GenerateTestData' and verifies that there are no differences in the 'common/testData' directory. This ensures that generated test data remains in sync with the tool logic.

Not sure which ticket to use so I used CLDR-19258. I can file a new one if you prefer

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
