### PR TITLE
CLDR-19394 on/off: copy from "ss", also improve CLDRModify

### DIFF
--- a/common/main/af.xml
+++ b/common/main/af.xml
@@ -1071,6 +1071,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Af</type>
 			<type key="ss" type="standard" scope="core">Aan</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Af</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Aan</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrieke stelsel</measurementSystemName>
 			<measurementSystemName type="UK">VK</measurementSystemName>

--- a/common/main/am.xml
+++ b/common/main/am.xml
@@ -1124,6 +1124,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ጠፍቷል</type>
 			<type key="ss" type="standard" scope="core">በርቷል</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ጠፍቷል</typeValue>
+			<typeValue type="yes" draft="unconfirmed">በርቷል</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ሜትሪክ</measurementSystemName>
 			<measurementSystemName type="UK">ዩኬ</measurementSystemName>

--- a/common/main/ar.xml
+++ b/common/main/ar.xml
@@ -1267,6 +1267,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">غير مفعّل</type>
 			<type key="ss" type="standard" scope="core">مفعّل</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">غير مفعّل</typeValue>
+			<typeValue type="yes" draft="unconfirmed">مفعّل</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">النظام المتري</measurementSystemName>
 			<measurementSystemName type="UK">النظام البريطاني</measurementSystemName>

--- a/common/main/as.xml
+++ b/common/main/as.xml
@@ -995,6 +995,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ঃ</type>
 			<type key="ss" type="standard" scope="core">ঃ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ঃ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ঃ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">মেট্ৰিক</measurementSystemName>
 			<measurementSystemName type="UK">ইউ. কে.</measurementSystemName>

--- a/common/main/az.xml
+++ b/common/main/az.xml
@@ -1179,6 +1179,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Deaktiv</type>
 			<type key="ss" type="standard" scope="core">Aktiv</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Deaktiv</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Aktiv</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">Britaniya</measurementSystemName>

--- a/common/main/ba.xml
+++ b/common/main/ba.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1151,6 +1151,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">һүндерелгән</type>
 			<type key="ss" type="standard" scope="core">ҡабыҙылған</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">һүндерелгән</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ҡабыҙылған</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрик</measurementSystemName>
 			<measurementSystemName type="UK">Бөйөк Британия</measurementSystemName>

--- a/common/main/be.xml
+++ b/common/main/be.xml
@@ -1015,6 +1015,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">выключана</type>
 			<type key="ss" type="standard" scope="core">уключана</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">выключана</typeValue>
+			<typeValue type="yes" draft="unconfirmed">уключана</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрычная</measurementSystemName>
 			<measurementSystemName type="UK">брытанская</measurementSystemName>

--- a/common/main/bg.xml
+++ b/common/main/bg.xml
@@ -1260,6 +1260,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">изкл.</type>
 			<type key="ss" type="standard" scope="core">вкл.</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">изкл.</typeValue>
+			<typeValue type="yes" draft="unconfirmed">вкл.</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрична</measurementSystemName>
 			<measurementSystemName type="UK">имперска</measurementSystemName>

--- a/common/main/bn.xml
+++ b/common/main/bn.xml
@@ -1275,6 +1275,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">বন্ধ</type>
 			<type key="ss" type="standard" scope="core">চালু</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">বন্ধ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">চালু</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">মেট্রিক</measurementSystemName>
 			<measurementSystemName type="UK">ইউকে</measurementSystemName>

--- a/common/main/bs.xml
+++ b/common/main/bs.xml
@@ -1464,6 +1464,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Uključeno</type>
 			<type key="ss" type="standard" scope="core">Isključeno</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Uključeno</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Isključeno</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrički</measurementSystemName>
 			<measurementSystemName type="UK">britanski</measurementSystemName>

--- a/common/main/ca.xml
+++ b/common/main/ca.xml
@@ -1403,6 +1403,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">desactivada</type>
 			<type key="ss" type="standard" scope="core">activada</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">desactivada</typeValue>
+			<typeValue type="yes" draft="unconfirmed">activada</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">mètric</measurementSystemName>
 			<measurementSystemName type="UK">RU</measurementSystemName>

--- a/common/main/chr.xml
+++ b/common/main/chr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -984,6 +984,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ᎤᏣᏘᎾ</type>
 			<type key="ss" type="standard" scope="core">ᎾᎿ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ᎤᏣᏘᎾ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ᎾᎿ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ᎠᏂᎩᎸᏥ ᏂᏓᏳᏓᎴᏅᎯ ᏗᏎᏍᏗ</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/cs.xml
+++ b/common/main/cs.xml
@@ -1379,6 +1379,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Ne</type>
 			<type key="ss" type="standard" scope="core">Ano</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Ne</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ano</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrický</measurementSystemName>
 			<measurementSystemName type="UK">Velká Británie</measurementSystemName>

--- a/common/main/cv.xml
+++ b/common/main/cv.xml
@@ -1225,6 +1225,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">сӳнтернӗ</type>
 			<type key="ss" type="standard" scope="core">ҫутнӑ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">сӳнтернӗ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ҫутнӑ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Метрла</measurementSystemName>
 			<measurementSystemName type="UK">Акӑлчанла</measurementSystemName>

--- a/common/main/cy.xml
+++ b/common/main/cy.xml
@@ -1154,6 +1154,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Wedi’i ddiffodd</type>
 			<type key="ss" type="standard" scope="core">Ymlaen</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Wedi’i ddiffodd</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ymlaen</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrig</measurementSystemName>
 			<measurementSystemName type="UK">DU</measurementSystemName>

