### PR TITLE
CLDR-19406 Make 5 Append Date-Time Items visible

### DIFF
--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1637,7 +1637,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT appendItem ( #PCDATA ) >
 <!ATTLIST appendItem request CDATA #REQUIRED >
-    <!--@MATCH:literal/Date-Timezone, Day, Time-Day-of-Week, Day-Of-Week, Era, Hour, Minute, Month, Quarter, Second, Timezone, Week, Year-->
+    <!--@MATCH:literal/Date-Timezone, Day, Time-Day-Of-Week, Day-Of-Week, Era, Hour, Minute, Month, Quarter, Second, Timezone, Week, Year-->
 <!ATTLIST appendItem alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST appendItem draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/dtd/ldml.dtd
+++ b/common/dtd/ldml.dtd
@@ -1637,7 +1637,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 
 <!ELEMENT appendItem ( #PCDATA ) >
 <!ATTLIST appendItem request CDATA #REQUIRED >
-    <!--@MATCH:literal/Date-Timezone, Day, Day-Of-Week, Era, Hour, Minute, Month, Quarter, Second, Timezone, Week, Year-->
+    <!--@MATCH:literal/Date-Timezone, Day, Time-Day-of-Week, Day-Of-Week, Era, Hour, Minute, Month, Quarter, Second, Timezone, Week, Year-->
 <!ATTLIST appendItem alt NMTOKENS #IMPLIED >
     <!--@MATCH:literal/variant-->
 <!ATTLIST appendItem draft (approved | contributed | provisional | unconfirmed | true | false) #IMPLIED >

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2335,6 +2335,11 @@ annotations.
 						<appendItem request="Year">{0} {1}</appendItem>
 					</appendItems>
 					<intervalFormats>
+						<intervalFormatRanges>
+							<intervalFormatRange type="mixed">{0} – {1}</intervalFormatRange>
+							<intervalFormatRange type="non-numeric">{0}–{1}</intervalFormatRange>
+							<intervalFormatRange type="numeric">{0}–{1}</intervalFormatRange>
+						</intervalFormatRanges>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
 							<greatestDifference id="B">h B – h B</greatestDifference>

--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -2321,7 +2321,8 @@ annotations.
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0}, {1}</appendItem>
+						<appendItem request="Day-Of-Week">{1}, {0}</appendItem>
+						<appendItem request="Time-Day-Of-Week">{1}, {0}</appendItem>
 						<appendItem request="Era">{0} {1}</appendItem>
 						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
 						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
@@ -2329,6 +2330,7 @@ annotations.
 						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
 						<appendItem request="Second">{0} ({2}: {1})</appendItem>
 						<appendItem request="Timezone">{0} {1}</appendItem>
+						<appendItem request="Date-Timezone">{0} {1}</appendItem>
 						<appendItem request="Week">{0} ({2}: {1})</appendItem>
 						<appendItem request="Year">{0} {1}</appendItem>
 					</appendItems>
@@ -2972,7 +2974,8 @@ annotations.
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0}, {1}</appendItem>
+						<appendItem request="Day-Of-Week">{1}, {0}</appendItem>
+						<appendItem request="Time-Day-Of-Week">{1}, {0}</appendItem>
 						<appendItem request="Era">{0} {1}</appendItem>
 						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
 						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
@@ -2980,6 +2983,7 @@ annotations.
 						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
 						<appendItem request="Second">{0} ({2}: {1})</appendItem>
 						<appendItem request="Timezone">{0} {1}</appendItem>
+						<appendItem request="Date-Timezone">{0} {1}</appendItem>
 						<appendItem request="Week">{0} ({2}: {1})</appendItem>
 						<appendItem request="Year">{0} {1}</appendItem>
 					</appendItems>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -495,18 +495,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">r(U) QQQQ</dateFormatItem>
 					</availableFormats>
 					<appendItems>
