### PR TITLE
CLDR-19353 Tags for Show Hidden in main vetting table

### DIFF
--- a/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrAddValue.mjs
@@ -1,7 +1,8 @@
 /*
- * cldrAddValue: enable submitting a new value for a path
+ * cldrAddValue: enable displaying a value (for a CLDR path), or submitting (adding) a new value
  */
 import * as cldrChar from "./cldrChar.mjs";
+import * as cldrEscaper from "./cldrEscaper.mjs";
 import * as cldrNotify from "./cldrNotify.mjs";
 import * as cldrSurvey from "./cldrSurvey.mjs";
 import * as cldrTable from "./cldrTable.mjs";
@@ -10,6 +11,12 @@ import * as cldrVue from "./cldrVue.mjs";
 import * as cldrXpathUtils from "./cldrXpathUtils.mjs";
 
 import AddValue from "../views/AddValue.vue";
+import ValueTags from "../views/ValueTags.vue";
+
+/**
+ * Should ASCII space (U+0020) be displayed as a tag?
+ */
+const SPACES_HAVE_TAGS = false;
 
 /**
  * Is the "Add Value" form currently visible?
@@ -134,7 +141,50 @@ function convertTextToTags(text) {
   return tags;
 }
 
+function addTagsReadyOnly(containerEl, value) {
+  try {
+    const valueTagWrapper = cldrVue.mount(ValueTags, containerEl);
+    valueTagWrapper.setValue(value);
+  } catch (e) {
+    console.error("Error loading Value Tag vue " + e.message + " / " + e.name);
+    cldrNotify.exception(e, "while loading ValueTags");
+  }
+}
+
+function shouldDisplayAsTag(tag) {
+  const c = cldrChar.firstChar(tag);
+  if (SPACES_HAVE_TAGS) {
+    return cldrChar.isSpecial(c);
+  } else {
+    return c !== " " && cldrChar.isSpecial(c);
+  }
+}
+
+function textForTag(tag) {
+  const c = cldrChar.firstChar(tag);
+  const shortName = cldrEscaper.getShortName(c);
+  if (shortName) {
+    return shortName;
+  } else {
+    return tag;
+  }
+}
+function tagTooltipPlusClick(tag) {
+  return tagTooltip(tag) + " Click to choose an alternative";
+}
+
+function tagTooltip(tag) {
+  const c = cldrChar.firstChar(tag);
+  const info = cldrEscaper.getCharInfo(c);
+  const codePoint = cldrChar.firstCodePoint(tag);
+  const usv = cldrChar.uPlus(codePoint);
+  return (
+    info.name + " = " + info.shortName + " " + usv + ": " + info.description
+  );
+}
+
 export {
+  addTagsReadyOnly,
   addValueButton,
   convertTagsToText,
   convertTextToTags,
@@ -143,4 +193,8 @@ export {
   isFormVisible,
   sendRequest,
   setFormIsVisible,
+  shouldDisplayAsTag,
+  tagTooltip,
+  tagTooltipPlusClick,
+  textForTag,
 };

--- a/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrEscaper.mjs
@@ -36,38 +36,9 @@ function needsEscaping(str) {
   return !!str.match(data.forceEscape);
 }
 
-/**
- * Escape any named invisible code points, if needed
- * @param {string} str input string
- * @returns escaped string such as `<span class="visible-mark">&lt;LRM&gt;</span>` or falsy if no escaping was needed
- */
-export function getEscapedHtml(str) {
-  if (needsEscaping(str)) {
-    const escaped = escapeHtml(str);
-    return escaped;
-  }
-  return undefined;
-}
-
 /** get information for one char, or null */
 function getCharInfo(str) {
   return data.escapedCharInfo?.names[str];
-}
-
-const PREFIX = "❰";
-const SUFFIX = "❱";
-
-/** Unconditionally escape (without testing) */
-function escapeHtml(str) {
-  return str.replaceAll(data.forceEscape, (o) => {
-    const hexName = `U+${Number(o.codePointAt(0)).toString(16).toUpperCase()}`;
-    let e = getCharInfo(o) || {};
-    const name = e.name || e.shortName;
-    const body = name || hexName;
-    const description = e.description;
-    const title = `${e.shortName || ""} ${hexName}\n${description || ""}`;
-    return `<span class="visible-mark" title="${title}">${PREFIX}${body}${SUFFIX}</span>`;
-  });
 }
 
 function getShortName(str) {

--- a/tools/cldr-apps/js/src/esm/cldrTable.mjs
+++ b/tools/cldr-apps/js/src/esm/cldrTable.mjs
@@ -1013,24 +1013,8 @@ function setDivClass(div, testKind) {
  * @param value the value of votes (check &lrm; &rlm)
  */
 function checkLRmarker(field, value) {
-  if (value) {
-    const escapedValue = cldrEscaper.getEscapedHtml(value);
-    if (escapedValue) {
-      const lrm = document.createElement("div");
-      lrm.className = "lrmarker-container";
-      const lrmtext = document.createElement("div");
-      lrmtext.innerHTML = escapedValue;
-      lrmtext.className = "lrmarker-text";
-      lrm.appendChild(lrmtext);
-      const moreInfo = cldrDom.createChunk("ⓘ", "a", "hiddenMoreInfo");
-      moreInfo.setAttribute(
-        "href",
-        "https://cldr.unicode.org/translation/getting-started/guide#special-characters"
-      );
-      lrm.appendChild(moreInfo);
-      lrm.setAttribute("title", "Special characters, click ⓘ for details.");
-      field.appendChild(lrm);
-    }
+  if (value && cldrEscaper.needsEscaping(value)) {
+    cldrAddValue.addTagsReadyOnly(field, value);
   }
 }
 

--- a/tools/cldr-apps/js/src/views/AddValue.vue
+++ b/tools/cldr-apps/js/src/views/AddValue.vue
@@ -372,9 +372,9 @@ defineExpose({
   align-items: stretch;
   flex-wrap: wrap;
   margin: 1em 0; /* top left = bottom right */
-  background-color: #dff; /* like lrmarker-container in redesign.css */
-  border: 1px solid #0ff; /* like lrmarker-container in redesign.css */
-  border-radius: 2px; /* like Ant a-input; was 5px in lrmarker-container in redesign.css */
+  background-color: #dff;
+  border: 1px solid #0ff;
+  border-radius: 2px; /* like Ant a-input */
 }
 
 .eyeIcon {

--- a/tools/cldr-apps/js/src/views/AddValueCharMenu.vue
+++ b/tools/cldr-apps/js/src/views/AddValueCharMenu.vue
@@ -96,7 +96,7 @@ function populateCharMenu() {
         // info.char, info.shortName, info.description
         // Generally name is shorter than shortName
         const codePoint = cldrChar.firstCodePoint(info.char);
-        const hover = makeHover(name, codePoint, info);
+        const hover = cldrAddValue.tagTooltip(info.char);
         const item = {
           codePoint: codePoint,
           label: name,
@@ -107,11 +107,6 @@ function populateCharMenu() {
     }
     menuOptions.value = options;
   }
-}
-
-function makeHover(name, codePoint, info) {
-  const usv = cldrChar.uPlus(codePoint);
-  return name + " = " + info.shortName + " " + usv + ": " + info.description;
 }
 
 function handleChange(codePoint) {

--- a/tools/cldr-apps/js/src/views/AddValueTags.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTags.vue
@@ -12,12 +12,8 @@
           ref="addValueCharMenuRef"
         />
       </template>
-      <template v-if="tagIsClickable(tag)">
-        <a-tag
-          @click="handleClickTag($event, index)"
-          class="regular-tag"
-          :id="makeTagId(index)"
-        >
+      <template v-if="shouldDisplayAsTag(tag)">
+        <a-tag @click="handleClickTag($event, index)" class="regular-tag">
           <a-tooltip>
             <template #title> {{ tagTooltip(tag) }} </template>
             {{ displayTag(tag) }}
@@ -34,16 +30,10 @@ import { onMounted, ref } from "vue";
 
 import * as cldrAddValue from "../esm/cldrAddValue.mjs";
 import * as cldrChar from "../esm/cldrChar.mjs";
-import * as cldrEscaper from "../esm/cldrEscaper.mjs";
 
 import AddValueCharMenu from "./AddValueCharMenu.vue";
 
 const DEBUG = false;
-
-/**
- * Should ASCII space (U+0020) be displayed as a tag?
- */
-const SPACES_HAVE_TAGS = false;
 
 const props = defineProps({
   modelValue: String,
@@ -68,44 +58,16 @@ function updateParent() {
   emit("update:modelValue", cldrAddValue.convertTagsToText(tagArray.value));
 }
 
-function makeTagId(index) {
-  return "cldr-tag-" + index;
-}
-
-function tagIsClickable(tag) {
-  const c = cldrChar.firstChar(tag);
-  if (SPACES_HAVE_TAGS) {
-    return cldrChar.isSpecial(c);
-  } else {
-    return c !== " " && cldrChar.isSpecial(c);
-  }
+function shouldDisplayAsTag(tag) {
+  return cldrAddValue.shouldDisplayAsTag(tag);
 }
 
 function displayTag(tag) {
-  const c = cldrChar.firstChar(tag);
-  const shortName = cldrEscaper.getShortName(c);
-  if (shortName) {
-    return shortName;
-  } else {
-    return tag;
-  }
+  return cldrAddValue.textForTag(tag);
 }
 
 function tagTooltip(tag) {
-  const c = cldrChar.firstChar(tag);
-  const info = cldrEscaper.getCharInfo(c);
-  const codePoint = cldrChar.firstCodePoint(tag);
-  const usv = cldrChar.uPlus(codePoint);
-  return (
-    info.name +
-    " = " +
-    info.shortName +
-    " " +
-    usv +
-    ": " +
-    info.description +
-    " Click to choose an alternative"
-  );
+  return cldrAddValue.tagTooltipPlusClick(tag);
 }
 
 function handleClickTag(event, index) {
@@ -151,8 +113,8 @@ function handleChooseCharacter() {
 
 <style scoped>
 .regular-tag {
-  margin: 1pt;
-  padding: 1pt;
+  margin: 1px;
+  padding: 1px;
 }
 
 /* Prevent the text to the right of the menu moving when the menu is opened */
@@ -161,7 +123,6 @@ function handleChooseCharacter() {
 }
 
 .tag-array {
-  /* Compare lrmarker-container in redesign.css; see also the surrounding style tag-area in AddValue.vue */
   font-weight: bold;
   color: black;
   margin: 1px;

--- a/tools/cldr-apps/js/src/views/AddValueTagsBasic.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTagsBasic.vue
@@ -12,6 +12,7 @@
 <script setup>
 import { onMounted, ref } from "vue";
 
+import * as cldrAddValue from "../esm/cldrAddValue.mjs";
 import * as cldrChar from "../esm/cldrChar.mjs";
 
 const DEBUG = false;
@@ -29,8 +30,7 @@ function mounted() {
 const tagArray = ref([]);
 
 function convertTextToTags(text) {
-  // Currently each character becomes a tag.
-  // In the future some sequences of characters might be combined into single tags.
+  // Each character becomes a tag (in this "basic" version)
   const tags = cldrChar.split(text);
   tagArray.value = tags;
   if (DEBUG) {
@@ -39,18 +39,11 @@ function convertTextToTags(text) {
 }
 
 function displayTag(tag) {
-  const c = cldrChar.firstChar(tag);
-  const shortName = cldrEscaper.getShortName(c);
-  if (shortName) {
-    return shortName;
-  } else {
-    return tag;
-  }
+  return cldrAddValue.textForTag(tag);
 }
 
 function tagTooltip(tag) {
-  const codePoint = cldrChar.firstCodePoint(tag);
-  return cldrChar.uPlus(codePoint) + " " + cldrChar.name(codePoint);
+  return cldrAddValue.tagTooltip(tag);
 }
 </script>
 

--- a/tools/cldr-apps/js/src/views/AddValueTagsEdit.vue
+++ b/tools/cldr-apps/js/src/views/AddValueTagsEdit.vue
@@ -56,6 +56,7 @@
 <script setup>
 import { onMounted, ref } from "vue";
 
+import * as cldrAddValue from "../esm/cldrAddValue.mjs";
 import * as cldrChar from "../esm/cldrChar.mjs";
 import * as cldrEscaper from "../esm/cldrEscaper.mjs";
 
@@ -133,8 +134,7 @@ function convertTagsToText() {
 }
 
 function convertTextToTags(text) {
-  // Currently each character becomes a tag.
-  // In the future some sequences of characters might be combined into single tags.
+  // Currently each character becomes a tag, in this "Edit" version.
   const tags = cldrChar.split(text);
   tags.push(END_TAG);
   tagArray.value = tags;
@@ -152,18 +152,11 @@ function processInput(s) {
 }
 
 function displayTag(tag) {
-  const c = cldrChar.firstChar(tag);
-  const shortName = cldrEscaper.getShortName(c);
-  if (shortName) {
-    return shortName;
-  } else {
-    return tag;
-  }
+  return cldrAddValue.textForTag(tag);
 }
 
 function tagTooltip(tag) {
-  const codePoint = cldrChar.firstCodePoint(tag);
-  return cldrChar.uPlus(codePoint) + " " + cldrChar.name(codePoint);
+  return cldrAddValue.tagTooltipPlusClick(tag);
 }
 
 const menuIsVisible = ref(false);

--- a/tools/cldr-apps/js/src/views/ValueTags.vue
+++ b/tools/cldr-apps/js/src/views/ValueTags.vue
@@ -1,0 +1,91 @@
+<!-- This is displayed in a cell (English/Winning/Others) of the main vetting table.
+    It resembles part of AddValueTags.vue, which is displayed in an Add-Value dialog box.
+    There are some style and user-interface differences between those two contexts, and
+    also similarities that should be preserved for consistency. -->
+<template>
+  <span class="tag-area" title="Special characters, click ⓘ for details.">
+    <span class="left-side">
+      <template v-for="(tag, index) in tagArray" :key="index">
+        <template v-if="shouldDisplayAsTag(tag)">
+          <a-tag class="regular-tag">
+            <a-tooltip>
+              <template #title> {{ tagTooltip(tag) }} </template>
+              {{ displayTag(tag) }}
+            </a-tooltip>
+          </a-tag>
+        </template>
+        <template v-else> {{ tag }} </template>
+      </template>
+    </span>
+    <span class="right-side">
+      <a
+        href="https://cldr.unicode.org/translation/getting-started/guide#special-characters"
+        >ⓘ</a
+      >
+    </span>
+  </span>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+import * as cldrAddValue from "../esm/cldrAddValue.mjs";
+
+const tagArray = ref([]);
+
+function setValue(s) {
+  tagArray.value = cldrAddValue.convertTextToTags(s);
+}
+
+function shouldDisplayAsTag(tag) {
+  return cldrAddValue.shouldDisplayAsTag(tag);
+}
+
+function displayTag(tag) {
+  return cldrAddValue.textForTag(tag);
+}
+
+function tagTooltip(tag) {
+  return cldrAddValue.tagTooltip(tag);
+}
+
+defineExpose({
+  setValue,
+});
+</script>
+
+<style scoped>
+.regular-tag {
+  margin: 0 1px; /* top right (bottom left) */
+  padding: 0 1px;
+}
+
+.tag-area {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 1px;
+  padding: 1px;
+  background-color: #dff;
+  border: 1px solid #0ff;
+  border-radius: 2px; /* like Ant a-input */
+  font-weight: bold;
+}
+
+/* Make the ⓘ (right side) right-justified by adding this style to the left side */
+.left-side {
+  flex-grow: 1;
+}
+
+.right-side {
+  color: black;
+}
+
+/* Make the ⓘ (right side) more salient when hovering on the tag area, less salient otherwise */
+.tag-area:hover > .right-side {
+  opacity: 1;
+}
+
+.tag-area > .right-side {
+  opacity: 0.1;
+}
+</style>

--- a/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
+++ b/tools/cldr-apps/js/test/nonbrowser/test-cldrEscaper.mjs
@@ -29,30 +29,15 @@ describe("cldrEscaper test", function () {
       });
     }
   });
-  describe("Escaping Test", () => {
-    const VISIBLE_MARK = /class="visible-mark"/g;
-    it(`Should return undefined for a non-escapable str`, () => {
-      expect(cldrEscaper.getEscapedHtml(`dd/MM/y`)).to.not.be.ok;
+  describe("getMapByName Test", () => {
+    const map = cldrEscaper.getMapByName();
+    it(`Should exist`, () => {
+      expect(map).to.be.ok;
     });
-    it(`Should return HTML for an escapable str`, () => {
-      const html = cldrEscaper.getEscapedHtml(`dd‏/MM‏/y`); // U+200F / U+200F here
-      expect(html).to.be.ok;
-      expect(html).to.contain('class="visible-mark"');
-      expect(html).to.contain("RLM");
-      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(
-        2,
-        "number of escapes"
-      );
-    });
-    it(`Should return hex for a unknown str`, () => {
-      const html = cldrEscaper.getEscapedHtml(`\uFFF0`); // U+200F / U+200F here
-      expect(html).to.be.ok;
-      expect(html).to.contain('class="visible-mark"');
-      expect(html).to.contain("U+FFF0");
-      expect(Array.from(html.matchAll(VISIBLE_MARK)).length).to.equal(
-        1,
-        "number of escapes"
-      );
+    it(`Should map RLM to 200f`, () => {
+      const rlm = map["RLM"]; // "\u200f"
+      expect(rlm).to.be.ok;
+      expect(rlm.char).to.equal("\u200f");
     });
   });
 });

--- a/tools/cldr-apps/src/main/webapp/css/redesign.css
+++ b/tools/cldr-apps/src/main/webapp/css/redesign.css
@@ -227,57 +227,11 @@ h3.collapse-review > span:first-child {position: relative; top: -220px;display: 
 .data label {
 	cursor:pointer;
 }
-.data .lrmarker-container{
-	margin-top: 5px;
-	font-weight: bold;
-	color: black;
-	border-collapse: separate;
-	background-color: #DFF;
-	display: inline-block;
-	margin: 1px;
-	padding: 1px;
-	border-radius: 5px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	display: flex;
-	border: 1px solid #0FF;
-}
-.data .visible-mark{
-	background-color: #d9edf7;
-	border-color: #bce8f1;
-	color: #666666;
-	margin: 0 2.5px;
-	font-size: small;
-}
-.data .visible-mark:hover{
-	color: #d9edf7;
-	background-color: #666666;
-}
-.lrmarker-container > .lrmarker-text {
-	flex-grow: 1;
-
-}
-.lrmarker-container .visible-mark{
-	flex-grow: 0;
-}
-.lrmarker-container > .hiddenMoreInfo {
-	opacity: .1;
-}
-.lrmarker-container:hover > .hiddenMoreInfo {
-	opacity: 1;
-}
-.hiddenMoreInfo{
-	color: black;
-}
 
 .data .subSpan {
 	margin-left:9px;
 	position:relative;
 	top:2px;
-}
-
-.help-comment {
-	margin-left:4px;
 }
 
 .table-vote {


### PR DESCRIPTION
-Display special characters in main table similar to the Add Value dialog

-New ValueTags.vue, similar to AddValueTags.vue but read-only, ⓘ, other differences

-Move shared code to cldrAddValue.mjs

-Remove obsolete code

CLDR-19353

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