--- a/common/main/da.xml
+++ b/common/main/da.xml
@@ -1365,6 +1365,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Fra</type>
 			<type key="ss" type="standard" scope="core">Til</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Fra</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Til</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">det metriske system</measurementSystemName>
 			<measurementSystemName type="UK">de britiske målesystemer</measurementSystemName>

--- a/common/main/de.xml
+++ b/common/main/de.xml
@@ -1467,6 +1467,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core" draft="contributed">Aus</type>
 			<type key="ss" type="standard" scope="core" draft="contributed">Ein</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Aus</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ein</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Internationales (SI)</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/de_CH.xml
+++ b/common/main/de_CH.xml
@@ -1230,6 +1230,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core" draft="contributed">Aus</type>
 			<type key="ss" type="standard" scope="core" draft="contributed">Ein</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Aus</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ein</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/dsb.xml
+++ b/common/main/dsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -991,6 +991,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ně</type>
 			<type key="ss" type="standard" scope="core">jo</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ně</typeValue>
+			<typeValue type="yes" draft="unconfirmed">jo</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metriski</measurementSystemName>
 			<measurementSystemName type="UK">britiski</measurementSystemName>

--- a/common/main/el.xml
+++ b/common/main/el.xml
@@ -1289,6 +1289,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Απενεργοποίηση</type>
 			<type key="ss" type="standard" scope="core">Ενεργοποίηση</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Απενεργοποίηση</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ενεργοποίηση</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Μετρικό</measurementSystemName>
 			<measurementSystemName type="UK">Αγγλοσαξονικό</measurementSystemName>

--- a/common/main/en_AU.xml
+++ b/common/main/en_AU.xml
@@ -1508,6 +1508,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 			<type key="t0" type="und">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/en_CA.xml
+++ b/common/main/en_CA.xml
@@ -1305,6 +1305,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 			<type key="t0" type="und">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/en_GB.xml
+++ b/common/main/en_GB.xml
@@ -1440,6 +1440,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="t0" type="und">↑↑↑</type>
 			<type key="va" type="posix">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/en_IN.xml
+++ b/common/main/en_IN.xml
@@ -1307,6 +1307,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 			<type key="t0" type="und">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/en_Shaw.xml
+++ b/common/main/en_Shaw.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -298,6 +298,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core" draft="unconfirmed">𐑪𐑓</type>
 			<type key="ss" type="standard" scope="core" draft="unconfirmed">𐑪𐑯</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">𐑪𐑓</typeValue>
+			<typeValue type="yes" draft="unconfirmed">𐑪𐑯</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric" draft="unconfirmed">𐑥𐑧𐑑𐑮𐑦𐑒</measurementSystemName>
 			<measurementSystemName type="UK" draft="unconfirmed">𐑿𐑒𐑱</measurementSystemName>

--- a/common/main/eo.xml
+++ b/common/main/eo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -984,6 +984,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ne</type>
 			<type key="ss" type="standard" scope="core">jes</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ne</typeValue>
+			<typeValue type="yes" draft="unconfirmed">jes</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metra</measurementSystemName>
 			<measurementSystemName type="UK">brita</measurementSystemName>

--- a/common/main/es.xml
+++ b/common/main/es.xml
@@ -1284,6 +1284,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">desactivado</type>
 			<type key="ss" type="standard" scope="core">activado</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">desactivado</typeValue>
+			<typeValue type="yes" draft="unconfirmed">activado</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">métrico</measurementSystemName>
 			<measurementSystemName type="UK">anglosajón</measurementSystemName>

--- a/common/main/es_419.xml
+++ b/common/main/es_419.xml
@@ -1166,6 +1166,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">no</type>
 			<type key="ss" type="standard" scope="core">sí</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">no</typeValue>
+			<typeValue type="yes" draft="unconfirmed">sí</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/es_MX.xml
+++ b/common/main/es_MX.xml
@@ -1151,6 +1151,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">↑↑↑</type>
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">imperial</measurementSystemName>

--- a/common/main/es_US.xml
+++ b/common/main/es_US.xml
@@ -1158,6 +1158,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">desactivado</type>
 			<type key="ss" type="standard" scope="core">activado</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">desactivado</typeValue>
+			<typeValue type="yes" draft="unconfirmed">activado</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">imperial</measurementSystemName>

--- a/common/main/et.xml
+++ b/common/main/et.xml
@@ -1487,6 +1487,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">välja lülitatud</type>
 			<type key="ss" type="standard" scope="core">sisse lülitatud</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">välja lülitatud</typeValue>
+			<typeValue type="yes" draft="unconfirmed">sisse lülitatud</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">meetermõõdustik</measurementSystemName>
 			<measurementSystemName type="UK">inglise mõõdustik</measurementSystemName>

--- a/common/main/eu.xml
+++ b/common/main/eu.xml
@@ -1320,6 +1320,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Aktibatuta</type>
 			<type key="ss" type="standard" scope="core">Desaktibatuta</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Aktibatuta</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Desaktibatuta</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Sistema metrikoa</measurementSystemName>
 			<measurementSystemName type="UK">Erresuma Batuko sistema</measurementSystemName>

--- a/common/main/fa.xml
+++ b/common/main/fa.xml
@@ -1266,6 +1266,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">خاموش</type>
 			<type key="ss" type="standard" scope="core">روشن</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">خاموش</typeValue>