-						<appendItem request="Date-Timezone">{0} {1}</appendItem>
-						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0} {1}</appendItem>
-						<appendItem request="Era">{1} {0}</appendItem>
-						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
-						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
-						<appendItem request="Month">{0} ({2}: {1})</appendItem>
-						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
-						<appendItem request="Second">{0} ({2}: {1})</appendItem>
-						<appendItem request="Timezone">{0} {1}</appendItem>
-						<appendItem request="Week">{0} ({2}: {1})</appendItem>
-						<appendItem request="Year">{1} {0}</appendItem>
+						<alias source="locale" path="../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/appendItems"/>					
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>
@@ -1051,17 +1040,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<appendItems>
-						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0} {1}</appendItem>
-						<appendItem request="Era">{1} {0}</appendItem>
-						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
-						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
-						<appendItem request="Month">{0} ({2}: {1})</appendItem>
-						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
-						<appendItem request="Second">{0} ({2}: {1})</appendItem>
-						<appendItem request="Timezone">{0} {1}</appendItem>
-						<appendItem request="Week">{0} ({2}: {1})</appendItem>
-						<appendItem request="Year">{1} {0}</appendItem>
+						<alias source="locale" path="../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/appendItems"/>					
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>
@@ -1553,6 +1532,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<appendItem request="Month">{0} ({2}: {1})</appendItem>
 						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
 						<appendItem request="Second">{0} ({2}: {1})</appendItem>
+						<appendItem request="Time-Day-of-Week">{0} {1}</appendItem>
 						<appendItem request="Timezone">{0} {1}</appendItem>
 						<appendItem request="Week">{0} ({2}: {1})</appendItem>
 						<appendItem request="Year">{1} {0}</appendItem>
@@ -2224,17 +2204,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yw" count="other">Y 'week' w</dateFormatItem>
 					</availableFormats>
 					<appendItems>
-						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0} {1}</appendItem>
-						<appendItem request="Era">{1} {0}</appendItem>
-						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
-						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
-						<appendItem request="Month">{0} ({2}: {1})</appendItem>
-						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
-						<appendItem request="Second">{0} ({2}: {1})</appendItem>
-						<appendItem request="Timezone">{0} {1}</appendItem>
-						<appendItem request="Week">{0} ({2}: {1})</appendItem>
-						<appendItem request="Year">{1} {0}</appendItem>
+						<alias source="locale" path="../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/appendItems"/>					
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -1525,14 +1525,15 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					</availableFormats>
 					<appendItems>
 						<appendItem request="Day">{0} ({2}: {1})</appendItem>
-						<appendItem request="Day-Of-Week">{0} {1}</appendItem>
+						<appendItem request="Time-Day-Of-Week">{1} {0}</appendItem>
+						<appendItem request="Day-Of-Week">{1} {0}</appendItem>
 						<appendItem request="Era">{1} {0}</appendItem>
 						<appendItem request="Hour">{0} ({2}: {1})</appendItem>
 						<appendItem request="Minute">{0} ({2}: {1})</appendItem>
 						<appendItem request="Month">{0} ({2}: {1})</appendItem>
 						<appendItem request="Quarter">{0} ({2}: {1})</appendItem>
 						<appendItem request="Second">{0} ({2}: {1})</appendItem>
-						<appendItem request="Time-Day-of-Week">{0} {1}</appendItem>
+						<appendItem request="Date-Timezone">{0} {1}</appendItem>
 						<appendItem request="Timezone">{0} {1}</appendItem>
 						<appendItem request="Week">{0} ({2}: {1})</appendItem>
 						<appendItem request="Year">{1} {0}</appendItem>

--- a/common/main/root.xml
+++ b/common/main/root.xml
@@ -495,7 +495,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">r(U) QQQQ</dateFormatItem>
 					</availableFormats>
 					<appendItems>
-						<alias source="locale" path="../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/appendItems"/>					
+						<alias source="locale" path="../../../calendar[@type='gregorian']/dateTimeFormats/appendItems"/>					
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>
@@ -1040,11 +1040,11 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yyyyQQQQ">G y QQQQ</dateFormatItem>
 					</availableFormats>
 					<appendItems>
-						<alias source="locale" path="../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/appendItems"/>					
+						<alias source="locale" path="../../../calendar[@type='gregorian']/dateTimeFormats/appendItems"/>					
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>
-							<alias source="locale" path="../../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatRanges"/>
+							<alias source="locale" path="../../../../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/intervalFormatRanges"/>
 						</intervalFormatRanges>
 						<intervalFormatFallback>{0} – {1}</intervalFormatFallback>
 						<intervalFormatItem id="Bh">
@@ -2205,7 +2205,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						<dateFormatItem id="yw" count="other">Y 'week' w</dateFormatItem>
 					</availableFormats>
 					<appendItems>
-						<alias source="locale" path="../calendar[@type='gregorian']/dateTimeFormats/intervalFormats/appendItems"/>					
+						<alias source="locale" path="../../../calendar[@type='gregorian']/dateTimeFormats/appendItems"/>					
 					</appendItems>
 					<intervalFormats>
 						<intervalFormatRanges>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -1014,7 +1014,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='vaii']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='vaii']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 
