### PR TITLE
CLDR-8260 Add range patterns for intervals

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1659,6 +1659,8 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@DEPRECATED-->
 
 <!ELEMENT intervalFormatFallback ( #PCDATA ) >
+<!ATTLIST intervalFormatFallback type NMTOKEN #IMPLIED >
+    <!--@MATCH:literal/same-->
 <!ATTLIST intervalFormatFallback alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST intervalFormatFallback draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1662,7 +1662,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT intervalFormatRange ( #PCDATA ) >
 <!ATTLIST intervalFormatRange type NMTOKEN #REQUIRED >
-    <!--@MATCH:literal/fallback, same, numeric-->
+    <!--@MATCH:literal/numeric, non-numeric, mixed -->
 <!ATTLIST intervalFormatRange alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST intervalFormatRange draft (approved | contributed | provisional | unconfirmed) #IMPLIED >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1646,7 +1646,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST appendItem references CDATA #IMPLIED >
     <!--@METADATA-->
 
-<!ELEMENT intervalFormats ( alias | ( intervalFormatFallback*, intervalFormatItem*, special* ) ) >
+<!ELEMENT intervalFormats ( alias | ( intervalFormatRanges*, intervalFormatFallback*, intervalFormatItem*, special* ) ) >
 <!ATTLIST intervalFormats alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST intervalFormats draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
@@ -1658,9 +1658,19 @@ CLDR data files are interpreted according to the LDML specification (http://unic
     <!--@VALUE-->
     <!--@DEPRECATED-->
 
+<!ELEMENT intervalFormatRanges ( alias | ( intervalFormatRange*, special* ) ) >
+
+<!ELEMENT intervalFormatRange ( #PCDATA ) >
+<!ATTLIST intervalFormatRange type NMTOKEN #REQUIRED >
+    <!--@MATCH:literal/fallback, same, numeric-->
+<!ATTLIST intervalFormatRange alt NMTOKENS #IMPLIED >
+    <!--@MATCH:literal/variant-->
+<!ATTLIST intervalFormatRange draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
+    <!--@METADATA-->
+<!ATTLIST intervalFormatRange references CDATA #IMPLIED >
+    <!--@METADATA-->
+
 <!ELEMENT intervalFormatFallback ( #PCDATA ) >
-<!ATTLIST intervalFormatFallback type NMTOKEN #IMPLIED >
-    <!--@MATCH:literal/same-->
 <!ATTLIST intervalFormatFallback alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST intervalFormatFallback draft (approved | contributed | provisional | unconfirmed) #IMPLIED >
@@ -1670,7 +1680,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 <!ATTLIST intervalFormatFallback validSubLocales CDATA #IMPLIED >
     <!--@VALUE-->
     <!--@DEPRECATED-->
-
+    
 <!ELEMENT intervalFormatItem ( alias | ( greatestDifference*, special* ) ) >
 <!ATTLIST intervalFormatItem id NMTOKEN #REQUIRED >
     <!--@MATCH:regex/((H|h|Bh)m?(v|vvvv)?)|((G|GGGGG)?(y|yyyy)((M|MMM|MMMM)((E|EEEE)?d)?)?)|((M|MMM|MMMM)((E|EEEE)?d)?)|d-->

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2973,6 +2973,11 @@ annotations.
 						<appendItem request="Year">{0} {1}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatRanges>
+							<intervalFormatRange type="fallback">{0} – {1}</intervalFormatRange>
+							<intervalFormatRange type="numeric">{0}–{1}</intervalFormatRange>
+							<intervalFormatRange type="same">{0}–{1}</intervalFormatRange>
+						</intervalFormatRanges>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2974,9 +2974,9 @@ annotations.
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>
-							<intervalFormatRange type="fallback">{0} – {1}</intervalFormatRange>
+							<intervalFormatRange type="mixed">{0} – {1}</intervalFormatRange>
 							<intervalFormatRange type="numeric">{0}–{1}</intervalFormatRange>
-							<intervalFormatRange type="same">{0}–{1}</intervalFormatRange>
+							<intervalFormatRange type="non-numeric">{0}–{1}</intervalFormatRange>
 						</intervalFormatRanges>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -502,6 +502,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatRanges>
+							<alias source="locale" path="../../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatRanges"/>
+						</intervalFormatRanges>				
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
@@ -1038,6 +1041,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatRanges>
+							<alias source="locale" path="../../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatRanges"/>
+						</intervalFormatRanges>				
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
@@ -1522,6 +1528,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatRanges>
+							<intervalFormatRange type="fallback">{0} – {1}</intervalFormatRange>
+							<intervalFormatRange type="numeric">{0}–{1}</intervalFormatRange>
+							<intervalFormatRange type="same">{0}–{1}</intervalFormatRange>
+						</intervalFormatRanges>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>
@@ -2184,6 +2195,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Year">{1} {0}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatRanges>
+							<alias source="locale" path="../../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatRanges"/>
+						</intervalFormatRanges>				
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1529,9 +1529,9 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>
-							<intervalFormatRange type="fallback">{0} – {1}</intervalFormatRange>
+							<intervalFormatRange type="mixed">{0} – {1}</intervalFormatRange>
 							<intervalFormatRange type="numeric">{0}–{1}</intervalFormatRange>
-							<intervalFormatRange type="same">{0}–{1}</intervalFormatRange>
+							<intervalFormatRange type="non-numeric">{0}–{1}</intervalFormatRange>
 						</intervalFormatRanges>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -422,7 +422,9 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
-		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback[@type='%A']"/>
+
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type='%A']"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type='%A']"/>
 
 		<coverageLevel	value="basic"	 	    match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -422,6 +422,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 		<coverageLevel	value="basic"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback"/>
+		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='generic']/dateTimeFormats/intervalFormats/intervalFormatFallback[@type='%A']"/>
 
 		<coverageLevel	value="basic"	 	    match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%basicDateSkeletons']"/>
 		<coverageLevel	value="moderate"	 	match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/availableFormats/dateFormatItem[@id='%anyAttribute']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -1777,35 +1777,65 @@ public class ExampleGenerator {
     }
 
     private void handleIntervalFormats(XPathParts parts, String value, List<String> examples) {
-        if (parts.getElement(6).equals("intervalFormatFallback")) {
-            SimpleDateFormat dateFormat = new SimpleDateFormat();
-            String fallbackFormat = invertBackground(setBackground(value));
-            examples.add(
-                    format(
-                            fallbackFormat,
-                            dateFormat.format(FIRST_INTERVAL),
-                            dateFormat.format(SECOND_INTERVAL.get("y"))));
-            return;
+        switch (parts.getElement(6)) {
+            case "intervalFormatFallback":
+                {
+                    SimpleDateFormat dateFormat = new SimpleDateFormat();
+                    String formatted =
+                            getFormattedInterval(
+                                    value,
+                                    dateFormat.format(FIRST_INTERVAL),
+                                    dateFormat.format(SECOND_INTERVAL.get("y")));
+                    examples.add(formatted);
+                    break;
+                }
+            case "intervalFormatRanges":
+                String formatted = "";
+                switch (parts.getAttributeValue(-1, "type")) {
+                    case "mixed":
+                        formatted = getFormattedInterval(value, "1 March", "13 April");
+                        break;
+                    case "numeric":
+                        formatted = getFormattedInterval(value, "1", "23");
+                        break;
+                    case "non-numeric":
+                        formatted = getFormattedInterval(value, "March", "April");
+                        break;
+                }
+                examples.add(formatted);
+                break;
+            default:
+                {
+                    addIntervalExample(FIRST_INTERVAL, SECOND_INTERVAL, parts, value, examples);
+                    addIntervalExample(FIRST_INTERVAL2, SECOND_INTERVAL2, parts, value, examples);
+                    Set<String> relatedPatterns =
+                            RelatedDatePathValues.getRelatedPathValues(cldrFile, parts);
+                    if (!relatedPatterns.isEmpty()) {
+                        examples.add("Related Flexible Dates:");
+                        for (String pattern : relatedPatterns) {
+                            SimpleDateFormat sdf =
+                                    icuServiceBuilder.getDateFormat(
+                                            parts.getAttributeValue(
+                                                    RelatedDatePathValues.calendarElement, "type"),
+                                            pattern);
+                            examples.add(sdf.format(FIRST_INTERVAL));
+                            examples.add(sdf.format(FIRST_INTERVAL2));
+                        }
+                    }
+                    // de-dup, just in case
+                    LinkedHashSet<String> dedup = new LinkedHashSet<>(examples);
+                    examples.clear();
+                    examples.addAll(dedup);
+                    break;
+                }
         }
-        addIntervalExample(FIRST_INTERVAL, SECOND_INTERVAL, parts, value, examples);
-        addIntervalExample(FIRST_INTERVAL2, SECOND_INTERVAL2, parts, value, examples);
-        Set<String> relatedPatterns = RelatedDatePathValues.getRelatedPathValues(cldrFile, parts);
-        if (!relatedPatterns.isEmpty()) {
-            examples.add("Related Flexible Dates:");
-            for (String pattern : relatedPatterns) {
-                SimpleDateFormat sdf =
-                        icuServiceBuilder.getDateFormat(
-                                parts.getAttributeValue(
-                                        RelatedDatePathValues.calendarElement, "type"),
-                                pattern);
-                examples.add(sdf.format(FIRST_INTERVAL));
-                examples.add(sdf.format(FIRST_INTERVAL2));
-            }
-        }
-        // de-dup, just in case
-        LinkedHashSet<String> dedup = new LinkedHashSet<>(examples);
-        examples.clear();
-        examples.addAll(dedup);
+    }
+
+    private String getFormattedInterval(
+            String value, String firstOfInterval, String secondOfInterval) {
+        String fallbackFormat = invertBackground(setBackground(value));
+        String formatted = format(fallbackFormat, firstOfInterval, secondOfInterval);
+        return formatted;
     }
 
     private void addIntervalExample(

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/RelatedDatePathValues.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/RelatedDatePathValues.java
@@ -47,7 +47,10 @@ public class RelatedDatePathValues {
             case "availableFormats":
                 return forAvailable(cldrFile, xparts);
             case "intervalFormats":
-                return forInterval(cldrFile, xparts);
+                if ("intervalFormatItem".equals(xparts.getElement(6))) {
+                    return forInterval(cldrFile, xparts);
+                }
+                break;
             default:
                 break;
         }

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -144,7 +144,8 @@
 //ldml/dates/calendars/calendar[@type="(gregorian|iso8601)"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; DateTime ; &calendar($1) ; &calField(Formats:Flexible:Append) ; $2  ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Flexible:Append)-$2 ; HIDE
 
-//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type="%A"]                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Range) ; %1 ; LTR_ALWAYS
+//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type="%A"]                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Range) ; $2 ; LTR_ALWAYS
+//ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type="%A"]                              ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Intervals:Range)-$2 ; HIDE
 
 //ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatFallback                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Fallback) ; Fallback ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatFallback                              ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Intervals:Fallback)-Fallback ; HIDE

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -145,6 +145,7 @@
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Flexible:Append)-$2 ; HIDE
 
 //ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatFallback                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Fallback) ; Fallback ; LTR_ALWAYS
+//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatFallback[@type="%A"]                 ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Fallback) ; Fallback-$2 ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatFallback                              ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Intervals:Fallback)-Fallback ; HIDE
 
 //ldml/dates/calendars/calendar[@type="(gregorian|iso8601)"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="h%A"]/greatestDifference[@id="%A"] ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:time12) ; h$2/$3 ; LTR_ALWAYS

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -144,8 +144,9 @@
 //ldml/dates/calendars/calendar[@type="(gregorian|iso8601)"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; DateTime ; &calendar($1) ; &calField(Formats:Flexible:Append) ; $2  ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Flexible:Append)-$2 ; HIDE
 
+//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type="%A"]                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Range) ; %1 ; LTR_ALWAYS
+
 //ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatFallback                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Fallback) ; Fallback ; LTR_ALWAYS
-//ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatFallback[@type="%A"]                 ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Fallback) ; Fallback-$2 ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatFallback                              ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Intervals:Fallback)-Fallback ; HIDE
 
 //ldml/dates/calendars/calendar[@type="(gregorian|iso8601)"]/dateTimeFormats/intervalFormats/intervalFormatItem[@id="h%A"]/greatestDifference[@id="%A"] ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:time12) ; h$2/$3 ; LTR_ALWAYS

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -154,6 +154,10 @@
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="(Month)"] ; {0}=BASE_FORMAT Monday, January 23; {1}=APPEND_FIELD_FORMAT February; {2}=APPEND_FIELD_NAME $1
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="(Minute|Second)"] ; {0}=BASE_FORMAT Monday, January 23; {1}=APPEND_FIELD_FORMAT 53; {2}=APPEND_FIELD_NAME $1
 
+^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange\[@type="numeric"] ; {0}=START_DATE_OR_TIME 9; {1}=END_DATE_OR_TIME 12
+^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange\[@type="non-numeric"] ; {0}=START_DATE_OR_TIME January; {1}=END_DATE_OR_TIME March
+^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange\[@type="mixed"] ; {0}=START_DATE_OR_TIME January 9; {1}=END_DATE_OR_TIME March 12
+
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatFallback ; {0}=START_DATE_OR_TIME Nov 10; {1}=END_DATE_OR_TIME Dec 10
 ^//ldml/dates/calendars/calendar\[@type="%A"]/monthPatterns/monthPatternContext\[@type="%A"]/monthPatternWidth\[@type="%A"]/monthPattern\[@type="%A"] ; {0}=CHINESE_CALENDAR_MONTH_NAME Month4
 


### PR DESCRIPTION
CLDR-8260

This is the only part of CLDR-8260 that needs to be done before the start of submission. It is adding 3 new range symbols. The types are:
- `numeric`: for two numeric fields of the same type (eg, days) that form a range, eg in "March 3–9"
- `non-numeric`: for two non-numeric fields of the same type (eg Months) that form a range, eg in "March-May 2026"
- `mixed`: for two parts that are complex, such as in "March 23 – May 17". (The range symbol doesn't separate two fields of the same type).

The design doc just added one, but it is useful to add all 3 instead of overloading other fields.
- The numeric may be different for different calendar systems
- We need to split the mixed from non-numeric
- Having the patterns in a common element lets us inherit everything from 'gregorian'.

Here is the structure:
```
<intervalFormatRanges>
	<intervalFormatRange type="mixed">{0} – {1}</intervalFormatRange>
	<intervalFormatRange type="numeric">{0}–{1}</intervalFormatRange>
	<intervalFormatRange type="non-numeric">{0}–{1}</intervalFormatRange>
</intervalFormatRanges>
```
For English, mixed has thin spaces around an en-dash, and numeric & non-numeric are identical (as per Chicago Manual of Style).

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