+			<typeValue type="yes" draft="unconfirmed">روشن</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">متریک</measurementSystemName>
 			<measurementSystemName type="UK">بریتانیایی</measurementSystemName>

--- a/common/main/fi.xml
+++ b/common/main/fi.xml
@@ -1579,6 +1579,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">pois</type>
 			<type key="ss" type="standard" scope="core">päällä</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">pois</typeValue>
+			<typeValue type="yes" draft="unconfirmed">päällä</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrinen</measurementSystemName>
 			<measurementSystemName type="UK">brittiläinen</measurementSystemName>

--- a/common/main/fil.xml
+++ b/common/main/fil.xml
@@ -1082,6 +1082,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Naka-off</type>
 			<type key="ss" type="standard" scope="core">Naka-on</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Naka-off</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Naka-on</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metriko</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/fr.xml
+++ b/common/main/fr.xml
@@ -1570,6 +1570,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Désactivé</type>
 			<type key="ss" type="standard" scope="core">Activé</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Désactivé</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Activé</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">métrique</measurementSystemName>
 			<measurementSystemName type="UK">impérial</measurementSystemName>

--- a/common/main/fr_CA.xml
+++ b/common/main/fr_CA.xml
@@ -1235,6 +1235,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Désactivé</type>
 			<type key="ss" type="standard" scope="core">Activé</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Désactivé</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Activé</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/frr.xml
+++ b/common/main/frr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -996,6 +996,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core" draft="unconfirmed">Uf</type>
 			<type key="ss" type="standard" scope="core" draft="unconfirmed">Uun</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Uf</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Uun</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric" draft="unconfirmed">Meetrisk</measurementSystemName>
 			<measurementSystemName type="UK" draft="unconfirmed">Britisk</measurementSystemName>

--- a/common/main/ga.xml
+++ b/common/main/ga.xml
@@ -1274,6 +1274,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Múchta</type>
 			<type key="ss" type="standard" scope="core">Ar siúl</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Múchta</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ar siúl</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Méadrach</measurementSystemName>
 			<measurementSystemName type="UK">RA</measurementSystemName>

--- a/common/main/gd.xml
+++ b/common/main/gd.xml
@@ -1529,6 +1529,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Dheth</type>
 			<type key="ss" type="standard" scope="core">Air</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Dheth</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Air</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Meatrach</measurementSystemName>
 			<measurementSystemName type="UK">RA</measurementSystemName>

--- a/common/main/gl.xml
+++ b/common/main/gl.xml
@@ -1052,6 +1052,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">activado</type>
 			<type key="ss" type="standard" scope="core">desactivado</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">activado</typeValue>
+			<typeValue type="yes" draft="unconfirmed">desactivado</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">métrico decimal</measurementSystemName>
 			<measurementSystemName type="UK">británico</measurementSystemName>

--- a/common/main/gu.xml
+++ b/common/main/gu.xml
@@ -1247,6 +1247,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">બંધ</type>
 			<type key="ss" type="standard" scope="core">ચાલુ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">બંધ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ચાલુ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">મેટ્રિક</measurementSystemName>
 			<measurementSystemName type="UK">યુકે</measurementSystemName>

--- a/common/main/ha.xml
+++ b/common/main/ha.xml
@@ -978,6 +978,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Kashe</type>
 			<type key="ss" type="standard" scope="core">Kunna</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Kashe</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Kunna</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Tsarin awo</measurementSystemName>
 			<measurementSystemName type="UK">Tsarin awon ƙasar Ingila</measurementSystemName>

--- a/common/main/ha_NE.xml
+++ b/common/main/ha_NE.xml
@@ -979,6 +979,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Kashe</type>
 			<type key="ss" type="standard" scope="core">Kunna</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Kashe</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Kunna</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Tsarin awo</measurementSystemName>
 			<measurementSystemName type="UK">Tsarin awon ƙasar Ingila</measurementSystemName>

--- a/common/main/he.xml
+++ b/common/main/he.xml
@@ -1453,6 +1453,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">כבוי</type>
 			<type key="ss" type="standard" scope="core">פועל</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">כבוי</typeValue>
+			<typeValue type="yes" draft="unconfirmed">פועל</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">מטרי</measurementSystemName>
 			<measurementSystemName type="UK">אימפריאלי</measurementSystemName>

--- a/common/main/hi.xml
+++ b/common/main/hi.xml
@@ -1269,6 +1269,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">बंद</type>
 			<type key="ss" type="standard" scope="core">चालू</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">बंद</typeValue>
+			<typeValue type="yes" draft="unconfirmed">चालू</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">मीट्रिक</measurementSystemName>
 			<measurementSystemName type="UK">यूके</measurementSystemName>

--- a/common/main/hi_Latn.xml
+++ b/common/main/hi_Latn.xml
@@ -1315,6 +1315,10 @@ annotations.
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 			<type key="t0" type="und">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">U.K.</measurementSystemName>

--- a/common/main/hr.xml
+++ b/common/main/hr.xml
@@ -1326,6 +1326,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">isključeno</type>
 			<type key="ss" type="standard" scope="core">uključeno</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">isključeno</typeValue>
+			<typeValue type="yes" draft="unconfirmed">uključeno</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrički sustav</measurementSystemName>
 			<measurementSystemName type="UK">imperijalni sustav</measurementSystemName>