-		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/appendItems/appendItem[@request='(Era|Timezone|Date-Timezonez|Day-Of-Week|Time-Day-Of-Week)']"/>
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/appendItems/appendItem[@request='(Era|Timezone|Date-Timezone|Day-Of-Week|Time-Day-Of-Week)']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%timeFormatItems']"/>
 		<coverageLevel inTerritory="TH" value="modern" match="dates/calendars/calendar[@type='buddhist']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>

--- a/common/supplemental/coverageLevels.xml
+++ b/common/supplemental/coverageLevels.xml
@@ -1014,7 +1014,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/percentFormats[@numberSystem='vaii']/percentFormatLength/percentFormat%stdPattern"/>
 		<coverageLevel inLanguage="%vaiiNativeLanguages" value="moderate" match="numbers/decimalFormats[@numberSystem='vaii']/decimalFormatLength[@type='%shortLong']/decimalFormat[@type='standard']/pattern[@type='%compactDecimalTypes']"/>
 
-		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/appendItems/appendItem[@request='Timezone']"/>
+		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='gregorian']/dateTimeFormats/appendItems/appendItem[@request='(Era|Timezone|Date-Timezonez|Day-Of-Week|Time-Day-Of-Week)']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>
 		<coverageLevel value="moderate" match="dates/calendars/calendar[@type='generic']/dateTimeFormats/availableFormats/dateFormatItem[@id='%timeFormatItems']"/>
 		<coverageLevel inTerritory="TH" value="modern" match="dates/calendars/calendar[@type='buddhist']/dateTimeFormats/availableFormats/dateFormatItem[@id='%dateFormatItems']"/>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2156,43 +2156,55 @@ public class ExampleGenerator {
     }
 
     private void handleAppendItems(XPathParts parts, String value, List<String> examples) {
-        // Example parts: //ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/appendItems/appendItem[@request="Timezone"]
+        // Example parts:
+        // //ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/appendItems/appendItem[@request="Timezone"]
         String request = parts.getAttributeValue(-1, "request");
         String calendar = parts.getAttributeValue(3, "type");
         // what we append to
         int dateIndex = 0;
         int timeIndex = 0;
         String toAppend = "";
-        switch(request) {
-        case "Era": 
-            dateIndex = DateFormat.MEDIUM;
-            toAppend = cldrFile.getStringValue("//ldml/dates/calendars/calendar[@type=\"" + calendar
-                + "\"]/eras/eraAbbr/era[@type=\"1\"]");
-            break;
-        case "Day-Of-Week": 
-            dateIndex = DateFormat.MEDIUM;
-            toAppend = cldrFile.getStringValue("//ldml/dates/calendars/calendar[@type=\"" + calendar
-                + "\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]");
-            break;
-        case "Time-Day-Of-Week": 
-            timeIndex = DateFormat.MEDIUM;
-            toAppend = cldrFile.getStringValue("//ldml/dates/calendars/calendar[@type=\"" + calendar
-                + "\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]");
-            break;
-        case "Timezone": 
-            timeIndex = DateFormat.MEDIUM;
-            toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
-            break;
-        case "Date-Timezone": 
-            dateIndex = DateFormat.MEDIUM;
-            toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
-            break;
-        default: return;
+        switch (request) {
+            case "Era":
+                dateIndex = DateFormat.MEDIUM;
+                toAppend =
+                        cldrFile.getStringValue(
+                                "//ldml/dates/calendars/calendar[@type=\""
+                                        + calendar
+                                        + "\"]/eras/eraAbbr/era[@type=\"1\"]");
+                break;
+            case "Day-Of-Week":
+                dateIndex = DateFormat.MEDIUM;
+                toAppend =
+                        cldrFile.getStringValue(
+                                "//ldml/dates/calendars/calendar[@type=\""
+                                        + calendar
+                                        + "\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]");
+                break;
+            case "Time-Day-Of-Week":
+                timeIndex = DateFormat.MEDIUM;
+                toAppend =
+                        cldrFile.getStringValue(
+                                "//ldml/dates/calendars/calendar[@type=\""
+                                        + calendar
+                                        + "\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]");
+                break;
+            case "Timezone":
+                timeIndex = DateFormat.MEDIUM;
+                toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
+                break;
+            case "Date-Timezone":
+                dateIndex = DateFormat.MEDIUM;
+                toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
+                break;
+            default:
+                return;
         }
 
         SimpleDateFormat sdf =
                 icuServiceBuilder.getDateFormat(calendar, dateIndex, timeIndex, null);
-        examples.add(format(value, setBackground(sdf.format(DATE_SAMPLE)), setBackground(toAppend)));
+        examples.add(
+                format(value, setBackground(sdf.format(DATE_SAMPLE)), setBackground(toAppend)));
     }
 
     public class IntervalFormat {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/ExampleGenerator.java
@@ -2156,16 +2156,43 @@ public class ExampleGenerator {
     }
 
     private void handleAppendItems(XPathParts parts, String value, List<String> examples) {
+        // Example parts: //ldml/dates/calendars/calendar[@type="gregorian"]/dateTimeFormats/appendItems/appendItem[@request="Timezone"]
         String request = parts.getAttributeValue(-1, "request");
-        if (!"Timezone".equals(request)) {
-            return;
-        }
         String calendar = parts.getAttributeValue(3, "type");
+        // what we append to
+        int dateIndex = 0;
+        int timeIndex = 0;
+        String toAppend = "";
+        switch(request) {
+        case "Era": 
+            dateIndex = DateFormat.MEDIUM;
+            toAppend = cldrFile.getStringValue("//ldml/dates/calendars/calendar[@type=\"" + calendar
+                + "\"]/eras/eraAbbr/era[@type=\"1\"]");
+            break;
+        case "Day-Of-Week": 
+            dateIndex = DateFormat.MEDIUM;
+            toAppend = cldrFile.getStringValue("//ldml/dates/calendars/calendar[@type=\"" + calendar
+                + "\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]");
+            break;
+        case "Time-Day-Of-Week": 
+            timeIndex = DateFormat.MEDIUM;
+            toAppend = cldrFile.getStringValue("//ldml/dates/calendars/calendar[@type=\"" + calendar
+                + "\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]");
+            break;
+        case "Timezone": 
+            timeIndex = DateFormat.MEDIUM;
+            toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
+            break;
+        case "Date-Timezone": 
+            dateIndex = DateFormat.MEDIUM;
+            toAppend = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
+            break;
+        default: return;
+        }
 
         SimpleDateFormat sdf =
-                icuServiceBuilder.getDateFormat(calendar, 0, DateFormat.MEDIUM, null);
-        String zone = cldrFile.getStringValue("//ldml/dates/timeZoneNames/gmtZeroFormat");
-        examples.add(format(value, setBackground(sdf.format(DATE_SAMPLE)), setBackground(zone)));
+                icuServiceBuilder.getDateFormat(calendar, dateIndex, timeIndex, null);
+        examples.add(format(value, setBackground(sdf.format(DATE_SAMPLE)), setBackground(toAppend)));
     }
 
     public class IntervalFormat {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/XMLSource.java
@@ -42,6 +42,9 @@ import org.xml.sax.Locator;
  * Please update that document if major changes are made.
  */
 public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String> {
+
+    public static final boolean TRACE_ALIAS = CldrUtility.getProperty("TRACE_ALIAS", false);
+
     public static final String CODE_FALLBACK_ID = "code-fallback";
     public static final String ROOT_ID = "root";
     private static final String TRACE_INDENT = " "; // "\t"
@@ -1072,16 +1075,27 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                 // Check if there is an alias for a subset xpath.
                 // If there are one or more matching aliases, lowerKey() will
                 // return the alias with the longest matching prefix since the
-                // hashmap is sorted according to xpath.
+                // treemap is sorted according to xpath.
 
                 //                // The following is a work in progress
                 //                // We need to recurse, since we might have a chain of aliases
                 //                while (true) {
                 String possibleSubpath = aliases.lowerKey(xpath);
+                if (TRACE_ALIAS) {
+                    System.out.println("\nxpath:                  " + xpath);
+                    System.out.println("possibleSubpath:        " + possibleSubpath);
+                }
                 if (possibleSubpath != null && xpath.startsWith(possibleSubpath)) {
-                    aliasedPath =
-                            aliases.get(possibleSubpath)
-                                    + xpath.substring(possibleSubpath.length());
+                    String aliasedPossibleSubpath = aliases.get(possibleSubpath);
+                    String trailingXpath = xpath.substring(possibleSubpath.length());
+
+                    aliasedPath = aliasedPossibleSubpath + trailingXpath;
+                    if (TRACE_ALIAS) {
+                        System.out.println("aliasedPossibleSubpath: " + aliasedPossibleSubpath);
+                        System.out.println("trailingXpath:            " + trailingXpath);
+                        System.out.println("aliasedPath:            " + aliasedPath);
+                    }
+
                     if (doInternStrings) {
                         aliasedPath = aliasedPath.intern();
                     }
@@ -1091,10 +1105,6 @@ public abstract class XMLSource implements Freezable<XMLSource>, Iterable<String
                                 new LocaleInheritanceInfo(
                                         rootAliasLocale, aliasedPath, Reason.alias));
                     }
-                    //                        xpath = aliasedPath;
-                    //                    } else {
-                    //                        break;
-                    //                    }
                 }
             } else {
                 if (list != null) {

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/PathHeader.txt
@@ -141,8 +141,7 @@
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/availableFormats/dateFormatItem[@id="%A"][@count="%A"]              ; Special  ; Suppress ; &calendar($1); &calField(Formats:Flexible:date)-$2-$3 ; HIDE
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/availableFormats/dateFormatItem[@id="%A"]                           ; Special  ; Suppress ; &calendar($1); &calField(Formats:Flexible:date)-$2 ; HIDE
 
-//ldml/dates/calendars/calendar[@type="(gregorian|iso8601)"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; DateTime ; &calendar($1) ; &calField(Formats:Flexible:Append) ; $2  ; LTR_ALWAYS
-//ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/appendItems/appendItem[@request="(Timezone)"]    ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Flexible:Append)-$2 ; HIDE
+//ldml/dates/calendars/calendar[@type="(gregorian|generic)"]/dateTimeFormats/appendItems/appendItem[@request="(Era|Day-Of-Week|Time-Day-Of-Week|Timezone|Date-Timezone)"]    ; DateTime ; &calendar($1) ; &calField(Formats:Flexible:Append) ; $2  ; LTR_ALWAYS
 
 //ldml/dates/calendars/calendar[@type="%N"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type="%A"]                              ; DateTime ; &calendar($1) ; &calField(Formats:Intervals:Range) ; $2 ; LTR_ALWAYS
 //ldml/dates/calendars/calendar[@type="%A"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type="%A"]                              ; Special  ; Suppress ; &calendar($1) ; &calField(Formats:Intervals:Range)-$2 ; HIDE

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/util/data/Placeholders.txt
@@ -144,6 +144,7 @@
 ^//ldml/dates/fields/field\[@type="week-narrow"]/relativePeriod ; locale ; {0}=NUMBER_OF_WEEKS 3
 
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="Date-Timezone"] ; {0}=BASE_FORMAT January 23; {1}=APPEND_FIELD_FORMAT Pacific Time
+^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="Time-Day-Of-Week"] ; {0}=BASE_FORMAT 14:30; {1}=APPEND_FIELD_FORMAT Monday
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="Day-Of-Week"] ; {0}=BASE_FORMAT January 23; {1}=APPEND_FIELD_FORMAT Monday
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="Timezone"] ; {0}=BASE_FORMAT 12:30; {1}=APPEND_FIELD_FORMAT Pacific Time
 ^//ldml/dates/calendars/calendar\[@type="%A"]/dateTimeFormats/appendItems/appendItem\[@request="Era"] ; {0}=BASE_FORMAT Monday, January 23; {1}=APPEND_FIELD_FORMAT A.D.

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/unittest/TestCLDRFile.java
@@ -1034,4 +1034,17 @@ public class TestCLDRFile extends TestFmwk {
             }
         }
     }
