### PR TITLE
CLDR-19096 Remove Samoan time zone names

### DIFF
--- a/common/main/ab.xml
+++ b/common/main/ab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3057,9 +3057,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">Апиа</generic>
 					<standard draft="unconfirmed">Апиа, астандартә аамҭа</standard>
-					<daylight draft="unconfirmed">Апиа, аԥхынтәи аамҭа</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -4014,9 +4014,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia-tyd</generic>
 					<standard>Apia-standaardtyd</standard>
-					<daylight>Apia-dagligtyd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ak.xml
+++ b/common/main/ak.xml
@@ -3514,9 +3514,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia Berɛ</generic>
 					<standard>Apia Susudua Berɛ</standard>
-					<daylight>Apia Awia Berɛ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -5011,9 +5011,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>የአፒያ ሰዓት</generic>
 					<standard>የአፒያ መደበኛ ሰዓት</standard>
-					<daylight>የአፒያ የቀን ጊዜ ሰዓት</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -5039,9 +5039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>توقيت آبيا</generic>
 					<standard>التوقيت الرسمي لآبيا</standard>
-					<daylight>التوقيت الصيفي لأبيا</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -3939,9 +3939,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>আপিয়াৰ সময়</generic>
 					<standard>আপিয়াৰ মান সময়</standard>
-					<daylight>আপিয়াৰ ডেলাইট সময়</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ast.xml
+++ b/common/main/ast.xml
@@ -5667,9 +5667,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Hora d’Apia</generic>
 					<standard>Hora estándar d’Apia</standard>
-					<daylight>Hora braniega d’Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -4365,9 +4365,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia Vaxtı</generic>
 					<standard>Apia Standart Vaxtı</standard>
-					<daylight>Apia Yay Vaxtı</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ba.xml
+++ b/common/main/ba.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4788,9 +4788,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Самоа ваҡыты</generic>
 					<standard>Самоа стандарт ваҡыты</standard>
-					<daylight>Самоа йәйге ваҡыты</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/bal_Latn.xml
+++ b/common/main/bal_Latn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4813,9 +4813,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apiáay wahd</generic>
 					<standard>Apiáay anjári wahd</standard>
-					<daylight>Apiáay róchi wahd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -4333,9 +4333,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Час Апіі</generic>
 					<standard>Стандартны час Апіі</standard>
-					<daylight>Летні час Апіі</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/be_TARASK.xml
+++ b/common/main/be_TARASK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3891,9 +3891,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="provisional">↑↑↑</generic>
 					<standard draft="provisional">Змоўчны час Апіі</standard>
-					<daylight draft="provisional">↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/bew.xml
+++ b/common/main/bew.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3983,9 +3983,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">Waktu Apia</generic>
 					<standard draft="unconfirmed">Waktu Pakem Apia</standard>
-					<daylight draft="unconfirmed">Waktu Musim Pentèr Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -4321,9 +4321,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апия</generic>
 					<standard>Апия – стандартно време</standard>
-					<daylight>Апия – лятно часово време</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/blo.xml
+++ b/common/main/blo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3176,9 +3176,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Samowa kaakɔŋkɔŋɔ̀</generic>
 					<standard>Samowa kaakɔŋkɔŋɔ̀ ɖeiɖei</standard>
-					<daylight>Samowa kaakɔŋkɔŋɔ̀ gafʊbaka</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -5269,9 +5269,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>অপিয়া সময়</generic>
 					<standard>অপিয়া মানক সময়</standard>
-					<daylight>অপিয়া দিনের সময়</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/br.xml
+++ b/common/main/br.xml
@@ -7838,9 +7838,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>eur Samoa</generic>
 					<standard>eur cʼhoañv Samoa</standard>
-					<daylight>eur hañv Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/brx.xml
+++ b/common/main/brx.xml
@@ -4021,9 +4021,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>आपिया सम</generic>
 					<standard>आपिया थाखोआरि सम</standard>
-					<daylight>आपिया सान सम</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -9467,9 +9467,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apijsko vrijeme</generic>
 					<standard>Apijsko standardno vrijeme</standard>
-					<daylight>Apijsko ljetno vrijeme</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/bs_Cyrl.xml
+++ b/common/main/bs_Cyrl.xml
@@ -4500,9 +4500,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апија вријеме</generic>
 					<standard>Апија стандардно вријеме</standard>