--- a/common/main/hsb.xml
+++ b/common/main/hsb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -991,6 +991,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ně</type>
 			<type key="ss" type="standard" scope="core">haj</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ně</typeValue>
+			<typeValue type="yes" draft="unconfirmed">haj</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metriski</measurementSystemName>
 			<measurementSystemName type="UK">britiski</measurementSystemName>

--- a/common/main/hu.xml
+++ b/common/main/hu.xml
@@ -1322,6 +1322,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Ki</type>
 			<type key="ss" type="standard" scope="core">Be</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Ki</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Be</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrikus</measurementSystemName>
 			<measurementSystemName type="UK">angol</measurementSystemName>

--- a/common/main/hy.xml
+++ b/common/main/hy.xml
@@ -1069,6 +1069,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Անջ․</type>
 			<type key="ss" type="standard" scope="core">Միաց․</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Անջ․</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Միաց․</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Մետրական</measurementSystemName>
 			<measurementSystemName type="UK">Անգլիական</measurementSystemName>

--- a/common/main/id.xml
+++ b/common/main/id.xml
@@ -1443,6 +1443,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Nonaktif</type>
 			<type key="ss" type="standard" scope="core">Aktif</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Nonaktif</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Aktif</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/ig.xml
+++ b/common/main/ig.xml
@@ -1189,6 +1189,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Mgbanyụ</type>
 			<type key="ss" type="standard" scope="core">Mgbanye</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Mgbanyụ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Mgbanye</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metriik</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/is.xml
+++ b/common/main/is.xml
@@ -1207,6 +1207,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Slökkt</type>
 			<type key="ss" type="standard" scope="core">Kveikt</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Slökkt</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Kveikt</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrakerfi</measurementSystemName>
 			<measurementSystemName type="UK">breskt</measurementSystemName>

--- a/common/main/it.xml
+++ b/common/main/it.xml
@@ -1422,6 +1422,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Off</type>
 			<type key="ss" type="standard" scope="core">On</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Off</typeValue>
+			<typeValue type="yes" draft="unconfirmed">On</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrico</measurementSystemName>
 			<measurementSystemName type="UK">britannico</measurementSystemName>

--- a/common/main/ja.xml
+++ b/common/main/ja.xml
@@ -1448,6 +1448,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">オフ</type>
 			<type key="ss" type="standard" scope="core">オン</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">オフ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">オン</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">メートル法</measurementSystemName>
 			<measurementSystemName type="UK">英ヤード・ポンド法</measurementSystemName>

--- a/common/main/jv.xml
+++ b/common/main/jv.xml
@@ -981,6 +981,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Mati</type>
 			<type key="ss" type="standard" scope="core">Urip</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Mati</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Urip</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">BR</measurementSystemName>

--- a/common/main/ka.xml
+++ b/common/main/ka.xml
@@ -1261,6 +1261,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">გამორთული</type>
 			<type key="ss" type="standard" scope="core">ჩართული</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">გამორთული</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ჩართული</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">მეტრული</measurementSystemName>
 			<measurementSystemName type="UK">ბრიტანული</measurementSystemName>

--- a/common/main/kk.xml
+++ b/common/main/kk.xml
@@ -1312,6 +1312,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Өшіру</type>
 			<type key="ss" type="standard" scope="core">Қосу</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Өшіру</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Қосу</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Метрлік</measurementSystemName>
 			<measurementSystemName type="UK">Ағылшын</measurementSystemName>

--- a/common/main/kk_Arab.xml
+++ b/common/main/kk_Arab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -1214,6 +1214,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ءوشىرۋ</type>
 			<type key="ss" type="standard" scope="core">قوسۋ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ءوشىرۋ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">قوسۋ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">مەترلىك</measurementSystemName>
 			<measurementSystemName type="UK">اعىلشىن</measurementSystemName>

--- a/common/main/km.xml
+++ b/common/main/km.xml
@@ -1036,6 +1036,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">បិទ</type>
 			<type key="ss" type="standard" scope="core">បើក</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">បិទ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">បើក</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">រង្វាស់​ប្រវែង</measurementSystemName>
 			<measurementSystemName type="UK">ចក្រភព​អង់គ្លេស</measurementSystemName>

--- a/common/main/kn.xml
+++ b/common/main/kn.xml
@@ -1240,6 +1240,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ಆಫ್</type>
 			<type key="ss" type="standard" scope="core">ಆನ್</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ಆಫ್</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ಆನ್</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ಮೆಟ್ರಿಕ್</measurementSystemName>
 			<measurementSystemName type="UK">ಯುಕೆ</measurementSystemName>

--- a/common/main/ko.xml
+++ b/common/main/ko.xml
@@ -1371,6 +1371,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core" draft="contributed">끔</type>
 			<type key="ss" type="standard" scope="core" draft="contributed">켬</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">끔</typeValue>
+			<typeValue type="yes" draft="unconfirmed">켬</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">미터법</measurementSystemName>
 			<measurementSystemName type="UK">영국식</measurementSystemName>

--- a/common/main/kok.xml
+++ b/common/main/kok.xml
@@ -988,6 +988,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">बंद करचें</type>
 			<type key="ss" type="standard" scope="core">चालू</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">बंद करचें</typeValue>
+			<typeValue type="yes" draft="unconfirmed">चालू</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">मॅट्रिक</measurementSystemName>
 			<measurementSystemName type="UK">युके</measurementSystemName>

