### PR TITLE
CLDR-18977 Remove minimalPair placeholders in root

### DIFF
--- a/common/main/bal_Latn.xml
+++ b/common/main/bal_Latn.xml
@@ -8037,11 +8037,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="atMost">↑↑↑</pattern>
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
-		<minimalPairs>
-			<pluralMinimalPairs count="one" draft="contributed">↑↑↑</pluralMinimalPairs>
-			<pluralMinimalPairs count="other" draft="contributed">↑↑↑</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
-		</minimalPairs>
 	</numbers>
 	<units>
 		<unitLength type="long">

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -6148,7 +6148,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimalPairs>
 			<pluralMinimalPairs count="one">rana {0}</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">kwanaki {0}</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -6145,7 +6145,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		<minimalPairs>
 			<pluralMinimalPairs count="one">rana {0}</pluralMinimalPairs>
 			<pluralMinimalPairs count="other">kwanaki {0}</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">↑↑↑</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>
 	<units>

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -5867,7 +5867,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 		</miscPatterns>
 		<minimalPairs>
 			<pluralMinimalPairs count="one">{0} dè</pluralMinimalPairs>
-			<pluralMinimalPairs count="other">↑↑↑</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Take the {0}th right.</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -5570,7 +5570,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="other" draft="contributed">↑↑↑</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">{0}qi yupayta hapiy.</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -5230,10 +5230,6 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 		<miscPatterns numberSystem="wcho">
 			<alias source="locale" path="../miscPatterns[@numberSystem='latn']"/>
 		</miscPatterns>
-		<minimalPairs>
-			<pluralMinimalPairs count="other">{0}?</pluralMinimalPairs>
-			<ordinalMinimalPairs ordinal="other">{0}?</ordinalMinimalPairs>
-		</minimalPairs>
 	</numbers>
 	<units>
 		<unitLength type="long">

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -5099,7 +5099,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<pattern type="range">↑↑↑</pattern>
 		</miscPatterns>
 		<minimalPairs>
-			<pluralMinimalPairs count="other">↑↑↑</pluralMinimalPairs>
 			<ordinalMinimalPairs ordinal="other">Jël {0} ci ndeyjoor.</ordinalMinimalPairs>
 		</minimalPairs>
 	</numbers>


### PR DESCRIPTION
CLDR-18977

The paths are included in ExtraPaths, so the root value (which is bogus) is not needed.

Also removed items in locales that had inherited bogus values from from root by having ↑↑↑ as values for some MinimalPairs. So this will get vetters to supply real values!

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