-					<daylight>Апија љетње рачунање времена</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -4879,9 +4879,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Hora d’Apia</generic>
 					<standard>Hora estàndard d’Apia</standard>
-					<daylight>Hora d’estiu d’Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ccp.xml
+++ b/common/main/ccp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3887,9 +3887,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>𑄃𑄧𑄛𑄨𑄠 𑄃𑄧𑄇𑄴𑄖𑄧</generic>
 					<standard>𑄃𑄧𑄛𑄨𑄠 𑄟𑄚𑄧𑄇𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</standard>
-					<daylight>𑄃𑄧𑄛𑄨𑄠 𑄘𑄨𑄚𑄮𑄢𑄴 𑄃𑄧𑄇𑄴𑄖𑄧</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ce.xml
+++ b/common/main/ce.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2904,9 +2904,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>хан Апиа, Самоа</generic>
 					<standard>стандартан хан Апиа, Самоа</standard>
-					<daylight>аьхкенан хан Апиа, Самоа</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ceb.xml
+++ b/common/main/ceb.xml
@@ -2709,9 +2709,7 @@ the LDML specification (http://unicode.org/reports/tr35/)
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Oras sa Apia</generic>
 					<standard>Samoa Standard Time</standard>
-					<daylight>Samoa Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3871,9 +3871,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ᎠᏈᎠ ᎠᏟᎢᎵᏒ</generic>
 					<standard>ᎠᏈᎠ ᎠᏟᎶᏍᏗ ᎠᏟᎢᎵᏒ</standard>
-					<daylight>ᎠᏈᎠ ᎪᎯ ᎢᎦ ᎠᏟᎢᎵᏒ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/cop.xml
+++ b/common/main/cop.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2755,9 +2755,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ⲥⲁⲙⲟⲁ</generic>
 					<standard draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ϩⲟⲣⲟⲥ ⲛ̀ⲥⲁⲙⲟⲁ</standard>
-					<daylight draft="unconfirmed">ⲡ̀ⲥⲏⲟⲩ ⲛ̀ⲧⲟⲟⲩⲓ ⲛ̀ⲥⲁⲙⲟⲁ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -8413,9 +8413,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>apijský čas</generic>
 					<standard>apijský standardní čas</standard>
-					<daylight>apijský letní čas</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -9323,9 +9323,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апиа вӑхӑчӗ</generic>
 					<standard>Апиа стандартлӑ вӑхӑчӗ</standard>
-					<daylight>Апиа ҫуллахи вӑхӑчӗ</daylight>
 				</long>
 				<short>
 					<generic draft="contributed">SST Samoa Apia</generic>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -4447,9 +4447,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Amser Apia</generic>
 					<standard>Amser Safonol Apia</standard>
-					<daylight>Amser Haf Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -4574,9 +4574,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia-tid</generic>
 					<standard>Apia-normaltid</standard>
-					<daylight>Apia-sommertid</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -5593,9 +5593,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia-Zeit</generic>
 					<standard>Apia-Normalzeit</standard>
-					<daylight>Apia-Sommerzeit</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -4118,9 +4118,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3770,9 +3770,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apiaski cas</generic>
 					<standard>Apiaski standardny cas</standard>
-					<daylight>Apiaski lěśojski cas</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ee.xml
+++ b/common/main/ee.xml
@@ -3672,9 +3672,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia gaƒoƒo me</generic>
 					<standard>Apia nutome gaƒoƒo me</standard>
-					<daylight>Apia kele gaƒoƒo me</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -4945,9 +4945,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ώρα Απία</generic>
 					<standard>Χειμερινή ώρα Απία</standard>
-					<daylight>Θερινή ώρα Απία</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -4918,9 +4918,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -4722,9 +4722,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -5375,9 +5375,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -4707,9 +4707,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3859,9 +3859,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>samoa tempo</generic>
 					<standard>samoa norma tempo</standard>
-					<daylight>samoa somera tempo</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -5039,9 +5039,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>hora de Apia</generic>
 					<standard>hora estándar de Apia</standard>
-					<daylight>horario de verano de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -4426,9 +4426,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -4068,9 +4068,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>hora de verano de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -4120,9 +4120,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>hora de verano de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -4534,9 +4534,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia aeg</generic>
 					<standard>Apia standardaeg</standard>
-					<daylight>Apia suveaeg</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -9297,9 +9297,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apiako ordua</generic>
 					<standard>Apiako ordu estandarra</standard>
-					<daylight>Apiako udako ordua</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -5350,9 +5350,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>وقت آپیا</generic>
 					<standard>وقت عادی آپیا</standard>
-					<daylight>وقت تابستانی آپیا</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ff_Adlm.xml
+++ b/common/main/ff_Adlm.xml
@@ -8741,9 +8741,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤀𞥄𞤨𞤭𞤴𞤢</generic>
 					<standard>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤖𞤢𞤱𞤪𞤵𞤲𞥋𞤣𞤫 𞤀𞥄𞤨𞤭𞤴𞤢</standard>
-					<daylight>𞤑𞤭𞤶𞤮𞥅𞤪𞤫 𞤕𞤫𞥅𞤯𞤵 𞤀𞥄𞤨𞤭𞤴𞤢</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -5304,9 +5304,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apian aika</generic>
 					<standard>Apian normaaliaika</standard>
-					<daylight>Apian kesäaika</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -6125,9 +6125,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Oras sa Apia</generic>
 					<standard>Standard na Oras sa Apia</standard>
-					<daylight>Daylight Time sa Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/fo.xml
+++ b/common/main/fo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3986,9 +3986,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia tíð</generic>
 					<standard>Apia vanlig tíð</standard>
-					<daylight>Apia summartíð</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -6230,9 +6230,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>heure d’Apia</generic>
 					<standard>heure normale d’Apia</standard>
-					<daylight>heure d’été d’Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -5001,9 +5001,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>heure avancée d’Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3750,9 +3750,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">Samoa Tidj</generic>
 					<standard draft="unconfirmed">Samoa Standard Tidj</standard>
-					<daylight draft="unconfirmed">Samoa Somertidj</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/fy.xml
+++ b/common/main/fy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -5030,9 +5030,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">Apia-tiid</generic>
 					<standard draft="unconfirmed">Apia-standerttiid</standard>
-					<daylight draft="unconfirmed">Apia-simmertiid</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -4669,9 +4669,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Am Shamó</generic>
 					<standard>Am Caighdeánach Shamó</standard>
-					<daylight>Am Samhraidh Shamó</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -5936,9 +5936,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Àm Apia</generic>
 					<standard>Bun-àm Apia</standard>
-					<daylight>Tìde samhraidh Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -4005,9 +4005,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>hora de Apia</generic>
 					<standard>hora estándar de Apia</standard>
-					<daylight>hora de verán de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -4851,9 +4851,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>એપિયા સમય</generic>
 					<standard>એપિયા માનક સમય</standard>
-					<daylight>એપિયા દિવસ સમય</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -3991,9 +3991,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Lokacin Apia</generic>
 					<standard>Tsayayyen Lokacin Apia</standard>
-					<daylight>Lokacin Rana na Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3988,9 +3988,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Lokacin Apia</generic>
 					<standard>Tsayayyen Lokacin Apia</standard>
-					<daylight>Lokacin Rana na Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -6003,9 +6003,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>שעון אפיה</generic>
 					<standard>שעון אפיה (חורף)</standard>
-					<daylight>שעון אפיה (קיץ)</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -4695,9 +4695,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>एपिआ समय</generic>
 					<standard>एपिआ मानक समय</standard>
-					<daylight>एपिआ डेलाइट समय</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -4595,9 +4595,7 @@ annotations.
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -4951,9 +4951,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>vrijeme Apije</generic>
 					<standard>standardno vrijeme Apije</standard>
-					<daylight>ljetno vrijeme Apije</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4010,9 +4010,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apiaski čas</generic>
 					<standard>Apiaski standardny čas</standard>
-					<daylight>Apiaski lětni čas</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -4911,9 +4911,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>apiai idő</generic>
 					<standard>apiai téli idő</standard>
-					<daylight>apiai nyári idő</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -3991,9 +3991,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ապիայի ժամանակ</generic>
 					<standard>Ապիայի ստանդարտ ժամանակ</standard>
-					<daylight>Ապիայի ամառային ժամանակ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ia.xml
+++ b/common/main/ia.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3840,9 +3840,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>hora de Samoa</generic>
 					<standard>hora normal de Samoa</standard>
-					<daylight>hora estive de Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -6026,9 +6026,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Waktu Apia</generic>
 					<standard>Waktu Standar Apia</standard>
-					<daylight>Waktu Musim Panas Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -3961,9 +3961,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Oge Apia</generic>
 					<standard>Oge Izugbe Apia</standard>
-					<daylight>Oge Ihe Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -6507,9 +6507,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Tími í Apía</generic>
 					<standard>Staðaltími í Apía</standard>
-					<daylight>Sumartími í Apía</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -4476,9 +4476,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ora di Apia</generic>
 					<standard>Ora standard di Apia</standard>
-					<daylight>Ora legale di Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -5979,9 +5979,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>サモア時間</generic>
 					<standard>サモア標準時</standard>
-					<daylight>サモア夏時間</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -3888,9 +3888,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Wektu Apia</generic>
 					<standard>Wektu Standar Samoa</standard>
-					<daylight>Wektu Ketiga Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -4460,9 +4460,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>აპიას დრო</generic>
 					<standard>აპიას სტანდარტული დრო</standard>
-					<daylight>აპიას ზაფხულის დრო</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kab.xml
+++ b/common/main/kab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3870,9 +3870,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">Akud n Apya</generic>
 					<standard draft="unconfirmed">Akud amezday n Apya</standard>
-					<daylight draft="unconfirmed">Akud n unebdu n Apya</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kgp.xml
+++ b/common/main/kgp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4239,9 +4239,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Óra Apija tá</generic>
 					<standard>Óra Pã Apija tá</standard>
-					<daylight>Rỹ Kã óra Apija tá</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -5090,9 +5090,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апиа уақыты</generic>
 					<standard>Апиа стандартты уақыты</standard>
-					<daylight>Апиа жазғы уақыты</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kk_Arab.xml
+++ b/common/main/kk_Arab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4471,9 +4471,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>اپيا ۋاقىتى</generic>
 					<standard>اپيا ستاندارتتى ۋاقىتى</standard>
-					<daylight>اپيا جازعى ۋاقىتى</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -3879,9 +3879,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ម៉ោង​នៅ​អាប្យា</generic>
 					<standard>ម៉ោង​ស្តង់ដា​នៅ​អាប្យា</standard>
-					<daylight>ម៉ោង​ពេល​ថ្ងៃ​នៅ​អាប្យា</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -4861,9 +4861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ಅಪಿಯಾ ಸಮಯ</generic>
 					<standard>ಅಪಿಯಾ ಪ್ರಮಾಣಿತ ಸಮಯ</standard>
-					<daylight>ಅಪಿಯಾ ಹಗಲು ಸಮಯ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -5546,9 +5546,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>아피아 시간</generic>
 					<standard>아피아 표준시</standard>
-					<daylight>아피아 하계 표준시</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -4013,9 +4013,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>अपिया वेळ</generic>
 					<standard>अपिया प्रमाणित वेळ</standard>
-					<daylight>अपिया डेलायट वेळ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ku.xml
+++ b/common/main/ku.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -7659,9 +7659,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Saeta Apiayê</generic>
 					<standard>Saeta Apiayê ya Standard</standard>
-					<daylight>Saeta Havînê ya Apiayê</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/kxv.xml
+++ b/common/main/kxv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2544,9 +2544,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>epiā belā</generic>
 					<standard>epiā mānānka belā</standard>
-					<daylight>epiā delāit belā</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kxv_Deva.xml
+++ b/common/main/kxv_Deva.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2431,9 +2431,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>एपिआ बेला</generic>
 					<standard>एपिआ मानांकॉ बेला</standard>
-					<daylight>एपिआ डेलाइट बेला</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kxv_Orya.xml
+++ b/common/main/kxv_Orya.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2433,9 +2433,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ଏପିଆ ବେଲା</generic>
 					<standard>ଏପିଆ ମାନାଙ୍କ ବେଲା</standard>
-					<daylight>ଏପିଆ ଡେଲାଇଟ୍ ବେଲା</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/kxv_Telu.xml
+++ b/common/main/kxv_Telu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2407,9 +2407,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ఏపియా సమయం</generic>
 					<standard>ఏపియా ప్రామాణిక సమయం</standard>
-					<daylight>ఏపియా పగటి సమయం</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -3930,9 +3930,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апиа убактысы</generic>
 					<standard>Апиа кышкы убактысы</standard>
-					<daylight>Апиа жайкы убактысы</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/lij.xml
+++ b/common/main/lij.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3757,9 +3757,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">oa de Apia</generic>
 					<standard draft="unconfirmed">oa standard de Apia</standard>
-					<daylight draft="unconfirmed">oa de stæ de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/lld.xml
+++ b/common/main/lld.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3294,9 +3294,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ora de Apia</generic>
 					<standard>Ora standard de Apia</standard>
-					<daylight>Ora da d’isté de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -5005,9 +5005,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ເວລາເອເພຍ</generic>
 					<standard>ເວລາມາດຕະຖານເອເພຍ</standard>
-					<daylight>ເວລາກາງເວັນອາເພຍ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -6049,9 +6049,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apijos laikas</generic>
 					<standard>Apijos žiemos laikas</standard>
-					<daylight>Apijos vasaros laikas</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -4685,9 +4685,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apijas laiks</generic>
 					<standard>Apijas ziemas laiks</standard>
-					<daylight>Apijas vasaras laiks</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/mi.xml
+++ b/common/main/mi.xml
@@ -3669,9 +3669,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Wā Āpia</generic>
 					<standard>Wā Āpia Arowhānui</standard>
-					<daylight>Wā Āpia Awatea</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -5497,9 +5497,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Време во Апија</generic>
 					<standard>Стандардно време во Апија</standard>
-					<daylight>Летно време во Апија</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -5621,9 +5621,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>അപിയ സമയം</generic>
 					<standard>അപിയ സ്റ്റാൻഡേർഡ് സമയം</standard>
-					<daylight>അപിയ ഡേലൈറ്റ് സമയം</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -4462,9 +4462,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апиагийн цаг</generic>
 					<standard>Апиагийн стандарт цаг</standard>
-					<daylight>Апиагийн зуны цаг</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -4861,9 +4861,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>एपिया वेळ</generic>
 					<standard>एपिया प्रमाण वेळ</standard>
-					<daylight>एपिया सूर्यप्रकाश वेळ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -5830,9 +5830,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Waktu Apia</generic>
 					<standard>Waktu Piawai Apia</standard>
-					<daylight>Waktu Siang Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -3871,9 +3871,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>အပီယာ အချိန်</generic>
 					<standard>အပီယာ စံတော်ချိန်</standard>
-					<daylight>အပီယာ နွေရာသီ အချိန်</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -4366,9 +4366,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>आपिया समय</generic>
 					<standard>आपिया मानक समय</standard>
-					<daylight>आपिया दिवा समय</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -9520,9 +9520,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia-tijd</generic>
 					<standard>Apia-standaardtijd</standard>
-					<daylight>Apia-zomertijd</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -4955,9 +4955,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>sommartid for Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -8590,9 +8590,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>tidssone for Apia</generic>
 					<standard>normaltid for Apia</standard>
-					<daylight>sommertid for Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/nqo.xml
+++ b/common/main/nqo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2600,9 +2600,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ߊߔߌߦߊ߫ ߕߎ߬ߡߊ߬ߘߊ</generic>
 					<standard>ߊߔߌߦߊ߫ ߕߎ߬ߡߘߊ߬ ߛߎߡߊ߲ߘߊ߲ߕߊ</standard>
-					<daylight>ߊߔߌߦߊ߫ ߕߟߋ߬ߡߊ߬ ߕߎ߬ߡߘߊ߬ ߛߎߡߊ߲ߘߊ߲ߕߊ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/oc.xml
+++ b/common/main/oc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3022,9 +3022,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">ora d’Apia</generic>
 					<standard draft="unconfirmed">ora estandard d’Apia</standard>
-					<daylight draft="unconfirmed">ora d’esiu d’Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/oc_ES.xml
+++ b/common/main/oc_ES.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2731,9 +2731,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">↑↑↑</generic>
 					<standard draft="unconfirmed">↑↑↑</standard>
-					<daylight draft="unconfirmed">↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/om.xml
+++ b/common/main/om.xml
@@ -3395,9 +3395,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Sa’aatii Apia</generic>
 					<standard>Sa’aatii Istaandaardii Apia</standard>
-					<daylight>Sa’aatii Guyyaa Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -4162,9 +4162,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ଆପିଆ ସମୟ</generic>
 					<standard>ଆପିଆ ମାନାଙ୍କ ସମୟ</standard>
-					<daylight>ଆପିଆ ଦିବାଲୋକ ସମୟ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -4712,9 +4712,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ਐਪੀਆ ਵੇਲਾ</generic>
 					<standard>ਐਪੀਆ ਮਿਆਰੀ ਵੇਲਾ</standard>
-					<daylight>ਐਪੀਆ ਪ੍ਰਕਾਸ਼ ਵੇਲਾ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -3819,9 +3819,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ápia Taim</generic>
 					<standard>Ápia Fíksd Taim</standard>
-					<daylight>Ápia Délaít Taim</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -5077,9 +5077,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>czas Apia</generic>
 					<standard>Apia (czas standardowy)</standard>
-					<daylight>Apia (czas letni)</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -4204,9 +4204,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>اپیا وخت</generic>
 					<standard>اپیا معياري وخت</standard>
-					<daylight>اپيا د ورځې روښانه وخت</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ps_PK.xml
+++ b/common/main/ps_PK.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -160,11 +160,6 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<metazone type="America_Pacific">
 				<long>
 					<daylight>پیسفک د رڼا ورځے وخت</daylight>
-				</long>
-			</metazone>
-			<metazone type="Apia">
-				<long>
-					<daylight>د اپیا د ورځے وخت</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -5161,9 +5161,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Horário de Apia</generic>
 					<standard>Horário Padrão de Apia</standard>
-					<daylight>Horário de Verão de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -4427,9 +4427,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Hora de Samoa</generic>
 					<standard>Hora padrão de Samoa</standard>
-					<daylight>Hora de verão de Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -3740,9 +3740,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Hora de Apia</generic>
 					<standard>Hora Estandar de Apia</standard>
-					<daylight>Hora de Verano de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/rif.xml
+++ b/common/main/rif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -2809,9 +2809,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">akud n samwa</generic>
 					<standard draft="unconfirmed">akud anaway n samwa</standard>
-					<daylight draft="unconfirmed">akud n uzil n samwa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4115,9 +4115,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>temp da la Samoa</generic>
 					<standard>temp normal da la Samoa</standard>
-					<daylight>temp da stad da la Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -5600,9 +5600,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ora din Samoa</generic>
 					<standard>Ora standard din Samoa</standard>
-					<daylight>Ora de vară din Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -5336,9 +5336,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апиа</generic>
 					<standard>Апиа, стандартное время</standard>
-					<daylight>Апиа, летнее время</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -9334,9 +9334,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ora de Apia</generic>
 					<standard>Ora istandard de Apia</standard>
-					<daylight>Ora legale de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/scn.xml
+++ b/common/main/scn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3227,9 +3227,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ura di Samoa</generic>
 					<standard>Ura sulari di Samoa</standard>
-					<daylight>Ura ligali di Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -4276,9 +4276,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>اپيا جو وقت</generic>
 					<standard>اپيا جو معياري وقت</standard>
-					<daylight>اپيا جي ڏينهن جو وقت</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/se_FI.xml
+++ b/common/main/se_FI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1404,9 +1404,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia áigi</generic>
 					<standard>Apia dálveáigi</standard>
-					<daylight>Apia geasseáigi</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/shn.xml
+++ b/common/main/shn.xml
@@ -7439,9 +7439,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ၶၢဝ်းယၢမ်း သႃႇမူဝ်းဝႃႇ</generic>
 					<standard>လၵ်းၸဵင် ၶၢဝ်းယၢမ်း သႃႇမူဝ်းဝႃႇ</standard>
-					<daylight>ၶၢဝ်းယၢမ်း ၵၢင်ဝၼ်း သႃႇမူဝ်းဝႃႇ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -3939,9 +3939,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>අපියා වේලාව</generic>
 					<standard>අපියා සම්මත වේලාව</standard>
-					<daylight>අපියා දිවා වේලාව</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -4859,9 +4859,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>apijský čas</generic>
 					<standard>apijský štandardný čas</standard>
-					<daylight>apijský letný čas</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -5096,9 +5096,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Čas: Apia</generic>
 					<standard>Standardni čas: Apia</standard>
-					<daylight>Poletni čas: Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -7704,9 +7704,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Wakhtiga Samoa</generic>
 					<standard>Waqtiga Caadiga Ah ee Samoa</standard>
-					<daylight>Waqtiga Dharaarta ee Samoa</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -4291,9 +4291,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ora e Apias</generic>
 					<standard>Ora standarde e Apias</standard>
-					<daylight>Ora verore e Apias</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -4651,9 +4651,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апија време</generic>
 					<standard>Апија, стандардно време</standard>
-					<daylight>Апија, летње време</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sr_Cyrl_BA.xml
+++ b/common/main/sr_Cyrl_BA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4204,9 +4204,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апија вријеме</generic>
 					<standard>Апија, стандардно вријеме</standard>
-					<daylight>Апија, љетње вријеме</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -4650,9 +4650,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apija vreme</generic>
 					<standard>Apija, standardno vreme</standard>
-					<daylight>Apija, letnje vreme</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sr_Latn_BA.xml
+++ b/common/main/sr_Latn_BA.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4204,9 +4204,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apija vrijeme</generic>
 					<standard>Apija, standardno vrijeme</standard>
-					<daylight>Apija, ljetnje vrijeme</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -5644,9 +5644,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apiatid</generic>
 					<standard>Apia, normaltid</standard>
-					<daylight>Apia, sommartid</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -4019,9 +4019,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Saa za Apia</generic>
 					<standard>Saa za Wastani za Apia</standard>
-					<daylight>Saa za Mchana za Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/sw_KE.xml
+++ b/common/main/sw_KE.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3833,9 +3833,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/syr.xml
+++ b/common/main/syr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3462,9 +3462,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ܥܕܢܐ ܕܐܦܝܐ</generic>
 					<standard>ܥܕܢܐ ܡܫܘܚܬܢܝܬܐ ܕܐܦܝܐ</standard>
-					<daylight>ܥܕܢܐ ܕܒܗܪ ܝܘܡܐ ܕܐܦܝܐ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -4942,9 +4942,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ஏபியா நேரம்</generic>
 					<standard>ஏபியா நிலையான நேரம்</standard>
-					<daylight>ஏபியா பகலொளி நேரம்</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -4864,9 +4864,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>సమోవా సమయం</generic>
 					<standard>సమోవా ప్రామాణిక సమయం</standard>
-					<daylight>సమోవా పగటి వెలుతురు సమయం</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/tg.xml
+++ b/common/main/tg.xml
@@ -3655,9 +3655,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Вақти Апиа</generic>
 					<standard>Вақти стандартии Апиа</standard>
-					<daylight>Вақти рӯзонаи Апиа</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -5839,9 +5839,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>เวลาอาปีอา</generic>
 					<standard>เวลามาตรฐานอาปีอา</standard>
-					<daylight>เวลาออมแสงอาปีอา</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -4258,9 +4258,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ናይ አፒያ ግዘ</generic>
 					<standard>ናይ መደበኛ አፒያ ግዘ</standard>
-					<daylight>ናይ መዓልቲ አፒያ ግዘ</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -4057,9 +4057,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia wagty</generic>
 					<standard>Apia standart wagty</standard>
-					<daylight>Apia tomusky wagty</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/to.xml
+++ b/common/main/to.xml
@@ -4790,9 +4790,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>houa fakaapia</generic>
 					<standard>houa fakaapia taimi totonu</standard>
-					<daylight>houa fakaapia taimi liliu</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -4964,9 +4964,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia Saati</generic>
 					<standard>Apia Standart Saati</standard>
-					<daylight>Apia Yaz Saati</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/trw.xml
+++ b/common/main/trw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3047,9 +3047,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic draft="unconfirmed">ایپیا ٹائم</generic>
 					<standard draft="unconfirmed">ایپیا سٹینڈرڈ ٹائم</standard>
-					<daylight draft="unconfirmed">ایپیا ڈے لائٹ ٹائم</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -3505,9 +3505,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Апиа вакыты</generic>
 					<standard>Апиа стандарт вакыты</standard>
-					<daylight>Апиа җәйге вакыты</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -5060,9 +5060,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>за часом в Апіа</generic>
 					<standard>за стандартним часом в Апіа</standard>
-					<daylight>за літнім часом в Апіа</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -4591,9 +4591,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>ایپیا ٹائم</generic>
 					<standard>ایپیا سٹینڈرڈ ٹائم</standard>
-					<daylight>ایپیا ڈے لائٹ ٹائم</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -4138,9 +4138,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia vaqti</generic>
 					<standard>Apia standart vaqti</standard>
-					<daylight>Apia yozgi vaqti</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/vec.xml
+++ b/common/main/vec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3949,9 +3949,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Ora de Apia</generic>
 					<standard>Ora normale de Apia</standard>
-					<daylight>Ora d’istà de Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -6091,9 +6091,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Giờ Apia</generic>
 					<standard>Giờ Chuẩn Apia</standard>
-					<daylight>Giờ Mùa Hè Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/wo.xml
+++ b/common/main/wo.xml
@@ -3270,9 +3270,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Waxtu Apia</generic>
 					<standard>Waxtu buñ miin ci Apia</standard>
-					<daylight>Apia waxtu bëccëg</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/xh.xml
+++ b/common/main/xh.xml
@@ -3325,9 +3325,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apia Time</generic>
 					<standard>Apia Standard Time</standard>
-					<daylight>Apia Daylight Time</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/xnr.xml
+++ b/common/main/xnr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3509,9 +3509,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>एपिआ दा टैम</generic>
 					<standard>एपिआ दा मानक टैम</standard>
-					<daylight>एपिआ दे ध्याड़े दे उजाले दा टैम</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -3762,9 +3762,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Àkókò Apia</generic>
 					<standard>Àkókò Àfẹnukò Apia</standard>
-					<daylight>Àkókò Ojúmọmọ Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -3759,9 +3759,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Àkókò Apia</generic>
 					<standard>Àkókò Àfɛnukò Apia</standard>
-					<daylight>Àkókò Ojúmɔmɔ Apia</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/common/main/yrl.xml
+++ b/common/main/yrl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -4237,9 +4237,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Apiya Hurariyu</generic>
 					<standard>Apiya Uraruiyu Retewa</standard>
-					<daylight>Apiya Kurasí Ara Hurariyu</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -5809,9 +5809,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>阿皮亞時間</generic>
 					<standard>阿皮亞標準時間</standard>
-					<daylight>阿皮亞夏令時間</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -5806,9 +5806,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>阿皮亚时间</generic>
 					<standard>阿皮亚标准时间</standard>
-					<daylight>阿皮亚夏令时间</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -6855,9 +6855,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>阿皮亚时间</generic>
 					<standard>阿皮亚标准时间</standard>
-					<daylight>阿皮亚夏令时间</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -8812,9 +8812,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>阿皮亞時間</generic>
 					<standard>阿皮亞標準時間</standard>
-					<daylight>阿皮亞夏令時間</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -8851,9 +8851,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>↑↑↑</generic>
 					<standard>↑↑↑</standard>
-					<daylight>↑↑↑</daylight>
 				</long>
 			</metazone>
 			<metazone type="Aqtau">

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -4524,9 +4524,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			</metazone>
 			<metazone type="Apia">
 				<long>
-					<generic>Isikhathi sase-Apia</generic>
 					<standard>Isikhathi sase-Apia esivamile</standard>
-					<daylight>Isikhathi sase-Apia sasemini</daylight>
 				</long>
 			</metazone>
 			<metazone type="Arabian">

--- a/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
+++ b/tools/cldr-code/src/main/resources/org/unicode/cldr/tool/modify_config.txt
@@ -1,3 +1,3 @@
 #locale;	action	path	new_value
-locale=* ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Apia"]/long/standard
-locale=* ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Apia"]/long/daylight
+locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Apia"]/long/generic
+locale=/.*/ ; action=delete ; path=//ldml/dates/timeZoneNames/metazone[@type="Apia"]/long/daylight


### PR DESCRIPTION
-In all locales except en, remove metazone long/generic and long/daylight paths with type Apia

CLDR-19096

- [x] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