--- a/common/main/ky.xml
+++ b/common/main/ky.xml
@@ -1002,6 +1002,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Өчүк</type>
 			<type key="ss" type="standard" scope="core">Күйүк</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Өчүк</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Күйүк</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Метрикалык өлчөө тутуму</measurementSystemName>
 			<measurementSystemName type="UK">Британия</measurementSystemName>

--- a/common/main/lo.xml
+++ b/common/main/lo.xml
@@ -1297,6 +1297,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ປິດ</type>
 			<type key="ss" type="standard" scope="core">ເປີດ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ປິດ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ເປີດ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ເມທຣິກ</measurementSystemName>
 			<measurementSystemName type="UK">ສະຫະລາດຊະອານາຈັກອັງກິດ</measurementSystemName>

--- a/common/main/lt.xml
+++ b/common/main/lt.xml
@@ -1410,6 +1410,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">išjungta</type>
 			<type key="ss" type="standard" scope="core">įjungta</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">išjungta</typeValue>
+			<typeValue type="yes" draft="unconfirmed">įjungta</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrinė</measurementSystemName>
 			<measurementSystemName type="UK">JK</measurementSystemName>

--- a/common/main/lv.xml
+++ b/common/main/lv.xml
@@ -1213,6 +1213,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Izsl.</type>
 			<type key="ss" type="standard" scope="core">Iesl.</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Izsl.</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Iesl.</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metriskā</measurementSystemName>
 			<measurementSystemName type="UK">angļu</measurementSystemName>

--- a/common/main/mk.xml
+++ b/common/main/mk.xml
@@ -1325,6 +1325,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Исклучено</type>
 			<type key="ss" type="standard" scope="core">Вклучено</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Исклучено</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Вклучено</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрички</measurementSystemName>
 			<measurementSystemName type="UK">британски</measurementSystemName>

--- a/common/main/ml.xml
+++ b/common/main/ml.xml
@@ -1299,6 +1299,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ഓഫ്</type>
 			<type key="ss" type="standard" scope="core">ഓൺ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ഓഫ്</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ഓൺ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">മെട്രിക്ക്</measurementSystemName>
 			<measurementSystemName type="UK">യുകെ</measurementSystemName>

--- a/common/main/mn.xml
+++ b/common/main/mn.xml
@@ -1169,6 +1169,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Унтраалттай</type>
 			<type key="ss" type="standard" scope="core">Асаалттай</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Унтраалттай</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Асаалттай</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрийн систем</measurementSystemName>
 			<measurementSystemName type="UK">ИБ</measurementSystemName>

--- a/common/main/mr.xml
+++ b/common/main/mr.xml
@@ -1237,6 +1237,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">बंद</type>
 			<type key="ss" type="standard" scope="core">सुरू</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">बंद</typeValue>
+			<typeValue type="yes" draft="unconfirmed">सुरू</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">मेट्रिक</measurementSystemName>
 			<measurementSystemName type="UK">यूके</measurementSystemName>

--- a/common/main/ms.xml
+++ b/common/main/ms.xml
@@ -1347,6 +1347,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Matikan</type>
 			<type key="ss" type="standard" scope="core">Hidupkan</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Matikan</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Hidupkan</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/my.xml
+++ b/common/main/my.xml
@@ -1037,6 +1037,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ပိတ်</type>
 			<type key="ss" type="standard" scope="core">ဖွင့်</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ပိတ်</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ဖွင့်</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">မက်ထရစ်စနစ်</measurementSystemName>
 			<measurementSystemName type="UK">ဗြိတိန်စနစ်</measurementSystemName>

--- a/common/main/ne.xml
+++ b/common/main/ne.xml
@@ -1227,6 +1227,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">अफ</type>
 			<type key="ss" type="standard" scope="core">अन</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">अफ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">अन</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">मेट्रिक</measurementSystemName>
 			<measurementSystemName type="UK">संयुक्त अधिराज्य</measurementSystemName>

--- a/common/main/nl.xml
+++ b/common/main/nl.xml
@@ -1575,6 +1575,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">uit</type>
 			<type key="ss" type="standard" scope="core">aan</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">uit</typeValue>
+			<typeValue type="yes" draft="unconfirmed">aan</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metriek</measurementSystemName>
 			<measurementSystemName type="UK">Brits</measurementSystemName>

--- a/common/main/nn.xml
+++ b/common/main/nn.xml
@@ -1336,6 +1336,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">↑↑↑</type>
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">britisk</measurementSystemName>

--- a/common/main/no.xml
+++ b/common/main/no.xml
@@ -1466,6 +1466,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">av</type>
 			<type key="ss" type="standard" scope="core">på</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">av</typeValue>
+			<typeValue type="yes" draft="unconfirmed">på</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrisk</measurementSystemName>
 			<measurementSystemName type="UK">engelsk</measurementSystemName>

--- a/common/main/or.xml
+++ b/common/main/or.xml
@@ -1184,6 +1184,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ଅଫ୍‌</type>
 			<type key="ss" type="standard" scope="core">ଅନ୍‌</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ଅଫ୍‌</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ଅନ୍‌</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ମେଟ୍ରିକ୍‌</measurementSystemName>
 			<measurementSystemName type="UK">ୟୁକେ</measurementSystemName>

--- a/common/main/pa.xml
+++ b/common/main/pa.xml
@@ -1022,6 +1022,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ਬੰਦ</type>
 			<type key="ss" type="standard" scope="core">ਚਾਲੂ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ਬੰਦ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ਚਾਲੂ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ਮੀਟਰਿਕ</measurementSystemName>
 			<measurementSystemName type="UK">ਯੂ. ਕੇ.</measurementSystemName>

