### PR TITLE
CLDR-11043 Add en name for Urumqi metazone

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -5367,6 +5367,11 @@ annotations.
 					<daylight>Uruguay Summer Time</daylight>
 				</long>
 			</metazone>
+			<metazone type="Urumqi">
+				<long>
+					<standard>Ürümqi Time</standard>
+				</long>
+			</metazone>
 			<metazone type="Uzbekistan">
 				<long>
 					<generic>Uzbekistan Time</generic>


### PR DESCRIPTION
CLDR-11043 

This matches the location name, which is also "Ürümqi Time" in English.

- [ ] This PR completes the ticket.

ALLOW_MANY_COMMITS=true
