### PR TITLE
CLDR-19640 update CLDRModify and docs (add 'copy')

### DIFF
--- a/docs/site/development/cldr-big-red-switch/cldrmodify-using-config-file.md
+++ b/docs/site/development/cldr-big-red-switch/cldrmodify-using-config-file.md
@@ -6,11 +6,13 @@ title: CLDRModify using Config file
 
 The CLDRModify tool can be used to make changes to a number of files, based on a configuration file.
 
-* Either put your changes into cldr/tool/modify\_config.txt, or use \-k config\_file to specify a different file.  
-  * Use the format specified below.  
-  * The path is relative to cldr/tool/  
-* Remember to specify the target directory, if different than common/main  
-* Run CLDRModify with the \-fk option, and as usual, diff your changes. For more info, see [CLDRModify Passes](cldrmodify-passes).  
+* Either put your changes into cldr/tool/modify\_config.txt, or use \-k config\_file to specify a different file.
+  * Use the format specified below.
+  * The path is relative to cldr/tool/
+* Remember to specify the target directory, if different than common/main
+* Run CLDRModify with the \-fk option, and as usual, diff your changes. For more info, see [CLDRModify Passes](cldrmodify-passes).
+* Use the `-I` option so that the original files are overwritten in-place.
+* Hint: Try with a subset of locales first, before applying to all.
 * The format may change in the future\!
 
 As an example of how this is done, and the results, see: [TODO ADD EXAMPLE]