--- a/common/main/pcm.xml
+++ b/common/main/pcm.xml
@@ -974,6 +974,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Off</type>
 			<type key="ss" type="standard" scope="core">On</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Off</typeValue>
+			<typeValue type="yes" draft="unconfirmed">On</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Mẹ́trik</measurementSystemName>
 			<measurementSystemName type="UK">Brítish</measurementSystemName>

--- a/common/main/pl.xml
+++ b/common/main/pl.xml
@@ -1398,6 +1398,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">wył.</type>
 			<type key="ss" type="standard" scope="core">wł.</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">wył.</typeValue>
+			<typeValue type="yes" draft="unconfirmed">wł.</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metryczny</measurementSystemName>
 			<measurementSystemName type="UK">brytyjski</measurementSystemName>

--- a/common/main/ps.xml
+++ b/common/main/ps.xml
@@ -989,6 +989,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">بند</type>
 			<type key="ss" type="standard" scope="core">چالان</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">بند</typeValue>
+			<typeValue type="yes" draft="unconfirmed">چالان</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">مېټرک</measurementSystemName>
 			<measurementSystemName type="UK">برتانوې</measurementSystemName>

--- a/common/main/pt.xml
+++ b/common/main/pt.xml
@@ -1303,6 +1303,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Desativado</type>
 			<type key="ss" type="standard" scope="core">Ativado</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Desativado</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Ativado</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">métrico</measurementSystemName>
 			<measurementSystemName type="UK">Reino Unido</measurementSystemName>

--- a/common/main/pt_PT.xml
+++ b/common/main/pt_PT.xml
@@ -1200,6 +1200,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">↑↑↑</type>
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/qu.xml
+++ b/common/main/qu.xml
@@ -978,6 +978,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Off</type>
 			<type key="ss" type="standard" scope="core">On</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Off</typeValue>
+			<typeValue type="yes" draft="unconfirmed">On</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/rm.xml
+++ b/common/main/rm.xml
@@ -1182,6 +1182,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Deactivà</type>
 			<type key="ss" type="standard" scope="core">Activà</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Deactivà</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Activà</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metric</measurementSystemName>
 			<measurementSystemName type="UK">britannic</measurementSystemName>

--- a/common/main/ro.xml
+++ b/common/main/ro.xml
@@ -1462,6 +1462,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">dezactivată</type>
 			<type key="ss" type="standard" scope="core">activată</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">dezactivată</typeValue>
+			<typeValue type="yes" draft="unconfirmed">activată</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metric</measurementSystemName>
 			<measurementSystemName type="UK">britanic</measurementSystemName>

--- a/common/main/ru.xml
+++ b/common/main/ru.xml
@@ -1341,6 +1341,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">выключено</type>
 			<type key="ss" type="standard" scope="core">включено</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">выключено</typeValue>
+			<typeValue type="yes" draft="unconfirmed">включено</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Метрическая</measurementSystemName>
 			<measurementSystemName type="UK">Английская</measurementSystemName>

--- a/common/main/sc.xml
+++ b/common/main/sc.xml
@@ -1322,6 +1322,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">alluta</type>
 			<type key="ss" type="standard" scope="core">istudada</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">alluta</typeValue>
+			<typeValue type="yes" draft="unconfirmed">istudada</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">mètricu</measurementSystemName>
 			<measurementSystemName type="UK">britànnicu</measurementSystemName>

--- a/common/main/sd.xml
+++ b/common/main/sd.xml
@@ -999,6 +999,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">بند</type>
 			<type key="ss" type="standard" scope="core">چالو</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">بند</typeValue>
+			<typeValue type="yes" draft="unconfirmed">چالو</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ميٽرڪ</measurementSystemName>
 			<measurementSystemName type="UK">برطانيه</measurementSystemName>

--- a/common/main/shn.xml
+++ b/common/main/shn.xml
@@ -1151,6 +1151,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ဢိုတ်း</type>
 			<type key="ss" type="standard" scope="core">ပိုတ်ႇ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ဢိုတ်း</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ပိုတ်ႇ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">မႅတ်ႉထရိတ်ႉ</measurementSystemName>
 			<measurementSystemName type="UK">ယူႇၶေႇ</measurementSystemName>

--- a/common/main/si.xml
+++ b/common/main/si.xml
@@ -1003,6 +1003,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ක්‍රියාවිරහිතයි</type>
 			<type key="ss" type="standard" scope="core">ක්‍රියාත්මකයි</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ක්‍රියාවිරහිතයි</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ක්‍රියාත්මකයි</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">මෙට්රික්</measurementSystemName>
 			<measurementSystemName type="UK">එංගලන්ත</measurementSystemName>

--- a/common/main/sk.xml
+++ b/common/main/sk.xml
@@ -1187,6 +1187,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">vypnuté</type>
 			<type key="ss" type="standard" scope="core">zapnuté</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">vypnuté</typeValue>
+			<typeValue type="yes" draft="unconfirmed">zapnuté</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrický</measurementSystemName>
 			<measurementSystemName type="UK">britský</measurementSystemName>

--- a/common/main/sl.xml
+++ b/common/main/sl.xml
@@ -1297,6 +1297,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Izklopljeno</type>
 			<type key="ss" type="standard" scope="core">Vklopljeno</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Izklopljeno</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Vklopljeno</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrični</measurementSystemName>
 			<measurementSystemName type="UK">angleški</measurementSystemName>