+
+    public void TestAlias() {
+        String[] testPaths = {
+            "//ldml/dates/calendars/calendar[@type=\"generic\"]/days/dayContext[@type=\"format\"]/dayWidth[@type=\"abbreviated\"]/day[@type=\"sun\"]",
+            "//ldml/dates/calendars/calendar[@type=\"generic\"]/dateTimeFormats/appendItems/appendItem[@request=\"Date-Timezone\"]",
+            "//ldml/dates/calendars/calendar[@type=\"generic\"]/dateTimeFormats/intervalFormats/intervalFormatRanges/intervalFormatRange[@type=\"mixed\"]"
+        };
+        for (String testPath : testPaths) {
+            CLDRFile rootCldrFile = testInfo.getRoot();
+            String value = rootCldrFile.getStringValue(testPath);
+            assertNotNull(testPath, value);
+        }
+    }
 }


### PR DESCRIPTION
CLDR-19406

From the ticket:

- Add Time-Day-of-Week (we added Date-Timezone for 49, but missed this one).
- Change root so that other calendars alias to gregorian. (This makes them available in islamic, etc)
- Surface the 4 missing ones in coverage. 

This would add 8 items per calendar that the locale cares about. Defaults would be as current.

Would also need to add to InfoHub, but not doing here because of possible conflicts.

- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