@@ -31,7 +33,7 @@ You can also search for /fixList.add('k',/ in the file, and put a breakpoint in 
 
 ### ConfigKeys
 
-*locale*, *action*, *path*, *value, new\_path, new\_value*
+*locale*, *action*, *path*, *value, new\_path, new\_value*, *draft*
 
 A locale (regex) must be present.
 
@@ -49,7 +51,7 @@ If the locale is /./, then any locale matches.
 
 ***Warning\! This won't work if you need certain literal characters (such as ; or a leading or trailing space, etc.).*** See [TODO](#todo)
 
-* *If it is in a regex, you can use the **\\x3B** format to work around this.*  
+* *If it is in a regex, you can use the **\\x3B** format to work around this.*
 * *If it is in a UnicodeSet use **\\u003B** format.*
 
 ### ConfigAction
@@ -71,6 +73,18 @@ Same as add, but only for paths that don't have values in the original value.
 **action=replace**
 
 Replace \<path, value\> with \<newPath, newValue\>
+
+**action=copy**
+
+Add \<newPath\> with any values at paths matched by \<path\>.
+If *draft* is set, draft status will be *draft*.
+
+- TODO: optional match *value* as a regex
+- TODO: optional *newValue* with regex-replacement from matched *value*
+
+**action=copyNew**
+
+Same as **copy** but only for paths that don't have values in the original value.
 
 ### Example file
 

--- a/docs/site/development/cldr-big-red-switch/cldrmodify-using-config-file.md
+++ b/docs/site/development/cldr-big-red-switch/cldrmodify-using-config-file.md
@@ -6,7 +6,7 @@ title: CLDRModify using Config file
 
 The CLDRModify tool can be used to make changes to a number of files, based on a configuration file.
 
-* Either put your changes into cldr/tool/modify\_config.txt, or use \-k config\_file to specify a different file.
+* Either put your changes into `cldr/tool/modify_config.txt`, or use `-k config_file` to specify a different file.
   * Use the format specified below.
   * The path is relative to cldr/tool/
 * Remember to specify the target directory, if different than common/main
@@ -14,6 +14,7 @@ The CLDRModify tool can be used to make changes to a number of files, based on a
 * Use the `-I` option so that the original files are overwritten in-place.
 * Hint: Try with a subset of locales first, before applying to all.
 * The format may change in the future\!
+* be aware that `[@` in the path is automatically replaced with `\[@`.
 
 As an example of how this is done, and the results, see: [TODO ADD EXAMPLE]
 
@@ -82,9 +83,26 @@ If *draft* is set, draft status will be *draft*.
 - TODO: optional match *value* as a regex
 - TODO: optional *newValue* with regex-replacement from matched *value*
 
+Example:
+
+```
+# CLDR-19394 copy Off/On from "ss" to the new typeValues (as unconfirmed)
+locale=/^.*/ ; action=copy ; path=//ldml/localeDisplayNames/types/type[@key="ss"][@type="none"][@scope="core"] ; new_path=//ldml/localeDisplayNames/typeValues/typeValue[@type="no"] ; draft=unconfirmed
+locale=/^.*/ ; action=copy ; path=//ldml/localeDisplayNames/types/type[@key="ss"][@type="standard"][@scope="core"] ; new_path=//ldml/localeDisplayNames/typeValues/typeValue[@type="yes"] ; draft=unconfirmed
+```
+
+If **path** begins with `/^` then it is a regex match, and **new_path** can contain replacement values such as `$0`…`$9`
+
 **action=copyNew**
 
 Same as **copy** but only for paths that don't have values in the original value.
+
+Example:
+
+```
+# CLDR-19640 copy 'other' to 'many' for certain locales.
+locale=/^(ca|es|fr|it|pt|pt_PT)$/ ; action=copyNew ; path=/^(.*)[@count="other"](.*)$/ ; new_path=$1[@count="many"]$2 ; draft=unconfirmed
+```
 
 ### Example file
 

--- a/docs/site/development/cldr-big-red-switch/cldrmodify-using-config-file.md
+++ b/docs/site/development/cldr-big-red-switch/cldrmodify-using-config-file.md
@@ -14,7 +14,8 @@ The CLDRModify tool can be used to make changes to a number of files, based on a
 * Use the `-I` option so that the original files are overwritten in-place.
 * Hint: Try with a subset of locales first, before applying to all.
 * The format may change in the future\!
-* be aware that `[@` in the path is automatically replaced with `\[@`.
+* Be aware that if a value starts with `/` indicating a regex,
+  `[@` in the path is automatically replaced with `\[@`.
 
 As an example of how this is done, and the results, see: [TODO ADD EXAMPLE]
 

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRConfigFileFilter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRConfigFileFilter.java
@@ -1,0 +1,394 @@
+package org.unicode.cldr.tool;
+
+import com.google.common.base.Splitter;
+import com.ibm.icu.text.UnicodeSet;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import org.unicode.cldr.util.CLDRFile;
+import org.unicode.cldr.util.FileProcessor;
+import org.unicode.cldr.util.Joiners;
+import org.unicode.cldr.util.PatternCache;
+import org.unicode.cldr.util.RegexUtilities;
+import org.unicode.cldr.util.StringId;
+
+/** implementation for option -fk */
+class CLDRConfigFileFilter extends CLDRModify.CLDRFilter {
+
+    // pattern for a hex string id
+    static final UnicodeSet HEX = new UnicodeSet("[a-fA-F0-9]").freeze();
+
+    enum ConfigKeys {
+        action,
+        locale,
+        path,
+        value,
+        new_path,
+        new_value,
+        draft
+    }
+
+    enum ConfigAction {
+        /** Remove a path */
+        delete,
+        /** Add a path/value */
+        add,
+        /** Replace a path/value. Equals 'add' but tests selected paths */
+        replace,
+        /** Add a a path/value. Equals 'add' but tests that path did NOT exist */
+        addNew,
+        /** Copy a path to new_path */
+        copy,
+        /** Equals 'copy' but tsts that path did NOT exist. */
+        copyNew
+    }
+
+    static final class ConfigMatch {
+        final String exactMatch;
+        final Matcher regexMatch; // doesn't have to be thread safe
+        final ConfigAction action;
+        final boolean hexPath;
+
+        static UnicodeSet SUSPICIOUS_NON_REGEX = new UnicodeSet("[*|]").freeze();
+
+        public ConfigMatch(ConfigKeys key, String match) {
+            if (key == ConfigKeys.action) {
+                exactMatch = null;
+                regexMatch = null;
+                action = ConfigAction.valueOf(match);
+                hexPath = false;
+            } else if (match.length() > 1 && match.startsWith("/") && match.endsWith("/")) {
+                if (key != ConfigKeys.locale && key != ConfigKeys.path && key != ConfigKeys.value) {
+                    throw new IllegalArgumentException(
+                            "Regex only allowed for locale=, path=, or value'.");
+                }
+                exactMatch = null;
+                // for convenience, we automatically change [@attr="something"] to
+                // \[@attr="something"]
+                regexMatch =
+                        PatternCache.get(
+                                        match.substring(1, match.length() - 1)
+                                                .replace("[@", "\\[@"))
+                                .matcher("");
+                action = null;
+                hexPath = false;
+            } else {
+                exactMatch = match;
+                regexMatch = null;
+                action = null;
+                hexPath =
+                        (key == ConfigKeys.new_path || key == ConfigKeys.path)
+                                && HEX.containsAll(match);
+                if (key == ConfigKeys.locale || key == ConfigKeys.path) {
+                    if (SUSPICIOUS_NON_REGEX.containsSome(match)) {
+                        System.out.println(
+                                Joiners.ES.join(
+                                        "The value ",
+                                        match,
+                                        " is being matched literally, but contains regex charcters. Did you mean /",
+                                        match,
+                                        "/ ?"));
+                    }
+                }
+            }
+        }
+
+        public boolean matches(String other) {
+            if (exactMatch == null) {
+                return regexMatch.reset(other).find();
+            } else if (hexPath) {
+                // convert path to id for comparison
+                return exactMatch.equals(StringId.getHexId(other));
+            } else {
+                return exactMatch.equals(other);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return action != null
+                    ? action.toString()
+                    : exactMatch == null
+                            ? regexMatch.toString()
+                            : hexPath ? "*" + exactMatch + "*" : exactMatch;
+        }
+
+        public String getPath(CLDRFile cldrFileToFilter) {
+            if (!hexPath) {
+                return exactMatch;
+            }
+            // ensure that we have all the possible paths cached
+            String path = StringId.getStringFromHexId(exactMatch);
+            if (path == null) {
+                for (String eachPath : cldrFileToFilter.fullIterable()) {
+                    StringId.getHexId(eachPath);
+                }
+                path = StringId.getStringFromHexId(exactMatch);
+                if (path == null) {
+                    throw new IllegalArgumentException("No path for hex id: " + exactMatch);
+                }
+            }
+            return path;
+        }
+
+        public static String getModified(
+                ConfigMatch valueMatch, String value, ConfigMatch newValue) {
+            if (valueMatch == null) { // match anything
+                if (newValue != null && newValue.exactMatch != null) {
+                    return newValue.exactMatch;
+                }
+                if (value != null) {
+                    return value;
+                }
+                throw new IllegalArgumentException("Can't have both old and new be null.");
+            } else if (valueMatch.exactMatch == null) { // regex
+                if (newValue == null || newValue.exactMatch == null) {
+                    throw new IllegalArgumentException("Can't have regex without replacement.");
+                }
+                StringBuffer buffer = new StringBuffer();
+                valueMatch.regexMatch.appendReplacement(buffer, newValue.exactMatch);
+                return buffer.toString();
+            } else {
+                return newValue.exactMatch != null ? newValue.exactMatch : value;
+            }
+        }
+    }
+
+    static final String DEBUG_PATHS = null; // ".*currency.*";
+
+    private Map<ConfigMatch, LinkedHashSet<Map<ConfigKeys, ConfigMatch>>> locale2keyValues;
+    private LinkedHashSet<Map<ConfigKeys, ConfigMatch>> keyValues = new LinkedHashSet<>();
+    final String DEBUG_PATH = null;
+    private final Supplier<Boolean> configOptionChosen;
+    private final Supplier<String> configFileName;
+
+    public CLDRConfigFileFilter(
+            Supplier<Boolean> configOptionChosen, Supplier<String> configFileName) {
+        // Note, Supplier must be used because this is constructed at static init time.
+        this.configOptionChosen = configOptionChosen;
+        this.configFileName = configFileName;
+    }
+
+    @Override
+    public void handleStart() {
+        super.handleStart();
+        if (!configOptionChosen.get()) {
+            return;
+        }
+        if (locale2keyValues == null) {
+            fillCache();
+        }
+        // set up for the specific locale we are dealing with.
+        // a small optimization
+        String localeId = getLocaleID();
+        keyValues.clear();
+        for (Entry<ConfigMatch, LinkedHashSet<Map<ConfigKeys, ConfigMatch>>> localeMatcher :
+                locale2keyValues.entrySet()) {
+            if (localeMatcher.getKey().matches(localeId)) {
+                keyValues.addAll(localeMatcher.getValue());
+            }
+        }
+        // System.out.println("# Checking entries & changing:\t" +
+        // keyValues.size());
+        for (Map<ConfigKeys, ConfigMatch> entry : keyValues) {
+            ConfigMatch action = entry.get(ConfigKeys.action);
+            ConfigMatch pathMatch = entry.get(ConfigKeys.path);
+            ConfigMatch valueMatch = entry.get(ConfigKeys.value);
+            ConfigMatch newPath = entry.get(ConfigKeys.new_path);
+            ConfigMatch newValue = entry.get(ConfigKeys.new_value);
+
+            CLDRModify.verboseln(
+                    "Action=%s, pathMatch=%s, newPath=%s", action.action, pathMatch, newPath);
+
+            switch (action.action) {
+                // we add all the values up front
+                case addNew:
+                case add:
+                    {
+                        if (pathMatch != null
+                                || valueMatch != null
+                                || newPath == null
+                                || newValue == null) {
+                            throw new IllegalArgumentException(
+                                    action.action
+                                            + ": must have no path nor value = null AND new_path or new_value:\n\t"
+                                            + entry);
+                        }
+                        String newPathString = newPath.getPath(getResolved());
+                        if (action.action == ConfigAction.add
+                                || cldrFileToFilter.getStringValue(newPathString) == null) {
+                            replace(newPathString, newPathString, newValue.exactMatch, "config");
+                        }
+                    }
+                    break;
+                case copy:
+                case copyNew:
+                    {
+                        // just check
+                        if (pathMatch == null || newPath == null) {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "%s: must have path and new_path", action.action));
+                        }
+                    }
+                    break;
+                // we just check
+                case replace:
+                    if ((pathMatch == null && valueMatch == null)
+                            || (newPath == null && newValue == null)) {
+                        throw new IllegalArgumentException(
+                                action.action
+                                        + ": must have (path or value) AND (new_path or new_value):\n\t"
+                                        + entry);
+                    }
+                    break;
+                // For delete, we just check; we'll remove later
+                case delete:
+                    if (newPath != null || newValue != null) {
+                        throw new IllegalArgumentException(
+                                action.action
+                                        + ": must have no new_path nor new_value:\n\t"
+                                        + entry);
+                    }
+                    break;
+                default: // fall through
+                    throw new IllegalArgumentException("Internal Error");
+            }
+        }
+    }
+
+    private static final Splitter SPLIT_ON_SEMI = Splitter.onPattern("\\s*;\\s+");
+
+    private void fillCache() {
+        locale2keyValues = new LinkedHashMap<>();
+        FileProcessor myReader =
+                new FileProcessor() {
+                    {
+                        doHash = false;
+                    }
+
+                    @Override
+                    protected boolean handleLine(int lineCount, String line) {
+                        line = line.trim();
+                        Iterable<String> lineParts = SPLIT_ON_SEMI.split(line);
+                        Map<ConfigKeys, ConfigMatch> keyValue = new EnumMap<>(ConfigKeys.class);
+                        for (String linePart : lineParts) {
+                            int pos = linePart.indexOf('=');
+                            if (pos < 0) {
+                                // WARNING; the code doesn't allow for ; within
+                                // values; need to restructure for that.
+                                throw new IllegalArgumentException(
+                                        lineCount
+                                                + ":\t No = in command: «"
+                                                + linePart
+                                                + "» in "
+                                                + line);
+                            }
+                            ConfigKeys key = ConfigKeys.valueOf(linePart.substring(0, pos).trim());
+                            if (keyValue.containsKey(key)) {
+                                throw new IllegalArgumentException(
+                                        "Must not have multiple keys: " + key);
+                            }
+                            String match = linePart.substring(pos + 1).trim();
+                            keyValue.put(key, new ConfigMatch(key, match));
+                        }
+                        final ConfigMatch locale = keyValue.get(ConfigKeys.locale);
+                        if (locale == null || keyValue.get(ConfigKeys.action) == null) {
+                            throw new IllegalArgumentException();
+                        }
+
+                        // validate new path
+                        LinkedHashSet<Map<ConfigKeys, ConfigMatch>> keyValues =
+                                locale2keyValues.get(locale);
+                        if (keyValues == null) {
+                            locale2keyValues.put(locale, keyValues = new LinkedHashSet<>());
+                        }
+                        keyValues.add(keyValue);
+                        return true;
+                    }
+                };
+        myReader.process(CLDRModify.class, configFileName.get());
+    }
+
+    @SuppressWarnings("incomplete-switch")
+    @Override
+    public void handlePath(String xpath) {
+        // slow method; could optimize
+        if (DEBUG_PATH != null && DEBUG_PATH.equals(xpath)) {
+            System.out.println(xpath);
+        }
+        for (Map<ConfigKeys, ConfigMatch> entry : keyValues) {
+            ConfigMatch pathMatch = entry.get(ConfigKeys.path);
+            if (pathMatch != null && !pathMatch.matches(xpath)) {
+                if (DEBUG_PATH != null && pathMatch != null && pathMatch.regexMatch != null) {
+                    System.out.println(RegexUtilities.showMismatch(pathMatch.regexMatch, xpath));
+                }
+                continue;
+            }
+            ConfigMatch valueMatch = entry.get(ConfigKeys.value);
+            final String value = cldrFileToFilter.getStringValue(xpath);
+            if (valueMatch != null && !valueMatch.matches(value)) {
+                continue;
+            }
+            ConfigMatch action = entry.get(ConfigKeys.action);
+            switch (action.action) {
+                case delete:
+                    {
+                        remove(xpath, "config");
+                    }
+                    break;
+                case replace:
+                    {
+                        ConfigMatch newPath = entry.get(ConfigKeys.new_path);
+                        ConfigMatch newValue = entry.get(ConfigKeys.new_value);
+
+                        String fullpath = cldrFileToFilter.getFullXPath(xpath);
+                        String draft = "";
+                        int loc = fullpath.indexOf("[@draft=");
+                        if (loc >= 0) {
+                            int loc2 = fullpath.indexOf(']', loc + 7);
+                            draft = fullpath.substring(loc, loc2 + 1);
+                        }
+
+                        String modPath = ConfigMatch.getModified(pathMatch, xpath, newPath) + draft;
+                        String modValue = ConfigMatch.getModified(valueMatch, value, newValue);
+                        replace(xpath, modPath, modValue, "config");
+                    }
+                    break;
+                case copy:
+                case copyNew:
+                    {
+                        // get out if there's no existing value
+                        if (value == null) break;
+                        ConfigMatch draft = entry.get(ConfigKeys.draft);
+                        ConfigMatch newPath = entry.get(ConfigKeys.new_path);
+                        final String oldNewPathString =
+                                ConfigMatch.getModified(pathMatch, xpath, newPath);
+                        String newPathString;
+                        if (draft != null && !oldNewPathString.contains("[@draft=")) {
+                            newPathString = oldNewPathString + "[@draft=\"" + draft + "\"]";
+                        } else {
+                            newPathString = oldNewPathString;
+                        }
+                        if (action.action == ConfigAction.copyNew
+                                && cldrFileToFilter.isHere(oldNewPathString)) {
+                            // the copyNew action skips if it's already here
+                            break;
+                        }
+                        // TOOD: Allow skipping inheritance marker?
+                        replace(
+                                oldNewPathString,
+                                newPathString,
+                                value, // TODO: allow new_value to override with
+                                // match
+                                "config");
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRConfigFileFilter.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRConfigFileFilter.java
@@ -43,7 +43,7 @@ class CLDRConfigFileFilter extends CLDRModify.CLDRFilter {
         addNew,
         /** Copy a path to new_path */
         copy,
-        /** Equals 'copy' but tsts that path did NOT exist. */
+        /** Equals 'copy' but tests that path did NOT exist. */
         copyNew
     }
 
@@ -64,7 +64,7 @@ class CLDRConfigFileFilter extends CLDRModify.CLDRFilter {
             } else if (match.length() > 1 && match.startsWith("/") && match.endsWith("/")) {
                 if (key != ConfigKeys.locale && key != ConfigKeys.path && key != ConfigKeys.value) {
                     throw new IllegalArgumentException(
-                            "Regex only allowed for locale=, path=, or value'.");
+                            "Regex only allowed for locale=, path=, or value=.");
                 }
                 exactMatch = null;
                 // for convenience, we automatically change [@attr="something"] to
@@ -89,7 +89,7 @@ class CLDRConfigFileFilter extends CLDRModify.CLDRFilter {
                                 Joiners.ES.join(
                                         "The value ",
                                         match,
-                                        " is being matched literally, but contains regex charcters. Did you mean /",
+                                        " is being matched literally, but contains regex characters. Did you mean /",
                                         match,
                                         "/ ?"));
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -98,6 +98,8 @@ import org.unicode.cldr.util.XPathParts.Comments.CommentType;
         description =
                 "Tool for applying modifications to the CLDR files. Use -h to see the options.")
 public class CLDRModify {
+    private static final String CONFIG_FILE_DOCS =
+            "https://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-using-config-file";
     private static final Splitter SPLIT_ON_SEMI = Splitter.onPattern("\\s*;\\s+");
     static final String DEBUG_PATHS = null; // ".*currency.*";
     static final boolean COMMENT_REMOVALS = false; // append removals as comments
@@ -113,7 +115,8 @@ public class CLDRModify {
         path,
         value,
         new_path,
-        new_value
+        new_value,
+        draft
     }
 
     enum ConfigAction {
@@ -125,6 +128,10 @@ public class CLDRModify {
         replace,
         /** Add a a path/value. Equals 'add' but tests that path did NOT exist */
         addNew,
+        /** Copy a path to new_path */
+        copy,
+        /** Equals 'copy' but tsts that path did NOT exist. */
+        copyNew
     }
 
     static final class ConfigMatch {
@@ -325,7 +332,8 @@ public class CLDRModify {
                     + XPathParts.NEWLINE
                     + "-k\t config_file\twith -fk perform modifications according to what is in the config file. For format details, see:"
                     + XPathParts.NEWLINE
-                    + "\t\thttp://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-passes/cldrmodify-config."
+                    + "\t\t"
+                    + CONFIG_FILE_DOCS
                     + XPathParts.NEWLINE
                     + "-R\t retain unchanged files"
                     + XPathParts.NEWLINE
@@ -2378,7 +2386,7 @@ public class CLDRModify {
 
         fixList.add(
                 'k',
-                "fix according to -k config file. Details on http://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-passes/cldrmodify-config",
+                "fix according to -k config file. Details on " + CONFIG_FILE_DOCS,
                 new CLDRFilter() {
                     private Map<ConfigMatch, LinkedHashSet<Map<ConfigKeys, ConfigMatch>>>
                             locale2keyValues;
@@ -2416,24 +2424,38 @@ public class CLDRModify {
                                 // we add all the values up front
                                 case addNew:
                                 case add:
-                                    if (pathMatch != null
-                                            || valueMatch != null
-                                            || newPath == null
-                                            || newValue == null) {
-                                        throw new IllegalArgumentException(
-                                                action.action
-                                                        + ": must have no path nor value = null AND new_path or new_value:\n\t"
-                                                        + entry);
+                                    {
+                                        if (pathMatch != null
+                                                || valueMatch != null
+                                                || newPath == null
+                                                || newValue == null) {
+                                            throw new IllegalArgumentException(
+                                                    action.action
+                                                            + ": must have no path nor value = null AND new_path or new_value:\n\t"
+                                                            + entry);
+                                        }
+                                        String newPathString = newPath.getPath(getResolved());
+                                        if (action.action == ConfigAction.add
+                                                || cldrFileToFilter.getStringValue(newPathString)
+                                                        == null) {
+                                            replace(
+                                                    newPathString,
+                                                    newPathString,
+                                                    newValue.exactMatch,
+                                                    "config");
+                                        }
                                     }
-                                    String newPathString = newPath.getPath(getResolved());
-                                    if (action.action == ConfigAction.add
-                                            || cldrFileToFilter.getStringValue(newPathString)
-                                                    == null) {
-                                        replace(
-                                                newPathString,
-                                                newPathString,
-                                                newValue.exactMatch,
-                                                "config");
+                                    break;
+                                case copy:
+                                case copyNew:
+                                    {
+                                        // just check
+                                        if (pathMatch == null || newPath == null) {
+                                            throw new IllegalArgumentException(
+                                                    String.format(
+                                                            "%s: must have path and new_path",
+                                                            action.action));
+                                        }
                                     }
                                     break;
                                 // we just check
@@ -2550,26 +2572,62 @@ public class CLDRModify {
                             ConfigMatch action = entry.get(ConfigKeys.action);
                             switch (action.action) {
                                 case delete:
-                                    remove(xpath, "config");
+                                    {
+                                        remove(xpath, "config");
+                                    }
                                     break;
                                 case replace:
-                                    ConfigMatch newPath = entry.get(ConfigKeys.new_path);
-                                    ConfigMatch newValue = entry.get(ConfigKeys.new_value);
+                                    {
+                                        ConfigMatch newPath = entry.get(ConfigKeys.new_path);
+                                        ConfigMatch newValue = entry.get(ConfigKeys.new_value);
 
-                                    String fullpath = cldrFileToFilter.getFullXPath(xpath);
-                                    String draft = "";
-                                    int loc = fullpath.indexOf("[@draft=");
-                                    if (loc >= 0) {
-                                        int loc2 = fullpath.indexOf(']', loc + 7);
-                                        draft = fullpath.substring(loc, loc2 + 1);
+                                        String fullpath = cldrFileToFilter.getFullXPath(xpath);
+                                        String draft = "";
+                                        int loc = fullpath.indexOf("[@draft=");
+                                        if (loc >= 0) {
+                                            int loc2 = fullpath.indexOf(']', loc + 7);
+                                            draft = fullpath.substring(loc, loc2 + 1);
+                                        }
+
+                                        String modPath =
+                                                ConfigMatch.getModified(pathMatch, xpath, newPath)
+                                                        + draft;
+                                        String modValue =
+                                                ConfigMatch.getModified(
+                                                        valueMatch, value, newValue);
+                                        replace(xpath, modPath, modValue, "config");
                                     }
-
-                                    String modPath =
-                                            ConfigMatch.getModified(pathMatch, xpath, newPath)
-                                                    + draft;
-                                    String modValue =
-                                            ConfigMatch.getModified(valueMatch, value, newValue);
-                                    replace(xpath, modPath, modValue, "config");
+                                    break;
+                                case copy:
+                                case copyNew:
+                                    {
+                                        // get out if there's no existing value
+                                        if (value == null) break;
+                                        ConfigMatch draft = entry.get(ConfigKeys.draft);
+                                        ConfigMatch newPath = entry.get(ConfigKeys.new_path);
+                                        final String oldNewPathString = newPath.exactMatch;
+                                        String newPathString;
+                                        if (draft != null
+                                                && !oldNewPathString.contains("[@draft=")) {
+                                            newPathString =
+                                                    oldNewPathString + "[@draft=\"" + draft + "\"]";
+                                        } else {
+                                            newPathString = oldNewPathString;
+                                        }
+                                        if (action.action == ConfigAction.copyNew
+                                                && cldrFileToFilter.isHere(oldNewPathString)) {
+                                            // the copyNew action skips if it's already here
+                                            break;
+                                        }
+                                        // TOOD: Allow skipping inheritance marker?
+                                        replace(
+                                                oldNewPathString,
+                                                newPathString,
+                                                value, // TODO: allow new_value to override with
+                                                // match
+                                                "config");
+                                    }
+                                    break;
                             }
                         }
                     }

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -218,7 +218,7 @@ public class CLDRModify {
     }
 
     static CLDRTreeWriter treeWriter = null;
-    private static boolean isVerbose = true;
+    private static boolean isVerbose = false;
 
     /** Picks options and executes. Use -h to see options. */
     public static void main(String[] args) throws Exception {

--- a/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
+++ b/tools/cldr-code/src/main/java/org/unicode/cldr/tool/CLDRModify.java
@@ -22,11 +22,9 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,9 +61,7 @@ import org.unicode.cldr.util.DtdData;
 import org.unicode.cldr.util.DtdType;
 import org.unicode.cldr.util.ExemplarSets.ExemplarType;
 import org.unicode.cldr.util.Factory;
-import org.unicode.cldr.util.FileProcessor;
 import org.unicode.cldr.util.GlossonymConstructor;
-import org.unicode.cldr.util.Joiners;
 import org.unicode.cldr.util.LanguageTagParser;
 import org.unicode.cldr.util.Level;
 import org.unicode.cldr.util.LocaleIDParser;
@@ -74,10 +70,8 @@ import org.unicode.cldr.util.LogicalGrouping;
 import org.unicode.cldr.util.PathChecker;
 import org.unicode.cldr.util.PatternCache;
 import org.unicode.cldr.util.RegexLookup;
-import org.unicode.cldr.util.RegexUtilities;
 import org.unicode.cldr.util.SimpleFactory;
 import org.unicode.cldr.util.StandardCodes;
-import org.unicode.cldr.util.StringId;
 import org.unicode.cldr.util.SupplementalDataInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo;
 import org.unicode.cldr.util.SupplementalDataInfo.PluralInfo.Count;
@@ -100,148 +94,12 @@ import org.unicode.cldr.util.XPathParts.Comments.CommentType;
 public class CLDRModify {
     private static final String CONFIG_FILE_DOCS =
             "https://cldr.unicode.org/development/cldr-big-red-switch/cldrmodify-using-config-file";
-    private static final Splitter SPLIT_ON_SEMI = Splitter.onPattern("\\s*;\\s+");
     static final String DEBUG_PATHS = null; // ".*currency.*";
     static final boolean COMMENT_REMOVALS = false; // append removals as comments
     static final UnicodeSet whitespace = new UnicodeSet("[:whitespace:]").freeze();
-    static final UnicodeSet HEX = new UnicodeSet("[a-fA-F0-9]").freeze();
     private static final DtdData dtdData = DtdData.getInstance(DtdType.ldml);
 
     // TODO make this into input option.
-
-    enum ConfigKeys {
-        action,
-        locale,
-        path,
-        value,
-        new_path,
-        new_value,
-        draft
-    }
-
-    enum ConfigAction {
-        /** Remove a path */
-        delete,
-        /** Add a path/value */
-        add,
-        /** Replace a path/value. Equals 'add' but tests selected paths */
-        replace,
-        /** Add a a path/value. Equals 'add' but tests that path did NOT exist */
-        addNew,
-        /** Copy a path to new_path */
-        copy,
-        /** Equals 'copy' but tsts that path did NOT exist. */
-        copyNew
-    }
-
-    static final class ConfigMatch {
-        final String exactMatch;
-        final Matcher regexMatch; // doesn't have to be thread safe
-        final ConfigAction action;
-        final boolean hexPath;
-
-        static UnicodeSet SUSPICIOUS_NON_REGEX = new UnicodeSet("[*|]").freeze();
-
-        public ConfigMatch(ConfigKeys key, String match) {
-            if (key == ConfigKeys.action) {
-                exactMatch = null;
-                regexMatch = null;
-                action = ConfigAction.valueOf(match);
-                hexPath = false;
-            } else if (match.length() > 1 && match.startsWith("/") && match.endsWith("/")) {
-                if (key != ConfigKeys.locale && key != ConfigKeys.path && key != ConfigKeys.value) {
-                    throw new IllegalArgumentException(
-                            "Regex only allowed for locale=, path=, or value'.");
-                }
-                exactMatch = null;
-                regexMatch =
-                        PatternCache.get(
-                                        match.substring(1, match.length() - 1)
-                                                .replace("[@", "\\[@"))
-                                .matcher("");
-                action = null;
-                hexPath = false;
-            } else {
-                exactMatch = match;
-                regexMatch = null;
-                action = null;
-                hexPath =
-                        (key == ConfigKeys.new_path || key == ConfigKeys.path)
-                                && HEX.containsAll(match);
-                if (key == ConfigKeys.locale || key == ConfigKeys.path) {
-                    if (SUSPICIOUS_NON_REGEX.containsSome(match)) {
-                        System.out.println(
-                                Joiners.ES.join(
-                                        "The value ",
-                                        match,
-                                        " is being matched literally, but contains regex charcters. Did you mean /",
-                                        match,
-                                        "/ ?"));
-                    }
-                }
-            }
-        }
-
-        public boolean matches(String other) {
-            if (exactMatch == null) {
-                return regexMatch.reset(other).find();
-            } else if (hexPath) {
-                // convert path to id for comparison
-                return exactMatch.equals(StringId.getHexId(other));
-            } else {
-                return exactMatch.equals(other);
-            }
-        }
-
-        @Override
-        public String toString() {
-            return action != null
-                    ? action.toString()
-                    : exactMatch == null
-                            ? regexMatch.toString()
-                            : hexPath ? "*" + exactMatch + "*" : exactMatch;
-        }
-
-        public String getPath(CLDRFile cldrFileToFilter) {
-            if (!hexPath) {
-                return exactMatch;
-            }
-            // ensure that we have all the possible paths cached
-            String path = StringId.getStringFromHexId(exactMatch);
-            if (path == null) {
-                for (String eachPath : cldrFileToFilter.fullIterable()) {
-                    StringId.getHexId(eachPath);
-                }
-                path = StringId.getStringFromHexId(exactMatch);
-                if (path == null) {
-                    throw new IllegalArgumentException("No path for hex id: " + exactMatch);
-                }
-            }
-            return path;
-        }
-
-        public static String getModified(
-                ConfigMatch valueMatch, String value, ConfigMatch newValue) {
-            if (valueMatch == null) { // match anything
-                if (newValue != null && newValue.exactMatch != null) {
-                    return newValue.exactMatch;
-                }
-                if (value != null) {
-                    return value;
-                }
-                throw new IllegalArgumentException("Can't have both old and new be null.");
-            } else if (valueMatch.exactMatch == null) { // regex
-                if (newValue == null || newValue.exactMatch == null) {
-                    throw new IllegalArgumentException("Can't have regex without replacement.");
-                }
-                StringBuffer buffer = new StringBuffer();
-                valueMatch.regexMatch.appendReplacement(buffer, newValue.exactMatch);
-                return buffer.toString();
-            } else {
-                return newValue.exactMatch != null ? newValue.exactMatch : value;
-            }
-        }
-    }
 
     static FixList fixList = new FixList();
 
@@ -262,7 +120,8 @@ public class CLDRModify {
             CHECK = 14,
             KONFIG = 15,
             RETAIN = 16,
-            INPLACE = 17;
+            INPLACE = 17,
+            VERBOSE = 18;
 
     private static final UOption[] options = {
         UOption.HELP_H(),
@@ -282,7 +141,8 @@ public class CLDRModify {
         UOption.create("check", 'c', UOption.NO_ARG),
         UOption.create("konfig", 'k', UOption.OPTIONAL_ARG).setDefault("modify_config.txt"),
         UOption.create("Retain", 'R', UOption.NO_ARG),
-        UOption.create("Inplace", 'I', UOption.NO_ARG)
+        UOption.create("Inplace", 'I', UOption.NO_ARG),
+        UOption.create("Verbose", 'V', UOption.NO_ARG)
     };
 
     private static final UnicodeSet allMergeOptions = new UnicodeSet("[rcd]");
@@ -340,6 +200,8 @@ public class CLDRModify {
                     + "-f\t to perform various fixes on the files (add following arguments to specify which ones, eg -fxi)"
                     + XPathParts.NEWLINE
                     + "-I\t to write files inplace instead of to the generated dir"
+                    + XPathParts.NEWLINE
+                    + "-V\tverbose mode"
                     + XPathParts.NEWLINE;
 
     static final String HELP_TEXT2 =
@@ -350,7 +212,13 @@ public class CLDRModify {
 
     static String sourceInput;
 
+    /** print out if in verbose mode */
+    public static final void verboseln(String fmtString, Object... opts) {
+        if (isVerbose) System.err.println("CLDRModify: " + String.format(fmtString, opts));
+    }
+
     static CLDRTreeWriter treeWriter = null;
+    private static boolean isVerbose = true;
 
     /** Picks options and executes. Use -h to see options. */
     public static void main(String[] args) throws Exception {
@@ -360,6 +228,8 @@ public class CLDRModify {
             System.out.println(HELP_TEXT1 + fixList.showHelp() + HELP_TEXT2);
             return;
         }
+        isVerbose = options[VERBOSE].doesOccur;
+        verboseln("Verbose mode");
         checkSuboptions(FIX, fixList.getOptions());
         checkSuboptions(JOIN_ARGS, allMergeOptions);
         String recurseOnDirectories = options[ALL_DIRS].value;
@@ -2387,251 +2257,9 @@ public class CLDRModify {
         fixList.add(
                 'k',
                 "fix according to -k config file. Details on " + CONFIG_FILE_DOCS,
-                new CLDRFilter() {
-                    private Map<ConfigMatch, LinkedHashSet<Map<ConfigKeys, ConfigMatch>>>
-                            locale2keyValues;
-                    private LinkedHashSet<Map<ConfigKeys, ConfigMatch>> keyValues =
-                            new LinkedHashSet<>();
-
-                    @Override
-                    public void handleStart() {
-                        super.handleStart();
-                        if (!options[FIX].doesOccur || !options[FIX].value.equals("k")) {
-                            return;
-                        }
-                        if (locale2keyValues == null) {
-                            fillCache();
-                        }
-                        // set up for the specific locale we are dealing with.
-                        // a small optimization
-                        String localeId = getLocaleID();
-                        keyValues.clear();
-                        for (Entry<ConfigMatch, LinkedHashSet<Map<ConfigKeys, ConfigMatch>>>
-                                localeMatcher : locale2keyValues.entrySet()) {
-                            if (localeMatcher.getKey().matches(localeId)) {
-                                keyValues.addAll(localeMatcher.getValue());
-                            }
-                        }
-                        // System.out.println("# Checking entries & changing:\t" +
-                        // keyValues.size());
-                        for (Map<ConfigKeys, ConfigMatch> entry : keyValues) {
-                            ConfigMatch action = entry.get(ConfigKeys.action);
-                            ConfigMatch pathMatch = entry.get(ConfigKeys.path);
-                            ConfigMatch valueMatch = entry.get(ConfigKeys.value);
-                            ConfigMatch newPath = entry.get(ConfigKeys.new_path);
-                            ConfigMatch newValue = entry.get(ConfigKeys.new_value);
-                            switch (action.action) {
-                                // we add all the values up front
-                                case addNew:
-                                case add:
-                                    {
-                                        if (pathMatch != null
-                                                || valueMatch != null
-                                                || newPath == null
-                                                || newValue == null) {
-                                            throw new IllegalArgumentException(
-                                                    action.action
-                                                            + ": must have no path nor value = null AND new_path or new_value:\n\t"
-                                                            + entry);
-                                        }
-                                        String newPathString = newPath.getPath(getResolved());
-                                        if (action.action == ConfigAction.add
-                                                || cldrFileToFilter.getStringValue(newPathString)
-                                                        == null) {
-                                            replace(
-                                                    newPathString,
-                                                    newPathString,
-                                                    newValue.exactMatch,
-                                                    "config");
-                                        }
-                                    }
-                                    break;
-                                case copy:
-                                case copyNew:
-                                    {
-                                        // just check
-                                        if (pathMatch == null || newPath == null) {
-                                            throw new IllegalArgumentException(
-                                                    String.format(
-                                                            "%s: must have path and new_path",
-                                                            action.action));
-                                        }
-                                    }
-                                    break;
-                                // we just check
-                                case replace:
-                                    if ((pathMatch == null && valueMatch == null)
-                                            || (newPath == null && newValue == null)) {
-                                        throw new IllegalArgumentException(
-                                                action.action
-                                                        + ": must have (path or value) AND (new_path or new_value):\n\t"
-                                                        + entry);
-                                    }
-                                    break;
-                                // For delete, we just check; we'll remove later
-                                case delete:
-                                    if (newPath != null || newValue != null) {
-                                        throw new IllegalArgumentException(
-                                                action.action
-                                                        + ": must have no new_path nor new_value:\n\t"
-                                                        + entry);
-                                    }
-                                    break;
-                                default: // fall through
-                                    throw new IllegalArgumentException("Internal Error");
-                            }
-                        }
-                    }
-
-                    private void fillCache() {
-                        locale2keyValues = new LinkedHashMap<>();
-                        String configFileName = options[KONFIG].value;
-                        FileProcessor myReader =
-                                new FileProcessor() {
-                                    {
-                                        doHash = false;
-                                    }
-
-                                    @Override
-                                    protected boolean handleLine(int lineCount, String line) {
-                                        line = line.trim();
-                                        Iterable<String> lineParts = SPLIT_ON_SEMI.split(line);
-                                        Map<ConfigKeys, ConfigMatch> keyValue =
-                                                new EnumMap<>(ConfigKeys.class);
-                                        for (String linePart : lineParts) {
-                                            int pos = linePart.indexOf('=');
-                                            if (pos < 0) {
-                                                // WARNING; the code doesn't allow for ; within
-                                                // values; need to restructure for that.
-                                                throw new IllegalArgumentException(
-                                                        lineCount
-                                                                + ":\t No = in command: «"
-                                                                + linePart
-                                                                + "» in "
-                                                                + line);
-                                            }
-                                            ConfigKeys key =
-                                                    ConfigKeys.valueOf(
-                                                            linePart.substring(0, pos).trim());
-                                            if (keyValue.containsKey(key)) {
-                                                throw new IllegalArgumentException(
-                                                        "Must not have multiple keys: " + key);
-                                            }
-                                            String match = linePart.substring(pos + 1).trim();
-                                            keyValue.put(key, new ConfigMatch(key, match));
-                                        }
-                                        final ConfigMatch locale = keyValue.get(ConfigKeys.locale);
-                                        if (locale == null
-                                                || keyValue.get(ConfigKeys.action) == null) {
-                                            throw new IllegalArgumentException();
-                                        }
-
-                                        // validate new path
-                                        LinkedHashSet<Map<ConfigKeys, ConfigMatch>> keyValues =
-                                                locale2keyValues.get(locale);
-                                        if (keyValues == null) {
-                                            locale2keyValues.put(
-                                                    locale, keyValues = new LinkedHashSet<>());
-                                        }
-                                        keyValues.add(keyValue);
-                                        return true;
-                                    }
-                                };
-                        myReader.process(CLDRModify.class, configFileName);
-                    }
-
-                    final String DEBUG_PATH = null;
-
-                    // example:
-                    // "//ldml/personNames/personName[@order=\"givenFirst\"][@length=\"long\"][@usage=\"referring\"][@formality=\"formal\"]/namePattern";
-
-                    @SuppressWarnings("incomplete-switch")
-                    @Override
-                    public void handlePath(String xpath) {
-                        // slow method; could optimize
-                        if (DEBUG_PATH != null && DEBUG_PATH.equals(xpath)) {
-                            System.out.println(xpath);
-                        }
-                        for (Map<ConfigKeys, ConfigMatch> entry : keyValues) {
-                            ConfigMatch pathMatch = entry.get(ConfigKeys.path);
-                            if (pathMatch != null && !pathMatch.matches(xpath)) {
-                                if (DEBUG_PATH != null
-                                        && pathMatch != null
-                                        && pathMatch.regexMatch != null) {
-                                    System.out.println(
-                                            RegexUtilities.showMismatch(
-                                                    pathMatch.regexMatch, xpath));
-                                }
-                                continue;
-                            }
-                            ConfigMatch valueMatch = entry.get(ConfigKeys.value);
-                            final String value = cldrFileToFilter.getStringValue(xpath);
-                            if (valueMatch != null && !valueMatch.matches(value)) {
-                                continue;
-                            }
-                            ConfigMatch action = entry.get(ConfigKeys.action);
-                            switch (action.action) {
-                                case delete:
-                                    {
-                                        remove(xpath, "config");
-                                    }
-                                    break;
-                                case replace:
-                                    {
-                                        ConfigMatch newPath = entry.get(ConfigKeys.new_path);
-                                        ConfigMatch newValue = entry.get(ConfigKeys.new_value);
-
-                                        String fullpath = cldrFileToFilter.getFullXPath(xpath);
-                                        String draft = "";
-                                        int loc = fullpath.indexOf("[@draft=");
-                                        if (loc >= 0) {
-                                            int loc2 = fullpath.indexOf(']', loc + 7);
-                                            draft = fullpath.substring(loc, loc2 + 1);
-                                        }
-
-                                        String modPath =
-                                                ConfigMatch.getModified(pathMatch, xpath, newPath)
-                                                        + draft;
-                                        String modValue =
-                                                ConfigMatch.getModified(
-                                                        valueMatch, value, newValue);
-                                        replace(xpath, modPath, modValue, "config");
-                                    }
-                                    break;
-                                case copy:
-                                case copyNew:
-                                    {
-                                        // get out if there's no existing value
-                                        if (value == null) break;
-                                        ConfigMatch draft = entry.get(ConfigKeys.draft);
-                                        ConfigMatch newPath = entry.get(ConfigKeys.new_path);
-                                        final String oldNewPathString = newPath.exactMatch;
-                                        String newPathString;
-                                        if (draft != null
-                                                && !oldNewPathString.contains("[@draft=")) {
-                                            newPathString =
-                                                    oldNewPathString + "[@draft=\"" + draft + "\"]";
-                                        } else {
-                                            newPathString = oldNewPathString;
-                                        }
-                                        if (action.action == ConfigAction.copyNew
-                                                && cldrFileToFilter.isHere(oldNewPathString)) {
-                                            // the copyNew action skips if it's already here
-                                            break;
-                                        }
-                                        // TOOD: Allow skipping inheritance marker?
-                                        replace(
-                                                oldNewPathString,
-                                                newPathString,
-                                                value, // TODO: allow new_value to override with
-                                                // match
-                                                "config");
-                                    }
-                                    break;
-                            }
-                        }
-                    }
-                });
+                new CLDRConfigFileFilter(
+                        () -> (options[FIX].doesOccur && options[FIX].value.equals("k")),
+                        () -> options[KONFIG].value));
         fixList.add('i', "fix Identical Children");
         fixList.add('o', "check attribute validity");
 


### PR DESCRIPTION
CLDR-19640

- This adds `copy` and `copyNew` features to CLDRModify's config file mode (`-fk`)
- also, split out the config file mode of CLDRModify to a separate file (CLDRModify.java is nearly 4,000 lines)
- also, add `-V` option to CLDRModify

This was used to generate the changes in these PRs:
- #5888
- #5664


- [ ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