--- a/common/main/so.xml
+++ b/common/main/so.xml
@@ -1199,6 +1199,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Dami</type>
 			<type key="ss" type="standard" scope="core">Daar</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Dami</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Daar</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">Boqortooyada Midawday</measurementSystemName>

--- a/common/main/sq.xml
+++ b/common/main/sq.xml
@@ -1174,6 +1174,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">joaktive</type>
 			<type key="ss" type="standard" scope="core">aktive</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">joaktive</typeValue>
+			<typeValue type="yes" draft="unconfirmed">aktive</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrik</measurementSystemName>
 			<measurementSystemName type="UK">britanik (imperial)</measurementSystemName>

--- a/common/main/sr.xml
+++ b/common/main/sr.xml
@@ -1278,6 +1278,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Укључено</type>
 			<type key="ss" type="standard" scope="core">Искључено</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Укључено</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Искључено</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрички</measurementSystemName>
 			<measurementSystemName type="UK">британски</measurementSystemName>

--- a/common/main/sr_Latn.xml
+++ b/common/main/sr_Latn.xml
@@ -1277,6 +1277,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Uključeno</type>
 			<type key="ss" type="standard" scope="core">Isključeno</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Uključeno</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Isključeno</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">metrički</measurementSystemName>
 			<measurementSystemName type="UK">britanski</measurementSystemName>

--- a/common/main/sv.xml
+++ b/common/main/sv.xml
@@ -1539,6 +1539,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">av</type>
 			<type key="ss" type="standard" scope="core">på</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">av</typeValue>
+			<typeValue type="yes" draft="unconfirmed">på</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">SI-enheter</measurementSystemName>
 			<measurementSystemName type="UK">engelska enheter</measurementSystemName>

--- a/common/main/sw.xml
+++ b/common/main/sw.xml
@@ -1082,6 +1082,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Imezimwa</type>
 			<type key="ss" type="standard" scope="core">Imewashwa</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Imezimwa</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Imewashwa</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Mfumo wa Mita</measurementSystemName>
 			<measurementSystemName type="UK">Uingereza</measurementSystemName>

--- a/common/main/ta.xml
+++ b/common/main/ta.xml
@@ -1245,6 +1245,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">முடக்கம்</type>
 			<type key="ss" type="standard" scope="core">இயக்கம்</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">முடக்கம்</typeValue>
+			<typeValue type="yes" draft="unconfirmed">இயக்கம்</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">மெட்ரிக்</measurementSystemName>
 			<measurementSystemName type="UK">யூகே</measurementSystemName>

--- a/common/main/te.xml
+++ b/common/main/te.xml
@@ -1249,6 +1249,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ఆఫ్</type>
 			<type key="ss" type="standard" scope="core">ఆన్</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ఆఫ్</typeValue>
+			<typeValue type="yes" draft="unconfirmed">ఆన్</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">దశాంశం</measurementSystemName>
 			<measurementSystemName type="UK">యుకె</measurementSystemName>

--- a/common/main/th.xml
+++ b/common/main/th.xml
@@ -1450,6 +1450,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">ปิด</type>
 			<type key="ss" type="standard" scope="core">เปิด</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ปิด</typeValue>
+			<typeValue type="yes" draft="unconfirmed">เปิด</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">เมตริก</measurementSystemName>
 			<measurementSystemName type="UK">สหราชอาณาจักร</measurementSystemName>

--- a/common/main/ti.xml
+++ b/common/main/ti.xml
@@ -1014,6 +1014,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">ጠፊኡ</type>
 			<type key="ss" type="standard" scope="core">በሪሑ</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">ጠፊኡ</typeValue>
+			<typeValue type="yes" draft="unconfirmed">በሪሑ</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">ሜትሪክ</measurementSystemName>
 			<measurementSystemName type="UK">ብሪጣንያ</measurementSystemName>

--- a/common/main/tk.xml
+++ b/common/main/tk.xml
@@ -989,6 +989,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">öçürilen</type>
 			<type key="ss" type="standard" scope="core">açyk</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">öçürilen</typeValue>
+			<typeValue type="yes" draft="unconfirmed">açyk</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">Birleşen Patyşalyk</measurementSystemName>

--- a/common/main/tr.xml
+++ b/common/main/tr.xml
@@ -1440,6 +1440,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Kapalı</type>
 			<type key="ss" type="standard" scope="core">Açık</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Kapalı</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Açık</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">İngiliz</measurementSystemName>

--- a/common/main/tt.xml
+++ b/common/main/tt.xml
@@ -739,6 +739,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core" draft="unconfirmed">сүн</type>
 			<type key="ss" type="standard" scope="core" draft="unconfirmed">каб</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">сүн</typeValue>
+			<typeValue type="yes" draft="unconfirmed">каб</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">метрик</measurementSystemName>
 			<measurementSystemName type="UK">Бөекбритания</measurementSystemName>

--- a/common/main/uk.xml
+++ b/common/main/uk.xml
@@ -1321,6 +1321,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">вимкнено</type>
 			<type key="ss" type="standard" scope="core">увімкнено</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">вимкнено</typeValue>
+			<typeValue type="yes" draft="unconfirmed">увімкнено</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Метрична</measurementSystemName>
 			<measurementSystemName type="UK">Британська</measurementSystemName>

