### PR TITLE
CLDR-18954 Tags: revise visual appearance

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -1,5 +1,7 @@
 let data = null;
 
+let mapByName = null;
+
 const staticInfo = {
   forceEscapeRegex: "[\\u200e\\u200f\\uFFF0]",
   names: {
@@ -7,19 +9,29 @@ const staticInfo = {
     "\u200e": { name: "LRM" },
     "\u200f": { name: "RLM" },
   },
+  namesForMenu: ["LRM", "RLM", "SP"],
 }; // start from static info - useful for tests
-
-/** updates content and recompiles regex */
-export function updateInfo(escapedCharInfo) {
-  const updatedRegex = escapedCharInfo.forceEscapeRegex;
-  const forceEscape = new RegExp(updatedRegex, "gu");
-  data = { escapedCharInfo, forceEscape };
-}
 
 // we preload the static info
 updateInfo(staticInfo);
 
-export function needsEscaping(str) {
+/** updates content and recompiles regex */
+function updateInfo(escapedCharInfo) {
+  const updatedRegex = escapedCharInfo.forceEscapeRegex;
+  const forceEscape = new RegExp(updatedRegex, "gu");
+  data = { escapedCharInfo, forceEscape };
+  mapByName = {};
+  for (const key of Object.keys(escapedCharInfo.names)) {
+    const info = escapedCharInfo.names[key];
+    mapByName[info.name] = {
+      char: key,
+      shortName: info.shortName,
+      description: info.description,
+    };
+  }
+}
+
+function needsEscaping(str) {
   if (!str) return false;
   return !!str.match(data.forceEscape);
 }
@@ -38,7 +50,7 @@ export function getEscapedHtml(str) {
 }
 
 /** get information for one char, or null */
-export function getCharInfo(str) {
+function getCharInfo(str) {
   return data.escapedCharInfo?.names[str];
 }
 
@@ -58,7 +70,7 @@ function escapeHtml(str) {
   });
 }
 
-export function getShortName(str) {
+function getShortName(str) {
   const e = getCharInfo(str);
   if (e) {
     return e.name || e.shortName;
@@ -66,6 +78,19 @@ export function getShortName(str) {
   return null;
 }
 
-export function getAllNames() {
-  return data.escapedCharInfo?.names;
+function getMapByName() {
+  return mapByName;
 }
+
+function getNamesForMenu() {
+  return data.escapedCharInfo?.namesForMenu;
+}
+
+export {
+  getCharInfo,
+  getMapByName,
+  getNamesForMenu,
+  getShortName,
+  needsEscaping,
+  updateInfo,
+};

--- a/tools/cldr-apps/js/src/views/AddValue.vue
+++ b/tools/cldr-apps/js/src/views/AddValue.vue
@@ -46,7 +46,7 @@
           />
         </span>
       </a-config-provider>
-      <span class="tag-area" v-show="useTags">
+      <span class="tag-area" v-show="useTags && newValue">
         <a-config-provider :direction="dir">
           <div v-show="tagMode === TAG_MODE_MENUS">
             <component
@@ -371,10 +371,10 @@ defineExpose({
   display: flex;
   align-items: stretch;
   flex-wrap: wrap;
-  margin: 1em 0 1em 0;
-  border: 1px solid #d9d9d9;
-  border-radius: 2px;
-  padding: 4px 11px;
+  margin: 1em 0; /* top left = bottom right */
+  background-color: #dff; /* like lrmarker-container in redesign.css */
+  border: 1px solid #0ff; /* like lrmarker-container in redesign.css */
+  border-radius: 2px; /* like Ant a-input; was 5px in lrmarker-container in redesign.css */
 }
 
 .eyeIcon {

--- a/tools/cldr-apps/js/src/views/AddValueCharMenu.vue
+++ b/tools/cldr-apps/js/src/views/AddValueCharMenu.vue
@@ -19,7 +19,9 @@
       <!-- https://www.antdv.com/components/tooltip/ -->
       <a-tooltip placement="left"
         ><template #title> {{ option.hover }} </template>
-        {{ option.label }}
+        <div class="tag-menu-option">
+          {{ option.label }}
+        </div>
       </a-tooltip>
     </a-select-option>
   </a-select>
@@ -84,34 +86,30 @@ const insertMenuIsVisible = ref(false);
 
 function populateCharMenu() {
   if (menuOptions.value.length == 0) {
-    const map = cldrEscaper.getAllNames();
     const options = [];
-    for (let key of Object.keys(map)) {
-      const info = map[key];
+    const mapByName = cldrEscaper.getMapByName();
+    const namesForMenu = cldrEscaper.getNamesForMenu();
+    // namesForMenu is filtered and sorted differently from Object.keys(mapByName)
+    for (const name of namesForMenu) {
+      const info = mapByName[name];
       if (info) {
-        // info.name, info.shortName, info.description
+        // info.char, info.shortName, info.description
         // Generally name is shorter than shortName
-        const codePoint = cldrChar.firstCodePoint(key);
-        const label = makeLabel(info);
-        const hover = makeHover(codePoint, info);
+        const codePoint = cldrChar.firstCodePoint(info.char);
+        const hover = makeHover(name, codePoint, info);
         const item = {
           codePoint: codePoint,
-          label: label,
+          label: name,
           hover: hover,
         };
         options.push(item);
       }
     }
-    menuOptions.value = options.sort((a, b) => a.label.localeCompare(b.label));
+    menuOptions.value = options;
   }
 }
 
-function makeLabel(info) {
-  return info?.name || info?.shortName;
-}
-
-function makeHover(codePoint, info) {
-  const name = info?.name || info?.shortName;
+function makeHover(name, codePoint, info) {
   const usv = cldrChar.uPlus(codePoint);
   return (
     name + " (" + info.shortName + " " + usv + ": " + info.description + ")"
@@ -169,7 +167,11 @@ function handleDropdownVisibleChange(isVisible) {
 
 <style scoped>
 .tag-menu {
-  /* Prevent the text to the right of the tag moving when the menu is opened */
+  /* Prevent the text to the right of the icon/tag moving when the menu is opened */
   width: 0 !important;
+}
+
+.tag-menu-option {
+  width: 100% !important;
 }
 </style>

--- a/tools/cldr-apps/js/src/views/AddValueTags.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTags.vue
@@ -1,30 +1,32 @@
 <template>
-  <template v-for="(tag, index) in tagArray" :key="index">
-    <!-- Clicking a tag brings up a menu to change its value -->
-    <template v-if="index == chosenIndex">
-      <AddValueCharMenu
-        v-if="menuIsVisible"
-        :key="componentKeyInsert"
-        v-model="chosenChar"
-        @change="handleChooseCharacter"
-        @isVisible="menuIsVisible"
-        ref="addValueCharMenuRef"
-      />
+  <span class="tag-array">
+    <template v-for="(tag, index) in tagArray" :key="index">
+      <!-- Clicking a tag brings up a menu to change its value -->
+      <template v-if="index == chosenIndex">
+        <AddValueCharMenu
+          v-if="menuIsVisible"
+          :key="componentKeyInsert"
+          v-model="chosenChar"
+          @change="handleChooseCharacter"
+          @isVisible="menuIsVisible"
+          ref="addValueCharMenuRef"
+        />
+      </template>
+      <template v-if="tagIsClickable(tag)">
+        <a-tag
+          @click="handleClickTag($event, index)"
+          class="regular-tag"
+          :id="makeTagId(index)"
+        >
+          <a-tooltip>
+            <template #title> {{ tagTooltip(tag) }} </template>
+            {{ displayTag(tag) }}
+          </a-tooltip>
+        </a-tag>
+      </template>
+      <template v-else> {{ tag }} </template>
     </template>
-    <template v-if="tagIsClickable(tag)">
-      <a-tag
-        @click="handleClickTag($event, index)"
-        class="regular-tag"
-        :id="makeTagId(index)"
-      >
-        <a-tooltip>
-          <template #title> {{ tagTooltip(tag) }} </template>
-          {{ displayTag(tag) }}
-        </a-tooltip>
-      </a-tag>
-    </template>
-    <template v-else> {{ tag }} </template>
-  </template>
+  </span>
 </template>
 
 <script setup>
@@ -143,11 +145,21 @@ function handleChooseCharacter() {
 
 <style scoped>
 .regular-tag {
-  margin: 0 3px 0 3px;
+  margin: 1pt;
+  padding: 1pt;
 }
 
-/* Prevent the text to the right of the tag moving when the menu is opened */
+/* Prevent the text to the right of the menu moving when the menu is opened */
 .tag-menu {
   width: 0 !important;
+}
+
+.tag-array {
+  /* Compare lrmarker-container in redesign.css; see also the surrounding style tag-area in AddValue.vue */
+  font-weight: bold;
+  color: black;
+  margin: 1px;
+  padding: 1px;
+  display: unset;
 }
 </style>

--- a/tools/cldr-apps/js/src/views/AddValueTagsEdit.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTagsEdit.vue
@@ -186,7 +186,7 @@ function handleClickTag(event, index) {
   menuLeft.value = event.clientX - event.offsetX;
   menuTop.value = event.clientY - event.offsetY;
   if (menuOptions.value.length == 0) {
-    const map = cldrEscaper.getAllNames();
+    const map = cldrEscaper.getNamesForMenu();
     for (let key of Object.keys(map).sort()) {
       const info = map[key];
       if (info) {

--- a/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
+++ b/tools/cldr-apps/src/main/java/org/unicode/cldr/web/api/CharInfo.java
@@ -52,14 +52,29 @@ public class CharInfo {
     }
 
     public static final class EscapedCharInfo {
+        @Schema(
+                description = "A regex indicating the front end should escape matching values",
+                required = true)
         public final String forceEscapeRegex =
                 CodePointEscaper.regexPattern(CodePointEscaper.ESCAPE_IN_SURVEYTOOL, "\\u{", "}");
+
+        @Schema(
+                description =
+                        "A map from characters to character data, ordered by Unicode Scalar Value",
+                required = true)
         public final Map<String, EscapedCharEntry> names = new HashMap<>();
+
+        @Schema(
+                description =
+                        "An array of character names, filtered and ordered suitably for an input menu",
+                required = true)
+        public final String[] namesForMenu;
 
         EscapedCharInfo() {
             for (final CodePointEscaper c : CodePointEscaper.values()) {
                 names.put(c.getString(), new EscapedCharEntry(c));
             }
+            namesForMenu = CodePointEscaper.getNamesForMenuList().toArray(new String[0]);
         }
 
         /** Constant data, so a singleton is fine */

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/CodePointEscaper.java
@@ -5,6 +5,8 @@ import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
@@ -16,6 +18,7 @@ import java.util.stream.Collectors;
 public enum CodePointEscaper {
     // These are characters found in CLDR data fields
     // The long names don't necessarily match the formal Unicode names
+    // The ordering is important; for example, it determines the order in Survey Tool menus
 
     // Spaces
     TSP(
@@ -143,19 +146,26 @@ public enum CodePointEscaper {
     private final String shortName;
     private final String description;
 
-    private CodePointEscaper(int codePoint, String shortName, String description) {
+    CodePointEscaper(int codePoint, String shortName, String description) {
         this.codePoint = codePoint;
         this.shortName = shortName;
         this.description = description;
     }
 
-    public static final UnicodeSet getNamedEscapes() {
+    public static UnicodeSet getNamedEscapes() {
         return _fromCodePoint.keySet().freeze();
     }
 
     /**
      * Return long names for this character. The set is immutable and ordered, with the first name
      * being the most user-friendly.
+     *
+     * <p>TODO: revise the above comment. How can a "long name" be named shortName? Why is "long
+     * names" plural, when only one name is returned? What do "the set" and "first name" mean in
+     * this context? Note that the enum name such as "TSP" is a shorter name than shortName such as
+     * "Thin space". Reference: https://unicode-org.atlassian.net/browse/CLDR-18954
+     *
+     * @return the shortName
      */
     public String getShortName() {
         return shortName;
@@ -164,7 +174,7 @@ public enum CodePointEscaper {
     /**
      * Return a longer description, if available; otherwise ""
      *
-     * @return
+     * @return the description
      */
     public String getDescription() {
         return description;
@@ -369,7 +379,7 @@ public enum CodePointEscaper {
         return hexEscape(codepoint, "\\x{", "}");
     }
 
-    public static final String getHtmlRows(
+    public static String getHtmlRows(
             UnicodeSet escapesToShow, String tableOptions, String cellOptions) {
         if (!escapesToShow.strings().isEmpty()) {
             throw new IllegalArgumentException("No strings allowed in the unicode set.");
@@ -410,12 +420,34 @@ public enum CodePointEscaper {
                 .append(tdPlus)
                 .append(ESCAPE_START)
                 .append(id)
-                .append(ESCAPE_END + "</td>")
+                .append(ESCAPE_END)
+                .append("</td>")
                 .append(tdPlus)
                 .append(shortName)
                 .append("</td>")
                 .append(tdPlus)
                 .append(description)
                 .append("</td><tr>");
+    }
+
+    /** Items after this in the enum are currently not suitable for Survey Tool input menus */
+    private static final CodePointEscaper LAST_SUITABLE_FOR_MENU = ALM; // last before ANS
+
+    /**
+     * Get an ordered list of CodePointEscaper names suitable for showing in a Survey tool input
+     * menu. The list should not include anything targeted just at Exemplar sets, that is any of the
+     * enums at or below “ANS(0x0600, "Arabic number sign", "For use in Exemplar sets"),”
+     *
+     * @return the list
+     */
+    public static List<String> getNamesForMenuList() {
+        ArrayList<String> orderedNames = new ArrayList<>();
+        for (final CodePointEscaper c : CodePointEscaper.values()) {
+            orderedNames.add(c.name());
+            if (c == LAST_SUITABLE_FOR_MENU) {
+                break;
+            }
+        }
+        return orderedNames;
     }
 }


### PR DESCRIPTION
-Order tag menu items the same as CodePointEscaper enum; stop at ALM; extend CharInfo.java and CodePointEscaper.java accordingly

-Color/style the tag area like similar escapes in the main vetting table

-Reduce individual tag padding/margin to 1pt

-Add data and methods to cldrEscaper.mjs; move exports to bottom

-Collapse the tag area if the value is empty

-Enclose insert menu options in div with width 100 percent to enlarge hover area

-Extend CharInfo.java to deliver the menu labels

-Fix minor Java compiler warnings

-Comments, including TODO for long shortName comment

CLDR-18954

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
