### PR TITLE
CLDR-19421 reduce key types

### DIFF
--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -346,13 +346,24 @@ public class ExtraPaths {
 
                     final String typeKeyTypePath =
                             typeKeyPath + String.format("[@type=\"%s\"]", type);
-                    pathsTemp.add(typeKeyTypePath);
+                    // add unless skipped
+                    if (!skipNoncoreType(originalKey, t)) {
+                        pathsTemp.add(typeKeyTypePath);
+                    }
                     // add some of these with [@scope="core"]
                     if (!skipCoreType(k, t)) {
                         pathsTemp.add(typeKeyTypePath + SCOPE_CORE);
                     }
                 }
             }
+        }
+
+        static final Pattern MATCH_LOWERCASE_SCRIPT_CODE = PatternCache.get("^[a-z]{4}$");
+
+        private boolean skipNoncoreType(final String originalKey, String t) {
+            if (originalKey.equals("nu") && MATCH_LOWERCASE_SCRIPT_CODE.matcher(t).matches())
+                return true;
+            return skipNoncoreKeyType.contains(Pair.of(originalKey, t));
         }
 
         // skip these core 'keys' entirely from extraPaths - they are constructed
@@ -382,7 +393,31 @@ public class ExtraPaths {
                         "s0",
                         "t0");
 
-        static final Pattern MATCH_LOWERCASE_SCRIPT_CODE = PatternCache.get("^[a-z]{4}$");
+        @SuppressWarnings("null")
+        private static final Set<Pair<String, String>> skipNoncoreKeyType =
+                ImmutableSet.of(
+                        Pair.of("d0", "ascii"),
+                        Pair.of("d0", "lower"),
+                        Pair.of("d0", "title"),
+                        Pair.of("d0", "upper"),
+                        Pair.of("em", "default"),
+                        Pair.of("em", "emoji"),
+                        Pair.of("em", "text"),
+                        Pair.of("fw", "fri"),
+                        Pair.of("fw", "mon"),
+                        Pair.of("fw", "sat"),
+                        Pair.of("fw", "sun"),
+                        Pair.of("fw", "thu"),
+                        Pair.of("fw", "tue"),
+                        Pair.of("fw", "wed"),
+                        Pair.of("lw", "breakall"),
+                        Pair.of("lw", "keepall"),
+                        Pair.of("lw", "normal"),
+                        Pair.of("lw", "phrase"),
+                        Pair.of("m0", "prprname"),
+                        // plus numbers w/ any simple script id
+                        Pair.of("ss", "none"),
+                        Pair.of("ss", "standard"));
 
         private static final boolean skipCoreType(final String k, String t) {
             // always skip these

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/util/ExtraPaths.java
@@ -361,8 +361,9 @@ public class ExtraPaths {
         static final Pattern MATCH_LOWERCASE_SCRIPT_CODE = PatternCache.get("^[a-z]{4}$");
 
         private boolean skipNoncoreType(final String originalKey, String t) {
-            if (originalKey.equals("nu") && MATCH_LOWERCASE_SCRIPT_CODE.matcher(t).matches())
+            if (originalKey.equals("nu") && MATCH_LOWERCASE_SCRIPT_CODE.matcher(t).matches()) {
                 return true;
+            }
             return skipNoncoreKeyType.contains(Pair.of(originalKey, t));
         }
 

--- a/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
+++ b/tools/cldr-code/src/test/java/org/unicode/cldr/util/TestExtraPaths.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.unicode.cldr.icu.LDMLConstants;
@@ -169,13 +170,14 @@ public class TestExtraPaths {
         final Set<String> paths = getExtraPathsFor(localeId);
         final Set<String> missing = new TreeSet<>();
         final CLDRFile f = CLDRConfig.getInstance().getCLDRFile(localeId, true);
-        // Relation<R2<String,String>,String> aliases =
-        // CLDRConfig.getInstance().getSupplementalDataInfo().getBcp47Aliases();
+        // skip these
+        final Pattern skipNumbers =
+                Pattern.compile("^.*\\[@key=\"numbers\"\\]\\[@type=\"[a-z]{4}\"\\]$");
         for (Iterator<String> i =
                         f.iteratorWithoutExtras("//ldml/localeDisplayNames/types/type", null);
                 i.hasNext(); ) {
             final String path = i.next();
-            if (!paths.contains(path)) {
+            if (!paths.contains(path) && !skipNumbers.matcher(path).matches()) {
                 missing.add(path);
             }
         }


### PR DESCRIPTION
CLDR-19421
- Removes items from ExtraPaths as requested.
- Note that numbers/thai (noncore) for example are in en, so will show up. 

- [X] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

<img width="1077" height="527" alt="image" src="https://github.com/user-attachments/assets/fc1ff1a2-2189-4a88-b083-34a20927090b" />


ALLOW_MANY_COMMITS=true