--- a/common/main/ur.xml
+++ b/common/main/ur.xml
@@ -1055,6 +1055,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">آف</type>
 			<type key="ss" type="standard" scope="core">آن</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">آف</typeValue>
+			<typeValue type="yes" draft="unconfirmed">آن</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">میٹرک</measurementSystemName>
 			<measurementSystemName type="UK">برطانیہ</measurementSystemName>

--- a/common/main/uz.xml
+++ b/common/main/uz.xml
@@ -999,6 +999,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">oʻchiq</type>
 			<type key="ss" type="standard" scope="core">yoniq</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">oʻchiq</typeValue>
+			<typeValue type="yes" draft="unconfirmed">yoniq</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Metrik</measurementSystemName>
 			<measurementSystemName type="UK">Buyuk Britaniya</measurementSystemName>

--- a/common/main/vi.xml
+++ b/common/main/vi.xml
@@ -1407,6 +1407,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Tắt</type>
 			<type key="ss" type="standard" scope="core">Bật</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Tắt</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Bật</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Hệ mét</measurementSystemName>
 			<measurementSystemName type="UK">Hệ Anh</measurementSystemName>

--- a/common/main/yo.xml
+++ b/common/main/yo.xml
@@ -998,6 +998,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Pípa</type>
 			<type key="ss" type="standard" scope="core">Títàn</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Pípa</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Títàn</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Mẹ́tíríìkì</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/yo_BJ.xml
+++ b/common/main/yo_BJ.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE ldml SYSTEM "../../common/dtd/ldml.dtd">
-<!-- Copyright © 1991-2025 Unicode, Inc.
+<!-- Copyright © 1991-2026 Unicode, Inc.
 For terms of use, see http://www.unicode.org/copyright.html
 SPDX-License-Identifier: Unicode-3.0
 CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -999,6 +999,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">Pípa</type>
 			<type key="ss" type="standard" scope="core">Títàn</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Pípa</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Títàn</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">Mɛ́tíríìkì</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/yue.xml
+++ b/common/main/yue.xml
@@ -1427,6 +1427,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">閂</type>
 			<type key="ss" type="standard" scope="core">開</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">閂</typeValue>
+			<typeValue type="yes" draft="unconfirmed">開</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">公制</measurementSystemName>
 			<measurementSystemName type="UK">英制</measurementSystemName>

--- a/common/main/yue_Hans.xml
+++ b/common/main/yue_Hans.xml
@@ -1428,6 +1428,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">闩</type>
 			<type key="ss" type="standard" scope="core">开</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">闩</typeValue>
+			<typeValue type="yes" draft="unconfirmed">开</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">公制</measurementSystemName>
 			<measurementSystemName type="UK">英制</measurementSystemName>

--- a/common/main/zh.xml
+++ b/common/main/zh.xml
@@ -1484,6 +1484,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">关闭</type>
 			<type key="ss" type="standard" scope="core">开启</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">关闭</typeValue>
+			<typeValue type="yes" draft="unconfirmed">开启</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">公制</measurementSystemName>
 			<measurementSystemName type="UK">英制</measurementSystemName>

--- a/common/main/zh_Hant.xml
+++ b/common/main/zh_Hant.xml
@@ -1504,6 +1504,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">關閉</type>
 			<type key="ss" type="standard" scope="core">開啟</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">關閉</typeValue>
+			<typeValue type="yes" draft="unconfirmed">開啟</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">公制</measurementSystemName>
 			<measurementSystemName type="UK">英制</measurementSystemName>

--- a/common/main/zh_Hant_HK.xml
+++ b/common/main/zh_Hant_HK.xml
@@ -1494,6 +1494,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<type key="ss" type="none" scope="core">↑↑↑</type>
 			<type key="ss" type="standard" scope="core">↑↑↑</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">↑↑↑</typeValue>
+			<typeValue type="yes" draft="unconfirmed">↑↑↑</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">↑↑↑</measurementSystemName>
 			<measurementSystemName type="UK">↑↑↑</measurementSystemName>

--- a/common/main/zu.xml
+++ b/common/main/zu.xml
@@ -1311,6 +1311,10 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 			<type key="ss" type="none" scope="core">Cishiwe</type>
 			<type key="ss" type="standard" scope="core">Vuliwe</type>
 		</types>
+		<typeValues>
+			<typeValue type="no" draft="unconfirmed">Cishiwe</typeValue>
+			<typeValue type="yes" draft="unconfirmed">Vuliwe</typeValue>
+		</typeValues>
 		<measurementSystemNames>
 			<measurementSystemName type="metric">i-Metric</measurementSystemName>
 			<measurementSystemName type="UK">i-UK</measurementSystemName>

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/test/CheckForCopy.java
@@ -69,7 +69,8 @@ public class CheckForCopy extends FactoryCheckCLDR {
                     .add(
                             "^//ldml/localeDisplayNames/types/type\\[@key=\"collation\"]\\[@type=\"standard\"]",
                             true)
-                    .add("^//ldml/typographicNames", true);
+                    .add("^//ldml/typographicNames", true)
+                    .add("^//ldml/localeDisplayNames/typeValues/typeValue\\[@type=\"no\"]", true);
 
     static UnicodeSet ASCII_LETTER = new UnicodeSet("[a-zA-Z]").freeze();
 


### PR DESCRIPTION
CLDR-19394

- [ ] This PR completes the ticket.

What's in the box:
- Copying from `ss` On/Off to `typeValues` (as unconfirmed)

**Note** CLDRModify stuff schlepped off to another PR.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
